### PR TITLE
Update translations catalog

### DIFF
--- a/app/Resources/translations/default/AdminActions.xlf
+++ b/app/Resources/translations/default/AdminActions.xlf
@@ -1,764 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/ps_facetedsearch/views/templates/admin/add.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c9cc8cce247e49bae79f15173ce97354">
-        <source>Save</source>
-        <target>Save</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:397</note>
-      </trans-unit>
-      <trans-unit id="ea4788705e6873b424c65e91c2846b19">
-        <source>Cancel</source>
-        <target>Cancel</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:399</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d3b206d196cd6be3a2764c1fb90b200f">
-        <source>Delete selected</source>
-        <target>Delete selected</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php:202</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_facetedsearch/views/templates/admin/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f2a6c498fb90ee345d997f888fce3b18">
-        <source>Delete</source>
-        <target>Delete</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:87</note>
-      </trans-unit>
-      <trans-unit id="7dce122004969d56ae2e0245cb754d35">
-        <source>Edit</source>
-        <target>Edit</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:78</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2faec1f9f8cc7f8f40d521c4dd574f49">
-        <source>Enable</source>
-        <target>Enable</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:121</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/blockreassurance/blockreassurance.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="630f6dc397fe74e52d5189e2c80f282b">
-        <source>Back to list</source>
-        <target>Back to list</target>
-        <note>Context:
-File: modules/blockreassurance/blockreassurance.php:299</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="72d6d7a1885885bb55a565fd1070581a">
-        <source>Import</source>
-        <target>Import</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="f4ec5f57bd4d31b803312d873be40da9">
-        <source>Change</source>
-        <target>Change</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:179</note>
-      </trans-unit>
-      <trans-unit id="ad8783089f828b927473fb61d51940ec">
-        <source>Use</source>
-        <target>Use</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:142</note>
-      </trans-unit>
-      <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d">
-        <source>Download</source>
-        <target>Download</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:119</note>
-      </trans-unit>
-      <trans-unit id="91412465ea9169dfd901dd5e7c96dd99">
-        <source>Upload</source>
-        <target>Upload</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:79</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="de9ced9bf5e9829de4a93ad8c9d7a170">
-        <source>Add New</source>
-        <target>Add New</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:328</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9ea67be453eaccf020697b4654fc021a">
-        <source>Save and stay</source>
-        <target>Save and stay</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:90</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCmsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f8825c9f08ff15b5ef6bc3a3898817e8">
-        <source>Save and preview</source>
-        <target>Save and preview</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:242</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_imageslider/views/templates/hook/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ef61fb324d729c341ea8ab9901e23566">
-        <source>Add new</source>
-        <target>Add new</target>
-        <note>Context:
-File: modules/ps_imageslider/views/templates/hook/list.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0095a9fa74d1713e43e370a7d7846224">
-        <source>Export</source>
-        <target>Export</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig:74</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e25f0ecd41211b01c83e5fec41df4fe7">
-        <source>Delete selected items?</source>
-        <target>Delete selected items?</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:48</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a20ddccbb6f808ec42cd66323e6c6061">
-        <source>Finish</source>
-        <target>Finish</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:133</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_categorytree/ps_categorytree.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6b46ae48421828d9973deec5fa9aa0c3">
-        <source>Sort</source>
-        <target>Sort</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:202</note>
-      </trans-unit>
-      <trans-unit id="06f1ac65b0a6a548339a38b348e64d79">
-        <source>Sort order</source>
-        <target>Sort order</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:219</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/calendar/calendar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9639e32cab248434a17ab32237cb3b71">
-        <source>Apply</source>
-        <target>Apply</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:101</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_mainmenu/views/templates/admin/_configure/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ec211f7c20af43e742bf2570c3cb84f9">
-        <source>Add</source>
-        <target>Add</target>
-        <note>Context:
-File: modules/ps_mainmenu/views/templates/admin/_configure/helpers/form/form.tpl:120</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="06933067aafd48425d67bcb01bba5cb6">
-        <source>Update</source>
-        <target>Update</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_shipping.tpl:122</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/statscatalog/statscatalog.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680">
-        <source>All</source>
-        <target>All</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:188</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="4351cfebe4b61d8aa5efa1d020710005">
-        <source>View</source>
-        <target>View</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl:497</note>
-      </trans-unit>
       <trans-unit id="a27dfe771799a09fd55fea73286eb6ab">
         <source>Uninstall</source>
         <target>Uninstall</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl:505</note>
+        <note>Line: 505</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="dbb392a2dc9b38722e69f6032faea73e">
-        <source>Export .CSV file</source>
-        <target>Export .CSV file</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:995</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/page.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
-        <source>Search</source>
-        <target>Search</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:103</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/tools.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dbcd43f8ba2bafd1bccc57fe9c8b5d7b">
-        <source>Show SQL query</source>
-        <target>Show SQL query</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/tools.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="351b6d570b6ba15fe66e85c1eaf9ec64">
-        <source>Export to SQL Manager</source>
-        <target>Export to SQL Manager</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/tools.html.twig:48</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ede4759c9afae620fd586628789fa304">
-        <source>Enable selection</source>
-        <target>Enable selection</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php:231</note>
-      </trans-unit>
-      <trans-unit id="ab7fd6e250b64a46027a996088fdff74">
-        <source>Disable selection</source>
-        <target>Disable selection</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php:237</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="526d688f37a86d3c3f27d0c5016eb71d">
-        <source>Reset</source>
-        <target>Reset</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_header.tpl:76</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4eac69549b8424b6cf5852421f327838">
-        <source>Confirm this action</source>
-        <target>Confirm this action</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/InternationalApi.php:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8098b34f582537833b36b58273c3545b">
-        <source>Expand</source>
-        <target>Expand</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:40</note>
-      </trans-unit>
-      <trans-unit id="2b31634e3cfef1bfdd7d0d2cdfdc3f9d">
-        <source>Collapse</source>
-        <target>Collapse</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:41</note>
-      </trans-unit>
-      <trans-unit id="686e697538050e4664636337cc3b834f">
-        <source>Create</source>
-        <target>Create</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:72</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ab76f8687bae4be1912889f2328fc8ea">
-        <source>Filter by categories</source>
-        <target>Filter by categories</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig:37</note>
-      </trans-unit>
-      <trans-unit id="46b816f573557a53c93ac78bbcfa9493">
-        <source>Unselect</source>
-        <target>Unselect</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig:66</note>
-      </trans-unit>
-      <trans-unit id="7bbd046ab824701b2e019e5d07d6ab99">
-        <source>Activate selection</source>
-        <target>Activate selection</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig:86</note>
-      </trans-unit>
-      <trans-unit id="fa870a208f7f70af5ead1f1992f6d9e2">
-        <source>Deactivate selection</source>
-        <target>Deactivate selection</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig:90</note>
-      </trans-unit>
-      <trans-unit id="e2afd6b97d2eac4817170845d26b9c9b">
-        <source>Duplicate selection</source>
-        <target>Duplicate selection</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig:100</note>
-      </trans-unit>
-      <trans-unit id="6adab6d3fdf92c448d60cf8824e4851c">
-        <source>Delete selection</source>
-        <target>Delete selection</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig:111</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="656c3be690ee43df4b845bd2a2ebe587">
-        <source>New product</source>
-        <target>New product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:325</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_livetranslation/views/templates/hook/ps_livetranslation.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bcfaccebf745acfd5e75351095a5394a">
-        <source>Disable</source>
-        <target>Disable</target>
-        <note>Context:
-File: modules/ps_livetranslation/views/templates/hook/ps_livetranslation.tpl:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cc3787ca78f445f481069a4c047f7e7a">
-        <source>Choose language:</source>
-        <target>Choose language:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:77</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ed75712b0eb1913c28a3872731ffd48d">
-        <source>Duplicate</source>
-        <target>Duplicate</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:131</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/helper/Helper.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b56c3bda503a8dc4be356edb0cc31793">
-        <source>Collapse All</source>
-        <target>Collapse All</target>
-        <note>Context:
-File: classes/helper/Helper.php:172</note>
-      </trans-unit>
-      <trans-unit id="5ffd7a335dd836b3373f5ec570a58bdc">
-        <source>Expand All</source>
-        <target>Expand All</target>
-        <note>Context:
-File: classes/helper/Helper.php:173</note>
-      </trans-unit>
-      <trans-unit id="5e9df908eafa83cb51c0a3720e8348c7">
-        <source>Check All</source>
-        <target>Check All</target>
-        <note>Context:
-File: classes/helper/Helper.php:174</note>
-      </trans-unit>
-      <trans-unit id="9747d23c8cc358c5ef78c51e59cd6817">
-        <source>Uncheck All</source>
-        <target>Uncheck All</target>
-        <note>Context:
-File: classes/helper/Helper.php:175</note>
-      </trans-unit>
-      <trans-unit id="17f5f00c6d09158f70718e353e91d20e">
-        <source>Find a category</source>
-        <target>Find a category</target>
-        <note>Context:
-File: classes/helper/Helper.php:176</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4c41e0bd957698b58100a5c687d757d9">
-        <source>Select all</source>
-        <target>Select all</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_footer.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="237c7b6874386141a095e321c9fdfd38">
-        <source>Unselect all</source>
-        <target>Unselect all</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_footer.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="b9987a246a537f4fe86f1f2e3d10dbdb">
-        <source>Display</source>
-        <target>Display</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_footer.tpl:63</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c770d8e0d1d1943ce239c64dbd6acc20">
-        <source>Add my IP</source>
-        <target>Add my IP</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig:116</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="33d8042bd735c559cc3206f4bc99aedc">
-        <source>Sort by</source>
-        <target>Sort by</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="01fda57aa6c7e9f07f5aa36b108e95cb">
-        <source>Order by</source>
-        <target>Order by</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig:53</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/see_more.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="891ad007e2e9f2d55be6669cd9abc7a0">
-        <source>See more</source>
-        <target>See more</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/see_more.html.twig:28</note>
-      </trans-unit>
-      <trans-unit id="58de647698e3130c85d5c20670852608">
-        <source>See less</source>
-        <target>See less</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/see_more.html.twig:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="634efc0701950e9b2b97384327c8d5d2">
-        <source>Let's go!</source>
-        <target>Let's go!</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig:65</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f1206f9fadc5ce41694f69129aecac26">
-        <source>Configure</source>
-        <target>Configure</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:36</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_loader.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f915a95e609bbd517a8a1e7bdcceef37">
-        <source>Try again</source>
-        <target>Try again</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_loader.html.twig:56</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d3d2e617335f08df83599665eef8a418">
-        <source>Close</source>
-        <target>Close</target>
-        <note>Context:
-File: admin-dev/themes/default/template/modal.tpl:39</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e54081e38ac9d11f4426975774eca447">
-        <source>Delete now</source>
-        <target>Delete now</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:198</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/statuses/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="31fde7b05ac8952dacf4af8a704074ec">
-        <source>Preview</source>
-        <target>Preview</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/statuses/helpers/form/form.tpl:77</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="332c80b1838dc515f5031e09da3b7f3f">
-        <source>Reorder</source>
-        <target>Reorder</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig:160</note>
-      </trans-unit>
-      <trans-unit id="f5cb84b93af7d426e14a49b2804d0f29">
-        <source><![CDATA[Save & refresh]]></source>
-        <target><![CDATA[Save & refresh]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig:162</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="43340e6cc4e88197d57f8d6d5ea50a46">
-        <source>Read more</source>
-        <target>Read more</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d5ef96e383d376beeec28da7acfea516">
-        <source>Download file</source>
-        <target>Download file</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig:105</note>
-      </trans-unit>
-      <trans-unit id="a1997856e58a07d80e27aaf4bc7eaf88">
-        <source>Delete this file</source>
-        <target>Delete this file</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig:106</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="50de2399e96ac57bed17e95376046c3b">
-        <source>Check / Uncheck all</source>
-        <target>Check / Uncheck all</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7f090bbab1cc7f9c08bf4e54d932d3c0">
-        <source>Modify</source>
-        <target>Modify</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig:103</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5fb63579fc981698f97d55bfecb213ea">
-        <source>Copy</source>
-        <target>Copy</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig:87</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="498f79c4c5bbde77f1bceb6c86fd0f6d">
-        <source>Show</source>
-        <target>Show</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d59048f21fd887ad520398ce677be586">
-        <source>Learn more</source>
-        <target>Learn more</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig:36</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1063e38cb53d94d386f21227fcd84717">
-        <source>Remove</source>
-        <target>Remove</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:324</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/ProductImage/form.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="baf47af13c027a9c747328bbfbcb9178">
-        <source>Save image settings</source>
-        <target>Save image settings</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/ProductImage/form.html.twig:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/footer_toolbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e9c7e4df74077626f7e42797c65273c4">
-        <source>and stay</source>
-        <target>and stay</target>
-        <note>Context:
-File: admin-dev/themes/default/template/footer_toolbar.tpl:64</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7bc873cba11f035df692c3549366c722">
-        <source>-- Choose --</source>
-        <target>-- Choose --</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl:48</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="961f2247a2070bedff9f9cd8d64e2650">
-        <source>Choose</source>
-        <target>Choose</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/product_rule.tpl:38</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
-        <source>Shipping</source>
-        <target>Shipping</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1405</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="daf51d7d9e10e6a469434ae548d9a173">
-        <source>Print out</source>
-        <target>Print out</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/informations.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="32b919d18cfaca89383f6000dcc9c031">
-        <source>Generate</source>
-        <target>Generate</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:83</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/configure.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="deccbe4e9083c3b5f7cd2632722765bb">
-        <source>Translate</source>
-        <target>Translate</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:86</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d7778d0c64b6ba21494c97f77a66885a">
-        <source>Filter</source>
-        <target>Filter</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:78</note>
+      <trans-unit id="92fbf0e5d97b8afd7e73126b52bdc4bb">
+        <source>Choose a file</source>
+        <target>Choose a file</target>
+        <note>Line: 52</note>
       </trans-unit>
     </body>
   </file>
@@ -767,28 +23,695 @@ File: admin-dev/themes/default/template/controllers/modules/filters.tpl:78</note
       <trans-unit id="ad3d06d03d94223fa652babc913de686">
         <source>Validate</source>
         <target>Validate</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/view/view.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_imageslider/views/templates/admin/_configure/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/informations.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="92fbf0e5d97b8afd7e73126b52bdc4bb">
-        <source>Choose a file</source>
-        <target>Choose a file</target>
-        <note>Context:
-File: modules/ps_imageslider/views/templates/admin/_configure/helpers/form/form.tpl:44</note>
+      <trans-unit id="32b919d18cfaca89383f6000dcc9c031">
+        <source>Generate</source>
+        <target>Generate</target>
+        <note>Line: 83</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/countries/helpers/list/list_footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4c41e0bd957698b58100a5c687d757d9">
+        <source>Select all</source>
+        <target>Select all</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="237c7b6874386141a095e321c9fdfd38">
+        <source>Unselect all</source>
+        <target>Unselect all</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="b9987a246a537f4fe86f1f2e3d10dbdb">
+        <source>Display</source>
+        <target>Display</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7bc873cba11f035df692c3549366c722">
+        <source>-- Choose --</source>
+        <target>-- Choose --</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/message.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4351cfebe4b61d8aa5efa1d020710005">
+        <source>View</source>
+        <target>View</target>
+        <note>Line: 85</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f4ec5f57bd4d31b803312d873be40da9">
+        <source>Change</source>
+        <target>Change</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="ad8783089f828b927473fb61d51940ec">
+        <source>Use</source>
+        <target>Use</target>
+        <note>Line: 142</note>
+      </trans-unit>
+      <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d">
+        <source>Download</source>
+        <target>Download</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="91412465ea9169dfd901dd5e7c96dd99">
+        <source>Upload</source>
+        <target>Upload</target>
+        <note>Line: 79</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="72d6d7a1885885bb55a565fd1070581a">
+        <source>Import</source>
+        <target>Import</target>
+        <note>Line: 141</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3d2e617335f08df83599665eef8a418">
+        <source>Close</source>
+        <target>Close</target>
+        <note>Line: 108</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/configure.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bcfaccebf745acfd5e75351095a5394a">
+        <source>Disable</source>
+        <target>Disable</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="f1206f9fadc5ce41694f69129aecac26">
+        <source>Configure</source>
+        <target>Configure</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="deccbe4e9083c3b5f7cd2632722765bb">
+        <source>Translate</source>
+        <target>Translate</target>
+        <note>Line: 86</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d7778d0c64b6ba21494c97f77a66885a">
+        <source>Filter</source>
+        <target>Filter</target>
+        <note>Line: 78</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="498f79c4c5bbde77f1bceb6c86fd0f6d">
+        <source>Show</source>
+        <target>Show</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="06933067aafd48425d67bcb01bba5cb6">
+        <source>Update</source>
+        <target>Update</target>
+        <note>Line: 233</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7dce122004969d56ae2e0245cb754d35">
+        <source>Edit</source>
+        <target>Edit</target>
+        <note>Line: 1388</note>
+      </trans-unit>
+      <trans-unit id="961f2247a2070bedff9f9cd8d64e2650">
+        <source>Choose</source>
+        <target>Choose</target>
+        <note>Line: 502</note>
+      </trans-unit>
+      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
+        <source>Shipping</source>
+        <target>Shipping</target>
+        <note>Line: 1405</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="daf51d7d9e10e6a469434ae548d9a173">
+        <source>Print out</source>
+        <target>Print out</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/statuses/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="31fde7b05ac8952dacf4af8a704074ec">
+        <source>Preview</source>
+        <target>Preview</target>
+        <note>Line: 77</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/tags/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1063e38cb53d94d386f21227fcd84717">
+        <source>Remove</source>
+        <target>Remove</target>
+        <note>Line: 51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="526d688f37a86d3c3f27d0c5016eb71d">
+        <source>Reset</source>
+        <target>Reset</target>
+        <note>Line: 76</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9ea67be453eaccf020697b4654fc021a">
+        <source>Save and stay</source>
+        <target>Save and stay</target>
+        <note>Line: 90</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/footer_toolbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e9c7e4df74077626f7e42797c65273c4">
+        <source>and stay</source>
+        <target>and stay</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cc3787ca78f445f481069a4c047f7e7a">
+        <source>Choose language:</source>
+        <target>Choose language:</target>
+        <note>Line: 77</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/calendar/calendar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ea4788705e6873b424c65e91c2846b19">
+        <source>Cancel</source>
+        <target>Cancel</target>
+        <note>Line: 97</note>
+      </trans-unit>
+      <trans-unit id="9639e32cab248434a17ab32237cb3b71">
+        <source>Apply</source>
+        <target>Apply</target>
+        <note>Line: 101</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ec211f7c20af43e742bf2570c3cb84f9">
+        <source>Add</source>
+        <target>Add</target>
+        <note>Line: 311</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
+        <source>Search</source>
+        <target>Search</target>
+        <note>Line: 382</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/required_fields.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c9cc8cce247e49bae79f15173ce97354">
+        <source>Save</source>
+        <target>Save</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/uploader/simple.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f2a6c498fb90ee345d997f888fce3b18">
+        <source>Delete</source>
+        <target>Delete</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/helper/Helper.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b56c3bda503a8dc4be356edb0cc31793">
+        <source>Collapse All</source>
+        <target>Collapse All</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="5ffd7a335dd836b3373f5ec570a58bdc">
+        <source>Expand All</source>
+        <target>Expand All</target>
+        <note>Line: 173</note>
+      </trans-unit>
+      <trans-unit id="5e9df908eafa83cb51c0a3720e8348c7">
+        <source>Check All</source>
+        <target>Check All</target>
+        <note>Line: 174</note>
+      </trans-unit>
+      <trans-unit id="9747d23c8cc358c5ef78c51e59cd6817">
+        <source>Uncheck All</source>
+        <target>Uncheck All</target>
+        <note>Line: 175</note>
+      </trans-unit>
+      <trans-unit id="17f5f00c6d09158f70718e353e91d20e">
+        <source>Find a category</source>
+        <target>Find a category</target>
+        <note>Line: 176</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="630f6dc397fe74e52d5189e2c80f282b">
+        <source>Back to list</source>
+        <target>Back to list</target>
+        <note>Line: 577</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a20ddccbb6f808ec42cd66323e6c6061">
+        <source>Finish</source>
+        <target>Finish</target>
+        <note>Line: 133</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="de9ced9bf5e9829de4a93ad8c9d7a170">
+        <source>Add New</source>
+        <target>Add New</target>
+        <note>Line: 328</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f8825c9f08ff15b5ef6bc3a3898817e8">
+        <source>Save and preview</source>
+        <target>Save and preview</target>
+        <note>Line: 269</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e25f0ecd41211b01c83e5fec41df4fe7">
+        <source>Delete selected items?</source>
+        <target>Delete selected items?</target>
+        <note>Line: 48</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="63a6a88c066880c5ac42394a22803ca6">
         <source>Refresh</source>
         <target>Refresh</target>
-        <note>Context:
-File: modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl:49</note>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/gsitemap/views/templates/admin/configuration.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a0bfb8e59e6c13fc8d990781f77694fe">
+        <source>Continue</source>
+        <target>Continue</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_categorytree/ps_categorytree.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6b46ae48421828d9973deec5fa9aa0c3">
+        <source>Sort</source>
+        <target>Sort</target>
+        <note>Line: 202</note>
+      </trans-unit>
+      <trans-unit id="06f1ac65b0a6a548339a38b348e64d79">
+        <source>Sort order</source>
+        <target>Sort order</target>
+        <note>Line: 219</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dbb392a2dc9b38722e69f6032faea73e">
+        <source>Export .CSV file</source>
+        <target>Export .CSV file</target>
+        <note>Line: 995</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_imageslider/views/templates/hook/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ef61fb324d729c341ea8ab9901e23566">
+        <source>Add new</source>
+        <target>Add new</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/include/menu_top.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="33d8042bd735c559cc3206f4bc99aedc">
+        <source>Sort by</source>
+        <target>Sort by</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/include/modal_addons_connect.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="634efc0701950e9b2b97384327c8d5d2">
+        <source>Let's go!</source>
+        <target>Let's go!</target>
+        <note>Line: 68</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/include/modal_import.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f915a95e609bbd517a8a1e7bdcceef37">
+        <source>Try again</source>
+        <target>Try again</target>
+        <note>Line: 80</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/statscatalog/statscatalog.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680">
+        <source>All</source>
+        <target>All</target>
+        <note>Line: 188</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3b206d196cd6be3a2764c1fb90b200f">
+        <source>Delete selected</source>
+        <target>Delete selected</target>
+        <note>Line: 257</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ede4759c9afae620fd586628789fa304">
+        <source>Enable selection</source>
+        <target>Enable selection</target>
+        <note>Line: 231</note>
+      </trans-unit>
+      <trans-unit id="ab7fd6e250b64a46027a996088fdff74">
+        <source>Disable selection</source>
+        <target>Disable selection</target>
+        <note>Line: 237</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2faec1f9f8cc7f8f40d521c4dd574f49">
+        <source>Enable</source>
+        <target>Enable</target>
+        <note>Line: 122</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="656c3be690ee43df4b845bd2a2ebe587">
+        <source>New product</source>
+        <target>New product</target>
+        <note>Line: 325</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/grid_actions.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="351b6d570b6ba15fe66e85c1eaf9ec64">
+        <source>Export to SQL Manager</source>
+        <target>Export to SQL Manager</target>
+        <note>Line: 51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d59048f21fd887ad520398ce677be586">
+        <source>Learn more</source>
+        <target>Learn more</target>
+        <note>Line: 36</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5fb63579fc981698f97d55bfecb213ea">
+        <source>Copy</source>
+        <target>Copy</target>
+        <note>Line: 87</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0095a9fa74d1713e43e370a7d7846224">
+        <source>Export</source>
+        <target>Export</target>
+        <note>Line: 74</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7f090bbab1cc7f9c08bf4e54d932d3c0">
+        <source>Modify</source>
+        <target>Modify</target>
+        <note>Line: 103</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="01fda57aa6c7e9f07f5aa36b108e95cb">
+        <source>Order by</source>
+        <target>Order by</target>
+        <note>Line: 53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/see_more.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="891ad007e2e9f2d55be6669cd9abc7a0">
+        <source>See more</source>
+        <target>See more</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="58de647698e3130c85d5c20670852608">
+        <source>See less</source>
+        <target>See less</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ab76f8687bae4be1912889f2328fc8ea">
+        <source>Filter by categories</source>
+        <target>Filter by categories</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="46b816f573557a53c93ac78bbcfa9493">
+        <source>Unselect</source>
+        <target>Unselect</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="7bbd046ab824701b2e019e5d07d6ab99">
+        <source>Activate selection</source>
+        <target>Activate selection</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="fa870a208f7f70af5ead1f1992f6d9e2">
+        <source>Deactivate selection</source>
+        <target>Deactivate selection</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="e2afd6b97d2eac4817170845d26b9c9b">
+        <source>Duplicate selection</source>
+        <target>Duplicate selection</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="6adab6d3fdf92c448d60cf8824e4851c">
+        <source>Delete selection</source>
+        <target>Delete selection</target>
+        <note>Line: 111</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/tools.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dbcd43f8ba2bafd1bccc57fe9c8b5d7b">
+        <source>Show SQL query</source>
+        <target>Show SQL query</target>
+        <note>Line: 45</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="332c80b1838dc515f5031e09da3b7f3f">
+        <source>Reorder</source>
+        <target>Reorder</target>
+        <note>Line: 160</note>
+      </trans-unit>
+      <trans-unit id="f5cb84b93af7d426e14a49b2804d0f29">
+        <source><![CDATA[Save & refresh]]></source>
+        <target><![CDATA[Save & refresh]]></target>
+        <note>Line: 162</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e54081e38ac9d11f4426975774eca447">
+        <source>Delete now</source>
+        <target>Delete now</target>
+        <note>Line: 198</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ed75712b0eb1913c28a3872731ffd48d">
+        <source>Duplicate</source>
+        <target>Duplicate</target>
+        <note>Line: 131</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8098b34f582537833b36b58273c3545b">
+        <source>Expand</source>
+        <target>Expand</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="2b31634e3cfef1bfdd7d0d2cdfdc3f9d">
+        <source>Collapse</source>
+        <target>Collapse</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="686e697538050e4664636337cc3b834f">
+        <source>Create</source>
+        <target>Create</target>
+        <note>Line: 72</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="50de2399e96ac57bed17e95376046c3b">
+        <source>Check / Uncheck all</source>
+        <target>Check / Uncheck all</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d5ef96e383d376beeec28da7acfea516">
+        <source>Download file</source>
+        <target>Download file</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="a1997856e58a07d80e27aaf4bc7eaf88">
+        <source>Delete this file</source>
+        <target>Delete this file</target>
+        <note>Line: 106</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="43340e6cc4e88197d57f8d6d5ea50a46">
+        <source>Read more</source>
+        <target>Read more</target>
+        <note>Line: 72</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/ProductImage/form.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="baf47af13c027a9c747328bbfbcb9178">
+        <source>Save image settings</source>
+        <target>Save image settings</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c770d8e0d1d1943ce239c64dbd6acc20">
+        <source>Add my IP</source>
+        <target>Add my IP</target>
+        <note>Line: 116</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4eac69549b8424b6cf5852421f327838">
+        <source>Confirm this action</source>
+        <target>Confirm this action</target>
+        <note>Line: 41</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminAdvparametersFeature.xlf
+++ b/app/Resources/translations/default/AdminAdvparametersFeature.xlf
@@ -1,2251 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminQuickAccessesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="8ceefbf99a59faebc1abfe60004fa5cd">
-        <source>%class_name% addition</source>
-        <target>%class_name% addition</target>
-        <note>Context:
-File: controllers/admin/AdminQuickAccessesController.php:194
- Comment: voluntary do affectation here</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopUrlController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4a4d1260782270739eeeef6d58db0f73">
-        <source>Shop URL ID</source>
-        <target>Shop URL ID</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:57</note>
-      </trans-unit>
-      <trans-unit id="e93c33bd1341ab74195430daeb63db13">
-        <source>Shop name</source>
-        <target>Shop name</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:62</note>
-      </trans-unit>
-      <trans-unit id="71a7f085c9ecfd1ac1042c32c0656927">
-        <source>Is it the main URL?</source>
-        <target>Is it the main URL?</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:72</note>
-      </trans-unit>
-      <trans-unit id="bfc70beddce99a8ab159563d4e03f7af">
-        <source>URL options</source>
-        <target>URL options</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:135</note>
-      </trans-unit>
-      <trans-unit id="438ddd6a05ebb1af2b3e5dc794489f57">
-        <source>Is it the main URL for this shop?</source>
-        <target>Is it the main URL for this shop?</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:158</note>
-      </trans-unit>
-      <trans-unit id="37d00f4554dc3c0baeb34a9c22d787d9">
-        <source>Shop URL</source>
-        <target>Shop URL</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:211</note>
-      </trans-unit>
-      <trans-unit id="eae639a70006feff484a39363c977e24">
-        <source>Domain</source>
-        <target>Domain</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:217</note>
-      </trans-unit>
-      <trans-unit id="f9f0dece476d9f76e4130347b6e31b94">
-        <source>SSL Domain</source>
-        <target>SSL Domain</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:223</note>
-      </trans-unit>
-      <trans-unit id="4f04a71599485ace316aa8ed38348875">
-        <source>Physical URL</source>
-        <target>Physical URL</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:240</note>
-      </trans-unit>
-      <trans-unit id="bbc1203755645168294af35f880d61e5">
-        <source>Virtual URL</source>
-        <target>Virtual URL</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:253</note>
-      </trans-unit>
-      <trans-unit id="1dcec4396291e2fbdc02c03526fe2b88">
-        <source>Final URL</source>
-        <target>Final URL</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:261</note>
-      </trans-unit>
-      <trans-unit id="d63c1ea9ab7850a74940ff760f25034b">
-        <source>Edit this shop</source>
-        <target>Edit this shop</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:310</note>
-      </trans-unit>
-      <trans-unit id="157d64669ca816a7153ac30d2e16690a">
-        <source>Add a new URL</source>
-        <target>Add a new URL</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:335</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopGroupController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="224154fa6f3601b7de4690ba6a9ad8b4">
-        <source>Multistore tree</source>
-        <target>Multistore tree</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:111</note>
-      </trans-unit>
-      <trans-unit id="4493e821e06072415518bd7ae4077996">
-        <source>Shop group</source>
-        <target>Shop group</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:177</note>
-      </trans-unit>
-      <trans-unit id="90f72fb554403a6b1cb46741c5f348f2">
-        <source>Multistore options</source>
-        <target>Multistore options</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:66</note>
-      </trans-unit>
-      <trans-unit id="8cdf1c6345219fcfde50615a78ad3ce6">
-        <source>Default shop</source>
-        <target>Default shop</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:69</note>
-      </trans-unit>
-      <trans-unit id="d60f2e4b0fe028af01eb653ff90f7675">
-        <source>Add a new shop group</source>
-        <target>Add a new shop group</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:167</note>
-      </trans-unit>
-      <trans-unit id="99dba47935ec26654ca99c21650779e6">
-        <source>Add a new shop</source>
-        <target>Add a new shop</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:153</note>
-      </trans-unit>
-      <trans-unit id="07a415776bc6aefc538acd85f4d56730">
-        <source>Shop group name</source>
-        <target>Shop group name</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:184</note>
-      </trans-unit>
-      <trans-unit id="5b55607ff39362e86c0693626a6cc20f">
-        <source>Share customers</source>
-        <target>Share customers</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:190</note>
-      </trans-unit>
-      <trans-unit id="4a1f6ec3d9ae0c871dfb29d01a150d6f">
-        <source>Share available quantities to sell</source>
-        <target>Share available quantities to sell</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:210</note>
-      </trans-unit>
-      <trans-unit id="166dcd2b34652eee355742934826795a">
-        <source>Share available quantities between shops of this group. When changing this option, all available products quantities will be reset to 0.</source>
-        <target>Share available quantities between shops of this group. When changing this option, all available products quantities will be reset to 0.</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:225</note>
-      </trans-unit>
-      <trans-unit id="a23a8100bb34ea482c8fb134da89710e">
-        <source>Share orders</source>
-        <target>Share orders</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:229</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6b127dc82937049e45e74aebca783e74">
-        <source>Store contacts</source>
-        <target>Store contacts</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php:62</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0440efe0a9a9bc643eaec7dbdade39df">
-        <source>Supply Orders</source>
-        <target>Supply Orders</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4509</note>
-      </trans-unit>
-      <trans-unit id="9f954c5e16659673382f03fa027772ea">
-        <source>Supply Order Details</source>
-        <target>Supply Order Details</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4514</note>
-      </trans-unit>
-      <trans-unit id="b8495b50f5c172ebad1cc5c615548afa">
-        <source>Ignore this column</source>
-        <target>Ignore this column</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:567</note>
-      </trans-unit>
-      <trans-unit id="97f08a40f22a625d0cbfe03db3349108">
-        <source>Product ID</source>
-        <target>Product ID</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:123</note>
-      </trans-unit>
-      <trans-unit id="fa4ecc0168c2a9e448f469e3835d2a68">
-        <source>Product Reference</source>
-        <target>Product Reference</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:124</note>
-      </trans-unit>
-      <trans-unit id="8ae880593c2afcc7da6d3530513a05d6">
-        <source>Attribute (Name:Type:Position)</source>
-        <target>Attribute (Name:Type:Position)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:126</note>
-      </trans-unit>
-      <trans-unit id="e1b8b0be45098d71aba659e1149ea395">
-        <source>Value (Value:Position)</source>
-        <target>Value (Value:Position)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:129</note>
-      </trans-unit>
-      <trans-unit id="8284ae5df53e6e7ffc1f2cc67ae68765">
-        <source>Supplier reference</source>
-        <target>Supplier reference</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:131</note>
-      </trans-unit>
-      <trans-unit id="52eb5928a34db3e3da7ba52b0644273b">
-        <source>EAN13</source>
-        <target>EAN13</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:243</note>
-      </trans-unit>
-      <trans-unit id="fbd99ad01b92dbafc686772a39e3d065">
-        <source>UPC</source>
-        <target>UPC</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:244</note>
-      </trans-unit>
-      <trans-unit id="ac0b7d0703609cbbfa09b53f8d793d29">
-        <source>Minimal quantity</source>
-        <target>Minimal quantity</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:265</note>
-      </trans-unit>
-      <trans-unit id="5db5f3f0c5f233fbc13f08c052e98281">
-        <source>Default (0 = No, 1 = Yes)</source>
-        <target>Default (0 = No, 1 = Yes)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:143</note>
-      </trans-unit>
-      <trans-unit id="e933b93c26b14c12ac7818867e54c5d9">
-        <source>Combination availability date</source>
-        <target>Combination availability date</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:144</note>
-      </trans-unit>
-      <trans-unit id="657645fae83ad1673b25d3c027b77ed8">
-        <source>Choose among product images by position (1,2,3...)</source>
-        <target>Choose among product images by position (1,2,3...)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:146</note>
-      </trans-unit>
-      <trans-unit id="4d2589e1bcd4263cb99927b59f0f88d2">
-        <source>Image URLs (x,y,z...)</source>
-        <target>Image URLs (x,y,z...)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:285</note>
-      </trans-unit>
-      <trans-unit id="7a2ec0911e94664f3dfcc8cbefb0e908">
-        <source>Image alt texts (x,y,z...)</source>
-        <target>Image alt texts (x,y,z...)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:286</note>
-      </trans-unit>
-      <trans-unit id="f8a0fa3674c3336359b77bbe8e942a2c">
-        <source>ID / Name of shop</source>
-        <target>ID / Name of shop</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:515</note>
-      </trans-unit>
-      <trans-unit id="70b8833184afe1b309f4d679acff991e">
-        <source>Advanced Stock Management</source>
-        <target>Advanced Stock Management</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:313</note>
-      </trans-unit>
-      <trans-unit id="53acc0172842523c8a52f50894c6df15">
-        <source>Depends on stock</source>
-        <target>Depends on stock</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:317</note>
-      </trans-unit>
-      <trans-unit id="6416e8cb5fc0a208d94fa7f5a300dbc4">
-        <source>Warehouse</source>
-        <target>Warehouse</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:321</note>
-      </trans-unit>
-      <trans-unit id="fd0dcc6233b026d257763713c133cf72">
-        <source>Active (0/1)</source>
-        <target>Active (0/1)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:498</note>
-      </trans-unit>
-      <trans-unit id="6c7c9fbb27699c4018dc15744547b4a4">
-        <source>Root category (0/1)</source>
-        <target>Root category (0/1)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:196</note>
-      </trans-unit>
-      <trans-unit id="427b6d816d7fdd86cabe48d8180a3cc9">
-        <source>Image URL</source>
-        <target>Image URL</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:513</note>
-      </trans-unit>
-      <trans-unit id="df8ffb90c945e796f2cfd9265325b9c3">
-        <source>Categories (x,y,z...)</source>
-        <target>Categories (x,y,z...)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:229</note>
-      </trans-unit>
-      <trans-unit id="88627291a92931577d427c5fd68f511e">
-        <source>Price tax excluded</source>
-        <target>Price tax excluded</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:230</note>
-      </trans-unit>
-      <trans-unit id="f154d2146a2acf439d955fea9d396ec2">
-        <source>Price tax included</source>
-        <target>Price tax included</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:231</note>
-      </trans-unit>
-      <trans-unit id="8a1cabdfd802aa4ea2ec774feb832a1e">
-        <source>Tax rule ID</source>
-        <target>Tax rule ID</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:232</note>
-      </trans-unit>
-      <trans-unit id="b548dcad953710689b3066823b90f517">
-        <source>On sale (0/1)</source>
-        <target>On sale (0/1)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:234</note>
-      </trans-unit>
-      <trans-unit id="b30690be173bcd4a83df0cd68f89a385">
-        <source>Discount amount</source>
-        <target>Discount amount</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:235</note>
-      </trans-unit>
-      <trans-unit id="5d01d5588119abec82fd8004995de275">
-        <source>Discount percent</source>
-        <target>Discount percent</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:236</note>
-      </trans-unit>
-      <trans-unit id="bfd574f8096a396d831b1c1ac88c75d1">
-        <source>Discount from (yyyy-mm-dd)</source>
-        <target>Discount from (yyyy-mm-dd)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:237</note>
-      </trans-unit>
-      <trans-unit id="48d6c0804dd92fb5463bba154a8a747f">
-        <source>Discount to (yyyy-mm-dd)</source>
-        <target>Discount to (yyyy-mm-dd)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:238</note>
-      </trans-unit>
-      <trans-unit id="6928b30c9f87670d7621fe8f1fef7054">
-        <source>Reference #</source>
-        <target>Reference #</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:239</note>
-      </trans-unit>
-      <trans-unit id="c7d4affd54ce760d4731e21e3aa506fd">
-        <source>Supplier reference #</source>
-        <target>Supplier reference #</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:240</note>
-      </trans-unit>
-      <trans-unit id="f6db0ad0a1b6aff800f260a83bc06584">
-        <source>Delivery time of out-of-stock products with allowed orders:</source>
-        <target>Delivery time of out-of-stock products with allowed orders:</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:259</note>
-      </trans-unit>
-      <trans-unit id="7bbdd372c9d171174e3ce1ba9d97d5f6">
-        <source>Additional shipping cost</source>
-        <target>Additional shipping cost</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:269</note>
-      </trans-unit>
-      <trans-unit id="0246175f81454bc445f908bac64f354c">
-        <source>Unit for the price per unit</source>
-        <target>Unit for the price per unit</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:270</note>
-      </trans-unit>
-      <trans-unit id="bede52f418b34b1ab0db65f9450bdfc3">
-        <source>Tags (x,y,z...)</source>
-        <target>Tags (x,y,z...)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:274</note>
-      </trans-unit>
-      <trans-unit id="db72e24b402e8baf8df6ca786a59e4de">
-        <source>Rewritten URL</source>
-        <target>Rewritten URL</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:278</note>
-      </trans-unit>
-      <trans-unit id="6be65deefdf4fae21955e2c060815530">
-        <source>Label when backorder allowed</source>
-        <target>Label when backorder allowed</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:280</note>
-      </trans-unit>
-      <trans-unit id="cf7a1f189bbd1f48db0ece1da9cc0802">
-        <source>Available for order (0 = No, 1 = Yes)</source>
-        <target>Available for order (0 = No, 1 = Yes)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:281</note>
-      </trans-unit>
-      <trans-unit id="d24a6864b6139a2423c8f3004c8f7751">
-        <source>Product availability date</source>
-        <target>Product availability date</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:282</note>
-      </trans-unit>
-      <trans-unit id="21f7b5b011f253b35340528b7f190282">
-        <source>Product creation date</source>
-        <target>Product creation date</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:283</note>
-      </trans-unit>
-      <trans-unit id="76aeea9f48196068e6b47d46d41e7618">
-        <source>Show price (0 = No, 1 = Yes)</source>
-        <target>Show price (0 = No, 1 = Yes)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:284</note>
-      </trans-unit>
-      <trans-unit id="4f5dc004cdd01ec9cf7fbbcf9f812aa7">
-        <source>Delete existing images (0 = No, 1 = Yes)</source>
-        <target>Delete existing images (0 = No, 1 = Yes)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:288</note>
-      </trans-unit>
-      <trans-unit id="2fe5beaf842ddac297ade8ef5ba379cc">
-        <source>Feature (Name:Value:Position:Customized)</source>
-        <target>Feature (Name:Value:Position:Customized)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:290</note>
-      </trans-unit>
-      <trans-unit id="446e04d1ed3b8fca04274d7c726a3fd5">
-        <source>Available online only (0 = No, 1 = Yes)</source>
-        <target>Available online only (0 = No, 1 = Yes)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:291</note>
-      </trans-unit>
-      <trans-unit id="f53c39de16dea1ee2352ab566702eb27">
-        <source>Customizable (0 = No, 1 = Yes)</source>
-        <target>Customizable (0 = No, 1 = Yes)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:293</note>
-      </trans-unit>
-      <trans-unit id="da505e5a6dd5678894aa9f8663bf4db0">
-        <source>Uploadable files (0 = No, 1 = Yes)</source>
-        <target>Uploadable files (0 = No, 1 = Yes)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:294</note>
-      </trans-unit>
-      <trans-unit id="6bfdfdf56a73c0726864489f78e4f91b">
-        <source>Text fields (0 = No, 1 = Yes)</source>
-        <target>Text fields (0 = No, 1 = Yes)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:295</note>
-      </trans-unit>
-      <trans-unit id="27cb4532e39ccfac2114be6223cf3534">
-        <source>Action when out of stock</source>
-        <target>Action when out of stock</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:296</note>
-      </trans-unit>
-      <trans-unit id="81188f605f25cfc48952bb6b754cf69f">
-        <source>Virtual product (0 = No, 1 = Yes)</source>
-        <target>Virtual product (0 = No, 1 = Yes)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:297</note>
-      </trans-unit>
-      <trans-unit id="b3d2db69feecaedff30f1e0bc60206d6">
-        <source>File URL</source>
-        <target>File URL</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:298</note>
-      </trans-unit>
-      <trans-unit id="8b155133fee28ec212ccf75a28e0711e">
-        <source>Expiration date (yyyy-mm-dd)</source>
-        <target>Expiration date (yyyy-mm-dd)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:303</note>
-      </trans-unit>
-      <trans-unit id="58fd2b2308056ad80255a322b305742b">
-        <source>Number of days</source>
-        <target>Number of days</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:305</note>
-      </trans-unit>
-      <trans-unit id="63a293f69541c07a826ac0e8f35e6222">
-        <source>Accessories (x,y,z...)</source>
-        <target>Accessories (x,y,z...)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:324</note>
-      </trans-unit>
-      <trans-unit id="a10d0bff85112a2b35f885a38088cd20">
-        <source>Active  (0/1)</source>
-        <target>Active  (0/1)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:408</note>
-      </trans-unit>
-      <trans-unit id="f323be7152201bfc856e649e84e9d64c">
-        <source>Titles ID (Mr = 1, Ms = 2, else 0)</source>
-        <target>Titles ID (Mr = 1, Ms = 2, else 0)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:368</note>
-      </trans-unit>
-      <trans-unit id="9588fe347c3d1c8b41a762b2de764bf6">
-        <source>Birth date (yyyy-mm-dd)</source>
-        <target>Birth date (yyyy-mm-dd)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:371</note>
-      </trans-unit>
-      <trans-unit id="b884d81a33fb67e1d4fe450b3cbde8d6">
-        <source>Newsletter (0/1)</source>
-        <target>Newsletter (0/1)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:374</note>
-      </trans-unit>
-      <trans-unit id="7a39b81015194bb83112801572292040">
-        <source>Partner offers (0/1)</source>
-        <target>Partner offers (0/1)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:375</note>
-      </trans-unit>
-      <trans-unit id="d6ac7b9d5e3b186f26efc9a5309d8985">
-        <source>Registration date (yyyy-mm-dd)</source>
-        <target>Registration date (yyyy-mm-dd)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:376</note>
-      </trans-unit>
-      <trans-unit id="8ed4a31f87f37636186bd6bdbc646f1f">
-        <source>Groups (x,y,z...)</source>
-        <target>Groups (x,y,z...)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:377</note>
-      </trans-unit>
-      <trans-unit id="b0869dd58b90ec940e91a195d754a155">
-        <source>Default group ID</source>
-        <target>Default group ID</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:378</note>
-      </trans-unit>
-      <trans-unit id="03361eda68f746619c2ae3341eaa2f07">
-        <source>Customer email</source>
-        <target>Customer email</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:409</note>
-      </trans-unit>
-      <trans-unit id="3d1c10fcfac7da07fdb8b9f99d1c0901">
-        <source>ID / Name of group shop</source>
-        <target>ID / Name of group shop</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:457</note>
-      </trans-unit>
-      <trans-unit id="783cb853aae6984e51583b3bb80c09d2">
-        <source>Address (2)</source>
-        <target>Address (2)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:501</note>
-      </trans-unit>
-      <trans-unit id="3b0eb7469ba9c95f3a05c4cef1f6aac4">
-        <source>Latitude</source>
-        <target>Latitude</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:506</note>
-      </trans-unit>
-      <trans-unit id="9b4dabc50f0b8ccba1c8981831abdad8">
-        <source>Longitude</source>
-        <target>Longitude</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:507</note>
-      </trans-unit>
-      <trans-unit id="3b0649c72650c313a357338dcdfb64ec">
-        <source>Note</source>
-        <target>Note</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:511</note>
-      </trans-unit>
-      <trans-unit id="f42301fc8497aeb77b516f31b2d57d61">
-        <source>Hours (x,y,z...)</source>
-        <target>Hours (x,y,z...)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:512</note>
-      </trans-unit>
-      <trans-unit id="9b1f5ada3db7e58544806a11099b7103">
-        <source>Supplier ID *</source>
-        <target>Supplier ID *</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:540</note>
-      </trans-unit>
-      <trans-unit id="84560d7d7c4d97c640d09a58491a3677">
-        <source>Lang ID</source>
-        <target>Lang ID</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:541</note>
-      </trans-unit>
-      <trans-unit id="8954e2e0d62b56db3c10df45a7602cd3">
-        <source>Warehouse ID *</source>
-        <target>Warehouse ID *</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:542</note>
-      </trans-unit>
-      <trans-unit id="dfa8db9b8d08689d8a23067e93ef4ef9">
-        <source>Currency ID *</source>
-        <target>Currency ID *</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:543</note>
-      </trans-unit>
-      <trans-unit id="e11d1e5d17a3f9ce34faccbb5cc61394">
-        <source>Supply Order Reference *</source>
-        <target>Supply Order Reference *</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:568</note>
-      </trans-unit>
-      <trans-unit id="f9c5030e9d71a6ba285489576e1d0e3f">
-        <source>Delivery Date (Y-M-D)*</source>
-        <target>Delivery Date (Y-M-D)*</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:545</note>
-      </trans-unit>
-      <trans-unit id="9e57c2dbcacea5e2e8aa3edde11cf976">
-        <source>Discount rate</source>
-        <target>Discount rate</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:546</note>
-      </trans-unit>
-      <trans-unit id="c5d4da7adbd98e284ef9a8733a9ceaf2">
-        <source>Product ID *</source>
-        <target>Product ID *</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:569</note>
-      </trans-unit>
-      <trans-unit id="41b00531a619d5e0f965854e352529f1">
-        <source>Product Attribute ID</source>
-        <target>Product Attribute ID</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:570</note>
-      </trans-unit>
-      <trans-unit id="94fb72f3353fb2507e18fc6748f7a811">
-        <source>Unit Price (tax excl.)*</source>
-        <target>Unit Price (tax excl.)*</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:571</note>
-      </trans-unit>
-      <trans-unit id="f41a10a672cbcdecaad1d2f73f30b1f8">
-        <source>Quantity Expected *</source>
-        <target>Quantity Expected *</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:572</note>
-      </trans-unit>
-      <trans-unit id="6703aa9936582b4381418f7d523370b4">
-        <source>Discount Rate</source>
-        <target>Discount Rate</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:573</note>
-      </trans-unit>
-      <trans-unit id="8fe77c2601e54f1aaef28cfde997bbad">
-        <source>Tax Rate</source>
-        <target>Tax Rate</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:574</note>
-      </trans-unit>
-      <trans-unit id="2415390fb5052bb8221a93c9fc51b17f">
-        <source>Import .CSV data</source>
-        <target>Import .CSV data</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:823</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9d20a93036ba910dd75ffbcec173798e">
-        <source>Price per unit</source>
-        <target>Price per unit</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:926</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/statslive/statslive.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d37c2bf1bd3143847fca087b354f920e">
-        <source>Customer ID</source>
-        <target>Customer ID</target>
-        <note>Context:
-File: modules/statslive/statslive.php:159</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="278c491bdd8a53618c149c4ac790da34">
-        <source>Template</source>
-        <target>Template</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php:120</note>
-      </trans-unit>
-      <trans-unit id="5d6103b662f41b07e10687f03aca8fdc">
-        <source>Recipient</source>
-        <target>Recipient</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php:114</note>
-      </trans-unit>
-      <trans-unit id="c7892ebbb139886662c6f2fc8c450710">
-        <source>Subject</source>
-        <target>Subject</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php:132</note>
-      </trans-unit>
-      <trans-unit id="7f8c0283f16925caed8e632086b81b9c">
-        <source>Sent</source>
-        <target>Sent</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php:138</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminEmployeesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cce99c598cfdb9773ab041d54c3d973a">
-        <source>Profile</source>
-        <target>Profile</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:88</note>
-      </trans-unit>
-      <trans-unit id="a19df5d477865657e2e2d4f9c30325db">
-        <source>Employee options</source>
-        <target>Employee options</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:96</note>
-      </trans-unit>
-      <trans-unit id="67dc4a38907a53d52fb27cd3ae7972d6">
-        <source>Password regeneration</source>
-        <target>Password regeneration</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:99</note>
-      </trans-unit>
-      <trans-unit id="4513dcc4cec4ce6e5a428c81ce7592ae">
-        <source>Security: Minimum time to wait between two password changes.</source>
-        <target>Security: Minimum time to wait between two password changes.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:100</note>
-      </trans-unit>
-      <trans-unit id="640fd0cc0ffa0316ae087652871f4486">
-        <source>minutes</source>
-        <target>minutes</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:103</note>
-      </trans-unit>
-      <trans-unit id="987f9e9654b8201f8a428d71d903b1d2">
-        <source>Memorize the language used in Admin panel forms</source>
-        <target>Memorize the language used in Admin panel forms</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:107</note>
-      </trans-unit>
-      <trans-unit id="4696cdea33eee7e2c4fcb5dca30ccf56">
-        <source>Allow employees to select a specific language for the Admin panel form.</source>
-        <target>Allow employees to select a specific language for the Admin panel form.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:108</note>
-      </trans-unit>
-      <trans-unit id="485263210a4a12e35e3426045e3301b1">
-        <source>Add new employee</source>
-        <target>Add new employee</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:169</note>
-      </trans-unit>
-      <trans-unit id="04acbae6db9450374e9102fffd51d802">
-        <source>Edit: %lastname% %firstname%</source>
-        <target>Edit: %lastname% %firstname%</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:179</note>
-      </trans-unit>
-      <trans-unit id="d52c376b3badee6132116bb9af74d0d2">
-        <source>Subscribe to PrestaShop newsletter</source>
-        <target>Subscribe to PrestaShop newsletter</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:290</note>
-      </trans-unit>
-      <trans-unit id="435a2d71a0c6c33cd2c917b00b8e0da1">
-        <source>Default page</source>
-        <target>Default page</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:310</note>
-      </trans-unit>
-      <trans-unit id="57452e2dda1a10cfe2cc34c575e6b9d0">
-        <source>Permission profile</source>
-        <target>Permission profile</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:361</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminProfilesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="69d18853cb35672b765f55ae37ae4967">
-        <source>Add new profile</source>
-        <target>Add new profile</target>
-        <note>Context:
-File: controllers/admin/AdminProfilesController.php:112</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminLoginController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="60e3ee398aa0ee3498c68914b5d5fb1a">
-        <source>Back office connection from %ip%</source>
-        <target>Back office connection from %ip%</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:206</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="eb626c94531ec554f93b2b78a77c8b1b">
-        <source>Employees</source>
-        <target>Employees</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:543</note>
-      </trans-unit>
-      <trans-unit id="5e3d6d040d8a81befd75127d526646bc">
-        <source>Contact information</source>
-        <target>Contact information</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:539</note>
-      </trans-unit>
-      <trans-unit id="a66b5528ae08e780a5df59ae913c66e7">
-        <source>Discount prices</source>
-        <target>Discount prices</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:542</note>
-      </trans-unit>
-      <trans-unit id="b71593973c58bb41eb302d037f6b1230">
-        <source>Module hooks</source>
-        <target>Module hooks</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:548</note>
-      </trans-unit>
-      <trans-unit id="f71429893913cde74dcacde3d283626e">
-        <source>Meta information</source>
-        <target>Meta information</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:549</note>
-      </trans-unit>
-      <trans-unit id="4ae24b703273d53941a17737bb2b1a9a">
-        <source>Product combinations</source>
-        <target>Product combinations</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:551</note>
-      </trans-unit>
-      <trans-unit id="cf173b732a2a0377698d631db6185836">
-        <source>Available quantities for sale</source>
-        <target>Available quantities for sale</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:552</note>
-      </trans-unit>
-      <trans-unit id="3020c78ae45aff9a35b95856af076765">
-        <source>Warehouses</source>
-        <target>Warehouses</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:554</note>
-      </trans-unit>
-      <trans-unit id="339b1acb0d1f26923dc4545a9f749ab3">
-        <source>Webservice accounts</source>
-        <target>Webservice accounts</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:555</note>
-      </trans-unit>
-      <trans-unit id="775a3ab6add326ef93f2382f49f9e500">
-        <source>Attribute groups</source>
-        <target>Attribute groups</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:556</note>
-      </trans-unit>
-      <trans-unit id="6fab199dbf5a4155871fb0d5dbfa9827">
-        <source>Tax rules groups</source>
-        <target>Tax rules groups</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:559</note>
-      </trans-unit>
-      <trans-unit id="812293a0a3e2ca81fb23c076c13eaa10">
-        <source>Referrers/affiliates</source>
-        <target>Referrers/affiliates</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:561</note>
-      </trans-unit>
-      <trans-unit id="3b8c8bf8ab2226d5a44454a20ad7fafb">
-        <source>Cart rules</source>
-        <target>Cart rules</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:563</note>
-      </trans-unit>
-      <trans-unit id="c8cfbbbe4253e14390b2b14d7e60d9c8">
-        <source>Import data</source>
-        <target>Import data</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:580</note>
-      </trans-unit>
-      <trans-unit id="5fb93170a6b0ac85ca8c080d2c469702">
-        <source>Choose the source shop</source>
-        <target>Choose the source shop</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:587</note>
-      </trans-unit>
-      <trans-unit id="1d92a46c4e14c43c3096d85c9f26fc4e">
-        <source>Choose data to import</source>
-        <target>Choose data to import</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:595</note>
-      </trans-unit>
-      <trans-unit id="5a8f8f8e0bcbfcd926271ee7d7351134">
-        <source>Shop groups list</source>
-        <target>Shop groups list</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:846</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="897356954c2cd3d41b221e3f24f99bba">
-        <source>Key</source>
-        <target>Key</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php:112</note>
-      </trans-unit>
-      <trans-unit id="52699c78843b98f98620186a59b0a3fa">
-        <source>Key description</source>
-        <target>Key description</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php:118</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice_settings.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a3946b47f44a8f7adf9c9b6e38911790">
-        <source>Enable PrestaShop's webservice</source>
-        <target>Enable PrestaShop's webservice</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice_settings.html.twig:39</note>
-      </trans-unit>
-      <trans-unit id="8a05d87b51cc003b5a3c018b37a6d311">
-        <source>Enable CGI mode for PHP</source>
-        <target>Enable CGI mode for PHP</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice_settings.html.twig:56</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="644ebe55744f361a22bc3c9be9bc4ccf">
-        <source>Add new webservice key</source>
-        <target>Add new webservice key</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php:76</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminWebserviceController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="58af3456f86b42c86f963d896a62644f">
-        <source>Webservice Accounts</source>
-        <target>Webservice Accounts</target>
-        <note>Context:
-File: controllers/admin/AdminWebserviceController.php:126</note>
-      </trans-unit>
-      <trans-unit id="20eebdc752ee86d49f5d090759b237aa">
-        <source>Webservice account key.</source>
-        <target>Webservice account key.</target>
-        <note>Context:
-File: controllers/admin/AdminWebserviceController.php:136</note>
-      </trans-unit>
-      <trans-unit id="45fff8bcdd979fde32df8435f29553ab">
-        <source>Generate!</source>
-        <target>Generate!</target>
-        <note>Context:
-File: controllers/admin/AdminWebserviceController.php:138</note>
-      </trans-unit>
-      <trans-unit id="d08ccf52b4cdd08e41cfb99ec42e0b29">
-        <source>Permissions</source>
-        <target>Permissions</target>
-        <note>Context:
-File: controllers/admin/AdminWebserviceController.php:173</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="517a8a7dbf1f6e371509817de328e396">
-        <source>Customer groups</source>
-        <target>Customer groups</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:172</note>
-      </trans-unit>
-      <trans-unit id="79c0d6cba080dc90b01c887064c9fc2f">
-        <source>Clear cache</source>
-        <target>Clear cache</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:74</note>
-      </trans-unit>
-      <trans-unit id="f8d698aea36fcbead2b9d5359ffca76f">
-        <source>Smarty</source>
-        <target>Smarty</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:41</note>
-      </trans-unit>
-      <trans-unit id="770d85a02ce8841bd4dac97b57c7fa17">
-        <source>Template compilation</source>
-        <target>Template compilation</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:46</note>
-      </trans-unit>
-      <trans-unit id="ab0cf104f39708eabd07b8cb67e149ba">
-        <source>Cache</source>
-        <target>Cache</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:53</note>
-      </trans-unit>
-      <trans-unit id="0d6bf1934cab1de045b189eed03c3d42">
-        <source>Should be enabled except for debugging.</source>
-        <target>Should be enabled except for debugging.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:53</note>
-      </trans-unit>
-      <trans-unit id="1c9e9fdb43035d78fc94dd37c357869c">
-        <source>Multi-front optimizations</source>
-        <target>Multi-front optimizations</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:60</note>
-      </trans-unit>
-      <trans-unit id="bfa7e629b4eaa924530242510a50679e">
-        <source>Caching type</source>
-        <target>Caching type</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:67</note>
-      </trans-unit>
-      <trans-unit id="ec3028a12402ab7f43962a6f3a667b6e">
-        <source>Debug mode</source>
-        <target>Debug mode</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:115</note>
-      </trans-unit>
-      <trans-unit id="0da6a47faba382116423315f9e61b9e2">
-        <source>Disable non PrestaShop modules</source>
-        <target>Disable non PrestaShop modules</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:101</note>
-      </trans-unit>
-      <trans-unit id="edf05af828595f01ae00b209ef0b1e1f">
-        <source>Enable or disable non PrestaShop Modules.</source>
-        <target>Enable or disable non PrestaShop Modules.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:101</note>
-      </trans-unit>
-      <trans-unit id="03a9e6840847f96325b7184d5f3c2769">
-        <source>Disable all overrides</source>
-        <target>Disable all overrides</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:108</note>
-      </trans-unit>
-      <trans-unit id="29826f9f4da3d473c1e4ecf2f6c4ef9f">
-        <source>Enable or disable all classes and controllers overrides.</source>
-        <target>Enable or disable all classes and controllers overrides.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:108</note>
-      </trans-unit>
-      <trans-unit id="010a6cb0eccdea35662ad711d443f2ec">
-        <source>Optional features</source>
-        <target>Optional features</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:137</note>
-      </trans-unit>
-      <trans-unit id="f4efdd180586cba038b52f2471e4075d">
-        <source>CCC (Combine, Compress and Cache)</source>
-        <target>CCC (Combine, Compress and Cache)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:194</note>
-      </trans-unit>
-      <trans-unit id="c7ceaefb9d7fd3731ae2a28abad2cb95">
-        <source>Smart cache for CSS</source>
-        <target>Smart cache for CSS</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:204</note>
-      </trans-unit>
-      <trans-unit id="cf00874a93cf1cca317853c54c9f40e3">
-        <source>Smart cache for JavaScript</source>
-        <target>Smart cache for JavaScript</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:211</note>
-      </trans-unit>
-      <trans-unit id="0b388064aa29e8576990d9eb5da8d43e">
-        <source>Apache optimization</source>
-        <target>Apache optimization</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:218</note>
-      </trans-unit>
-      <trans-unit id="3ffcac2b857b421d5418b748b411265b">
-        <source>Media servers (use only with CCC)</source>
-        <target>Media servers (use only with CCC)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:240</note>
-      </trans-unit>
-      <trans-unit id="2d29e91503465ed72170623f37458e32">
-        <source>You must enter another domain, or subdomain, in order to use cookieless static content.</source>
-        <target>You must enter another domain, or subdomain, in order to use cookieless static content.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:246</note>
-      </trans-unit>
-      <trans-unit id="3ed7fddd0f381c4fe4683fc9e856dbcf">
-        <source>Media server #1</source>
-        <target>Media server #1</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:250</note>
-      </trans-unit>
-      <trans-unit id="9dafd449b62301e26c635b976b231b88">
-        <source>Media server #2</source>
-        <target>Media server #2</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:257</note>
-      </trans-unit>
-      <trans-unit id="391e79edab921e1974705a7096055dde">
-        <source>Media server #3</source>
-        <target>Media server #3</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:264</note>
-      </trans-unit>
-      <trans-unit id="02d56cf7754ce16d7ce0193fbca7c90a">
-        <source>Caching</source>
-        <target>Caching</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:286</note>
-      </trans-unit>
-      <trans-unit id="276e3171a63595e207ec292fce891277">
-        <source>Use cache</source>
-        <target>Use cache</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:291</note>
-      </trans-unit>
-      <trans-unit id="aa7ef82bc75491903bfc4838957265be">
-        <source>Caching system</source>
-        <target>Caching system</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:298</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="822376c59b7b86a05a2519f85f88da55">
-        <source>SQL query Name</source>
-        <target>SQL query Name</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php:103</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/form.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dddc702fcffceb2ac77291954897d747">
-        <source>SQL query</source>
-        <target>SQL query</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/form.html.twig:47</note>
-      </trans-unit>
-      <trans-unit id="9b5c3d6674b3af1946fb50faae7079e2">
-        <source>SQL query name</source>
-        <target>SQL query name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/form.html.twig:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/settings_panel.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="10d8074bf1e35bcac9911c5fe26261cf">
-        <source>Select your default file encoding</source>
-        <target>Select your default file encoding</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/settings_panel.html.twig:38</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminRequestSqlController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bbed49e90ee59ac450e80b492f452d0e">
-        <source>Edit this SQL query</source>
-        <target>Edit this SQL query</target>
-        <note>Context:
-File: controllers/admin/AdminRequestSqlController.php:98</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="26420bd9e260012164a58a0f002e4821">
-        <source>Add new SQL query</source>
-        <target>Add new SQL query</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php:95</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="130c5b3473c57faa76e2a1c54e26f88e">
-        <source>Both</source>
-        <target>Both</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php:91</note>
-      </trans-unit>
-      <trans-unit id="970e79a141128a95d3c2f35f622b6710">
-        <source>Send email in HTML format</source>
-        <target>Send email in HTML format</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php:89</note>
-      </trans-unit>
-      <trans-unit id="9f1b874f3886d361d6eb6b079639c385">
-        <source>Send email in text format</source>
-        <target>Send email in text format</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php:90</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6adf97f83acf6453d4a6a4b1070f3754">
-        <source>None</source>
-        <target>None</target>
-        <note>Context:
-          File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php:63</note>
-      </trans-unit>
-      <trans-unit id="099d7d04319e5191b7473e016c55e320">
-        <source>TLS</source>
-        <target>TLS</target>
-        <note>Context:
-          File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php:64</note>
-      </trans-unit>
-      <trans-unit id="ea52c36203c5f99c3ce2442d531b1a22">
-        <source>SSL</source>
-        <target>SSL</target>
-        <note>Context:
-          File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php:65</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Grid/Definition/Factory/BackupDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9d8d2d5ab12b515182a505f54db7f538">
-        <source>Age</source>
-        <target>Age</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/BackupDefinitionFactory.php:79</note>
-      </trans-unit>
-      <trans-unit id="1908624a0bca678cd26b99bfd405324e">
-        <source>File size</source>
-        <target>File size</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/BackupDefinitionFactory.php:93</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e129ae480280e47ef82fc7702f8321ba">
-        <source>Refresh list</source>
-        <target>Refresh list</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php:230</note>
-      </trans-unit>
-      <trans-unit id="dcc459e0cef1e36a18a356fbc5789b16">
-        <source>Erase all</source>
-        <target>Erase all</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php:222</note>
-      </trans-unit>
-      <trans-unit id="ecb833e2dc5d6c03d4d0cddf1b15e85a">
-        <source>Severity (1-4)</source>
-        <target>Severity (1-4)</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php:106</note>
-      </trans-unit>
-      <trans-unit id="0610bbb9dba03bb8037e468534b65a1a">
-        <source>Object type</source>
-        <target>Object type</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php:119</note>
-      </trans-unit>
-      <trans-unit id="d95fc016a6eee828f434ed5f55504427">
-        <source>Object ID</source>
-        <target>Object ID</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php:125</note>
-      </trans-unit>
-      <trans-unit id="5f36cf760a5c474cc32a6d35d9c50d05">
-        <source>Error code</source>
-        <target>Error code</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php:131</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Form/ChoiceProvider/MailMethodChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="11812952ae95fbc6ebc323426262bb51">
-        <source>Use PHP's mail() function (recommended; works in most cases)</source>
-        <target>Use PHP's mail() function (recommended; works in most cases)</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/MailMethodChoiceProvider.php:70</note>
-      </trans-unit>
-      <trans-unit id="e6095b01597caf275fb24fa766fb8a57">
-        <source>Set my own SMTP parameters (for advanced users ONLY)</source>
-        <target>Set my own SMTP parameters (for advanced users ONLY)</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/MailMethodChoiceProvider.php:75</note>
-      </trans-unit>
-      <trans-unit id="982bb3f2cc4922620fd3aee7ff15b552">
-        <source>Never send emails (may be useful for testing purposes)</source>
-        <target>Never send emails (may be useful for testing purposes)</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/MailMethodChoiceProvider.php:79</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Requirement/CheckRequirements.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="15cfc4f0fa73c3f13280e47c5621a615">
-        <source>%key% (missing description)</source>
-        <target>%key% (missing description)</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:149</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Email/EmailConfigurationTester.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="94fc5d3be31c72a400c50aae395f1f1f">
-        <source>This is a test message. Your server is now configured to send email.</source>
-        <target>This is a test message. Your server is now configured to send email.</target>
-        <note>Context:
-File: src/Adapter/Email/EmailConfigurationTester.php:71</note>
-      </trans-unit>
-      <trans-unit id="e379446940f88886aba80367a10fa4cc">
-        <source>Test message -- Prestashop</source>
-        <target>Test message -- Prestashop</target>
-        <note>Context:
-File: src/Adapter/Email/EmailConfigurationTester.php:75</note>
-      </trans-unit>
-      <trans-unit id="4e6ebf3087084e1fda3554d154851ef0">
-        <source>Error: Please check your configuration</source>
-        <target>Error: Please check your configuration</target>
-        <note>Context:
-File: src/Adapter/Email/EmailConfigurationTester.php:107</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bd74be2b0190f4b7f3ef117342771f70">
-        <source>Memcached via PHP::Memcache</source>
-        <target>Memcached via PHP::Memcache</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php:117</note>
-      </trans-unit>
-      <trans-unit id="e6f9c14400a56127e7397b4f8afeae10">
-        <source>Memcached via PHP::Memcached</source>
-        <target>Memcached via PHP::Memcached</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php:127</note>
-      </trans-unit>
-      <trans-unit id="0e68f753bc601f5d9d04717f95042762">
-        <source>APC</source>
-        <target>APC</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php:137</note>
-      </trans-unit>
-      <trans-unit id="38ca568bbe61771c6456a5c7b8d419ee">
-        <source>Xcache</source>
-        <target>Xcache</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php:147</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2c111a587b8e6a65856ac7933d76bdce">
-        <source>megabytes</source>
-        <target>megabytes</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php:63</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Api/StockController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="75ed578ac3cb02b0ba40002a25bc0403">
-        <source>Product reference</source>
-        <target>Product reference</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Api/StockController.php:159</note>
-      </trans-unit>
-      <trans-unit id="ae5977a08e8a3d45283789d99c67c3c3">
-        <source>Combination reference</source>
-        <target>Combination reference</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Api/StockController.php:160</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/ProfileLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0b28a5799a32c687dad2c5183718ceac">
-        <source>SuperAdmin</source>
-        <target>SuperAdmin</target>
-        <note>Context:
-File: classes/lang/KeysReference/ProfileLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="f5130b14aee3fd950fae10a832e4aefe">
-        <source>Logistician</source>
-        <target>Logistician</target>
-        <note>Context:
-File: classes/lang/KeysReference/ProfileLang.php:27</note>
-      </trans-unit>
-      <trans-unit id="8d4f90eeea46d604a6410c9bd877f582">
-        <source>Translator</source>
-        <target>Translator</target>
-        <note>Context:
-File: classes/lang/KeysReference/ProfileLang.php:28</note>
-      </trans-unit>
-      <trans-unit id="5ae0061f57027b2344a537eab86c1de2">
-        <source>Salesman</source>
-        <target>Salesman</target>
-        <note>Context:
-File: classes/lang/KeysReference/ProfileLang.php:29</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8b9a96e40ebcda35ce12190b41789b64">
-        <source>Configuration information</source>
-        <target>Configuration information</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="cca793d1dbd9d60b8574a869cf212630">
-        <source>This information must be provided when you report an issue on our bug tracker or forum.</source>
-        <target>This information must be provided when you report an issue on our bug tracker or forum.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:37</note>
-      </trans-unit>
-      <trans-unit id="7d30d49dcf91d103c59496aafc4e3187">
-        <source>Server information</source>
-        <target>Server information</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:50</note>
-      </trans-unit>
-      <trans-unit id="ad41419235c76297eaf568c7656da881">
-        <source>Server software version:</source>
-        <target>Server software version:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:54</note>
-      </trans-unit>
-      <trans-unit id="e2551ec433c9623fed56f27ca2b91a35">
-        <source>PHP version:</source>
-        <target>PHP version:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:57</note>
-      </trans-unit>
-      <trans-unit id="94be595f109f75bfcced2d3bec366128">
-        <source>Memory limit:</source>
-        <target>Memory limit:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:60</note>
-      </trans-unit>
-      <trans-unit id="f3bd61801b2a43ad234af6e6fc917583">
-        <source>Max execution time:</source>
-        <target>Max execution time:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:63</note>
-      </trans-unit>
-      <trans-unit id="3d8a3c1f364b4767769b36eedbe66bb0">
-        <source>Upload Max File size:</source>
-        <target>Upload Max File size:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:66</note>
-      </trans-unit>
-      <trans-unit id="fc0eeb8415aed39a9d3624c7fc2fe47c">
-        <source>PageSpeed module for Apache installed (mod_instaweb)</source>
-        <target>PageSpeed module for Apache installed (mod_instaweb)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:69</note>
-      </trans-unit>
-      <trans-unit id="2933fa807adda5cc00e163479de35538">
-        <source>Database information</source>
-        <target>Database information</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:77</note>
-      </trans-unit>
-      <trans-unit id="52018f4304c11e4bd288a533b122ccf7">
-        <source>MySQL version:</source>
-        <target>MySQL version:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:82</note>
-      </trans-unit>
-      <trans-unit id="dbaf046be46df36dab10f0a54e94b95e">
-        <source>MySQL server:</source>
-        <target>MySQL server:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:85</note>
-      </trans-unit>
-      <trans-unit id="a720577895f55e35dd9ea15feeadc35e">
-        <source>MySQL name:</source>
-        <target>MySQL name:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:88</note>
-      </trans-unit>
-      <trans-unit id="6088e183841f22493e40f574376240cb">
-        <source>MySQL user:</source>
-        <target>MySQL user:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:91</note>
-      </trans-unit>
-      <trans-unit id="fe453b675e37e3a3d2ca501d7ef3135e">
-        <source>Tables prefix:</source>
-        <target>Tables prefix:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:94</note>
-      </trans-unit>
-      <trans-unit id="b888bbc9841a225c7780b20f2c2db60c">
-        <source>MySQL engine:</source>
-        <target>MySQL engine:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:97</note>
-      </trans-unit>
-      <trans-unit id="9369ef07178c0e2be115d85fab6eb6cb">
-        <source>MySQL driver:</source>
-        <target>MySQL driver:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:100</note>
-      </trans-unit>
-      <trans-unit id="3aea774cdcd8f2c45549f10758a71323">
-        <source>Store information</source>
-        <target>Store information</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:110</note>
-      </trans-unit>
-      <trans-unit id="59681d7f729ee8ffdfbc99b8c935c41b">
-        <source>PrestaShop version:</source>
-        <target>PrestaShop version:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:115</note>
-      </trans-unit>
-      <trans-unit id="76c01eed328aa2411b18f007c77d2eeb">
-        <source>Shop URL:</source>
-        <target>Shop URL:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:118</note>
-      </trans-unit>
-      <trans-unit id="b5b3eed3efd6cfebfea270066a1e1f9b">
-        <source>Current theme in use:</source>
-        <target>Current theme in use:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:121</note>
-      </trans-unit>
-      <trans-unit id="4e37aa2987c0876f7f7b2104927df1a1">
-        <source>Mail configuration</source>
-        <target>Mail configuration</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:129</note>
-      </trans-unit>
-      <trans-unit id="aee55e0ed7a06f68ed5e13f235a8bfd8">
-        <source>Mail method:</source>
-        <target>Mail method:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:134</note>
-      </trans-unit>
-      <trans-unit id="f882852afa750c241cdb951bc52539fd">
-        <source>You are using the PHP mail() function.</source>
-        <target>You are using the PHP mail() function.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:137</note>
-      </trans-unit>
-      <trans-unit id="cffa72aaebae1bd90bbe1b8d827ecb1c">
-        <source>You are using your own SMTP parameters.</source>
-        <target>You are using your own SMTP parameters.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:139</note>
-      </trans-unit>
-      <trans-unit id="33b3f142e242a624cb69a5f5f689039d">
-        <source>SMTP server:</source>
-        <target>SMTP server:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:141</note>
-      </trans-unit>
-      <trans-unit id="5489d25adfc42d3aadcb90b679405bda">
-        <source>SMTP username:</source>
-        <target>SMTP username:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:144</note>
-      </trans-unit>
-      <trans-unit id="c4e9522d7b3c8c652f7f0333ff436eec">
-        <source>Defined</source>
-        <target>Defined</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:154</note>
-      </trans-unit>
-      <trans-unit id="f8b1369a8e9d90da0cae0b11049309af">
-        <source>Not defined</source>
-        <target>Not defined</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:156</note>
-      </trans-unit>
-      <trans-unit id="037373672dd4a89426144d40f2e8ad91">
-        <source>SMTP password:</source>
-        <target>SMTP password:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:152</note>
-      </trans-unit>
-      <trans-unit id="8a7363b823dce00b3b1b7e62ca1d777d">
-        <source>Encryption:</source>
-        <target>Encryption:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:160</note>
-      </trans-unit>
-      <trans-unit id="599303a627bf19148eedd5fe29112729">
-        <source>SMTP port:</source>
-        <target>SMTP port:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:163</note>
-      </trans-unit>
-      <trans-unit id="8746097684bc64be8b7eff424c4debdb">
-        <source>Your information</source>
-        <target>Your information</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:172</note>
-      </trans-unit>
-      <trans-unit id="11eb3e792866d1433dd4ca9d7e49b5ac">
-        <source>Your web browser:</source>
-        <target>Your web browser:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:177</note>
-      </trans-unit>
-      <trans-unit id="e91dd9bbca6e42bb85c0f2d94aaee995">
-        <source>Check your configuration</source>
-        <target>Check your configuration</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:185</note>
-      </trans-unit>
-      <trans-unit id="a3810ddb5a67e550cb3ca9c1cffce800">
-        <source>Required parameters:</source>
-        <target>Required parameters:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:190</note>
-      </trans-unit>
-      <trans-unit id="0297eee5a43818dda6ad1e1b36f08965">
-        <source>Optional parameters:</source>
-        <target>Optional parameters:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:207</note>
-      </trans-unit>
-      <trans-unit id="d5c0bb5c1df152c6fe45bd07e303cb69">
-        <source>List of changed files</source>
-        <target>List of changed files</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:231</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c9869fa659bd86f03aba826acd8db5b5">
-        <source>Meaning of severity levels:</source>
-        <target>Meaning of severity levels:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig:33</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5d1f62be1608c8c55ca77098efe5f053">
-        <source>Logs by email</source>
-        <target>Logs by email</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig:50</note>
-      </trans-unit>
-      <trans-unit id="daf5a89c7110f00485d0737ff765e830">
-        <source>Minimum severity level</source>
-        <target>Minimum severity level</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig:56</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="46f18d3960afc01e5a1a5a0e0e9d571b">
-        <source>Automatically check for module updates</source>
-        <target>Automatically check for module updates</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:43</note>
-      </trans-unit>
-      <trans-unit id="967db4d257af07feced01d6633f575f7">
-        <source>Check the cookie's IP address</source>
-        <target>Check the cookie's IP address</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:50</note>
-      </trans-unit>
-      <trans-unit id="dcfba1534995899d2ca36cda978da215">
-        <source>Lifetime of front office cookies</source>
-        <target>Lifetime of front office cookies</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:57</note>
-      </trans-unit>
-      <trans-unit id="e62d77475fe6318731b4411ba1181dca">
-        <source>Lifetime of back office cookies</source>
-        <target>Lifetime of back office cookies</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:64</note>
-      </trans-unit>
-      <trans-unit id="ade28d54bcdbc7c4cfd45d84ad517f7b">
-        <source>Upload quota</source>
-        <target>Upload quota</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:86</note>
-      </trans-unit>
-      <trans-unit id="454036c51196464f8d9c84ded5808985">
-        <source>Maximum size for attached files</source>
-        <target>Maximum size for attached files</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:91</note>
-      </trans-unit>
-      <trans-unit id="4ae386b852a3ee22324e8922e50c9aec">
-        <source>Maximum size for a downloadable product</source>
-        <target>Maximum size for a downloadable product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:98</note>
-      </trans-unit>
-      <trans-unit id="a1652ab7a761fa7bb3726fe28b97d1f3">
-        <source>Maximum size for a product's image</source>
-        <target>Maximum size for a product's image</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:105</note>
-      </trans-unit>
-      <trans-unit id="1b1befcb86d487715da458117710dfeb">
-        <source>Show notifications for new orders</source>
-        <target>Show notifications for new orders</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:139</note>
-      </trans-unit>
-      <trans-unit id="8004e61ca76ff500d1e6ee92f7cb7f93">
-        <source>Show notifications for new customers</source>
-        <target>Show notifications for new customers</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:146</note>
-      </trans-unit>
-      <trans-unit id="4e7ff7ca556a7ac8329ab27834e9631b">
-        <source>Show notifications for new messages</source>
-        <target>Show notifications for new messages</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:153</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a274f4d4670213a9045ce258c6c56b80">
-        <source>Notifications</source>
-        <target>Notifications</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:99</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5489cb5630228b5afe0c21cc2ac9242c">
-        <source>What do you want to import?</source>
-        <target>What do you want to import?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:52</note>
-      </trans-unit>
-      <trans-unit id="14020ff11547c4c18da91394d1cae2a6">
-        <source>Select a file to import</source>
-        <target>Select a file to import</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:74</note>
-      </trans-unit>
-      <trans-unit id="b70c07744607bb44ce5a520716a7f8ed">
-        <source>Choose from history / FTP</source>
-        <target>Choose from history / FTP</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:84</note>
-      </trans-unit>
-      <trans-unit id="2a1a026f56b4c51cc839e513370379fd">
-        <source>Language of the file</source>
-        <target>Language of the file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:189</note>
-      </trans-unit>
-      <trans-unit id="35ebd0ba1ead54eee9c5684437aa519b">
-        <source>Field separator</source>
-        <target>Field separator</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:202</note>
-      </trans-unit>
-      <trans-unit id="1269b023d7c37aceefb33ef49c9fec4d">
-        <source>Delete all [1]categories[/1] before import</source>
-        <target>Delete all [1]categories[/1] before import</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:218</note>
-      </trans-unit>
-      <trans-unit id="feae9fd88b4d107b4de593e8b5a494d8">
-        <source>Use product reference as key</source>
-        <target>Use product reference as key</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:237</note>
-      </trans-unit>
-      <trans-unit id="ff4ba5e49465c8bc4fb9ac41e57ae73d">
-        <source>Skip thumbnails regeneration</source>
-        <target>Skip thumbnails regeneration</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:252</note>
-      </trans-unit>
-      <trans-unit id="0cbac2aa7274da1457a7c645202fcfbc">
-        <source>Force all ID numbers</source>
-        <target>Force all ID numbers</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:267</note>
-      </trans-unit>
-      <trans-unit id="347ad906588aa29395f77470509165ec">
-        <source>Send notification email</source>
-        <target>Send notification email</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:284</note>
-      </trans-unit>
-      <trans-unit id="c290a5941ad6eb0d5fe8752c15c5fd78">
-        <source>Next step</source>
-        <target>Next step</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:299</note>
-      </trans-unit>
-      <trans-unit id="fdab87b387380c9bac4c542c90f1ce24">
-        <source>Available fields</source>
-        <target>Available fields</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:310</note>
-      </trans-unit>
-      <trans-unit id="25a7ad3a7ab1d5e1f468448adf17f963">
-        <source>* Required field</source>
-        <target>* Required field</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:315</note>
-      </trans-unit>
-      <trans-unit id="c67947a1e18c763a4fc8e973caafacd8">
-        <source>History of uploaded files</source>
-        <target>History of uploaded files</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:97</note>
-      </trans-unit>
-      <trans-unit id="8d97a849e6ac533d633f32fb829aa78c">
-        <source>Download sample csv files</source>
-        <target>Download sample csv files</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:320</note>
-      </trans-unit>
-      <trans-unit id="cbfb910715c99134a5987630fff104da">
-        <source>Sample Categories file</source>
-        <target>Sample Categories file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:325</note>
-      </trans-unit>
-      <trans-unit id="e6d1ad59ffb524154c47ef02bb67bb79">
-        <source>Sample Products file</source>
-        <target>Sample Products file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:328</note>
-      </trans-unit>
-      <trans-unit id="2a08996307b8694521492f3ca7b5df40">
-        <source>Sample Combinations file</source>
-        <target>Sample Combinations file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:331</note>
-      </trans-unit>
-      <trans-unit id="b12be4b8c3871a251b314b36da7b847e">
-        <source>Sample Customers file</source>
-        <target>Sample Customers file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:334</note>
-      </trans-unit>
-      <trans-unit id="eafce46b9013f4d12336785c388b664c">
-        <source>Sample Addresses file</source>
-        <target>Sample Addresses file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:337</note>
-      </trans-unit>
-      <trans-unit id="cadad3173909b0c9a319da9c48ebe8a8">
-        <source>Sample Brands file</source>
-        <target>Sample Brands file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:340</note>
-      </trans-unit>
-      <trans-unit id="2028e5ca793760b03ead6560e353b6f2">
-        <source>Sample Suppliers file</source>
-        <target>Sample Suppliers file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:343</note>
-      </trans-unit>
-      <trans-unit id="4e76fa0dec3ddee7efdb0871ef5dd37c">
-        <source>Sample Aliases file</source>
-        <target>Sample Aliases file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:346</note>
-      </trans-unit>
-      <trans-unit id="7c5b94a32245a59bf441c8dcd4d65cfd">
-        <source>Sample Store Contacts file</source>
-        <target>Sample Store Contacts file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:349</note>
-      </trans-unit>
-      <trans-unit id="754fec39af6e1ff8618a1a3cd414af47">
-        <source>Sample Supply Orders file</source>
-        <target>Sample Supply Orders file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:353</note>
-      </trans-unit>
-      <trans-unit id="85769e64d6e480bba48ea2332db57ed7">
-        <source>Sample Supply Order Details file</source>
-        <target>Sample Supply Order Details file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:356</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e08caeac3f80ffa7889cdf1c8f30111f">
-        <source>Multiple value separator</source>
-        <target>Multiple value separator</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig:125</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_file_history.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d">
-        <source>Download</source>
-        <target>Download</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_file_history.html.twig:91</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a8a9e7c120e7020435d955d3a0c96471">
-        <source>Test your email configuration</source>
-        <target>Test your email configuration</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="5f23f9739fa16efc7ddd06bb03096998">
-        <source>Send a test email to</source>
-        <target>Send a test email to</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig:39</note>
-      </trans-unit>
-      <trans-unit id="0bb7ea7550d2e7caf5e32329bc7423cd">
-        <source>A test email has been sent to the email address you provided.</source>
-        <target>A test email has been sent to the email address you provided.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig:50</note>
-      </trans-unit>
-      <trans-unit id="16186ead9220c2a4646402c69109cfa0">
-        <source>Send a test email</source>
-        <target>Send a test email</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig:61</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c098053744ce979cbd030908105d54fe">
-        <source>Mail domain name</source>
-        <target>Mail domain name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig:36</note>
-      </trans-unit>
-      <trans-unit id="bdd48fb41b9d0a4a1051fa22a87eb5a2">
-        <source>SMTP server</source>
-        <target>SMTP server</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig:44</note>
-      </trans-unit>
-      <trans-unit id="a7bfd8847270913b15396380c3627d76">
-        <source>SMTP username</source>
-        <target>SMTP username</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="3cffa2fabd5519beaf4c2fbd0610899b">
-        <source>SMTP password</source>
-        <target>SMTP password</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig:60</note>
-      </trans-unit>
-      <trans-unit id="d7f2615c71a1567cc13cf3a7f7de0aea">
-        <source>Encryption</source>
-        <target>Encryption</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig:68</note>
-      </trans-unit>
-      <trans-unit id="762160912d2bac8eb64bc00b711d6f6c">
-        <source>Port number to use.</source>
-        <target>Port number to use.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig:81</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="60aaf44d4b562252c04db7f98497e9aa">
-        <source>Port</source>
-        <target>Port</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig:80</note>
-      </trans-unit>
-      <trans-unit id="74c9e12c3a19cfb79b79faf579934844">
-        <source>Add server</source>
-        <target>Add server</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig:35</note>
-      </trans-unit>
-      <trans-unit id="5b8c99dad1893a85076709b2d3c2d2d0">
-        <source>IP Address</source>
-        <target>IP Address</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig:40</note>
-      </trans-unit>
-      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
-        <source>Weight</source>
-        <target>Weight</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig:81</note>
-      </trans-unit>
-      <trans-unit id="003744a685f896a2d9764655f67f1a24">
-        <source>Add Server</source>
-        <target>Add Server</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig:67</note>
-      </trans-unit>
-      <trans-unit id="dd11871dd215aec96a2eb051116bac00">
-        <source>Test Server</source>
-        <target>Test Server</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig:68</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_logs_grid.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="86c9ce4b2e3b43353a23861c053a594b">
-        <source>Back to the dashboard</source>
-        <target>Back to the dashboard</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_logs_grid.html.twig:33</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ec76c5b544633d334c7a3f92db1c7efd">
-        <source>Send emails to</source>
-        <target>Send emails to</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig:36</note>
-      </trans-unit>
-      <trans-unit id="c63600a5ac5af840103d0ee9608e7b44">
-        <source>Log Emails</source>
-        <target>Log Emails</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig:63</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ac104da0cd80e52437b67aefa351e177">
-        <source>List of MySQL Tables</source>
-        <target>List of MySQL Tables</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="1ee79b4b20638d135b8ae8122f7770b9">
-        <source>Please choose a table.</source>
-        <target>Please choose a table.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl:104</note>
-      </trans-unit>
-      <trans-unit id="1a696d8e9ac51e281e1cf1b646ddcc96">
-        <source>Add table name to SQL query</source>
-        <target>Add table name to SQL query</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="1938087a74c4d20f5454850ffbaf0e26">
-        <source>List of attributes for this MySQL table</source>
-        <target>List of attributes for this MySQL table</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl:47</note>
-      </trans-unit>
-      <trans-unit id="1141c5086ed62bf696bccf7de6b885bd">
-        <source>Add attribute to SQL query</source>
-        <target>Add attribute to SQL query</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl:90</note>
-      </trans-unit>
-      <trans-unit id="004bf6c9a40003140292e97330236c53">
-        <source>Action</source>
-        <target>Action</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl:81</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="526a00f8a3c4c865b9c1834f38b5e2c6">
-        <source>SQL query result</source>
-        <target>SQL query result</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="30c210e0173f2ff607cc84dc01ffc1f0">
-        <source>Backup options</source>
-        <target>Backup options</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="6afc2b40f9acff2a4d1e67f2dfcd8a30">
-        <source>Ignore statistics tables</source>
-        <target>Ignore statistics tables</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="8859ec81a77f2f2b165bf5ea9858ecfc">
-        <source>Drop existing tables during import</source>
-        <target>Drop existing tables during import</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig:54</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/download_file.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b3b5aea1ae3bf83287bde7e5295a22b4">
-        <source>Download the backup file (%s MB)</source>
-        <target>Download the backup file (%s MB)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/download_file.html.twig:37</note>
-      </trans-unit>
-      <trans-unit id="0478391d3c5bfff8ce84cabb1ac330ee">
-        <source>Tip: You can also download this file from your FTP server. Backup files are located in the "/adminXXXX/backups" directory.</source>
-        <target>Tip: You can also download this file from your FTP server. Backup files are located in the "/adminXXXX/backups" directory.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/download_file.html.twig:40</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="99104e1966b34f0320d33c5892946a82">
-        <source>Import data from another shop</source>
-        <target>Import data from another shop</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="51ba9470e0c6fcc53b976a6854b0f2e0">
-        <source>Set the resource permissions for this key:</source>
-        <target>Set the resource permissions for this key:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="f1a627ad565dc779ed5a01edafd18640">
-        <source>View (GET)</source>
-        <target>View (GET)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="9fd0670413556e6cbdc490e09833a30f">
-        <source>Modify (PUT)</source>
-        <target>Modify (PUT)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl:36</note>
-      </trans-unit>
-      <trans-unit id="b28e80674d48866203b7790f730dfa30">
-        <source>Add (POST)</source>
-        <target>Add (POST)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="6c0c2b9ec9a4188db4cfd4f8a0fee415">
-        <source>Delete (DELETE)</source>
-        <target>Delete (DELETE)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="028f42454a71f86007a79664b2a35882">
-        <source>Fast view (HEAD)</source>
-        <target>Fast view (HEAD)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl:39</note>
+      <trans-unit id="b61541208db7fa7dba42c85224405911">
+        <source>Menu</source>
+        <target>Menu</target>
+        <note>Line: 274</note>
+      </trans-unit>
+      <trans-unit id="1587f391edb6fe6f3b919aaa27e25cfb">
+        <source>No menu</source>
+        <target>No menu</target>
+        <note>Line: 284</note>
       </trans-unit>
     </body>
   </file>
@@ -2254,36 +19,1922 @@ File: admin-dev/themes/default/template/controllers/webservice/helpers/form/form
       <trans-unit id="e3a918d60c36cd5892cd6913d72f68d9">
         <source>You are currently connected as %username%</source>
         <target>You are currently connected as %username%</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/employees/helpers/form/form.tpl:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="ed688d6bd2aad0e1ae319ba23e60bb68">
         <source>Sign out from PrestaShop Addons</source>
         <target>Sign out from PrestaShop Addons</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/employees/helpers/form/form.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="b6d4223e60986fa4c9af77ee5f7149c5">
         <source>Sign in</source>
         <target>Sign in</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/employees/helpers/form/form.tpl:37</note>
+        <note>Line: 37</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="b61541208db7fa7dba42c85224405911">
-        <source>Menu</source>
-        <target>Menu</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl:274</note>
+      <trans-unit id="5489cb5630228b5afe0c21cc2ac9242c">
+        <source>What do you want to import?</source>
+        <target>What do you want to import?</target>
+        <note>Line: 52</note>
       </trans-unit>
-      <trans-unit id="1587f391edb6fe6f3b919aaa27e25cfb">
-        <source>No menu</source>
-        <target>No menu</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl:284</note>
+      <trans-unit id="14020ff11547c4c18da91394d1cae2a6">
+        <source>Select a file to import</source>
+        <target>Select a file to import</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="b70c07744607bb44ce5a520716a7f8ed">
+        <source>Choose from history / FTP</source>
+        <target>Choose from history / FTP</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="2a1a026f56b4c51cc839e513370379fd">
+        <source>Language of the file</source>
+        <target>Language of the file</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="35ebd0ba1ead54eee9c5684437aa519b">
+        <source>Field separator</source>
+        <target>Field separator</target>
+        <note>Line: 202</note>
+      </trans-unit>
+      <trans-unit id="1269b023d7c37aceefb33ef49c9fec4d">
+        <source>Delete all [1]categories[/1] before import</source>
+        <target>Delete all [1]categories[/1] before import</target>
+        <note>Line: 218</note>
+      </trans-unit>
+      <trans-unit id="feae9fd88b4d107b4de593e8b5a494d8">
+        <source>Use product reference as key</source>
+        <target>Use product reference as key</target>
+        <note>Line: 237</note>
+      </trans-unit>
+      <trans-unit id="ff4ba5e49465c8bc4fb9ac41e57ae73d">
+        <source>Skip thumbnails regeneration</source>
+        <target>Skip thumbnails regeneration</target>
+        <note>Line: 252</note>
+      </trans-unit>
+      <trans-unit id="0cbac2aa7274da1457a7c645202fcfbc">
+        <source>Force all ID numbers</source>
+        <target>Force all ID numbers</target>
+        <note>Line: 267</note>
+      </trans-unit>
+      <trans-unit id="347ad906588aa29395f77470509165ec">
+        <source>Send notification email</source>
+        <target>Send notification email</target>
+        <note>Line: 284</note>
+      </trans-unit>
+      <trans-unit id="c290a5941ad6eb0d5fe8752c15c5fd78">
+        <source>Next step</source>
+        <target>Next step</target>
+        <note>Line: 299</note>
+      </trans-unit>
+      <trans-unit id="fdab87b387380c9bac4c542c90f1ce24">
+        <source>Available fields</source>
+        <target>Available fields</target>
+        <note>Line: 310</note>
+      </trans-unit>
+      <trans-unit id="25a7ad3a7ab1d5e1f468448adf17f963">
+        <source>* Required field</source>
+        <target>* Required field</target>
+        <note>Line: 315</note>
+      </trans-unit>
+      <trans-unit id="c67947a1e18c763a4fc8e973caafacd8">
+        <source>History of uploaded files</source>
+        <target>History of uploaded files</target>
+        <note>Line: 97</note>
+      </trans-unit>
+      <trans-unit id="8d97a849e6ac533d633f32fb829aa78c">
+        <source>Download sample csv files</source>
+        <target>Download sample csv files</target>
+        <note>Line: 320</note>
+      </trans-unit>
+      <trans-unit id="cbfb910715c99134a5987630fff104da">
+        <source>Sample Categories file</source>
+        <target>Sample Categories file</target>
+        <note>Line: 325</note>
+      </trans-unit>
+      <trans-unit id="e6d1ad59ffb524154c47ef02bb67bb79">
+        <source>Sample Products file</source>
+        <target>Sample Products file</target>
+        <note>Line: 328</note>
+      </trans-unit>
+      <trans-unit id="2a08996307b8694521492f3ca7b5df40">
+        <source>Sample Combinations file</source>
+        <target>Sample Combinations file</target>
+        <note>Line: 331</note>
+      </trans-unit>
+      <trans-unit id="b12be4b8c3871a251b314b36da7b847e">
+        <source>Sample Customers file</source>
+        <target>Sample Customers file</target>
+        <note>Line: 334</note>
+      </trans-unit>
+      <trans-unit id="eafce46b9013f4d12336785c388b664c">
+        <source>Sample Addresses file</source>
+        <target>Sample Addresses file</target>
+        <note>Line: 337</note>
+      </trans-unit>
+      <trans-unit id="cadad3173909b0c9a319da9c48ebe8a8">
+        <source>Sample Brands file</source>
+        <target>Sample Brands file</target>
+        <note>Line: 340</note>
+      </trans-unit>
+      <trans-unit id="2028e5ca793760b03ead6560e353b6f2">
+        <source>Sample Suppliers file</source>
+        <target>Sample Suppliers file</target>
+        <note>Line: 343</note>
+      </trans-unit>
+      <trans-unit id="4e76fa0dec3ddee7efdb0871ef5dd37c">
+        <source>Sample Aliases file</source>
+        <target>Sample Aliases file</target>
+        <note>Line: 346</note>
+      </trans-unit>
+      <trans-unit id="7c5b94a32245a59bf441c8dcd4d65cfd">
+        <source>Sample Store Contacts file</source>
+        <target>Sample Store Contacts file</target>
+        <note>Line: 349</note>
+      </trans-unit>
+      <trans-unit id="754fec39af6e1ff8618a1a3cd414af47">
+        <source>Sample Supply Orders file</source>
+        <target>Sample Supply Orders file</target>
+        <note>Line: 353</note>
+      </trans-unit>
+      <trans-unit id="85769e64d6e480bba48ea2332db57ed7">
+        <source>Sample Supply Order Details file</source>
+        <target>Sample Supply Order Details file</target>
+        <note>Line: 356</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9d20a93036ba910dd75ffbcec173798e">
+        <source>Price per unit</source>
+        <target>Price per unit</target>
+        <note>Line: 926</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ac104da0cd80e52437b67aefa351e177">
+        <source>List of MySQL Tables</source>
+        <target>List of MySQL Tables</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="1ee79b4b20638d135b8ae8122f7770b9">
+        <source>Please choose a table.</source>
+        <target>Please choose a table.</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="1a696d8e9ac51e281e1cf1b646ddcc96">
+        <source>Add table name to SQL query</source>
+        <target>Add table name to SQL query</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="1938087a74c4d20f5454850ffbaf0e26">
+        <source>List of attributes for this MySQL table</source>
+        <target>List of attributes for this MySQL table</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="1141c5086ed62bf696bccf7de6b885bd">
+        <source>Add attribute to SQL query</source>
+        <target>Add attribute to SQL query</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="004bf6c9a40003140292e97330236c53">
+        <source>Action</source>
+        <target>Action</target>
+        <note>Line: 81</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="526a00f8a3c4c865b9c1834f38b5e2c6">
+        <source>SQL query result</source>
+        <target>SQL query result</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="99104e1966b34f0320d33c5892946a82">
+        <source>Import data from another shop</source>
+        <target>Import data from another shop</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="51ba9470e0c6fcc53b976a6854b0f2e0">
+        <source>Set the resource permissions for this key:</source>
+        <target>Set the resource permissions for this key:</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="f1a627ad565dc779ed5a01edafd18640">
+        <source>View (GET)</source>
+        <target>View (GET)</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="9fd0670413556e6cbdc490e09833a30f">
+        <source>Modify (PUT)</source>
+        <target>Modify (PUT)</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="b28e80674d48866203b7790f730dfa30">
+        <source>Add (POST)</source>
+        <target>Add (POST)</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="6c0c2b9ec9a4188db4cfd4f8a0fee415">
+        <source>Delete (DELETE)</source>
+        <target>Delete (DELETE)</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="028f42454a71f86007a79664b2a35882">
+        <source>Fast view (HEAD)</source>
+        <target>Fast view (HEAD)</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/ProfileLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0b28a5799a32c687dad2c5183718ceac">
+        <source>SuperAdmin</source>
+        <target>SuperAdmin</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="f5130b14aee3fd950fae10a832e4aefe">
+        <source>Logistician</source>
+        <target>Logistician</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="8d4f90eeea46d604a6410c9bd877f582">
+        <source>Translator</source>
+        <target>Translator</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="5ae0061f57027b2344a537eab86c1de2">
+        <source>Salesman</source>
+        <target>Salesman</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminEmployeesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cce99c598cfdb9773ab041d54c3d973a">
+        <source>Profile</source>
+        <target>Profile</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="a19df5d477865657e2e2d4f9c30325db">
+        <source>Employee options</source>
+        <target>Employee options</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="67dc4a38907a53d52fb27cd3ae7972d6">
+        <source>Password regeneration</source>
+        <target>Password regeneration</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="4513dcc4cec4ce6e5a428c81ce7592ae">
+        <source>Security: Minimum time to wait between two password changes.</source>
+        <target>Security: Minimum time to wait between two password changes.</target>
+        <note>Line: 122</note>
+      </trans-unit>
+      <trans-unit id="640fd0cc0ffa0316ae087652871f4486">
+        <source>minutes</source>
+        <target>minutes</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="987f9e9654b8201f8a428d71d903b1d2">
+        <source>Memorize the language used in Admin panel forms</source>
+        <target>Memorize the language used in Admin panel forms</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="4696cdea33eee7e2c4fcb5dca30ccf56">
+        <source>Allow employees to select a specific language for the Admin panel form.</source>
+        <target>Allow employees to select a specific language for the Admin panel form.</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="485263210a4a12e35e3426045e3301b1">
+        <source>Add new employee</source>
+        <target>Add new employee</target>
+        <note>Line: 191</note>
+      </trans-unit>
+      <trans-unit id="04acbae6db9450374e9102fffd51d802">
+        <source>Edit: %lastname% %firstname%</source>
+        <target>Edit: %lastname% %firstname%</target>
+        <note>Line: 201</note>
+      </trans-unit>
+      <trans-unit id="d52c376b3badee6132116bb9af74d0d2">
+        <source>Subscribe to PrestaShop newsletter</source>
+        <target>Subscribe to PrestaShop newsletter</target>
+        <note>Line: 312</note>
+      </trans-unit>
+      <trans-unit id="435a2d71a0c6c33cd2c917b00b8e0da1">
+        <source>Default page</source>
+        <target>Default page</target>
+        <note>Line: 332</note>
+      </trans-unit>
+      <trans-unit id="57452e2dda1a10cfe2cc34c575e6b9d0">
+        <source>Permission profile</source>
+        <target>Permission profile</target>
+        <note>Line: 383</note>
+      </trans-unit>
+      <trans-unit id="eb626c94531ec554f93b2b78a77c8b1b">
+        <source>Employees</source>
+        <target>Employees</target>
+        <note>Line: 242</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0440efe0a9a9bc643eaec7dbdade39df">
+        <source>Supply Orders</source>
+        <target>Supply Orders</target>
+        <note>Line: 4509</note>
+      </trans-unit>
+      <trans-unit id="9f954c5e16659673382f03fa027772ea">
+        <source>Supply Order Details</source>
+        <target>Supply Order Details</target>
+        <note>Line: 4514</note>
+      </trans-unit>
+      <trans-unit id="b8495b50f5c172ebad1cc5c615548afa">
+        <source>Ignore this column</source>
+        <target>Ignore this column</target>
+        <note>Line: 567</note>
+      </trans-unit>
+      <trans-unit id="97f08a40f22a625d0cbfe03db3349108">
+        <source>Product ID</source>
+        <target>Product ID</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="fa4ecc0168c2a9e448f469e3835d2a68">
+        <source>Product Reference</source>
+        <target>Product Reference</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="8ae880593c2afcc7da6d3530513a05d6">
+        <source>Attribute (Name:Type:Position)</source>
+        <target>Attribute (Name:Type:Position)</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="e1b8b0be45098d71aba659e1149ea395">
+        <source>Value (Value:Position)</source>
+        <target>Value (Value:Position)</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="8284ae5df53e6e7ffc1f2cc67ae68765">
+        <source>Supplier reference</source>
+        <target>Supplier reference</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="52eb5928a34db3e3da7ba52b0644273b">
+        <source>EAN13</source>
+        <target>EAN13</target>
+        <note>Line: 243</note>
+      </trans-unit>
+      <trans-unit id="fbd99ad01b92dbafc686772a39e3d065">
+        <source>UPC</source>
+        <target>UPC</target>
+        <note>Line: 244</note>
+      </trans-unit>
+      <trans-unit id="ac0b7d0703609cbbfa09b53f8d793d29">
+        <source>Minimal quantity</source>
+        <target>Minimal quantity</target>
+        <note>Line: 265</note>
+      </trans-unit>
+      <trans-unit id="5db5f3f0c5f233fbc13f08c052e98281">
+        <source>Default (0 = No, 1 = Yes)</source>
+        <target>Default (0 = No, 1 = Yes)</target>
+        <note>Line: 143</note>
+      </trans-unit>
+      <trans-unit id="e933b93c26b14c12ac7818867e54c5d9">
+        <source>Combination availability date</source>
+        <target>Combination availability date</target>
+        <note>Line: 144</note>
+      </trans-unit>
+      <trans-unit id="657645fae83ad1673b25d3c027b77ed8">
+        <source>Choose among product images by position (1,2,3...)</source>
+        <target>Choose among product images by position (1,2,3...)</target>
+        <note>Line: 146</note>
+      </trans-unit>
+      <trans-unit id="4d2589e1bcd4263cb99927b59f0f88d2">
+        <source>Image URLs (x,y,z...)</source>
+        <target>Image URLs (x,y,z...)</target>
+        <note>Line: 285</note>
+      </trans-unit>
+      <trans-unit id="7a2ec0911e94664f3dfcc8cbefb0e908">
+        <source>Image alt texts (x,y,z...)</source>
+        <target>Image alt texts (x,y,z...)</target>
+        <note>Line: 286</note>
+      </trans-unit>
+      <trans-unit id="f8a0fa3674c3336359b77bbe8e942a2c">
+        <source>ID / Name of shop</source>
+        <target>ID / Name of shop</target>
+        <note>Line: 515</note>
+      </trans-unit>
+      <trans-unit id="70b8833184afe1b309f4d679acff991e">
+        <source>Advanced Stock Management</source>
+        <target>Advanced Stock Management</target>
+        <note>Line: 313</note>
+      </trans-unit>
+      <trans-unit id="53acc0172842523c8a52f50894c6df15">
+        <source>Depends on stock</source>
+        <target>Depends on stock</target>
+        <note>Line: 317</note>
+      </trans-unit>
+      <trans-unit id="6416e8cb5fc0a208d94fa7f5a300dbc4">
+        <source>Warehouse</source>
+        <target>Warehouse</target>
+        <note>Line: 321</note>
+      </trans-unit>
+      <trans-unit id="fd0dcc6233b026d257763713c133cf72">
+        <source>Active (0/1)</source>
+        <target>Active (0/1)</target>
+        <note>Line: 498</note>
+      </trans-unit>
+      <trans-unit id="6c7c9fbb27699c4018dc15744547b4a4">
+        <source>Root category (0/1)</source>
+        <target>Root category (0/1)</target>
+        <note>Line: 196</note>
+      </trans-unit>
+      <trans-unit id="427b6d816d7fdd86cabe48d8180a3cc9">
+        <source>Image URL</source>
+        <target>Image URL</target>
+        <note>Line: 513</note>
+      </trans-unit>
+      <trans-unit id="df8ffb90c945e796f2cfd9265325b9c3">
+        <source>Categories (x,y,z...)</source>
+        <target>Categories (x,y,z...)</target>
+        <note>Line: 229</note>
+      </trans-unit>
+      <trans-unit id="88627291a92931577d427c5fd68f511e">
+        <source>Price tax excluded</source>
+        <target>Price tax excluded</target>
+        <note>Line: 230</note>
+      </trans-unit>
+      <trans-unit id="f154d2146a2acf439d955fea9d396ec2">
+        <source>Price tax included</source>
+        <target>Price tax included</target>
+        <note>Line: 231</note>
+      </trans-unit>
+      <trans-unit id="8a1cabdfd802aa4ea2ec774feb832a1e">
+        <source>Tax rule ID</source>
+        <target>Tax rule ID</target>
+        <note>Line: 232</note>
+      </trans-unit>
+      <trans-unit id="b548dcad953710689b3066823b90f517">
+        <source>On sale (0/1)</source>
+        <target>On sale (0/1)</target>
+        <note>Line: 234</note>
+      </trans-unit>
+      <trans-unit id="b30690be173bcd4a83df0cd68f89a385">
+        <source>Discount amount</source>
+        <target>Discount amount</target>
+        <note>Line: 235</note>
+      </trans-unit>
+      <trans-unit id="5d01d5588119abec82fd8004995de275">
+        <source>Discount percent</source>
+        <target>Discount percent</target>
+        <note>Line: 236</note>
+      </trans-unit>
+      <trans-unit id="bfd574f8096a396d831b1c1ac88c75d1">
+        <source>Discount from (yyyy-mm-dd)</source>
+        <target>Discount from (yyyy-mm-dd)</target>
+        <note>Line: 237</note>
+      </trans-unit>
+      <trans-unit id="48d6c0804dd92fb5463bba154a8a747f">
+        <source>Discount to (yyyy-mm-dd)</source>
+        <target>Discount to (yyyy-mm-dd)</target>
+        <note>Line: 238</note>
+      </trans-unit>
+      <trans-unit id="6928b30c9f87670d7621fe8f1fef7054">
+        <source>Reference #</source>
+        <target>Reference #</target>
+        <note>Line: 239</note>
+      </trans-unit>
+      <trans-unit id="c7d4affd54ce760d4731e21e3aa506fd">
+        <source>Supplier reference #</source>
+        <target>Supplier reference #</target>
+        <note>Line: 240</note>
+      </trans-unit>
+      <trans-unit id="f6db0ad0a1b6aff800f260a83bc06584">
+        <source>Delivery time of out-of-stock products with allowed orders:</source>
+        <target>Delivery time of out-of-stock products with allowed orders:</target>
+        <note>Line: 259</note>
+      </trans-unit>
+      <trans-unit id="7bbdd372c9d171174e3ce1ba9d97d5f6">
+        <source>Additional shipping cost</source>
+        <target>Additional shipping cost</target>
+        <note>Line: 269</note>
+      </trans-unit>
+      <trans-unit id="0246175f81454bc445f908bac64f354c">
+        <source>Unit for the price per unit</source>
+        <target>Unit for the price per unit</target>
+        <note>Line: 270</note>
+      </trans-unit>
+      <trans-unit id="bede52f418b34b1ab0db65f9450bdfc3">
+        <source>Tags (x,y,z...)</source>
+        <target>Tags (x,y,z...)</target>
+        <note>Line: 274</note>
+      </trans-unit>
+      <trans-unit id="db72e24b402e8baf8df6ca786a59e4de">
+        <source>Rewritten URL</source>
+        <target>Rewritten URL</target>
+        <note>Line: 278</note>
+      </trans-unit>
+      <trans-unit id="6be65deefdf4fae21955e2c060815530">
+        <source>Label when backorder allowed</source>
+        <target>Label when backorder allowed</target>
+        <note>Line: 280</note>
+      </trans-unit>
+      <trans-unit id="cf7a1f189bbd1f48db0ece1da9cc0802">
+        <source>Available for order (0 = No, 1 = Yes)</source>
+        <target>Available for order (0 = No, 1 = Yes)</target>
+        <note>Line: 281</note>
+      </trans-unit>
+      <trans-unit id="d24a6864b6139a2423c8f3004c8f7751">
+        <source>Product availability date</source>
+        <target>Product availability date</target>
+        <note>Line: 282</note>
+      </trans-unit>
+      <trans-unit id="21f7b5b011f253b35340528b7f190282">
+        <source>Product creation date</source>
+        <target>Product creation date</target>
+        <note>Line: 283</note>
+      </trans-unit>
+      <trans-unit id="76aeea9f48196068e6b47d46d41e7618">
+        <source>Show price (0 = No, 1 = Yes)</source>
+        <target>Show price (0 = No, 1 = Yes)</target>
+        <note>Line: 284</note>
+      </trans-unit>
+      <trans-unit id="4f5dc004cdd01ec9cf7fbbcf9f812aa7">
+        <source>Delete existing images (0 = No, 1 = Yes)</source>
+        <target>Delete existing images (0 = No, 1 = Yes)</target>
+        <note>Line: 288</note>
+      </trans-unit>
+      <trans-unit id="2fe5beaf842ddac297ade8ef5ba379cc">
+        <source>Feature (Name:Value:Position:Customized)</source>
+        <target>Feature (Name:Value:Position:Customized)</target>
+        <note>Line: 290</note>
+      </trans-unit>
+      <trans-unit id="446e04d1ed3b8fca04274d7c726a3fd5">
+        <source>Available online only (0 = No, 1 = Yes)</source>
+        <target>Available online only (0 = No, 1 = Yes)</target>
+        <note>Line: 291</note>
+      </trans-unit>
+      <trans-unit id="f53c39de16dea1ee2352ab566702eb27">
+        <source>Customizable (0 = No, 1 = Yes)</source>
+        <target>Customizable (0 = No, 1 = Yes)</target>
+        <note>Line: 293</note>
+      </trans-unit>
+      <trans-unit id="da505e5a6dd5678894aa9f8663bf4db0">
+        <source>Uploadable files (0 = No, 1 = Yes)</source>
+        <target>Uploadable files (0 = No, 1 = Yes)</target>
+        <note>Line: 294</note>
+      </trans-unit>
+      <trans-unit id="6bfdfdf56a73c0726864489f78e4f91b">
+        <source>Text fields (0 = No, 1 = Yes)</source>
+        <target>Text fields (0 = No, 1 = Yes)</target>
+        <note>Line: 295</note>
+      </trans-unit>
+      <trans-unit id="27cb4532e39ccfac2114be6223cf3534">
+        <source>Action when out of stock</source>
+        <target>Action when out of stock</target>
+        <note>Line: 296</note>
+      </trans-unit>
+      <trans-unit id="81188f605f25cfc48952bb6b754cf69f">
+        <source>Virtual product (0 = No, 1 = Yes)</source>
+        <target>Virtual product (0 = No, 1 = Yes)</target>
+        <note>Line: 297</note>
+      </trans-unit>
+      <trans-unit id="b3d2db69feecaedff30f1e0bc60206d6">
+        <source>File URL</source>
+        <target>File URL</target>
+        <note>Line: 298</note>
+      </trans-unit>
+      <trans-unit id="8b155133fee28ec212ccf75a28e0711e">
+        <source>Expiration date (yyyy-mm-dd)</source>
+        <target>Expiration date (yyyy-mm-dd)</target>
+        <note>Line: 303</note>
+      </trans-unit>
+      <trans-unit id="58fd2b2308056ad80255a322b305742b">
+        <source>Number of days</source>
+        <target>Number of days</target>
+        <note>Line: 305</note>
+      </trans-unit>
+      <trans-unit id="63a293f69541c07a826ac0e8f35e6222">
+        <source>Accessories (x,y,z...)</source>
+        <target>Accessories (x,y,z...)</target>
+        <note>Line: 324</note>
+      </trans-unit>
+      <trans-unit id="a10d0bff85112a2b35f885a38088cd20">
+        <source>Active  (0/1)</source>
+        <target>Active  (0/1)</target>
+        <note>Line: 408</note>
+      </trans-unit>
+      <trans-unit id="f323be7152201bfc856e649e84e9d64c">
+        <source>Titles ID (Mr = 1, Ms = 2, else 0)</source>
+        <target>Titles ID (Mr = 1, Ms = 2, else 0)</target>
+        <note>Line: 368</note>
+      </trans-unit>
+      <trans-unit id="9588fe347c3d1c8b41a762b2de764bf6">
+        <source>Birth date (yyyy-mm-dd)</source>
+        <target>Birth date (yyyy-mm-dd)</target>
+        <note>Line: 371</note>
+      </trans-unit>
+      <trans-unit id="b884d81a33fb67e1d4fe450b3cbde8d6">
+        <source>Newsletter (0/1)</source>
+        <target>Newsletter (0/1)</target>
+        <note>Line: 374</note>
+      </trans-unit>
+      <trans-unit id="7a39b81015194bb83112801572292040">
+        <source>Partner offers (0/1)</source>
+        <target>Partner offers (0/1)</target>
+        <note>Line: 375</note>
+      </trans-unit>
+      <trans-unit id="d6ac7b9d5e3b186f26efc9a5309d8985">
+        <source>Registration date (yyyy-mm-dd)</source>
+        <target>Registration date (yyyy-mm-dd)</target>
+        <note>Line: 376</note>
+      </trans-unit>
+      <trans-unit id="8ed4a31f87f37636186bd6bdbc646f1f">
+        <source>Groups (x,y,z...)</source>
+        <target>Groups (x,y,z...)</target>
+        <note>Line: 377</note>
+      </trans-unit>
+      <trans-unit id="b0869dd58b90ec940e91a195d754a155">
+        <source>Default group ID</source>
+        <target>Default group ID</target>
+        <note>Line: 378</note>
+      </trans-unit>
+      <trans-unit id="03361eda68f746619c2ae3341eaa2f07">
+        <source>Customer email</source>
+        <target>Customer email</target>
+        <note>Line: 409</note>
+      </trans-unit>
+      <trans-unit id="3d1c10fcfac7da07fdb8b9f99d1c0901">
+        <source>ID / Name of group shop</source>
+        <target>ID / Name of group shop</target>
+        <note>Line: 457</note>
+      </trans-unit>
+      <trans-unit id="783cb853aae6984e51583b3bb80c09d2">
+        <source>Address (2)</source>
+        <target>Address (2)</target>
+        <note>Line: 501</note>
+      </trans-unit>
+      <trans-unit id="3b0eb7469ba9c95f3a05c4cef1f6aac4">
+        <source>Latitude</source>
+        <target>Latitude</target>
+        <note>Line: 506</note>
+      </trans-unit>
+      <trans-unit id="9b4dabc50f0b8ccba1c8981831abdad8">
+        <source>Longitude</source>
+        <target>Longitude</target>
+        <note>Line: 507</note>
+      </trans-unit>
+      <trans-unit id="3b0649c72650c313a357338dcdfb64ec">
+        <source>Note</source>
+        <target>Note</target>
+        <note>Line: 511</note>
+      </trans-unit>
+      <trans-unit id="f42301fc8497aeb77b516f31b2d57d61">
+        <source>Hours (x,y,z...)</source>
+        <target>Hours (x,y,z...)</target>
+        <note>Line: 512</note>
+      </trans-unit>
+      <trans-unit id="9b1f5ada3db7e58544806a11099b7103">
+        <source>Supplier ID *</source>
+        <target>Supplier ID *</target>
+        <note>Line: 540</note>
+      </trans-unit>
+      <trans-unit id="84560d7d7c4d97c640d09a58491a3677">
+        <source>Lang ID</source>
+        <target>Lang ID</target>
+        <note>Line: 541</note>
+      </trans-unit>
+      <trans-unit id="8954e2e0d62b56db3c10df45a7602cd3">
+        <source>Warehouse ID *</source>
+        <target>Warehouse ID *</target>
+        <note>Line: 542</note>
+      </trans-unit>
+      <trans-unit id="dfa8db9b8d08689d8a23067e93ef4ef9">
+        <source>Currency ID *</source>
+        <target>Currency ID *</target>
+        <note>Line: 543</note>
+      </trans-unit>
+      <trans-unit id="e11d1e5d17a3f9ce34faccbb5cc61394">
+        <source>Supply Order Reference *</source>
+        <target>Supply Order Reference *</target>
+        <note>Line: 568</note>
+      </trans-unit>
+      <trans-unit id="f9c5030e9d71a6ba285489576e1d0e3f">
+        <source>Delivery Date (Y-M-D)*</source>
+        <target>Delivery Date (Y-M-D)*</target>
+        <note>Line: 545</note>
+      </trans-unit>
+      <trans-unit id="9e57c2dbcacea5e2e8aa3edde11cf976">
+        <source>Discount rate</source>
+        <target>Discount rate</target>
+        <note>Line: 546</note>
+      </trans-unit>
+      <trans-unit id="c5d4da7adbd98e284ef9a8733a9ceaf2">
+        <source>Product ID *</source>
+        <target>Product ID *</target>
+        <note>Line: 569</note>
+      </trans-unit>
+      <trans-unit id="41b00531a619d5e0f965854e352529f1">
+        <source>Product Attribute ID</source>
+        <target>Product Attribute ID</target>
+        <note>Line: 570</note>
+      </trans-unit>
+      <trans-unit id="94fb72f3353fb2507e18fc6748f7a811">
+        <source>Unit Price (tax excl.)*</source>
+        <target>Unit Price (tax excl.)*</target>
+        <note>Line: 571</note>
+      </trans-unit>
+      <trans-unit id="f41a10a672cbcdecaad1d2f73f30b1f8">
+        <source>Quantity Expected *</source>
+        <target>Quantity Expected *</target>
+        <note>Line: 572</note>
+      </trans-unit>
+      <trans-unit id="6703aa9936582b4381418f7d523370b4">
+        <source>Discount Rate</source>
+        <target>Discount Rate</target>
+        <note>Line: 573</note>
+      </trans-unit>
+      <trans-unit id="8fe77c2601e54f1aaef28cfde997bbad">
+        <source>Tax Rate</source>
+        <target>Tax Rate</target>
+        <note>Line: 574</note>
+      </trans-unit>
+      <trans-unit id="2415390fb5052bb8221a93c9fc51b17f">
+        <source>Import .CSV data</source>
+        <target>Import .CSV data</target>
+        <note>Line: 823</note>
+      </trans-unit>
+      <trans-unit id="d37c2bf1bd3143847fca087b354f920e">
+        <source>Customer ID</source>
+        <target>Customer ID</target>
+        <note>Line: 410</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminLoginController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="60e3ee398aa0ee3498c68914b5d5fb1a">
+        <source>Back office connection from %ip%</source>
+        <target>Back office connection from %ip%</target>
+        <note>Line: 206</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminProfilesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="69d18853cb35672b765f55ae37ae4967">
+        <source>Add new profile</source>
+        <target>Add new profile</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminQuickAccessesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8ceefbf99a59faebc1abfe60004fa5cd">
+        <source>%class_name% addition</source>
+        <target>%class_name% addition</target>
+        <note>Line: 194
+Comment: voluntary do affectation here</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminRequestSqlController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bbed49e90ee59ac450e80b492f452d0e">
+        <source>Edit this SQL query</source>
+        <target>Edit this SQL query</target>
+        <note>Line: 101</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5e3d6d040d8a81befd75127d526646bc">
+        <source>Contact information</source>
+        <target>Contact information</target>
+        <note>Line: 539</note>
+      </trans-unit>
+      <trans-unit id="a66b5528ae08e780a5df59ae913c66e7">
+        <source>Discount prices</source>
+        <target>Discount prices</target>
+        <note>Line: 542</note>
+      </trans-unit>
+      <trans-unit id="b71593973c58bb41eb302d037f6b1230">
+        <source>Module hooks</source>
+        <target>Module hooks</target>
+        <note>Line: 548</note>
+      </trans-unit>
+      <trans-unit id="f71429893913cde74dcacde3d283626e">
+        <source>Meta information</source>
+        <target>Meta information</target>
+        <note>Line: 549</note>
+      </trans-unit>
+      <trans-unit id="4ae24b703273d53941a17737bb2b1a9a">
+        <source>Product combinations</source>
+        <target>Product combinations</target>
+        <note>Line: 551</note>
+      </trans-unit>
+      <trans-unit id="cf173b732a2a0377698d631db6185836">
+        <source>Available quantities for sale</source>
+        <target>Available quantities for sale</target>
+        <note>Line: 552</note>
+      </trans-unit>
+      <trans-unit id="3020c78ae45aff9a35b95856af076765">
+        <source>Warehouses</source>
+        <target>Warehouses</target>
+        <note>Line: 554</note>
+      </trans-unit>
+      <trans-unit id="339b1acb0d1f26923dc4545a9f749ab3">
+        <source>Webservice accounts</source>
+        <target>Webservice accounts</target>
+        <note>Line: 555</note>
+      </trans-unit>
+      <trans-unit id="775a3ab6add326ef93f2382f49f9e500">
+        <source>Attribute groups</source>
+        <target>Attribute groups</target>
+        <note>Line: 556</note>
+      </trans-unit>
+      <trans-unit id="6fab199dbf5a4155871fb0d5dbfa9827">
+        <source>Tax rules groups</source>
+        <target>Tax rules groups</target>
+        <note>Line: 559</note>
+      </trans-unit>
+      <trans-unit id="812293a0a3e2ca81fb23c076c13eaa10">
+        <source>Referrers/affiliates</source>
+        <target>Referrers/affiliates</target>
+        <note>Line: 561</note>
+      </trans-unit>
+      <trans-unit id="3b8c8bf8ab2226d5a44454a20ad7fafb">
+        <source>Cart rules</source>
+        <target>Cart rules</target>
+        <note>Line: 563</note>
+      </trans-unit>
+      <trans-unit id="c8cfbbbe4253e14390b2b14d7e60d9c8">
+        <source>Import data</source>
+        <target>Import data</target>
+        <note>Line: 580</note>
+      </trans-unit>
+      <trans-unit id="5fb93170a6b0ac85ca8c080d2c469702">
+        <source>Choose the source shop</source>
+        <target>Choose the source shop</target>
+        <note>Line: 587</note>
+      </trans-unit>
+      <trans-unit id="1d92a46c4e14c43c3096d85c9f26fc4e">
+        <source>Choose data to import</source>
+        <target>Choose data to import</target>
+        <note>Line: 595</note>
+      </trans-unit>
+      <trans-unit id="5a8f8f8e0bcbfcd926271ee7d7351134">
+        <source>Shop groups list</source>
+        <target>Shop groups list</target>
+        <note>Line: 846</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopGroupController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="224154fa6f3601b7de4690ba6a9ad8b4">
+        <source>Multistore tree</source>
+        <target>Multistore tree</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="4493e821e06072415518bd7ae4077996">
+        <source>Shop group</source>
+        <target>Shop group</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="90f72fb554403a6b1cb46741c5f348f2">
+        <source>Multistore options</source>
+        <target>Multistore options</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="8cdf1c6345219fcfde50615a78ad3ce6">
+        <source>Default shop</source>
+        <target>Default shop</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="d60f2e4b0fe028af01eb653ff90f7675">
+        <source>Add a new shop group</source>
+        <target>Add a new shop group</target>
+        <note>Line: 167</note>
+      </trans-unit>
+      <trans-unit id="99dba47935ec26654ca99c21650779e6">
+        <source>Add a new shop</source>
+        <target>Add a new shop</target>
+        <note>Line: 153</note>
+      </trans-unit>
+      <trans-unit id="07a415776bc6aefc538acd85f4d56730">
+        <source>Shop group name</source>
+        <target>Shop group name</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="5b55607ff39362e86c0693626a6cc20f">
+        <source>Share customers</source>
+        <target>Share customers</target>
+        <note>Line: 190</note>
+      </trans-unit>
+      <trans-unit id="4a1f6ec3d9ae0c871dfb29d01a150d6f">
+        <source>Share available quantities to sell</source>
+        <target>Share available quantities to sell</target>
+        <note>Line: 210</note>
+      </trans-unit>
+      <trans-unit id="166dcd2b34652eee355742934826795a">
+        <source>Share available quantities between shops of this group. When changing this option, all available products quantities will be reset to 0.</source>
+        <target>Share available quantities between shops of this group. When changing this option, all available products quantities will be reset to 0.</target>
+        <note>Line: 225</note>
+      </trans-unit>
+      <trans-unit id="a23a8100bb34ea482c8fb134da89710e">
+        <source>Share orders</source>
+        <target>Share orders</target>
+        <note>Line: 229</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopUrlController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4a4d1260782270739eeeef6d58db0f73">
+        <source>Shop URL ID</source>
+        <target>Shop URL ID</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="e93c33bd1341ab74195430daeb63db13">
+        <source>Shop name</source>
+        <target>Shop name</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="71a7f085c9ecfd1ac1042c32c0656927">
+        <source>Is it the main URL?</source>
+        <target>Is it the main URL?</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="bfc70beddce99a8ab159563d4e03f7af">
+        <source>URL options</source>
+        <target>URL options</target>
+        <note>Line: 135</note>
+      </trans-unit>
+      <trans-unit id="438ddd6a05ebb1af2b3e5dc794489f57">
+        <source>Is it the main URL for this shop?</source>
+        <target>Is it the main URL for this shop?</target>
+        <note>Line: 158</note>
+      </trans-unit>
+      <trans-unit id="37d00f4554dc3c0baeb34a9c22d787d9">
+        <source>Shop URL</source>
+        <target>Shop URL</target>
+        <note>Line: 211</note>
+      </trans-unit>
+      <trans-unit id="eae639a70006feff484a39363c977e24">
+        <source>Domain</source>
+        <target>Domain</target>
+        <note>Line: 217</note>
+      </trans-unit>
+      <trans-unit id="f9f0dece476d9f76e4130347b6e31b94">
+        <source>SSL Domain</source>
+        <target>SSL Domain</target>
+        <note>Line: 223</note>
+      </trans-unit>
+      <trans-unit id="4f04a71599485ace316aa8ed38348875">
+        <source>Physical URL</source>
+        <target>Physical URL</target>
+        <note>Line: 240</note>
+      </trans-unit>
+      <trans-unit id="bbc1203755645168294af35f880d61e5">
+        <source>Virtual URL</source>
+        <target>Virtual URL</target>
+        <note>Line: 253</note>
+      </trans-unit>
+      <trans-unit id="1dcec4396291e2fbdc02c03526fe2b88">
+        <source>Final URL</source>
+        <target>Final URL</target>
+        <note>Line: 261</note>
+      </trans-unit>
+      <trans-unit id="d63c1ea9ab7850a74940ff760f25034b">
+        <source>Edit this shop</source>
+        <target>Edit this shop</target>
+        <note>Line: 310</note>
+      </trans-unit>
+      <trans-unit id="157d64669ca816a7153ac30d2e16690a">
+        <source>Add a new URL</source>
+        <target>Add a new URL</target>
+        <note>Line: 335</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminWebserviceController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="58af3456f86b42c86f963d896a62644f">
+        <source>Webservice Accounts</source>
+        <target>Webservice Accounts</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="20eebdc752ee86d49f5d090759b237aa">
+        <source>Webservice account key.</source>
+        <target>Webservice account key.</target>
+        <note>Line: 136</note>
+      </trans-unit>
+      <trans-unit id="45fff8bcdd979fde32df8435f29553ab">
+        <source>Generate!</source>
+        <target>Generate!</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="d08ccf52b4cdd08e41cfb99ec42e0b29">
+        <source>Permissions</source>
+        <target>Permissions</target>
+        <note>Line: 173</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a274f4d4670213a9045ce258c6c56b80">
+        <source>Notifications</source>
+        <target>Notifications</target>
+        <note>Line: 99</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Email/EmailConfigurationTester.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="94fc5d3be31c72a400c50aae395f1f1f">
+        <source>This is a test message. Your server is now configured to send email.</source>
+        <target>This is a test message. Your server is now configured to send email.</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="e379446940f88886aba80367a10fa4cc">
+        <source>Test message -- Prestashop</source>
+        <target>Test message -- Prestashop</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="4e6ebf3087084e1fda3554d154851ef0">
+        <source>Error: Please check your configuration</source>
+        <target>Error: Please check your configuration</target>
+        <note>Line: 107</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Requirement/CheckRequirements.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="15cfc4f0fa73c3f13280e47c5621a615">
+        <source>%key% (missing description)</source>
+        <target>%key% (missing description)</target>
+        <note>Line: 149</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Form/ChoiceProvider/MailMethodChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="11812952ae95fbc6ebc323426262bb51">
+        <source>Use PHP's mail() function (recommended; works in most cases)</source>
+        <target>Use PHP's mail() function (recommended; works in most cases)</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="e6095b01597caf275fb24fa766fb8a57">
+        <source>Set my own SMTP parameters (for advanced users ONLY)</source>
+        <target>Set my own SMTP parameters (for advanced users ONLY)</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="982bb3f2cc4922620fd3aee7ff15b552">
+        <source>Never send emails (may be useful for testing purposes)</source>
+        <target>Never send emails (may be useful for testing purposes)</target>
+        <note>Line: 79</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/BackupDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9d8d2d5ab12b515182a505f54db7f538">
+        <source>Age</source>
+        <target>Age</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="1908624a0bca678cd26b99bfd405324e">
+        <source>File size</source>
+        <target>File size</target>
+        <note>Line: 93</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="278c491bdd8a53618c149c4ac790da34">
+        <source>Template</source>
+        <target>Template</target>
+        <note>Line: 120</note>
+      </trans-unit>
+      <trans-unit id="5d6103b662f41b07e10687f03aca8fdc">
+        <source>Recipient</source>
+        <target>Recipient</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="c7892ebbb139886662c6f2fc8c450710">
+        <source>Subject</source>
+        <target>Subject</target>
+        <note>Line: 132</note>
+      </trans-unit>
+      <trans-unit id="7f8c0283f16925caed8e632086b81b9c">
+        <source>Sent</source>
+        <target>Sent</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="e129ae480280e47ef82fc7702f8321ba">
+        <source>Refresh list</source>
+        <target>Refresh list</target>
+        <note>Line: 236</note>
+      </trans-unit>
+      <trans-unit id="dcc459e0cef1e36a18a356fbc5789b16">
+        <source>Erase all</source>
+        <target>Erase all</target>
+        <note>Line: 228</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ecb833e2dc5d6c03d4d0cddf1b15e85a">
+        <source>Severity (1-4)</source>
+        <target>Severity (1-4)</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="0610bbb9dba03bb8037e468534b65a1a">
+        <source>Object type</source>
+        <target>Object type</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="d95fc016a6eee828f434ed5f55504427">
+        <source>Object ID</source>
+        <target>Object ID</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="5f36cf760a5c474cc32a6d35d9c50d05">
+        <source>Error code</source>
+        <target>Error code</target>
+        <note>Line: 131</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="822376c59b7b86a05a2519f85f88da55">
+        <source>SQL query Name</source>
+        <target>SQL query Name</target>
+        <note>Line: 103</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="897356954c2cd3d41b221e3f24f99bba">
+        <source>Key</source>
+        <target>Key</target>
+        <note>Line: 112</note>
+      </trans-unit>
+      <trans-unit id="52699c78843b98f98620186a59b0a3fa">
+        <source>Key description</source>
+        <target>Key description</target>
+        <note>Line: 118</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="26420bd9e260012164a58a0f002e4821">
+        <source>Add new SQL query</source>
+        <target>Add new SQL query</target>
+        <note>Line: 95</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="644ebe55744f361a22bc3c9be9bc4ccf">
+        <source>Add new webservice key</source>
+        <target>Add new webservice key</target>
+        <note>Line: 76</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Api/StockController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="75ed578ac3cb02b0ba40002a25bc0403">
+        <source>Product reference</source>
+        <target>Product reference</target>
+        <note>Line: 159</note>
+      </trans-unit>
+      <trans-unit id="ae5977a08e8a3d45283789d99c67c3c3">
+        <source>Combination reference</source>
+        <target>Combination reference</target>
+        <note>Line: 160</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bd74be2b0190f4b7f3ef117342771f70">
+        <source>Memcached via PHP::Memcache</source>
+        <target>Memcached via PHP::Memcache</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="e6f9c14400a56127e7397b4f8afeae10">
+        <source>Memcached via PHP::Memcached</source>
+        <target>Memcached via PHP::Memcached</target>
+        <note>Line: 127</note>
+      </trans-unit>
+      <trans-unit id="0e68f753bc601f5d9d04717f95042762">
+        <source>APC</source>
+        <target>APC</target>
+        <note>Line: 137</note>
+      </trans-unit>
+      <trans-unit id="38ca568bbe61771c6456a5c7b8d419ee">
+        <source>Xcache</source>
+        <target>Xcache</target>
+        <note>Line: 147</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2c111a587b8e6a65856ac7933d76bdce">
+        <source>megabytes</source>
+        <target>megabytes</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="130c5b3473c57faa76e2a1c54e26f88e">
+        <source>Both</source>
+        <target>Both</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="970e79a141128a95d3c2f35f622b6710">
+        <source>Send email in HTML format</source>
+        <target>Send email in HTML format</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="9f1b874f3886d361d6eb6b079639c385">
+        <source>Send email in text format</source>
+        <target>Send email in text format</target>
+        <note>Line: 90</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6adf97f83acf6453d4a6a4b1070f3754">
+        <source>None</source>
+        <target>None</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="099d7d04319e5191b7473e016c55e320">
+        <source>TLS</source>
+        <target>TLS</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="ea52c36203c5f99c3ce2442d531b1a22">
+        <source>SSL</source>
+        <target>SSL</target>
+        <note>Line: 65</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6b127dc82937049e45e74aebca783e74">
+        <source>Store contacts</source>
+        <target>Store contacts</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/download_file.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b3b5aea1ae3bf83287bde7e5295a22b4">
+        <source>Download the backup file (%s MB)</source>
+        <target>Download the backup file (%s MB)</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="0478391d3c5bfff8ce84cabb1ac330ee">
+        <source>Tip: You can also download this file from your FTP server. Backup files are located in the "/adminXXXX/backups" directory.</source>
+        <target>Tip: You can also download this file from your FTP server. Backup files are located in the "/adminXXXX/backups" directory.</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="30c210e0173f2ff607cc84dc01ffc1f0">
+        <source>Backup options</source>
+        <target>Backup options</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="6afc2b40f9acff2a4d1e67f2dfcd8a30">
+        <source>Ignore statistics tables</source>
+        <target>Ignore statistics tables</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="8859ec81a77f2f2b165bf5ea9858ecfc">
+        <source>Drop existing tables during import</source>
+        <target>Drop existing tables during import</target>
+        <note>Line: 54</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_file_history.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d">
+        <source>Download</source>
+        <target>Download</target>
+        <note>Line: 91</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e08caeac3f80ffa7889cdf1c8f30111f">
+        <source>Multiple value separator</source>
+        <target>Multiple value separator</target>
+        <note>Line: 125</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ec76c5b544633d334c7a3f92db1c7efd">
+        <source>Send emails to</source>
+        <target>Send emails to</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="c63600a5ac5af840103d0ee9608e7b44">
+        <source>Log Emails</source>
+        <target>Log Emails</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_logs_grid.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="86c9ce4b2e3b43353a23861c053a594b">
+        <source>Back to the dashboard</source>
+        <target>Back to the dashboard</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c098053744ce979cbd030908105d54fe">
+        <source>Mail domain name</source>
+        <target>Mail domain name</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="bdd48fb41b9d0a4a1051fa22a87eb5a2">
+        <source>SMTP server</source>
+        <target>SMTP server</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="a7bfd8847270913b15396380c3627d76">
+        <source>SMTP username</source>
+        <target>SMTP username</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="3cffa2fabd5519beaf4c2fbd0610899b">
+        <source>SMTP password</source>
+        <target>SMTP password</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="d7f2615c71a1567cc13cf3a7f7de0aea">
+        <source>Encryption</source>
+        <target>Encryption</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="762160912d2bac8eb64bc00b711d6f6c">
+        <source>Port number to use.</source>
+        <target>Port number to use.</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="60aaf44d4b562252c04db7f98497e9aa">
+        <source>Port</source>
+        <target>Port</target>
+        <note>Line: 81</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a8a9e7c120e7020435d955d3a0c96471">
+        <source>Test your email configuration</source>
+        <target>Test your email configuration</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="5f23f9739fa16efc7ddd06bb03096998">
+        <source>Send a test email to</source>
+        <target>Send a test email to</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="0bb7ea7550d2e7caf5e32329bc7423cd">
+        <source>A test email has been sent to the email address you provided.</source>
+        <target>A test email has been sent to the email address you provided.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="16186ead9220c2a4646402c69109cfa0">
+        <source>Send a test email</source>
+        <target>Send a test email</target>
+        <note>Line: 61</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c9869fa659bd86f03aba826acd8db5b5">
+        <source>Meaning of severity levels:</source>
+        <target>Meaning of severity levels:</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5d1f62be1608c8c55ca77098efe5f053">
+        <source>Logs by email</source>
+        <target>Logs by email</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="daf5a89c7110f00485d0737ff765e830">
+        <source>Minimum severity level</source>
+        <target>Minimum severity level</target>
+        <note>Line: 56</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/settings_panel.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="10d8074bf1e35bcac9911c5fe26261cf">
+        <source>Select your default file encoding</source>
+        <target>Select your default file encoding</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/form.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dddc702fcffceb2ac77291954897d747">
+        <source>SQL query</source>
+        <target>SQL query</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="9b5c3d6674b3af1946fb50faae7079e2">
+        <source>SQL query name</source>
+        <target>SQL query name</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice_settings.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a3946b47f44a8f7adf9c9b6e38911790">
+        <source>Enable PrestaShop's webservice</source>
+        <target>Enable PrestaShop's webservice</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="8a05d87b51cc003b5a3c018b37a6d311">
+        <source>Enable CGI mode for PHP</source>
+        <target>Enable CGI mode for PHP</target>
+        <note>Line: 56</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="46f18d3960afc01e5a1a5a0e0e9d571b">
+        <source>Automatically check for module updates</source>
+        <target>Automatically check for module updates</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="967db4d257af07feced01d6633f575f7">
+        <source>Check the cookie's IP address</source>
+        <target>Check the cookie's IP address</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="dcfba1534995899d2ca36cda978da215">
+        <source>Lifetime of front office cookies</source>
+        <target>Lifetime of front office cookies</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="e62d77475fe6318731b4411ba1181dca">
+        <source>Lifetime of back office cookies</source>
+        <target>Lifetime of back office cookies</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="ade28d54bcdbc7c4cfd45d84ad517f7b">
+        <source>Upload quota</source>
+        <target>Upload quota</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="454036c51196464f8d9c84ded5808985">
+        <source>Maximum size for attached files</source>
+        <target>Maximum size for attached files</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="4ae386b852a3ee22324e8922e50c9aec">
+        <source>Maximum size for a downloadable product</source>
+        <target>Maximum size for a downloadable product</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="a1652ab7a761fa7bb3726fe28b97d1f3">
+        <source>Maximum size for a product's image</source>
+        <target>Maximum size for a product's image</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="1b1befcb86d487715da458117710dfeb">
+        <source>Show notifications for new orders</source>
+        <target>Show notifications for new orders</target>
+        <note>Line: 139</note>
+      </trans-unit>
+      <trans-unit id="8004e61ca76ff500d1e6ee92f7cb7f93">
+        <source>Show notifications for new customers</source>
+        <target>Show notifications for new customers</target>
+        <note>Line: 146</note>
+      </trans-unit>
+      <trans-unit id="4e7ff7ca556a7ac8329ab27834e9631b">
+        <source>Show notifications for new messages</source>
+        <target>Show notifications for new messages</target>
+        <note>Line: 153</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="74c9e12c3a19cfb79b79faf579934844">
+        <source>Add server</source>
+        <target>Add server</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="5b8c99dad1893a85076709b2d3c2d2d0">
+        <source>IP Address</source>
+        <target>IP Address</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
+        <source>Weight</source>
+        <target>Weight</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="003744a685f896a2d9764655f67f1a24">
+        <source>Add Server</source>
+        <target>Add Server</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="dd11871dd215aec96a2eb051116bac00">
+        <source>Test Server</source>
+        <target>Test Server</target>
+        <note>Line: 68</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="517a8a7dbf1f6e371509817de328e396">
+        <source>Customer groups</source>
+        <target>Customer groups</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="79c0d6cba080dc90b01c887064c9fc2f">
+        <source>Clear cache</source>
+        <target>Clear cache</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="f8d698aea36fcbead2b9d5359ffca76f">
+        <source>Smarty</source>
+        <target>Smarty</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="770d85a02ce8841bd4dac97b57c7fa17">
+        <source>Template compilation</source>
+        <target>Template compilation</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="ab0cf104f39708eabd07b8cb67e149ba">
+        <source>Cache</source>
+        <target>Cache</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="0d6bf1934cab1de045b189eed03c3d42">
+        <source>Should be enabled except for debugging.</source>
+        <target>Should be enabled except for debugging.</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="1c9e9fdb43035d78fc94dd37c357869c">
+        <source>Multi-front optimizations</source>
+        <target>Multi-front optimizations</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="bfa7e629b4eaa924530242510a50679e">
+        <source>Caching type</source>
+        <target>Caching type</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="ec3028a12402ab7f43962a6f3a667b6e">
+        <source>Debug mode</source>
+        <target>Debug mode</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="0da6a47faba382116423315f9e61b9e2">
+        <source>Disable non PrestaShop modules</source>
+        <target>Disable non PrestaShop modules</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="edf05af828595f01ae00b209ef0b1e1f">
+        <source>Enable or disable non PrestaShop Modules.</source>
+        <target>Enable or disable non PrestaShop Modules.</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="03a9e6840847f96325b7184d5f3c2769">
+        <source>Disable all overrides</source>
+        <target>Disable all overrides</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="29826f9f4da3d473c1e4ecf2f6c4ef9f">
+        <source>Enable or disable all classes and controllers overrides.</source>
+        <target>Enable or disable all classes and controllers overrides.</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="010a6cb0eccdea35662ad711d443f2ec">
+        <source>Optional features</source>
+        <target>Optional features</target>
+        <note>Line: 137</note>
+      </trans-unit>
+      <trans-unit id="f4efdd180586cba038b52f2471e4075d">
+        <source>CCC (Combine, Compress and Cache)</source>
+        <target>CCC (Combine, Compress and Cache)</target>
+        <note>Line: 194</note>
+      </trans-unit>
+      <trans-unit id="c7ceaefb9d7fd3731ae2a28abad2cb95">
+        <source>Smart cache for CSS</source>
+        <target>Smart cache for CSS</target>
+        <note>Line: 204</note>
+      </trans-unit>
+      <trans-unit id="cf00874a93cf1cca317853c54c9f40e3">
+        <source>Smart cache for JavaScript</source>
+        <target>Smart cache for JavaScript</target>
+        <note>Line: 211</note>
+      </trans-unit>
+      <trans-unit id="0b388064aa29e8576990d9eb5da8d43e">
+        <source>Apache optimization</source>
+        <target>Apache optimization</target>
+        <note>Line: 218</note>
+      </trans-unit>
+      <trans-unit id="3ffcac2b857b421d5418b748b411265b">
+        <source>Media servers (use only with CCC)</source>
+        <target>Media servers (use only with CCC)</target>
+        <note>Line: 240</note>
+      </trans-unit>
+      <trans-unit id="2d29e91503465ed72170623f37458e32">
+        <source>You must enter another domain, or subdomain, in order to use cookieless static content.</source>
+        <target>You must enter another domain, or subdomain, in order to use cookieless static content.</target>
+        <note>Line: 246</note>
+      </trans-unit>
+      <trans-unit id="3ed7fddd0f381c4fe4683fc9e856dbcf">
+        <source>Media server #1</source>
+        <target>Media server #1</target>
+        <note>Line: 250</note>
+      </trans-unit>
+      <trans-unit id="9dafd449b62301e26c635b976b231b88">
+        <source>Media server #2</source>
+        <target>Media server #2</target>
+        <note>Line: 257</note>
+      </trans-unit>
+      <trans-unit id="391e79edab921e1974705a7096055dde">
+        <source>Media server #3</source>
+        <target>Media server #3</target>
+        <note>Line: 264</note>
+      </trans-unit>
+      <trans-unit id="02d56cf7754ce16d7ce0193fbca7c90a">
+        <source>Caching</source>
+        <target>Caching</target>
+        <note>Line: 286</note>
+      </trans-unit>
+      <trans-unit id="276e3171a63595e207ec292fce891277">
+        <source>Use cache</source>
+        <target>Use cache</target>
+        <note>Line: 291</note>
+      </trans-unit>
+      <trans-unit id="aa7ef82bc75491903bfc4838957265be">
+        <source>Caching system</source>
+        <target>Caching system</target>
+        <note>Line: 298</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8b9a96e40ebcda35ce12190b41789b64">
+        <source>Configuration information</source>
+        <target>Configuration information</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="cca793d1dbd9d60b8574a869cf212630">
+        <source>This information must be provided when you report an issue on our bug tracker or forum.</source>
+        <target>This information must be provided when you report an issue on our bug tracker or forum.</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="7d30d49dcf91d103c59496aafc4e3187">
+        <source>Server information</source>
+        <target>Server information</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="ad41419235c76297eaf568c7656da881">
+        <source>Server software version:</source>
+        <target>Server software version:</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="e2551ec433c9623fed56f27ca2b91a35">
+        <source>PHP version:</source>
+        <target>PHP version:</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="94be595f109f75bfcced2d3bec366128">
+        <source>Memory limit:</source>
+        <target>Memory limit:</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="f3bd61801b2a43ad234af6e6fc917583">
+        <source>Max execution time:</source>
+        <target>Max execution time:</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="3d8a3c1f364b4767769b36eedbe66bb0">
+        <source>Upload Max File size:</source>
+        <target>Upload Max File size:</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="fc0eeb8415aed39a9d3624c7fc2fe47c">
+        <source>PageSpeed module for Apache installed (mod_instaweb)</source>
+        <target>PageSpeed module for Apache installed (mod_instaweb)</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="2933fa807adda5cc00e163479de35538">
+        <source>Database information</source>
+        <target>Database information</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="52018f4304c11e4bd288a533b122ccf7">
+        <source>MySQL version:</source>
+        <target>MySQL version:</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="dbaf046be46df36dab10f0a54e94b95e">
+        <source>MySQL server:</source>
+        <target>MySQL server:</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="a720577895f55e35dd9ea15feeadc35e">
+        <source>MySQL name:</source>
+        <target>MySQL name:</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="6088e183841f22493e40f574376240cb">
+        <source>MySQL user:</source>
+        <target>MySQL user:</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="fe453b675e37e3a3d2ca501d7ef3135e">
+        <source>Tables prefix:</source>
+        <target>Tables prefix:</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="b888bbc9841a225c7780b20f2c2db60c">
+        <source>MySQL engine:</source>
+        <target>MySQL engine:</target>
+        <note>Line: 97</note>
+      </trans-unit>
+      <trans-unit id="9369ef07178c0e2be115d85fab6eb6cb">
+        <source>MySQL driver:</source>
+        <target>MySQL driver:</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="3aea774cdcd8f2c45549f10758a71323">
+        <source>Store information</source>
+        <target>Store information</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="59681d7f729ee8ffdfbc99b8c935c41b">
+        <source>PrestaShop version:</source>
+        <target>PrestaShop version:</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="76c01eed328aa2411b18f007c77d2eeb">
+        <source>Shop URL:</source>
+        <target>Shop URL:</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="b5b3eed3efd6cfebfea270066a1e1f9b">
+        <source>Current theme in use:</source>
+        <target>Current theme in use:</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="4e37aa2987c0876f7f7b2104927df1a1">
+        <source>Mail configuration</source>
+        <target>Mail configuration</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="aee55e0ed7a06f68ed5e13f235a8bfd8">
+        <source>Mail method:</source>
+        <target>Mail method:</target>
+        <note>Line: 134</note>
+      </trans-unit>
+      <trans-unit id="f882852afa750c241cdb951bc52539fd">
+        <source>You are using the PHP mail() function.</source>
+        <target>You are using the PHP mail() function.</target>
+        <note>Line: 137</note>
+      </trans-unit>
+      <trans-unit id="cffa72aaebae1bd90bbe1b8d827ecb1c">
+        <source>You are using your own SMTP parameters.</source>
+        <target>You are using your own SMTP parameters.</target>
+        <note>Line: 139</note>
+      </trans-unit>
+      <trans-unit id="33b3f142e242a624cb69a5f5f689039d">
+        <source>SMTP server:</source>
+        <target>SMTP server:</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="5489d25adfc42d3aadcb90b679405bda">
+        <source>SMTP username:</source>
+        <target>SMTP username:</target>
+        <note>Line: 144</note>
+      </trans-unit>
+      <trans-unit id="c4e9522d7b3c8c652f7f0333ff436eec">
+        <source>Defined</source>
+        <target>Defined</target>
+        <note>Line: 154</note>
+      </trans-unit>
+      <trans-unit id="f8b1369a8e9d90da0cae0b11049309af">
+        <source>Not defined</source>
+        <target>Not defined</target>
+        <note>Line: 156</note>
+      </trans-unit>
+      <trans-unit id="037373672dd4a89426144d40f2e8ad91">
+        <source>SMTP password:</source>
+        <target>SMTP password:</target>
+        <note>Line: 152</note>
+      </trans-unit>
+      <trans-unit id="8a7363b823dce00b3b1b7e62ca1d777d">
+        <source>Encryption:</source>
+        <target>Encryption:</target>
+        <note>Line: 160</note>
+      </trans-unit>
+      <trans-unit id="599303a627bf19148eedd5fe29112729">
+        <source>SMTP port:</source>
+        <target>SMTP port:</target>
+        <note>Line: 163</note>
+      </trans-unit>
+      <trans-unit id="8746097684bc64be8b7eff424c4debdb">
+        <source>Your information</source>
+        <target>Your information</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="11eb3e792866d1433dd4ca9d7e49b5ac">
+        <source>Your web browser:</source>
+        <target>Your web browser:</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="e91dd9bbca6e42bb85c0f2d94aaee995">
+        <source>Check your configuration</source>
+        <target>Check your configuration</target>
+        <note>Line: 185</note>
+      </trans-unit>
+      <trans-unit id="a3810ddb5a67e550cb3ca9c1cffce800">
+        <source>Required parameters:</source>
+        <target>Required parameters:</target>
+        <note>Line: 190</note>
+      </trans-unit>
+      <trans-unit id="0297eee5a43818dda6ad1e1b36f08965">
+        <source>Optional parameters:</source>
+        <target>Optional parameters:</target>
+        <note>Line: 207</note>
+      </trans-unit>
+      <trans-unit id="d5c0bb5c1df152c6fe45bd07e303cb69">
+        <source>List of changed files</source>
+        <target>List of changed files</target>
+        <note>Line: 231</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminAdvparametersHelp.xlf
+++ b/app/Resources/translations/default/AdminAdvparametersHelp.xlf
@@ -1,101 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminShopUrlController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="c688fbbc9468ea3473172ca924290860">
-        <source>If you want to add a virtual URL, you need to activate URL rewriting on your web server and enable Friendly URL option.</source>
-        <target>If you want to add a virtual URL, you need to activate URL rewriting on your web server and enable Friendly URL option.</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:123</note>
+      <trans-unit id="084ad8abffc138f8d43f0a77824396b9">
+        <source>You can read information on import at:</source>
+        <target>You can read information on import at:</target>
+        <note>Line: 41</note>
       </trans-unit>
-      <trans-unit id="05f8f0fab3ff5d86e0de9db902da7045">
-        <source>You can use this option if you want to create a store with a URL that doesn't exist on your server (e.g. if you want your store to be available with the URL www.example.com/my-store/shoes/, you have to set shoes/ in this field, assuming that my-store/ is your Physical URL).</source>
-        <target>You can use this option if you want to create a store with a URL that doesn't exist on your server (e.g. if you want your store to be available with the URL www.example.com/my-store/shoes/, you have to set shoes/ in this field, assuming that my-store/ is your Physical URL).</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:127</note>
+      <trans-unit id="4e7357d876d6d15fe084be41934e6555">
+        <source>http://doc.prestashop.com/display/PS17/Import</source>
+        <target>http://doc.prestashop.com/display/PS17/Import</target>
+        <note>Line: 42</note>
       </trans-unit>
-      <trans-unit id="f6e7829277b67d5a8805d6728a810362">
-        <source>URL rewriting must be activated on your server to use this feature.</source>
-        <target>URL rewriting must be activated on your server to use this feature.</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:128</note>
+      <trans-unit id="9d23c31f2dcc1ace9296037f327563a4">
+        <source>https://en.wikipedia.org/wiki/Comma-separated_values</source>
+        <target>https://en.wikipedia.org/wiki/Comma-separated_values</target>
+        <note>Line: 45</note>
       </trans-unit>
-      <trans-unit id="a2e8a639b5fd3e34ab4def1e7aac3383">
-        <source>If you set this URL as the Main URL for the selected shop, all URLs set to this shop will be redirected to this URL (you can only have one Main URL per shop).</source>
-        <target>If you set this URL as the Main URL for the selected shop, all URLs set to this shop will be redirected to this URL (you can only have one Main URL per shop).</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:173</note>
+      <trans-unit id="a27780d9bb7b3595998465aadcaaeed7">
+        <source>Allowed formats: .csv, .xls, .xlsx, .xlst, .ods, .ots</source>
+        <target>Allowed formats: .csv, .xls, .xlsx, .xlst, .ods, .ots</target>
+        <note>Line: 87</note>
       </trans-unit>
-      <trans-unit id="819e18d335155ef4a9cdfe926ac8a3de">
-        <source>Since the selected shop has no main URL, you have to set this URL as the Main URL.</source>
-        <target>Since the selected shop has no main URL, you have to set this URL as the Main URL.</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:175</note>
+      <trans-unit id="c9f7248e8f5712f5438def77389e1c46">
+        <source>Only UTF-8 and ISO 8859-1 encodings are allowed</source>
+        <target>Only UTF-8 and ISO 8859-1 encodings are allowed</target>
+        <note>Line: 88</note>
       </trans-unit>
-      <trans-unit id="fe42e7cf02611b9719a6db6513de19eb">
-        <source>The selected shop already has a Main URL. Therefore, if you set this one as the Main URL, the older Main URL will be set as a regular URL.</source>
-        <target>The selected shop already has a Main URL. Therefore, if you set this one as the Main URL, the older Main URL will be set as a regular URL.</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:179</note>
+      <trans-unit id="6578c8c9a3dbadb0a3672c3ca6c0b513">
+        <source>You can also upload your file via FTP to the following directory: %s .</source>
+        <target>You can also upload your file via FTP to the following directory: %s .</target>
+        <note>Line: 89</note>
       </trans-unit>
-      <trans-unit id="7e7b350e5cee624789b1e263ec59db26">
-        <source>This is the physical folder for your store on the web server. Leave this field empty if your store is installed on the root path. For instance, if your store is available at www.example.com/my-store/, you must input my-store/ in this field.</source>
-        <target>This is the physical folder for your store on the web server. Leave this field empty if your store is installed on the root path. For instance, if your store is available at www.example.com/my-store/, you must input my-store/ in this field.</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:242</note>
+      <trans-unit id="b070d64c5a2f10b4b8eb361ba4f61833">
+        <source>e.g. </source>
+        <target>e.g. </target>
+        <note>Line: 211</note>
       </trans-unit>
-      <trans-unit id="29f3eb1bea3049b52600a18ad4d0b96c">
-        <source>Warning: URL rewriting (e.g. mod_rewrite for Apache) seems to be disabled. If your Virtual URL doesn't work, please check with your hosting provider on how to activate URL rewriting.</source>
-        <target>Warning: URL rewriting (e.g. mod_rewrite for Apache) seems to be disabled. If your Virtual URL doesn't work, please check with your hosting provider on how to activate URL rewriting.</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:257</note>
+      <trans-unit id="1d3be023802846145f9b75fc90b4cf21">
+        <source>If enabled, the product's reference number MUST be unique!</source>
+        <target>If enabled, the product's reference number MUST be unique!</target>
+        <note>Line: 236</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="11cd708df7411da4546d8580356e711a">
-        <source>Ignore this field if you don't use the Multistore tool. If you leave this field empty, the default shop will be used.</source>
-        <target>Ignore this field if you don't use the Multistore tool. If you leave this field empty, the default shop will be used.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:516</note>
+      <trans-unit id="f66963da2d51d637afa80ff8edf8d734">
+        <source>If you enable this option, your imported items' ID number will be used as is. If you do not enable this option, the imported ID numbers will be ignored, and PrestaShop will instead create auto-incremented ID numbers for all the imported items.</source>
+        <target>If you enable this option, your imported items' ID number will be used as is. If you do not enable this option, the imported ID numbers will be ignored, and PrestaShop will instead create auto-incremented ID numbers for all the imported items.</target>
+        <note>Line: 266</note>
       </trans-unit>
-      <trans-unit id="5702db29cfdd93934ed330edb201ecf3">
-        <source>Enable Advanced Stock Management on product (0 = No, 1 = Yes)</source>
-        <target>Enable Advanced Stock Management on product (0 = No, 1 = Yes)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:156</note>
-      </trans-unit>
-      <trans-unit id="2d743ae4c74db2a22d79e1e950e719e5">
-        <source>0 = Use quantity set in product, 1 = Use quantity from warehouse.</source>
-        <target>0 = Use quantity set in product, 1 = Use quantity from warehouse.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:318</note>
-      </trans-unit>
-      <trans-unit id="aaf88088b0ac3f2992888fdfe00b5d76">
-        <source>ID of the warehouse to set as storage.</source>
-        <target>ID of the warehouse to set as storage.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:322</note>
-      </trans-unit>
-      <trans-unit id="4bc14a0f722453ba235bc3fb52d95ffb">
-        <source>A category root is where a category tree can begin. This is used with multistore.</source>
-        <target>A category root is where a category tree can begin. This is used with multistore.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:197</note>
-      </trans-unit>
-      <trans-unit id="7506b41cf1aa65b2663b038e465c0d6d">
-        <source>Enable Advanced Stock Management on product (0 = No, 1 = Yes).</source>
-        <target>Enable Advanced Stock Management on product (0 = No, 1 = Yes).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:314</note>
-      </trans-unit>
-      <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">
-        <source>or</source>
-        <target>or</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1005
- Comment: Special case for Product : either one or the other. Not both.</note>
+      <trans-unit id="04d39f4c0f667d58c8c5540514ebf0eb">
+        <source>Sends an email to let you know your import is complete. It can be useful when handling large files, as the import may take some time.</source>
+        <target>Sends an email to let you know your import is complete. It can be useful when handling large files, as the import may take some time.</target>
+        <note>Line: 283</note>
       </trans-unit>
     </body>
   </file>
@@ -104,82 +59,77 @@ File: controllers/admin/AdminImportController.php:1005
       <trans-unit id="14a966a005ea5262cd09332f4e50b7b1">
         <source>Your avatar in PrestaShop 1.7.x is your profile picture on %url%. To change your avatar, log in to PrestaShop.com with your email %email% and follow the on-screen instructions.</source>
         <target>Your avatar in PrestaShop 1.7.x is your profile picture on %url%. To change your avatar, log in to PrestaShop.com with your email %email% and follow the on-screen instructions.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:243</note>
+        <note>Line: 265</note>
       </trans-unit>
       <trans-unit id="d222c4d0463bd3f146536ac89c0d7c77">
         <source>Password should be at least %num% characters long.</source>
         <target>Password should be at least %num% characters long.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:282</note>
+        <note>Line: 304</note>
       </trans-unit>
       <trans-unit id="0b2827832fff3d973ee0ed2e6c7d4b23">
         <source>PrestaShop can provide you with guidance on a regular basis by sending you tips on how to optimize the management of your store which will help you grow your business. If you do not wish to receive these tips, you can disable this option.</source>
         <target>PrestaShop can provide you with guidance on a regular basis by sending you tips on how to optimize the management of your store which will help you grow your business. If you do not wish to receive these tips, you can disable this option.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:306</note>
+        <note>Line: 328</note>
       </trans-unit>
       <trans-unit id="c4e326fcaa83c6b1ca3856175bb86d2e">
         <source>This page will be displayed just after login.</source>
         <target>This page will be displayed just after login.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:312</note>
+        <note>Line: 334</note>
       </trans-unit>
       <trans-unit id="d970370797ba19bba5524b480d3526fb">
         <source>Allow or disallow this employee to log in to the Admin panel.</source>
         <target>Allow or disallow this employee to log in to the Admin panel.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:347</note>
+        <note>Line: 369</note>
       </trans-unit>
       <trans-unit id="7bc873cba11f035df692c3549366c722">
         <source>-- Choose --</source>
         <target>-- Choose --</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:370</note>
+        <note>Line: 392</note>
       </trans-unit>
       <trans-unit id="1a7f0b984884e66e95a86b9b5d857b5b">
         <source>Select the shops the employee is allowed to access.</source>
         <target>Select the shops the employee is allowed to access.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:380</note>
+        <note>Line: 402</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice_settings.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="e8602bda90ef985a71054950e6f1981e">
-        <source>Before activating the webservice, you must be sure to: </source>
-        <target>Before activating the webservice, you must be sure to:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice_settings.html.twig:46</note>
+      <trans-unit id="11cd708df7411da4546d8580356e711a">
+        <source>Ignore this field if you don't use the Multistore tool. If you leave this field empty, the default shop will be used.</source>
+        <target>Ignore this field if you don't use the Multistore tool. If you leave this field empty, the default shop will be used.</target>
+        <note>Line: 516</note>
       </trans-unit>
-      <trans-unit id="45d7b1d28cb1afbb45fdb620db725c10">
-        <source>Check that URL rewriting is available on this server.</source>
-        <target>Check that URL rewriting is available on this server.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice_settings.html.twig:48</note>
+      <trans-unit id="5702db29cfdd93934ed330edb201ecf3">
+        <source>Enable Advanced Stock Management on product (0 = No, 1 = Yes)</source>
+        <target>Enable Advanced Stock Management on product (0 = No, 1 = Yes)</target>
+        <note>Line: 156</note>
       </trans-unit>
-      <trans-unit id="60da463f081084680c973ec554a995bb">
-        <source>Check that the five methods GET, POST, PUT, DELETE and HEAD are supported by this server.</source>
-        <target>Check that the five methods GET, POST, PUT, DELETE and HEAD are supported by this server.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice_settings.html.twig:50</note>
+      <trans-unit id="2d743ae4c74db2a22d79e1e950e719e5">
+        <source>0 = Use quantity set in product, 1 = Use quantity from warehouse.</source>
+        <target>0 = Use quantity set in product, 1 = Use quantity from warehouse.</target>
+        <note>Line: 318</note>
       </trans-unit>
-      <trans-unit id="c03f07bc287e77654a26af409b4d93fa">
-        <source>Before choosing "Yes", check that PHP is not configured as an Apache module on your server.</source>
-        <target>Before choosing "Yes", check that PHP is not configured as an Apache module on your server.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice_settings.html.twig:63</note>
+      <trans-unit id="aaf88088b0ac3f2992888fdfe00b5d76">
+        <source>ID of the warehouse to set as storage.</source>
+        <target>ID of the warehouse to set as storage.</target>
+        <note>Line: 322</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminWebserviceController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a5cb039db72d4c240b6cca34b48d61bc">
-        <source>Quick description of the key: who it is for, what permissions it has, etc.</source>
-        <target>Quick description of the key: who it is for, what permissions it has, etc.</target>
-        <note>Context:
-File: controllers/admin/AdminWebserviceController.php:150</note>
+      <trans-unit id="4bc14a0f722453ba235bc3fb52d95ffb">
+        <source>A category root is where a category tree can begin. This is used with multistore.</source>
+        <target>A category root is where a category tree can begin. This is used with multistore.</target>
+        <note>Line: 197</note>
+      </trans-unit>
+      <trans-unit id="7506b41cf1aa65b2663b038e465c0d6d">
+        <source>Enable Advanced Stock Management on product (0 = No, 1 = Yes).</source>
+        <target>Enable Advanced Stock Management on product (0 = No, 1 = Yes).</target>
+        <note>Line: 314</note>
+      </trans-unit>
+      <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">
+        <source>or</source>
+        <target>or</target>
+        <note>Line: 1005
+Comment: Special case for Product : either one or the other. Not both.</note>
       </trans-unit>
     </body>
   </file>
@@ -188,60 +138,22 @@ File: controllers/admin/AdminWebserviceController.php:150</note>
       <trans-unit id="c127560c7252928dc38d9a0ebf312ba4">
         <source>Use this option to associate data (products, modules, etc.) the same way for each selected shop.</source>
         <target>Use this option to associate data (products, modules, etc.) the same way for each selected shop.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:598</note>
+        <note>Line: 598</note>
       </trans-unit>
       <trans-unit id="41ff4b3ea277bdc597fce74850a85510">
         <source>Click here to display the shops in the %name% shop group</source>
         <target>Click here to display the shops in the %name% shop group</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:776</note>
+        <note>Line: 776</note>
       </trans-unit>
       <trans-unit id="d916f5b0696f10712fad55220707fab9">
         <source>Click here to display the URLs of the %name% shop</source>
         <target>Click here to display the URLs of the %name% shop</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:798</note>
+        <note>Line: 798</note>
       </trans-unit>
       <trans-unit id="01af4d9c4808ce3ccd662c0e5ef7f203">
         <source>Click here to display the list of shop groups</source>
         <target>Click here to display the list of shop groups</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:850</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/list.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="68db67219aa1fd6e5f8820e20fd78b25">
-        <source>How do I create a new SQL query?</source>
-        <target>How do I create a new SQL query?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/list.html.twig:34</note>
-      </trans-unit>
-      <trans-unit id="555f1c93c6aa30a9b28e5cb37eaade53">
-        <source>Click "Add New".</source>
-        <target>Click "Add New".</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/list.html.twig:36</note>
-      </trans-unit>
-      <trans-unit id="b7ccdf6ab58f5514acc520721ddc9f08">
-        <source>Fill in the fields and click "Save".</source>
-        <target>Fill in the fields and click "Save".</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/list.html.twig:37</note>
-      </trans-unit>
-      <trans-unit id="64427cd6d9efe12b779a1e3bb2fafc06">
-        <source>You can then view the query results by clicking on the Edit action in the dropdown menu</source>
-        <target>You can then view the query results by clicking on the Edit action in the dropdown menu</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/list.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="29147406190a86209d5f4b3080cc7fa9">
-        <source>You can also export the query results as a CSV file by clicking on the Export button</source>
-        <target>You can also export the query results as a CSV file by clicking on the Export button</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/list.html.twig:39</note>
+        <note>Line: 850</note>
       </trans-unit>
     </body>
   </file>
@@ -250,264 +162,109 @@ File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Re
       <trans-unit id="0c2afe3d3eb02183ee182aa447608bc4">
         <source>Warning: Enabling the "share customers" and "share orders" options is not recommended. Once activated and orders are created, you will not be able to disable these options. If you need these options, we recommend using several categories rather than several shops.</source>
         <target>Warning: Enabling the "share customers" and "share orders" options is not recommended. Once activated and orders are created, you will not be able to disable these options. If you need these options, we recommend using several categories rather than several shops.</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:180</note>
+        <note>Line: 180</note>
       </trans-unit>
       <trans-unit id="ee5d0efc6b5d41f7ee2ac5ea831f2a7f">
         <source>Once this option is enabled, the shops in this group will share customers. If a customer registers in any one of these shops, the account will automatically be available in the others shops of this group.</source>
         <target>Once this option is enabled, the shops in this group will share customers. If a customer registers in any one of these shops, the account will automatically be available in the others shops of this group.</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:206</note>
+        <note>Line: 206</note>
       </trans-unit>
       <trans-unit id="dace58c348a19d7bddb7a3fe4fd3ebfa">
         <source>Warning: you will not be able to disable this option once you have registered customers.</source>
         <target>Warning: you will not be able to disable this option once you have registered customers.</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:206</note>
+        <note>Line: 206</note>
       </trans-unit>
       <trans-unit id="059a6f0b1a0a28d15ee51fe80670f6f2">
         <source>Once this option is enabled (which is only possible if customers and available quantities are shared among shops), the customer's cart will be shared by all shops in this group. This way, any purchase started in one shop will be able to be completed in another shop from the same group.</source>
         <target>Once this option is enabled (which is only possible if customers and available quantities are shared among shops), the customer's cart will be shared by all shops in this group. This way, any purchase started in one shop will be able to be completed in another shop from the same group.</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:245</note>
+        <note>Line: 245</note>
       </trans-unit>
       <trans-unit id="697ce708715d1f771177623968e8c6a4">
         <source>Warning: You will not be able to disable this option once you've started to accept orders.</source>
         <target>Warning: You will not be able to disable this option once you've started to accept orders.</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:245</note>
+        <note>Line: 245</note>
       </trans-unit>
       <trans-unit id="e667b16af30e0820218ad32242e284dc">
         <source>Enable or disable this shop group?</source>
         <target>Enable or disable this shop group?</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:264</note>
+        <note>Line: 264</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/admin/AdminShopUrlController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c688fbbc9468ea3473172ca924290860">
+        <source>If you want to add a virtual URL, you need to activate URL rewriting on your web server and enable Friendly URL option.</source>
+        <target>If you want to add a virtual URL, you need to activate URL rewriting on your web server and enable Friendly URL option.</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="05f8f0fab3ff5d86e0de9db902da7045">
+        <source>You can use this option if you want to create a store with a URL that doesn't exist on your server (e.g. if you want your store to be available with the URL www.example.com/my-store/shoes/, you have to set shoes/ in this field, assuming that my-store/ is your Physical URL).</source>
+        <target>You can use this option if you want to create a store with a URL that doesn't exist on your server (e.g. if you want your store to be available with the URL www.example.com/my-store/shoes/, you have to set shoes/ in this field, assuming that my-store/ is your Physical URL).</target>
+        <note>Line: 127</note>
+      </trans-unit>
+      <trans-unit id="f6e7829277b67d5a8805d6728a810362">
+        <source>URL rewriting must be activated on your server to use this feature.</source>
+        <target>URL rewriting must be activated on your server to use this feature.</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="a2e8a639b5fd3e34ab4def1e7aac3383">
+        <source>If you set this URL as the Main URL for the selected shop, all URLs set to this shop will be redirected to this URL (you can only have one Main URL per shop).</source>
+        <target>If you set this URL as the Main URL for the selected shop, all URLs set to this shop will be redirected to this URL (you can only have one Main URL per shop).</target>
+        <note>Line: 173</note>
+      </trans-unit>
+      <trans-unit id="819e18d335155ef4a9cdfe926ac8a3de">
+        <source>Since the selected shop has no main URL, you have to set this URL as the Main URL.</source>
+        <target>Since the selected shop has no main URL, you have to set this URL as the Main URL.</target>
+        <note>Line: 175</note>
+      </trans-unit>
+      <trans-unit id="fe42e7cf02611b9719a6db6513de19eb">
+        <source>The selected shop already has a Main URL. Therefore, if you set this one as the Main URL, the older Main URL will be set as a regular URL.</source>
+        <target>The selected shop already has a Main URL. Therefore, if you set this one as the Main URL, the older Main URL will be set as a regular URL.</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="7e7b350e5cee624789b1e263ec59db26">
+        <source>This is the physical folder for your store on the web server. Leave this field empty if your store is installed on the root path. For instance, if your store is available at www.example.com/my-store/, you must input my-store/ in this field.</source>
+        <target>This is the physical folder for your store on the web server. Leave this field empty if your store is installed on the root path. For instance, if your store is available at www.example.com/my-store/, you must input my-store/ in this field.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="29f3eb1bea3049b52600a18ad4d0b96c">
+        <source>Warning: URL rewriting (e.g. mod_rewrite for Apache) seems to be disabled. If your Virtual URL doesn't work, please check with your hosting provider on how to activate URL rewriting.</source>
+        <target>Warning: URL rewriting (e.g. mod_rewrite for Apache) seems to be disabled. If your Virtual URL doesn't work, please check with your hosting provider on how to activate URL rewriting.</target>
+        <note>Line: 257</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminWebserviceController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a5cb039db72d4c240b6cca34b48d61bc">
+        <source>Quick description of the key: who it is for, what permissions it has, etc.</source>
+        <target>Quick description of the key: who it is for, what permissions it has, etc.</target>
+        <note>Line: 150</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/severity_level.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="b80c52e7f679fba3c2837b42705fe779">
         <source>Informative only</source>
         <target>Informative only</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig:37</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="0eaadb4fcb48a0a0ed7bc9868be9fbaa">
         <source>Warning</source>
         <target>Warning</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig:42</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="902b0d55fddef6f8d651fe1035b7d4bd">
         <source>Error</source>
         <target>Error</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig:47</note>
+        <note>Line: 37</note>
       </trans-unit>
       <trans-unit id="4a378407770df6a42474ec5db9f54740">
         <source>Major issue (crash)!</source>
         <target>Major issue (crash)!</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="3979bb684920e9e9dc86e266f93d8c87">
-        <source>Severity levels</source>
-        <target>Severity levels</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig:29</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="25047dda7ccdbdb758df436ada087c4e">
-        <source>Enter "5" if you do not want to receive any emails.</source>
-        <target>Enter "5" if you do not want to receive any emails.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig:55</note>
-      </trans-unit>
-      <trans-unit id="0250518090d13c807ece595694bffa98">
-        <source>Emails will be sent to the shop owner.</source>
-        <target>Emails will be sent to the shop owner.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/logs.html.twig:55</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="99059a2047f475cdc6428076e3360134">
-        <source>New modules and updates are displayed on the modules page.</source>
-        <target>New modules and updates are displayed on the modules page.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:43</note>
-      </trans-unit>
-      <trans-unit id="0f81567617bb8ebc23f48e74d8ae8acf">
-        <source>Check the IP address of the cookie in order to prevent your cookie from being stolen.</source>
-        <target>Check the IP address of the cookie in order to prevent your cookie from being stolen.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:50</note>
-      </trans-unit>
-      <trans-unit id="20d6b6498eab9f749d55c9b53151e00a">
-        <source>Set the amount of hours during which the front office cookies are valid. After that amount of time, the customer will have to log in again.</source>
-        <target>Set the amount of hours during which the front office cookies are valid. After that amount of time, the customer will have to log in again.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:57</note>
-      </trans-unit>
-      <trans-unit id="a676520f8296be0319ad6268657471ea">
-        <source>Set the amount of hours during which the back office cookies are valid. After that amount of time, the PrestaShop user will have to log in again.</source>
-        <target>Set the amount of hours during which the back office cookies are valid. After that amount of time, the PrestaShop user will have to log in again.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:64</note>
-      </trans-unit>
-      <trans-unit id="a067e61c044ba333fae23b61c83d87c4">
-        <source>Set the maximum size allowed for attachment files (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</source>
-        <target>Set the maximum size allowed for attachment files (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:91</note>
-      </trans-unit>
-      <trans-unit id="dae623d110235f2837ca0a6e753305b8">
-        <source>Define the upload limit for a downloadable product (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</source>
-        <target>Define the upload limit for a downloadable product (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:98</note>
-      </trans-unit>
-      <trans-unit id="2a59c5a630e01a9a88e9bcb2863fd69f">
-        <source>Define the upload limit for an image (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</source>
-        <target>Define the upload limit for an image (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:105</note>
-      </trans-unit>
-      <trans-unit id="2566fed9ede40ae26636b773594094cf">
-        <source>Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop's name. They display the number of new items since you last clicked on them.</source>
-        <target>Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop's name. They display the number of new items since you last clicked on them.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:134</note>
-      </trans-unit>
-      <trans-unit id="e0853b619fbd24fdabc3ae78beb81193">
-        <source>This will display notifications when new orders are made in your shop.</source>
-        <target>This will display notifications when new orders are made in your shop.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:139</note>
-      </trans-unit>
-      <trans-unit id="11b3df1e92b11e2d899494d3cdf4dd13">
-        <source>This will display notifications every time a new customer registers in your shop.</source>
-        <target>This will display notifications every time a new customer registers in your shop.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:146</note>
-      </trans-unit>
-      <trans-unit id="b8a8fa662505e278031049e4990e428a">
-        <source>This will display notifications when new messages are posted in your shop.</source>
-        <target>This will display notifications when new messages are posted in your shop.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:153</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="084ad8abffc138f8d43f0a77824396b9">
-        <source>You can read information on import at:</source>
-        <target>You can read information on import at:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="4e7357d876d6d15fe084be41934e6555">
-        <source>http://doc.prestashop.com/display/PS17/Import</source>
-        <target>http://doc.prestashop.com/display/PS17/Import</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="9d23c31f2dcc1ace9296037f327563a4">
-        <source>https://en.wikipedia.org/wiki/Comma-separated_values</source>
-        <target>https://en.wikipedia.org/wiki/Comma-separated_values</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="a27780d9bb7b3595998465aadcaaeed7">
-        <source>Allowed formats: .csv, .xls, .xlsx, .xlst, .ods, .ots</source>
-        <target>Allowed formats: .csv, .xls, .xlsx, .xlst, .ods, .ots</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:87</note>
-      </trans-unit>
-      <trans-unit id="c9f7248e8f5712f5438def77389e1c46">
-        <source>Only UTF-8 and ISO 8859-1 encodings are allowed</source>
-        <target>Only UTF-8 and ISO 8859-1 encodings are allowed</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:88</note>
-      </trans-unit>
-      <trans-unit id="6578c8c9a3dbadb0a3672c3ca6c0b513">
-        <source>You can also upload your file via FTP to the following directory: %s .</source>
-        <target>You can also upload your file via FTP to the following directory: %s .</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:89</note>
-      </trans-unit>
-      <trans-unit id="b070d64c5a2f10b4b8eb361ba4f61833">
-        <source>e.g. </source>
-        <target>e.g. </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:211</note>
-      </trans-unit>
-      <trans-unit id="1d3be023802846145f9b75fc90b4cf21">
-        <source>If enabled, the product's reference number MUST be unique!</source>
-        <target>If enabled, the product's reference number MUST be unique!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:236</note>
-      </trans-unit>
-      <trans-unit id="f66963da2d51d637afa80ff8edf8d734">
-        <source>If you enable this option, your imported items' ID number will be used as is. If you do not enable this option, the imported ID numbers will be ignored, and PrestaShop will instead create auto-incremented ID numbers for all the imported items.</source>
-        <target>If you enable this option, your imported items' ID number will be used as is. If you do not enable this option, the imported ID numbers will be ignored, and PrestaShop will instead create auto-incremented ID numbers for all the imported items.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:266</note>
-      </trans-unit>
-      <trans-unit id="04d39f4c0f667d58c8c5540514ebf0eb">
-        <source>Sends an email to let you know your import is complete. It can be useful when handling large files, as the import may take some time.</source>
-        <target>Sends an email to let you know your import is complete. It can be useful when handling large files, as the import may take some time.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:283</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3bb4a695db0c87a3d70a2deffddeb743">
-        <source>Read more about the CSV format at:</source>
-        <target>Read more about the CSV format at:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a60bc065c0296646c5a07e55c0cfff6e">
-        <source>Fully qualified domain name (keep this field empty if you don't know).</source>
-        <target>Fully qualified domain name (keep this field empty if you don't know).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig:36</note>
-      </trans-unit>
-      <trans-unit id="2a3c280f73a3389c6ba4b2d87c8aa15f">
-        <source>IP address or server name (e.g. smtp.mydomain.com).</source>
-        <target>IP address or server name (e.g. smtp.mydomain.com).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig:44</note>
-      </trans-unit>
-      <trans-unit id="a5d35e0a66d41c7d12c0df6e643fa0ff">
-        <source>Leave blank if not applicable.</source>
-        <target>Leave blank if not applicable.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig:60</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e6f52e23510fd010aa5460c96fd67142">
-        <source>Where customers send messages from the order page.</source>
-        <target>Where customers send messages from the order page.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig:41</note>
+        <note>Line: 40</note>
       </trans-unit>
     </body>
   </file>
@@ -516,74 +273,62 @@ File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Em
       <trans-unit id="20fbc8f64351875f498d7d6f8c91810b">
         <source>How to restore a database backup in 10 easy steps</source>
         <target>How to restore a database backup in 10 easy steps</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:36</note>
+        <note>Line: 36</note>
       </trans-unit>
       <trans-unit id="7bf215c957e661c3bd8ad7f6221675c9">
         <source>Set "Enable Shop" to "No" in the "Maintenance" page under the "Preferences" menu.</source>
         <target>Set "Enable Shop" to "No" in the "Maintenance" page under the "Preferences" menu.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:38</note>
+        <note>Line: 38</note>
       </trans-unit>
       <trans-unit id="2dc09c116021fe75dd928d368a35e9d7">
         <source>Download the backup from the list below or from your FTP server (in the folder "admin/backups").</source>
         <target>Download the backup from the list below or from your FTP server (in the folder "admin/backups").</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:39</note>
+        <note>Line: 39</note>
       </trans-unit>
       <trans-unit id="3a86c87939c6bbaba4cb2e44e4734146">
         <source>Check the backup integrity: Look for errors, incomplete file, etc... Be sure to verify all of your data.</source>
         <target>Check the backup integrity: Look for errors, incomplete file, etc... Be sure to verify all of your data.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:40</note>
+        <note>Line: 40</note>
       </trans-unit>
       <trans-unit id="0ba394816eab81959ea7c442801b0819">
         <source>Please ask your hosting provider for "phpMyAdmin" access to your database.</source>
         <target>Please ask your hosting provider for "phpMyAdmin" access to your database.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="04abc58df1575dd465a28c86d859d302">
         <source>Connect to "phpMyAdmin" and select your current database.</source>
         <target>Connect to "phpMyAdmin" and select your current database.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:42</note>
+        <note>Line: 42</note>
       </trans-unit>
       <trans-unit id="197ebd1d022def92dd1c64aae3320d6a">
         <source>Unless you enabled the "Drop existing tables" option, you must delete all tables from your current database.</source>
         <target>Unless you enabled the "Drop existing tables" option, you must delete all tables from your current database.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="7d6044f9c5ec3bb7b89ac9328a871b2f">
         <source>At the top of the screen, please select the "Import" tab</source>
         <target>At the top of the screen, please select the "Import" tab</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:44</note>
+        <note>Line: 44</note>
       </trans-unit>
       <trans-unit id="6463499cc4522ee5cef415d727f543a3">
         <source>Click on the "Browse" button and select the backup file from your hard drive.</source>
         <target>Click on the "Browse" button and select the backup file from your hard drive.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="85614411a0c7c3eb8c7c7a81be9fb918">
         <source>Check the maximum filesize allowed (e.g. Max: 16MB)</source>
         <target>Check the maximum filesize allowed (e.g. Max: 16MB)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="d24e59c4885823395588f1b480876da5">
         <source>If your backup file exceeds this limit, contact your hosting provider for assistance. </source>
         <target>If your backup file exceeds this limit, contact your hosting provider for assistance.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="44b2f277fe0d0365bbc168e617387c73">
         <source>Click on the "Go" button and please wait patiently for the import process to conclude. This may take several minutes.</source>
         <target>Click on the "Go" button and please wait patiently for the import process to conclude. This may take several minutes.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:50</note>
+        <note>Line: 50</note>
       </trans-unit>
     </body>
   </file>
@@ -592,20 +337,189 @@ File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Ba
       <trans-unit id="1589ac76f2f88749f51028f09b23f9d4">
         <source>Drop existing tables during import.</source>
         <target>Drop existing tables during import.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig:44</note>
+        <note>Line: 44</note>
       </trans-unit>
       <trans-unit id="b07ccf1ffff29007509d45dbcc13f923">
         <source>If enabled, the backup script will drop your tables prior to restoring data.</source>
         <target>If enabled, the backup script will drop your tables prior to restoring data.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig:51</note>
+        <note>Line: 51</note>
       </trans-unit>
       <trans-unit id="2e25562aa49c13b17e979d826fecc25f">
         <source>(ie. "DROP TABLE IF EXISTS")</source>
         <target>(ie. "DROP TABLE IF EXISTS")</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig:52</note>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3bb4a695db0c87a3d70a2deffddeb743">
+        <source>Read more about the CSV format at:</source>
+        <target>Read more about the CSV format at:</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e6f52e23510fd010aa5460c96fd67142">
+        <source>Where customers send messages from the order page.</source>
+        <target>Where customers send messages from the order page.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a60bc065c0296646c5a07e55c0cfff6e">
+        <source>Fully qualified domain name (keep this field empty if you don't know).</source>
+        <target>Fully qualified domain name (keep this field empty if you don't know).</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="2a3c280f73a3389c6ba4b2d87c8aa15f">
+        <source>IP address or server name (e.g. smtp.mydomain.com).</source>
+        <target>IP address or server name (e.g. smtp.mydomain.com).</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="a5d35e0a66d41c7d12c0df6e643fa0ff">
+        <source>Leave blank if not applicable.</source>
+        <target>Leave blank if not applicable.</target>
+        <note>Line: 60</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3979bb684920e9e9dc86e266f93d8c87">
+        <source>Severity levels</source>
+        <target>Severity levels</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="25047dda7ccdbdb758df436ada087c4e">
+        <source>Enter "5" if you do not want to receive any emails.</source>
+        <target>Enter "5" if you do not want to receive any emails.</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="0250518090d13c807ece595694bffa98">
+        <source>Emails will be sent to the shop owner.</source>
+        <target>Emails will be sent to the shop owner.</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/list.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="68db67219aa1fd6e5f8820e20fd78b25">
+        <source>How do I create a new SQL query?</source>
+        <target>How do I create a new SQL query?</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="555f1c93c6aa30a9b28e5cb37eaade53">
+        <source>Click "Add New".</source>
+        <target>Click "Add New".</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="b7ccdf6ab58f5514acc520721ddc9f08">
+        <source>Fill in the fields and click "Save".</source>
+        <target>Fill in the fields and click "Save".</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="64427cd6d9efe12b779a1e3bb2fafc06">
+        <source>You can then view the query results by clicking on the Edit action in the dropdown menu</source>
+        <target>You can then view the query results by clicking on the Edit action in the dropdown menu</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="29147406190a86209d5f4b3080cc7fa9">
+        <source>You can also export the query results as a CSV file by clicking on the Export button</source>
+        <target>You can also export the query results as a CSV file by clicking on the Export button</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/WebservicePage/webservice_settings.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e8602bda90ef985a71054950e6f1981e">
+        <source>Before activating the webservice, you must be sure to: </source>
+        <target>Before activating the webservice, you must be sure to:</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="45d7b1d28cb1afbb45fdb620db725c10">
+        <source>Check that URL rewriting is available on this server.</source>
+        <target>Check that URL rewriting is available on this server.</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="60da463f081084680c973ec554a995bb">
+        <source>Check that the five methods GET, POST, PUT, DELETE and HEAD are supported by this server.</source>
+        <target>Check that the five methods GET, POST, PUT, DELETE and HEAD are supported by this server.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="c03f07bc287e77654a26af409b4d93fa">
+        <source>Before choosing "Yes", check that PHP is not configured as an Apache module on your server.</source>
+        <target>Before choosing "Yes", check that PHP is not configured as an Apache module on your server.</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="99059a2047f475cdc6428076e3360134">
+        <source>New modules and updates are displayed on the modules page.</source>
+        <target>New modules and updates are displayed on the modules page.</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="0f81567617bb8ebc23f48e74d8ae8acf">
+        <source>Check the IP address of the cookie in order to prevent your cookie from being stolen.</source>
+        <target>Check the IP address of the cookie in order to prevent your cookie from being stolen.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="20d6b6498eab9f749d55c9b53151e00a">
+        <source>Set the amount of hours during which the front office cookies are valid. After that amount of time, the customer will have to log in again.</source>
+        <target>Set the amount of hours during which the front office cookies are valid. After that amount of time, the customer will have to log in again.</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="a676520f8296be0319ad6268657471ea">
+        <source>Set the amount of hours during which the back office cookies are valid. After that amount of time, the PrestaShop user will have to log in again.</source>
+        <target>Set the amount of hours during which the back office cookies are valid. After that amount of time, the PrestaShop user will have to log in again.</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="a067e61c044ba333fae23b61c83d87c4">
+        <source>Set the maximum size allowed for attachment files (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</source>
+        <target>Set the maximum size allowed for attachment files (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="dae623d110235f2837ca0a6e753305b8">
+        <source>Define the upload limit for a downloadable product (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</source>
+        <target>Define the upload limit for a downloadable product (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="2a59c5a630e01a9a88e9bcb2863fd69f">
+        <source>Define the upload limit for an image (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</source>
+        <target>Define the upload limit for an image (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="2566fed9ede40ae26636b773594094cf">
+        <source>Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop's name. They display the number of new items since you last clicked on them.</source>
+        <target>Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop's name. They display the number of new items since you last clicked on them.</target>
+        <note>Line: 134</note>
+      </trans-unit>
+      <trans-unit id="e0853b619fbd24fdabc3ae78beb81193">
+        <source>This will display notifications when new orders are made in your shop.</source>
+        <target>This will display notifications when new orders are made in your shop.</target>
+        <note>Line: 139</note>
+      </trans-unit>
+      <trans-unit id="11b3df1e92b11e2d899494d3cdf4dd13">
+        <source>This will display notifications every time a new customer registers in your shop.</source>
+        <target>This will display notifications every time a new customer registers in your shop.</target>
+        <note>Line: 146</note>
+      </trans-unit>
+      <trans-unit id="b8a8fa662505e278031049e4990e428a">
+        <source>This will display notifications when new messages are posted in your shop.</source>
+        <target>This will display notifications when new messages are posted in your shop.</target>
+        <note>Line: 153</note>
       </trans-unit>
     </body>
   </file>
@@ -614,74 +528,62 @@ File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Ba
       <trans-unit id="30c802194b54f04e24a2abdc774c2f7e">
         <source>Should be enabled if you want to avoid to store the smarty cache on NFS.</source>
         <target>Should be enabled if you want to avoid to store the smarty cache on NFS.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:60</note>
+        <note>Line: 60</note>
       </trans-unit>
       <trans-unit id="853f64470ff7bb429d4d1febf19a2d58">
         <source>Enable or disable debug mode.</source>
         <target>Enable or disable debug mode.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:115</note>
+        <note>Line: 115</note>
       </trans-unit>
       <trans-unit id="bb3656a5447418f8f2644f3ac91b5c6f">
         <source>Some features can be disabled in order to improve performance.</source>
         <target>Some features can be disabled in order to improve performance.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:144</note>
+        <note>Line: 144</note>
       </trans-unit>
       <trans-unit id="dadb7368382c41e65db131dde4acbddd">
         <source>Choose "No" to disable Product Combinations.</source>
         <target>Choose "No" to disable Product Combinations.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:149</note>
+        <note>Line: 149</note>
       </trans-unit>
       <trans-unit id="31d21c53f8b07a3adcac80c8fab067db">
         <source>You cannot set this parameter to No when combinations are already used by some of your products</source>
         <target>You cannot set this parameter to No when combinations are already used by some of your products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:159</note>
+        <note>Line: 159</note>
       </trans-unit>
       <trans-unit id="755b5f88357c721918923199f02a127d">
         <source>Choose "No" to disable Product Features.</source>
         <target>Choose "No" to disable Product Features.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:165</note>
+        <note>Line: 165</note>
       </trans-unit>
       <trans-unit id="07e451f21d83658a364e0548c86926b3">
         <source>Choose "No" to disable Customer Groups.</source>
         <target>Choose "No" to disable Customer Groups.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:172</note>
+        <note>Line: 172</note>
       </trans-unit>
       <trans-unit id="ecffc19cb5ada347980c0fd06ca337f4">
         <source>CCC allows you to reduce the loading time of your page. With these settings you will gain performance without even touching the code of your theme. Make sure, however, that your theme is compatible with PrestaShop 1.4+. Otherwise, CCC will cause problems.</source>
         <target>CCC allows you to reduce the loading time of your page. With these settings you will gain performance without even touching the code of your theme. Make sure, however, that your theme is compatible with PrestaShop 1.4+. Otherwise, CCC will cause problems.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:200</note>
+        <note>Line: 200</note>
       </trans-unit>
       <trans-unit id="021007c7da195ab112330b846e0b1cbb">
         <source>This will add directives to your .htaccess file, which should improve caching and compression.</source>
         <target>This will add directives to your .htaccess file, which should improve caching and compression.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:218</note>
+        <note>Line: 218</note>
       </trans-unit>
       <trans-unit id="7d7364eb90dcf245641e4139c6ab1a7c">
         <source>Name of the second domain of your shop, (e.g. myshop-media-server-1.com). If you do not have another domain, leave this field blank.</source>
         <target>Name of the second domain of your shop, (e.g. myshop-media-server-1.com). If you do not have another domain, leave this field blank.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:250</note>
+        <note>Line: 250</note>
       </trans-unit>
       <trans-unit id="80ca4dd5f99b6572c93cec540caff504">
         <source>Name of the third domain of your shop, (e.g. myshop-media-server-2.com). If you do not have another domain, leave this field blank.</source>
         <target>Name of the third domain of your shop, (e.g. myshop-media-server-2.com). If you do not have another domain, leave this field blank.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:257</note>
+        <note>Line: 257</note>
       </trans-unit>
       <trans-unit id="1e4e1915fcb0b296ce2ffb029b27d730">
         <source>Name of the fourth domain of your shop, (e.g. myshop-media-server-3.com). If you do not have another domain, leave this field blank.</source>
         <target>Name of the fourth domain of your shop, (e.g. myshop-media-server-3.com). If you do not have another domain, leave this field blank.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig:264</note>
+        <note>Line: 264</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminAdvparametersNotification.xlf
+++ b/app/Resources/translations/default/AdminAdvparametersNotification.xlf
@@ -1,1542 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="67df6a66c109fbe53bfa02dc398bc258">
-        <source>Can't add the voucher.</source>
-        <target>Can't add the voucher.</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:636</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="af395851b27882221a6df82c727bca3e">
-        <source>The import directory doesn't exist. Please check your file path.</source>
-        <target>The import directory doesn't exist. Please check your file path.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php:67</note>
-      </trans-unit>
-      <trans-unit id="c775530fad852632f78395a11820ba23">
-        <source>The import directory must be writable (CHMOD 755 / 777).</source>
-        <target>The import directory must be writable (CHMOD 755 / 777).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php:79</note>
-      </trans-unit>
-      <trans-unit id="8c9067e52e4440d8a20e74fdc745b0c6">
-        <source>No file was uploaded.</source>
-        <target>No file was uploaded.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php:176</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Import/File/FileUploader.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="68e8d36b17584f88614fb3201925a7ac">
-        <source>The uploaded file exceeds the upload_max_filesize directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess.</source>
-        <target>The uploaded file exceeds the upload_max_filesize directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess.</target>
-        <note>Context:
-File: src/Core/Import/File/FileUploader.php:111</note>
-      </trans-unit>
-      <trans-unit id="0bedafc96db94da3f85caa7101944eb5">
-        <source>The uploaded file exceeds the post_max_size directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess, for example:</source>
-        <target>The uploaded file exceeds the post_max_size directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess, for example:</target>
-        <note>Context:
-File: src/Core/Import/File/FileUploader.php:114</note>
-      </trans-unit>
-      <trans-unit id="4f12b222c9659d62afa795987259933f">
-        <source>The uploaded file was only partially uploaded.</source>
-        <target>The uploaded file was only partially uploaded.</target>
-        <note>Context:
-File: src/Core/Import/File/FileUploader.php:118</note>
-      </trans-unit>
-      <trans-unit id="fc2e88db6e13898dab6ddf3b44c5d68a">
-        <source>The extension of your file should be .csv.</source>
-        <target>The extension of your file should be .csv.</target>
-        <note>Context:
-File: src/Core/Import/File/FileUploader.php:130</note>
-      </trans-unit>
-      <trans-unit id="50844c635a86264cc59d737d532df573">
-        <source>An error occurred while uploading / copying the file.</source>
-        <target>An error occurred while uploading / copying the file.</target>
-        <note>Context:
-File: src/Core/Import/File/FileUploader.php:90</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5b8f192b08644fdc9fd1fd86bcbbc57b">
-        <source>(click to open "Generators" page)</source>
-        <target>(click to open "Generators" page)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:731</note>
-      </trans-unit>
-      <trans-unit id="a080a85258618039d010a2136f85e69f">
-        <source>There is an empty row in the file that won't be imported.</source>
-        <target>There is an empty row in the file that won't be imported.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3725</note>
-      </trans-unit>
-      <trans-unit id="53d9fc1aa79e85c0f845139c6358daee">
-        <source>The category ID must be unique. It can't be the same as the one for Root or Home category.</source>
-        <target>The category ID must be unique. It can't be the same as the one for Root or Home category.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1309</note>
-      </trans-unit>
-      <trans-unit id="7a1bebdbf5770873f8172ecf27b2aa50">
-        <source>The category ID must be unique. It can't be the same as the one for the parent category (ID: %1$s).</source>
-        <target>The category ID must be unique. It can't be the same as the one for the parent category (ID: %1$s).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1332</note>
-      </trans-unit>
-      <trans-unit id="521531266ae042d0725d7a4aa22a49f4">
-        <source>A category can't be its own parent. You should rename it (current name: %1$s).</source>
-        <target>A category can't be its own parent. You should rename it (current name: %1$s).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1347</note>
-      </trans-unit>
-      <trans-unit id="1123af3eab25b7475419fcaecc6c3beb">
-        <source>%category_name% (ID: %id%) cannot be saved</source>
-        <target>%category_name% (ID: %id%) cannot be saved</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1373</note>
-      </trans-unit>
-      <trans-unit id="6c1e9fe2a61808296a44cee372124bcb">
-        <source>URL rewriting failed to auto-generate a friendly URL for: %category_name%</source>
-        <target>URL rewriting failed to auto-generate a friendly URL for: %category_name%</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1401</note>
-      </trans-unit>
-      <trans-unit id="4798b868d51d8e259321deff0452c0f9">
-        <source>Rewrite link for %1$s (ID %2$s): re-written as %3$s.</source>
-        <target>Rewrite link for %1$s (ID %2$s): re-written as %3$s.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1869</note>
-      </trans-unit>
-      <trans-unit id="a118c8120ef45c8b1bed36f341fa45f1">
-        <source>A category cannot be its own parent. The parent category ID is either missing or unknown (ID: %1$s).</source>
-        <target>A category cannot be its own parent. The parent category ID is either missing or unknown (ID: %1$s).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1433</note>
-      </trans-unit>
-      <trans-unit id="7bc08d1a3178f4927b2c07a18f417b4b">
-        <source>The root category cannot be modified.</source>
-        <target>The root category cannot be modified.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1452</note>
-      </trans-unit>
-      <trans-unit id="50fe5f166bc7695a0c0db12ea8a346e7">
-        <source>cannot be copied.</source>
-        <target>cannot be copied.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3762</note>
-      </trans-unit>
-      <trans-unit id="87098ca5171ae766269f50b24ef3189d">
-        <source>%1$s (ID: %2$s) cannot be %3$s</source>
-        <target>%1$s (ID: %2$s) cannot be %3$s</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1478</note>
-      </trans-unit>
-      <trans-unit id="2666baaca25feea0b2dc641cfab50d8a">
-        <source>Unknown tax rule group ID. You need to create a group with this ID first.</source>
-        <target>Unknown tax rule group ID. You need to create a group with this ID first.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1713</note>
-      </trans-unit>
-      <trans-unit id="43bf950e043950e2da10f917b902c131">
-        <source>%1$s (ID: %2$s) cannot be saved</source>
-        <target>%1$s (ID: %2$s) cannot be saved</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3863</note>
-      </trans-unit>
-      <trans-unit id="994e8f1b72a9fe7a9e8949343be6bde7">
-        <source>%data% cannot be saved</source>
-        <target>%data% cannot be saved</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3836</note>
-      </trans-unit>
-      <trans-unit id="32fa1d06b5d0a192c9991c4bf038b30c">
-        <source>Shop is not valid</source>
-        <target>Shop is not valid</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:1993</note>
-      </trans-unit>
-      <trans-unit id="87aae49bd054f2cfa4b7b395dee5f2d3">
-        <source>Discount is invalid</source>
-        <target>Discount is invalid</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2068</note>
-      </trans-unit>
-      <trans-unit id="664d4132fc8dc3a158be4692b4246528">
-        <source>Tags list is invalid</source>
-        <target>Tags list is invalid</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2098</note>
-      </trans-unit>
-      <trans-unit id="6170902c7935d644e280e440a28d5975">
-        <source>Error copying image: %url%</source>
-        <target>Error copying image: %url%</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2471</note>
-      </trans-unit>
-      <trans-unit id="61e49f62654858f3cd3d9b23bee90d06">
-        <source>Product #%id%: the picture (%url%) cannot be saved.</source>
-        <target>Product #%id%: the picture (%url%) cannot be saved.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2163</note>
-      </trans-unit>
-      <trans-unit id="c2758df7a8c70260e3b55e26c51b65fd">
-        <source>Advanced stock management has incorrect value. Not set for product %name% </source>
-        <target>Advanced stock management has incorrect value. Not set for product %name%</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2207</note>
-      </trans-unit>
-      <trans-unit id="bb80841517f78647c5bee69710820c8d">
-        <source>Advanced stock management is not enabled, cannot enable on product %name% </source>
-        <target>Advanced stock management is not enabled, cannot enable on product %name%</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2209</note>
-      </trans-unit>
-      <trans-unit id="651e202913d9229ff615d5afd6a6a168">
-        <source>Advanced stock management is not enabled, warehouse not set on product %name% </source>
-        <target>Advanced stock management is not enabled, warehouse not set on product %name%</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2222</note>
-      </trans-unit>
-      <trans-unit id="470d8f3caa9e30c426f8d49779cc7a36">
-        <source>Warehouse did not exist, cannot set on product  %name% </source>
-        <target>Warehouse did not exist, cannot set on product  %name%</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2242</note>
-      </trans-unit>
-      <trans-unit id="3d52f8b2b1a67aa8740b72b3752d54f3">
-        <source>Incorrect value for "Depends on stock" for product %name% </source>
-        <target>Incorrect value for "Depends on stock" for product %name%</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2250</note>
-      </trans-unit>
-      <trans-unit id="65167d7a989d3a25c4f81a7140b07b8f">
-        <source>Advanced stock management is not enabled, cannot set "Depends on stock" for product %name% </source>
-        <target>Advanced stock management is not enabled, cannot set "Depends on stock" for product %name%</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2788</note>
-      </trans-unit>
-      <trans-unit id="5c8707f79dbdd3abb28a8aa09e34f02f">
-        <source>No image was found for combination with id_product = %s and image position = %s.</source>
-        <target>No image was found for combination with id_product = %s and image position = %s.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2510</note>
-      </trans-unit>
-      <trans-unit id="b672cb1c6a798cfb9f54de7dd897abd8">
-        <source>EAN13 "%ean13%" has incorrect value for product with id %id%.</source>
-        <target>EAN13 "%ean13%" has incorrect value for product with id %id%.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2630</note>
-      </trans-unit>
-      <trans-unit id="85b637ec0128d136bf3794c79f2e7295">
-        <source>Advanced stock management has incorrect value. Not set for product with id %id%.</source>
-        <target>Advanced stock management has incorrect value. Not set for product with id %id%.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2747</note>
-      </trans-unit>
-      <trans-unit id="934b46cf9eb8a8595ca517b87de6bfb4">
-        <source>Advanced stock management is not enabled, cannot enable on product with id %id%.</source>
-        <target>Advanced stock management is not enabled, cannot enable on product with id %id%.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2749</note>
-      </trans-unit>
-      <trans-unit id="0081b2a315ed28289036fa6cc02a3819">
-        <source>Advanced stock management is not enabled, warehouse is not set on product with id %id%.</source>
-        <target>Advanced stock management is not enabled, warehouse is not set on product with id %id%.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2762</note>
-      </trans-unit>
-      <trans-unit id="c24928943071d3366164238b9413a211">
-        <source>Warehouse did not exist, cannot set on product %name%.</source>
-        <target>Warehouse did not exist, cannot set on product %name%.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2778</note>
-      </trans-unit>
-      <trans-unit id="fd6d9d3ba7d4aaacc49f53c2e8c082c0">
-        <source>Email address %1$s (ID: %2$s) cannot be validated.</source>
-        <target>Email address %1$s (ID: %2$s) cannot be validated.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3068</note>
-      </trans-unit>
-      <trans-unit id="9a19980e3db9fa010269bb72d31ee42a">
-        <source>Email address %1$s (ID: %2$s) cannot be saved.</source>
-        <target>Email address %1$s (ID: %2$s) cannot be saved.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3077</note>
-      </trans-unit>
-      <trans-unit id="14118fbc7d8c233f0ac36ffb31716605">
-        <source>%1$s does not exist in database %2$s (ID: %3$s), and therefore cannot be validated</source>
-        <target>%1$s does not exist in database %2$s (ID: %3$s), and therefore cannot be validated</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3264</note>
-      </trans-unit>
-      <trans-unit id="597cf702e07f3b35431d2a499b00cefd">
-        <source>%1$s does not exist in database %2$s (ID: %3$s), and therefore cannot be saved</source>
-        <target>%1$s does not exist in database %2$s (ID: %3$s), and therefore cannot be saved</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3274</note>
-      </trans-unit>
-      <trans-unit id="b06766963f3b27f47f5e6ddf68d8f07e">
-        <source>"%email%" is not a valid email address.</source>
-        <target>"%email%" is not a valid email address.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3250</note>
-      </trans-unit>
-      <trans-unit id="4a69d9da990728e003654d32a0b283a4">
-        <source>The customer ID #%d does not exist in the database, and therefore cannot be validated.</source>
-        <target>The customer ID #%d does not exist in the database, and therefore cannot be validated.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3287</note>
-      </trans-unit>
-      <trans-unit id="608ec99cc3ef74d962769c1958a1fa62">
-        <source>The customer ID #%d does not exist in the database, and therefore cannot be saved.</source>
-        <target>The customer ID #%d does not exist in the database, and therefore cannot be saved.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3295</note>
-      </trans-unit>
-      <trans-unit id="964e5a863ba051181f8f537626f5c953">
-        <source>Supplier is invalid</source>
-        <target>Supplier is invalid</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3624</note>
-      </trans-unit>
-      <trans-unit id="3cc21b7970c348679cb6a1323a2dc173">
-        <source>Alias is invalid</source>
-        <target>Alias is invalid</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3701</note>
-      </trans-unit>
-      <trans-unit id="52629716aa86c04b8d81bc7e9522463f">
-        <source>Store is invalid</source>
-        <target>Store is invalid</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3870</note>
-      </trans-unit>
-      <trans-unit id="2e73276e5106584df31fd1cc5823ba81">
-        <source>Supplier ID (%id%) is not valid (at line %line%).</source>
-        <target>Supplier ID (%id%) is not valid (at line %line%).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3940</note>
-      </trans-unit>
-      <trans-unit id="5dbfdcc4de08ec893f55919dc4e872dc">
-        <source>Lang ID (%id%) is not valid (at line %line%).</source>
-        <target>Lang ID (%id%) is not valid (at line %line%).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3943</note>
-      </trans-unit>
-      <trans-unit id="f0cf11a8f6275d2bac5a189cbb41c689">
-        <source>Warehouse ID (%id%) is not valid (at line %line%).</source>
-        <target>Warehouse ID (%id%) is not valid (at line %line%).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3946</note>
-      </trans-unit>
-      <trans-unit id="b390e8c2a66fd018293fb44a5b8208c8">
-        <source>Currency ID (%id%) is not valid (at line %line%).</source>
-        <target>Currency ID (%id%) is not valid (at line %line%).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3949</note>
-      </trans-unit>
-      <trans-unit id="41a2fc826e4bd29b8eaf497a89a9dc5d">
-        <source>Reference (%ref%) already exists (at line %line%).</source>
-        <target>Reference (%ref%) already exists (at line %line%).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3955</note>
-      </trans-unit>
-      <trans-unit id="70e7a6fcceb39a1e3ea3925182b85d18">
-        <source>YYYY-MM-DD</source>
-        <target>YYYY-MM-DD</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3960</note>
-      </trans-unit>
-      <trans-unit id="c1be0fbaeb4e6b509e2f65240b7e5970">
-        <source>Date format (%date%) is not valid (at line %line%). It should be: %date_format%.</source>
-        <target>Date format (%date%) is not valid (at line %line%). It should be: %date_format%.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3958</note>
-      </trans-unit>
-      <trans-unit id="8cc169924951a04aea4f6a86334f3ce6">
-        <source>Date (%date%) cannot be in the past (at line %line%). Format: %date_format%.</source>
-        <target>Date (%date%) cannot be in the past (at line %line%). Format: %date_format%.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3960</note>
-      </trans-unit>
-      <trans-unit id="ef1a78ea7433cfc92f358d6dbf4fcd48">
-        <source>Format: Between 0 and 100</source>
-        <target>Format: Between 0 and 100</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4121</note>
-      </trans-unit>
-      <trans-unit id="e0b985fb06e1498649ed1cfd6f3fb3e4">
-        <source>Discount rate (%rate%) is not valid (at line %line%). %format%.</source>
-        <target>Discount rate (%rate%) is not valid (at line %line%). %format%.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3963</note>
-      </trans-unit>
-      <trans-unit id="3f2f635ad300e97bc217b69cc06dfc30">
-        <source>Supply Order (%id%) is not editable (at line %line%).</source>
-        <target>Supply Order (%id%) is not editable (at line %line%).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3968</note>
-      </trans-unit>
-      <trans-unit id="ad1ce5290a697ed3729cbd520432cf22">
-        <source>Supply Order could not be saved (at line %line%).</source>
-        <target>Supply Order could not be saved (at line %line%).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:3999</note>
-      </trans-unit>
-      <trans-unit id="bb19d4490bdc48656603c0a7ef30db73">
-        <source>Supply Order (%s) could not be loaded (at line %d).</source>
-        <target>Supply Order (%s) could not be loaded (at line %d).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4066</note>
-      </trans-unit>
-      <trans-unit id="5e063c49ce8203f2ca7a496da24b819e">
-        <source>Product/Attribute (%d/%d) cannot be added twice (at line %d).</source>
-        <target>Product/Attribute (%d/%d) cannot be added twice (at line %d).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4084</note>
-      </trans-unit>
-      <trans-unit id="0a657a7416c29bdc5b134b61b863e7ee">
-        <source>Product (%d/%d) is not available for this order (at line %d).</source>
-        <target>Product (%d/%d) is not available for this order (at line %d).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4096</note>
-      </trans-unit>
-      <trans-unit id="ca676c9ec4e1ae9fe9df3ac28910e6ef">
-        <source>Unit Price (tax excl.) (%d) is not valid (at line %d).</source>
-        <target>Unit Price (tax excl.) (%d) is not valid (at line %d).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4103</note>
-      </trans-unit>
-      <trans-unit id="406eba9770c82a84cae2d6ee3e846a56">
-        <source>Quantity Expected (%d) is not valid (at line %d).</source>
-        <target>Quantity Expected (%d) is not valid (at line %d).</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4118</note>
-      </trans-unit>
-      <trans-unit id="8f7627c77b01dc968a9665c0156da405">
-        <source>Discount rate (%d) is not valid (at line %d). %s.</source>
-        <target>Discount rate (%d) is not valid (at line %d). %s.</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4110</note>
-      </trans-unit>
-      <trans-unit id="243c959202a4f6ce7f1ccba6bc19ff08">
-        <source>Cannot read the .CSV file</source>
-        <target>Cannot read the .CSV file</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4209</note>
-      </trans-unit>
-      <trans-unit id="931bbbb741d025e3ff25ee3c2e72f414">
-        <source>Linking Accessories...</source>
-        <target>Linking Accessories...</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4475</note>
-      </trans-unit>
-      <trans-unit id="d165f0c742c272ed88dc27acc91e2642">
-        <source>%s import</source>
-        <target>%s import</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4554</note>
-      </trans-unit>
-      <trans-unit id="02b5205ddff3073efc5c8b5b9cc165ba">
-        <source>(from %s to %s)</source>
-        <target>(from %s to %s)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4556</note>
-      </trans-unit>
-      <trans-unit id="b53b06c0e98a2db123f953f0059a0948">
-        <source>with truncate</source>
-        <target>with truncate</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4559</note>
-      </trans-unit>
-      <trans-unit id="32de857e46ef2b55ce3582004fef7a95">
-        <source>The confirmation email couldn't be sent, but the import is successful. Yay!</source>
-        <target>The confirmation email couldn't be sent, but the import is successful. Yay!</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4687</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="197f1953efd11637a634a7f9b269eac3">
-        <source>To proceed, please upload a file first.</source>
-        <target>To proceed, please upload a file first.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormDataProvider.php:81</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d85366190ecd2aebf8363980ad9d6740">
-        <source>Importing your data...</source>
-        <target>Importing your data...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:76</note>
-      </trans-unit>
-      <trans-unit id="8a1d14318cfc965da76c0b9d0a53bb93">
-        <source>Aborting, please wait...</source>
-        <target>Aborting, please wait...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:27</note>
-      </trans-unit>
-      <trans-unit id="e130ff31fe5f7a054a2db876a7acc94d">
-        <source>Data imported!</source>
-        <target>Data imported!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:33</note>
-      </trans-unit>
-      <trans-unit id="118f9dbc8442c6be19dfc0b70d965929">
-        <source>Look at your listings to make sure it's all there as you wished.</source>
-        <target>Look at your listings to make sure it's all there as you wished.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="4959a069997257077022c1b96b3b8001">
-        <source>Errors occurred:</source>
-        <target>Errors occurred:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="0ccb924c3db6a900cff26de895f756b8">
-        <source>Warning, the current import may require a PHP setting update, to allow more data to be transferred. If the current import stops before the end, you should increase your PHP "post_max_size" setting to [1]%size%[/1]MB at least, and try again.</source>
-        <target>Warning, the current import may require a PHP setting update, to allow more data to be transferred. If the current import stops before the end, you should increase your PHP "post_max_size" setting to [1]%size%[/1]MB at least, and try again.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="841e4579e55a01ab8f0c565995ba7cfc">
-        <source>Some errors were detected. Please check the details:</source>
-        <target>Some errors were detected. Please check the details:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:49</note>
-      </trans-unit>
-      <trans-unit id="3df311b82f78fa4059e9a78a26e77b06">
-        <source>We made the following adjustments:</source>
-        <target>We made the following adjustments:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:52</note>
-      </trans-unit>
-      <trans-unit id="6e17621d481059924339f91ed431a116">
-        <source>Validating data...</source>
-        <target>Validating data...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:57</note>
-      </trans-unit>
-      <trans-unit id="95fdb0ead4798ff27cce78fac3fd3c11">
-        <source>[1]%percentage%[/1]% validated</source>
-        <target>[1]%percentage%[/1]% validated</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="fd2f43e6f9f4de5be1b08cdac13d7749">
-        <source>Processing next page...</source>
-        <target>Processing next page...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:92</note>
-      </trans-unit>
-      <trans-unit id="f438c83e3ff4dd40a3fc1bf4bb3e79f5">
-        <source>Linking accessories...</source>
-        <target>Linking accessories...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:81</note>
-      </trans-unit>
-      <trans-unit id="2a44b5ac9f88c57f584bf083730a93f7">
-        <source>[1]%size%[/1]% imported</source>
-        <target>[1]%size%[/1]% imported</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:84</note>
-      </trans-unit>
-      <trans-unit id="650e0b1fd707ad8ad3a94e2eb494de3d">
-        <source>Ignore warnings and continue?</source>
-        <target>Ignore warnings and continue?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:100</note>
-      </trans-unit>
-      <trans-unit id="b8388ec68dcac2402d944fbb3382b0f1">
-        <source>Abort import</source>
-        <target>Abort import</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl:104</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminProfilesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7d6f235518e595f4e988b6811d2ceeab">
-        <source>For security reasons, you cannot delete the Administrator's profile.</source>
-        <target>For security reasons, you cannot delete the Administrator's profile.</target>
-        <note>Context:
-File: controllers/admin/AdminProfilesController.php:101</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminEmployeesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a375d9230fd61b4a70ac109ab7b11082">
-        <source>You cannot edit the SuperAdmin profile.</source>
-        <target>You cannot edit the SuperAdmin profile.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:213</note>
-      </trans-unit>
-      <trans-unit id="cd34716bc68eb08479ddf16f17b2580e">
-        <source>The provided profile is invalid</source>
-        <target>The provided profile is invalid</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:407</note>
-      </trans-unit>
-      <trans-unit id="f5d44b60e38b28d19549bb7a107654ca">
-        <source>You cannot disable or delete your own account.</source>
-        <target>You cannot disable or delete your own account.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:453</note>
-      </trans-unit>
-      <trans-unit id="2450228823b8e17792cf687b8543b59d">
-        <source>You cannot disable or delete the administrator account.</source>
-        <target>You cannot disable or delete the administrator account.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:547</note>
-      </trans-unit>
-      <trans-unit id="8fd6c902e0a6186ebc62b4c3c65dc528">
-        <source>You cannot delete this account because it manages warehouses. Check your warehouses first.</source>
-        <target>You cannot delete this account because it manages warehouses. Check your warehouses first.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:468</note>
-      </trans-unit>
-      <trans-unit id="4220fb02fdc65e838a02a3b51c6f737f">
-        <source>Your current password is invalid.</source>
-        <target>Your current password is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:484</note>
-      </trans-unit>
-      <trans-unit id="1a33d52d73377516254da97f9fee027e">
-        <source>The confirmation password does not match.</source>
-        <target>The confirmation password does not match.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:486</note>
-      </trans-unit>
-      <trans-unit id="c7cd7ecd5b19e01f74cad32af30c9ac4">
-        <source>You should have at least one employee in the administrator group.</source>
-        <target>You should have at least one employee in the administrator group.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:541</note>
-      </trans-unit>
-      <trans-unit id="cfe45dd92c1b71a640ea19767578f38c">
-        <source>The employee must be associated with at least one shop.</source>
-        <target>The employee must be associated with at least one shop.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:556</note>
-      </trans-unit>
-      <trans-unit id="46cf0d0972e77638e099815140a0d302">
-        <source>The password must be at least %length% characters long.</source>
-        <target>The password must be at least %length% characters long.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:572</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminWebserviceController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="155657899b93f70358eed115631fdb04">
-        <source>Key length must be 32 character long.</source>
-        <target>Key length must be 32 character long.</target>
-        <note>Context:
-File: controllers/admin/AdminWebserviceController.php:248</note>
-      </trans-unit>
-      <trans-unit id="441006dbdaef41a163047624fe1241ab">
-        <source>This key already exists.</source>
-        <target>This key already exists.</target>
-        <note>Context:
-File: controllers/admin/AdminWebserviceController.php:251</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Webservice/ServerRequirementsChecker.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3a1d42e50ada009f2ef187fbf6dc8a3f">
-        <source>To avoid operating problems, please use an Apache server.</source>
-        <target>To avoid operating problems, please use an Apache server.</target>
-        <note>Context:
-File: src/Core/Webservice/ServerRequirementsChecker.php:156</note>
-      </trans-unit>
-      <trans-unit id="d6305f2f8c5c0f95a367e618a64bb458">
-        <source>Please activate the 'mod_auth_basic' Apache module to allow authentication of PrestaShop's webservice.</source>
-        <target>Please activate the 'mod_auth_basic' Apache module to allow authentication of PrestaShop's webservice.</target>
-        <note>Context:
-File: src/Core/Webservice/ServerRequirementsChecker.php:161</note>
-      </trans-unit>
-      <trans-unit id="e11a22a5910f9f84a6630ee78e1a39f5">
-        <source>Please activate the 'mod_rewrite' Apache module to allow the PrestaShop webservice.</source>
-        <target>Please activate the 'mod_rewrite' Apache module to allow the PrestaShop webservice.</target>
-        <note>Context:
-File: src/Core/Webservice/ServerRequirementsChecker.php:166</note>
-      </trans-unit>
-      <trans-unit id="2c19e4b707a422ddbbc4d1c32966661d">
-        <source>We could not check to see if basic authentication and rewrite extensions have been activated. Please manually check if they've been activated in order to use the PrestaShop webservice.</source>
-        <target>We could not check to see if basic authentication and rewrite extensions have been activated. Please manually check if they've been activated in order to use the PrestaShop webservice.</target>
-        <note>Context:
-File: src/Core/Webservice/ServerRequirementsChecker.php:171</note>
-      </trans-unit>
-      <trans-unit id="ab60321a106f1e1ab65b76c1ca15dd7c">
-        <source>Please activate the 'SimpleXML' PHP extension to allow testing of PrestaShop's webservice.</source>
-        <target>Please activate the 'SimpleXML' PHP extension to allow testing of PrestaShop's webservice.</target>
-        <note>Context:
-File: src/Core/Webservice/ServerRequirementsChecker.php:176</note>
-      </trans-unit>
-      <trans-unit id="0508bbb36fb6b5db31edf2f45cd687ea">
-        <source>It is preferable to use SSL (https:) for webservice calls, as it avoids the "man in the middle" type security issues.</source>
-        <target>It is preferable to use SSL (https:) for webservice calls, as it avoids the "man in the middle" type security issues.</target>
-        <note>Context:
-File: src/Core/Webservice/ServerRequirementsChecker.php:181</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTabsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5bb701014490e33a37ecdc43ce578404">
-        <source>You can't put this menu inside itself. </source>
-        <target>You can't put this menu inside itself.</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:297</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3235afa1d3eec16220f80e4acd0dd8da">
-        <source>You cannot have two shops with the same name in the same group.</source>
-        <target>You cannot have two shops with the same name in the same group.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:240</note>
-      </trans-unit>
-      <trans-unit id="55d56a8de1af2dc393f6bf33e873f0b4">
-        <source>Unable to load this shop.</source>
-        <target>Unable to load this shop.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:265</note>
-      </trans-unit>
-      <trans-unit id="cf52c411b5659457074fd9962435307f">
-        <source>You need to select at least the root category.</source>
-        <target>You need to select at least the root category.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:645</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6e61f7cd17315db8599a202172a096d5">
-        <source>You've selected a state for a country that does not contain states.</source>
-        <target>You've selected a state for a country that does not contain states.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:350</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/list.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0ee028bcc2a0101d4d65745086eefc03">
-        <source>When saving the query, only the "SELECT" SQL statement is allowed.</source>
-        <target>When saving the query, only the "SELECT" SQL statement is allowed.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/list.html.twig:50</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminRequestSqlController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c232ec1eb797989616b3ab59a5777b69">
-        <source>The file is too large and cannot be downloaded. Please use the LIMIT clause in this query.</source>
-        <target>The file is too large and cannot be downloaded. Please use the LIMIT clause in this query.</target>
-        <note>Context:
-File: controllers/admin/AdminRequestSqlController.php:363</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/SqlManager/SqlQueryValidator.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a0e587425d03db434bd7ad7081913cb4">
-        <source>The "%tablename%" table does not exist.</source>
-        <target>The "%tablename%" table does not exist.</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:166</note>
-      </trans-unit>
-      <trans-unit id="9caefacc2d658e65a31461564c163624">
-        <source>The "%attribute%" attribute does not exist in the "%table%" table.</source>
-        <target>The "%attribute%" attribute does not exist in the "%table%" table.</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:320</note>
-      </trans-unit>
-      <trans-unit id="b162612cdcbf01c01421bad2e8b39432">
-        <source>Undefined "%s" error</source>
-        <target>Undefined "%s" error</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:330</note>
-      </trans-unit>
-      <trans-unit id="dbea0ef67609a60a1f71f8d19e132d1e">
-        <source>The "*" operator cannot be used in a nested query.</source>
-        <target>The "*" operator cannot be used in a nested query.</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:187</note>
-      </trans-unit>
-      <trans-unit id="20cc3893d65fa16fcd2fe317c555e28a">
-        <source>The operator "%s" is incorrect.</source>
-        <target>The operator "%s" is incorrect.</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:213</note>
-      </trans-unit>
-      <trans-unit id="dde2543d498ef763b41a2e5ddad7ecdd">
-        <source>The "%operator%" operator is incorrect.</source>
-        <target>The "%operator%" operator is incorrect.</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:252</note>
-      </trans-unit>
-      <trans-unit id="19681d28ed1cc72479bc26b7e76ad240">
-        <source>The LIMIT clause must contain numeric arguments.</source>
-        <target>The LIMIT clause must contain numeric arguments.</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:346</note>
-      </trans-unit>
-      <trans-unit id="37074dedaa80ce0e038f92b668fb2350">
-        <source>The "%reference%" reference does not exist in the "%table%" table.</source>
-        <target>The "%reference%" reference does not exist in the "%table%" table.</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:363</note>
-      </trans-unit>
-      <trans-unit id="7b4dd672e3b87269079894e693ce9b76">
-        <source>When multiple tables are used, each attribute must refer back to a table.</source>
-        <target>When multiple tables are used, each attribute must refer back to a table.</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:373</note>
-      </trans-unit>
-      <trans-unit id="8ff8844bb02822975904934598298987">
-        <source>"%key%" is an unauthorized keyword.</source>
-        <target>"%key%" is an unauthorized keyword.</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:407</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/backup.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="b42cd3af71fc00ef268910709255320a">
         <source>You do not have permission to view this.</source>
         <target>You do not have permission to view this.</target>
-        <note>Context:
-File: admin-dev/backup.php:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="e38d3ed240ea149315399f76813ad836">
         <source>There is no "/backup" directory.</source>
         <target>There is no "/backup" directory.</target>
-        <note>Context:
-File: admin-dev/backup.php:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="8a5a71bcb5b4e12673c79e3d8b1deb56">
         <source>No file has been specified.</source>
         <target>No file has been specified.</target>
-        <note>Context:
-File: admin-dev/backup.php:61</note>
+        <note>Line: 61</note>
       </trans-unit>
       <trans-unit id="db5aa3efeee3f75954f4a6de541f7fd2">
         <source>Unable to open backup file(s).</source>
         <target>Unable to open backup file(s).</target>
-        <note>Context:
-File: admin-dev/backup.php:85</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="089426c3b86f7f52cc14c3ebf5ca5b8f">
         <source>Unable to display backup file(s).</source>
         <target>Unable to display backup file(s).</target>
-        <note>Context:
-File: admin-dev/backup.php:105</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Upload/UploadQuotaConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c3ecc0e8b4dc11a1d2c66d81439b4a42">
-        <source>The limit chosen is larger than the server's maximum upload limit. Please increase the limits of your server.</source>
-        <target>The limit chosen is larger than the server's maximum upload limit. Please increase the limits of your server.</target>
-        <note>Context:
-File: src/Adapter/Upload/UploadQuotaConfiguration.php:94</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Debug/DebugModeConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="667685497be44ab0fc2d4334a512405b">
-        <source>Error: Could not write to file. Make sure that the correct permissions are set on the file %s</source>
-        <target>Error: Could not write to file. Make sure that the correct permissions are set on the file %s</target>
-        <note>Context:
-File: src/Adapter/Debug/DebugModeConfiguration.php:111</note>
-      </trans-unit>
-      <trans-unit id="d4fb191ef219af010cc664bf47393e97">
-        <source>Error: Could not find whether debug mode is enabled. Make sure that the correct permissions are set on the file %s</source>
-        <target>Error: Could not find whether debug mode is enabled. Make sure that the correct permissions are set on the file %s</target>
-        <note>Context:
-File: src/Adapter/Debug/DebugModeConfiguration.php:97</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Requirement/CheckRequirements.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4f32e16f17a3ba8527cd8160ad85de37">
-        <source>Update your PHP version.</source>
-        <target>Update your PHP version.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:101</note>
-      </trans-unit>
-      <trans-unit id="726f1a9982e9ced2818f72090683e077">
-        <source>Configure your server to allow file uploads.</source>
-        <target>Configure your server to allow file uploads.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:102</note>
-      </trans-unit>
-      <trans-unit id="ba29b5ac8580aaa26d3166f32da8ac10">
-        <source>Configure your server to allow the creation of directories and files with write permissions.</source>
-        <target>Configure your server to allow the creation of directories and files with write permissions.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:103</note>
-      </trans-unit>
-      <trans-unit id="98bbaed82b3e7d2b957be02ac1f91f36">
-        <source>Enable the CURL extension on your server.</source>
-        <target>Enable the CURL extension on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:104</note>
-      </trans-unit>
-      <trans-unit id="36da7cbbc854d7861db49d5e82bf932b">
-        <source>Enable the DOM extension on your server.</source>
-        <target>Enable the DOM extension on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:105</note>
-      </trans-unit>
-      <trans-unit id="3ac2fbb7427ea6dac01c40ed70350fb0">
-        <source>Enable the Fileinfo extension on your server.</source>
-        <target>Enable the Fileinfo extension on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:106</note>
-      </trans-unit>
-      <trans-unit id="b5f353847bbb01ca0feda2a3b0e5b1a9">
-        <source>Enable the GD library on your server.</source>
-        <target>Enable the GD library on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:107</note>
-      </trans-unit>
-      <trans-unit id="ebcb30cdf6fa4833f9e0115eb92deb7a">
-        <source>Enable the JSON extension on your server.</source>
-        <target>Enable the JSON extension on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:108</note>
-      </trans-unit>
-      <trans-unit id="4212b25cc6780f5551bcaadeca27c791">
-        <source>Enable the Mbstring extension on your server.</source>
-        <target>Enable the Mbstring extension on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:109</note>
-      </trans-unit>
-      <trans-unit id="aa08f94ed008490c748301ea5db9568b">
-        <source>Enable the OpenSSL extension on your server.</source>
-        <target>Enable the OpenSSL extension on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:110</note>
-      </trans-unit>
-      <trans-unit id="a06111807d1bd6e8dd420e7ee5d0b0f8">
-        <source>Enable the PDO Mysql extension on your server.</source>
-        <target>Enable the PDO Mysql extension on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:111</note>
-      </trans-unit>
-      <trans-unit id="60575cad0e1f106447cb0dfa37c01daf">
-        <source>Enable the XML extension on your server.</source>
-        <target>Enable the XML extension on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:112</note>
-      </trans-unit>
-      <trans-unit id="cc4c22b3f8726001cf1c1663cd4845c2">
-        <source>Enable the ZIP extension on your server.</source>
-        <target>Enable the ZIP extension on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:113</note>
-      </trans-unit>
-      <trans-unit id="4fc7f05f412a1684ce4996e51ffff7fe">
-        <source>Enable the MySQL support on your server.</source>
-        <target>Enable the MySQL support on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:114</note>
-      </trans-unit>
-      <trans-unit id="fbc80a46761028390cb9f217affc1ad4">
-        <source>Set write permissions for the "config" folder.</source>
-        <target>Set write permissions for the "config" folder.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:115</note>
-      </trans-unit>
-      <trans-unit id="d667dd7ea28dcabe347120a1ea277658">
-        <source>Set write permissions for the "cache" folder.</source>
-        <target>Set write permissions for the "cache" folder.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:116</note>
-      </trans-unit>
-      <trans-unit id="9c05ffb08aed8df408a9338efa0de1ce">
-        <source>Set write permissions for the "sitemap.xml" file.</source>
-        <target>Set write permissions for the "sitemap.xml" file.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:117</note>
-      </trans-unit>
-      <trans-unit id="515ba9f393d74cfb3a8551b171652f4d">
-        <source>Set write permissions for the "img" folder and subfolders.</source>
-        <target>Set write permissions for the "img" folder and subfolders.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:118</note>
-      </trans-unit>
-      <trans-unit id="5c482561c321c3f8b1ed436afdfab4aa">
-        <source>Set write permissions for the "log" folder and subfolders.</source>
-        <target>Set write permissions for the "log" folder and subfolders.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:119</note>
-      </trans-unit>
-      <trans-unit id="fea054b13666afb1d5d776afb925d288">
-        <source>Set write permissions for the "mails" folder and subfolders.</source>
-        <target>Set write permissions for the "mails" folder and subfolders.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:120</note>
-      </trans-unit>
-      <trans-unit id="5a44bd60b36b50f3dafd07404ebce84d">
-        <source>Set write permissions for the "modules" folder and subfolders.</source>
-        <target>Set write permissions for the "modules" folder and subfolders.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:121</note>
-      </trans-unit>
-      <trans-unit id="e1bb8996c82be1d540c7cc0d409bcd2f">
-        <source>Set write permissions for the "themes/%s/cache/" folder and subfolders, recursively.</source>
-        <target>Set write permissions for the "themes/%s/cache/" folder and subfolders, recursively.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:122</note>
-      </trans-unit>
-      <trans-unit id="9c56996f2d8597e1f4ff15556128ee7d">
-        <source>Set write permissions for the "themes/%s/lang/" folder and subfolders, recursively.</source>
-        <target>Set write permissions for the "themes/%s/lang/" folder and subfolders, recursively.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:123</note>
-      </trans-unit>
-      <trans-unit id="cf707d7f4da3b1134a8c9470fae8720c">
-        <source>Set write permissions for the "themes/%s/pdf/lang/" folder and subfolders, recursively.</source>
-        <target>Set write permissions for the "themes/%s/pdf/lang/" folder and subfolders, recursively.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:124</note>
-      </trans-unit>
-      <trans-unit id="c0bda45f4bd14c8138cc5107c813167f">
-        <source>Set write permissions for the "app/config/" folder and subfolders, recursively.</source>
-        <target>Set write permissions for the "app/config/" folder and subfolders, recursively.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:125</note>
-      </trans-unit>
-      <trans-unit id="c64f03a0316f495425715feacdddb42a">
-        <source>Set write permissions for the "app/Resources/translations/" folder and subfolders, recursively.</source>
-        <target>Set write permissions for the "app/Resources/translations/" folder and subfolders, recursively.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:126</note>
-      </trans-unit>
-      <trans-unit id="fed1803fba6b27ae43103e333a5600eb">
-        <source>Set write permissions for the "translations" folder and subfolders.</source>
-        <target>Set write permissions for the "translations" folder and subfolders.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:127</note>
-      </trans-unit>
-      <trans-unit id="94f3a2dc6474b8b097c257fa1da2c9e1">
-        <source>Set write permissions for the "upload" folder and subfolders.</source>
-        <target>Set write permissions for the "upload" folder and subfolders.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:128</note>
-      </trans-unit>
-      <trans-unit id="dbbb85913376aec586b97adc72268a5c">
-        <source>Set write permissions for the "download" folder and subfolders.</source>
-        <target>Set write permissions for the "download" folder and subfolders.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:129</note>
-      </trans-unit>
-      <trans-unit id="4993d8516d8737159bcd735ca8075e6e">
-        <source>Allow the PHP fopen() function on your server.</source>
-        <target>Allow the PHP fopen() function on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:130</note>
-      </trans-unit>
-      <trans-unit id="4a344651fb10eb9e339838fab7bb97ae">
-        <source>Enable GZIP compression on your server.</source>
-        <target>Enable GZIP compression on your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:131</note>
-      </trans-unit>
-      <trans-unit id="0996c7cf8e7f49f54d15b68262a6b68d">
-        <source>Some PrestaShop files are missing from your server.</source>
-        <target>Some PrestaShop files are missing from your server.</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:132</note>
-      </trans-unit>
-      <trans-unit id="e567554b1238bc9e85e38b01e6b198e9">
-        <source>You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.6. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.6 now!</source>
-        <target>You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.6. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.6 now!</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:133</note>
-      </trans-unit>
-      <trans-unit id="0b9193ca4af6867c1f50a07097254b62">
-        <source>Enable the Apache mod_rewrite module</source>
-        <target>Enable the Apache mod_rewrite module</target>
-        <note>Context:
-File: src/Adapter/Requirement/CheckRequirements.php:134</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Media/MediaServerConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ea030df6cb392bef66cde22c94578ae4">
-        <source>Media server #1 is invalid</source>
-        <target>Media server #1 is invalid</target>
-        <note>Context:
-File: src/Adapter/Media/MediaServerConfiguration.php:100</note>
-      </trans-unit>
-      <trans-unit id="32d841e578ff7560bbaeda96f5328e9e">
-        <source>Media server #2 is invalid</source>
-        <target>Media server #2 is invalid</target>
-        <note>Context:
-File: src/Adapter/Media/MediaServerConfiguration.php:108</note>
-      </trans-unit>
-      <trans-unit id="63ae8982fa76c668cbfc774ccf083d26">
-        <source>Media server #3 is invalid</source>
-        <target>Media server #3 is invalid</target>
-        <note>Context:
-File: src/Adapter/Media/MediaServerConfiguration.php:116</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Cache/CombineCompressCacheConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="525bb5c93bbb92dd0a3e8378a43ee1e7">
-        <source>To use Smarty Cache, the directory %directorypath% must be writable.</source>
-        <target>To use Smarty Cache, the directory %directorypath% must be writable.</target>
-        <note>Context:
-File: src/Adapter/Cache/CombineCompressCacheConfiguration.php:103</note>
-      </trans-unit>
-      <trans-unit id="91e3dffab90db947ea156087dadaa9c0">
-        <source>Before being able to use this tool, you need to:[1][2]Create a blank .htaccess in your root directory.[/2][2]Give it write permissions (CHMOD 666 on Unix system).[/2][/1]</source>
-        <target>Before being able to use this tool, you need to:[1][2]Create a blank .htaccess in your root directory.[/2][2]Give it write permissions (CHMOD 666 on Unix system).[/2][/1]</target>
-        <note>Context:
-File: src/Adapter/Cache/CombineCompressCacheConfiguration.php:203</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Cache/CachingConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6f6a61bc2bf0a0f7a104f8c526d86206">
-        <source>The settings file cannot be overwritten.</source>
-        <target>The settings file cannot be overwritten.</target>
-        <note>Context:
-File: src/Adapter/Cache/CachingConfiguration.php:138</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="023d53a99c8074e823e5b2db4c19dfa4">
-        <source>(you must install the [a]Memcache PECL extension[/a])</source>
-        <target>(you must install the [a]Memcache PECL extension[/a])</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php:120</note>
-      </trans-unit>
-      <trans-unit id="82742001d67f4446f50d68908f0f8b96">
-        <source>(you must install the [a]Memcached PECL extension[/a])</source>
-        <target>(you must install the [a]Memcached PECL extension[/a])</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php:130</note>
-      </trans-unit>
-      <trans-unit id="78ae94b19fc38f9a35d20bc67cde2d61">
-        <source>(you must install the [a]APC PECL extension[/a])</source>
-        <target>(you must install the [a]APC PECL extension[/a])</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php:140</note>
-      </trans-unit>
-      <trans-unit id="8b763a82c2aa7875f3da39399ba350d7">
-        <source>(you must install the [a]Xcache extension[/a])</source>
-        <target>(you must install the [a]Xcache extension[/a])</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php:150</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9ad28fef1c6184adfe7397838891ba76">
-        <source>The Memcached server cannot be added.</source>
-        <target>The Memcached server cannot be added.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php:125</note>
-      </trans-unit>
-      <trans-unit id="bf4ddd37d9f82a3ad1f405891dfaa235">
-        <source>There was an error when attempting to delete the Memcached server.</source>
-        <target>There was an error when attempting to delete the Memcached server.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php:170</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f36c9a20c2ce51f491c944e41fde5ace">
-        <source>It appears the backup was successful, however you must download and carefully verify the backup file before proceeding.</source>
-        <target>It appears the backup was successful, however you must download and carefully verify the backup file before proceeding.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php:163</note>
-      </trans-unit>
-      <trans-unit id="2c7338ad06a6bb0747b0d432c33464ce">
-        <source>The "Backups" directory located in the admin directory must be writable (CHMOD 755 / 777).</source>
-        <target>The "Backups" directory located in the admin directory must be writable (CHMOD 755 / 777).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php:173</note>
-      </trans-unit>
-      <trans-unit id="fe7ff4ed0a66abe86361ba0f8d6e919a">
-        <source>The backup file does not exist</source>
-        <target>The backup file does not exist</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php:178</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/PrestaShopBackup.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4e0ac45de6bd848503ffa98ff6247f2f">
-        <source>Error deleting</source>
-        <target>Error deleting</target>
-        <note>Context:
-File: classes/PrestaShopBackup.php:172</note>
-      </trans-unit>
-      <trans-unit id="47218fe85410a7029c216ef926cef044">
-        <source>"Backup" directory does not exist.</source>
-        <target>"Backup" directory does not exist.</target>
-        <note>Context:
-File: classes/PrestaShopBackup.php:148</note>
-      </trans-unit>
-      <trans-unit id="c1c8a564c10a0efe07bb4e4b20d88cc9">
-        <source>Invalid ID</source>
-        <target>Invalid ID</target>
-        <note>Context:
-File: classes/PrestaShopBackup.php:173</note>
-      </trans-unit>
-      <trans-unit id="4eb9ec8ac71ad17fdc99b5371ace9f6e">
-        <source>Unable to create backup file</source>
-        <target>Unable to create backup file</target>
-        <note>Context:
-File: classes/PrestaShopBackup.php:231</note>
-      </trans-unit>
-      <trans-unit id="52033453d4d673bae012b9c8ccb1e79c">
-        <source>An error occurred while backing up. Unable to obtain the schema of %s</source>
-        <target>An error occurred while backing up. Unable to obtain the schema of %s</target>
-        <note>Context:
-File: classes/PrestaShopBackup.php:260</note>
-      </trans-unit>
-      <trans-unit id="a12b8823ac5b71b9d09f9c7b09e54c48">
-        <source>No valid tables were found to backup.</source>
-        <target>No valid tables were found to backup.</target>
-        <note>Context:
-File: classes/PrestaShopBackup.php:323</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fd4adc19ae7e0f0391f617451f3729cf">
-        <source>All caches cleared successfully</source>
-        <target>All caches cleared successfully</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php:120</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Mail.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3ed07fe73e25bba69e3e5dac234b1941">
-        <source>Error - The following e-mail template is missing: %s</source>
-        <target>Error - The following e-mail template is missing: %s</target>
-        <note>Context:
-File: classes/Mail.php:410</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e0aa021e21dddbd6d8cecec71e9cf564">
-        <source>OK</source>
-        <target>OK</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:209</note>
-      </trans-unit>
-      <trans-unit id="2ad1ffcbe2184ed25baa66baece8908b">
-        <source>Please fix the following error(s)</source>
-        <target>Please fix the following error(s)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:212</note>
-      </trans-unit>
-      <trans-unit id="d5df5b42d8fa5fed36fbd1cda0112f40">
-        <source>Checking files...</source>
-        <target>Checking files...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:235</note>
-      </trans-unit>
-      <trans-unit id="a2db667abfde7a08ee094d460102f268">
-        <source>Missing files</source>
-        <target>Missing files</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:245</note>
-      </trans-unit>
-      <trans-unit id="b5871613cbf4ab8b21d528ff2576fcbf">
-        <source>Updated files</source>
-        <target>Updated files</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:246</note>
-      </trans-unit>
-      <trans-unit id="c49d6d58d1c98f34a15bbd169f82961a">
-        <source>Changed/missing files have been detected.</source>
-        <target>Changed/missing files have been detected.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:247</note>
-      </trans-unit>
-      <trans-unit id="4757718002cbae6feee5c372b66b6a29">
-        <source>No change has been detected in your files.</source>
-        <target>No change has been detected in your files.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig:248</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6dc43a448d1a98e265b2632d5fa41ec6">
-        <source>Are you sure that you would like to delete this entity:</source>
-        <target>Are you sure that you would like to delete this entity:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig:29</note>
-      </trans-unit>
-      <trans-unit id="e4cdcd51e6cf787d4ecc7d813f0c23cb">
-        <source>The locale must be installed</source>
-        <target>The locale must be installed</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig:112</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="418dde4b22e22a725e75b2819c0373b2">
-        <source>Note that the Category import does not support having two categories with the same name.</source>
-        <target>Note that the Category import does not support having two categories with the same name.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:65</note>
-      </trans-unit>
-      <trans-unit id="b990d5cecd822de3b6922abcf71549b4">
-        <source>Note that you can have several products with the same reference.</source>
-        <target>Note that you can have several products with the same reference.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:66</note>
-      </trans-unit>
-      <trans-unit id="613260718349db00d0b7b9c1eb77c76c">
-        <source>Your file has been successfully imported into your shop. Don't forget to re-build the products' search index.</source>
-        <target>Your file has been successfully imported into your shop. Don't forget to re-build the products' search index.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="7ec8e6a8a53cd81e13594780931cfce5">
-        <source>Importing Supply Order Details will reset your history of ordered products, if there are any.</source>
-        <target>Importing Supply Order Details will reset your history of ordered products, if there are any.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:70</note>
-      </trans-unit>
-      <trans-unit id="df6e9862566912e908ef785e860f9c71">
-        <source>Are you sure that you would like to delete this entity: </source>
-        <target>Are you sure that you would like to delete this entity: </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:493</note>
-      </trans-unit>
-      <trans-unit id="83a1698a445036a9a65686ac61879794">
-        <source>You do not have permission to delete this. When the MultiStore mode is enabled, only a SuperAdmin can delete all items before an import.</source>
-        <target>You do not have permission to delete this. When the MultiStore mode is enabled, only a SuperAdmin can delete all items before an import.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:497</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5b8df4265c79cd43831e740281850c84">
-        <source>SSL does not seem to be available on your server.</source>
-        <target>SSL does not seem to be available on your server.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig:74</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0fe194d9bb812c48dfe35a3cf6d0af52">
-        <source>Please choose a MySQL table</source>
-        <target>Please choose a MySQL table</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl:49</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3be751fc7ab3f3ced8007796fe8bde7d">
-        <source>This SQL query has no result.</source>
-        <target>This SQL query has no result.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/download_view.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cd7fa1b4a137bf4da20f84bed6624fa5">
-        <source>Beginning the download ...</source>
-        <target>Beginning the download ...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/download_view.html.twig:41</note>
-      </trans-unit>
-      <trans-unit id="6a278621d6f2e7dbd56c7beca4081e2d">
-        <source>Backup files should automatically start downloading.</source>
-        <target>Backup files should automatically start downloading.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/download_view.html.twig:44</note>
-      </trans-unit>
-      <trans-unit id="da61b0c3311560af7fa1d9a515b309f6">
-        <source>If not,[1][2] please click here[/1]!</source>
-        <target>If not,[1][2] please click here[/1]!</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/download_view.html.twig:45</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="088e7482af32200b588d22e5f0af4f94">
-        <source>How to restore a database backup</source>
-        <target>How to restore a database backup</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:29</note>
-      </trans-unit>
-      <trans-unit id="bcb4db2b36ea3b1e20e5ee4aa9a68665">
-        <source>If you need to restore a database backup, we invite you to subscribe to a [1][2]technical support plan[/2][/1].</source>
-        <target>If you need to restore a database backup, we invite you to subscribe to a [1][2]technical support plan[/2][/1].</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:30</note>
-      </trans-unit>
-      <trans-unit id="0929b3759c8eef31c299400f513072dd">
-        <source>Our team will take care of restoring your database safely.</source>
-        <target>Our team will take care of restoring your database safely.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:31</note>
-      </trans-unit>
-      <trans-unit id="c4b6a12f5f4cbbeb2353a718ee9a8a9a">
-        <source>Why can't I restore it by myself?</source>
-        <target>Why can't I restore it by myself?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="d4ef96663955ee203ce986ef40945199">
-        <source>Your shop is hosted by PrestaShop. Although you can create backup files here below, there are core settings you cannot access for security reasons, like the database management. Thus, only our team can proceed to a restoration.</source>
-        <target>Your shop is hosted by PrestaShop. Although you can create backup files here below, there are core settings you cannot access for security reasons, like the database management. Thus, only our team can proceed to a restoration.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_form.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5b739e824ccebf9cd8c5b4ef774c59a7">
-        <source>I have read the disclaimer. Please create a new backup.</source>
-        <target>I have read the disclaimer. Please create a new backup.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_form.html.twig:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="54ee283a75b8a8a38f0b4996e4e69db5">
-        <source>Disclaimer before creating a new backup</source>
-        <target>Disclaimer before creating a new backup</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig:29</note>
-      </trans-unit>
-      <trans-unit id="0869c85782ee2481b83a9f580a09e963">
-        <source>PrestaShop is not responsible for your database, its backups and/or recovery.</source>
-        <target>PrestaShop is not responsible for your database, its backups and/or recovery.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig:31</note>
-      </trans-unit>
-      <trans-unit id="cc6f77e8d23517366b4380f9a180655f">
-        <source>PrestaShop is open-source software. You are using it at your own risk under the license agreement.</source>
-        <target>PrestaShop is open-source software. You are using it at your own risk under the license agreement.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig:32</note>
-      </trans-unit>
-      <trans-unit id="99c8acd81f347dd6268fda9bf9e61b97">
-        <source>You should back up your data on a regular basis (both files and database).</source>
-        <target>You should back up your data on a regular basis (both files and database).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="4d247cbe2dbd06ce20b9affd635e7982">
-        <source>This function only backs up your database, not your files.</source>
-        <target>This function only backs up your database, not your files.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig:34</note>
-      </trans-unit>
-      <trans-unit id="b2a110974050263fde4c0c7cf15013b3">
-        <source>By default, your existing database tables will be dropped during the backup recovery (see "Backup options" below).</source>
-        <target>By default, your existing database tables will be dropped during the backup recovery (see "Backup options" below).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig:35</note>
-      </trans-unit>
-      <trans-unit id="dba49284eb0830e849635506a961aa7c">
-        <source>Always verify the quality and integrity of your backup files!</source>
-        <target>Always verify the quality and integrity of your backup files!</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig:36</note>
-      </trans-unit>
-      <trans-unit id="5cb0e756d153cfcfac763077a5f0628c">
-        <source>Always verify that your backup files are complete, up-to-date and valid, even if you had a success message appear during the backup process.</source>
-        <target>Always verify that your backup files are complete, up-to-date and valid, even if you had a success message appear during the backup process.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig:37</note>
-      </trans-unit>
-      <trans-unit id="0dc51a7afc30b342b827df535ff616f2">
-        <source>Always check your data.</source>
-        <target>Always check your data.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="804206afa5249349d8bfea4cc78c48d7">
-        <source>Never restore a backup on a live site.</source>
-        <target>Never restore a backup on a live site.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig:39</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="29be13f78208f2e848c6b6645a79f813">
-        <source>Do you really want to remove the server %serverIp%:%serverPort% ?</source>
-        <target>Do you really want to remove the server %serverIp%:%serverPort% ?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig:93</note>
+        <note>Line: 105</note>
       </trans-unit>
     </body>
   </file>
@@ -1545,8 +34,1288 @@ File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/me
       <trans-unit id="b04c5e39cb3460a062bba48d85567cdb">
         <source>Administrator permissions cannot be modified.</source>
         <target>Administrator permissions cannot be modified.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl:515</note>
+        <note>Line: 515</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="418dde4b22e22a725e75b2819c0373b2">
+        <source>Note that the Category import does not support having two categories with the same name.</source>
+        <target>Note that the Category import does not support having two categories with the same name.</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="b990d5cecd822de3b6922abcf71549b4">
+        <source>Note that you can have several products with the same reference.</source>
+        <target>Note that you can have several products with the same reference.</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="613260718349db00d0b7b9c1eb77c76c">
+        <source>Your file has been successfully imported into your shop. Don't forget to re-build the products' search index.</source>
+        <target>Your file has been successfully imported into your shop. Don't forget to re-build the products' search index.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="7ec8e6a8a53cd81e13594780931cfce5">
+        <source>Importing Supply Order Details will reset your history of ordered products, if there are any.</source>
+        <target>Importing Supply Order Details will reset your history of ordered products, if there are any.</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="df6e9862566912e908ef785e860f9c71">
+        <source>Are you sure that you would like to delete this entity: </source>
+        <target>Are you sure that you would like to delete this entity: </target>
+        <note>Line: 493</note>
+      </trans-unit>
+      <trans-unit id="83a1698a445036a9a65686ac61879794">
+        <source>You do not have permission to delete this. When the MultiStore mode is enabled, only a SuperAdmin can delete all items before an import.</source>
+        <target>You do not have permission to delete this. When the MultiStore mode is enabled, only a SuperAdmin can delete all items before an import.</target>
+        <note>Line: 497</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d85366190ecd2aebf8363980ad9d6740">
+        <source>Importing your data...</source>
+        <target>Importing your data...</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="8a1d14318cfc965da76c0b9d0a53bb93">
+        <source>Aborting, please wait...</source>
+        <target>Aborting, please wait...</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="e130ff31fe5f7a054a2db876a7acc94d">
+        <source>Data imported!</source>
+        <target>Data imported!</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="118f9dbc8442c6be19dfc0b70d965929">
+        <source>Look at your listings to make sure it's all there as you wished.</source>
+        <target>Look at your listings to make sure it's all there as you wished.</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="4959a069997257077022c1b96b3b8001">
+        <source>Errors occurred:</source>
+        <target>Errors occurred:</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="0ccb924c3db6a900cff26de895f756b8">
+        <source>Warning, the current import may require a PHP setting update, to allow more data to be transferred. If the current import stops before the end, you should increase your PHP "post_max_size" setting to [1]%size%[/1]MB at least, and try again.</source>
+        <target>Warning, the current import may require a PHP setting update, to allow more data to be transferred. If the current import stops before the end, you should increase your PHP "post_max_size" setting to [1]%size%[/1]MB at least, and try again.</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="841e4579e55a01ab8f0c565995ba7cfc">
+        <source>Some errors were detected. Please check the details:</source>
+        <target>Some errors were detected. Please check the details:</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="3df311b82f78fa4059e9a78a26e77b06">
+        <source>We made the following adjustments:</source>
+        <target>We made the following adjustments:</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="6e17621d481059924339f91ed431a116">
+        <source>Validating data...</source>
+        <target>Validating data...</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="95fdb0ead4798ff27cce78fac3fd3c11">
+        <source>[1]%percentage%[/1]% validated</source>
+        <target>[1]%percentage%[/1]% validated</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="fd2f43e6f9f4de5be1b08cdac13d7749">
+        <source>Processing next page...</source>
+        <target>Processing next page...</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="f438c83e3ff4dd40a3fc1bf4bb3e79f5">
+        <source>Linking accessories...</source>
+        <target>Linking accessories...</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="2a44b5ac9f88c57f584bf083730a93f7">
+        <source>[1]%size%[/1]% imported</source>
+        <target>[1]%size%[/1]% imported</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="650e0b1fd707ad8ad3a94e2eb494de3d">
+        <source>Ignore warnings and continue?</source>
+        <target>Ignore warnings and continue?</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="b8388ec68dcac2402d944fbb3382b0f1">
+        <source>Abort import</source>
+        <target>Abort import</target>
+        <note>Line: 104</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0fe194d9bb812c48dfe35a3cf6d0af52">
+        <source>Please choose a MySQL table</source>
+        <target>Please choose a MySQL table</target>
+        <note>Line: 49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3be751fc7ab3f3ced8007796fe8bde7d">
+        <source>This SQL query has no result.</source>
+        <target>This SQL query has no result.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Mail.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3ed07fe73e25bba69e3e5dac234b1941">
+        <source>Error - The following e-mail template is missing: %s</source>
+        <target>Error - The following e-mail template is missing: %s</target>
+        <note>Line: 410</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/PrestaShopBackup.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="47218fe85410a7029c216ef926cef044">
+        <source>"Backup" directory does not exist.</source>
+        <target>"Backup" directory does not exist.</target>
+        <note>Line: 148</note>
+      </trans-unit>
+      <trans-unit id="c1c8a564c10a0efe07bb4e4b20d88cc9">
+        <source>Invalid ID</source>
+        <target>Invalid ID</target>
+        <note>Line: 173</note>
+      </trans-unit>
+      <trans-unit id="4eb9ec8ac71ad17fdc99b5371ace9f6e">
+        <source>Unable to create backup file</source>
+        <target>Unable to create backup file</target>
+        <note>Line: 231</note>
+      </trans-unit>
+      <trans-unit id="52033453d4d673bae012b9c8ccb1e79c">
+        <source>An error occurred while backing up. Unable to obtain the schema of %s</source>
+        <target>An error occurred while backing up. Unable to obtain the schema of %s</target>
+        <note>Line: 260</note>
+      </trans-unit>
+      <trans-unit id="a12b8823ac5b71b9d09f9c7b09e54c48">
+        <source>No valid tables were found to backup.</source>
+        <target>No valid tables were found to backup.</target>
+        <note>Line: 323</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="67df6a66c109fbe53bfa02dc398bc258">
+        <source>Can't add the voucher.</source>
+        <target>Can't add the voucher.</target>
+        <note>Line: 636</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminEmployeesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a375d9230fd61b4a70ac109ab7b11082">
+        <source>You cannot edit the SuperAdmin profile.</source>
+        <target>You cannot edit the SuperAdmin profile.</target>
+        <note>Line: 235</note>
+      </trans-unit>
+      <trans-unit id="cd34716bc68eb08479ddf16f17b2580e">
+        <source>The provided profile is invalid</source>
+        <target>The provided profile is invalid</target>
+        <note>Line: 429</note>
+      </trans-unit>
+      <trans-unit id="f5d44b60e38b28d19549bb7a107654ca">
+        <source>You cannot disable or delete your own account.</source>
+        <target>You cannot disable or delete your own account.</target>
+        <note>Line: 475</note>
+      </trans-unit>
+      <trans-unit id="2450228823b8e17792cf687b8543b59d">
+        <source>You cannot disable or delete the administrator account.</source>
+        <target>You cannot disable or delete the administrator account.</target>
+        <note>Line: 569</note>
+      </trans-unit>
+      <trans-unit id="8fd6c902e0a6186ebc62b4c3c65dc528">
+        <source>You cannot delete this account because it manages warehouses. Check your warehouses first.</source>
+        <target>You cannot delete this account because it manages warehouses. Check your warehouses first.</target>
+        <note>Line: 490</note>
+      </trans-unit>
+      <trans-unit id="4220fb02fdc65e838a02a3b51c6f737f">
+        <source>Your current password is invalid.</source>
+        <target>Your current password is invalid.</target>
+        <note>Line: 506</note>
+      </trans-unit>
+      <trans-unit id="1a33d52d73377516254da97f9fee027e">
+        <source>The confirmation password does not match.</source>
+        <target>The confirmation password does not match.</target>
+        <note>Line: 508</note>
+      </trans-unit>
+      <trans-unit id="c7cd7ecd5b19e01f74cad32af30c9ac4">
+        <source>You should have at least one employee in the administrator group.</source>
+        <target>You should have at least one employee in the administrator group.</target>
+        <note>Line: 563</note>
+      </trans-unit>
+      <trans-unit id="cfe45dd92c1b71a640ea19767578f38c">
+        <source>The employee must be associated with at least one shop.</source>
+        <target>The employee must be associated with at least one shop.</target>
+        <note>Line: 578</note>
+      </trans-unit>
+      <trans-unit id="46cf0d0972e77638e099815140a0d302">
+        <source>The password must be at least %length% characters long.</source>
+        <target>The password must be at least %length% characters long.</target>
+        <note>Line: 594</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5b8f192b08644fdc9fd1fd86bcbbc57b">
+        <source>(click to open "Generators" page)</source>
+        <target>(click to open "Generators" page)</target>
+        <note>Line: 731</note>
+      </trans-unit>
+      <trans-unit id="a080a85258618039d010a2136f85e69f">
+        <source>There is an empty row in the file that won't be imported.</source>
+        <target>There is an empty row in the file that won't be imported.</target>
+        <note>Line: 3725</note>
+      </trans-unit>
+      <trans-unit id="53d9fc1aa79e85c0f845139c6358daee">
+        <source>The category ID must be unique. It can't be the same as the one for Root or Home category.</source>
+        <target>The category ID must be unique. It can't be the same as the one for Root or Home category.</target>
+        <note>Line: 1309</note>
+      </trans-unit>
+      <trans-unit id="7a1bebdbf5770873f8172ecf27b2aa50">
+        <source>The category ID must be unique. It can't be the same as the one for the parent category (ID: %1$s).</source>
+        <target>The category ID must be unique. It can't be the same as the one for the parent category (ID: %1$s).</target>
+        <note>Line: 1332</note>
+      </trans-unit>
+      <trans-unit id="521531266ae042d0725d7a4aa22a49f4">
+        <source>A category can't be its own parent. You should rename it (current name: %1$s).</source>
+        <target>A category can't be its own parent. You should rename it (current name: %1$s).</target>
+        <note>Line: 1347</note>
+      </trans-unit>
+      <trans-unit id="1123af3eab25b7475419fcaecc6c3beb">
+        <source>%category_name% (ID: %id%) cannot be saved</source>
+        <target>%category_name% (ID: %id%) cannot be saved</target>
+        <note>Line: 1373</note>
+      </trans-unit>
+      <trans-unit id="6c1e9fe2a61808296a44cee372124bcb">
+        <source>URL rewriting failed to auto-generate a friendly URL for: %category_name%</source>
+        <target>URL rewriting failed to auto-generate a friendly URL for: %category_name%</target>
+        <note>Line: 1401</note>
+      </trans-unit>
+      <trans-unit id="4798b868d51d8e259321deff0452c0f9">
+        <source>Rewrite link for %1$s (ID %2$s): re-written as %3$s.</source>
+        <target>Rewrite link for %1$s (ID %2$s): re-written as %3$s.</target>
+        <note>Line: 1869</note>
+      </trans-unit>
+      <trans-unit id="a118c8120ef45c8b1bed36f341fa45f1">
+        <source>A category cannot be its own parent. The parent category ID is either missing or unknown (ID: %1$s).</source>
+        <target>A category cannot be its own parent. The parent category ID is either missing or unknown (ID: %1$s).</target>
+        <note>Line: 1433</note>
+      </trans-unit>
+      <trans-unit id="7bc08d1a3178f4927b2c07a18f417b4b">
+        <source>The root category cannot be modified.</source>
+        <target>The root category cannot be modified.</target>
+        <note>Line: 1452</note>
+      </trans-unit>
+      <trans-unit id="50fe5f166bc7695a0c0db12ea8a346e7">
+        <source>cannot be copied.</source>
+        <target>cannot be copied.</target>
+        <note>Line: 3762</note>
+      </trans-unit>
+      <trans-unit id="87098ca5171ae766269f50b24ef3189d">
+        <source>%1$s (ID: %2$s) cannot be %3$s</source>
+        <target>%1$s (ID: %2$s) cannot be %3$s</target>
+        <note>Line: 1478</note>
+      </trans-unit>
+      <trans-unit id="2666baaca25feea0b2dc641cfab50d8a">
+        <source>Unknown tax rule group ID. You need to create a group with this ID first.</source>
+        <target>Unknown tax rule group ID. You need to create a group with this ID first.</target>
+        <note>Line: 1713</note>
+      </trans-unit>
+      <trans-unit id="43bf950e043950e2da10f917b902c131">
+        <source>%1$s (ID: %2$s) cannot be saved</source>
+        <target>%1$s (ID: %2$s) cannot be saved</target>
+        <note>Line: 3863</note>
+      </trans-unit>
+      <trans-unit id="994e8f1b72a9fe7a9e8949343be6bde7">
+        <source>%data% cannot be saved</source>
+        <target>%data% cannot be saved</target>
+        <note>Line: 3836</note>
+      </trans-unit>
+      <trans-unit id="32fa1d06b5d0a192c9991c4bf038b30c">
+        <source>Shop is not valid</source>
+        <target>Shop is not valid</target>
+        <note>Line: 1993</note>
+      </trans-unit>
+      <trans-unit id="87aae49bd054f2cfa4b7b395dee5f2d3">
+        <source>Discount is invalid</source>
+        <target>Discount is invalid</target>
+        <note>Line: 2068</note>
+      </trans-unit>
+      <trans-unit id="664d4132fc8dc3a158be4692b4246528">
+        <source>Tags list is invalid</source>
+        <target>Tags list is invalid</target>
+        <note>Line: 2098</note>
+      </trans-unit>
+      <trans-unit id="6170902c7935d644e280e440a28d5975">
+        <source>Error copying image: %url%</source>
+        <target>Error copying image: %url%</target>
+        <note>Line: 2471</note>
+      </trans-unit>
+      <trans-unit id="61e49f62654858f3cd3d9b23bee90d06">
+        <source>Product #%id%: the picture (%url%) cannot be saved.</source>
+        <target>Product #%id%: the picture (%url%) cannot be saved.</target>
+        <note>Line: 2163</note>
+      </trans-unit>
+      <trans-unit id="c2758df7a8c70260e3b55e26c51b65fd">
+        <source>Advanced stock management has incorrect value. Not set for product %name% </source>
+        <target>Advanced stock management has incorrect value. Not set for product %name%</target>
+        <note>Line: 2207</note>
+      </trans-unit>
+      <trans-unit id="bb80841517f78647c5bee69710820c8d">
+        <source>Advanced stock management is not enabled, cannot enable on product %name% </source>
+        <target>Advanced stock management is not enabled, cannot enable on product %name%</target>
+        <note>Line: 2209</note>
+      </trans-unit>
+      <trans-unit id="651e202913d9229ff615d5afd6a6a168">
+        <source>Advanced stock management is not enabled, warehouse not set on product %name% </source>
+        <target>Advanced stock management is not enabled, warehouse not set on product %name%</target>
+        <note>Line: 2222</note>
+      </trans-unit>
+      <trans-unit id="470d8f3caa9e30c426f8d49779cc7a36">
+        <source>Warehouse did not exist, cannot set on product  %name% </source>
+        <target>Warehouse did not exist, cannot set on product  %name%</target>
+        <note>Line: 2242</note>
+      </trans-unit>
+      <trans-unit id="3d52f8b2b1a67aa8740b72b3752d54f3">
+        <source>Incorrect value for "Depends on stock" for product %name% </source>
+        <target>Incorrect value for "Depends on stock" for product %name%</target>
+        <note>Line: 2250</note>
+      </trans-unit>
+      <trans-unit id="65167d7a989d3a25c4f81a7140b07b8f">
+        <source>Advanced stock management is not enabled, cannot set "Depends on stock" for product %name% </source>
+        <target>Advanced stock management is not enabled, cannot set "Depends on stock" for product %name%</target>
+        <note>Line: 2788</note>
+      </trans-unit>
+      <trans-unit id="5c8707f79dbdd3abb28a8aa09e34f02f">
+        <source>No image was found for combination with id_product = %s and image position = %s.</source>
+        <target>No image was found for combination with id_product = %s and image position = %s.</target>
+        <note>Line: 2510</note>
+      </trans-unit>
+      <trans-unit id="b672cb1c6a798cfb9f54de7dd897abd8">
+        <source>EAN13 "%ean13%" has incorrect value for product with id %id%.</source>
+        <target>EAN13 "%ean13%" has incorrect value for product with id %id%.</target>
+        <note>Line: 2630</note>
+      </trans-unit>
+      <trans-unit id="85b637ec0128d136bf3794c79f2e7295">
+        <source>Advanced stock management has incorrect value. Not set for product with id %id%.</source>
+        <target>Advanced stock management has incorrect value. Not set for product with id %id%.</target>
+        <note>Line: 2747</note>
+      </trans-unit>
+      <trans-unit id="934b46cf9eb8a8595ca517b87de6bfb4">
+        <source>Advanced stock management is not enabled, cannot enable on product with id %id%.</source>
+        <target>Advanced stock management is not enabled, cannot enable on product with id %id%.</target>
+        <note>Line: 2749</note>
+      </trans-unit>
+      <trans-unit id="0081b2a315ed28289036fa6cc02a3819">
+        <source>Advanced stock management is not enabled, warehouse is not set on product with id %id%.</source>
+        <target>Advanced stock management is not enabled, warehouse is not set on product with id %id%.</target>
+        <note>Line: 2762</note>
+      </trans-unit>
+      <trans-unit id="c24928943071d3366164238b9413a211">
+        <source>Warehouse did not exist, cannot set on product %name%.</source>
+        <target>Warehouse did not exist, cannot set on product %name%.</target>
+        <note>Line: 2778</note>
+      </trans-unit>
+      <trans-unit id="fd6d9d3ba7d4aaacc49f53c2e8c082c0">
+        <source>Email address %1$s (ID: %2$s) cannot be validated.</source>
+        <target>Email address %1$s (ID: %2$s) cannot be validated.</target>
+        <note>Line: 3068</note>
+      </trans-unit>
+      <trans-unit id="9a19980e3db9fa010269bb72d31ee42a">
+        <source>Email address %1$s (ID: %2$s) cannot be saved.</source>
+        <target>Email address %1$s (ID: %2$s) cannot be saved.</target>
+        <note>Line: 3077</note>
+      </trans-unit>
+      <trans-unit id="14118fbc7d8c233f0ac36ffb31716605">
+        <source>%1$s does not exist in database %2$s (ID: %3$s), and therefore cannot be validated</source>
+        <target>%1$s does not exist in database %2$s (ID: %3$s), and therefore cannot be validated</target>
+        <note>Line: 3264</note>
+      </trans-unit>
+      <trans-unit id="597cf702e07f3b35431d2a499b00cefd">
+        <source>%1$s does not exist in database %2$s (ID: %3$s), and therefore cannot be saved</source>
+        <target>%1$s does not exist in database %2$s (ID: %3$s), and therefore cannot be saved</target>
+        <note>Line: 3274</note>
+      </trans-unit>
+      <trans-unit id="b06766963f3b27f47f5e6ddf68d8f07e">
+        <source>"%email%" is not a valid email address.</source>
+        <target>"%email%" is not a valid email address.</target>
+        <note>Line: 3250</note>
+      </trans-unit>
+      <trans-unit id="4a69d9da990728e003654d32a0b283a4">
+        <source>The customer ID #%d does not exist in the database, and therefore cannot be validated.</source>
+        <target>The customer ID #%d does not exist in the database, and therefore cannot be validated.</target>
+        <note>Line: 3287</note>
+      </trans-unit>
+      <trans-unit id="608ec99cc3ef74d962769c1958a1fa62">
+        <source>The customer ID #%d does not exist in the database, and therefore cannot be saved.</source>
+        <target>The customer ID #%d does not exist in the database, and therefore cannot be saved.</target>
+        <note>Line: 3295</note>
+      </trans-unit>
+      <trans-unit id="964e5a863ba051181f8f537626f5c953">
+        <source>Supplier is invalid</source>
+        <target>Supplier is invalid</target>
+        <note>Line: 3624</note>
+      </trans-unit>
+      <trans-unit id="3cc21b7970c348679cb6a1323a2dc173">
+        <source>Alias is invalid</source>
+        <target>Alias is invalid</target>
+        <note>Line: 3701</note>
+      </trans-unit>
+      <trans-unit id="52629716aa86c04b8d81bc7e9522463f">
+        <source>Store is invalid</source>
+        <target>Store is invalid</target>
+        <note>Line: 3870</note>
+      </trans-unit>
+      <trans-unit id="2e73276e5106584df31fd1cc5823ba81">
+        <source>Supplier ID (%id%) is not valid (at line %line%).</source>
+        <target>Supplier ID (%id%) is not valid (at line %line%).</target>
+        <note>Line: 3940</note>
+      </trans-unit>
+      <trans-unit id="5dbfdcc4de08ec893f55919dc4e872dc">
+        <source>Lang ID (%id%) is not valid (at line %line%).</source>
+        <target>Lang ID (%id%) is not valid (at line %line%).</target>
+        <note>Line: 3943</note>
+      </trans-unit>
+      <trans-unit id="f0cf11a8f6275d2bac5a189cbb41c689">
+        <source>Warehouse ID (%id%) is not valid (at line %line%).</source>
+        <target>Warehouse ID (%id%) is not valid (at line %line%).</target>
+        <note>Line: 3946</note>
+      </trans-unit>
+      <trans-unit id="b390e8c2a66fd018293fb44a5b8208c8">
+        <source>Currency ID (%id%) is not valid (at line %line%).</source>
+        <target>Currency ID (%id%) is not valid (at line %line%).</target>
+        <note>Line: 3949</note>
+      </trans-unit>
+      <trans-unit id="41a2fc826e4bd29b8eaf497a89a9dc5d">
+        <source>Reference (%ref%) already exists (at line %line%).</source>
+        <target>Reference (%ref%) already exists (at line %line%).</target>
+        <note>Line: 3955</note>
+      </trans-unit>
+      <trans-unit id="70e7a6fcceb39a1e3ea3925182b85d18">
+        <source>YYYY-MM-DD</source>
+        <target>YYYY-MM-DD</target>
+        <note>Line: 3960</note>
+      </trans-unit>
+      <trans-unit id="c1be0fbaeb4e6b509e2f65240b7e5970">
+        <source>Date format (%date%) is not valid (at line %line%). It should be: %date_format%.</source>
+        <target>Date format (%date%) is not valid (at line %line%). It should be: %date_format%.</target>
+        <note>Line: 3958</note>
+      </trans-unit>
+      <trans-unit id="8cc169924951a04aea4f6a86334f3ce6">
+        <source>Date (%date%) cannot be in the past (at line %line%). Format: %date_format%.</source>
+        <target>Date (%date%) cannot be in the past (at line %line%). Format: %date_format%.</target>
+        <note>Line: 3960</note>
+      </trans-unit>
+      <trans-unit id="ef1a78ea7433cfc92f358d6dbf4fcd48">
+        <source>Format: Between 0 and 100</source>
+        <target>Format: Between 0 and 100</target>
+        <note>Line: 4121</note>
+      </trans-unit>
+      <trans-unit id="e0b985fb06e1498649ed1cfd6f3fb3e4">
+        <source>Discount rate (%rate%) is not valid (at line %line%). %format%.</source>
+        <target>Discount rate (%rate%) is not valid (at line %line%). %format%.</target>
+        <note>Line: 3963</note>
+      </trans-unit>
+      <trans-unit id="3f2f635ad300e97bc217b69cc06dfc30">
+        <source>Supply Order (%id%) is not editable (at line %line%).</source>
+        <target>Supply Order (%id%) is not editable (at line %line%).</target>
+        <note>Line: 3968</note>
+      </trans-unit>
+      <trans-unit id="ad1ce5290a697ed3729cbd520432cf22">
+        <source>Supply Order could not be saved (at line %line%).</source>
+        <target>Supply Order could not be saved (at line %line%).</target>
+        <note>Line: 3999</note>
+      </trans-unit>
+      <trans-unit id="bb19d4490bdc48656603c0a7ef30db73">
+        <source>Supply Order (%s) could not be loaded (at line %d).</source>
+        <target>Supply Order (%s) could not be loaded (at line %d).</target>
+        <note>Line: 4066</note>
+      </trans-unit>
+      <trans-unit id="5e063c49ce8203f2ca7a496da24b819e">
+        <source>Product/Attribute (%d/%d) cannot be added twice (at line %d).</source>
+        <target>Product/Attribute (%d/%d) cannot be added twice (at line %d).</target>
+        <note>Line: 4084</note>
+      </trans-unit>
+      <trans-unit id="0a657a7416c29bdc5b134b61b863e7ee">
+        <source>Product (%d/%d) is not available for this order (at line %d).</source>
+        <target>Product (%d/%d) is not available for this order (at line %d).</target>
+        <note>Line: 4096</note>
+      </trans-unit>
+      <trans-unit id="ca676c9ec4e1ae9fe9df3ac28910e6ef">
+        <source>Unit Price (tax excl.) (%d) is not valid (at line %d).</source>
+        <target>Unit Price (tax excl.) (%d) is not valid (at line %d).</target>
+        <note>Line: 4103</note>
+      </trans-unit>
+      <trans-unit id="406eba9770c82a84cae2d6ee3e846a56">
+        <source>Quantity Expected (%d) is not valid (at line %d).</source>
+        <target>Quantity Expected (%d) is not valid (at line %d).</target>
+        <note>Line: 4118</note>
+      </trans-unit>
+      <trans-unit id="8f7627c77b01dc968a9665c0156da405">
+        <source>Discount rate (%d) is not valid (at line %d). %s.</source>
+        <target>Discount rate (%d) is not valid (at line %d). %s.</target>
+        <note>Line: 4110</note>
+      </trans-unit>
+      <trans-unit id="243c959202a4f6ce7f1ccba6bc19ff08">
+        <source>Cannot read the .CSV file</source>
+        <target>Cannot read the .CSV file</target>
+        <note>Line: 4209</note>
+      </trans-unit>
+      <trans-unit id="931bbbb741d025e3ff25ee3c2e72f414">
+        <source>Linking Accessories...</source>
+        <target>Linking Accessories...</target>
+        <note>Line: 4475</note>
+      </trans-unit>
+      <trans-unit id="d165f0c742c272ed88dc27acc91e2642">
+        <source>%s import</source>
+        <target>%s import</target>
+        <note>Line: 4554</note>
+      </trans-unit>
+      <trans-unit id="02b5205ddff3073efc5c8b5b9cc165ba">
+        <source>(from %s to %s)</source>
+        <target>(from %s to %s)</target>
+        <note>Line: 4556</note>
+      </trans-unit>
+      <trans-unit id="b53b06c0e98a2db123f953f0059a0948">
+        <source>with truncate</source>
+        <target>with truncate</target>
+        <note>Line: 4559</note>
+      </trans-unit>
+      <trans-unit id="32de857e46ef2b55ce3582004fef7a95">
+        <source>The confirmation email couldn't be sent, but the import is successful. Yay!</source>
+        <target>The confirmation email couldn't be sent, but the import is successful. Yay!</target>
+        <note>Line: 4687</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminProfilesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7d6f235518e595f4e988b6811d2ceeab">
+        <source>For security reasons, you cannot delete the Administrator's profile.</source>
+        <target>For security reasons, you cannot delete the Administrator's profile.</target>
+        <note>Line: 101</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminRequestSqlController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c232ec1eb797989616b3ab59a5777b69">
+        <source>The file is too large and cannot be downloaded. Please use the LIMIT clause in this query.</source>
+        <target>The file is too large and cannot be downloaded. Please use the LIMIT clause in this query.</target>
+        <note>Line: 366</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3235afa1d3eec16220f80e4acd0dd8da">
+        <source>You cannot have two shops with the same name in the same group.</source>
+        <target>You cannot have two shops with the same name in the same group.</target>
+        <note>Line: 240</note>
+      </trans-unit>
+      <trans-unit id="55d56a8de1af2dc393f6bf33e873f0b4">
+        <source>Unable to load this shop.</source>
+        <target>Unable to load this shop.</target>
+        <note>Line: 265</note>
+      </trans-unit>
+      <trans-unit id="cf52c411b5659457074fd9962435307f">
+        <source>You need to select at least the root category.</source>
+        <target>You need to select at least the root category.</target>
+        <note>Line: 645</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6e61f7cd17315db8599a202172a096d5">
+        <source>You've selected a state for a country that does not contain states.</source>
+        <target>You've selected a state for a country that does not contain states.</target>
+        <note>Line: 350</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTabsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5bb701014490e33a37ecdc43ce578404">
+        <source>You can't put this menu inside itself. </source>
+        <target>You can't put this menu inside itself.</target>
+        <note>Line: 297</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminWebserviceController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="155657899b93f70358eed115631fdb04">
+        <source>Key length must be 32 character long.</source>
+        <target>Key length must be 32 character long.</target>
+        <note>Line: 248</note>
+      </trans-unit>
+      <trans-unit id="441006dbdaef41a163047624fe1241ab">
+        <source>This key already exists.</source>
+        <target>This key already exists.</target>
+        <note>Line: 251</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Cache/CachingConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6f6a61bc2bf0a0f7a104f8c526d86206">
+        <source>The settings file cannot be overwritten.</source>
+        <target>The settings file cannot be overwritten.</target>
+        <note>Line: 138</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Cache/CombineCompressCacheConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="525bb5c93bbb92dd0a3e8378a43ee1e7">
+        <source>To use Smarty Cache, the directory %directorypath% must be writable.</source>
+        <target>To use Smarty Cache, the directory %directorypath% must be writable.</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="91e3dffab90db947ea156087dadaa9c0">
+        <source>Before being able to use this tool, you need to:[1][2]Create a blank .htaccess in your root directory.[/2][2]Give it write permissions (CHMOD 666 on Unix system).[/2][/1]</source>
+        <target>Before being able to use this tool, you need to:[1][2]Create a blank .htaccess in your root directory.[/2][2]Give it write permissions (CHMOD 666 on Unix system).[/2][/1]</target>
+        <note>Line: 203</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Debug/DebugModeConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="667685497be44ab0fc2d4334a512405b">
+        <source>Error: Could not write to file. Make sure that the correct permissions are set on the file %s</source>
+        <target>Error: Could not write to file. Make sure that the correct permissions are set on the file %s</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="d4fb191ef219af010cc664bf47393e97">
+        <source>Error: Could not find whether debug mode is enabled. Make sure that the correct permissions are set on the file %s</source>
+        <target>Error: Could not find whether debug mode is enabled. Make sure that the correct permissions are set on the file %s</target>
+        <note>Line: 97</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Media/MediaServerConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ea030df6cb392bef66cde22c94578ae4">
+        <source>Media server #1 is invalid</source>
+        <target>Media server #1 is invalid</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="32d841e578ff7560bbaeda96f5328e9e">
+        <source>Media server #2 is invalid</source>
+        <target>Media server #2 is invalid</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="63ae8982fa76c668cbfc774ccf083d26">
+        <source>Media server #3 is invalid</source>
+        <target>Media server #3 is invalid</target>
+        <note>Line: 116</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Requirement/CheckRequirements.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4f32e16f17a3ba8527cd8160ad85de37">
+        <source>Update your PHP version.</source>
+        <target>Update your PHP version.</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="726f1a9982e9ced2818f72090683e077">
+        <source>Configure your server to allow file uploads.</source>
+        <target>Configure your server to allow file uploads.</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="ba29b5ac8580aaa26d3166f32da8ac10">
+        <source>Configure your server to allow the creation of directories and files with write permissions.</source>
+        <target>Configure your server to allow the creation of directories and files with write permissions.</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="98bbaed82b3e7d2b957be02ac1f91f36">
+        <source>Enable the CURL extension on your server.</source>
+        <target>Enable the CURL extension on your server.</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="36da7cbbc854d7861db49d5e82bf932b">
+        <source>Enable the DOM extension on your server.</source>
+        <target>Enable the DOM extension on your server.</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="3ac2fbb7427ea6dac01c40ed70350fb0">
+        <source>Enable the Fileinfo extension on your server.</source>
+        <target>Enable the Fileinfo extension on your server.</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="b5f353847bbb01ca0feda2a3b0e5b1a9">
+        <source>Enable the GD library on your server.</source>
+        <target>Enable the GD library on your server.</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="ebcb30cdf6fa4833f9e0115eb92deb7a">
+        <source>Enable the JSON extension on your server.</source>
+        <target>Enable the JSON extension on your server.</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="4212b25cc6780f5551bcaadeca27c791">
+        <source>Enable the Mbstring extension on your server.</source>
+        <target>Enable the Mbstring extension on your server.</target>
+        <note>Line: 109</note>
+      </trans-unit>
+      <trans-unit id="aa08f94ed008490c748301ea5db9568b">
+        <source>Enable the OpenSSL extension on your server.</source>
+        <target>Enable the OpenSSL extension on your server.</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="a06111807d1bd6e8dd420e7ee5d0b0f8">
+        <source>Enable the PDO Mysql extension on your server.</source>
+        <target>Enable the PDO Mysql extension on your server.</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="60575cad0e1f106447cb0dfa37c01daf">
+        <source>Enable the XML extension on your server.</source>
+        <target>Enable the XML extension on your server.</target>
+        <note>Line: 112</note>
+      </trans-unit>
+      <trans-unit id="cc4c22b3f8726001cf1c1663cd4845c2">
+        <source>Enable the ZIP extension on your server.</source>
+        <target>Enable the ZIP extension on your server.</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="4fc7f05f412a1684ce4996e51ffff7fe">
+        <source>Enable the MySQL support on your server.</source>
+        <target>Enable the MySQL support on your server.</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="fbc80a46761028390cb9f217affc1ad4">
+        <source>Set write permissions for the "config" folder.</source>
+        <target>Set write permissions for the "config" folder.</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="d667dd7ea28dcabe347120a1ea277658">
+        <source>Set write permissions for the "cache" folder.</source>
+        <target>Set write permissions for the "cache" folder.</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="9c05ffb08aed8df408a9338efa0de1ce">
+        <source>Set write permissions for the "sitemap.xml" file.</source>
+        <target>Set write permissions for the "sitemap.xml" file.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="515ba9f393d74cfb3a8551b171652f4d">
+        <source>Set write permissions for the "img" folder and subfolders.</source>
+        <target>Set write permissions for the "img" folder and subfolders.</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="5c482561c321c3f8b1ed436afdfab4aa">
+        <source>Set write permissions for the "log" folder and subfolders.</source>
+        <target>Set write permissions for the "log" folder and subfolders.</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="fea054b13666afb1d5d776afb925d288">
+        <source>Set write permissions for the "mails" folder and subfolders.</source>
+        <target>Set write permissions for the "mails" folder and subfolders.</target>
+        <note>Line: 120</note>
+      </trans-unit>
+      <trans-unit id="5a44bd60b36b50f3dafd07404ebce84d">
+        <source>Set write permissions for the "modules" folder and subfolders.</source>
+        <target>Set write permissions for the "modules" folder and subfolders.</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="e1bb8996c82be1d540c7cc0d409bcd2f">
+        <source>Set write permissions for the "themes/%s/cache/" folder and subfolders, recursively.</source>
+        <target>Set write permissions for the "themes/%s/cache/" folder and subfolders, recursively.</target>
+        <note>Line: 122</note>
+      </trans-unit>
+      <trans-unit id="9c56996f2d8597e1f4ff15556128ee7d">
+        <source>Set write permissions for the "themes/%s/lang/" folder and subfolders, recursively.</source>
+        <target>Set write permissions for the "themes/%s/lang/" folder and subfolders, recursively.</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="cf707d7f4da3b1134a8c9470fae8720c">
+        <source>Set write permissions for the "themes/%s/pdf/lang/" folder and subfolders, recursively.</source>
+        <target>Set write permissions for the "themes/%s/pdf/lang/" folder and subfolders, recursively.</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="c0bda45f4bd14c8138cc5107c813167f">
+        <source>Set write permissions for the "app/config/" folder and subfolders, recursively.</source>
+        <target>Set write permissions for the "app/config/" folder and subfolders, recursively.</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="c64f03a0316f495425715feacdddb42a">
+        <source>Set write permissions for the "app/Resources/translations/" folder and subfolders, recursively.</source>
+        <target>Set write permissions for the "app/Resources/translations/" folder and subfolders, recursively.</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="fed1803fba6b27ae43103e333a5600eb">
+        <source>Set write permissions for the "translations" folder and subfolders.</source>
+        <target>Set write permissions for the "translations" folder and subfolders.</target>
+        <note>Line: 127</note>
+      </trans-unit>
+      <trans-unit id="94f3a2dc6474b8b097c257fa1da2c9e1">
+        <source>Set write permissions for the "upload" folder and subfolders.</source>
+        <target>Set write permissions for the "upload" folder and subfolders.</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="dbbb85913376aec586b97adc72268a5c">
+        <source>Set write permissions for the "download" folder and subfolders.</source>
+        <target>Set write permissions for the "download" folder and subfolders.</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="4993d8516d8737159bcd735ca8075e6e">
+        <source>Allow the PHP fopen() function on your server.</source>
+        <target>Allow the PHP fopen() function on your server.</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="4a344651fb10eb9e339838fab7bb97ae">
+        <source>Enable GZIP compression on your server.</source>
+        <target>Enable GZIP compression on your server.</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="0996c7cf8e7f49f54d15b68262a6b68d">
+        <source>Some PrestaShop files are missing from your server.</source>
+        <target>Some PrestaShop files are missing from your server.</target>
+        <note>Line: 132</note>
+      </trans-unit>
+      <trans-unit id="e567554b1238bc9e85e38b01e6b198e9">
+        <source>You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.6. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.6 now!</source>
+        <target>You are using PHP %s version. Soon, the latest PHP version supported by PrestaShop will be PHP 5.6. To make sure you’re ready for the future, we recommend you to upgrade to PHP 5.6 now!</target>
+        <note>Line: 133</note>
+      </trans-unit>
+      <trans-unit id="0b9193ca4af6867c1f50a07097254b62">
+        <source>Enable the Apache mod_rewrite module</source>
+        <target>Enable the Apache mod_rewrite module</target>
+        <note>Line: 134</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/SqlManager/SqlQueryValidator.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a0e587425d03db434bd7ad7081913cb4">
+        <source>The "%tablename%" table does not exist.</source>
+        <target>The "%tablename%" table does not exist.</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="9caefacc2d658e65a31461564c163624">
+        <source>The "%attribute%" attribute does not exist in the "%table%" table.</source>
+        <target>The "%attribute%" attribute does not exist in the "%table%" table.</target>
+        <note>Line: 320</note>
+      </trans-unit>
+      <trans-unit id="b162612cdcbf01c01421bad2e8b39432">
+        <source>Undefined "%s" error</source>
+        <target>Undefined "%s" error</target>
+        <note>Line: 330</note>
+      </trans-unit>
+      <trans-unit id="dbea0ef67609a60a1f71f8d19e132d1e">
+        <source>The "*" operator cannot be used in a nested query.</source>
+        <target>The "*" operator cannot be used in a nested query.</target>
+        <note>Line: 187</note>
+      </trans-unit>
+      <trans-unit id="20cc3893d65fa16fcd2fe317c555e28a">
+        <source>The operator "%s" is incorrect.</source>
+        <target>The operator "%s" is incorrect.</target>
+        <note>Line: 213</note>
+      </trans-unit>
+      <trans-unit id="dde2543d498ef763b41a2e5ddad7ecdd">
+        <source>The "%operator%" operator is incorrect.</source>
+        <target>The "%operator%" operator is incorrect.</target>
+        <note>Line: 252</note>
+      </trans-unit>
+      <trans-unit id="19681d28ed1cc72479bc26b7e76ad240">
+        <source>The LIMIT clause must contain numeric arguments.</source>
+        <target>The LIMIT clause must contain numeric arguments.</target>
+        <note>Line: 346</note>
+      </trans-unit>
+      <trans-unit id="37074dedaa80ce0e038f92b668fb2350">
+        <source>The "%reference%" reference does not exist in the "%table%" table.</source>
+        <target>The "%reference%" reference does not exist in the "%table%" table.</target>
+        <note>Line: 363</note>
+      </trans-unit>
+      <trans-unit id="7b4dd672e3b87269079894e693ce9b76">
+        <source>When multiple tables are used, each attribute must refer back to a table.</source>
+        <target>When multiple tables are used, each attribute must refer back to a table.</target>
+        <note>Line: 373</note>
+      </trans-unit>
+      <trans-unit id="8ff8844bb02822975904934598298987">
+        <source>"%key%" is an unauthorized keyword.</source>
+        <target>"%key%" is an unauthorized keyword.</target>
+        <note>Line: 407</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Upload/UploadQuotaConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c3ecc0e8b4dc11a1d2c66d81439b4a42">
+        <source>The limit chosen is larger than the server's maximum upload limit. Please increase the limits of your server.</source>
+        <target>The limit chosen is larger than the server's maximum upload limit. Please increase the limits of your server.</target>
+        <note>Line: 94</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Import/File/FileUploader.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8c9067e52e4440d8a20e74fdc745b0c6">
+        <source>No file was uploaded.</source>
+        <target>No file was uploaded.</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="68e8d36b17584f88614fb3201925a7ac">
+        <source>The uploaded file exceeds the upload_max_filesize directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess.</source>
+        <target>The uploaded file exceeds the upload_max_filesize directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess.</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="0bedafc96db94da3f85caa7101944eb5">
+        <source>The uploaded file exceeds the post_max_size directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess, for example:</source>
+        <target>The uploaded file exceeds the post_max_size directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess, for example:</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="4f12b222c9659d62afa795987259933f">
+        <source>The uploaded file was only partially uploaded.</source>
+        <target>The uploaded file was only partially uploaded.</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="fc2e88db6e13898dab6ddf3b44c5d68a">
+        <source>The extension of your file should be .csv.</source>
+        <target>The extension of your file should be .csv.</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="50844c635a86264cc59d737d532df573">
+        <source>An error occurred while uploading / copying the file.</source>
+        <target>An error occurred while uploading / copying the file.</target>
+        <note>Line: 90</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Webservice/ServerRequirementsChecker.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3a1d42e50ada009f2ef187fbf6dc8a3f">
+        <source>To avoid operating problems, please use an Apache server.</source>
+        <target>To avoid operating problems, please use an Apache server.</target>
+        <note>Line: 156</note>
+      </trans-unit>
+      <trans-unit id="d6305f2f8c5c0f95a367e618a64bb458">
+        <source>Please activate the 'mod_auth_basic' Apache module to allow authentication of PrestaShop's webservice.</source>
+        <target>Please activate the 'mod_auth_basic' Apache module to allow authentication of PrestaShop's webservice.</target>
+        <note>Line: 161</note>
+      </trans-unit>
+      <trans-unit id="e11a22a5910f9f84a6630ee78e1a39f5">
+        <source>Please activate the 'mod_rewrite' Apache module to allow the PrestaShop webservice.</source>
+        <target>Please activate the 'mod_rewrite' Apache module to allow the PrestaShop webservice.</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="2c19e4b707a422ddbbc4d1c32966661d">
+        <source>We could not check to see if basic authentication and rewrite extensions have been activated. Please manually check if they've been activated in order to use the PrestaShop webservice.</source>
+        <target>We could not check to see if basic authentication and rewrite extensions have been activated. Please manually check if they've been activated in order to use the PrestaShop webservice.</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="ab60321a106f1e1ab65b76c1ca15dd7c">
+        <source>Please activate the 'SimpleXML' PHP extension to allow testing of PrestaShop's webservice.</source>
+        <target>Please activate the 'SimpleXML' PHP extension to allow testing of PrestaShop's webservice.</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="0508bbb36fb6b5db31edf2f45cd687ea">
+        <source>It is preferable to use SSL (https:) for webservice calls, as it avoids the "man in the middle" type security issues.</source>
+        <target>It is preferable to use SSL (https:) for webservice calls, as it avoids the "man in the middle" type security issues.</target>
+        <note>Line: 181</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f36c9a20c2ce51f491c944e41fde5ace">
+        <source>It appears the backup was successful, however you must download and carefully verify the backup file before proceeding.</source>
+        <target>It appears the backup was successful, however you must download and carefully verify the backup file before proceeding.</target>
+        <note>Line: 161</note>
+      </trans-unit>
+      <trans-unit id="2c7338ad06a6bb0747b0d432c33464ce">
+        <source>The "Backups" directory located in the admin directory must be writable (CHMOD 755 / 777).</source>
+        <target>The "Backups" directory located in the admin directory must be writable (CHMOD 755 / 777).</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="fe7ff4ed0a66abe86361ba0f8d6e919a">
+        <source>The backup file does not exist</source>
+        <target>The backup file does not exist</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="4e0ac45de6bd848503ffa98ff6247f2f">
+        <source>Error deleting</source>
+        <target>Error deleting</target>
+        <note>Line: 202</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="af395851b27882221a6df82c727bca3e">
+        <source>The import directory doesn't exist. Please check your file path.</source>
+        <target>The import directory doesn't exist. Please check your file path.</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="c775530fad852632f78395a11820ba23">
+        <source>The import directory must be writable (CHMOD 755 / 777).</source>
+        <target>The import directory must be writable (CHMOD 755 / 777).</target>
+        <note>Line: 79</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9ad28fef1c6184adfe7397838891ba76">
+        <source>The Memcached server cannot be added.</source>
+        <target>The Memcached server cannot be added.</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="bf4ddd37d9f82a3ad1f405891dfaa235">
+        <source>There was an error when attempting to delete the Memcached server.</source>
+        <target>There was an error when attempting to delete the Memcached server.</target>
+        <note>Line: 170</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fd4adc19ae7e0f0391f617451f3729cf">
+        <source>All caches cleared successfully</source>
+        <target>All caches cleared successfully</target>
+        <note>Line: 124</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="023d53a99c8074e823e5b2db4c19dfa4">
+        <source>(you must install the [a]Memcache PECL extension[/a])</source>
+        <target>(you must install the [a]Memcache PECL extension[/a])</target>
+        <note>Line: 120</note>
+      </trans-unit>
+      <trans-unit id="82742001d67f4446f50d68908f0f8b96">
+        <source>(you must install the [a]Memcached PECL extension[/a])</source>
+        <target>(you must install the [a]Memcached PECL extension[/a])</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="78ae94b19fc38f9a35d20bc67cde2d61">
+        <source>(you must install the [a]APC PECL extension[/a])</source>
+        <target>(you must install the [a]APC PECL extension[/a])</target>
+        <note>Line: 140</note>
+      </trans-unit>
+      <trans-unit id="8b763a82c2aa7875f3da39399ba350d7">
+        <source>(you must install the [a]Xcache extension[/a])</source>
+        <target>(you must install the [a]Xcache extension[/a])</target>
+        <note>Line: 150</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="197f1953efd11637a634a7f9b269eac3">
+        <source>To proceed, please upload a file first.</source>
+        <target>To proceed, please upload a file first.</target>
+        <note>Line: 81</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_form.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5b739e824ccebf9cd8c5b4ef774c59a7">
+        <source>I have read the disclaimer. Please create a new backup.</source>
+        <target>I have read the disclaimer. Please create a new backup.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="088e7482af32200b588d22e5f0af4f94">
+        <source>How to restore a database backup</source>
+        <target>How to restore a database backup</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="bcb4db2b36ea3b1e20e5ee4aa9a68665">
+        <source>If you need to restore a database backup, we invite you to subscribe to a [1][2]technical support plan[/2][/1].</source>
+        <target>If you need to restore a database backup, we invite you to subscribe to a [1][2]technical support plan[/2][/1].</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="0929b3759c8eef31c299400f513072dd">
+        <source>Our team will take care of restoring your database safely.</source>
+        <target>Our team will take care of restoring your database safely.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="c4b6a12f5f4cbbeb2353a718ee9a8a9a">
+        <source>Why can't I restore it by myself?</source>
+        <target>Why can't I restore it by myself?</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="d4ef96663955ee203ce986ef40945199">
+        <source>Your shop is hosted by PrestaShop. Although you can create backup files here below, there are core settings you cannot access for security reasons, like the database management. Thus, only our team can proceed to a restoration.</source>
+        <target>Your shop is hosted by PrestaShop. Although you can create backup files here below, there are core settings you cannot access for security reasons, like the database management. Thus, only our team can proceed to a restoration.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="54ee283a75b8a8a38f0b4996e4e69db5">
+        <source>Disclaimer before creating a new backup</source>
+        <target>Disclaimer before creating a new backup</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="0869c85782ee2481b83a9f580a09e963">
+        <source>PrestaShop is not responsible for your database, its backups and/or recovery.</source>
+        <target>PrestaShop is not responsible for your database, its backups and/or recovery.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="cc6f77e8d23517366b4380f9a180655f">
+        <source>PrestaShop is open-source software. You are using it at your own risk under the license agreement.</source>
+        <target>PrestaShop is open-source software. You are using it at your own risk under the license agreement.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="99c8acd81f347dd6268fda9bf9e61b97">
+        <source>You should back up your data on a regular basis (both files and database).</source>
+        <target>You should back up your data on a regular basis (both files and database).</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="4d247cbe2dbd06ce20b9affd635e7982">
+        <source>This function only backs up your database, not your files.</source>
+        <target>This function only backs up your database, not your files.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="b2a110974050263fde4c0c7cf15013b3">
+        <source>By default, your existing database tables will be dropped during the backup recovery (see "Backup options" below).</source>
+        <target>By default, your existing database tables will be dropped during the backup recovery (see "Backup options" below).</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="dba49284eb0830e849635506a961aa7c">
+        <source>Always verify the quality and integrity of your backup files!</source>
+        <target>Always verify the quality and integrity of your backup files!</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="5cb0e756d153cfcfac763077a5f0628c">
+        <source>Always verify that your backup files are complete, up-to-date and valid, even if you had a success message appear during the backup process.</source>
+        <target>Always verify that your backup files are complete, up-to-date and valid, even if you had a success message appear during the backup process.</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="0dc51a7afc30b342b827df535ff616f2">
+        <source>Always check your data.</source>
+        <target>Always check your data.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="804206afa5249349d8bfea4cc78c48d7">
+        <source>Never restore a backup on a live site.</source>
+        <target>Never restore a backup on a live site.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/download_view.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cd7fa1b4a137bf4da20f84bed6624fa5">
+        <source>Beginning the download ...</source>
+        <target>Beginning the download ...</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="6a278621d6f2e7dbd56c7beca4081e2d">
+        <source>Backup files should automatically start downloading.</source>
+        <target>Backup files should automatically start downloading.</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="da61b0c3311560af7fa1d9a515b309f6">
+        <source>If not,[1][2] please click here[/1]!</source>
+        <target>If not,[1][2] please click here[/1]!</target>
+        <note>Line: 45</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6dc43a448d1a98e265b2632d5fa41ec6">
+        <source>Are you sure that you would like to delete this entity:</source>
+        <target>Are you sure that you would like to delete this entity:</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="e4cdcd51e6cf787d4ecc7d813f0c23cb">
+        <source>The locale must be installed</source>
+        <target>The locale must be installed</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/smtp_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5b8df4265c79cd43831e740281850c84">
+        <source>SSL does not seem to be available on your server.</source>
+        <target>SSL does not seem to be available on your server.</target>
+        <note>Line: 74</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/list.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0ee028bcc2a0101d4d65745086eefc03">
+        <source>When saving the query, only the "SELECT" SQL statement is allowed.</source>
+        <target>When saving the query, only the "SELECT" SQL statement is allowed.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/memcache_servers.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="29be13f78208f2e848c6b6645a79f813">
+        <source>Do you really want to remove the server %serverIp%:%serverPort% ?</source>
+        <target>Do you really want to remove the server %serverIp%:%serverPort% ?</target>
+        <note>Line: 93</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e0aa021e21dddbd6d8cecec71e9cf564">
+        <source>OK</source>
+        <target>OK</target>
+        <note>Line: 209</note>
+      </trans-unit>
+      <trans-unit id="2ad1ffcbe2184ed25baa66baece8908b">
+        <source>Please fix the following error(s)</source>
+        <target>Please fix the following error(s)</target>
+        <note>Line: 212</note>
+      </trans-unit>
+      <trans-unit id="d5df5b42d8fa5fed36fbd1cda0112f40">
+        <source>Checking files...</source>
+        <target>Checking files...</target>
+        <note>Line: 235</note>
+      </trans-unit>
+      <trans-unit id="a2db667abfde7a08ee094d460102f268">
+        <source>Missing files</source>
+        <target>Missing files</target>
+        <note>Line: 245</note>
+      </trans-unit>
+      <trans-unit id="b5871613cbf4ab8b21d528ff2576fcbf">
+        <source>Updated files</source>
+        <target>Updated files</target>
+        <note>Line: 246</note>
+      </trans-unit>
+      <trans-unit id="c49d6d58d1c98f34a15bbd169f82961a">
+        <source>Changed/missing files have been detected.</source>
+        <target>Changed/missing files have been detected.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="4757718002cbae6feee5c372b66b6a29">
+        <source>No change has been detected in your files.</source>
+        <target>No change has been detected in your files.</target>
+        <note>Line: 248</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminCatalogFeature.xlf
+++ b/app/Resources/translations/default/AdminCatalogFeature.xlf
@@ -1,2833 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminAttachmentsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bdf4f1da184f2dc052c75ad7e1afbd4a">
-        <source>Associated with</source>
-        <target>Associated with</target>
-        <note>Context:
-File: controllers/admin/AdminAttachmentsController.php:71</note>
-      </trans-unit>
-      <trans-unit id="fc1ff5390ecc7efd695f697f3d6b7e4b">
-        <source>product(s)</source>
-        <target>product(s)</target>
-        <note>Context:
-File: controllers/admin/AdminAttachmentsController.php:72</note>
-      </trans-unit>
-      <trans-unit id="3f1f6fb24d408c8ddead60bd41063b02">
-        <source>Add new file</source>
-        <target>Add new file</target>
-        <note>Context:
-File: controllers/admin/AdminAttachmentsController.php:135</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c82a6100dace2b41087ba6cf99a5976a">
-        <source>Values</source>
-        <target>Values</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:61</note>
-      </trans-unit>
-      <trans-unit id="689202409e48743b914713f96d93947c">
-        <source>Value</source>
-        <target>Value</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:131</note>
-      </trans-unit>
-      <trans-unit id="cb5feb1b7314637725a2e73bdc9f7295">
-        <source>Color</source>
-        <target>Color</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:308</note>
-      </trans-unit>
-      <trans-unit id="f68b27443f6e6f685cce3f9f422a2b84">
-        <source>Color or texture</source>
-        <target>Color or texture</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:185</note>
-      </trans-unit>
-      <trans-unit id="287234a1ff35a314b5b6bc4e5828e745">
-        <source>Attributes</source>
-        <target>Attributes</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:191</note>
-      </trans-unit>
-      <trans-unit id="d274013ea65428454962a59b7b373a41">
-        <source>Public name</source>
-        <target>Public name</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:206</note>
-      </trans-unit>
-      <trans-unit id="17af8baa9b3f90e936589069e4223280">
-        <source>Attribute type</source>
-        <target>Attribute type</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:215</note>
-      </trans-unit>
-      <trans-unit id="0e010c6b3fb88bf4277c880d1657787a">
-        <source>Attribute group</source>
-        <target>Attribute group</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:264</note>
-      </trans-unit>
-      <trans-unit id="561f47d9c8a6153b011def4fd72386d5">
-        <source>Current texture</source>
-        <target>Current texture</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:325</note>
-      </trans-unit>
-      <trans-unit id="00039b674d8ced58313546dcab88a032">
-        <source>Add new attribute</source>
-        <target>Add new attribute</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:519</note>
-      </trans-unit>
-      <trans-unit id="2dce4461e5743f3b01acd4599a38d646">
-        <source>Add new value</source>
-        <target>Add new value</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:533</note>
-      </trans-unit>
-      <trans-unit id="71e8f8a090925f75719dfa0a5eae059e">
-        <source>Add New Values</source>
-        <target>Add New Values</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:571</note>
-      </trans-unit>
-      <trans-unit id="52729803b243ea9693a892161d5b8e38">
-        <source>Add New Attributes</source>
-        <target>Add New Attributes</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:583</note>
-      </trans-unit>
-      <trans-unit id="1f40023e11d8401b0bffadc419135247">
-        <source>Edit New Attribute</source>
-        <target>Edit New Attribute</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:600</note>
-      </trans-unit>
-      <trans-unit id="713271e705e5269fc82684445cd063a8">
-        <source>Add New Attribute</source>
-        <target>Add New Attribute</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:604</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/attributes/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="a3e8ae43188ae76d38f414b2bdb0077b">
         <source>Texture</source>
         <target>Texture</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attributes/helpers/form/form.tpl:45</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminFeaturesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7d5672f569de406c85249db6f1c99ec0">
-        <source>Save then add another value</source>
-        <target>Save then add another value</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:362</note>
-      </trans-unit>
-      <trans-unit id="4472046c137171c7adf7c4fe5a72b6b9">
-        <source>Edit: %value%</source>
-        <target>Edit: %value%</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:303</note>
-      </trans-unit>
-      <trans-unit id="577cf2cf1be74419ac04093a2b4cd64d">
-        <source>Edit Value</source>
-        <target>Edit Value</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:306</note>
-      </trans-unit>
-      <trans-unit id="fce2e84f3cce0e5351e85e9f0cb20107">
-        <source>Add New Value</source>
-        <target>Add New Value</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:309</note>
-      </trans-unit>
-      <trans-unit id="d6ae681fcd58f1e1936ca97da36528ff">
-        <source>Add a new feature</source>
-        <target>Add a new feature</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:161</note>
-      </trans-unit>
-      <trans-unit id="5f46be79c24b6cde1ff2176a2ce917e9">
-        <source>Add new feature</source>
-        <target>Add new feature</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:201</note>
-      </trans-unit>
-      <trans-unit id="ef8edef8db1844688f6a542b9cf45742">
-        <source>Edit New Feature</source>
-        <target>Edit New Feature</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:281</note>
-      </trans-unit>
-      <trans-unit id="dd261387b1ad7605716e5edbc0164028">
-        <source>Add New Feature</source>
-        <target>Add New Feature</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:286</note>
-      </trans-unit>
-      <trans-unit id="6c3205f235918451faca3dcd6e63d760">
-        <source>Feature value</source>
-        <target>Feature value</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:332</note>
-      </trans-unit>
-      <trans-unit id="0c8a987e64c2d46886bf92e29c736bdc">
-        <source>Add a new feature value</source>
-        <target>Add a new feature value</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:406</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c3bf447eabe632720a3aa1a7ce401274">
-        <source>Open</source>
-        <target>Open</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:56</note>
-      </trans-unit>
-      <trans-unit id="03f4a47830f97377a35321051685071e">
-        <source>Closed</source>
-        <target>Closed</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:57</note>
-      </trans-unit>
-      <trans-unit id="70e7ab74282fb27b8c100e017b037135">
-        <source>Pending 1</source>
-        <target>Pending 1</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:58</note>
-      </trans-unit>
-      <trans-unit id="1033cc268ed0919b5d4e76ea6053ed25">
-        <source>Pending 2</source>
-        <target>Pending 2</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:59</note>
-      </trans-unit>
-      <trans-unit id="41de6d6cfb8953c021bbe4ba0701c8a1">
-        <source>Messages</source>
-        <target>Messages</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:111</note>
-      </trans-unit>
-      <trans-unit id="47f9082fc380ca62d531096aa1d110f1">
-        <source>Private</source>
-        <target>Private</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:117</note>
-      </trans-unit>
-      <trans-unit id="cf090b8fa4a136ed6058aaf84d5d2538">
-        <source>Last message</source>
-        <target>Last message</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:129</note>
-      </trans-unit>
-      <trans-unit id="8058aef8e4c03453b1b088795677726a">
-        <source>Contact options</source>
-        <target>Contact options</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:147</note>
-      </trans-unit>
-      <trans-unit id="42d99bbf0d1cd9ffe4a5ff746d177aba">
-        <source>Allow file uploading</source>
-        <target>Allow file uploading</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:150</note>
-      </trans-unit>
-      <trans-unit id="2da2fc7f382fa2e5b9d0e433fa71a475">
-        <source>Default message</source>
-        <target>Default message</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:155</note>
-      </trans-unit>
-      <trans-unit id="0e9470c5e6bfee40004f22f543b8b2a6">
-        <source>Customer service options</source>
-        <target>Customer service options</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:164</note>
-      </trans-unit>
-      <trans-unit id="13ec82d83a5254297003cc1b41f19edb">
-        <source>IMAP URL</source>
-        <target>IMAP URL</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:167</note>
-      </trans-unit>
-      <trans-unit id="197f7f372a439787cef040d61f4dbe83">
-        <source>IMAP port</source>
-        <target>IMAP port</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:172</note>
-      </trans-unit>
-      <trans-unit id="f9b68c21c5d51df2d6b54cfbfa985abe">
-        <source>IMAP user</source>
-        <target>IMAP user</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:178</note>
-      </trans-unit>
-      <trans-unit id="2cacfd762c9fc6f7a140aadc7b5a608c">
-        <source>IMAP password</source>
-        <target>IMAP password</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:183</note>
-      </trans-unit>
-      <trans-unit id="ca7e64e3f55ef8e0f50818d8117d26cc">
-        <source>Delete messages</source>
-        <target>Delete messages</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:188</note>
-      </trans-unit>
-      <trans-unit id="1fd5325f317b2c9aacc11fb393fd2aa8">
-        <source>Create new threads</source>
-        <target>Create new threads</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:193</note>
-      </trans-unit>
-      <trans-unit id="ebcb544208ccfe2e3fe98c8380518300">
-        <source>IMAP options</source>
-        <target>IMAP options</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:228</note>
-      </trans-unit>
-      <trans-unit id="693c61ec70b6c06dbd376fd208a125a0">
-        <source>Total threads</source>
-        <target>Total threads</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:281</note>
-      </trans-unit>
-      <trans-unit id="068f62c804cc9c4cd4f6dfc5b5d3ecaa">
-        <source>Threads pending</source>
-        <target>Threads pending</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:282</note>
-      </trans-unit>
-      <trans-unit id="2fb7efc7cfbbb4672a5f3a021f1a2462">
-        <source>Total number of customer messages</source>
-        <target>Total number of customer messages</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:283</note>
-      </trans-unit>
-      <trans-unit id="8d937d958b984dde93c972a335f87d4b">
-        <source>Total number of employee messages</source>
-        <target>Total number of employee messages</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:284</note>
-      </trans-unit>
-      <trans-unit id="da2f2f1035487e79b7f5bfd9c5c3eeab">
-        <source>Unread threads</source>
-        <target>Unread threads</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:285</note>
-      </trans-unit>
-      <trans-unit id="939315783ef4f2eb1cbdac37f3fd1e6b">
-        <source>Closed threads</source>
-        <target>Closed threads</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:286</note>
-      </trans-unit>
-      <trans-unit id="d21b5a78517318e6d35414d4217950ce">
-        <source>Message forwarded to</source>
-        <target>Message forwarded to</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:410</note>
-      </trans-unit>
-      <trans-unit id="0134539df13231b95613415c0a75af42">
-        <source>Pending Discussion Threads</source>
-        <target>Pending Discussion Threads</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:549</note>
-      </trans-unit>
-      <trans-unit id="c61b4a4520f875b20f7ff3e6ff502ebe">
-        <source>Average Response Time</source>
-        <target>Average Response Time</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:561</note>
-      </trans-unit>
-      <trans-unit id="6092e157634b78d790fc607b587d1274">
-        <source>Messages per Thread</source>
-        <target>Messages per Thread</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:574</note>
-      </trans-unit>
-      <trans-unit id="dab57a3f740e26922519aebc7e3d602a">
-        <source>Reply to the next unanswered message in this thread</source>
-        <target>Reply to the next unanswered message in this thread</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:634</note>
-      </trans-unit>
-      <trans-unit id="5e7304b3032d56f1e9a1ce34cfd4a4ff">
-        <source>Mark as "handled"</source>
-        <target>Mark as "handled"</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:641</note>
-      </trans-unit>
-      <trans-unit id="ea907b9c1af0f060fa2c21beed25880e">
-        <source>Re-open</source>
-        <target>Re-open</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:648</note>
-      </trans-unit>
-      <trans-unit id="4e852df9fae5b1f8b5e97233733dca5e">
-        <source>Mark as "pending 1" (will be answered later)</source>
-        <target>Mark as "pending 1" (will be answered later)</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:657</note>
-      </trans-unit>
-      <trans-unit id="bd31a5029e3ca883955fdf21f7528078">
-        <source>Disable pending status</source>
-        <target>Disable pending status</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:680</note>
-      </trans-unit>
-      <trans-unit id="005ae88a1f2c4664a5009cc0c8d14f7b">
-        <source>Mark as "pending 2" (will be answered later)</source>
-        <target>Mark as "pending 2" (will be answered later)</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:673</note>
-      </trans-unit>
-      <trans-unit id="119ce51409ff0ec366e67df0c852ede7">
-        <source>Message to: </source>
-        <target>Message to:</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:759</note>
-      </trans-unit>
-      <trans-unit id="ed96f783e467cc984e4945063760e2c4">
-        <source>Product: </source>
-        <target>Product:</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:762</note>
-      </trans-unit>
-      <trans-unit id="24a23d787190f2c4812ff9ab11847a72">
-        <source>Status:</source>
-        <target>Status:</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:783</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_discount_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a1fa27779242b4902f7ae3bdd5c6d508">
-        <source>Type</source>
-        <target>Type</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_discount_form.tpl:38</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="13f13e9a00350642fed860ff27b9976e">
-        <source>Cost price</source>
-        <target>Cost price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:111</note>
-      </trans-unit>
-      <trans-unit id="1fd6db3332676692077360fec4df12e4">
-        <source>Retail price</source>
-        <target>Retail price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:32</note>
-      </trans-unit>
-      <trans-unit id="784cfc140d0ef59d7f48342f7f1636e0">
-        <source>Manage tax rules</source>
-        <target>Manage tax rules</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:87</note>
-      </trans-unit>
-      <trans-unit id="ad6097fc9736641b0b94a1b5f02840f5">
-        <source>Final retail price: [1][2][/2] tax incl.[/1] / [3][/3] tax excl.</source>
-        <target>Final retail price: [1][2][/2] tax incl.[/1] / [3][/3] tax excl.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:98</note>
-      </trans-unit>
-      <trans-unit id="5b14ab8904d8a735edd6ea4cff8f7b7c">
-        <source>Specific prices</source>
-        <target>Specific prices</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:128</note>
-      </trans-unit>
-      <trans-unit id="c625329eae5c7836f78bbdfc9e1fa577">
-        <source>Add a specific price</source>
-        <target>Add a specific price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:137</note>
-      </trans-unit>
-      <trans-unit id="ab7a485ebe75b6dd7243ad719f23c7de">
-        <source>Rule</source>
-        <target>Rule</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:150</note>
-      </trans-unit>
-      <trans-unit id="47ac923d219501859fb68fed8c8db77b">
-        <source>Combination</source>
-        <target>Combination</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:151</note>
-      </trans-unit>
-      <trans-unit id="be6dfa820509f5ce1c052c2e5e0e3dff">
-        <source>Fixed price</source>
-        <target>Fixed price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:156</note>
-      </trans-unit>
-      <trans-unit id="21f59b54f62b5b8b4bc0f63f0f617fc1">
-        <source>Impact</source>
-        <target>Impact</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:157</note>
-      </trans-unit>
-      <trans-unit id="5da618e8e4b89c66fe86e32cdafde142">
-        <source>From</source>
-        <target>From</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:159</note>
-      </trans-unit>
-      <trans-unit id="8e99fa97ef8d51d9215028842c7ad57c">
-        <source>Priority management</source>
-        <target>Priority management</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:180</note>
-      </trans-unit>
-      <trans-unit id="8d3444a0aa942bf7a1979b8270f5c8e5">
-        <source>Priorities</source>
-        <target>Priorities</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:187</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="622d67c7a2ea6386a4480e02b12fadd8">
-        <source>Impact on price</source>
-        <target>Impact on price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:88</note>
-      </trans-unit>
-      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
-        <source>Quantity</source>
-        <target>Quantity</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:91</note>
-      </trans-unit>
-      <trans-unit id="ed26f5ba7a0f0f6ca8b16c3886eb68ad">
-        <source>Final price</source>
-        <target>Final price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:89</note>
-      </trans-unit>
-      <trans-unit id="b9208b03bcc9eb4a336258dcdcb66207">
-        <source>Combinations</source>
-        <target>Combinations</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:87</note>
-      </trans-unit>
-      <trans-unit id="7e64da36262d906a23b4b8614018bcd1">
-        <source>Manage your product combinations</source>
-        <target>Manage your product combinations</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:28</note>
-      </trans-unit>
-      <trans-unit id="146cda0589b3eb8697196bdc05e6b049">
-        <source>Bulk actions ([1]/[2] combination(s) selected)</source>
-        <target>Bulk actions ([1]/[2] combination(s) selected)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:67</note>
-      </trans-unit>
-      <trans-unit id="7c52393eaa879dd8c3081f4c3c847846">
-        <source>Default combination</source>
-        <target>Default combination</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:93</note>
-      </trans-unit>
-      <trans-unit id="410dcd654c1ca6b558fb122cec55f36f">
-        <source>Availability preferences</source>
-        <target>Availability preferences</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:171</note>
-      </trans-unit>
-      <trans-unit id="4ad46e43817d735c3cadff659cc8a455">
-        <source>Behavior when out of stock</source>
-        <target>Behavior when out of stock</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:175</note>
-      </trans-unit>
-      <trans-unit id="9a9d0d58778ce84d86a1f07df5867112">
-        <source>Stock management is disabled</source>
-        <target>Stock management is disabled</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:193</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e92cfa244b5eb9025d07522080468445">
-        <source>Ecotax</source>
-        <target>Ecotax</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:128</note>
-      </trans-unit>
-      <trans-unit id="3c1a34587e45bd9e9ae2efd9a6ecbb92">
-        <source>Impact on weight</source>
-        <target>Impact on weight</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:137</note>
-      </trans-unit>
-      <trans-unit id="cdba184783a0253218efd734da81a9da">
-        <source>Stock location</source>
-        <target>Stock location</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:154</note>
-      </trans-unit>
-      <trans-unit id="2438bf77baed0680f816ca0f4a7d0321">
-        <source>Availability date</source>
-        <target>Availability date</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:177</note>
-      </trans-unit>
-      <trans-unit id="8ef6e226754a31bf67ebf50047c142b9">
-        <source>Impact on price (tax excl.)</source>
-        <target>Impact on price (tax excl.)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:115</note>
-      </trans-unit>
-      <trans-unit id="152feab7588733220c3720773724c8d5">
-        <source>Impact on price (tax incl.)</source>
-        <target>Impact on price (tax incl.)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:122</note>
-      </trans-unit>
-      <trans-unit id="5bb4529a7441854e00e00f8ed0096756">
-        <source>UPC barcode</source>
-        <target>UPC barcode</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:101</note>
-      </trans-unit>
-      <trans-unit id="c8effe37e0fefd95ff0cc4873de6e6a6">
-        <source>EAN-13 or JAN barcode</source>
-        <target>EAN-13 or JAN barcode</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:85</note>
-      </trans-unit>
-      <trans-unit id="cc11780aa5b292dfe984aefc0d76bfad">
-        <source>ISBN code</source>
-        <target>ISBN code</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:93</note>
-      </trans-unit>
-      <trans-unit id="a04586da5cc69ed7dee68e3b26786999">
-        <source>Impact on price per unit (tax excl.)</source>
-        <target>Impact on price per unit (tax excl.)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:141</note>
-      </trans-unit>
-      <trans-unit id="92fa99e34de79a48fc85c66eb627e70f">
-        <source>Min. quantity for sale</source>
-        <target>Min. quantity for sale</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:147</note>
-      </trans-unit>
-      <trans-unit id="e9d0876ad242d421e19d583f6f379f5f">
-        <source>Set as default combination</source>
-        <target>Set as default combination</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:181</note>
-      </trans-unit>
-      <trans-unit id="a22ed40bafe8f07b6d02c4a4966c8aea">
-        <source>Select images of this combination:</source>
-        <target>Select images of this combination:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:204</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Api/StockController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="78167a214fe755d9a2f5a7f2bc62cecf">
-        <source>Low stock level</source>
-        <target>Low stock level</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Api/StockController.php:168</note>
-      </trans-unit>
-      <trans-unit id="0826c628f8c5f6895c8a1e27e99457fb">
-        <source>Send me an email when the quantity is below or equals this level</source>
-        <target>Send me an email when the quantity is below or equals this level</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Api/StockController.php:169</note>
-      </trans-unit>
-      <trans-unit id="5321a616e36742f66aa933956e839217">
-        <source>Combination name</source>
-        <target>Combination name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Api/StockController.php:162</note>
-      </trans-unit>
-      <trans-unit id="a094699b1837834e13875a06773bcf28">
-        <source>Physical quantity</source>
-        <target>Physical quantity</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Api/StockController.php:165</note>
-      </trans-unit>
-      <trans-unit id="82325d4b818ad2b7f46dfe72e186d016">
-        <source>Reserved quantity</source>
-        <target>Reserved quantity</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Api/StockController.php:166</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9aa4e1b6c10cf1bc2a8145dcc8476b0f">
-        <source>Send me an email when the quantity is under this level</source>
-        <target>Send me an email when the quantity is under this level</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:267</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="52b68aaa602d202c340d9e4e9157f276">
-        <source>Parent category</source>
-        <target>Parent category</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:542</note>
-      </trans-unit>
-      <trans-unit id="5f573e91e5eaa092e00a4c4df393c0cb">
-        <source>Add new root category</source>
-        <target>Add new root category</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:178</note>
-      </trans-unit>
-      <trans-unit id="d0d4e3688fdaee5afa292083b855e143">
-        <source>Add new category</source>
-        <target>Add new category</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:185</note>
-      </trans-unit>
-      <trans-unit id="42c9e94e8e5c29861de422525262ff17">
-        <source>Disabled Categories</source>
-        <target>Disabled Categories</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:393</note>
-      </trans-unit>
-      <trans-unit id="850da4810ae3771d696d504d7346caa6">
-        <source>Empty Categories</source>
-        <target>Empty Categories</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:406</note>
-      </trans-unit>
-      <trans-unit id="3b449120fdb2867c000d7bba671aead3">
-        <source>Top Category</source>
-        <target>Top Category</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:418</note>
-      </trans-unit>
-      <trans-unit id="a6398f9bbc9739ed67ca273b82da0a55">
-        <source>Average number of products per category</source>
-        <target>Average number of products per category</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:431</note>
-      </trans-unit>
-      <trans-unit id="86a230fec38eb3957d48a8ffdfcb4722">
-        <source>%group_name% - All people without a valid customer account.</source>
-        <target>%group_name% - All people without a valid customer account.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:458</note>
-      </trans-unit>
-      <trans-unit id="8a11a183559fcb803b95e9a2e3efb47d">
-        <source>%group_name% - Customer who placed an order with the guest checkout.</source>
-        <target>%group_name% - Customer who placed an order with the guest checkout.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:459</note>
-      </trans-unit>
-      <trans-unit id="7ed584948027b1d0117b1c73f80ea50f">
-        <source>%group_name% - All people who have created an account on this site.</source>
-        <target>%group_name% - All people who have created an account on this site.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:460</note>
-      </trans-unit>
-      <trans-unit id="2028f52eb6d12dc1814f92f18c7365a0">
-        <source>Category Cover Image</source>
-        <target>Category Cover Image</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:561</note>
-      </trans-unit>
-      <trans-unit id="4ae362f049719078c429941bed5dd440">
-        <source>Category thumbnail</source>
-        <target>Category thumbnail</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:572</note>
-      </trans-unit>
-      <trans-unit id="eea317348d82718d49f9a79189dc0f93">
-        <source>Menu thumbnails</source>
-        <target>Menu thumbnails</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:582</note>
-      </trans-unit>
-      <trans-unit id="920bd1fb6d54c93fca528ce941464225">
-        <source>Group access</source>
-        <target>Group access</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:630</note>
-      </trans-unit>
-      <trans-unit id="154b6e494bf56cc4c787bfee6deac113">
-        <source>Root Category</source>
-        <target>Root Category</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:654</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7e34f33e1a881aff98acbf2b766ac883">
-        <source>Delivery time of in-stock products:</source>
-        <target>Delivery time of in-stock products:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:204</note>
-      </trans-unit>
-      <trans-unit id="6adf97f83acf6453d4a6a4b1070f3754">
-        <source>None</source>
-        <target>None</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:159</note>
-      </trans-unit>
-      <trans-unit id="32954654ac8fe66a1d09be19001de2d4">
-        <source>Width</source>
-        <target>Width</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:87</note>
-      </trans-unit>
-      <trans-unit id="eec6c4bdbd339edf8cbea68becb85244">
-        <source>Height</source>
-        <target>Height</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:99</note>
-      </trans-unit>
-      <trans-unit id="675056ad1441b6375b2c5abd48c27ef1">
-        <source>Depth</source>
-        <target>Depth</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:111</note>
-      </trans-unit>
-      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
-        <source>Weight</source>
-        <target>Weight</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:123</note>
-      </trans-unit>
-      <trans-unit id="6fa573b52d8f35231304916ea67f94a8">
-        <source>Shipping fees</source>
-        <target>Shipping fees</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:135</note>
-      </trans-unit>
-      <trans-unit id="582d519b697f8d1a558e91220beea671">
-        <source>Available carriers</source>
-        <target>Available carriers</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:151</note>
-      </trans-unit>
-      <trans-unit id="d41e652e3ec13615827534c10beac3ee">
-        <source>Default delivery time</source>
-        <target>Default delivery time</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:160</note>
-      </trans-unit>
-      <trans-unit id="16599dbd0bf238cbae4090fe1db04145">
-        <source>Specific delivery time to this product</source>
-        <target>Specific delivery time to this product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:161</note>
-      </trans-unit>
-      <trans-unit id="205b01b3197cf06688f6ed574faf5664">
-        <source>Delivery Time</source>
-        <target>Delivery Time</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:168</note>
-      </trans-unit>
-      <trans-unit id="02746d0355a6c94c9ca770302e9da1ca">
-        <source>Delivered within 5-7 days</source>
-        <target>Delivered within 5-7 days</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:178</note>
-      </trans-unit>
-      <trans-unit id="f6db0ad0a1b6aff800f260a83bc06584">
-        <source>Delivery time of out-of-stock products with allowed orders:</source>
-        <target>Delivery time of out-of-stock products with allowed orders:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:185</note>
-      </trans-unit>
-      <trans-unit id="777ca35e6f4ddd56c7b8c16d8f74ad13">
-        <source>Delivered within 3-4 days</source>
-        <target>Delivered within 3-4 days</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php:198</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1729a56cfc89021478498fe0c89a843a">
-        <source>Visibility</source>
-        <target>Visibility</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:37</note>
-      </trans-unit>
-      <trans-unit id="189f63f277cd73395561651753563065">
-        <source>Tags</source>
-        <target>Tags</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:67</note>
-      </trans-unit>
-      <trans-unit id="0250085516590c4fa032d89ae2511adf">
-        <source>Where do you want your product to appear?</source>
-        <target>Where do you want your product to appear?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="b7b224084f1aea992af0ae90ad7761a1">
-        <source><![CDATA[Condition & References]]></source>
-        <target><![CDATA[Condition & References]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:92</note>
-      </trans-unit>
-      <trans-unit id="55de886c2b1929108d8c8cf6d9a703cb">
-        <source>Customers can personalize the product by entering some text or by providing custom image files.</source>
-        <target>Customers can personalize the product by entering some text or by providing custom image files.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:147</note>
-      </trans-unit>
-      <trans-unit id="513987b37a2501ed83af5686ed34624e">
-        <source>Add a customization field</source>
-        <target>Add a customization field</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:161</note>
-      </trans-unit>
-      <trans-unit id="9fb17d168ec32414787e4f47ccd3812c">
-        <source>Attached files</source>
-        <target>Attached files</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:169</note>
-      </trans-unit>
-      <trans-unit id="3a97ab5db26de551af8e0e63c280d56f">
-        <source>Add files that customers can download directly on the product page (instructions, manual, recipe, etc.).</source>
-        <target>Add files that customers can download directly on the product page (instructions, manual, recipe, etc.).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:170</note>
-      </trans-unit>
-      <trans-unit id="16be564a60317ed9d5eef83c90eaf225">
-        <source>Attach a new file</source>
-        <target>Attach a new file</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:184</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="290612199861c31d1036b185b4e69b75">
-        <source>Summary</source>
-        <target>Summary</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:95</note>
-      </trans-unit>
-      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca">
-        <source>Reference</source>
-        <target>Reference</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:181</note>
-      </trans-unit>
-      <trans-unit id="befcac0f9644a7abee43e69f49252ac4">
-        <source>Tax excluded</source>
-        <target>Tax excluded</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:221</note>
-      </trans-unit>
-      <trans-unit id="f4a0d7cb0cd45214c8ca5912c970de13">
-        <source>Tax included</source>
-        <target>Tax included</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:226</note>
-      </trans-unit>
-      <trans-unit id="d8409efcbf2c3444399daa83172dd35a">
-        <source>Tax rule</source>
-        <target>Tax rule</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:252</note>
-      </trans-unit>
-      <trans-unit id="c795dfff10a7c952f4c5438951e9ece9">
-        <source>Cover</source>
-        <target>Cover</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:77</note>
-      </trans-unit>
-      <trans-unit id="e84a11dfbf24b5bdcc71adef877f3157">
-        <source>View all images</source>
-        <target>View all images</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:87</note>
-      </trans-unit>
-      <trans-unit id="889f380bf53d998cf3be4466cd0a4359">
-        <source>View less</source>
-        <target>View less</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:88</note>
-      </trans-unit>
-      <trans-unit id="98f770b0af18ca763421bac22b4b6805">
-        <source>Features</source>
-        <target>Features</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:113</note>
-      </trans-unit>
-      <trans-unit id="8408c9e822e4412516d0ac876d683b6c">
-        <source>Add a feature</source>
-        <target>Add a feature</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:128</note>
-      </trans-unit>
-      <trans-unit id="90d98afb8f4c3436765b9eb47127577d">
-        <source>Simple product</source>
-        <target>Simple product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:161</note>
-      </trans-unit>
-      <trans-unit id="f99f15e7e2a30d8522f0a39ecf6bcc0d">
-        <source>Product with combinations</source>
-        <target>Product with combinations</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:167</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="af39c53c91dc46e2576f28b843b82988">
-        <source>Label when in stock</source>
-        <target>Label when in stock</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:204</note>
-      </trans-unit>
-      <trans-unit id="b2c80334809f9130d46e89b66b6d8544">
-        <source>Create combinations</source>
-        <target>Create combinations</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:89</note>
-      </trans-unit>
-      <trans-unit id="66de7ffcf9f515fb047045299ab0b3a3">
-        <source>I want to use the advanced stock management system for this product.</source>
-        <target>I want to use the advanced stock management system for this product.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:99</note>
-      </trans-unit>
-      <trans-unit id="4aeb39ce058edebf91ef47818c092420">
-        <source>The available quantities for the current product and its combinations are based on the stock in your warehouse (using the advanced stock management system). </source>
-        <target>The available quantities for the current product and its combinations are based on the stock in your warehouse (using the advanced stock management system).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:115</note>
-      </trans-unit>
-      <trans-unit id="78ab705faa894d700a6db78ffa88bb24">
-        <source>I want to specify available quantities manually.</source>
-        <target>I want to specify available quantities manually.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:120</note>
-      </trans-unit>
-      <trans-unit id="6014344a66ff2f266fb4bc987178493f">
-        <source>Minimum quantity for sale</source>
-        <target>Minimum quantity for sale</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:155</note>
-      </trans-unit>
-      <trans-unit id="a532f6edbb8880c752b74073710b285a">
-        <source>Label when out of stock (and back order allowed)</source>
-        <target>Label when out of stock (and back order allowed)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:216</note>
-      </trans-unit>
-      <trans-unit id="6ece9a14d0c8da14a1af607f9f7e0b36">
-        <source>Does this product have an associated file?</source>
-        <target>Does this product have an associated file?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:237</note>
-      </trans-unit>
-      <trans-unit id="989d17fa8f3081cc0d66838c7504c0ef">
-        <source>Use default behavior</source>
-        <target>Use default behavior</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:251</note>
-      </trans-unit>
-      <trans-unit id="119a7c88cf8f1c685c57981abff26f43">
-        <source>Allow orders</source>
-        <target>Allow orders</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:266</note>
-      </trans-unit>
-      <trans-unit id="f072da215c080d985d44361e96a3cf60">
-        <source>Deny orders</source>
-        <target>Deny orders</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:265</note>
-      </trans-unit>
-      <trans-unit id="5ce00f66be3fd54e40eab844c446e80d">
-        <source>When out of stock</source>
-        <target>When out of stock</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:272</note>
-      </trans-unit>
-      <trans-unit id="175db77b6b3ecd9633e85b5efc28bbc1">
-        <source>Decrement pack only.</source>
-        <target>Decrement pack only.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:300</note>
-      </trans-unit>
-      <trans-unit id="1ba020dea4ce06fa139a471db21f41a7">
-        <source>Decrement products in pack only.</source>
-        <target>Decrement products in pack only.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:301</note>
-      </trans-unit>
-      <trans-unit id="61b912928e920c280798dc648d4068fe">
-        <source>Decrement both.</source>
-        <target>Decrement both.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:302</note>
-      </trans-unit>
-      <trans-unit id="4b2f63dbdead89ca4263ede71ae4a892">
-        <source>Pack quantities</source>
-        <target>Pack quantities</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:308</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9e2941b3c81256fac10392aaca4ccfde">
-        <source>Condition</source>
-        <target>Condition</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:207</note>
-      </trans-unit>
-      <trans-unit id="13787cfb1a15ae6690a29d3895c54de9">
-        <source>Everywhere</source>
-        <target>Everywhere</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:103</note>
-      </trans-unit>
-      <trans-unit id="96c7d7f87187cc14ead1f887407d0edc">
-        <source>Catalog only</source>
-        <target>Catalog only</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:104</note>
-      </trans-unit>
-      <trans-unit id="2ba18b8df558ceaabcc89f3a16772a9b">
-        <source>Search only</source>
-        <target>Search only</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:105</note>
-      </trans-unit>
-      <trans-unit id="e56fc964976b3770a35b2d6fb4b78224">
-        <source>Nowhere</source>
-        <target>Nowhere</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:106</note>
-      </trans-unit>
-      <trans-unit id="d1109f3240d262e842e8f6ff5ea755d9">
-        <source>Display options</source>
-        <target>Display options</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:131</note>
-      </trans-unit>
-      <trans-unit id="f2149c422ab7577f063b69a2884d17f0">
-        <source>Available for order</source>
-        <target>Available for order</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:138</note>
-      </trans-unit>
-      <trans-unit id="e1a5e653bc356ed6745d6814d50213eb">
-        <source>Show price</source>
-        <target>Show price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:146</note>
-      </trans-unit>
-      <trans-unit id="fd531d460cecb407f3628d25c4574acc">
-        <source>Web only (not sold in your retail store)</source>
-        <target>Web only (not sold in your retail store)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:155</note>
-      </trans-unit>
-      <trans-unit id="9609dddf3618cff8f67b7829e6fc575e">
-        <source>ISBN</source>
-        <target>ISBN</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:182</note>
-      </trans-unit>
-      <trans-unit id="527618353332c282892ba960ef1f0230">
-        <source>Display condition on product page</source>
-        <target>Display condition on product page</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:195</note>
-      </trans-unit>
-      <trans-unit id="efb78d0dd61da3bb7e5ca1770b894420">
-        <source>Default suppliers</source>
-        <target>Default suppliers</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:227</note>
-      </trans-unit>
-      <trans-unit id="9d38722749ec2101e437414ac2a743f9">
-        <source>Attachments for this product:</source>
-        <target>Attachments for this product:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:277</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c925e061d42989c43e6d3a7e43f2a878">
-        <source>Number of allowed downloads</source>
-        <target>Number of allowed downloads</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php:104</note>
-      </trans-unit>
-      <trans-unit id="8c1279db4db86553e4b9682f78cf500e">
-        <source>Expiration date</source>
-        <target>Expiration date</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php:115</note>
-      </trans-unit>
-      <trans-unit id="58fd2b2308056ad80255a322b305742b">
-        <source>Number of days</source>
-        <target>Number of days</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php:124</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c1069a480848e06782b81b8bea9c0c94">
-        <source>Short description</source>
-        <target>Short description</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:208</note>
-      </trans-unit>
-      <trans-unit id="2b5d1ce10d1df2892eb6033604e4df0b">
-        <source>Standard product</source>
-        <target>Standard product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:134</note>
-      </trans-unit>
-      <trans-unit id="49a2d6f2a33dc367666a860bff4a8f5f">
-        <source>Pack of products</source>
-        <target>Pack of products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:135</note>
-      </trans-unit>
-      <trans-unit id="27818c0656c429503efc4e67e149bcc7">
-        <source>Add products to your pack</source>
-        <target>Add products to your pack</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:156</note>
-      </trans-unit>
-      <trans-unit id="4c32794a96aec43624f14839274174bf">
-        <source>Pre-tax retail price</source>
-        <target>Pre-tax retail price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:234</note>
-      </trans-unit>
-      <trans-unit id="ce0ec0f2b759fa68416e3bc96ee59276">
-        <source>Retail price with tax</source>
-        <target>Retail price with tax</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:244</note>
-      </trans-unit>
-      <trans-unit id="a17f5bc22553d897f6363867c0165256">
-        <source>Default category</source>
-        <target>Default category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:269</note>
-      </trans-unit>
-      <trans-unit id="46c8280e993148f9cc6e26875d972169">
-        <source>Add a new category</source>
-        <target>Add a new category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:276</note>
-      </trans-unit>
-      <trans-unit id="98edb85b00d9527ad5acebe451b3fae6">
-        <source>Accessories</source>
-        <target>Accessories</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:288</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3adbdb3ac060038aa0e6e6c138ef9873">
-        <source>Category</source>
-        <target>Category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig:54</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminManufacturersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
-        <source>Addresses</source>
-        <target>Addresses</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:457</note>
-      </trans-unit>
-      <trans-unit id="068f80c7519d0528fb08e82137a72131">
-        <source>Products</source>
-        <target>Products</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:86</note>
-      </trans-unit>
-      <trans-unit id="ba8df31467300b4fef9b40f4efa8c33c">
-        <source>Add new brand</source>
-        <target>Add new brand</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:113</note>
-      </trans-unit>
-      <trans-unit id="2d236afdc6efc79d47ac67807be0b798">
-        <source>Add new brand address</source>
-        <target>Add new brand address</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:118</note>
-      </trans-unit>
-      <trans-unit id="55caa82d08a11359bf043f8e2a1d4ad1">
-        <source>List of brands</source>
-        <target>List of brands</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:155</note>
-      </trans-unit>
-      <trans-unit id="2d993f0eea2cfe4881542ab187d1c350">
-        <source>Brand addresses</source>
-        <target>Brand addresses</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:258</note>
-      </trans-unit>
-      <trans-unit id="84be54bb4bd1b755a27d86388700d097">
-        <source>Brands</source>
-        <target>Brands</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:312</note>
-      </trans-unit>
-      <trans-unit id="7c7c12e999629a6bf8dac0cb2119c261">
-        <source>Choose the brand</source>
-        <target>Choose the brand</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:465</note>
-      </trans-unit>
-      <trans-unit id="804f1e6cd9e6d68208f39932da191f61">
-        <source>Edit Addresses</source>
-        <target>Edit Addresses</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:633</note>
-      </trans-unit>
-      <trans-unit id="6bc011e375bcee14786bb43acdf00a8a">
-        <source>Add address</source>
-        <target>Add address</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:695</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCartRulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="447da4af35bd09b4d501afb8a2090909">
-        <source>Add new cart rule</source>
-        <target>Add new cart rule</target>
-        <note>Context:
-File: controllers/admin/AdminCartRulesController.php:135</note>
-      </trans-unit>
-      <trans-unit id="bd0e34e5be6447844e6f262d51f1a9dc">
-        <source>Payment: </source>
-        <target>Payment:</target>
-        <note>Context:
-File: controllers/admin/AdminCartRulesController.php:679</note>
-      </trans-unit>
-      <trans-unit id="65b7eaeb9ba4e9903f82297face9f7cd">
-        <source>Cart Rules</source>
-        <target>Cart Rules</target>
-        <note>Context:
-File: controllers/admin/AdminCartRulesController.php:679</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e192956d901dff59c35fd2c477ed28d6">
-        <source>Price (tax excl.)</source>
-        <target>Price (tax excl.)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig:50</note>
-      </trans-unit>
-      <trans-unit id="e84e4bed9536affd3b2db4c43cb39f29">
-        <source>Supplier reference(s)</source>
-        <target>Supplier reference(s)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig:26</note>
-      </trans-unit>
-      <trans-unit id="8284ae5df53e6e7ffc1f2cc67ae68765">
-        <source>Supplier reference</source>
-        <target>Supplier reference</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig:49</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="77eb276f5dcdf4fbca854e908216f7b2">
-        <source>Price (tax incl.)</source>
-        <target>Price (tax incl.)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php:113</note>
-      </trans-unit>
-      <trans-unit id="6f3455d187a23443796efdcbe044096b">
-        <source>No tax</source>
-        <target>No tax</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php:90</note>
-      </trans-unit>
-      <trans-unit id="c265e7bd60b9bf0470d39a8ef87e0727">
-        <source>Ecotax (tax incl.)</source>
-        <target>Ecotax (tax incl.)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php:122</note>
-      </trans-unit>
-      <trans-unit id="133bc9aa44eaaf809041c01ea1361a07">
-        <source>Display the "On sale!" flag on the product page, and on product listings.</source>
-        <target>Display the "On sale!" flag on the product page, and on product listings.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php:156</note>
-      </trans-unit>
-      <trans-unit id="1ea8a394583d38bd981b70c7dcebb104">
-        <source>Price per unit (tax excl.)</source>
-        <target>Price per unit (tax excl.)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php:176</note>
-      </trans-unit>
-      <trans-unit id="48881913e6addc0c3c439f02229ac91e">
-        <source>Apply to all products</source>
-        <target>Apply to all products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php:199</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="21021ea0e52be8e9c599f4dff41e5be0">
-        <source>Feature</source>
-        <target>Feature</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php:76</note>
-      </trans-unit>
-      <trans-unit id="5ebd6e1c1cdeac7a7c1896ab842d98da">
-        <source>Choose a feature</source>
-        <target>Choose a feature</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php:85</note>
-      </trans-unit>
-      <trans-unit id="8bcdd31a1ab28f0db60efb2087c3f235">
-        <source>Pre-defined value</source>
-        <target>Pre-defined value</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php:144</note>
-      </trans-unit>
-      <trans-unit id="5da9eb58e1c3816d0a2fbaa50e9de78e">
-        <source>OR Customized value</source>
-        <target>OR Customized value</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php:103</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
-        <source>Categories</source>
-        <target>Categories</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:25</note>
-      </trans-unit>
-      <trans-unit id="c24c379ede5dfa7b82a91bfcc5c3deef">
-        <source>Associated categories</source>
-        <target>Associated categories</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:35</note>
-      </trans-unit>
-      <trans-unit id="cb15931e1a86254a2440cb3bf0a52374">
-        <source>Create a new category</source>
-        <target>Create a new category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:51</note>
-      </trans-unit>
-      <trans-unit id="b9a492bdfa9de54c963f71db20af3b94">
-        <source>New category name</source>
-        <target>New category name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:58</note>
-      </trans-unit>
-      <trans-unit id="cff15d43797962a1e28c0515ab556743">
-        <source>Create a category</source>
-        <target>Create a category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:78</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminAttributeGeneratorController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="81315cfd898aada1e99e0034b4b078c3">
-        <source>Attributes generator</source>
-        <target>Attributes generator</target>
-        <note>Context:
-File: controllers/admin/AdminAttributeGeneratorController.php:217</note>
-      </trans-unit>
-      <trans-unit id="402784f5f14c30e7309a135ba6be531f">
-        <source>Back to the product</source>
-        <target>Back to the product</target>
-        <note>Context:
-File: controllers/admin/AdminAttributeGeneratorController.php:220</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="428a70e43c5371126c0fb675e98c61d5">
-        <source>List of empty categories:</source>
-        <target>List of empty categories:</target>
-        <note>Context:
-File: controllers/admin/AdminTrackingController.php:114</note>
-      </trans-unit>
-      <trans-unit id="0181e2b8568143a3608fea8e657a81cb">
-        <source>List of products with combinations but without available quantities for sale:</source>
-        <target>List of products with combinations but without available quantities for sale:</target>
-        <note>Context:
-File: controllers/admin/AdminTrackingController.php:159</note>
-      </trans-unit>
-      <trans-unit id="d06aa90bdc7545b64a808ef956b20b77">
-        <source>List of products without combinations and without available quantities for sale:</source>
-        <target>List of products without combinations and without available quantities for sale:</target>
-        <note>Context:
-File: controllers/admin/AdminTrackingController.php:204</note>
-      </trans-unit>
-      <trans-unit id="40be52ec4b8eab2321f116914858ce6a">
-        <source>List of disabled products</source>
-        <target>List of disabled products</target>
-        <note>Context:
-File: controllers/admin/AdminTrackingController.php:235</note>
-      </trans-unit>
-      <trans-unit id="c205cafb2813572f3f96669cf2b97cf0">
-        <source>List of products without images</source>
-        <target>List of products without images</target>
-        <note>Context:
-File: controllers/admin/AdminTrackingController.php:267</note>
-      </trans-unit>
-      <trans-unit id="eaff59412c15abca3419aee22b02d726">
-        <source>List of products without description</source>
-        <target>List of products without description</target>
-        <note>Context:
-File: controllers/admin/AdminTrackingController.php:304</note>
-      </trans-unit>
-      <trans-unit id="3368abb84d65a50813d1ed17708ec130">
-        <source>List of products without price</source>
-        <target>List of products without price</target>
-        <note>Context:
-File: controllers/admin/AdminTrackingController.php:336</note>
-      </trans-unit>
-      <trans-unit id="bcaad756615668f5e8e0447aa36f4f22">
-        <source>Product disabled</source>
-        <target>Product disabled</target>
-        <note>Context:
-File: controllers/admin/AdminTrackingController.php:448</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1379a6b19242372c1f23cc9adedfcdd6">
-        <source>Category root</source>
-        <target>Category root</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:439</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSuppliersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="990fc90e39367377c314f1d61522ae61">
-        <source>Number of products</source>
-        <target>Number of products</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:67</note>
-      </trans-unit>
-      <trans-unit id="094ada406018db9fe3601b65e7502c82">
-        <source>Add new supplier</source>
-        <target>Add new supplier</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:84</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSpecificPriceRuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fc7b398d4af2074cfe73febdb5971153">
-        <source>From quantity</source>
-        <target>From quantity</target>
-        <note>Context:
-File: controllers/admin/AdminSpecificPriceRuleController.php:229</note>
-      </trans-unit>
-      <trans-unit id="0558dcc45dad1cfe3d4e55ca16bfbb12">
-        <source>Beginning</source>
-        <target>Beginning</target>
-        <note>Context:
-File: controllers/admin/AdminSpecificPriceRuleController.php:123</note>
-      </trans-unit>
-      <trans-unit id="87557f11575c0ad78e4e28abedc13b6e">
-        <source>End</source>
-        <target>End</target>
-        <note>Context:
-File: controllers/admin/AdminSpecificPriceRuleController.php:128</note>
-      </trans-unit>
-      <trans-unit id="c1da0bfd4d60d1aab58fcf8a8e933972">
-        <source>Add new catalog price rule</source>
-        <target>Add new catalog price rule</target>
-        <note>Context:
-File: controllers/admin/AdminSpecificPriceRuleController.php:140</note>
-      </trans-unit>
-      <trans-unit id="e5bfab8b7f97b8f0b19ad7e393d7c566">
-        <source>Catalog price rules</source>
-        <target>Catalog price rules</target>
-        <note>Context:
-File: controllers/admin/AdminSpecificPriceRuleController.php:174</note>
-      </trans-unit>
-      <trans-unit id="5e3c40bfa4026ab071712bf230b8f52f">
-        <source>Reduction with or without taxes</source>
-        <target>Reduction with or without taxes</target>
-        <note>Context:
-File: controllers/admin/AdminSpecificPriceRuleController.php:280</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7b28d39c479ba659159b3356616b0a04">
-        <source>Reduction type</source>
-        <target>Reduction type</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:253</note>
-      </trans-unit>
-      <trans-unit id="9e834f13e35e4edf64863ab414a6217a">
-        <source>Reduction</source>
-        <target>Reduction</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:244</note>
-      </trans-unit>
-      <trans-unit id="8766423201bb422154bcad9d1d590207">
-        <source>Leave initial price</source>
-        <target>Leave initial price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:236</note>
-      </trans-unit>
-      <trans-unit id="e3ec664efb1dcbafb161a2da6c0e5b3b">
-        <source>Add customer</source>
-        <target>Add customer</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:174</note>
-      </trans-unit>
-      <trans-unit id="c77b86cdeed7ed9197db5858fa3b5fd0">
-        <source>Apply to all combinations</source>
-        <target>Apply to all combinations</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:183</note>
-      </trans-unit>
-      <trans-unit id="1432596d084873bee8df589b0b01448c">
-        <source>Available from</source>
-        <target>Available from</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:197</note>
-      </trans-unit>
-      <trans-unit id="95b6faa9d75417fe5e7767a733ab6fb4">
-        <source>Starting at</source>
-        <target>Starting at</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:215</note>
-      </trans-unit>
-      <trans-unit id="7015235e67d6f01728b655ca7bc8e8ae">
-        <source>Product price (tax excl.)</source>
-        <target>Product price (tax excl.)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:226</note>
-      </trans-unit>
-      <trans-unit id="9bccc98ae31786b6062c540931d1467e">
-        <source>Reduction tax</source>
-        <target>Reduction tax</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:265</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Product/AdminProductWrapper.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4e021cd834848e751e2d1bc66cee697d">
-        <source>All combinations</source>
-        <target>All combinations</target>
-        <note>Context:
-File: src/Adapter/Product/AdminProductWrapper.php:455</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Translation/Api/StockApi.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5f89a705df3646f402ca886e3c01b034">
-        <source>Use checkboxes to bulk edit quantities</source>
-        <target>Use checkboxes to bulk edit quantities</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:37</note>
-      </trans-unit>
-      <trans-unit id="d9c3a508aadc89c987a08811138836e2">
-        <source>Advanced filters</source>
-        <target>Advanced filters</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:38</note>
-      </trans-unit>
-      <trans-unit id="d17ef666e0e109b8ff0889c4666816c4">
-        <source>Apply advanced filters</source>
-        <target>Apply advanced filters</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:39</note>
-      </trans-unit>
-      <trans-unit id="08f2624d7719fac81f1af3e3e64d5e63">
-        <source>Apply new quantity</source>
-        <target>Apply new quantity</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:40</note>
-      </trans-unit>
-      <trans-unit id="b11806ab5d886adeeeddbc591eb52688">
-        <source>Display products below low stock level first</source>
-        <target>Display products below low stock level first</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:45</note>
-      </trans-unit>
-      <trans-unit id="7f84fa02a3bf4c70c747b29908a03096">
-        <source>Filter by movement type</source>
-        <target>Filter by movement type</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:46</note>
-      </trans-unit>
-      <trans-unit id="5110c1f147fe533096f7dead2dac17ee">
-        <source>Filter by employee</source>
-        <target>Filter by employee</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:47</note>
-      </trans-unit>
-      <trans-unit id="d940660a1591632abf56608dd80b0f41">
-        <source>Filter by period</source>
-        <target>Filter by period</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:48</note>
-      </trans-unit>
-      <trans-unit id="d0f06038b6b3aa5edc07c7a6fd3ca3f9">
-        <source>Search a category</source>
-        <target>Search a category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:49</note>
-      </trans-unit>
-      <trans-unit id="e8324c0368f5e686c879ba246e36903f">
-        <source>Search a supplier</source>
-        <target>Search a supplier</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:50</note>
-      </trans-unit>
-      <trans-unit id="5dd5cd6670a0fc8e47a47aa94d27b8b2">
-        <source>Filter by status</source>
-        <target>Filter by status</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:51</note>
-      </trans-unit>
-      <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680">
-        <source>All</source>
-        <target>All</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:53
- Comment: 'All' refers to statuses as if "All statuses". Please adapt as necessary in your language</note>
-      </trans-unit>
-      <trans-unit id="3704fd59c2d4295b196008f9ebe09267">
-        <source>Filter by supplier</source>
-        <target>Filter by supplier</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:56</note>
-      </trans-unit>
-      <trans-unit id="dc7f9d531239c6acc08b99236a4204cd">
-        <source>Stock management</source>
-        <target>Stock management</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:61</note>
-      </trans-unit>
-      <trans-unit id="898bed66d82aeaab1d62875fd3657c40">
-        <source>Movements</source>
-        <target>Movements</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:63</note>
-      </trans-unit>
-      <trans-unit id="083e99de177243cffe65b7f8724c89ca">
-        <source>Search products (search by name, reference, supplier)</source>
-        <target>Search products (search by name, reference, supplier)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:67</note>
-      </trans-unit>
-      <trans-unit id="0e1f77838d33f77fef1c66958da371e6">
-        <source>This product is below the low stock level you have defined.</source>
-        <target>This product is below the low stock level you have defined.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:68</note>
-      </trans-unit>
-      <trans-unit id="5896dcc83ab833241ff671debffff23b">
-        <source>Low stock level:</source>
-        <target>Low stock level:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:69</note>
-      </trans-unit>
-      <trans-unit id="82bbaa81a9926aed70bfc811302bddaf">
-        <source>Low stock alert:</source>
-        <target>Low stock alert:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:70</note>
-      </trans-unit>
-      <trans-unit id="60ca6b20f2ef2afc178d7e5d7224b5c8">
-        <source>Bulk edit quantity</source>
-        <target>Bulk edit quantity</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:72</note>
-      </trans-unit>
-      <trans-unit id="0a31e37f4790bed575e702d61fcfb452">
-        <source><![CDATA[Date & Time]]></source>
-        <target><![CDATA[Date & Time]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:73</note>
-      </trans-unit>
-      <trans-unit id="ac43f4edefaf0db72e60d681332c8437">
-        <source>Edit quantity</source>
-        <target>Edit quantity</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:74</note>
-      </trans-unit>
-      <trans-unit id="f0d770125ad832142c2215d033525e78">
-        <source>Go to the import system</source>
-        <target>Go to the import system</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:76</note>
-      </trans-unit>
-      <trans-unit id="8273cff9da36d1ddc5ee3f19b1283f0c">
-        <source>Export data into CSV</source>
-        <target>Export data into CSV</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:77</note>
-      </trans-unit>
-      <trans-unit id="ce898d62ed9ca7653a01fe0c781e97e9">
-        <source>Physical</source>
-        <target>Physical</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:79</note>
-      </trans-unit>
-      <trans-unit id="942d4e37dd5607ab68e54755540d4a47">
-        <source>Reserved</source>
-        <target>Reserved</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:82</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bb34a159a88035cce7ef1607e7907f8f">
-        <source>Category name</source>
-        <target>Category name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php:84</note>
-      </trans-unit>
-      <trans-unit id="fa350f1440add1a91fb21c42c555b2eb">
-        <source>Parent of the category</source>
-        <target>Parent of the category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php:99</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/ProductImageController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b3d4e2bcdbf72f5828b3ef09b238c072">
-        <source>Please select a file</source>
-        <target>Please select a file</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductImageController.php:63</note>
-      </trans-unit>
-      <trans-unit id="272ba7d164aa836995be6319a698be84">
-        <source>Caption</source>
-        <target>Caption</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductImageController.php:139</note>
-      </trans-unit>
-      <trans-unit id="84967207ddc311cfbe8ee66f677a1544">
-        <source>Cover image</source>
-        <target>Cover image</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductImageController.php:143</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7bf2d26eab899c413218b729d4d914b7">
-        <source>Stored</source>
-        <target>Stored</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php:65</note>
-      </trans-unit>
-      <trans-unit id="ddedc546753b8ca7f0ecdad9d0863f95">
-        <source>Location (optional)</source>
-        <target>Location (optional)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php:72</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2a84584d4f095b4f6e660db58b9576d3">
-        <source>Cost Price</source>
-        <target>Cost Price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php:72</note>
-      </trans-unit>
-      <trans-unit id="1b72aed8e84b91d73896efd48cf1a4e0">
-        <source>Minimum quantity</source>
-        <target>Minimum quantity</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php:103</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9e11e4b371570340ca07913bc4783a7a">
-        <source>Meta title</source>
-        <target>Meta title</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:90</note>
-      </trans-unit>
-      <trans-unit id="3f64b2beede1082fd32ddb0bf11a641f">
-        <source>Meta description</source>
-        <target>Meta description</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:115</note>
-      </trans-unit>
-      <trans-unit id="1dec4f55522b828fe5dacf8478021a9e">
-        <source>Friendly URL</source>
-        <target>Friendly URL</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:132</note>
-      </trans-unit>
-      <trans-unit id="34c6d1495d38f91ae785bc94849dc771">
-        <source>Permanent redirection to a category (301)</source>
-        <target>Permanent redirection to a category (301)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:140</note>
-      </trans-unit>
-      <trans-unit id="7a13ef5d084a640d199018c55d415fac">
-        <source>Temporary redirection to a category (302)</source>
-        <target>Temporary redirection to a category (302)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:141</note>
-      </trans-unit>
-      <trans-unit id="5c841800fb570244d423fe0b273665fb">
-        <source>Permanent redirection to a product (301)</source>
-        <target>Permanent redirection to a product (301)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:142</note>
-      </trans-unit>
-      <trans-unit id="c36c68b574bddf55fe3ec5b8cc56a824">
-        <source>Temporary redirection to a product (302)</source>
-        <target>Temporary redirection to a product (302)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:143</note>
-      </trans-unit>
-      <trans-unit id="bae20d24a114242f9549679af3255ace">
-        <source>No redirection (404)</source>
-        <target>No redirection (404)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:144</note>
-      </trans-unit>
-      <trans-unit id="eab55e617090957b953e3dbdd801eea4">
-        <source>Redirection when offline</source>
-        <target>Redirection when offline</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:154</note>
-      </trans-unit>
-      <trans-unit id="2afea1f31bf30bdcef8b3316025d6ae5">
-        <source>Target product</source>
-        <target>Target product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:156</note>
-      </trans-unit>
-      <trans-unit id="f66b691f01d53d5af582136ebb63cfc5">
-        <source>Target category</source>
-        <target>Target category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:158</note>
-      </trans-unit>
-      <trans-unit id="c41a31890959544c6523af684561abe5">
-        <source>Target</source>
-        <target>Target</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:175</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="da22c93ccb398c72070f4000cc7b59a1">
-        <source>Customization</source>
-        <target>Customization</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:651</note>
-      </trans-unit>
-      <trans-unit id="9d20a93036ba910dd75ffbcec173798e">
-        <source>Price per unit</source>
-        <target>Price per unit</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1264</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/message.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e9cb217697088a98b1937d111d936281">
-        <source>Attachment</source>
-        <target>Attachment</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/message.tpl:56</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="23470f2faa48c53e6fb5fad4e3de3cdd">
-        <source>Virtual product</source>
-        <target>Virtual product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:347</note>
-      </trans-unit>
-      <trans-unit id="e6a4d0e7d64f63379da06c91a80e9c90">
-        <source>Drop images here</source>
-        <target>Drop images here</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:338</note>
-      </trans-unit>
-      <trans-unit id="aaa5309487aacf50e6413cf7a3074618">
-        <source>or select files</source>
-        <target>or select files</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:339</note>
-      </trans-unit>
-      <trans-unit id="b36c5a58c30cc53bab5e9b3fda84755c">
-        <source>Recommended size 800 x 800px for default theme.</source>
-        <target>Recommended size 800 x 800px for default theme.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:340</note>
-      </trans-unit>
-      <trans-unit id="0d23de90e7f537b035eb79a464eb8ecf">
-        <source>JPG, GIF or PNG format.</source>
-        <target>JPG, GIF or PNG format.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:341</note>
-      </trans-unit>
-      <trans-unit id="e2e79605fc9450ec17957cf0e910f5c6">
-        <source>tax incl.</source>
-        <target>tax incl.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:348</note>
-      </trans-unit>
-      <trans-unit id="887ee91702c962a70b87cbef07bbcaec">
-        <source>tax excl.</source>
-        <target>tax excl.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:349</note>
-      </trans-unit>
-      <trans-unit id="942e86be019b92367d4b1cb917a9ae9c">
-        <source>Module to configure</source>
-        <target>Module to configure</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:184</note>
-      </trans-unit>
-      <trans-unit id="fd6d6ce9526e7db581ba81ee86373e9e">
-        <source>Choose a module to configure</source>
-        <target>Choose a module to configure</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:195</note>
-      </trans-unit>
-      <trans-unit id="4a3b597e8860a1592e5e1fec28d74ef4">
-        <source>These modules are relative to the product page of your shop.</source>
-        <target>These modules are relative to the product page of your shop.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:196</note>
-      </trans-unit>
-      <trans-unit id="657c239908e72da26f995415f9b867a7">
-        <source>To manage all your modules go to the [1]Installed module page[/1]</source>
-        <target>To manage all your modules go to the [1]Installed module page[/1]</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:197</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_manufacturer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
-        <source>Brand</source>
-        <target>Brand</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_manufacturer.html.twig:26</note>
-      </trans-unit>
-      <trans-unit id="b7dcc53b5fa2ee513b3eac152af1c8d1">
-        <source>Add a brand</source>
-        <target>Add a brand</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_manufacturer.html.twig:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/FeatureController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fd380496c889dcb05d6e996fd1ecaf0b">
-        <source>Choose a value</source>
-        <target>Choose a value</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/FeatureController.php:58</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="df644ae155e79abf54175bd15d75f363">
-        <source>Product name</source>
-        <target>Product name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl:54</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f8a09f634b7b3ede2da34607da2aaebe">
-        <source>Available quantity</source>
-        <target>Available quantity</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl:124</note>
-      </trans-unit>
-      <trans-unit id="e78b6f4eb3be046f4d25c07ce54954d4">
-        <source>Ref:</source>
-        <target>Ref:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl:88</note>
-      </trans-unit>
-      <trans-unit id="ccf096490d2671f3ea97ea9289eee5b1">
-        <source>EAN13:</source>
-        <target>EAN13:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl:89</note>
-      </trans-unit>
-      <trans-unit id="af7448c885be0d8acd5eb84322176570">
-        <source>UPC:</source>
-        <target>UPC:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl:90</note>
-      </trans-unit>
-      <trans-unit id="647b89b705fafd7d44aa6f01a5cb4711">
-        <source>Qty:</source>
-        <target>Qty:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl:91</note>
-      </trans-unit>
-      <trans-unit id="1caa6ff629641a4eb20f190f7a0539ca">
-        <source>Attribute name</source>
-        <target>Attribute name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl:119</note>
-      </trans-unit>
-      <trans-unit id="52eb5928a34db3e3da7ba52b0644273b">
-        <source>EAN13</source>
-        <target>EAN13</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl:121</note>
-      </trans-unit>
-      <trans-unit id="fbd99ad01b92dbafc686772a39e3d065">
-        <source>UPC</source>
-        <target>UPC</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl:122</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/StockMvtReasonLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="aac247ca22789872bad95dc8f6c45d37">
-        <source>Increase</source>
-        <target>Increase</target>
-        <note>Context:
-File: classes/lang/KeysReference/StockMvtReasonLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="9e661cc6f7c72b95abfd6b372aacbfa1">
-        <source>Decrease</source>
-        <target>Decrease</target>
-        <note>Context:
-File: classes/lang/KeysReference/StockMvtReasonLang.php:28</note>
-      </trans-unit>
-      <trans-unit id="c9ef04d431a0f72fec2712c575fcaf15">
-        <source>Customer Order</source>
-        <target>Customer Order</target>
-        <note>Context:
-File: classes/lang/KeysReference/StockMvtReasonLang.php:30</note>
-      </trans-unit>
-      <trans-unit id="2c9697ad1bb585d6d1d0fabcb1028926">
-        <source>Adjustment following an inventory of stock</source>
-        <target>Adjustment following an inventory of stock</target>
-        <note>Context:
-File: classes/lang/KeysReference/StockMvtReasonLang.php:32</note>
-      </trans-unit>
-      <trans-unit id="02ef8bd47ce057b792bbd620d6059caa">
-        <source>Transfer to another warehouse</source>
-        <target>Transfer to another warehouse</target>
-        <note>Context:
-File: classes/lang/KeysReference/StockMvtReasonLang.php:34</note>
-      </trans-unit>
-      <trans-unit id="7829dec62809e15c4bb9bbc002fc5614">
-        <source>Transfer from another warehouse</source>
-        <target>Transfer from another warehouse</target>
-        <note>Context:
-File: classes/lang/KeysReference/StockMvtReasonLang.php:36</note>
-      </trans-unit>
-      <trans-unit id="6ae30b0a1badc7bc37e9fd794bca7e3f">
-        <source>Supply Order</source>
-        <target>Supply Order</target>
-        <note>Context:
-File: classes/lang/KeysReference/StockMvtReasonLang.php:38</note>
-      </trans-unit>
-      <trans-unit id="d664291d8860308c25f148de5831ad55">
-        <source>Product Return</source>
-        <target>Product Return</target>
-        <note>Context:
-File: classes/lang/KeysReference/StockMvtReasonLang.php:40</note>
-      </trans-unit>
-      <trans-unit id="1638bbd4664fd745118d95786b7e37b9">
-        <source>Manual Entry</source>
-        <target>Manual Entry</target>
-        <note>Context:
-File: classes/lang/KeysReference/StockMvtReasonLang.php:42</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/CategoryLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fa03eb688ad8aa1db593d33dabd89bad">
-        <source>Root</source>
-        <target>Root</target>
-        <note>Context:
-File: classes/lang/KeysReference/CategoryLang.php:26</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/CmsCategoryLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8cf04a9734132302f96da8e113e80ce5">
-        <source>Home</source>
-        <target>Home</target>
-        <note>Context:
-File: classes/lang/KeysReference/CmsCategoryLang.php:26</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1a6570d1068d7dd6f811ff022da8f76d">
-        <source>Main category</source>
-        <target>Main category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig:173</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d94d5f9a10b00bf59d7632a96ba7a1a0">
-        <source>List of products for this pack</source>
-        <target>List of products for this pack</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig:70</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_max_length.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="df211c3d69ca4c3564b6ac95d368dc2e">
-        <source>[1][/1] of [2][/2] characters used (recommended)</source>
-        <target>[1][/1] of [2][/2] characters used (recommended)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_max_length.html.twig:30</note>
-      </trans-unit>
-      <trans-unit id="db65e64331ad696848ba5bfa44a757b5">
-        <source>[1][/1] of [2][/2] characters allowed</source>
-        <target>[1][/1] of [2][/2] characters allowed</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_max_length.html.twig:37</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Common/pagination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="41d2418efb64cdecb72df1e2aeb7a36b">
-        <source>Viewing %from%-%to% on %total% (page %current_page% / %page_count%)</source>
-        <target>Viewing %from%-%to% on %total% (page %current_page% / %page_count%)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Common/pagination.html.twig:44</note>
-      </trans-unit>
-      <trans-unit id="a0c13a65c06cd78909e5842e19af2c49">
-        <source>Items per page:</source>
-        <target>Items per page:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Common/pagination.html.twig:55</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="71d6cf2ac276a448f7845e8422fa0db3">
-        <source>These products will be deleted for good. Please confirm.</source>
-        <target>These products will be deleted for good. Please confirm.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:205</note>
-      </trans-unit>
-      <trans-unit id="3e1af49c086d77fb4f9826caec6dea12">
-        <source>Delete products?</source>
-        <target>Delete products?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:194</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog_empty.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="432cfb26d9a4c71d6409e289771aedf1">
-        <source>[1]Add your first product[/1][2]or import a list of products (filetypes: .csv, .xls, .xlsx, .xlst, .ods, .ots).[/2]</source>
-        <target>[1]Add your first product[/1][2]or import a list of products (filetypes: .csv, .xls, .xlsx, .xlst, .ods, .ots).[/2]</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog_empty.html.twig:33</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="81355310011c137fdd21cf9a1394ed6a">
-        <source>Product list</source>
-        <target>Product list</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig:71</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/tabs.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="93d74901738e996378295fb0a59bb977">
-        <source>Basic settings</source>
-        <target>Basic settings</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/tabs.html.twig:31</note>
-      </trans-unit>
-      <trans-unit id="e22ac25b066b201473de7aa700ef5d92">
-        <source>Pricing</source>
-        <target>Pricing</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/tabs.html.twig:34</note>
-      </trans-unit>
-      <trans-unit id="d88946b678e4c2f251d4e292e8142291">
-        <source>SEO</source>
-        <target>SEO</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/tabs.html.twig:35</note>
-      </trans-unit>
-      <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2">
-        <source>Modules</source>
-        <target>Modules</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/tabs.html.twig:38</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="623a9a1f669b091dd76bead27c3252ed">
-        <source>Quantities</source>
-        <target>Quantities</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
-        <source>Shipping</source>
-        <target>Shipping</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1097</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d2adcceab126e15a1f46f5ed9980453e">
-        <source>Go to catalog</source>
-        <target>Go to catalog</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:138</note>
-      </trans-unit>
-      <trans-unit id="3fa8c89ef63fbb7056fc1d8d1b67f97a">
-        <source>Add new product</source>
-        <target>Add new product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:144</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="27ce7f8b5623b2e2df568d64cf051607">
-        <source>Stock</source>
-        <target>Stock</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:106</note>
-      </trans-unit>
-      <trans-unit id="1374a796a4d88166ce5107eb6aec41ff">
-        <source>Prev. combination</source>
-        <target>Prev. combination</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:55</note>
-      </trans-unit>
-      <trans-unit id="3c9d5cac3c3b1b3f40ef1d6ce929ad6e">
-        <source>Next combination</source>
-        <target>Next combination</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:56</note>
-      </trans-unit>
-      <trans-unit id="c0babe5601b3f91313d53267c3c7ec24">
-        <source>Back to product</source>
-        <target>Back to product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:60</note>
-      </trans-unit>
-      <trans-unit id="96aed2644a3249464e20729dc8c39fb2">
-        <source>Combination details</source>
-        <target>Combination details</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:63</note>
-      </trans-unit>
-      <trans-unit id="dd35c12c6b5ac6280956afd466d99766">
-        <source>Price and impact</source>
-        <target>Price and impact</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:135</note>
-      </trans-unit>
-      <trans-unit id="d448559c3ac8f5b7e49b7162e5fbc7f1">
-        <source>Final retail price (tax excl.) will be</source>
-        <target>Final retail price (tax excl.) will be</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:164</note>
-      </trans-unit>
-      <trans-unit id="2477a8ca4d9fe0ce57184d2ae0c59647">
-        <source>Does this combination have a different price per unit?</source>
-        <target>Does this combination have a different price per unit?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:180</note>
-      </trans-unit>
-      <trans-unit id="4c43a60b8005e29697dfbcf647f8096e">
-        <source>Specific references</source>
-        <target>Specific references</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:200</note>
-      </trans-unit>
-      <trans-unit id="fff0d600f8a0b5e19e88bfb821dd1157">
-        <source>Images</source>
-        <target>Images</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:230</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f5a592018c8b55d2c968515ad7c58c91">
-        <source>Search Engine Optimization</source>
-        <target>Search Engine Optimization</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:27</note>
-      </trans-unit>
-      <trans-unit id="926b7b9f596e468ebce7da2c42c1e27c">
-        <source>Improve your ranking and how your product page will appear in search engines results.</source>
-        <target>Improve your ranking and how your product page will appear in search engines results.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:28</note>
-      </trans-unit>
-      <trans-unit id="e1be175ec06a5890119e29ffdb34631e">
-        <source>Reset URL</source>
-        <target>Reset URL</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:67</note>
-      </trans-unit>
-      <trans-unit id="e642dbf4ded4c06ae9feae332a0a83c4">
-        <source>Redirection page</source>
-        <target>Redirection page</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:96</note>
-      </trans-unit>
-      <trans-unit id="c6b3d0f163e32b16cbdde201859d33e3">
-        <source>Here is a preview of your search engine result, play with it!</source>
-        <target>Here is a preview of your search engine result, play with it!</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_edit_specific_price_modal.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dc3e262677b716a8c75d128d10a65645">
-        <source>Edit a specific price</source>
-        <target>Edit a specific price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_edit_specific_price_modal.html.twig:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="183186d90901c257fa15cb0f888b354a">
-        <source>Specific price conditions</source>
-        <target>Specific price conditions</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig:40</note>
-      </trans-unit>
-      <trans-unit id="5ded995ff437b74c4b7ddc83f8a95919">
-        <source>Unit(s)</source>
-        <target>Unit(s)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig:121</note>
-      </trans-unit>
-      <trans-unit id="0c2bfe292269f73b23af08101939714a">
-        <source>Apply a discount of</source>
-        <target>Apply a discount of</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig:149</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_related_products.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9b9237161ab556e135d50c3384ba6599">
-        <source>Related product</source>
-        <target>Related product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_related_products.html.twig:27</note>
-      </trans-unit>
-      <trans-unit id="0e7abe02d1bb48b126ffaae21749ea13">
-        <source>Add a related product</source>
-        <target>Add a related product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_related_products.html.twig:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="96d0a6f41601d5c452d79d48f5b3f6bb">
-        <source>Package dimension</source>
-        <target>Package dimension</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig:28</note>
-      </trans-unit>
-      <trans-unit id="05031e9ff989f03f9ed271ddebbad2e8">
-        <source>Adjust your shipping costs by filling in the product dimensions.</source>
-        <target>Adjust your shipping costs by filling in the product dimensions.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig:29</note>
-      </trans-unit>
-      <trans-unit id="0a3e84ae4cda4472634f23aca39b5e31">
-        <source>Leave empty to disable.</source>
-        <target>Leave empty to disable.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig:118</note>
-      </trans-unit>
-      <trans-unit id="fb6d68835802519a7f425ca216778b15">
-        <source>Does this product incur additional shipping costs?</source>
-        <target>Does this product incur additional shipping costs?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig:129</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7e7371345a3de6936d16388f2f1315e2">
-        <source>Choose the suppliers associated with this product</source>
-        <target>Choose the suppliers associated with this product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig:54</note>
-      </trans-unit>
-      <trans-unit id="0b5c5a9176b94b7577e998f7440228a7">
-        <source>Default supplier</source>
-        <target>Default supplier</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig:55</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="37cfa6b25252ad29f15194e30147f02b">
-        <source>Product location in warehouses</source>
-        <target>Product location in warehouses</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig:26</note>
-      </trans-unit>
-      <trans-unit id="86521463bdd126930b4a5058c70e3e65">
-        <source>Please choose the warehouses associated with this product.</source>
-        <target>Please choose the warehouses associated with this product.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1ea5630be8a472f075b184deb7256e3d">
-        <source>You can increase or decrease low stock levels in bulk. You cannot disable them in bulk: you have to do it on a per-combination basis.</source>
-        <target>You can increase or decrease low stock levels in bulk. You cannot disable them in bulk: you have to do it on a per-combination basis.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig:78</note>
-      </trans-unit>
-      <trans-unit id="b470c441370492fc31529bb9b76eedb3">
-        <source><![CDATA[The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to Advanced Parameters > Team]]></source>
-        <target><![CDATA[The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to Advanced Parameters > Team]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig:88</note>
-      </trans-unit>
-      <trans-unit id="c24933abc09a6487f63ea8ddce98bfd4">
-        <source>Delete combinations</source>
-        <target>Delete combinations</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig:95</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/ProductImage/form.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4252b72e6ebcd4d4b4c2e46a786f03d2">
-        <source>Zoom</source>
-        <target>Zoom</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/ProductImage/form.html.twig:33</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="21534b955347d06c074955b008ccb0c9">
-        <source>Number of products required in the cart to enjoy the discount:</source>
-        <target>Number of products required in the cart to enjoy the discount:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8f36b08eb9ebba13ef930c9dd719ff7c">
-        <source>Limit to a single customer</source>
-        <target>Limit to a single customer</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="3ac705f2acd51a4613f9188c05c91d0d">
-        <source>Valid</source>
-        <target>Valid</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="9f6e99bdd4184b83dc478d0ab1b4cbf7">
-        <source>Minimum amount</source>
-        <target>Minimum amount</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:75</note>
-      </trans-unit>
-      <trans-unit id="89bea8045e50a337d8ce9849a4e1633c">
-        <source>Shipping excluded</source>
-        <target>Shipping excluded</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:105</note>
-      </trans-unit>
-      <trans-unit id="f7b8d9d5bbba937644a29be14e2654ed">
-        <source>Shipping included</source>
-        <target>Shipping included</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:106</note>
-      </trans-unit>
-      <trans-unit id="7d058d4cdbc3a0f480bd472b62a0bf53">
-        <source>Total available</source>
-        <target>Total available</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="9379f6f6c128b182600047d1b3090bc9">
-        <source>Total available for each user</source>
-        <target>Total available for each user</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:129</note>
-      </trans-unit>
-      <trans-unit id="e3e16bb73c0250a6a229fb457b4f957e">
-        <source>Restrictions</source>
-        <target>Restrictions</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:141</note>
-      </trans-unit>
-      <trans-unit id="cd8e66c655070f24cbece45141a505c3">
-        <source>Country selection</source>
-        <target>Country selection</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:148</note>
-      </trans-unit>
-      <trans-unit id="7922167568640bb2e57c1592a0b5945b">
-        <source>Unselected countries</source>
-        <target>Unselected countries</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:157</note>
-      </trans-unit>
-      <trans-unit id="7c160ccb02560f1adb25fb6b86d9ebce">
-        <source>Selected countries</source>
-        <target>Selected countries</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:166</note>
-      </trans-unit>
-      <trans-unit id="46b00dccbc9e441b3fcf567d39975f86">
-        <source>Carrier selection</source>
-        <target>Carrier selection</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:183</note>
-      </trans-unit>
-      <trans-unit id="3e9619330efb3bed62076dc6138a3889">
-        <source>Unselected carriers</source>
-        <target>Unselected carriers</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:191</note>
-      </trans-unit>
-      <trans-unit id="bd544756bba84765ddf991b01d7120d1">
-        <source>Selected carriers</source>
-        <target>Selected carriers</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:200</note>
-      </trans-unit>
-      <trans-unit id="c3f6634f087fc43dd62b3154e12d050d">
-        <source>Customer group selection</source>
-        <target>Customer group selection</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:217</note>
-      </trans-unit>
-      <trans-unit id="9463ae08271e82176b391f6cedb6e82b">
-        <source>Unselected groups</source>
-        <target>Unselected groups</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:225</note>
-      </trans-unit>
-      <trans-unit id="1fc6ed753100636e79df3831a3034531">
-        <source>Selected groups</source>
-        <target>Selected groups</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:234</note>
-      </trans-unit>
-      <trans-unit id="eb8bd4a7aeee5a49102d5269113b1142">
-        <source>Compatibility with other cart rules</source>
-        <target>Compatibility with other cart rules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:251</note>
-      </trans-unit>
-      <trans-unit id="06d8251983d901d62c12ed00fe65ddc1">
-        <source>Uncombinable cart rules</source>
-        <target>Uncombinable cart rules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:259</note>
-      </trans-unit>
-      <trans-unit id="53fb9df3249c49828006e57434d02d65">
-        <source>Combinable cart rules</source>
-        <target>Combinable cart rules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:267</note>
-      </trans-unit>
-      <trans-unit id="7f36b7eac5872d757b315ed431c4ad92">
-        <source>Product selection</source>
-        <target>Product selection</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:293</note>
-      </trans-unit>
-      <trans-unit id="e2bcac3dc51781abbc2938e16a0b0e72">
-        <source>Shop selection</source>
-        <target>Shop selection</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:301</note>
-      </trans-unit>
-      <trans-unit id="5e3f76cc2d68012faa5ce54aadf6cf84">
-        <source>Unselected shops</source>
-        <target>Unselected shops</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:309</note>
-      </trans-unit>
-      <trans-unit id="a5a08c71d0992427cfd8815ebc8f6152">
-        <source>Selected shops</source>
-        <target>Selected shops</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:318</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/informations.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0b90582f4589d84be89f5b847d4d1ed1">
-        <source>Highlight</source>
-        <target>Highlight</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:94</note>
-      </trans-unit>
-      <trans-unit id="f507c7574b6368f942ea9a2b959d8ec9">
-        <source>Partial use</source>
-        <target>Partial use</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:113</note>
+        <note>Line: 45</note>
       </trans-unit>
     </body>
   </file>
@@ -2836,74 +14,186 @@ File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:
       <trans-unit id="fc6341fa76fe93b837d748563e0a60c1">
         <source>Apply a discount</source>
         <target>Apply a discount</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="da73ea07f51049046d527dabd85170e1">
         <source>Percent (%)</source>
         <target>Percent (%)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="f1bffec1a42b7e6dd7e3613dbbb0a065">
         <source>Apply a discount to</source>
         <target>Apply a discount to</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:102</note>
+        <note>Line: 102</note>
       </trans-unit>
       <trans-unit id="629b9591d5085cf14edd26c9d376bb3a">
         <source>Order (without shipping)</source>
         <target>Order (without shipping)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:107</note>
+        <note>Line: 107</note>
       </trans-unit>
       <trans-unit id="1b343552de249749420ddd0fff731e0c">
         <source>Specific product</source>
         <target>Specific product</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:113</note>
+        <note>Line: 113</note>
       </trans-unit>
       <trans-unit id="8bab8ac32605948e59399033c7606222">
         <source>Cheapest product</source>
         <target>Cheapest product</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:119</note>
+        <note>Line: 119</note>
       </trans-unit>
       <trans-unit id="8cfdac16c15c9b130f26ca1d275035a0">
         <source>Selected product(s)</source>
         <target>Selected product(s)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:125</note>
+        <note>Line: 125</note>
       </trans-unit>
       <trans-unit id="3b3924db361bf202158d5a23ec10ea80">
         <source>Exclude discounted products</source>
         <target>Exclude discounted products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:146</note>
+        <note>Line: 146</note>
       </trans-unit>
       <trans-unit id="2f73d13f0a878086ce1f9933aed3ac80">
         <source>Send a free gift</source>
         <target>Send a free gift</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:165</note>
+        <note>Line: 165</note>
       </trans-unit>
       <trans-unit id="c5f17f7ca53d9225478fdbfd0a5583ac">
         <source>Search a product</source>
         <target>Search a product</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:182</note>
+        <note>Line: 182</note>
       </trans-unit>
       <trans-unit id="635c8dcb5a9c7f405ebf10ee3351a158">
         <source>Matching products</source>
         <target>Matching products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:193</note>
+        <note>Line: 193</note>
       </trans-unit>
       <trans-unit id="34b9126c1ba9f3b131875a8da7b426c4">
         <source>Available combinations</source>
         <target>Available combinations</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:201</note>
+        <note>Line: 201</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8f36b08eb9ebba13ef930c9dd719ff7c">
+        <source>Limit to a single customer</source>
+        <target>Limit to a single customer</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="3ac705f2acd51a4613f9188c05c91d0d">
+        <source>Valid</source>
+        <target>Valid</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="9f6e99bdd4184b83dc478d0ab1b4cbf7">
+        <source>Minimum amount</source>
+        <target>Minimum amount</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="89bea8045e50a337d8ce9849a4e1633c">
+        <source>Shipping excluded</source>
+        <target>Shipping excluded</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="f7b8d9d5bbba937644a29be14e2654ed">
+        <source>Shipping included</source>
+        <target>Shipping included</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="7d058d4cdbc3a0f480bd472b62a0bf53">
+        <source>Total available</source>
+        <target>Total available</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="9379f6f6c128b182600047d1b3090bc9">
+        <source>Total available for each user</source>
+        <target>Total available for each user</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="e3e16bb73c0250a6a229fb457b4f957e">
+        <source>Restrictions</source>
+        <target>Restrictions</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="cd8e66c655070f24cbece45141a505c3">
+        <source>Country selection</source>
+        <target>Country selection</target>
+        <note>Line: 148</note>
+      </trans-unit>
+      <trans-unit id="7922167568640bb2e57c1592a0b5945b">
+        <source>Unselected countries</source>
+        <target>Unselected countries</target>
+        <note>Line: 157</note>
+      </trans-unit>
+      <trans-unit id="7c160ccb02560f1adb25fb6b86d9ebce">
+        <source>Selected countries</source>
+        <target>Selected countries</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="46b00dccbc9e441b3fcf567d39975f86">
+        <source>Carrier selection</source>
+        <target>Carrier selection</target>
+        <note>Line: 183</note>
+      </trans-unit>
+      <trans-unit id="3e9619330efb3bed62076dc6138a3889">
+        <source>Unselected carriers</source>
+        <target>Unselected carriers</target>
+        <note>Line: 191</note>
+      </trans-unit>
+      <trans-unit id="bd544756bba84765ddf991b01d7120d1">
+        <source>Selected carriers</source>
+        <target>Selected carriers</target>
+        <note>Line: 200</note>
+      </trans-unit>
+      <trans-unit id="c3f6634f087fc43dd62b3154e12d050d">
+        <source>Customer group selection</source>
+        <target>Customer group selection</target>
+        <note>Line: 217</note>
+      </trans-unit>
+      <trans-unit id="9463ae08271e82176b391f6cedb6e82b">
+        <source>Unselected groups</source>
+        <target>Unselected groups</target>
+        <note>Line: 225</note>
+      </trans-unit>
+      <trans-unit id="1fc6ed753100636e79df3831a3034531">
+        <source>Selected groups</source>
+        <target>Selected groups</target>
+        <note>Line: 234</note>
+      </trans-unit>
+      <trans-unit id="eb8bd4a7aeee5a49102d5269113b1142">
+        <source>Compatibility with other cart rules</source>
+        <target>Compatibility with other cart rules</target>
+        <note>Line: 251</note>
+      </trans-unit>
+      <trans-unit id="06d8251983d901d62c12ed00fe65ddc1">
+        <source>Uncombinable cart rules</source>
+        <target>Uncombinable cart rules</target>
+        <note>Line: 259</note>
+      </trans-unit>
+      <trans-unit id="53fb9df3249c49828006e57434d02d65">
+        <source>Combinable cart rules</source>
+        <target>Combinable cart rules</target>
+        <note>Line: 267</note>
+      </trans-unit>
+      <trans-unit id="7f36b7eac5872d757b315ed431c4ad92">
+        <source>Product selection</source>
+        <target>Product selection</target>
+        <note>Line: 293</note>
+      </trans-unit>
+      <trans-unit id="e2bcac3dc51781abbc2938e16a0b0e72">
+        <source>Shop selection</source>
+        <target>Shop selection</target>
+        <note>Line: 301</note>
+      </trans-unit>
+      <trans-unit id="5e3f76cc2d68012faa5ce54aadf6cf84">
+        <source>Unselected shops</source>
+        <target>Unselected shops</target>
+        <note>Line: 309</note>
+      </trans-unit>
+      <trans-unit id="a5a08c71d0992427cfd8815ebc8f6152">
+        <source>Selected shops</source>
+        <target>Selected shops</target>
+        <note>Line: 318</note>
       </trans-unit>
     </body>
   </file>
@@ -2912,44 +202,154 @@ File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:201</
       <trans-unit id="48bc4d0ad8c02bb7d116b43d907570e2">
         <source>Cart rule</source>
         <target>Cart rule</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/form.tpl:26</note>
+        <note>Line: 26</note>
       </trans-unit>
       <trans-unit id="a82be0f551b8708bc08eb33cd9ded0cf">
         <source>Information</source>
         <target>Information</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/form.tpl:30</note>
+        <note>Line: 30</note>
       </trans-unit>
       <trans-unit id="1e1cc9bdeb2f29f5480106aec7e9bc48">
         <source>Now</source>
         <target>Now</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/form.tpl:62</note>
+        <note>Line: 62</note>
       </trans-unit>
       <trans-unit id="f92965e2c8a7afb3c1b9a5c09a263636">
         <source>Done</source>
         <target>Done</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/form.tpl:63</note>
+        <note>Line: 63</note>
       </trans-unit>
       <trans-unit id="3964fd83339fec5014c831822005653a">
         <source>Choose Time</source>
         <target>Choose Time</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/form.tpl:64</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="a76d4ef5f3f6a672bbfab2865563e530">
         <source>Time</source>
         <target>Time</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/form.tpl:65</note>
+        <note>Line: 65</note>
       </trans-unit>
       <trans-unit id="62902641c38f3a4a8eb3212454360e24">
         <source>Minute</source>
         <target>Minute</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/form.tpl:67</note>
+        <note>Line: 67</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/informations.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0b90582f4589d84be89f5b847d4d1ed1">
+        <source>Highlight</source>
+        <target>Highlight</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="f507c7574b6368f942ea9a2b959d8ec9">
+        <source>Partial use</source>
+        <target>Partial use</target>
+        <note>Line: 113</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="21534b955347d06c074955b008ccb0c9">
+        <source>Number of products required in the cart to enjoy the discount:</source>
+        <target>Number of products required in the cart to enjoy the discount:</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/message.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e9cb217697088a98b1937d111d936281">
+        <source>Attachment</source>
+        <target>Attachment</target>
+        <note>Line: 56</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f8a09f634b7b3ede2da34607da2aaebe">
+        <source>Available quantity</source>
+        <target>Available quantity</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="e78b6f4eb3be046f4d25c07ce54954d4">
+        <source>Ref:</source>
+        <target>Ref:</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="ccf096490d2671f3ea97ea9289eee5b1">
+        <source>EAN13:</source>
+        <target>EAN13:</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="af7448c885be0d8acd5eb84322176570">
+        <source>UPC:</source>
+        <target>UPC:</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="647b89b705fafd7d44aa6f01a5cb4711">
+        <source>Qty:</source>
+        <target>Qty:</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="1caa6ff629641a4eb20f190f7a0539ca">
+        <source>Attribute name</source>
+        <target>Attribute name</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="52eb5928a34db3e3da7ba52b0644273b">
+        <source>EAN13</source>
+        <target>EAN13</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="fbd99ad01b92dbafc686772a39e3d065">
+        <source>UPC</source>
+        <target>UPC</target>
+        <note>Line: 122</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_discount_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a1fa27779242b4902f7ae3bdd5c6d508">
+        <source>Type</source>
+        <target>Type</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="da22c93ccb398c72070f4000cc7b59a1">
+        <source>Customization</source>
+        <target>Customization</target>
+        <note>Line: 651</note>
+      </trans-unit>
+      <trans-unit id="9d20a93036ba910dd75ffbcec173798e">
+        <source>Price per unit</source>
+        <target>Price per unit</target>
+        <note>Line: 1264</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
+        <source>Shipping</source>
+        <target>Shipping</target>
+        <note>Line: 1097</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df644ae155e79abf54175bd15d75f363">
+        <source>Product name</source>
+        <target>Product name</target>
+        <note>Line: 54</note>
       </trans-unit>
     </body>
   </file>
@@ -2958,26 +358,2184 @@ File: admin-dev/themes/default/template/controllers/cart_rules/form.tpl:67</note
       <trans-unit id="229eb04083e06f419f9ac494329f957d">
         <source>Conditions</source>
         <target>Conditions</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:37</note>
+        <note>Line: 37</note>
       </trans-unit>
       <trans-unit id="6982640121765cb57f29e6fe170caadc">
         <source>Add a new condition group</source>
         <target>Add a new condition group</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="643202d7ee8cb01d888e058b5341455a">
         <source>Add condition</source>
         <target>Add condition</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:136</note>
+        <note>Line: 136</note>
       </trans-unit>
       <trans-unit id="e43e4f8aab3dbe1127082747a86a2120">
         <source>Condition group</source>
         <target>Condition group</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:197</note>
+        <note>Line: 197</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/CategoryLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fa03eb688ad8aa1db593d33dabd89bad">
+        <source>Root</source>
+        <target>Root</target>
+        <note>Line: 26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/CmsCategoryLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8cf04a9734132302f96da8e113e80ce5">
+        <source>Home</source>
+        <target>Home</target>
+        <note>Line: 26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/StockMvtReasonLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="aac247ca22789872bad95dc8f6c45d37">
+        <source>Increase</source>
+        <target>Increase</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="9e661cc6f7c72b95abfd6b372aacbfa1">
+        <source>Decrease</source>
+        <target>Decrease</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="c9ef04d431a0f72fec2712c575fcaf15">
+        <source>Customer Order</source>
+        <target>Customer Order</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="2c9697ad1bb585d6d1d0fabcb1028926">
+        <source>Adjustment following an inventory of stock</source>
+        <target>Adjustment following an inventory of stock</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="02ef8bd47ce057b792bbd620d6059caa">
+        <source>Transfer to another warehouse</source>
+        <target>Transfer to another warehouse</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="7829dec62809e15c4bb9bbc002fc5614">
+        <source>Transfer from another warehouse</source>
+        <target>Transfer from another warehouse</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="6ae30b0a1badc7bc37e9fd794bca7e3f">
+        <source>Supply Order</source>
+        <target>Supply Order</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="d664291d8860308c25f148de5831ad55">
+        <source>Product Return</source>
+        <target>Product Return</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="1638bbd4664fd745118d95786b7e37b9">
+        <source>Manual Entry</source>
+        <target>Manual Entry</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttachmentsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bdf4f1da184f2dc052c75ad7e1afbd4a">
+        <source>Associated with</source>
+        <target>Associated with</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="fc1ff5390ecc7efd695f697f3d6b7e4b">
+        <source>product(s)</source>
+        <target>product(s)</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="3f1f6fb24d408c8ddead60bd41063b02">
+        <source>Add new file</source>
+        <target>Add new file</target>
+        <note>Line: 135</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttributeGeneratorController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="81315cfd898aada1e99e0034b4b078c3">
+        <source>Attributes generator</source>
+        <target>Attributes generator</target>
+        <note>Line: 217</note>
+      </trans-unit>
+      <trans-unit id="402784f5f14c30e7309a135ba6be531f">
+        <source>Back to the product</source>
+        <target>Back to the product</target>
+        <note>Line: 220</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c82a6100dace2b41087ba6cf99a5976a">
+        <source>Values</source>
+        <target>Values</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="689202409e48743b914713f96d93947c">
+        <source>Value</source>
+        <target>Value</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="cb5feb1b7314637725a2e73bdc9f7295">
+        <source>Color</source>
+        <target>Color</target>
+        <note>Line: 308</note>
+      </trans-unit>
+      <trans-unit id="f68b27443f6e6f685cce3f9f422a2b84">
+        <source>Color or texture</source>
+        <target>Color or texture</target>
+        <note>Line: 185</note>
+      </trans-unit>
+      <trans-unit id="287234a1ff35a314b5b6bc4e5828e745">
+        <source>Attributes</source>
+        <target>Attributes</target>
+        <note>Line: 191</note>
+      </trans-unit>
+      <trans-unit id="d274013ea65428454962a59b7b373a41">
+        <source>Public name</source>
+        <target>Public name</target>
+        <note>Line: 206</note>
+      </trans-unit>
+      <trans-unit id="17af8baa9b3f90e936589069e4223280">
+        <source>Attribute type</source>
+        <target>Attribute type</target>
+        <note>Line: 215</note>
+      </trans-unit>
+      <trans-unit id="0e010c6b3fb88bf4277c880d1657787a">
+        <source>Attribute group</source>
+        <target>Attribute group</target>
+        <note>Line: 264</note>
+      </trans-unit>
+      <trans-unit id="561f47d9c8a6153b011def4fd72386d5">
+        <source>Current texture</source>
+        <target>Current texture</target>
+        <note>Line: 325</note>
+      </trans-unit>
+      <trans-unit id="00039b674d8ced58313546dcab88a032">
+        <source>Add new attribute</source>
+        <target>Add new attribute</target>
+        <note>Line: 519</note>
+      </trans-unit>
+      <trans-unit id="2dce4461e5743f3b01acd4599a38d646">
+        <source>Add new value</source>
+        <target>Add new value</target>
+        <note>Line: 533</note>
+      </trans-unit>
+      <trans-unit id="71e8f8a090925f75719dfa0a5eae059e">
+        <source>Add New Values</source>
+        <target>Add New Values</target>
+        <note>Line: 571</note>
+      </trans-unit>
+      <trans-unit id="52729803b243ea9693a892161d5b8e38">
+        <source>Add New Attributes</source>
+        <target>Add New Attributes</target>
+        <note>Line: 583</note>
+      </trans-unit>
+      <trans-unit id="1f40023e11d8401b0bffadc419135247">
+        <source>Edit New Attribute</source>
+        <target>Edit New Attribute</target>
+        <note>Line: 600</note>
+      </trans-unit>
+      <trans-unit id="713271e705e5269fc82684445cd063a8">
+        <source>Add New Attribute</source>
+        <target>Add New Attribute</target>
+        <note>Line: 604</note>
+      </trans-unit>
+      <trans-unit id="7d5672f569de406c85249db6f1c99ec0">
+        <source>Save then add another value</source>
+        <target>Save then add another value</target>
+        <note>Line: 340</note>
+      </trans-unit>
+      <trans-unit id="4472046c137171c7adf7c4fe5a72b6b9">
+        <source>Edit: %value%</source>
+        <target>Edit: %value%</target>
+        <note>Line: 627</note>
+      </trans-unit>
+      <trans-unit id="577cf2cf1be74419ac04093a2b4cd64d">
+        <source>Edit Value</source>
+        <target>Edit Value</target>
+        <note>Line: 635</note>
+      </trans-unit>
+      <trans-unit id="fce2e84f3cce0e5351e85e9f0cb20107">
+        <source>Add New Value</source>
+        <target>Add New Value</target>
+        <note>Line: 638</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCartRulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="447da4af35bd09b4d501afb8a2090909">
+        <source>Add new cart rule</source>
+        <target>Add new cart rule</target>
+        <note>Line: 135</note>
+      </trans-unit>
+      <trans-unit id="bd0e34e5be6447844e6f262d51f1a9dc">
+        <source>Payment: </source>
+        <target>Payment:</target>
+        <note>Line: 679</note>
+      </trans-unit>
+      <trans-unit id="65b7eaeb9ba4e9903f82297face9f7cd">
+        <source>Cart Rules</source>
+        <target>Cart Rules</target>
+        <note>Line: 679</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="52b68aaa602d202c340d9e4e9157f276">
+        <source>Parent category</source>
+        <target>Parent category</target>
+        <note>Line: 542</note>
+      </trans-unit>
+      <trans-unit id="5f573e91e5eaa092e00a4c4df393c0cb">
+        <source>Add new root category</source>
+        <target>Add new root category</target>
+        <note>Line: 178</note>
+      </trans-unit>
+      <trans-unit id="d0d4e3688fdaee5afa292083b855e143">
+        <source>Add new category</source>
+        <target>Add new category</target>
+        <note>Line: 185</note>
+      </trans-unit>
+      <trans-unit id="42c9e94e8e5c29861de422525262ff17">
+        <source>Disabled Categories</source>
+        <target>Disabled Categories</target>
+        <note>Line: 393</note>
+      </trans-unit>
+      <trans-unit id="850da4810ae3771d696d504d7346caa6">
+        <source>Empty Categories</source>
+        <target>Empty Categories</target>
+        <note>Line: 406</note>
+      </trans-unit>
+      <trans-unit id="3b449120fdb2867c000d7bba671aead3">
+        <source>Top Category</source>
+        <target>Top Category</target>
+        <note>Line: 418</note>
+      </trans-unit>
+      <trans-unit id="a6398f9bbc9739ed67ca273b82da0a55">
+        <source>Average number of products per category</source>
+        <target>Average number of products per category</target>
+        <note>Line: 431</note>
+      </trans-unit>
+      <trans-unit id="86a230fec38eb3957d48a8ffdfcb4722">
+        <source>%group_name% - All people without a valid customer account.</source>
+        <target>%group_name% - All people without a valid customer account.</target>
+        <note>Line: 458</note>
+      </trans-unit>
+      <trans-unit id="8a11a183559fcb803b95e9a2e3efb47d">
+        <source>%group_name% - Customer who placed an order with the guest checkout.</source>
+        <target>%group_name% - Customer who placed an order with the guest checkout.</target>
+        <note>Line: 459</note>
+      </trans-unit>
+      <trans-unit id="7ed584948027b1d0117b1c73f80ea50f">
+        <source>%group_name% - All people who have created an account on this site.</source>
+        <target>%group_name% - All people who have created an account on this site.</target>
+        <note>Line: 460</note>
+      </trans-unit>
+      <trans-unit id="2028f52eb6d12dc1814f92f18c7365a0">
+        <source>Category Cover Image</source>
+        <target>Category Cover Image</target>
+        <note>Line: 561</note>
+      </trans-unit>
+      <trans-unit id="4ae362f049719078c429941bed5dd440">
+        <source>Category thumbnail</source>
+        <target>Category thumbnail</target>
+        <note>Line: 572</note>
+      </trans-unit>
+      <trans-unit id="eea317348d82718d49f9a79189dc0f93">
+        <source>Menu thumbnails</source>
+        <target>Menu thumbnails</target>
+        <note>Line: 582</note>
+      </trans-unit>
+      <trans-unit id="920bd1fb6d54c93fca528ce941464225">
+        <source>Group access</source>
+        <target>Group access</target>
+        <note>Line: 630</note>
+      </trans-unit>
+      <trans-unit id="154b6e494bf56cc4c787bfee6deac113">
+        <source>Root Category</source>
+        <target>Root Category</target>
+        <note>Line: 654</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c3bf447eabe632720a3aa1a7ce401274">
+        <source>Open</source>
+        <target>Open</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="03f4a47830f97377a35321051685071e">
+        <source>Closed</source>
+        <target>Closed</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="70e7ab74282fb27b8c100e017b037135">
+        <source>Pending 1</source>
+        <target>Pending 1</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="1033cc268ed0919b5d4e76ea6053ed25">
+        <source>Pending 2</source>
+        <target>Pending 2</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="41de6d6cfb8953c021bbe4ba0701c8a1">
+        <source>Messages</source>
+        <target>Messages</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="47f9082fc380ca62d531096aa1d110f1">
+        <source>Private</source>
+        <target>Private</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="cf090b8fa4a136ed6058aaf84d5d2538">
+        <source>Last message</source>
+        <target>Last message</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="8058aef8e4c03453b1b088795677726a">
+        <source>Contact options</source>
+        <target>Contact options</target>
+        <note>Line: 147</note>
+      </trans-unit>
+      <trans-unit id="42d99bbf0d1cd9ffe4a5ff746d177aba">
+        <source>Allow file uploading</source>
+        <target>Allow file uploading</target>
+        <note>Line: 150</note>
+      </trans-unit>
+      <trans-unit id="2da2fc7f382fa2e5b9d0e433fa71a475">
+        <source>Default message</source>
+        <target>Default message</target>
+        <note>Line: 155</note>
+      </trans-unit>
+      <trans-unit id="0e9470c5e6bfee40004f22f543b8b2a6">
+        <source>Customer service options</source>
+        <target>Customer service options</target>
+        <note>Line: 164</note>
+      </trans-unit>
+      <trans-unit id="13ec82d83a5254297003cc1b41f19edb">
+        <source>IMAP URL</source>
+        <target>IMAP URL</target>
+        <note>Line: 167</note>
+      </trans-unit>
+      <trans-unit id="197f7f372a439787cef040d61f4dbe83">
+        <source>IMAP port</source>
+        <target>IMAP port</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="f9b68c21c5d51df2d6b54cfbfa985abe">
+        <source>IMAP user</source>
+        <target>IMAP user</target>
+        <note>Line: 178</note>
+      </trans-unit>
+      <trans-unit id="2cacfd762c9fc6f7a140aadc7b5a608c">
+        <source>IMAP password</source>
+        <target>IMAP password</target>
+        <note>Line: 183</note>
+      </trans-unit>
+      <trans-unit id="ca7e64e3f55ef8e0f50818d8117d26cc">
+        <source>Delete messages</source>
+        <target>Delete messages</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="1fd5325f317b2c9aacc11fb393fd2aa8">
+        <source>Create new threads</source>
+        <target>Create new threads</target>
+        <note>Line: 193</note>
+      </trans-unit>
+      <trans-unit id="ebcb544208ccfe2e3fe98c8380518300">
+        <source>IMAP options</source>
+        <target>IMAP options</target>
+        <note>Line: 228</note>
+      </trans-unit>
+      <trans-unit id="693c61ec70b6c06dbd376fd208a125a0">
+        <source>Total threads</source>
+        <target>Total threads</target>
+        <note>Line: 281</note>
+      </trans-unit>
+      <trans-unit id="068f62c804cc9c4cd4f6dfc5b5d3ecaa">
+        <source>Threads pending</source>
+        <target>Threads pending</target>
+        <note>Line: 282</note>
+      </trans-unit>
+      <trans-unit id="2fb7efc7cfbbb4672a5f3a021f1a2462">
+        <source>Total number of customer messages</source>
+        <target>Total number of customer messages</target>
+        <note>Line: 283</note>
+      </trans-unit>
+      <trans-unit id="8d937d958b984dde93c972a335f87d4b">
+        <source>Total number of employee messages</source>
+        <target>Total number of employee messages</target>
+        <note>Line: 284</note>
+      </trans-unit>
+      <trans-unit id="da2f2f1035487e79b7f5bfd9c5c3eeab">
+        <source>Unread threads</source>
+        <target>Unread threads</target>
+        <note>Line: 285</note>
+      </trans-unit>
+      <trans-unit id="939315783ef4f2eb1cbdac37f3fd1e6b">
+        <source>Closed threads</source>
+        <target>Closed threads</target>
+        <note>Line: 286</note>
+      </trans-unit>
+      <trans-unit id="d21b5a78517318e6d35414d4217950ce">
+        <source>Message forwarded to</source>
+        <target>Message forwarded to</target>
+        <note>Line: 410</note>
+      </trans-unit>
+      <trans-unit id="0134539df13231b95613415c0a75af42">
+        <source>Pending Discussion Threads</source>
+        <target>Pending Discussion Threads</target>
+        <note>Line: 549</note>
+      </trans-unit>
+      <trans-unit id="c61b4a4520f875b20f7ff3e6ff502ebe">
+        <source>Average Response Time</source>
+        <target>Average Response Time</target>
+        <note>Line: 561</note>
+      </trans-unit>
+      <trans-unit id="6092e157634b78d790fc607b587d1274">
+        <source>Messages per Thread</source>
+        <target>Messages per Thread</target>
+        <note>Line: 574</note>
+      </trans-unit>
+      <trans-unit id="dab57a3f740e26922519aebc7e3d602a">
+        <source>Reply to the next unanswered message in this thread</source>
+        <target>Reply to the next unanswered message in this thread</target>
+        <note>Line: 634</note>
+      </trans-unit>
+      <trans-unit id="5e7304b3032d56f1e9a1ce34cfd4a4ff">
+        <source>Mark as "handled"</source>
+        <target>Mark as "handled"</target>
+        <note>Line: 641</note>
+      </trans-unit>
+      <trans-unit id="ea907b9c1af0f060fa2c21beed25880e">
+        <source>Re-open</source>
+        <target>Re-open</target>
+        <note>Line: 648</note>
+      </trans-unit>
+      <trans-unit id="4e852df9fae5b1f8b5e97233733dca5e">
+        <source>Mark as "pending 1" (will be answered later)</source>
+        <target>Mark as "pending 1" (will be answered later)</target>
+        <note>Line: 657</note>
+      </trans-unit>
+      <trans-unit id="bd31a5029e3ca883955fdf21f7528078">
+        <source>Disable pending status</source>
+        <target>Disable pending status</target>
+        <note>Line: 680</note>
+      </trans-unit>
+      <trans-unit id="005ae88a1f2c4664a5009cc0c8d14f7b">
+        <source>Mark as "pending 2" (will be answered later)</source>
+        <target>Mark as "pending 2" (will be answered later)</target>
+        <note>Line: 673</note>
+      </trans-unit>
+      <trans-unit id="119ce51409ff0ec366e67df0c852ede7">
+        <source>Message to: </source>
+        <target>Message to:</target>
+        <note>Line: 759</note>
+      </trans-unit>
+      <trans-unit id="ed96f783e467cc984e4945063760e2c4">
+        <source>Product: </source>
+        <target>Product:</target>
+        <note>Line: 762</note>
+      </trans-unit>
+      <trans-unit id="24a23d787190f2c4812ff9ab11847a72">
+        <source>Status:</source>
+        <target>Status:</target>
+        <note>Line: 783</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminFeaturesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d6ae681fcd58f1e1936ca97da36528ff">
+        <source>Add a new feature</source>
+        <target>Add a new feature</target>
+        <note>Line: 161</note>
+      </trans-unit>
+      <trans-unit id="5f46be79c24b6cde1ff2176a2ce917e9">
+        <source>Add new feature</source>
+        <target>Add new feature</target>
+        <note>Line: 201</note>
+      </trans-unit>
+      <trans-unit id="ef8edef8db1844688f6a542b9cf45742">
+        <source>Edit New Feature</source>
+        <target>Edit New Feature</target>
+        <note>Line: 281</note>
+      </trans-unit>
+      <trans-unit id="dd261387b1ad7605716e5edbc0164028">
+        <source>Add New Feature</source>
+        <target>Add New Feature</target>
+        <note>Line: 286</note>
+      </trans-unit>
+      <trans-unit id="6c3205f235918451faca3dcd6e63d760">
+        <source>Feature value</source>
+        <target>Feature value</target>
+        <note>Line: 332</note>
+      </trans-unit>
+      <trans-unit id="0c8a987e64c2d46886bf92e29c736bdc">
+        <source>Add a new feature value</source>
+        <target>Add a new feature value</target>
+        <note>Line: 406</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9aa4e1b6c10cf1bc2a8145dcc8476b0f">
+        <source>Send me an email when the quantity is under this level</source>
+        <target>Send me an email when the quantity is under this level</target>
+        <note>Line: 267</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminManufacturersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
+        <source>Addresses</source>
+        <target>Addresses</target>
+        <note>Line: 459</note>
+      </trans-unit>
+      <trans-unit id="068f80c7519d0528fb08e82137a72131">
+        <source>Products</source>
+        <target>Products</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="ba8df31467300b4fef9b40f4efa8c33c">
+        <source>Add new brand</source>
+        <target>Add new brand</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="2d236afdc6efc79d47ac67807be0b798">
+        <source>Add new brand address</source>
+        <target>Add new brand address</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="55caa82d08a11359bf043f8e2a1d4ad1">
+        <source>List of brands</source>
+        <target>List of brands</target>
+        <note>Line: 155</note>
+      </trans-unit>
+      <trans-unit id="2d993f0eea2cfe4881542ab187d1c350">
+        <source>Brand addresses</source>
+        <target>Brand addresses</target>
+        <note>Line: 260</note>
+      </trans-unit>
+      <trans-unit id="84be54bb4bd1b755a27d86388700d097">
+        <source>Brands</source>
+        <target>Brands</target>
+        <note>Line: 314</note>
+      </trans-unit>
+      <trans-unit id="7c7c12e999629a6bf8dac0cb2119c261">
+        <source>Choose the brand</source>
+        <target>Choose the brand</target>
+        <note>Line: 467</note>
+      </trans-unit>
+      <trans-unit id="804f1e6cd9e6d68208f39932da191f61">
+        <source>Edit Addresses</source>
+        <target>Edit Addresses</target>
+        <note>Line: 635</note>
+      </trans-unit>
+      <trans-unit id="6bc011e375bcee14786bb43acdf00a8a">
+        <source>Add address</source>
+        <target>Add address</target>
+        <note>Line: 697</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1379a6b19242372c1f23cc9adedfcdd6">
+        <source>Category root</source>
+        <target>Category root</target>
+        <note>Line: 439</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSpecificPriceRuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fc7b398d4af2074cfe73febdb5971153">
+        <source>From quantity</source>
+        <target>From quantity</target>
+        <note>Line: 229</note>
+      </trans-unit>
+      <trans-unit id="0558dcc45dad1cfe3d4e55ca16bfbb12">
+        <source>Beginning</source>
+        <target>Beginning</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="87557f11575c0ad78e4e28abedc13b6e">
+        <source>End</source>
+        <target>End</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="c1da0bfd4d60d1aab58fcf8a8e933972">
+        <source>Add new catalog price rule</source>
+        <target>Add new catalog price rule</target>
+        <note>Line: 140</note>
+      </trans-unit>
+      <trans-unit id="e5bfab8b7f97b8f0b19ad7e393d7c566">
+        <source>Catalog price rules</source>
+        <target>Catalog price rules</target>
+        <note>Line: 174</note>
+      </trans-unit>
+      <trans-unit id="5e3c40bfa4026ab071712bf230b8f52f">
+        <source>Reduction with or without taxes</source>
+        <target>Reduction with or without taxes</target>
+        <note>Line: 280</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSuppliersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="990fc90e39367377c314f1d61522ae61">
+        <source>Number of products</source>
+        <target>Number of products</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="094ada406018db9fe3601b65e7502c82">
+        <source>Add new supplier</source>
+        <target>Add new supplier</target>
+        <note>Line: 84</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="428a70e43c5371126c0fb675e98c61d5">
+        <source>List of empty categories:</source>
+        <target>List of empty categories:</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="0181e2b8568143a3608fea8e657a81cb">
+        <source>List of products with combinations but without available quantities for sale:</source>
+        <target>List of products with combinations but without available quantities for sale:</target>
+        <note>Line: 159</note>
+      </trans-unit>
+      <trans-unit id="d06aa90bdc7545b64a808ef956b20b77">
+        <source>List of products without combinations and without available quantities for sale:</source>
+        <target>List of products without combinations and without available quantities for sale:</target>
+        <note>Line: 204</note>
+      </trans-unit>
+      <trans-unit id="40be52ec4b8eab2321f116914858ce6a">
+        <source>List of disabled products</source>
+        <target>List of disabled products</target>
+        <note>Line: 235</note>
+      </trans-unit>
+      <trans-unit id="c205cafb2813572f3f96669cf2b97cf0">
+        <source>List of products without images</source>
+        <target>List of products without images</target>
+        <note>Line: 267</note>
+      </trans-unit>
+      <trans-unit id="eaff59412c15abca3419aee22b02d726">
+        <source>List of products without description</source>
+        <target>List of products without description</target>
+        <note>Line: 304</note>
+      </trans-unit>
+      <trans-unit id="3368abb84d65a50813d1ed17708ec130">
+        <source>List of products without price</source>
+        <target>List of products without price</target>
+        <note>Line: 336</note>
+      </trans-unit>
+      <trans-unit id="bcaad756615668f5e8e0447aa36f4f22">
+        <source>Product disabled</source>
+        <target>Product disabled</target>
+        <note>Line: 448</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Product/AdminProductWrapper.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4e021cd834848e751e2d1bc66cee697d">
+        <source>All combinations</source>
+        <target>All combinations</target>
+        <note>Line: 455</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Product/ProductCsvExporter.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="77eb276f5dcdf4fbca854e908216f7b2">
+        <source>Price (tax incl.)</source>
+        <target>Price (tax incl.)</target>
+        <note>Line: 84</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/FeatureController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fd380496c889dcb05d6e996fd1ecaf0b">
+        <source>Choose a value</source>
+        <target>Choose a value</target>
+        <note>Line: 58</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/ProductImageController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b3d4e2bcdbf72f5828b3ef09b238c072">
+        <source>Please select a file</source>
+        <target>Please select a file</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="272ba7d164aa836995be6319a698be84">
+        <source>Caption</source>
+        <target>Caption</target>
+        <note>Line: 139</note>
+      </trans-unit>
+      <trans-unit id="84967207ddc311cfbe8ee66f677a1544">
+        <source>Cover image</source>
+        <target>Cover image</target>
+        <note>Line: 143</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Api/StockController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="78167a214fe755d9a2f5a7f2bc62cecf">
+        <source>Low stock level</source>
+        <target>Low stock level</target>
+        <note>Line: 168</note>
+      </trans-unit>
+      <trans-unit id="0826c628f8c5f6895c8a1e27e99457fb">
+        <source>Send me an email when the quantity is below or equals this level</source>
+        <target>Send me an email when the quantity is below or equals this level</target>
+        <note>Line: 169</note>
+      </trans-unit>
+      <trans-unit id="5321a616e36742f66aa933956e839217">
+        <source>Combination name</source>
+        <target>Combination name</target>
+        <note>Line: 162</note>
+      </trans-unit>
+      <trans-unit id="a094699b1837834e13875a06773bcf28">
+        <source>Physical quantity</source>
+        <target>Physical quantity</target>
+        <note>Line: 165</note>
+      </trans-unit>
+      <trans-unit id="82325d4b818ad2b7f46dfe72e186d016">
+        <source>Reserved quantity</source>
+        <target>Reserved quantity</target>
+        <note>Line: 166</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bb34a159a88035cce7ef1607e7907f8f">
+        <source>Category name</source>
+        <target>Category name</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="fa350f1440add1a91fb21c42c555b2eb">
+        <source>Parent of the category</source>
+        <target>Parent of the category</target>
+        <note>Line: 99</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="21021ea0e52be8e9c599f4dff41e5be0">
+        <source>Feature</source>
+        <target>Feature</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="5ebd6e1c1cdeac7a7c1896ab842d98da">
+        <source>Choose a feature</source>
+        <target>Choose a feature</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="8bcdd31a1ab28f0db60efb2087c3f235">
+        <source>Pre-defined value</source>
+        <target>Pre-defined value</target>
+        <note>Line: 144</note>
+      </trans-unit>
+      <trans-unit id="5da9eb58e1c3816d0a2fbaa50e9de78e">
+        <source>OR Customized value</source>
+        <target>OR Customized value</target>
+        <note>Line: 103</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e92cfa244b5eb9025d07522080468445">
+        <source>Ecotax</source>
+        <target>Ecotax</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="cc11780aa5b292dfe984aefc0d76bfad">
+        <source>ISBN code</source>
+        <target>ISBN code</target>
+        <note>Line: 93</note>
+      </trans-unit>
+      <trans-unit id="a04586da5cc69ed7dee68e3b26786999">
+        <source>Impact on price per unit (tax excl.)</source>
+        <target>Impact on price per unit (tax excl.)</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="92fa99e34de79a48fc85c66eb627e70f">
+        <source>Min. quantity for sale</source>
+        <target>Min. quantity for sale</target>
+        <note>Line: 147</note>
+      </trans-unit>
+      <trans-unit id="e9d0876ad242d421e19d583f6f379f5f">
+        <source>Set as default combination</source>
+        <target>Set as default combination</target>
+        <note>Line: 181</note>
+      </trans-unit>
+      <trans-unit id="a22ed40bafe8f07b6d02c4a4966c8aea">
+        <source>Select images of this combination:</source>
+        <target>Select images of this combination:</target>
+        <note>Line: 204</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3c1a34587e45bd9e9ae2efd9a6ecbb92">
+        <source>Impact on weight</source>
+        <target>Impact on weight</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="2438bf77baed0680f816ca0f4a7d0321">
+        <source>Availability date</source>
+        <target>Availability date</target>
+        <note>Line: 93</note>
+      </trans-unit>
+      <trans-unit id="8ef6e226754a31bf67ebf50047c142b9">
+        <source>Impact on price (tax excl.)</source>
+        <target>Impact on price (tax excl.)</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="152feab7588733220c3720773724c8d5">
+        <source>Impact on price (tax incl.)</source>
+        <target>Impact on price (tax incl.)</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="2a84584d4f095b4f6e660db58b9576d3">
+        <source>Cost Price</source>
+        <target>Cost Price</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="1b72aed8e84b91d73896efd48cf1a4e0">
+        <source>Minimum quantity</source>
+        <target>Minimum quantity</target>
+        <note>Line: 103</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c1069a480848e06782b81b8bea9c0c94">
+        <source>Short description</source>
+        <target>Short description</target>
+        <note>Line: 209</note>
+      </trans-unit>
+      <trans-unit id="2b5d1ce10d1df2892eb6033604e4df0b">
+        <source>Standard product</source>
+        <target>Standard product</target>
+        <note>Line: 135</note>
+      </trans-unit>
+      <trans-unit id="49a2d6f2a33dc367666a860bff4a8f5f">
+        <source>Pack of products</source>
+        <target>Pack of products</target>
+        <note>Line: 136</note>
+      </trans-unit>
+      <trans-unit id="27818c0656c429503efc4e67e149bcc7">
+        <source>Add products to your pack</source>
+        <target>Add products to your pack</target>
+        <note>Line: 157</note>
+      </trans-unit>
+      <trans-unit id="4c32794a96aec43624f14839274174bf">
+        <source>Pre-tax retail price</source>
+        <target>Pre-tax retail price</target>
+        <note>Line: 235</note>
+      </trans-unit>
+      <trans-unit id="ce0ec0f2b759fa68416e3bc96ee59276">
+        <source>Retail price with tax</source>
+        <target>Retail price with tax</target>
+        <note>Line: 245</note>
+      </trans-unit>
+      <trans-unit id="a17f5bc22553d897f6363867c0165256">
+        <source>Default category</source>
+        <target>Default category</target>
+        <note>Line: 270</note>
+      </trans-unit>
+      <trans-unit id="46c8280e993148f9cc6e26875d972169">
+        <source>Add a new category</source>
+        <target>Add a new category</target>
+        <note>Line: 277</note>
+      </trans-unit>
+      <trans-unit id="98edb85b00d9527ad5acebe451b3fae6">
+        <source>Accessories</source>
+        <target>Accessories</target>
+        <note>Line: 289</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5bb4529a7441854e00e00f8ed0096756">
+        <source>UPC barcode</source>
+        <target>UPC barcode</target>
+        <note>Line: 165</note>
+      </trans-unit>
+      <trans-unit id="c8effe37e0fefd95ff0cc4873de6e6a6">
+        <source>EAN-13 or JAN barcode</source>
+        <target>EAN-13 or JAN barcode</target>
+        <note>Line: 174</note>
+      </trans-unit>
+      <trans-unit id="9e2941b3c81256fac10392aaca4ccfde">
+        <source>Condition</source>
+        <target>Condition</target>
+        <note>Line: 207</note>
+      </trans-unit>
+      <trans-unit id="13787cfb1a15ae6690a29d3895c54de9">
+        <source>Everywhere</source>
+        <target>Everywhere</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="96c7d7f87187cc14ead1f887407d0edc">
+        <source>Catalog only</source>
+        <target>Catalog only</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="2ba18b8df558ceaabcc89f3a16772a9b">
+        <source>Search only</source>
+        <target>Search only</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="e56fc964976b3770a35b2d6fb4b78224">
+        <source>Nowhere</source>
+        <target>Nowhere</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="d1109f3240d262e842e8f6ff5ea755d9">
+        <source>Display options</source>
+        <target>Display options</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="f2149c422ab7577f063b69a2884d17f0">
+        <source>Available for order</source>
+        <target>Available for order</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="e1a5e653bc356ed6745d6814d50213eb">
+        <source>Show price</source>
+        <target>Show price</target>
+        <note>Line: 146</note>
+      </trans-unit>
+      <trans-unit id="fd531d460cecb407f3628d25c4574acc">
+        <source>Web only (not sold in your retail store)</source>
+        <target>Web only (not sold in your retail store)</target>
+        <note>Line: 155</note>
+      </trans-unit>
+      <trans-unit id="9609dddf3618cff8f67b7829e6fc575e">
+        <source>ISBN</source>
+        <target>ISBN</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="527618353332c282892ba960ef1f0230">
+        <source>Display condition on product page</source>
+        <target>Display condition on product page</target>
+        <note>Line: 195</note>
+      </trans-unit>
+      <trans-unit id="efb78d0dd61da3bb7e5ca1770b894420">
+        <source>Default suppliers</source>
+        <target>Default suppliers</target>
+        <note>Line: 227</note>
+      </trans-unit>
+      <trans-unit id="9d38722749ec2101e437414ac2a743f9">
+        <source>Attachments for this product:</source>
+        <target>Attachments for this product:</target>
+        <note>Line: 277</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6f3455d187a23443796efdcbe044096b">
+        <source>No tax</source>
+        <target>No tax</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="c265e7bd60b9bf0470d39a8ef87e0727">
+        <source>Ecotax (tax incl.)</source>
+        <target>Ecotax (tax incl.)</target>
+        <note>Line: 122</note>
+      </trans-unit>
+      <trans-unit id="133bc9aa44eaaf809041c01ea1361a07">
+        <source>Display the "On sale!" flag on the product page, and on product listings.</source>
+        <target>Display the "On sale!" flag on the product page, and on product listings.</target>
+        <note>Line: 156</note>
+      </trans-unit>
+      <trans-unit id="1ea8a394583d38bd981b70c7dcebb104">
+        <source>Price per unit (tax excl.)</source>
+        <target>Price per unit (tax excl.)</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="48881913e6addc0c3c439f02229ac91e">
+        <source>Apply to all products</source>
+        <target>Apply to all products</target>
+        <note>Line: 199</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cdba184783a0253218efd734da81a9da">
+        <source>Stock location</source>
+        <target>Stock location</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="af39c53c91dc46e2576f28b843b82988">
+        <source>Label when in stock</source>
+        <target>Label when in stock</target>
+        <note>Line: 204</note>
+      </trans-unit>
+      <trans-unit id="b2c80334809f9130d46e89b66b6d8544">
+        <source>Create combinations</source>
+        <target>Create combinations</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="66de7ffcf9f515fb047045299ab0b3a3">
+        <source>I want to use the advanced stock management system for this product.</source>
+        <target>I want to use the advanced stock management system for this product.</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="4aeb39ce058edebf91ef47818c092420">
+        <source>The available quantities for the current product and its combinations are based on the stock in your warehouse (using the advanced stock management system). </source>
+        <target>The available quantities for the current product and its combinations are based on the stock in your warehouse (using the advanced stock management system).</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="78ab705faa894d700a6db78ffa88bb24">
+        <source>I want to specify available quantities manually.</source>
+        <target>I want to specify available quantities manually.</target>
+        <note>Line: 120</note>
+      </trans-unit>
+      <trans-unit id="6014344a66ff2f266fb4bc987178493f">
+        <source>Minimum quantity for sale</source>
+        <target>Minimum quantity for sale</target>
+        <note>Line: 155</note>
+      </trans-unit>
+      <trans-unit id="a532f6edbb8880c752b74073710b285a">
+        <source>Label when out of stock (and back order allowed)</source>
+        <target>Label when out of stock (and back order allowed)</target>
+        <note>Line: 216</note>
+      </trans-unit>
+      <trans-unit id="6ece9a14d0c8da14a1af607f9f7e0b36">
+        <source>Does this product have an associated file?</source>
+        <target>Does this product have an associated file?</target>
+        <note>Line: 237</note>
+      </trans-unit>
+      <trans-unit id="989d17fa8f3081cc0d66838c7504c0ef">
+        <source>Use default behavior</source>
+        <target>Use default behavior</target>
+        <note>Line: 251</note>
+      </trans-unit>
+      <trans-unit id="119a7c88cf8f1c685c57981abff26f43">
+        <source>Allow orders</source>
+        <target>Allow orders</target>
+        <note>Line: 266</note>
+      </trans-unit>
+      <trans-unit id="f072da215c080d985d44361e96a3cf60">
+        <source>Deny orders</source>
+        <target>Deny orders</target>
+        <note>Line: 265</note>
+      </trans-unit>
+      <trans-unit id="5ce00f66be3fd54e40eab844c446e80d">
+        <source>When out of stock</source>
+        <target>When out of stock</target>
+        <note>Line: 272</note>
+      </trans-unit>
+      <trans-unit id="175db77b6b3ecd9633e85b5efc28bbc1">
+        <source>Decrement pack only.</source>
+        <target>Decrement pack only.</target>
+        <note>Line: 300</note>
+      </trans-unit>
+      <trans-unit id="1ba020dea4ce06fa139a471db21f41a7">
+        <source>Decrement products in pack only.</source>
+        <target>Decrement products in pack only.</target>
+        <note>Line: 301</note>
+      </trans-unit>
+      <trans-unit id="61b912928e920c280798dc648d4068fe">
+        <source>Decrement both.</source>
+        <target>Decrement both.</target>
+        <note>Line: 302</note>
+      </trans-unit>
+      <trans-unit id="4b2f63dbdead89ca4263ede71ae4a892">
+        <source>Pack quantities</source>
+        <target>Pack quantities</target>
+        <note>Line: 308</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9e11e4b371570340ca07913bc4783a7a">
+        <source>Meta title</source>
+        <target>Meta title</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="3f64b2beede1082fd32ddb0bf11a641f">
+        <source>Meta description</source>
+        <target>Meta description</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="1dec4f55522b828fe5dacf8478021a9e">
+        <source>Friendly URL</source>
+        <target>Friendly URL</target>
+        <note>Line: 136</note>
+      </trans-unit>
+      <trans-unit id="34c6d1495d38f91ae785bc94849dc771">
+        <source>Permanent redirection to a category (301)</source>
+        <target>Permanent redirection to a category (301)</target>
+        <note>Line: 144</note>
+      </trans-unit>
+      <trans-unit id="7a13ef5d084a640d199018c55d415fac">
+        <source>Temporary redirection to a category (302)</source>
+        <target>Temporary redirection to a category (302)</target>
+        <note>Line: 145</note>
+      </trans-unit>
+      <trans-unit id="5c841800fb570244d423fe0b273665fb">
+        <source>Permanent redirection to a product (301)</source>
+        <target>Permanent redirection to a product (301)</target>
+        <note>Line: 146</note>
+      </trans-unit>
+      <trans-unit id="c36c68b574bddf55fe3ec5b8cc56a824">
+        <source>Temporary redirection to a product (302)</source>
+        <target>Temporary redirection to a product (302)</target>
+        <note>Line: 147</note>
+      </trans-unit>
+      <trans-unit id="bae20d24a114242f9549679af3255ace">
+        <source>No redirection (404)</source>
+        <target>No redirection (404)</target>
+        <note>Line: 148</note>
+      </trans-unit>
+      <trans-unit id="eab55e617090957b953e3dbdd801eea4">
+        <source>Redirection when offline</source>
+        <target>Redirection when offline</target>
+        <note>Line: 158</note>
+      </trans-unit>
+      <trans-unit id="2afea1f31bf30bdcef8b3316025d6ae5">
+        <source>Target product</source>
+        <target>Target product</target>
+        <note>Line: 160</note>
+      </trans-unit>
+      <trans-unit id="f66b691f01d53d5af582136ebb63cfc5">
+        <source>Target category</source>
+        <target>Target category</target>
+        <note>Line: 162</note>
+      </trans-unit>
+      <trans-unit id="c41a31890959544c6523af684561abe5">
+        <source>Target</source>
+        <target>Target</target>
+        <note>Line: 179</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7e34f33e1a881aff98acbf2b766ac883">
+        <source>Delivery time of in-stock products:</source>
+        <target>Delivery time of in-stock products:</target>
+        <note>Line: 204</note>
+      </trans-unit>
+      <trans-unit id="32954654ac8fe66a1d09be19001de2d4">
+        <source>Width</source>
+        <target>Width</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="eec6c4bdbd339edf8cbea68becb85244">
+        <source>Height</source>
+        <target>Height</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="675056ad1441b6375b2c5abd48c27ef1">
+        <source>Depth</source>
+        <target>Depth</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
+        <source>Weight</source>
+        <target>Weight</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="6fa573b52d8f35231304916ea67f94a8">
+        <source>Shipping fees</source>
+        <target>Shipping fees</target>
+        <note>Line: 135</note>
+      </trans-unit>
+      <trans-unit id="582d519b697f8d1a558e91220beea671">
+        <source>Available carriers</source>
+        <target>Available carriers</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="d41e652e3ec13615827534c10beac3ee">
+        <source>Default delivery time</source>
+        <target>Default delivery time</target>
+        <note>Line: 160</note>
+      </trans-unit>
+      <trans-unit id="16599dbd0bf238cbae4090fe1db04145">
+        <source>Specific delivery time to this product</source>
+        <target>Specific delivery time to this product</target>
+        <note>Line: 161</note>
+      </trans-unit>
+      <trans-unit id="205b01b3197cf06688f6ed574faf5664">
+        <source>Delivery Time</source>
+        <target>Delivery Time</target>
+        <note>Line: 168</note>
+      </trans-unit>
+      <trans-unit id="02746d0355a6c94c9ca770302e9da1ca">
+        <source>Delivered within 5-7 days</source>
+        <target>Delivered within 5-7 days</target>
+        <note>Line: 178</note>
+      </trans-unit>
+      <trans-unit id="f6db0ad0a1b6aff800f260a83bc06584">
+        <source>Delivery time of out-of-stock products with allowed orders:</source>
+        <target>Delivery time of out-of-stock products with allowed orders:</target>
+        <note>Line: 185</note>
+      </trans-unit>
+      <trans-unit id="777ca35e6f4ddd56c7b8c16d8f74ad13">
+        <source>Delivered within 3-4 days</source>
+        <target>Delivered within 3-4 days</target>
+        <note>Line: 198</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7b28d39c479ba659159b3356616b0a04">
+        <source>Reduction type</source>
+        <target>Reduction type</target>
+        <note>Line: 253</note>
+      </trans-unit>
+      <trans-unit id="9e834f13e35e4edf64863ab414a6217a">
+        <source>Reduction</source>
+        <target>Reduction</target>
+        <note>Line: 244</note>
+      </trans-unit>
+      <trans-unit id="8766423201bb422154bcad9d1d590207">
+        <source>Leave initial price</source>
+        <target>Leave initial price</target>
+        <note>Line: 236</note>
+      </trans-unit>
+      <trans-unit id="e3ec664efb1dcbafb161a2da6c0e5b3b">
+        <source>Add customer</source>
+        <target>Add customer</target>
+        <note>Line: 174</note>
+      </trans-unit>
+      <trans-unit id="c77b86cdeed7ed9197db5858fa3b5fd0">
+        <source>Apply to all combinations</source>
+        <target>Apply to all combinations</target>
+        <note>Line: 183</note>
+      </trans-unit>
+      <trans-unit id="1432596d084873bee8df589b0b01448c">
+        <source>Available from</source>
+        <target>Available from</target>
+        <note>Line: 197</note>
+      </trans-unit>
+      <trans-unit id="95b6faa9d75417fe5e7767a733ab6fb4">
+        <source>Starting at</source>
+        <target>Starting at</target>
+        <note>Line: 215</note>
+      </trans-unit>
+      <trans-unit id="7015235e67d6f01728b655ca7bc8e8ae">
+        <source>Product price (tax excl.)</source>
+        <target>Product price (tax excl.)</target>
+        <note>Line: 226</note>
+      </trans-unit>
+      <trans-unit id="9bccc98ae31786b6062c540931d1467e">
+        <source>Reduction tax</source>
+        <target>Reduction tax</target>
+        <note>Line: 265</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c925e061d42989c43e6d3a7e43f2a878">
+        <source>Number of allowed downloads</source>
+        <target>Number of allowed downloads</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="8c1279db4db86553e4b9682f78cf500e">
+        <source>Expiration date</source>
+        <target>Expiration date</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="58fd2b2308056ad80255a322b305742b">
+        <source>Number of days</source>
+        <target>Number of days</target>
+        <note>Line: 124</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7bf2d26eab899c413218b729d4d914b7">
+        <source>Stored</source>
+        <target>Stored</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="ddedc546753b8ca7f0ecdad9d0863f95">
+        <source>Location (optional)</source>
+        <target>Location (optional)</target>
+        <note>Line: 72</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Common/pagination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="41d2418efb64cdecb72df1e2aeb7a36b">
+        <source>Viewing %from%-%to% on %total% (page %current_page% / %page_count%)</source>
+        <target>Viewing %from%-%to% on %total% (page %current_page% / %page_count%)</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="a0c13a65c06cd78909e5842e19af2c49">
+        <source>Items per page:</source>
+        <target>Items per page:</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3adbdb3ac060038aa0e6e6c138ef9873">
+        <source>Category</source>
+        <target>Category</target>
+        <note>Line: 54</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="71d6cf2ac276a448f7845e8422fa0db3">
+        <source>These products will be deleted for good. Please confirm.</source>
+        <target>These products will be deleted for good. Please confirm.</target>
+        <note>Line: 205</note>
+      </trans-unit>
+      <trans-unit id="3e1af49c086d77fb4f9826caec6dea12">
+        <source>Delete products?</source>
+        <target>Delete products?</target>
+        <note>Line: 194</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog_empty.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="432cfb26d9a4c71d6409e289771aedf1">
+        <source>[1]Add your first product[/1][2]or import a list of products (filetypes: .csv, .xls, .xlsx, .xlst, .ods, .ots).[/2]</source>
+        <target>[1]Add your first product[/1][2]or import a list of products (filetypes: .csv, .xls, .xlsx, .xlst, .ods, .ots).[/2]</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d2adcceab126e15a1f46f5ed9980453e">
+        <source>Go to catalog</source>
+        <target>Go to catalog</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="3fa8c89ef63fbb7056fc1d8d1b67f97a">
+        <source>Add new product</source>
+        <target>Add new product</target>
+        <note>Line: 144</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="81355310011c137fdd21cf9a1394ed6a">
+        <source>Product list</source>
+        <target>Product list</target>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/tabs.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="93d74901738e996378295fb0a59bb977">
+        <source>Basic settings</source>
+        <target>Basic settings</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="e22ac25b066b201473de7aa700ef5d92">
+        <source>Pricing</source>
+        <target>Pricing</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="d88946b678e4c2f251d4e292e8142291">
+        <source>SEO</source>
+        <target>SEO</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2">
+        <source>Modules</source>
+        <target>Modules</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
+        <source>Categories</source>
+        <target>Categories</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="c24c379ede5dfa7b82a91bfcc5c3deef">
+        <source>Associated categories</source>
+        <target>Associated categories</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="cb15931e1a86254a2440cb3bf0a52374">
+        <source>Create a new category</source>
+        <target>Create a new category</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="b9a492bdfa9de54c963f71db20af3b94">
+        <source>New category name</source>
+        <target>New category name</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="cff15d43797962a1e28c0515ab556743">
+        <source>Create a category</source>
+        <target>Create a category</target>
+        <note>Line: 78</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1374a796a4d88166ce5107eb6aec41ff">
+        <source>Prev. combination</source>
+        <target>Prev. combination</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="3c9d5cac3c3b1b3f40ef1d6ce929ad6e">
+        <source>Next combination</source>
+        <target>Next combination</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="c0babe5601b3f91313d53267c3c7ec24">
+        <source>Back to product</source>
+        <target>Back to product</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="96aed2644a3249464e20729dc8c39fb2">
+        <source>Combination details</source>
+        <target>Combination details</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="dd35c12c6b5ac6280956afd466d99766">
+        <source>Price and impact</source>
+        <target>Price and impact</target>
+        <note>Line: 135</note>
+      </trans-unit>
+      <trans-unit id="d448559c3ac8f5b7e49b7162e5fbc7f1">
+        <source>Final retail price (tax excl.) will be</source>
+        <target>Final retail price (tax excl.) will be</target>
+        <note>Line: 164</note>
+      </trans-unit>
+      <trans-unit id="2477a8ca4d9fe0ce57184d2ae0c59647">
+        <source>Does this combination have a different price per unit?</source>
+        <target>Does this combination have a different price per unit?</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="4c43a60b8005e29697dfbcf647f8096e">
+        <source>Specific references</source>
+        <target>Specific references</target>
+        <note>Line: 200</note>
+      </trans-unit>
+      <trans-unit id="fff0d600f8a0b5e19e88bfb821dd1157">
+        <source>Images</source>
+        <target>Images</target>
+        <note>Line: 230</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="622d67c7a2ea6386a4480e02b12fadd8">
+        <source>Impact on price</source>
+        <target>Impact on price</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="ed26f5ba7a0f0f6ca8b16c3886eb68ad">
+        <source>Final price</source>
+        <target>Final price</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="7e64da36262d906a23b4b8614018bcd1">
+        <source>Manage your product combinations</source>
+        <target>Manage your product combinations</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="146cda0589b3eb8697196bdc05e6b049">
+        <source>Bulk actions ([1]/[2] combination(s) selected)</source>
+        <target>Bulk actions ([1]/[2] combination(s) selected)</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="7c52393eaa879dd8c3081f4c3c847846">
+        <source>Default combination</source>
+        <target>Default combination</target>
+        <note>Line: 93</note>
+      </trans-unit>
+      <trans-unit id="410dcd654c1ca6b558fb122cec55f36f">
+        <source>Availability preferences</source>
+        <target>Availability preferences</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="4ad46e43817d735c3cadff659cc8a455">
+        <source>Behavior when out of stock</source>
+        <target>Behavior when out of stock</target>
+        <note>Line: 175</note>
+      </trans-unit>
+      <trans-unit id="9a9d0d58778ce84d86a1f07df5867112">
+        <source>Stock management is disabled</source>
+        <target>Stock management is disabled</target>
+        <note>Line: 193</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1ea5630be8a472f075b184deb7256e3d">
+        <source>You can increase or decrease low stock levels in bulk. You cannot disable them in bulk: you have to do it on a per-combination basis.</source>
+        <target>You can increase or decrease low stock levels in bulk. You cannot disable them in bulk: you have to do it on a per-combination basis.</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="b470c441370492fc31529bb9b76eedb3">
+        <source><![CDATA[The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to Advanced Parameters > Team]]></source>
+        <target><![CDATA[The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to Advanced Parameters > Team]]></target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="c24933abc09a6487f63ea8ddce98bfd4">
+        <source>Delete combinations</source>
+        <target>Delete combinations</target>
+        <note>Line: 95</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_edit_specific_price_modal.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dc3e262677b716a8c75d128d10a65645">
+        <source>Edit a specific price</source>
+        <target>Edit a specific price</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_manufacturer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
+        <source>Brand</source>
+        <target>Brand</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="b7dcc53b5fa2ee513b3eac152af1c8d1">
+        <source>Add a brand</source>
+        <target>Add a brand</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_related_products.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9b9237161ab556e135d50c3384ba6599">
+        <source>Related product</source>
+        <target>Related product</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="0e7abe02d1bb48b126ffaae21749ea13">
+        <source>Add a related product</source>
+        <target>Add a related product</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f5a592018c8b55d2c968515ad7c58c91">
+        <source>Search Engine Optimization</source>
+        <target>Search Engine Optimization</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="926b7b9f596e468ebce7da2c42c1e27c">
+        <source>Improve your ranking and how your product page will appear in search engines results.</source>
+        <target>Improve your ranking and how your product page will appear in search engines results.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="e1be175ec06a5890119e29ffdb34631e">
+        <source>Reset URL</source>
+        <target>Reset URL</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="e642dbf4ded4c06ae9feae332a0a83c4">
+        <source>Redirection page</source>
+        <target>Redirection page</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="c6b3d0f163e32b16cbdde201859d33e3">
+        <source>Here is a preview of your search engine result, play with it!</source>
+        <target>Here is a preview of your search engine result, play with it!</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="96d0a6f41601d5c452d79d48f5b3f6bb">
+        <source>Package dimension</source>
+        <target>Package dimension</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="05031e9ff989f03f9ed271ddebbad2e8">
+        <source>Adjust your shipping costs by filling in the product dimensions.</source>
+        <target>Adjust your shipping costs by filling in the product dimensions.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="0a3e84ae4cda4472634f23aca39b5e31">
+        <source>Leave empty to disable.</source>
+        <target>Leave empty to disable.</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="fb6d68835802519a7f425ca216778b15">
+        <source>Does this product incur additional shipping costs?</source>
+        <target>Does this product incur additional shipping costs?</target>
+        <note>Line: 129</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="183186d90901c257fa15cb0f888b354a">
+        <source>Specific price conditions</source>
+        <target>Specific price conditions</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="5ded995ff437b74c4b7ddc83f8a95919">
+        <source>Unit(s)</source>
+        <target>Unit(s)</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="0c2bfe292269f73b23af08101939714a">
+        <source>Apply a discount of</source>
+        <target>Apply a discount of</target>
+        <note>Line: 149</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7e7371345a3de6936d16388f2f1315e2">
+        <source>Choose the suppliers associated with this product</source>
+        <target>Choose the suppliers associated with this product</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="0b5c5a9176b94b7577e998f7440228a7">
+        <source>Default supplier</source>
+        <target>Default supplier</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e192956d901dff59c35fd2c477ed28d6">
+        <source>Price (tax excl.)</source>
+        <target>Price (tax excl.)</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="e84e4bed9536affd3b2db4c43cb39f29">
+        <source>Supplier reference(s)</source>
+        <target>Supplier reference(s)</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="8284ae5df53e6e7ffc1f2cc67ae68765">
+        <source>Supplier reference</source>
+        <target>Supplier reference</target>
+        <note>Line: 49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="37cfa6b25252ad29f15194e30147f02b">
+        <source>Product location in warehouses</source>
+        <target>Product location in warehouses</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="86521463bdd126930b4a5058c70e3e65">
+        <source>Please choose the warehouses associated with this product.</source>
+        <target>Please choose the warehouses associated with this product.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="27ce7f8b5623b2e2df568d64cf051607">
+        <source>Stock</source>
+        <target>Stock</target>
+        <note>Line: 54</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
+        <source>Quantity</source>
+        <target>Quantity</target>
+        <note>Line: 196</note>
+      </trans-unit>
+      <trans-unit id="290612199861c31d1036b185b4e69b75">
+        <source>Summary</source>
+        <target>Summary</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca">
+        <source>Reference</source>
+        <target>Reference</target>
+        <note>Line: 181</note>
+      </trans-unit>
+      <trans-unit id="befcac0f9644a7abee43e69f49252ac4">
+        <source>Tax excluded</source>
+        <target>Tax excluded</target>
+        <note>Line: 221</note>
+      </trans-unit>
+      <trans-unit id="f4a0d7cb0cd45214c8ca5912c970de13">
+        <source>Tax included</source>
+        <target>Tax included</target>
+        <note>Line: 226</note>
+      </trans-unit>
+      <trans-unit id="d8409efcbf2c3444399daa83172dd35a">
+        <source>Tax rule</source>
+        <target>Tax rule</target>
+        <note>Line: 252</note>
+      </trans-unit>
+      <trans-unit id="e84a11dfbf24b5bdcc71adef877f3157">
+        <source>View all images</source>
+        <target>View all images</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="889f380bf53d998cf3be4466cd0a4359">
+        <source>View less</source>
+        <target>View less</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="98f770b0af18ca763421bac22b4b6805">
+        <source>Features</source>
+        <target>Features</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="8408c9e822e4412516d0ac876d683b6c">
+        <source>Add a feature</source>
+        <target>Add a feature</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="90d98afb8f4c3436765b9eb47127577d">
+        <source>Simple product</source>
+        <target>Simple product</target>
+        <note>Line: 161</note>
+      </trans-unit>
+      <trans-unit id="f99f15e7e2a30d8522f0a39ecf6bcc0d">
+        <source>Product with combinations</source>
+        <target>Product with combinations</target>
+        <note>Line: 167</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1729a56cfc89021478498fe0c89a843a">
+        <source>Visibility</source>
+        <target>Visibility</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="189f63f277cd73395561651753563065">
+        <source>Tags</source>
+        <target>Tags</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="0250085516590c4fa032d89ae2511adf">
+        <source>Where do you want your product to appear?</source>
+        <target>Where do you want your product to appear?</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="b7b224084f1aea992af0ae90ad7761a1">
+        <source><![CDATA[Condition & References]]></source>
+        <target><![CDATA[Condition & References]]></target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="55de886c2b1929108d8c8cf6d9a703cb">
+        <source>Customers can personalize the product by entering some text or by providing custom image files.</source>
+        <target>Customers can personalize the product by entering some text or by providing custom image files.</target>
+        <note>Line: 147</note>
+      </trans-unit>
+      <trans-unit id="513987b37a2501ed83af5686ed34624e">
+        <source>Add a customization field</source>
+        <target>Add a customization field</target>
+        <note>Line: 161</note>
+      </trans-unit>
+      <trans-unit id="9fb17d168ec32414787e4f47ccd3812c">
+        <source>Attached files</source>
+        <target>Attached files</target>
+        <note>Line: 169</note>
+      </trans-unit>
+      <trans-unit id="3a97ab5db26de551af8e0e63c280d56f">
+        <source>Add files that customers can download directly on the product page (instructions, manual, recipe, etc.).</source>
+        <target>Add files that customers can download directly on the product page (instructions, manual, recipe, etc.).</target>
+        <note>Line: 170</note>
+      </trans-unit>
+      <trans-unit id="16be564a60317ed9d5eef83c90eaf225">
+        <source>Attach a new file</source>
+        <target>Attach a new file</target>
+        <note>Line: 184</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="13f13e9a00350642fed860ff27b9976e">
+        <source>Cost price</source>
+        <target>Cost price</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="1fd6db3332676692077360fec4df12e4">
+        <source>Retail price</source>
+        <target>Retail price</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="784cfc140d0ef59d7f48342f7f1636e0">
+        <source>Manage tax rules</source>
+        <target>Manage tax rules</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="ad6097fc9736641b0b94a1b5f02840f5">
+        <source>Final retail price: [1][2][/2] tax incl.[/1] / [3][/3] tax excl.</source>
+        <target>Final retail price: [1][2][/2] tax incl.[/1] / [3][/3] tax excl.</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="5b14ab8904d8a735edd6ea4cff8f7b7c">
+        <source>Specific prices</source>
+        <target>Specific prices</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="c625329eae5c7836f78bbdfc9e1fa577">
+        <source>Add a specific price</source>
+        <target>Add a specific price</target>
+        <note>Line: 137</note>
+      </trans-unit>
+      <trans-unit id="ab7a485ebe75b6dd7243ad719f23c7de">
+        <source>Rule</source>
+        <target>Rule</target>
+        <note>Line: 150</note>
+      </trans-unit>
+      <trans-unit id="47ac923d219501859fb68fed8c8db77b">
+        <source>Combination</source>
+        <target>Combination</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="be6dfa820509f5ce1c052c2e5e0e3dff">
+        <source>Fixed price</source>
+        <target>Fixed price</target>
+        <note>Line: 156</note>
+      </trans-unit>
+      <trans-unit id="21f59b54f62b5b8b4bc0f63f0f617fc1">
+        <source>Impact</source>
+        <target>Impact</target>
+        <note>Line: 157</note>
+      </trans-unit>
+      <trans-unit id="5da618e8e4b89c66fe86e32cdafde142">
+        <source>From</source>
+        <target>From</target>
+        <note>Line: 159</note>
+      </trans-unit>
+      <trans-unit id="8e99fa97ef8d51d9215028842c7ad57c">
+        <source>Priority management</source>
+        <target>Priority management</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="8d3444a0aa942bf7a1979b8270f5c8e5">
+        <source>Priorities</source>
+        <target>Priorities</target>
+        <note>Line: 187</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b9208b03bcc9eb4a336258dcdcb66207">
+        <source>Combinations</source>
+        <target>Combinations</target>
+        <note>Line: 346</note>
+      </trans-unit>
+      <trans-unit id="c795dfff10a7c952f4c5438951e9ece9">
+        <source>Cover</source>
+        <target>Cover</target>
+        <note>Line: 342</note>
+      </trans-unit>
+      <trans-unit id="23470f2faa48c53e6fb5fad4e3de3cdd">
+        <source>Virtual product</source>
+        <target>Virtual product</target>
+        <note>Line: 347</note>
+      </trans-unit>
+      <trans-unit id="e6a4d0e7d64f63379da06c91a80e9c90">
+        <source>Drop images here</source>
+        <target>Drop images here</target>
+        <note>Line: 338</note>
+      </trans-unit>
+      <trans-unit id="aaa5309487aacf50e6413cf7a3074618">
+        <source>or select files</source>
+        <target>or select files</target>
+        <note>Line: 339</note>
+      </trans-unit>
+      <trans-unit id="b36c5a58c30cc53bab5e9b3fda84755c">
+        <source>Recommended size 800 x 800px for default theme.</source>
+        <target>Recommended size 800 x 800px for default theme.</target>
+        <note>Line: 340</note>
+      </trans-unit>
+      <trans-unit id="0d23de90e7f537b035eb79a464eb8ecf">
+        <source>JPG, GIF or PNG format.</source>
+        <target>JPG, GIF or PNG format.</target>
+        <note>Line: 341</note>
+      </trans-unit>
+      <trans-unit id="e2e79605fc9450ec17957cf0e910f5c6">
+        <source>tax incl.</source>
+        <target>tax incl.</target>
+        <note>Line: 348</note>
+      </trans-unit>
+      <trans-unit id="887ee91702c962a70b87cbef07bbcaec">
+        <source>tax excl.</source>
+        <target>tax excl.</target>
+        <note>Line: 349</note>
+      </trans-unit>
+      <trans-unit id="942e86be019b92367d4b1cb917a9ae9c">
+        <source>Module to configure</source>
+        <target>Module to configure</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="fd6d6ce9526e7db581ba81ee86373e9e">
+        <source>Choose a module to configure</source>
+        <target>Choose a module to configure</target>
+        <note>Line: 195</note>
+      </trans-unit>
+      <trans-unit id="4a3b597e8860a1592e5e1fec28d74ef4">
+        <source>These modules are relative to the product page of your shop.</source>
+        <target>These modules are relative to the product page of your shop.</target>
+        <note>Line: 196</note>
+      </trans-unit>
+      <trans-unit id="657c239908e72da26f995415f9b867a7">
+        <source>To manage all your modules go to the [1]Installed module page[/1]</source>
+        <target>To manage all your modules go to the [1]Installed module page[/1]</target>
+        <note>Line: 197</note>
+      </trans-unit>
+      <trans-unit id="623a9a1f669b091dd76bead27c3252ed">
+        <source>Quantities</source>
+        <target>Quantities</target>
+        <note>Line: 345</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/ProductImage/form.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4252b72e6ebcd4d4b4c2e46a786f03d2">
+        <source>Zoom</source>
+        <target>Zoom</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1a6570d1068d7dd6f811ff022da8f76d">
+        <source>Main category</source>
+        <target>Main category</target>
+        <note>Line: 173</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_max_length.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df211c3d69ca4c3564b6ac95d368dc2e">
+        <source>[1][/1] of [2][/2] characters used (recommended)</source>
+        <target>[1][/1] of [2][/2] characters used (recommended)</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="db65e64331ad696848ba5bfa44a757b5">
+        <source>[1][/1] of [2][/2] characters allowed</source>
+        <target>[1][/1] of [2][/2] characters allowed</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d94d5f9a10b00bf59d7632a96ba7a1a0">
+        <source>List of products for this pack</source>
+        <target>List of products for this pack</target>
+        <note>Line: 70</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Translation/Api/StockApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6adf97f83acf6453d4a6a4b1070f3754">
+        <source>None</source>
+        <target>None</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="5f89a705df3646f402ca886e3c01b034">
+        <source>Use checkboxes to bulk edit quantities</source>
+        <target>Use checkboxes to bulk edit quantities</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="d9c3a508aadc89c987a08811138836e2">
+        <source>Advanced filters</source>
+        <target>Advanced filters</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="d17ef666e0e109b8ff0889c4666816c4">
+        <source>Apply advanced filters</source>
+        <target>Apply advanced filters</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="08f2624d7719fac81f1af3e3e64d5e63">
+        <source>Apply new quantity</source>
+        <target>Apply new quantity</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="b11806ab5d886adeeeddbc591eb52688">
+        <source>Display products below low stock level first</source>
+        <target>Display products below low stock level first</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="7f84fa02a3bf4c70c747b29908a03096">
+        <source>Filter by movement type</source>
+        <target>Filter by movement type</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="5110c1f147fe533096f7dead2dac17ee">
+        <source>Filter by employee</source>
+        <target>Filter by employee</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="d940660a1591632abf56608dd80b0f41">
+        <source>Filter by period</source>
+        <target>Filter by period</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="d0f06038b6b3aa5edc07c7a6fd3ca3f9">
+        <source>Search a category</source>
+        <target>Search a category</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="e8324c0368f5e686c879ba246e36903f">
+        <source>Search a supplier</source>
+        <target>Search a supplier</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="5dd5cd6670a0fc8e47a47aa94d27b8b2">
+        <source>Filter by status</source>
+        <target>Filter by status</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680">
+        <source>All</source>
+        <target>All</target>
+        <note>Line: 53
+Comment: 'All' refers to statuses as if "All statuses". Please adapt as necessary in your language</note>
+      </trans-unit>
+      <trans-unit id="3704fd59c2d4295b196008f9ebe09267">
+        <source>Filter by supplier</source>
+        <target>Filter by supplier</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="dc7f9d531239c6acc08b99236a4204cd">
+        <source>Stock management</source>
+        <target>Stock management</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="898bed66d82aeaab1d62875fd3657c40">
+        <source>Movements</source>
+        <target>Movements</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="083e99de177243cffe65b7f8724c89ca">
+        <source>Search products (search by name, reference, supplier)</source>
+        <target>Search products (search by name, reference, supplier)</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="0e1f77838d33f77fef1c66958da371e6">
+        <source>This product is below the low stock level you have defined.</source>
+        <target>This product is below the low stock level you have defined.</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="5896dcc83ab833241ff671debffff23b">
+        <source>Low stock level:</source>
+        <target>Low stock level:</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="82bbaa81a9926aed70bfc811302bddaf">
+        <source>Low stock alert:</source>
+        <target>Low stock alert:</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="60ca6b20f2ef2afc178d7e5d7224b5c8">
+        <source>Bulk edit quantity</source>
+        <target>Bulk edit quantity</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="0a31e37f4790bed575e702d61fcfb452">
+        <source><![CDATA[Date & Time]]></source>
+        <target><![CDATA[Date & Time]]></target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="ac43f4edefaf0db72e60d681332c8437">
+        <source>Edit quantity</source>
+        <target>Edit quantity</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="f0d770125ad832142c2215d033525e78">
+        <source>Go to the import system</source>
+        <target>Go to the import system</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="8273cff9da36d1ddc5ee3f19b1283f0c">
+        <source>Export data into CSV</source>
+        <target>Export data into CSV</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="ce898d62ed9ca7653a01fe0c781e97e9">
+        <source>Physical</source>
+        <target>Physical</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="942d4e37dd5607ab68e54755540d4a47">
+        <source>Reserved</source>
+        <target>Reserved</target>
+        <note>Line: 82</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminCatalogHelp.xlf
+++ b/app/Resources/translations/default/AdminCatalogHelp.xlf
@@ -1,860 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/actions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="f2d1c5443636295e9720caac90ea8d93">
-        <source>Your internal name for this attribute.</source>
-        <target>Your internal name for this attribute.</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:202</note>
-      </trans-unit>
-      <trans-unit id="b5e6921c2d093fbcb0088c9466ee9983">
-        <source>The public name for this attribute, displayed to the customers.</source>
-        <target>The public name for this attribute, displayed to the customers.</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:211</note>
-      </trans-unit>
-      <trans-unit id="580de47d3bc3e99a0b6aba55066a983a">
-        <source>The way the attribute's values will be presented to the customers in the product's page.</source>
-        <target>The way the attribute's values will be presented to the customers in the product's page.</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:224</note>
-      </trans-unit>
-      <trans-unit id="71c476c94d0a0e3dfc0826afd03d2dda">
-        <source>Choose the attribute group for this value.</source>
-        <target>Choose the attribute group for this value.</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:272</note>
-      </trans-unit>
-      <trans-unit id="22cbf85c41427960736dc10cfec5faf4">
-        <source>Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").</source>
-        <target>Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:310</note>
-      </trans-unit>
-      <trans-unit id="dd24a1142c1070a0efbdf43b4f0167cc">
-        <source>Upload an image file containing the color texture from your computer.</source>
-        <target>Upload an image file containing the color texture from your computer.</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:318</note>
-      </trans-unit>
-      <trans-unit id="ba353198430b2004efeb1ac6d1f410d0">
-        <source>This will override the HTML color!</source>
-        <target>This will override the HTML color!</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:319</note>
-      </trans-unit>
-      <trans-unit id="7d5672f569de406c85249db6f1c99ec0">
-        <source>Save then add another value</source>
-        <target>Save then add another value</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:558</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7db5022f86dda7b39e31e754afd5c6a0">
-        <source>Allow customers to upload files using the contact page.</source>
-        <target>Allow customers to upload files using the contact page.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:151</note>
-      </trans-unit>
-      <trans-unit id="1f2b974152999d549b89994879e452a3">
-        <source>Please fill out the message fields that appear by default when you answer a thread on the customer service page.</source>
-        <target>Please fill out the message fields that appear by default when you answer a thread on the customer service page.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:156</note>
-      </trans-unit>
-      <trans-unit id="61b7dba4b2704903e5a2434e1f3ab878">
-        <source>URL for your IMAP server (ie.: mail.server.com).</source>
-        <target>URL for your IMAP server (ie.: mail.server.com).</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:168</note>
-      </trans-unit>
-      <trans-unit id="d60419d8fec86275eb0752ce43556e6f">
-        <source>Port to use to connect to your IMAP server.</source>
-        <target>Port to use to connect to your IMAP server.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:173</note>
-      </trans-unit>
-      <trans-unit id="b8453d9982fb11c704dca368e5107677">
-        <source>User to use to connect to your IMAP server.</source>
-        <target>User to use to connect to your IMAP server.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:179</note>
-      </trans-unit>
-      <trans-unit id="849dafe04c2f54cb0dc079da9ca15a8f">
-        <source>Password to use to connect your IMAP server.</source>
-        <target>Password to use to connect your IMAP server.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:184</note>
-      </trans-unit>
-      <trans-unit id="e9d5cadd20f10058a5bb0823aed17584">
-        <source>Delete messages after synchronization. If you do not enable this option, the synchronization will take more time.</source>
-        <target>Delete messages after synchronization. If you do not enable this option, the synchronization will take more time.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:189</note>
-      </trans-unit>
-      <trans-unit id="eca83facb7294ab0f66e1dec9fc66efd">
-        <source>Create new threads for unrecognized emails.</source>
-        <target>Create new threads for unrecognized emails.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:194</note>
-      </trans-unit>
-      <trans-unit id="38033ed4d12ca354e503266bd9a59105">
-        <source>Use POP3 instead of IMAP.</source>
-        <target>Use POP3 instead of IMAP.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:199</note>
-      </trans-unit>
-      <trans-unit id="3abb33532b4b4e0201dbdde08eced7ee">
-        <source>Do not use RSH or SSH to establish a preauthenticated IMAP sessions.</source>
-        <target>Do not use RSH or SSH to establish a preauthenticated IMAP sessions.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:205</note>
-      </trans-unit>
-      <trans-unit id="89884c64df4330255f1fc07dadfb5dd4">
-        <source>Use the Secure Socket Layer (TLS/SSL) to encrypt the session.</source>
-        <target>Use the Secure Socket Layer (TLS/SSL) to encrypt the session.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:210</note>
-      </trans-unit>
-      <trans-unit id="f5c4e8df7daa8f49d8f68ae25deab8c7">
-        <source>Validate certificates from the TLS/SSL server.</source>
-        <target>Validate certificates from the TLS/SSL server.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:215</note>
-      </trans-unit>
-      <trans-unit id="244789498d5c439efc7a4a05975dc391">
-        <source>Do not validate certificates from the TLS/SSL server. This is only needed if a server uses self-signed certificates.</source>
-        <target>Do not validate certificates from the TLS/SSL server. This is only needed if a server uses self-signed certificates.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:220</note>
-      </trans-unit>
-      <trans-unit id="eabd6d4298e21426642606fe653585c9">
-        <source>Force use of start-TLS to encrypt the session, and reject connection to servers that do not support it.</source>
-        <target>Force use of start-TLS to encrypt the session, and reject connection to servers that do not support it.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:225</note>
-      </trans-unit>
-      <trans-unit id="5b035ec3dccf9e9d875e0b830062a9ff">
-        <source>Do not use start-TLS to encrypt the session, even with servers that support it.</source>
-        <target>Do not use start-TLS to encrypt the session, even with servers that support it.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:230</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5f4efe2735311bfd3e5784705fb0110f">
-        <source>Number of days this file can be accessed by customers. Set to zero for unlimited access.</source>
-        <target>Number of days this file can be accessed by customers. Set to zero for unlimited access.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig:141</note>
-      </trans-unit>
-      <trans-unit id="dbcf3c5f67528da5cf59dc0c042748da">
-        <source>Upload a file from your computer (%maxUploadSize% max.)</source>
-        <target>Upload a file from your computer (%maxUploadSize% max.)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig:100</note>
-      </trans-unit>
-      <trans-unit id="c312034c9f17a264365e734de442ca0a">
-        <source>The full filename with its extension (e.g. Book.pdf)</source>
-        <target>The full filename with its extension (e.g. Book.pdf)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig:114</note>
-      </trans-unit>
-      <trans-unit id="48da1c11d36bd8b34f13821e996c7f97">
-        <source>Number of downloads allowed per customer. Set to 0 for unlimited downloads.</source>
-        <target>Number of downloads allowed per customer. Set to 0 for unlimited downloads.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig:123</note>
-      </trans-unit>
-      <trans-unit id="f049153f2c655d6d1ebd123f04b432cf">
-        <source>If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date.</source>
-        <target>If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig:132</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d4be87a5a7a7e9bf633dc6d356968333">
-        <source>Click on "Displayed" to index the category on your shop.</source>
-        <target>Click on "Displayed" to index the category on your shop.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:526</note>
-      </trans-unit>
-      <trans-unit id="42f9ee5026d32792987af851a2ea0343">
-        <source>This is the main image for your category, displayed in the category page. The category description will overlap this image and appear in its top-left corner.</source>
-        <target>This is the main image for your category, displayed in the category page. The category description will overlap this image and appear in its top-left corner.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:567</note>
-      </trans-unit>
-      <trans-unit id="c5d262df2fa3b92141eb8bb37b1fb9b7">
-        <source>Displays a small image in the parent category's page, if the theme allows it.</source>
-        <target>Displays a small image in the parent category's page, if the theme allows it.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:578</note>
-      </trans-unit>
-      <trans-unit id="9cbbbb4e43f08deda211ff24e6fd542f">
-        <source>The category thumbnail appears in the menu as a small image representing the category, if the theme allows it.</source>
-        <target>The category thumbnail appears in the menu as a small image representing the category, if the theme allows it.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:589</note>
-      </trans-unit>
-      <trans-unit id="7e35726fb991605ab3d0e6406599e6ef">
-        <source>To add "tags," click in the field, write something, and then press "Enter."</source>
-        <target>To add "tags," click in the field, write something, and then press "Enter."</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:618</note>
-      </trans-unit>
-      <trans-unit id="09e2683b6b92b326691cd992f6e5684b">
-        <source>Only letters, numbers, underscore (_) and the minus (-) character are allowed.</source>
-        <target>Only letters, numbers, underscore (_) and the minus (-) character are allowed.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:626</note>
-      </trans-unit>
-      <trans-unit id="53d98bd116f47fdfe15c8eb4525c5e99">
-        <source>You now have three default customer groups.</source>
-        <target>You now have three default customer groups.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:633</note>
-      </trans-unit>
-      <trans-unit id="463848257c086c4816d9f4c020a8d19e">
-        <source>Mark all of the customer groups which you would like to have access to this category.</source>
-        <target>Mark all of the customer groups which you would like to have access to this category.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:637</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminManufacturersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0205bdbccc495138a109bd8710053565">
-        <source>Upload a brand logo from your computer.</source>
-        <target>Upload a brand logo from your computer.</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:354</note>
-      </trans-unit>
-      <trans-unit id="643544fd7876fa0f017ba6233f46b4c3">
-        <source>To add "tags," click inside the field, write something, and then press "Enter."</source>
-        <target>To add "tags," click inside the field, write something, and then press "Enter."</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:380</note>
-      </trans-unit>
-      <trans-unit id="b7d8f05036844ad562ed08715bb480b4">
-        <source>Company name for this brand</source>
-        <target>Company name for this brand</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:507</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminFeaturesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7aad0283b11e41230d9d1fc7372c3862">
-        <source>Add new feature value</source>
-        <target>Add new feature value</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:216</note>
-      </trans-unit>
-      <trans-unit id="21d883f3177ec09a845d9963eca239b1">
-        <source>Save and add another value</source>
-        <target>Save and add another value</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:244</note>
-      </trans-unit>
-      <trans-unit id="07fc7dc79c8046bb36d97b4332dab1ca">
-        <source>Back to the list</source>
-        <target>Back to the list</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:267</note>
-      </trans-unit>
-      <trans-unit id="d8aac6665c79faf4f411fe0da93ab23c">
-        <source>Add new feature values</source>
-        <target>Add new feature values</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:263</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCmsCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bed3b3133d292db46a0d28c5d91811b9">
-        <source>Only letters and the minus (-) character are allowed.</source>
-        <target>Only letters and the minus (-) character are allowed.</target>
-        <note>Context:
-File: controllers/admin/AdminCmsCategoriesController.php:291</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSuppliersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dd0479e67d24cd2c2868d4c6b2dcba9a">
-        <source>Company name for this supplier</source>
-        <target>Company name for this supplier</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:138</note>
-      </trans-unit>
-      <trans-unit id="afd7431f75b5801226c9ee37acc1a504">
-        <source>Will appear in the list of suppliers.</source>
-        <target>Will appear in the list of suppliers.</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:149</note>
-      </trans-unit>
-      <trans-unit id="b51bea4eee9d9ef6bd9a6849337013d5">
-        <source>Phone number for this supplier</source>
-        <target>Phone number for this supplier</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:160</note>
-      </trans-unit>
-      <trans-unit id="c24c0c9cd7bdb34eaff67028b0cb8349">
-        <source>Mobile phone number for this supplier.</source>
-        <target>Mobile phone number for this supplier.</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:169</note>
-      </trans-unit>
-      <trans-unit id="e865605842d16d0d11c266c731e00507">
-        <source>Upload a supplier logo from your computer.</source>
-        <target>Upload a supplier logo from your computer.</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:234</note>
-      </trans-unit>
-      <trans-unit id="3ef61077e04c24d0b712a1b0ea036255">
-        <source>To add "tags" click in the field, write something and then press "Enter".</source>
-        <target>To add "tags" click in the field, write something and then press "Enter".</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:259</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e63e2ba42470a41ba75e0d7ea35a410f">
-        <source>Combine several attributes, e.g.: "Size: all", "Color: red".</source>
-        <target>Combine several attributes, e.g.: "Size: all", "Color: red".</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php:82</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="16a5534d559007de7e8f5b4f17112203">
-        <source>Leave empty to disable</source>
-        <target>Leave empty to disable</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php:163</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="af809f35e40bd6f644509ad566ecf38c">
-        <source>To have a different title from the product name, enter it here.</source>
-        <target>To have a different title from the product name, enter it here.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:81</note>
-      </trans-unit>
-      <trans-unit id="b0ea2bd9df4b8ee746b4e5fd28503851">
-        <source>Public title for the product's page, and for search engines. Leave blank to use the product name. The number of remaining characters is displayed to the left of the field.</source>
-        <target>Public title for the product's page, and for search engines. Leave blank to use the product name. The number of remaining characters is displayed to the left of the field.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:92</note>
-      </trans-unit>
-      <trans-unit id="5f99bb8ecd940f311cb66fadfc467a2b">
-        <source>To have a different description than your product summary in search results pages, write it here.</source>
-        <target>To have a different description than your product summary in search results pages, write it here.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:106</note>
-      </trans-unit>
-      <trans-unit id="8533d8d42f2c7ef3078797984ea14675">
-        <source>This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)</source>
-        <target>This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:117</note>
-      </trans-unit>
-      <trans-unit id="26511e4120f7b4f3135a21b9f35efed8">
-        <source>To which product the page should redirect?</source>
-        <target>To which product the page should redirect?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:157</note>
-      </trans-unit>
-      <trans-unit id="024db530212734e5c28319bc4754ad85">
-        <source>To which category the page should redirect?</source>
-        <target>To which category the page should redirect?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:159</note>
-      </trans-unit>
-      <trans-unit id="2719055d3b2b4fc865a78df22462c96b">
-        <source>If no category is selected the Main Category is used</source>
-        <target>If no category is selected the Main Category is used</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php:160</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8246ddfaa2c607ace3ae3a4643d957d1">
-        <source>Use a comma to create separate tags. E.g.: dress, cotton, party dresses.</source>
-        <target>Use a comma to create separate tags. E.g.: dress, cotton, party dresses.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:119</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7bb36e0f484d91aeba5d83fe2af63d28">
-        <source>Search for a product</source>
-        <target>Search for a product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:148</note>
-      </trans-unit>
-      <trans-unit id="9242ed633bcac07574f63fba6e184fd8">
-        <source>Enter your product name</source>
-        <target>Enter your product name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:170</note>
-      </trans-unit>
-      <trans-unit id="7f6c27a96363effdda77216cf1251400">
-        <source><![CDATA[The summary is a short sentence describing your product.<br />It will appears at the top of your shop's product page, in product lists, and in search engines' results page (so it's important for SEO). To give more details about your product, use the "Description" tab.]]></source>
-        <target><![CDATA[The summary is a short sentence describing your product.<br />It will appears at the top of your shop's product page, in product lists, and in search engines' results page (so it's important for SEO). To give more details about your product, use the "Description" tab.]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:196</note>
-      </trans-unit>
-      <trans-unit id="1fbfcc9642d39544207c67f66ec3bc00">
-        <source>Search and add a related product</source>
-        <target>Search and add a related product</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:285</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="420f46a170eef476454fa134085a85a2">
-        <source>Per kilo, per litre</source>
-        <target>Per kilo, per litre</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php:185</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cc2ac103a9c1411fd67952983e25978a">
-        <source>Create a new product: CTRL+P</source>
-        <target>Create a new product: CTRL+P</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:327</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="607e1d854783c8229998ac2b5b6923d3">
-        <source>Invalid token</source>
-        <target>Invalid token</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig:48</note>
-      </trans-unit>
-      <trans-unit id="d24ec28b066e46d9d9ec3c1f39aa89ee">
-        <source>[1]Invalid token[/1]: direct access to this link may lead to a potential security breach.</source>
-        <target>[1]Invalid token[/1]: direct access to this link may lead to a potential security breach.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig:56</note>
-      </trans-unit>
-      <trans-unit id="f364944e8422977932bd21eb2d96963a">
-        <source>Do you want to display this page?</source>
-        <target>Do you want to display this page?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig:60</note>
-      </trans-unit>
-      <trans-unit id="a0d31e7f783700b99e15ce8621dc6381">
-        <source>Yes, I understand the risks</source>
-        <target>Yes, I understand the risks</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig:63</note>
-      </trans-unit>
-      <trans-unit id="a5b0a810681c7fca4581d7f7524009f4">
-        <source>Take me out of there!</source>
-        <target>Take me out of there!</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig:66</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="542f59279cd5d73dfbdb069ce0833b0a">
-        <source>Search name</source>
-        <target>Search name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig:99</note>
-      </trans-unit>
-      <trans-unit id="3ce14776b1408d0dc406766fd0c6a45d">
-        <source>Search ref.</source>
-        <target>Search ref.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig:108</note>
-      </trans-unit>
-      <trans-unit id="84645920bd0fb266cb4acdbc00003e62">
-        <source>Search category</source>
-        <target>Search category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig:117</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bb03c14d14caa07e21f97cbe5eab022d">
-        <source>Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, physical product?</source>
-        <target>Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, physical product?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="548f88021c5b960f7eccd9ee81871aad">
-        <source>Permanently delete this product.</source>
-        <target>Permanently delete this product.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="94e4259ad6f05c74b84eb6cca4d60ce6">
-        <source>See how your product sheet will look online: ALT+SHIFT+V</source>
-        <target>See how your product sheet will look online: ALT+SHIFT+V</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:47</note>
-      </trans-unit>
-      <trans-unit id="ad7478afcd575d882738a42546bc041a">
-        <source>Enable or disable the product on your shop: ALT+SHIFT+O</source>
-        <target>Enable or disable the product on your shop: ALT+SHIFT+O</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:55</note>
-      </trans-unit>
-      <trans-unit id="82e3cb7a4be4e299701a182197dc9410">
-        <source>Save the product and stay on the current page: ALT+SHIFT+S</source>
-        <target>Save the product and stay on the current page: ALT+SHIFT+S</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:74</note>
-      </trans-unit>
-      <trans-unit id="ac6f66dc450bc768229c1329aa7a48b1">
-        <source>Save and duplicate this product, then go to the new product: ALT+SHIFT+D</source>
-        <target>Save and duplicate this product, then go to the new product: ALT+SHIFT+D</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:83</note>
-      </trans-unit>
-      <trans-unit id="b110e989a1143b7f44cd5691324d4d11">
-        <source>Save and go back to the catalog: ALT+SHIFT+Q</source>
-        <target>Save and go back to the catalog: ALT+SHIFT+Q</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:94</note>
-      </trans-unit>
-      <trans-unit id="37163a2847189335a934c83e8ae32677">
-        <source>Save and create a new product: ALT+SHIFT+P</source>
-        <target>Save and create a new product: ALT+SHIFT+P</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:104</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a4a8ceb87fae812bfac552e0169bb0f9">
-        <source>This is the price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.</source>
-        <target>This is the price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:34</note>
-      </trans-unit>
-      <trans-unit id="b9c6e3712398e2df7d3ebd7ccc7d5132">
-        <source>Some products can be purchased by unit (per bottle, per pound, etc.),  and this is the price for one unit. For instance, if you’re selling fabrics, it would be the price per meter.</source>
-        <target>Some products can be purchased by unit (per bottle, per pound, etc.),  and this is the price for one unit. For instance, if you’re selling fabrics, it would be the price per meter.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:56</note>
-      </trans-unit>
-      <trans-unit id="eee67d763dcf287ca5d096650341f387">
-        <source>The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin.</source>
-        <target>The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:113</note>
-      </trans-unit>
-      <trans-unit id="959f5f13ee3cc4199a335d1738351596">
-        <source>You can set specific prices for customers belonging to different groups, different countries, etc.</source>
-        <target>You can set specific prices for customers belonging to different groups, different countries, etc.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:130</note>
-      </trans-unit>
-      <trans-unit id="fbade15b99b07c58fab7be777c0f4c0c">
-        <source>Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first.</source>
-        <target>Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:182</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6fcccfb9dbed970c59c18752f6372703">
-        <source>Tags are meant to help your customers find your products via the search bar.</source>
-        <target>Tags are meant to help your customers find your products via the search bar.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:74</note>
-      </trans-unit>
-      <trans-unit id="cfd69f4f64142b71ff1ddd21b0053026">
-        <source>Choose terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.</source>
-        <target>Choose terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:77</note>
-      </trans-unit>
-      <trans-unit id="8a08a645644d632f79ad988808ba2174">
-        <source>You can manage tag aliases in the [1]Search section[/1]. If you add new tags, you have to rebuild the index.</source>
-        <target>You can manage tag aliases in the [1]Search section[/1]. If you add new tags, you have to rebuild the index.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:78</note>
-      </trans-unit>
-      <trans-unit id="19f31a842add8b13595ddb3a41a1ff27">
-        <source>Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces.</source>
-        <target>Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:101</note>
-      </trans-unit>
-      <trans-unit id="633bf9436b67e19cd61db84ccab7fee2">
-        <source>ISBN is used internationally to identify books and their various editions.</source>
-        <target>ISBN is used internationally to identify books and their various editions.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:116</note>
-      </trans-unit>
-      <trans-unit id="39bd7eba8aa2033579b5ae60bf0c774d">
-        <source>This type of product code is widely used in the United States, Canada, the United Kingdom, Australia, New Zealand and in other countries.</source>
-        <target>This type of product code is widely used in the United States, Canada, the United Kingdom, Australia, New Zealand and in other countries.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig:136</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0041a5c39ca241f883f4e0516a32d290">
-        <source>This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America.</source>
-        <target>This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:215</note>
-      </trans-unit>
-      <trans-unit id="ea8d1b4f32f86030683d8f9252c0a3e1">
-        <source>The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity.</source>
-        <target>The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:91</note>
-      </trans-unit>
-      <trans-unit id="1914ce33841a6e52c0577751d9004159">
-        <source><![CDATA[The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]]]></source>
-        <target><![CDATA[The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:129</note>
-      </trans-unit>
-      <trans-unit id="53f3eb21de0c7a8c909a86be984996f6">
-        <source>Does this combination have a different price? Is it cheaper or more expensive than the default retail price?</source>
-        <target>Does this combination have a different price? Is it cheaper or more expensive than the default retail price?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig:150</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0745d3d4082ad910137e24fd2901ca63">
-        <source>Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?</source>
-        <target>Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:156</note>
-      </trans-unit>
-      <trans-unit id="0a4595dd800cb3338d233a177f422758">
-        <source>Advanced settings in [1][2]Combinations[/1]</source>
-        <target>Advanced settings in [1][2]Combinations[/1]</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:172</note>
-      </trans-unit>
-      <trans-unit id="01cfe41b8ece41634e85248382166271">
-        <source>Your reference code for this product. Allowed special characters: .-_#.</source>
-        <target>Your reference code for this product. Allowed special characters: .-_#.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:183</note>
-      </trans-unit>
-      <trans-unit id="e2c7ed083cb894812fb5d2539f5e7ecb">
-        <source>How many products should be available for sale?</source>
-        <target>How many products should be available for sale?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:198</note>
-      </trans-unit>
-      <trans-unit id="5e8b5ad38b1c0a76d41c2ebaa74c11f5">
-        <source>Advanced settings in [1][2]Quantities[/1]</source>
-        <target>Advanced settings in [1][2]Quantities[/1]</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:208</note>
-      </trans-unit>
-      <trans-unit id="1423e14cddc8aa38062c77d9b8fe8910">
-        <source>This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.</source>
-        <target>This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:217</note>
-      </trans-unit>
-      <trans-unit id="143cb6dd5281d68859217704ad9c9f60">
-        <source>Advanced settings in [1][2]Pricing[/1]</source>
-        <target>Advanced settings in [1][2]Pricing[/1]</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig:246</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="214396125ea99914d7f6faef5d612b85">
-        <source>You can specify product reference(s) for each associated supplier. Click "Save" after changing selected suppliers to display the associated product references.</source>
-        <target>You can specify product reference(s) for each associated supplier. Click "Save" after changing selected suppliers to display the associated product references.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c533675166b567256cae22139534b713">
-        <source>This is the human-readable URL, as generated from the product's name. You can change it if you want.</source>
-        <target>This is the human-readable URL, as generated from the product's name. You can change it if you want.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:59</note>
-      </trans-unit>
-      <trans-unit id="eb8b9b044f3b64b5ba5f7b047963714c">
-        <source>When your product is disabled, choose to which page you’d like to redirect the customers visiting its page by typing the product or category name.</source>
-        <target>When your product is disabled, choose to which page you’d like to redirect the customers visiting its page by typing the product or category name.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:98</note>
-      </trans-unit>
-      <trans-unit id="40464c1dbd8778600fba3f37d36e79dd">
-        <source>No redirection (404) = Do not redirect anywhere and display a 404 "Not Found" page.</source>
-        <target>No redirection (404) = Do not redirect anywhere and display a 404 "Not Found" page.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:124</note>
-      </trans-unit>
-      <trans-unit id="462864be2a8d87de471c82d553000030">
-        <source>Permanent redirection (301) = Permanently display another product or category instead.</source>
-        <target>Permanent redirection (301) = Permanently display another product or category instead.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:125</note>
-      </trans-unit>
-      <trans-unit id="50565048560ec8a9fe1f6ddec57a917a">
-        <source>Temporary redirection (302) = Temporarily display another product or category instead.</source>
-        <target>Temporary redirection (302) = Temporarily display another product or category instead.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:126</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="305c255586949e297af4d74bb1bc9563">
-        <source>Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws.</source>
-        <target>Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig:86</note>
-      </trans-unit>
-      <trans-unit id="de95b43bceeb4b998aed4aed5cef1ae7">
-        <source>edit</source>
-        <target>edit</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig:94</note>
-      </trans-unit>
-      <trans-unit id="8b2ff26690065c221599c196cb6adc82">
-        <source>If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping.</source>
-        <target>If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig:127</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="61010671991185f436b35030f599d327">
-        <source>Where should the product be available on your site? The main category is where the product appears by default: this is the category which is seen in the product page's URL. Disabled categories are written in italics.</source>
-        <target>Where should the product be available on your site? The main category is where the product appears by default: this is the category which is seen in the product page's URL. Disabled categories are written in italics.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:27</note>
-      </trans-unit>
-      <trans-unit id="c5abe76b24973299661ce389d1a092e1">
-        <source>Search categories</source>
-        <target>Search categories</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="b78db8ba6d89ef3a49b95e6f92235997">
-        <source>If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.).  A new category will not automatically appear in your shop's menu, please read the Help about it.</source>
-        <target>If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.).  A new category will not automatically appear in your shop's menu, please read the Help about it.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig:53</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="268bf51f15b2210472b2d42dd883214a">
-        <source><![CDATA[Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. To create a combination, you need to create your product attributes first. Go to Catalog > Attributes & Features for this!]]></source>
-        <target><![CDATA[Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. To create a combination, you need to create your product attributes first. Go to Catalog > Attributes & Features for this!]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:32</note>
-      </trans-unit>
-      <trans-unit id="57a23510ca35a7354d9208151c344364">
-        <source><![CDATA[To add combinations, you first need to create proper attributes and values in [1]Attributes & Features[/1]. <br> When done, you may enter the wanted attributes (like "size" or "color") and their respective values ("XS", "red", "all", etc.) in the field below; or simply select them from the right column. Then click on "Generate": it will automatically create all the combinations for you!]]></source>
-        <target><![CDATA[To add combinations, you first need to create proper attributes and values in [1]Attributes & Features[/1]. <br> When done, you may enter the wanted attributes (like "size" or "color") and their respective values ("XS", "red", "all", etc.) in the field below; or simply select them from the right column. Then click on "Generate": it will automatically create all the combinations for you!]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig:38</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="aa25978d6b02e4e469c205afa9de0c46">
-        <source>This interface allows you to specify the suppliers of the current product and its combinations, if any.</source>
-        <target>This interface allows you to specify the suppliers of the current product and its combinations, if any.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig:35</note>
-      </trans-unit>
-      <trans-unit id="5f5641c7f2d62db16c4d12ce2bcf5898">
-        <source>You can specify supplier references according to previously associated suppliers.</source>
-        <target>You can specify supplier references according to previously associated suppliers.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig:36</note>
-      </trans-unit>
-      <trans-unit id="d57ad4a0ab142c03bb1ced551f66ce9b">
-        <source><![CDATA[When using the advanced stock management tool (see Shop Parameters > Products settings), the values you define (price, references) will be used in supply orders.]]></source>
-        <target><![CDATA[When using the advanced stock management tool (see Shop Parameters > Products settings), the values you define (price, references) will be used in supply orders.]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig:40</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e3e5475e756a5faa16b7c97ca591c5d9">
-        <source>This interface allows you to specify the warehouse in which the product is stocked.</source>
-        <target>This interface allows you to specify the warehouse in which the product is stocked.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig:30</note>
-      </trans-unit>
-      <trans-unit id="d96fc45d9d293e923893a37d598ee960">
-        <source>It is also possible to specify the location within the warehouse for each product or combination.</source>
-        <target>It is also possible to specify the location within the warehouse for each product or combination.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig:31</note>
+      <trans-unit id="de11e2e4296bb20487b6430508866e06">
+        <source>Does not apply to the shipping costs</source>
+        <target>Does not apply to the shipping costs</target>
+        <note>Line: 73</note>
       </trans-unit>
     </body>
   </file>
@@ -863,38 +14,32 @@ File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_
       <trans-unit id="3fde87028c9327c15017b46e6d84ac80">
         <source>Optional: The cart rule will be available to everyone if you leave this field blank.</source>
         <target>Optional: The cart rule will be available to everyone if you leave this field blank.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="fc36a619a1f71bfe01203191c5c95675">
         <source>The default period is one month.</source>
         <target>The default period is one month.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="5b41d7dc2da5ea15baf3e2d62d820ac2">
         <source>You can choose a minimum amount for the cart either with or without the taxes and shipping.</source>
         <target>You can choose a minimum amount for the cart either with or without the taxes and shipping.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:74</note>
+        <note>Line: 74</note>
       </trans-unit>
       <trans-unit id="cfc9489072f04e808ce4e01948b7fef8">
         <source>The cart rule will be applied to the first "X" customers only.</source>
         <target>The cart rule will be applied to the first "X" customers only.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:116</note>
+        <note>Line: 116</note>
       </trans-unit>
       <trans-unit id="15391e9d908034a4458cd78296a945a8">
         <source>A customer will only be able to use the cart rule "X" time(s).</source>
         <target>A customer will only be able to use the cart rule "X" time(s).</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:128</note>
+        <note>Line: 128</note>
       </trans-unit>
       <trans-unit id="ced8a99398578936b21103cba545cd66">
         <source>This restriction applies to the country of delivery.</source>
         <target>This restriction applies to the country of delivery.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:151</note>
+        <note>Line: 151</note>
       </trans-unit>
     </body>
   </file>
@@ -903,70 +48,42 @@ File: admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl:15
       <trans-unit id="092ff92c5c5fb215f214c07d9221e949">
         <source>This will be displayed in the cart summary, as well as on the invoice.</source>
         <target>This will be displayed in the cart summary, as well as on the invoice.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="7560e0cd0768c203f178a95dbb586297">
         <source>For your eyes only. This will never be displayed to the customer.</source>
         <target>For your eyes only. This will never be displayed to the customer.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:63</note>
+        <note>Line: 63</note>
       </trans-unit>
       <trans-unit id="4c04b0afd7a378940377c1948fa65e5f">
         <source>This is the code users should enter to apply the voucher to a cart. Either create your own code or generate one by clicking on "Generate".</source>
         <target>This is the code users should enter to apply the voucher to a cart. Either create your own code or generate one by clicking on "Generate".</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:75</note>
+        <note>Line: 75</note>
       </trans-unit>
       <trans-unit id="b9fe1289d4d385c85d61f262aea8de40">
         <source>Caution! If you leave this field blank, the rule will automatically be applied to benefiting customers.</source>
         <target>Caution! If you leave this field blank, the rule will automatically be applied to benefiting customers.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:86</note>
+        <note>Line: 86</note>
       </trans-unit>
       <trans-unit id="9c0cc5911e6caceaa3f19e4bcf264ab0">
         <source>If the voucher is not yet in the cart, it will be displayed in the cart summary.</source>
         <target>If the voucher is not yet in the cart, it will be displayed in the cart summary.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:93</note>
+        <note>Line: 93</note>
       </trans-unit>
       <trans-unit id="b51a203cee37965537db75688feaef75">
         <source>Only applicable if the voucher value is greater than the cart total.</source>
         <target>Only applicable if the voucher value is greater than the cart total.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:111</note>
+        <note>Line: 111</note>
       </trans-unit>
       <trans-unit id="45ec8a24a8f55af16fad097e8a4fb9fe">
         <source>If you do not allow partial use, the voucher value will be lowered to the total order amount. If you allow partial use, however, a new voucher will be created with the remainder.</source>
         <target>If you do not allow partial use, the voucher value will be lowered to the total order amount. If you allow partial use, however, a new voucher will be created with the remainder.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:112</note>
+        <note>Line: 112</note>
       </trans-unit>
       <trans-unit id="0fcc630f536dae07ee7c1ac612654c1d">
         <source>Cart rules are applied by priority. A cart rule with a priority of "1" will be processed before a cart rule with a priority of "2".</source>
         <target>Cart rules are applied by priority. A cart rule with a priority of "1" will be processed before a cart rule with a priority of "2".</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:130</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/actions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="de11e2e4296bb20487b6430508866e06">
-        <source>Does not apply to the shipping costs</source>
-        <target>Does not apply to the shipping costs</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:73</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/tracking/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b40b4b1a0589005b45e9fa351c1b91f3">
-        <source>An empty category is a category that has no product directly associated to it. An empty category may however contain products through its subcategories.</source>
-        <target>An empty category is a category that has no product directly associated to it. An empty category may however contain products through its subcategories.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tracking/helpers/list/list_header.tpl:29</note>
+        <note>Line: 130</note>
       </trans-unit>
     </body>
   </file>
@@ -981,8 +98,752 @@ File: admin-dev/themes/default/template/controllers/categories/helpers/form/form
       <trans-unit id="5bc1667deb2b522c0cac00de5f15ffbc">
         <source>Recommended dimensions (for the default theme): %1spx x %2spx</source>
         <target>Recommended dimensions (for the default theme): %1spx x %2spx</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/categories/helpers/form/form.tpl:60</note>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="0f6ae5ebf937764fc48db601df56d0ca">
+        <source><![CDATA[If you want a category to appear in the menu of your shop, go to [1]Modules > Modules Manager.[/1] Then, configure your menu module.]]></source>
+        <target><![CDATA[If you want a category to appear in the menu of your shop, go to [1]Modules > Modules Manager.[/1] Then, configure your menu module.]]></target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/tracking/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b40b4b1a0589005b45e9fa351c1b91f3">
+        <source>An empty category is a category that has no product directly associated to it. An empty category may however contain products through its subcategories.</source>
+        <target>An empty category is a category that has no product directly associated to it. An empty category may however contain products through its subcategories.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f2d1c5443636295e9720caac90ea8d93">
+        <source>Your internal name for this attribute.</source>
+        <target>Your internal name for this attribute.</target>
+        <note>Line: 202</note>
+      </trans-unit>
+      <trans-unit id="b5e6921c2d093fbcb0088c9466ee9983">
+        <source>The public name for this attribute, displayed to the customers.</source>
+        <target>The public name for this attribute, displayed to the customers.</target>
+        <note>Line: 211</note>
+      </trans-unit>
+      <trans-unit id="580de47d3bc3e99a0b6aba55066a983a">
+        <source>The way the attribute's values will be presented to the customers in the product's page.</source>
+        <target>The way the attribute's values will be presented to the customers in the product's page.</target>
+        <note>Line: 224</note>
+      </trans-unit>
+      <trans-unit id="71c476c94d0a0e3dfc0826afd03d2dda">
+        <source>Choose the attribute group for this value.</source>
+        <target>Choose the attribute group for this value.</target>
+        <note>Line: 272</note>
+      </trans-unit>
+      <trans-unit id="22cbf85c41427960736dc10cfec5faf4">
+        <source>Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").</source>
+        <target>Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").</target>
+        <note>Line: 310</note>
+      </trans-unit>
+      <trans-unit id="dd24a1142c1070a0efbdf43b4f0167cc">
+        <source>Upload an image file containing the color texture from your computer.</source>
+        <target>Upload an image file containing the color texture from your computer.</target>
+        <note>Line: 318</note>
+      </trans-unit>
+      <trans-unit id="ba353198430b2004efeb1ac6d1f410d0">
+        <source>This will override the HTML color!</source>
+        <target>This will override the HTML color!</target>
+        <note>Line: 319</note>
+      </trans-unit>
+      <trans-unit id="7d5672f569de406c85249db6f1c99ec0">
+        <source>Save then add another value</source>
+        <target>Save then add another value</target>
+        <note>Line: 558</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d4be87a5a7a7e9bf633dc6d356968333">
+        <source>Click on "Displayed" to index the category on your shop.</source>
+        <target>Click on "Displayed" to index the category on your shop.</target>
+        <note>Line: 526</note>
+      </trans-unit>
+      <trans-unit id="42f9ee5026d32792987af851a2ea0343">
+        <source>This is the main image for your category, displayed in the category page. The category description will overlap this image and appear in its top-left corner.</source>
+        <target>This is the main image for your category, displayed in the category page. The category description will overlap this image and appear in its top-left corner.</target>
+        <note>Line: 567</note>
+      </trans-unit>
+      <trans-unit id="c5d262df2fa3b92141eb8bb37b1fb9b7">
+        <source>Displays a small image in the parent category's page, if the theme allows it.</source>
+        <target>Displays a small image in the parent category's page, if the theme allows it.</target>
+        <note>Line: 578</note>
+      </trans-unit>
+      <trans-unit id="9cbbbb4e43f08deda211ff24e6fd542f">
+        <source>The category thumbnail appears in the menu as a small image representing the category, if the theme allows it.</source>
+        <target>The category thumbnail appears in the menu as a small image representing the category, if the theme allows it.</target>
+        <note>Line: 589</note>
+      </trans-unit>
+      <trans-unit id="7e35726fb991605ab3d0e6406599e6ef">
+        <source>To add "tags," click in the field, write something, and then press "Enter."</source>
+        <target>To add "tags," click in the field, write something, and then press "Enter."</target>
+        <note>Line: 618</note>
+      </trans-unit>
+      <trans-unit id="09e2683b6b92b326691cd992f6e5684b">
+        <source>Only letters, numbers, underscore (_) and the minus (-) character are allowed.</source>
+        <target>Only letters, numbers, underscore (_) and the minus (-) character are allowed.</target>
+        <note>Line: 626</note>
+      </trans-unit>
+      <trans-unit id="53d98bd116f47fdfe15c8eb4525c5e99">
+        <source>You now have three default customer groups.</source>
+        <target>You now have three default customer groups.</target>
+        <note>Line: 633</note>
+      </trans-unit>
+      <trans-unit id="463848257c086c4816d9f4c020a8d19e">
+        <source>Mark all of the customer groups which you would like to have access to this category.</source>
+        <target>Mark all of the customer groups which you would like to have access to this category.</target>
+        <note>Line: 637</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bed3b3133d292db46a0d28c5d91811b9">
+        <source>Only letters and the minus (-) character are allowed.</source>
+        <target>Only letters and the minus (-) character are allowed.</target>
+        <note>Line: 291</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7db5022f86dda7b39e31e754afd5c6a0">
+        <source>Allow customers to upload files using the contact page.</source>
+        <target>Allow customers to upload files using the contact page.</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="1f2b974152999d549b89994879e452a3">
+        <source>Please fill out the message fields that appear by default when you answer a thread on the customer service page.</source>
+        <target>Please fill out the message fields that appear by default when you answer a thread on the customer service page.</target>
+        <note>Line: 156</note>
+      </trans-unit>
+      <trans-unit id="61b7dba4b2704903e5a2434e1f3ab878">
+        <source>URL for your IMAP server (ie.: mail.server.com).</source>
+        <target>URL for your IMAP server (ie.: mail.server.com).</target>
+        <note>Line: 168</note>
+      </trans-unit>
+      <trans-unit id="d60419d8fec86275eb0752ce43556e6f">
+        <source>Port to use to connect to your IMAP server.</source>
+        <target>Port to use to connect to your IMAP server.</target>
+        <note>Line: 173</note>
+      </trans-unit>
+      <trans-unit id="b8453d9982fb11c704dca368e5107677">
+        <source>User to use to connect to your IMAP server.</source>
+        <target>User to use to connect to your IMAP server.</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="849dafe04c2f54cb0dc079da9ca15a8f">
+        <source>Password to use to connect your IMAP server.</source>
+        <target>Password to use to connect your IMAP server.</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="e9d5cadd20f10058a5bb0823aed17584">
+        <source>Delete messages after synchronization. If you do not enable this option, the synchronization will take more time.</source>
+        <target>Delete messages after synchronization. If you do not enable this option, the synchronization will take more time.</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="eca83facb7294ab0f66e1dec9fc66efd">
+        <source>Create new threads for unrecognized emails.</source>
+        <target>Create new threads for unrecognized emails.</target>
+        <note>Line: 194</note>
+      </trans-unit>
+      <trans-unit id="38033ed4d12ca354e503266bd9a59105">
+        <source>Use POP3 instead of IMAP.</source>
+        <target>Use POP3 instead of IMAP.</target>
+        <note>Line: 199</note>
+      </trans-unit>
+      <trans-unit id="3abb33532b4b4e0201dbdde08eced7ee">
+        <source>Do not use RSH or SSH to establish a preauthenticated IMAP sessions.</source>
+        <target>Do not use RSH or SSH to establish a preauthenticated IMAP sessions.</target>
+        <note>Line: 205</note>
+      </trans-unit>
+      <trans-unit id="89884c64df4330255f1fc07dadfb5dd4">
+        <source>Use the Secure Socket Layer (TLS/SSL) to encrypt the session.</source>
+        <target>Use the Secure Socket Layer (TLS/SSL) to encrypt the session.</target>
+        <note>Line: 210</note>
+      </trans-unit>
+      <trans-unit id="f5c4e8df7daa8f49d8f68ae25deab8c7">
+        <source>Validate certificates from the TLS/SSL server.</source>
+        <target>Validate certificates from the TLS/SSL server.</target>
+        <note>Line: 215</note>
+      </trans-unit>
+      <trans-unit id="244789498d5c439efc7a4a05975dc391">
+        <source>Do not validate certificates from the TLS/SSL server. This is only needed if a server uses self-signed certificates.</source>
+        <target>Do not validate certificates from the TLS/SSL server. This is only needed if a server uses self-signed certificates.</target>
+        <note>Line: 220</note>
+      </trans-unit>
+      <trans-unit id="eabd6d4298e21426642606fe653585c9">
+        <source>Force use of start-TLS to encrypt the session, and reject connection to servers that do not support it.</source>
+        <target>Force use of start-TLS to encrypt the session, and reject connection to servers that do not support it.</target>
+        <note>Line: 225</note>
+      </trans-unit>
+      <trans-unit id="5b035ec3dccf9e9d875e0b830062a9ff">
+        <source>Do not use start-TLS to encrypt the session, even with servers that support it.</source>
+        <target>Do not use start-TLS to encrypt the session, even with servers that support it.</target>
+        <note>Line: 230</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminFeaturesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7aad0283b11e41230d9d1fc7372c3862">
+        <source>Add new feature value</source>
+        <target>Add new feature value</target>
+        <note>Line: 216</note>
+      </trans-unit>
+      <trans-unit id="21d883f3177ec09a845d9963eca239b1">
+        <source>Save and add another value</source>
+        <target>Save and add another value</target>
+        <note>Line: 244</note>
+      </trans-unit>
+      <trans-unit id="07fc7dc79c8046bb36d97b4332dab1ca">
+        <source>Back to the list</source>
+        <target>Back to the list</target>
+        <note>Line: 267</note>
+      </trans-unit>
+      <trans-unit id="d8aac6665c79faf4f411fe0da93ab23c">
+        <source>Add new feature values</source>
+        <target>Add new feature values</target>
+        <note>Line: 263</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminManufacturersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0205bdbccc495138a109bd8710053565">
+        <source>Upload a brand logo from your computer.</source>
+        <target>Upload a brand logo from your computer.</target>
+        <note>Line: 356</note>
+      </trans-unit>
+      <trans-unit id="643544fd7876fa0f017ba6233f46b4c3">
+        <source>To add "tags," click inside the field, write something, and then press "Enter."</source>
+        <target>To add "tags," click inside the field, write something, and then press "Enter."</target>
+        <note>Line: 382</note>
+      </trans-unit>
+      <trans-unit id="b7d8f05036844ad562ed08715bb480b4">
+        <source>Company name for this brand</source>
+        <target>Company name for this brand</target>
+        <note>Line: 509</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSuppliersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dd0479e67d24cd2c2868d4c6b2dcba9a">
+        <source>Company name for this supplier</source>
+        <target>Company name for this supplier</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="afd7431f75b5801226c9ee37acc1a504">
+        <source>Will appear in the list of suppliers.</source>
+        <target>Will appear in the list of suppliers.</target>
+        <note>Line: 149</note>
+      </trans-unit>
+      <trans-unit id="b51bea4eee9d9ef6bd9a6849337013d5">
+        <source>Phone number for this supplier</source>
+        <target>Phone number for this supplier</target>
+        <note>Line: 160</note>
+      </trans-unit>
+      <trans-unit id="c24c0c9cd7bdb34eaff67028b0cb8349">
+        <source>Mobile phone number for this supplier.</source>
+        <target>Mobile phone number for this supplier.</target>
+        <note>Line: 169</note>
+      </trans-unit>
+      <trans-unit id="e865605842d16d0d11c266c731e00507">
+        <source>Upload a supplier logo from your computer.</source>
+        <target>Upload a supplier logo from your computer.</target>
+        <note>Line: 234</note>
+      </trans-unit>
+      <trans-unit id="3ef61077e04c24d0b712a1b0ea036255">
+        <source>To add "tags" click in the field, write something and then press "Enter".</source>
+        <target>To add "tags" click in the field, write something and then press "Enter".</target>
+        <note>Line: 259</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cc2ac103a9c1411fd67952983e25978a">
+        <source>Create a new product: CTRL+P</source>
+        <target>Create a new product: CTRL+P</target>
+        <note>Line: 327</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7bb36e0f484d91aeba5d83fe2af63d28">
+        <source>Search for a product</source>
+        <target>Search for a product</target>
+        <note>Line: 149</note>
+      </trans-unit>
+      <trans-unit id="9242ed633bcac07574f63fba6e184fd8">
+        <source>Enter your product name</source>
+        <target>Enter your product name</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="7f6c27a96363effdda77216cf1251400">
+        <source><![CDATA[The summary is a short sentence describing your product.<br />It will appears at the top of your shop's product page, in product lists, and in search engines' results page (so it's important for SEO). To give more details about your product, use the "Description" tab.]]></source>
+        <target><![CDATA[The summary is a short sentence describing your product.<br />It will appears at the top of your shop's product page, in product lists, and in search engines' results page (so it's important for SEO). To give more details about your product, use the "Description" tab.]]></target>
+        <note>Line: 197</note>
+      </trans-unit>
+      <trans-unit id="1fbfcc9642d39544207c67f66ec3bc00">
+        <source>Search and add a related product</source>
+        <target>Search and add a related product</target>
+        <note>Line: 286</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8246ddfaa2c607ace3ae3a4643d957d1">
+        <source>Use a comma to create separate tags. E.g.: dress, cotton, party dresses.</source>
+        <target>Use a comma to create separate tags. E.g.: dress, cotton, party dresses.</target>
+        <note>Line: 119</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="420f46a170eef476454fa134085a85a2">
+        <source>Per kilo, per litre</source>
+        <target>Per kilo, per litre</target>
+        <note>Line: 185</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e63e2ba42470a41ba75e0d7ea35a410f">
+        <source>Combine several attributes, e.g.: "Size: all", "Color: red".</source>
+        <target>Combine several attributes, e.g.: "Size: all", "Color: red".</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="16a5534d559007de7e8f5b4f17112203">
+        <source>Leave empty to disable</source>
+        <target>Leave empty to disable</target>
+        <note>Line: 175</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="af809f35e40bd6f644509ad566ecf38c">
+        <source>To have a different title from the product name, enter it here.</source>
+        <target>To have a different title from the product name, enter it here.</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="b0ea2bd9df4b8ee746b4e5fd28503851">
+        <source>Public title for the product's page, and for search engines. Leave blank to use the product name. The number of remaining characters is displayed to the left of the field.</source>
+        <target>Public title for the product's page, and for search engines. Leave blank to use the product name. The number of remaining characters is displayed to the left of the field.</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="5f99bb8ecd940f311cb66fadfc467a2b">
+        <source>To have a different description than your product summary in search results pages, write it here.</source>
+        <target>To have a different description than your product summary in search results pages, write it here.</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="8533d8d42f2c7ef3078797984ea14675">
+        <source>This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)</source>
+        <target>This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="26511e4120f7b4f3135a21b9f35efed8">
+        <source>To which product the page should redirect?</source>
+        <target>To which product the page should redirect?</target>
+        <note>Line: 161</note>
+      </trans-unit>
+      <trans-unit id="024db530212734e5c28319bc4754ad85">
+        <source>To which category the page should redirect?</source>
+        <target>To which category the page should redirect?</target>
+        <note>Line: 163</note>
+      </trans-unit>
+      <trans-unit id="2719055d3b2b4fc865a78df22462c96b">
+        <source>If no category is selected the Main Category is used</source>
+        <target>If no category is selected the Main Category is used</target>
+        <note>Line: 164</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="542f59279cd5d73dfbdb069ce0833b0a">
+        <source>Search name</source>
+        <target>Search name</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="3ce14776b1408d0dc406766fd0c6a45d">
+        <source>Search ref.</source>
+        <target>Search ref.</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="84645920bd0fb266cb4acdbc00003e62">
+        <source>Search category</source>
+        <target>Search category</target>
+        <note>Line: 117</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="548f88021c5b960f7eccd9ee81871aad">
+        <source>Permanently delete this product.</source>
+        <target>Permanently delete this product.</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="94e4259ad6f05c74b84eb6cca4d60ce6">
+        <source>See how your product sheet will look online: ALT+SHIFT+V</source>
+        <target>See how your product sheet will look online: ALT+SHIFT+V</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="ad7478afcd575d882738a42546bc041a">
+        <source>Enable or disable the product on your shop: ALT+SHIFT+O</source>
+        <target>Enable or disable the product on your shop: ALT+SHIFT+O</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="82e3cb7a4be4e299701a182197dc9410">
+        <source>Save the product and stay on the current page: ALT+SHIFT+S</source>
+        <target>Save the product and stay on the current page: ALT+SHIFT+S</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="ac6f66dc450bc768229c1329aa7a48b1">
+        <source>Save and duplicate this product, then go to the new product: ALT+SHIFT+D</source>
+        <target>Save and duplicate this product, then go to the new product: ALT+SHIFT+D</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="b110e989a1143b7f44cd5691324d4d11">
+        <source>Save and go back to the catalog: ALT+SHIFT+Q</source>
+        <target>Save and go back to the catalog: ALT+SHIFT+Q</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="37163a2847189335a934c83e8ae32677">
+        <source>Save and create a new product: ALT+SHIFT+P</source>
+        <target>Save and create a new product: ALT+SHIFT+P</target>
+        <note>Line: 104</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bb03c14d14caa07e21f97cbe5eab022d">
+        <source>Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, physical product?</source>
+        <target>Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, physical product?</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="61010671991185f436b35030f599d327">
+        <source>Where should the product be available on your site? The main category is where the product appears by default: this is the category which is seen in the product page's URL. Disabled categories are written in italics.</source>
+        <target>Where should the product be available on your site? The main category is where the product appears by default: this is the category which is seen in the product page's URL. Disabled categories are written in italics.</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="c5abe76b24973299661ce389d1a092e1">
+        <source>Search categories</source>
+        <target>Search categories</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="b78db8ba6d89ef3a49b95e6f92235997">
+        <source>If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.).  A new category will not automatically appear in your shop's menu, please read the Help about it.</source>
+        <target>If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.).  A new category will not automatically appear in your shop's menu, please read the Help about it.</target>
+        <note>Line: 53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="53f3eb21de0c7a8c909a86be984996f6">
+        <source>Does this combination have a different price? Is it cheaper or more expensive than the default retail price?</source>
+        <target>Does this combination have a different price? Is it cheaper or more expensive than the default retail price?</target>
+        <note>Line: 150</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="268bf51f15b2210472b2d42dd883214a">
+        <source><![CDATA[Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. To create a combination, you need to create your product attributes first. Go to Catalog > Attributes & Features for this!]]></source>
+        <target><![CDATA[Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. To create a combination, you need to create your product attributes first. Go to Catalog > Attributes & Features for this!]]></target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="57a23510ca35a7354d9208151c344364">
+        <source><![CDATA[To add combinations, you first need to create proper attributes and values in [1]Attributes & Features[/1]. <br> When done, you may enter the wanted attributes (like "size" or "color") and their respective values ("XS", "red", "all", etc.) in the field below; or simply select them from the right column. Then click on "Generate": it will automatically create all the combinations for you!]]></source>
+        <target><![CDATA[To add combinations, you first need to create proper attributes and values in [1]Attributes & Features[/1]. <br> When done, you may enter the wanted attributes (like "size" or "color") and their respective values ("XS", "red", "all", etc.) in the field below; or simply select them from the right column. Then click on "Generate": it will automatically create all the combinations for you!]]></target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c533675166b567256cae22139534b713">
+        <source>This is the human-readable URL, as generated from the product's name. You can change it if you want.</source>
+        <target>This is the human-readable URL, as generated from the product's name. You can change it if you want.</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="eb8b9b044f3b64b5ba5f7b047963714c">
+        <source>When your product is disabled, choose to which page you’d like to redirect the customers visiting its page by typing the product or category name.</source>
+        <target>When your product is disabled, choose to which page you’d like to redirect the customers visiting its page by typing the product or category name.</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="40464c1dbd8778600fba3f37d36e79dd">
+        <source>No redirection (404) = Do not redirect anywhere and display a 404 "Not Found" page.</source>
+        <target>No redirection (404) = Do not redirect anywhere and display a 404 "Not Found" page.</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="462864be2a8d87de471c82d553000030">
+        <source>Permanent redirection (301) = Permanently display another product or category instead.</source>
+        <target>Permanent redirection (301) = Permanently display another product or category instead.</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="50565048560ec8a9fe1f6ddec57a917a">
+        <source>Temporary redirection (302) = Temporarily display another product or category instead.</source>
+        <target>Temporary redirection (302) = Temporarily display another product or category instead.</target>
+        <note>Line: 126</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="305c255586949e297af4d74bb1bc9563">
+        <source>Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws.</source>
+        <target>Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws.</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="de95b43bceeb4b998aed4aed5cef1ae7">
+        <source>edit</source>
+        <target>edit</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="8b2ff26690065c221599c196cb6adc82">
+        <source>If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping.</source>
+        <target>If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping.</target>
+        <note>Line: 127</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="aa25978d6b02e4e469c205afa9de0c46">
+        <source>This interface allows you to specify the suppliers of the current product and its combinations, if any.</source>
+        <target>This interface allows you to specify the suppliers of the current product and its combinations, if any.</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="5f5641c7f2d62db16c4d12ce2bcf5898">
+        <source>You can specify supplier references according to previously associated suppliers.</source>
+        <target>You can specify supplier references according to previously associated suppliers.</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="d57ad4a0ab142c03bb1ced551f66ce9b">
+        <source><![CDATA[When using the advanced stock management tool (see Shop Parameters > Products settings), the values you define (price, references) will be used in supply orders.]]></source>
+        <target><![CDATA[When using the advanced stock management tool (see Shop Parameters > Products settings), the values you define (price, references) will be used in supply orders.]]></target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="214396125ea99914d7f6faef5d612b85">
+        <source>You can specify product reference(s) for each associated supplier. Click "Save" after changing selected suppliers to display the associated product references.</source>
+        <target>You can specify product reference(s) for each associated supplier. Click "Save" after changing selected suppliers to display the associated product references.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e3e5475e756a5faa16b7c97ca591c5d9">
+        <source>This interface allows you to specify the warehouse in which the product is stocked.</source>
+        <target>This interface allows you to specify the warehouse in which the product is stocked.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="d96fc45d9d293e923893a37d598ee960">
+        <source>It is also possible to specify the location within the warehouse for each product or combination.</source>
+        <target>It is also possible to specify the location within the warehouse for each product or combination.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5f4efe2735311bfd3e5784705fb0110f">
+        <source>Number of days this file can be accessed by customers. Set to zero for unlimited access.</source>
+        <target>Number of days this file can be accessed by customers. Set to zero for unlimited access.</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="dbcf3c5f67528da5cf59dc0c042748da">
+        <source>Upload a file from your computer (%maxUploadSize% max.)</source>
+        <target>Upload a file from your computer (%maxUploadSize% max.)</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="c312034c9f17a264365e734de442ca0a">
+        <source>The full filename with its extension (e.g. Book.pdf)</source>
+        <target>The full filename with its extension (e.g. Book.pdf)</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="48da1c11d36bd8b34f13821e996c7f97">
+        <source>Number of downloads allowed per customer. Set to 0 for unlimited downloads.</source>
+        <target>Number of downloads allowed per customer. Set to 0 for unlimited downloads.</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="f049153f2c655d6d1ebd123f04b432cf">
+        <source>If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date.</source>
+        <target>If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date.</target>
+        <note>Line: 132</note>
+      </trans-unit>
+      <trans-unit id="ea8d1b4f32f86030683d8f9252c0a3e1">
+        <source>The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity.</source>
+        <target>The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="1914ce33841a6e52c0577751d9004159">
+        <source><![CDATA[The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]]]></source>
+        <target><![CDATA[The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]]]></target>
+        <note>Line: 74</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0745d3d4082ad910137e24fd2901ca63">
+        <source>Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?</source>
+        <target>Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?</target>
+        <note>Line: 156</note>
+      </trans-unit>
+      <trans-unit id="0a4595dd800cb3338d233a177f422758">
+        <source>Advanced settings in [1][2]Combinations[/1]</source>
+        <target>Advanced settings in [1][2]Combinations[/1]</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="01cfe41b8ece41634e85248382166271">
+        <source>Your reference code for this product. Allowed special characters: .-_#.</source>
+        <target>Your reference code for this product. Allowed special characters: .-_#.</target>
+        <note>Line: 183</note>
+      </trans-unit>
+      <trans-unit id="e2c7ed083cb894812fb5d2539f5e7ecb">
+        <source>How many products should be available for sale?</source>
+        <target>How many products should be available for sale?</target>
+        <note>Line: 198</note>
+      </trans-unit>
+      <trans-unit id="5e8b5ad38b1c0a76d41c2ebaa74c11f5">
+        <source>Advanced settings in [1][2]Quantities[/1]</source>
+        <target>Advanced settings in [1][2]Quantities[/1]</target>
+        <note>Line: 208</note>
+      </trans-unit>
+      <trans-unit id="1423e14cddc8aa38062c77d9b8fe8910">
+        <source>This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.</source>
+        <target>This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.</target>
+        <note>Line: 217</note>
+      </trans-unit>
+      <trans-unit id="143cb6dd5281d68859217704ad9c9f60">
+        <source>Advanced settings in [1][2]Pricing[/1]</source>
+        <target>Advanced settings in [1][2]Pricing[/1]</target>
+        <note>Line: 246</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6fcccfb9dbed970c59c18752f6372703">
+        <source>Tags are meant to help your customers find your products via the search bar.</source>
+        <target>Tags are meant to help your customers find your products via the search bar.</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="cfd69f4f64142b71ff1ddd21b0053026">
+        <source>Choose terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.</source>
+        <target>Choose terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="8a08a645644d632f79ad988808ba2174">
+        <source>You can manage tag aliases in the [1]Search section[/1]. If you add new tags, you have to rebuild the index.</source>
+        <target>You can manage tag aliases in the [1]Search section[/1]. If you add new tags, you have to rebuild the index.</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="19f31a842add8b13595ddb3a41a1ff27">
+        <source>Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces.</source>
+        <target>Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces.</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="633bf9436b67e19cd61db84ccab7fee2">
+        <source>ISBN is used internationally to identify books and their various editions.</source>
+        <target>ISBN is used internationally to identify books and their various editions.</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="39bd7eba8aa2033579b5ae60bf0c774d">
+        <source>This type of product code is widely used in the United States, Canada, the United Kingdom, Australia, New Zealand and in other countries.</source>
+        <target>This type of product code is widely used in the United States, Canada, the United Kingdom, Australia, New Zealand and in other countries.</target>
+        <note>Line: 136</note>
+      </trans-unit>
+      <trans-unit id="0041a5c39ca241f883f4e0516a32d290">
+        <source>This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America.</source>
+        <target>This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America.</target>
+        <note>Line: 125</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a4a8ceb87fae812bfac552e0169bb0f9">
+        <source>This is the price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.</source>
+        <target>This is the price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="b9c6e3712398e2df7d3ebd7ccc7d5132">
+        <source>Some products can be purchased by unit (per bottle, per pound, etc.),  and this is the price for one unit. For instance, if you’re selling fabrics, it would be the price per meter.</source>
+        <target>Some products can be purchased by unit (per bottle, per pound, etc.),  and this is the price for one unit. For instance, if you’re selling fabrics, it would be the price per meter.</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="eee67d763dcf287ca5d096650341f387">
+        <source>The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin.</source>
+        <target>The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin.</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="959f5f13ee3cc4199a335d1738351596">
+        <source>You can set specific prices for customers belonging to different groups, different countries, etc.</source>
+        <target>You can set specific prices for customers belonging to different groups, different countries, etc.</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="fbade15b99b07c58fab7be777c0f4c0c">
+        <source>Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first.</source>
+        <target>Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first.</target>
+        <note>Line: 182</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="607e1d854783c8229998ac2b5b6923d3">
+        <source>Invalid token</source>
+        <target>Invalid token</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="d24ec28b066e46d9d9ec3c1f39aa89ee">
+        <source>[1]Invalid token[/1]: direct access to this link may lead to a potential security breach.</source>
+        <target>[1]Invalid token[/1]: direct access to this link may lead to a potential security breach.</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="f364944e8422977932bd21eb2d96963a">
+        <source>Do you want to display this page?</source>
+        <target>Do you want to display this page?</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="a0d31e7f783700b99e15ce8621dc6381">
+        <source>Yes, I understand the risks</source>
+        <target>Yes, I understand the risks</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="a5b0a810681c7fca4581d7f7524009f4">
+        <source>Take me out of there!</source>
+        <target>Take me out of there!</target>
+        <note>Line: 66</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminCatalogNotification.xlf
+++ b/app/Resources/translations/default/AdminCatalogNotification.xlf
@@ -1,1110 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminAttachmentsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="935b31f32421029fb633ead151d69d83">
-        <source>This file is associated with the following products, do you really want to  delete it?</source>
-        <target>This file is associated with the following products, do you really want to  delete it?</target>
-        <note>Context:
-File: controllers/admin/AdminAttachmentsController.php:91</note>
-      </trans-unit>
-      <trans-unit id="5251010ec9e364492c236bf8b9983928">
-        <source>File not found</source>
-        <target>File not found</target>
-        <note>Context:
-File: controllers/admin/AdminAttachmentsController.php:119</note>
-      </trans-unit>
-      <trans-unit id="8a23b9ee3a4502a0de3fc32c5ba7aa65">
-        <source>Failed to copy the file.</source>
-        <target>Failed to copy the file.</target>
-        <note>Context:
-File: controllers/admin/AdminAttachmentsController.php:232</note>
-      </trans-unit>
-      <trans-unit id="8cb9da8e2fc65153510e4a067af0b32c">
-        <source>The file %file% exceeds the size allowed by the server. The limit is set to %size% MB.</source>
-        <target>The file %file% exceeds the size allowed by the server. The limit is set to %size% MB.</target>
-        <note>Context:
-File: controllers/admin/AdminAttachmentsController.php:246</note>
-      </trans-unit>
-      <trans-unit id="d647666a6c4cef994b4fa1a540ba4481">
-        <source>Upload error. Please check your server configurations for the maximum upload size allowed.</source>
-        <target>Upload error. Please check your server configurations for the maximum upload size allowed.</target>
-        <note>Context:
-File: controllers/admin/AdminAttachmentsController.php:250</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="815e471ea2970db0b63b9b09feacc70f">
-        <source>An error occurred while updating the status for an object.</source>
-        <target>An error occurred while updating the status for an object.</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:116</note>
-      </trans-unit>
-      <trans-unit id="77ae44aa6c998166fcf1a87496278ad5">
-        <source>(cannot load object)</source>
-        <target>(cannot load object)</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:118</note>
-      </trans-unit>
-      <trans-unit id="caecb49a7eec394177d054db34995bc0">
-        <source>The attribute value "%1$s" already exist for %2$s language</source>
-        <target>The attribute value "%1$s" already exist for %2$s language</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:411</note>
-      </trans-unit>
-      <trans-unit id="7f7cd1de48a84bc7ba0dfcde99de2604">
-        <source>Failed to delete the attribute.</source>
-        <target>Failed to delete the attribute.</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:767</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminAttributeGeneratorController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="de2a79b3b161c486acb8f80861cd107c">
-        <source>This feature has been disabled. You can activate it here: %link%.</source>
-        <target>This feature has been disabled. You can activate it here: %link%.</target>
-        <note>Context:
-File: controllers/admin/AdminAttributeGeneratorController.php:238</note>
-      </trans-unit>
-      <trans-unit id="1ef611e55a4e10ff65c1e64f962281c8">
-        <source>Please select at least one attribute.</source>
-        <target>Please select at least one attribute.</target>
-        <note>Context:
-File: controllers/admin/AdminAttributeGeneratorController.php:119</note>
-      </trans-unit>
-      <trans-unit id="6e89fd17c196488cfac8e63ec415d65f">
-        <source>Unable to initialize these parameters. A combination is missing or an object cannot be loaded.</source>
-        <target>Unable to initialize these parameters. A combination is missing or an object cannot be loaded.</target>
-        <note>Context:
-File: controllers/admin/AdminAttributeGeneratorController.php:171</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c1a4c1b929c4f5c81f80ece2d7b196aa">
-        <source>Invalid product</source>
-        <target>Invalid product</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:456</note>
-      </trans-unit>
-      <trans-unit id="e5b55dc69d10c8673f9d5db587591526">
-        <source>Invalid combination</source>
-        <target>Invalid combination</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:373</note>
-      </trans-unit>
-      <trans-unit id="7cc92687130ea12abb80556681538001">
-        <source>An error occurred during the image upload process.</source>
-        <target>An error occurred during the image upload process.</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:429</note>
-      </trans-unit>
-      <trans-unit id="b164de93448b61c61dd1c0f68c2c5884">
-        <source>An order has already been placed with this cart.</source>
-        <target>An order has already been placed with this cart.</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:454</note>
-      </trans-unit>
-      <trans-unit id="2cb44aa56605e05e0b912131875edcb7">
-        <source>There are not enough products in stock.</source>
-        <target>There are not enough products in stock.</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:468</note>
-      </trans-unit>
-      <trans-unit id="89ecb554b799211aca0441e691419963">
-        <source>This product cannot be added to the cart.</source>
-        <target>This product cannot be added to the cart.</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:475</note>
-      </trans-unit>
-      <trans-unit id="de10fc28511b894f704c1a67fcff7b4f">
-        <source>You already have the maximum quantity available for this product.</source>
-        <target>You already have the maximum quantity available for this product.</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:487</note>
-      </trans-unit>
-      <trans-unit id="fac7c1f73a2c97252e59cac143ae1930">
-        <source>Invalid voucher.</source>
-        <target>Invalid voucher.</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:630</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminProductsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="01816dd287bcb3b88ad3f63970ce045f">
-        <source>Invalid quantity</source>
-        <target>Invalid quantity</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1555</note>
-      </trans-unit>
-      <trans-unit id="99a6e6a05b8d706aeddf480c7e492949">
-        <source>Invalid description for %s language</source>
-        <target>Invalid description for %s language</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:428</note>
-      </trans-unit>
-      <trans-unit id="f19434225ce7712f091bcfc109413732">
-        <source>An attachment name is required.</source>
-        <target>An attachment name is required.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:433</note>
-      </trans-unit>
-      <trans-unit id="34a22d134d958abd17afd6e6cd8b79e2">
-        <source>This attachment was unable to be loaded into the database.</source>
-        <target>This attachment was unable to be loaded into the database.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:484</note>
-      </trans-unit>
-      <trans-unit id="64985418ce04cf0225e600592044206c">
-        <source>We were unable to associate this attachment to a product.</source>
-        <target>We were unable to associate this attachment to a product.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:491</note>
-      </trans-unit>
-      <trans-unit id="c8632adcab64537747393f4d0d5d77ac">
-        <source>An error occurred while saving product attachments.</source>
-        <target>An error occurred while saving product attachments.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:513</note>
-      </trans-unit>
-      <trans-unit id="da9f3aa8f8a01d2d7602ded33febacc7">
-        <source>You cannot delete this product because there is physical stock left.</source>
-        <target>You cannot delete this product because there is physical stock left.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:585</note>
-      </trans-unit>
-      <trans-unit id="838f6e1109a673896b448d9fb46dea57">
-        <source>You cannot change the product's cover image.</source>
-        <target>You cannot change the product's cover image.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:623</note>
-      </trans-unit>
-      <trans-unit id="b351af3dd276d0cac6594897a392e676">
-        <source>The image could not be found. </source>
-        <target>The image could not be found.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:636</note>
-      </trans-unit>
-      <trans-unit id="8df641fea3a5b1d0f8318ce97ecd0fd7">
-        <source>You cannot delete the product #%d because there is physical stock left.</source>
-        <target>You cannot delete the product #%d because there is physical stock left.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:675</note>
-      </trans-unit>
-      <trans-unit id="043432664c5abe8a28c4e7ad7191bccf">
-        <source>The price attribute is required.</source>
-        <target>The price attribute is required.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:715</note>
-      </trans-unit>
-      <trans-unit id="251db6b140bc5b3adcbe0c5efadb3c7d">
-        <source>You must add at least one attribute.</source>
-        <target>You must add at least one attribute.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:718</note>
-      </trans-unit>
-      <trans-unit id="e22a6ea51eb74bee7acaa4acf2846c7b">
-        <source>This combination already exists.</source>
-        <target>This combination already exists.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:798</note>
-      </trans-unit>
-      <trans-unit id="0e461384b2f94dcd87f56a8a178fe768">
-        <source>A product must be created before adding features.</source>
-        <target>A product must be created before adding features.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:891</note>
-      </trans-unit>
-      <trans-unit id="def4acf542de55ba41c7b7fde82bd5b6">
-        <source>Please specify priorities.</source>
-        <target>Please specify priorities.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1035</note>
-      </trans-unit>
-      <trans-unit id="23a15a97117c9d55d4ebda9373c8e45a">
-        <source>An error occurred while updating priorities.</source>
-        <target>An error occurred while updating priorities.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1038</note>
-      </trans-unit>
-      <trans-unit id="ce30da82a4a6b974c18780af4597c8ee">
-        <source>An error occurred while setting priorities.</source>
-        <target>An error occurred while setting priorities.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1043</note>
-      </trans-unit>
-      <trans-unit id="f100c143763d1b027a3e4cb77df9d1b7">
-        <source>An error occurred while creating customization fields.</source>
-        <target>An error occurred while creating customization fields.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1065</note>
-      </trans-unit>
-      <trans-unit id="d26c7c2a8aa5a3c082d8e710f796b918">
-        <source>An error occurred while updating customization fields.</source>
-        <target>An error occurred while updating customization fields.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1085</note>
-      </trans-unit>
-      <trans-unit id="c22861f3c2065a12f51c5f1fb2f83b54">
-        <source>An error occurred while updating the custom configuration.</source>
-        <target>An error occurred while updating the custom configuration.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1072</note>
-      </trans-unit>
-      <trans-unit id="6813b553c2718f4bf293d84d8193e6ea">
-        <source>The label fields defined are invalid.</source>
-        <target>The label fields defined are invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1081</note>
-      </trans-unit>
-      <trans-unit id="c99e8eb97ae8f12508cfd24d1083b8d7">
-        <source>A product must be created before adding customization.</source>
-        <target>A product must be created before adding customization.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1091</note>
-      </trans-unit>
-      <trans-unit id="1697ca7c85db2a8aefb7190bc6d60b96">
-        <source>The uploaded file exceeds the "Maximum size for a downloadable product" set in preferences (%1$dMB) or the post_max_size/ directive in php.ini (%2$dMB).</source>
-        <target>The uploaded file exceeds the "Maximum size for a downloadable product" set in preferences (%1$dMB) or the post_max_size/ directive in php.ini (%2$dMB).</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1222</note>
-      </trans-unit>
-      <trans-unit id="ed6c7c35c51ba299b38e3af151a5ec0f">
-        <source>An error occurred while attempting to associate this image with your shop. </source>
-        <target>An error occurred while attempting to associate this image with your shop.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1462</note>
-      </trans-unit>
-      <trans-unit id="3154baa59f6cfb5bb140601d79f61c84">
-        <source>An error occurred while attempting to move this picture.</source>
-        <target>An error occurred while attempting to move this picture.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1485</note>
-      </trans-unit>
-      <trans-unit id="0b4a86d617393c34bddd4367b84ddb2c">
-        <source>An error occurred while attempting to update the cover picture.</source>
-        <target>An error occurred while attempting to update the cover picture.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1504</note>
-      </trans-unit>
-      <trans-unit id="268b0ba02b8af913a35c543c793a99ef">
-        <source>An error occurred while attempting to delete the product image.</source>
-        <target>An error occurred while attempting to delete the product image.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1544</note>
-      </trans-unit>
-      <trans-unit id="c4e7595c4e8f49c80458997b912d749b">
-        <source>Wrong IDs</source>
-        <target>Wrong IDs</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1551</note>
-      </trans-unit>
-      <trans-unit id="74efb694173710062ae76c1e9949817e">
-        <source>Invalid price/discount amount</source>
-        <target>Invalid price/discount amount</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1553</note>
-      </trans-unit>
-      <trans-unit id="c1169398ceb716e384995717131c9ff7">
-        <source>Please select a discount type (amount or percentage).</source>
-        <target>Please select a discount type (amount or percentage).</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1557</note>
-      </trans-unit>
-      <trans-unit id="78682ae939690325cf8c96e22595c06a">
-        <source>The from/to date is invalid.</source>
-        <target>The from/to date is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1559</note>
-      </trans-unit>
-      <trans-unit id="c24ed8eb6e592f766cd1d31ae49ed5b1">
-        <source>A specific price already exists for these parameters.</source>
-        <target>A specific price already exists for these parameters.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1561</note>
-      </trans-unit>
-      <trans-unit id="fba78cbc51e76234884ba4d6c232bc12">
-        <source>The name for feature %1$s is too long in %2$s.</source>
-        <target>The name for feature %1$s is too long in %2$s.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1588</note>
-      </trans-unit>
-      <trans-unit id="bd43d37e6647d4638a621aa4ccbde2ff">
-        <source>A valid name required for feature. %1$s in %2$s.</source>
-        <target>A valid name required for feature. %1$s in %2$s.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1597</note>
-      </trans-unit>
-      <trans-unit id="0c58058923630a64ce3f415a07cbb00d">
-        <source>An error occurred while adding tags.</source>
-        <target>An error occurred while adding tags.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2332</note>
-      </trans-unit>
-      <trans-unit id="32caa1cdf0ea26b2e1267d45a57beacf">
-        <source>This %1$s field is required at least in %2$s</source>
-        <target>This %1$s field is required at least in %2$s</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2020</note>
-      </trans-unit>
-      <trans-unit id="0e2338b37ab3dfeed544e8233b53d4e0">
-        <source>The %1$s field is too long (%2$d chars max).</source>
-        <target>The %1$s field is too long (%2$d chars max).</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2077</note>
-      </trans-unit>
-      <trans-unit id="95c0b24839f6e4ffe0e395d8d26ce4ee">
-        <source>This %1$s field (%2$s) is too long: %3$d chars max (current count %4$d).</source>
-        <target>This %1$s field (%2$s) is too long: %3$d chars max (current count %4$d).</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2058</note>
-      </trans-unit>
-      <trans-unit id="2ac6fe3cbae5ffcef53a6bdddf888d70">
-        <source>The expiration-date attribute is required.</source>
-        <target>The expiration-date attribute is required.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2234</note>
-      </trans-unit>
-      <trans-unit id="5e2457ed64286c209f67a9333ed52a17">
-        <source>An error occurred while attempting to delete previous tags.</source>
-        <target>An error occurred while attempting to delete previous tags.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2322</note>
-      </trans-unit>
-      <trans-unit id="4177a725868ed37e7de5c8c65f4a8b0e">
-        <source>The selected currency is not valid</source>
-        <target>The selected currency is not valid</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2514</note>
-      </trans-unit>
-      <trans-unit id="48b51a11285fae0b1f416165ae8fd489">
-        <source>An error occurred while copying image, the file does not exist anymore.</source>
-        <target>An error occurred while copying image, the file does not exist anymore.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2824</note>
-      </trans-unit>
-      <trans-unit id="9f26cf683839613815feebc0b1e1c6b9">
-        <source>An error occurred while copying image, the file width is 0px.</source>
-        <target>An error occurred while copying image, the file width is 0px.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2828</note>
-      </trans-unit>
-      <trans-unit id="de880a806b9948f168a2e70fff130160">
-        <source>An error occurred while copying image, check your memory limit.</source>
-        <target>An error occurred while copying image, check your memory limit.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2832</note>
-      </trans-unit>
-      <trans-unit id="06b778accab7c14a499bc6e7a68138ec">
-        <source>An error occurred while copying the image.</source>
-        <target>An error occurred while copying the image.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2836</note>
-      </trans-unit>
-      <trans-unit id="c88e73613e3f68ead933cd57e2828323">
-        <source>You can't add product packs into a pack</source>
-        <target>You can't add product packs into a pack</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:3101</note>
-      </trans-unit>
-      <trans-unit id="5de4038e3ea0841bf6179f99103fcccd">
-        <source>An error occurred while attempting to add products to the pack.</source>
-        <target>An error occurred while attempting to add products to the pack.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:3103</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Product/AdminProductWrapper.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="162c051f703406dd4fab3fde66296a6e">
-        <source>Submitted reduction value (0-100) is out-of-range</source>
-        <target>Submitted reduction value (0-100) is out-of-range</target>
-        <note>Context:
-File: src/Adapter/Product/AdminProductWrapper.php:284</note>
-      </trans-unit>
-      <trans-unit id="9f0a59f1609218c049435abd2351bd84">
-        <source>An error occurred while updating the specific price.</source>
-        <target>An error occurred while updating the specific price.</target>
-        <note>Context:
-File: src/Adapter/Product/AdminProductWrapper.php:336</note>
-      </trans-unit>
-      <trans-unit id="22385bf735f96dbe1a4778d0b0d5345d">
-        <source>No reduction value has been submitted</source>
-        <target>No reduction value has been submitted</target>
-        <note>Context:
-File: src/Adapter/Product/AdminProductWrapper.php:280</note>
-      </trans-unit>
-      <trans-unit id="184a2ae304c9a05459cca0cbf8755b3a">
-        <source>The specific price ID is invalid.</source>
-        <target>The specific price ID is invalid.</target>
-        <note>Context:
-File: src/Adapter/Product/AdminProductWrapper.php:531</note>
-      </trans-unit>
-      <trans-unit id="0f8b5843f1391991d17f744ce9771e98">
-        <source>An error occurred while attempting to delete the specific price.</source>
-        <target>An error occurred while attempting to delete the specific price.</target>
-        <note>Context:
-File: src/Adapter/Product/AdminProductWrapper.php:535</note>
-      </trans-unit>
-      <trans-unit id="c7e56badecce297feefe2a9b50a68794">
-        <source>Invalid date range</source>
-        <target>Invalid date range</target>
-        <note>Context:
-File: src/Adapter/Product/AdminProductWrapper.php:282</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/QqUploadedFileForm.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="608860b0f96a18f3737756fc6b7766f9">
-        <source>Cannot add image because product creation failed.</source>
-        <target>Cannot add image because product creation failed.</target>
-        <note>Context:
-File: classes/QqUploadedFileForm.php:37</note>
-      </trans-unit>
-      <trans-unit id="c200140aea36e1efbf655fabf3f3b59e">
-        <source>Error while creating additional image</source>
-        <target>Error while creating additional image</target>
-        <note>Context:
-File: classes/QqUploadedFileForm.php:62</note>
-      </trans-unit>
-      <trans-unit id="2ddbcf3cd6846f895d2520d0227b7810">
-        <source>Error on image caption: "%1s" is not a valid caption.</source>
-        <target>Error on image caption: "%1s" is not a valid caption.</target>
-        <note>Context:
-File: classes/QqUploadedFileForm.php:48</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="535a56c364d0646b9319bafcb42a1357">
-        <source>The category cannot be moved here.</source>
-        <target>The category cannot be moved here.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:800</note>
-      </trans-unit>
-      <trans-unit id="22d26a77067dac07bf2cfaf501a64870">
-        <source>The category cannot be a parent of itself.</source>
-        <target>The category cannot be a parent of itself.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:803</note>
-      </trans-unit>
-      <trans-unit id="23be63a3d78c7375e59f5965f6ef9efd">
-        <source>Unknown delete mode: %s</source>
-        <target>Unknown delete mode: %s</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:824</note>
-      </trans-unit>
-      <trans-unit id="b50f440e3c9f14988bd0086683e77095">
-        <source>You cannot remove this category because one of your shops uses it as a root category.</source>
-        <target>You cannot remove this category because one of your shops uses it as a root category.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:860</note>
-      </trans-unit>
-      <trans-unit id="1887caa83cfc66cd8ab440cf70eca40b">
-        <source>An error occurred while uploading category image.</source>
-        <target>An error occurred while uploading category image.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:929</note>
-      </trans-unit>
-      <trans-unit id="87a130707b81cc037c9a95e74e7fbf37">
-        <source>An error occurred while uploading thumbnail image.</source>
-        <target>An error occurred while uploading thumbnail image.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:953</note>
-      </trans-unit>
-      <trans-unit id="a874ef298164bbd4d00d55901225cd87">
-        <source>An error occurred while uploading the image:</source>
-        <target>An error occurred while uploading the image:</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:1054</note>
-      </trans-unit>
-      <trans-unit id="b05c3c0bfce943b86e286e8e8103b6e5">
-        <source>An error occurred while uploading the image.</source>
-        <target>An error occurred while uploading the image.</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:1069</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminManufacturersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="60df675f17670057ec657783db03d35e">
-        <source>Unable to resize one or more of your pictures.</source>
-        <target>Unable to resize one or more of your pictures.</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:842</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCartRulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fdf5ec6ad9d20c9985038e5d6521159f">
-        <source>The voucher cannot end before it begins.</source>
-        <target>The voucher cannot end before it begins.</target>
-        <note>Context:
-File: controllers/admin/AdminCartRulesController.php:211</note>
-      </trans-unit>
-      <trans-unit id="5c7f52b03569889081067d1413b5edbd">
-        <source>The minimum amount cannot be lower than zero.</source>
-        <target>The minimum amount cannot be lower than zero.</target>
-        <note>Context:
-File: controllers/admin/AdminCartRulesController.php:214</note>
-      </trans-unit>
-      <trans-unit id="93c331edf337bac96fcbac751a492fe1">
-        <source>Reduction percentage must be between 0% and 100%</source>
-        <target>Reduction percentage must be between 0% and 100%</target>
-        <note>Context:
-File: controllers/admin/AdminCartRulesController.php:217</note>
-      </trans-unit>
-      <trans-unit id="a3ad09e600d30676504b705e29be782d">
-        <source>Reduction amount cannot be lower than zero.</source>
-        <target>Reduction amount cannot be lower than zero.</target>
-        <note>Context:
-File: controllers/admin/AdminCartRulesController.php:220</note>
-      </trans-unit>
-      <trans-unit id="7f5ef3543345170784cc954cffa697d6">
-        <source>This cart rule code is already used (conflict with cart rule %rulename%)</source>
-        <target>This cart rule code is already used (conflict with cart rule %rulename%)</target>
-        <note>Context:
-File: controllers/admin/AdminCartRulesController.php:223</note>
-      </trans-unit>
-      <trans-unit id="bbc6a34f03def2d56def8e7685a3fcae">
-        <source>An action is required for this cart rule.</source>
-        <target>An action is required for this cart rule.</target>
-        <note>Context:
-File: controllers/admin/AdminCartRulesController.php:226</note>
-      </trans-unit>
-      <trans-unit id="b4be93136a337fcef40c9eb87004c9d0">
-        <source>No product has been found.</source>
-        <target>No product has been found.</target>
-        <note>Context:
-File: controllers/admin/AdminCartRulesController.php:585</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminFeaturesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8be9030c26dd464a739bd131dff74336">
-        <source>This feature has been disabled. You can activate it here: %url%.</source>
-        <target>This feature has been disabled. You can activate it here: %url%.</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:442</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cf4f33891a4f0566c7afed3776d55446">
-        <source>List of products without available quantities for sale are not displayed because stock management is disabled.</source>
-        <target>List of products without available quantities for sale are not displayed because stock management is disabled.</target>
-        <note>Context:
-File: controllers/admin/AdminTrackingController.php:65</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSuppliersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="df1124d59279d11c66e179b7c4e6d9e8">
-        <source>You do not have permission to add suppliers.</source>
-        <target>You do not have permission to add suppliers.</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:447</note>
-      </trans-unit>
-      <trans-unit id="216083c0ecc41612e3355db66a1d2042">
-        <source>The address is not correct. Please make sure all of the required fields are completed.</source>
-        <target>The address is not correct. Please make sure all of the required fields are completed.</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:484</note>
-      </trans-unit>
-      <trans-unit id="925c714b657d85c49a9718ef792fcb95">
-        <source>It is not possible to delete a supplier if there are pending supplier orders.</source>
-        <target>It is not possible to delete a supplier if there are pending supplier orders.</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:499</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Order/Delivery/SlipPdfConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="afe2d0e6d792e09a2d3e6fb85a37af94">
-        <source>Invalid 'to' date</source>
-        <target>Invalid 'to' date</target>
-        <note>Context:
-File: src/Adapter/Order/Delivery/SlipPdfConfiguration.php:66</note>
-      </trans-unit>
-      <trans-unit id="32d3b531ad19ea651820651ca9d40d05">
-        <source>Invalid 'from' date</source>
-        <target>Invalid 'from' date</target>
-        <note>Context:
-File: src/Adapter/Order/Delivery/SlipPdfConfiguration.php:74</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cf3905df049698bb01639e4394e82048">
-        <source>It is not possible to delete a combination while it still has some quantities in the Advanced Stock Management. You must delete its stock first.</source>
-        <target>It is not possible to delete a combination while it still has some quantities in the Advanced Stock Management. You must delete its stock first.</target>
-        <note>Context:
-File: src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php:99</note>
-      </trans-unit>
-      <trans-unit id="66108be221251f01430ee5c2257e98ca">
-        <source>Error while deleting the stock</source>
-        <target>Error while deleting the stock</target>
-        <note>Context:
-File: src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php:115</note>
-      </trans-unit>
-      <trans-unit id="7173e38e8a10ed379625687638ddfe74">
-        <source>Successful deletion</source>
-        <target>Successful deletion</target>
-        <note>Context:
-File: src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php:120</note>
-      </trans-unit>
-      <trans-unit id="160f1ab34ecfb437b1767602d5ee093f">
-        <source>You cannot delete this attribute.</source>
-        <target>You cannot delete this attribute.</target>
-        <note>Context:
-File: src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php:127</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Translation/Api/StockApi.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5566045e38ed5e7bb072b8d55f3ceb2f">
-        <source>No product matches your search. Try changing search terms.</source>
-        <target>No product matches your search. Try changing search terms.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:64</note>
-      </trans-unit>
-      <trans-unit id="96d17a8fdea016168a9d506b0da23c07">
-        <source>Stock successfully updated</source>
-        <target>Stock successfully updated</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:66</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8bc6a12d95b969fb603306eab1f0603b">
-        <source>This pack is empty. You must add at least one product item.</source>
-        <target>This pack is empty. You must add at least one product item.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php:304</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cf456ee90912d9e25795925d067f8952">
-        <source>This value is too long. It should have %limit% characters or less.</source>
-        <target>This value is too long. It should have %limit% characters or less.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php:46</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="04f6302b96c8cbaaec71cc884a6626a5">
-        <source>Cannot find specific price %price%</source>
-        <target>Cannot find specific price %price%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php:126</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f4158fa3500ce1523a52bee74971f5f2">
-        <source>Product(s) successfully activated.</source>
-        <target>Product(s) successfully activated.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:714</note>
-      </trans-unit>
-      <trans-unit id="25b325c47f9b5f88d7820b079bafa02e">
-        <source>Product(s) successfully deactivated.</source>
-        <target>Product(s) successfully deactivated.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:739</note>
-      </trans-unit>
-      <trans-unit id="01996897996faf465514bdf1091b6d4d">
-        <source>Product(s) successfully deleted.</source>
-        <target>Product(s) successfully deleted.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:764</note>
-      </trans-unit>
-      <trans-unit id="290ed9aa59dd098c9e112c4f9770407d">
-        <source>Product(s) successfully duplicated.</source>
-        <target>Product(s) successfully duplicated.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:788</note>
-      </trans-unit>
-      <trans-unit id="c1746190e47d69ea7f0db7f098de7cab">
-        <source>Products successfully sorted.</source>
-        <target>Products successfully sorted.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:885</note>
-      </trans-unit>
-      <trans-unit id="7bdb2828f248bbd55bba16dcc63223d9">
-        <source>Product successfully deleted.</source>
-        <target>Product successfully deleted.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:972</note>
-      </trans-unit>
-      <trans-unit id="85d8f7e3038017826a8215396b96865b">
-        <source>Product successfully duplicated.</source>
-        <target>Product successfully duplicated.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:994</note>
-      </trans-unit>
-      <trans-unit id="98434b0cd2f3cf08418ea1f0a9c55f0a">
-        <source>Product successfully activated.</source>
-        <target>Product successfully activated.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:1017</note>
-      </trans-unit>
-      <trans-unit id="fd1d6d9c7d146c9f81572224bae86951">
-        <source>Product successfully deactivated.</source>
-        <target>Product successfully deactivated.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/ProductController.php:1039</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/stock/StockAvailable.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7e4621194575d7804ebfbbafcae9067a">
-        <source>You cannot update the available stock when it depends on stock.</source>
-        <target>You cannot update the available stock when it depends on stock.</target>
-        <note>Context:
-File: classes/stock/StockAvailable.php:108</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/stock/StockManagerModule.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bc6f653d2d54db1348de50fe0b0192e9">
-        <source>Incorrect Stock Manager class [%s]</source>
-        <target>Incorrect Stock Manager class [%s]</target>
-        <note>Context:
-File: classes/stock/StockManagerModule.php:44</note>
-      </trans-unit>
-      <trans-unit id="65d09c7dfa652d616875eddb50c18d2b">
-        <source>Stock Manager class not found [%s]</source>
-        <target>Stock Manager class not found [%s]</target>
-        <note>Context:
-File: classes/stock/StockManagerModule.php:50</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Product.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ffd818d6203d29bd38114292a759cb7d">
-        <source>You cannot set a negative position, the minimum for a position is 0.</source>
-        <target>You cannot set a negative position, the minimum for a position is 0.</target>
-        <note>Context:
-File: classes/Product.php:5961</note>
-      </trans-unit>
-      <trans-unit id="b945599a5e11b76711dad5f1d7eba181">
-        <source>You cannot set a position greater than the total number of products in the category, minus 1 (position numbering starts at 0).</source>
-        <target>You cannot set a position greater than the total number of products in the category, minus 1 (position numbering starts at 0).</target>
-        <note>Context:
-File: classes/Product.php:5970</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fc2c8663d58c42bc29edd45a79b4358c">
-        <source>The discount was successfully generated.</source>
-        <target>The discount was successfully generated.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:484</note>
-      </trans-unit>
-      <trans-unit id="801982917ddd7afd63f9e103ba4699bd">
-        <source>The root category of the shop %shop% is not associated with the current shop. You can't access this page. Please change the root category of the shop.</source>
-        <target>The root category of the shop %shop% is not associated with the current shop. You can't access this page. Please change the root category of the shop.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:490</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/helper/HelperList.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="55ffa325538ec4bd188604c30b29a168">
-        <source>This will copy the images too. If you wish to proceed, click "Yes". If not, click "No".</source>
-        <target>This will copy the images too. If you wish to proceed, click "Yes". If not, click "No".</target>
-        <note>Context:
-File: classes/helper/HelperList.php:394</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b385b71f1d14c0afa6d7ca6cb18927b3">
-        <source>There is no attachment yet.</source>
-        <target>There is no attachment yet.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig:352</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="90094f8ca4b0c893b2f7aef48fd2e73e">
-        <source>Duplication in progress...</source>
-        <target>Duplication in progress...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:116</note>
-      </trans-unit>
-      <trans-unit id="1c4a67678ffecd99e46e9686e3639789">
-        <source>Duplication failed.</source>
-        <target>Duplication failed.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:118</note>
-      </trans-unit>
-      <trans-unit id="e927fc858b3eccca1323ed79add38ed6">
-        <source>Activation in progress...</source>
-        <target>Activation in progress...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:138</note>
-      </trans-unit>
-      <trans-unit id="0eb7963a4b19bb1a361d2dfb0ef13ccf">
-        <source>Activation failed.</source>
-        <target>Activation failed.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:140</note>
-      </trans-unit>
-      <trans-unit id="58b01b30d683cbdb393f9ede59bdb697">
-        <source>Deactivation in progress...</source>
-        <target>Deactivation in progress...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:160</note>
-      </trans-unit>
-      <trans-unit id="036a5e2d815eaa9bddaebf0c12f94e17">
-        <source>Deactivation failed.</source>
-        <target>Deactivation failed.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:162</note>
-      </trans-unit>
-      <trans-unit id="557c57932d4eb9b108efcf050b9db862">
-        <source>Deletion in progress...</source>
-        <target>Deletion in progress...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:182</note>
-      </trans-unit>
-      <trans-unit id="51d0bf7f10d8d28ecd64d2aa3a5ca141">
-        <source>Deletion failed.</source>
-        <target>Deletion failed.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:184</note>
-      </trans-unit>
-      <trans-unit id="fc483403c3f9b9aa31a570b83cdfa6f3">
-        <source>Duplicating products</source>
-        <target>Duplicating products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:106</note>
-      </trans-unit>
-      <trans-unit id="34202dac3bbd97da03f56d3b2cf1386b">
-        <source>Duplicating...</source>
-        <target>Duplicating...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:110</note>
-      </trans-unit>
-      <trans-unit id="6d7447cf0c9efdaeb3a700de594a70cf">
-        <source>Activating products</source>
-        <target>Activating products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:128</note>
-      </trans-unit>
-      <trans-unit id="b850e16adbf88a6b6cb724630eff2c97">
-        <source>Activating...</source>
-        <target>Activating...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:132</note>
-      </trans-unit>
-      <trans-unit id="c1714105baaadc64c8e502f13ca10988">
-        <source>Deactivating products</source>
-        <target>Deactivating products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:150</note>
-      </trans-unit>
-      <trans-unit id="fe38be28e7e43dc0fb4c4d7ca1d60f90">
-        <source>Deactivating...</source>
-        <target>Deactivating...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:154</note>
-      </trans-unit>
-      <trans-unit id="ccfc7b0a56346cdac7fd40d2edd01c5a">
-        <source>Deleting products</source>
-        <target>Deleting products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:172</note>
-      </trans-unit>
-      <trans-unit id="1294e8c29fb59da902198447bd9a256c">
-        <source>Deleting...</source>
-        <target>Deleting...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:176</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list_quicknav.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1aa1527fa7dfdbe44acb4be33af88e4c">
-        <source>There is no result for this search. Update your filters to view other products.</source>
-        <target>There is no result for this search. Update your filters to view other products.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list_quicknav.html.twig:78</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/disabled_form_alert.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e1cc7a5b4545de2fa898ab70a12e2d54">
-        <source>You can't add or edit a product in this shop context: select a shop instead of a group of shops.</source>
-        <target>You can't add or edit a product in this shop context: select a shop instead of a group of shops.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/disabled_form_alert.html.twig:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9909f0bb3eb94634e3f8cd0164dbacac">
-        <source>You are in a multistore context: any modification will impact all your shops, or each shop of the active group.</source>
-        <target>You are in a multistore context: any modification will impact all your shops, or each shop of the active group.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1b89ef639dabfd2f6eb19886f7c9f8c8">
-        <source>This will delete all the combinations. Do you wish to proceed?</source>
-        <target>This will delete all the combinations. Do you wish to proceed?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:330</note>
-      </trans-unit>
-      <trans-unit id="ff8a012ee6cba99838a649d92ad1b34b">
-        <source>This will delete the specific price. Do you wish to proceed?</source>
-        <target>This will delete the specific price. Do you wish to proceed?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:344</note>
-      </trans-unit>
-      <trans-unit id="dfd19ad4f089996c7eabcd5935f75e98">
-        <source>A pack of products can't have combinations.</source>
-        <target>A pack of products can't have combinations.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:350</note>
-      </trans-unit>
-      <trans-unit id="5b75fdc0df647e8ac5275e31554dd0f9">
-        <source>A virtual product can't have combinations.</source>
-        <target>A virtual product can't have combinations.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:351</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d80ebf39e80e164a170987dcd4212136">
-        <source>When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.</source>
-        <target>When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig:159</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c292d80ff15bf0d38f63af320f9f7839">
-        <source>Friendly URLs are currently disabled.</source>
-        <target>Friendly URLs are currently disabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:77</note>
-      </trans-unit>
-      <trans-unit id="517937df76770fb3c4f9e6100ed69ce9">
-        <source>To enable it, go to [1]SEO and URLs[/1]</source>
-        <target>To enable it, go to [1]SEO and URLs[/1]</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:78</note>
-      </trans-unit>
-      <trans-unit id="9bbbc84f839137c71e79f1b8eaafc5b7">
-        <source>Friendly URLs are currently enabled.</source>
-        <target>Friendly URLs are currently enabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:80</note>
-      </trans-unit>
-      <trans-unit id="2d1df068fb2a9a3c4d9e3c361795c59c">
-        <source>To disable it, go to [1]SEO and URLs[/1]</source>
-        <target>To disable it, go to [1]SEO and URLs[/1]</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:81</note>
-      </trans-unit>
-      <trans-unit id="d7e9bf98e857f83943b3b75fce04cea9">
-        <source>The "Force update of friendly URL" option is currently enabled.</source>
-        <target>The "Force update of friendly URL" option is currently enabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:86</note>
-      </trans-unit>
-      <trans-unit id="87ffb4b96479e24281064ad98ddfd16f">
-        <source>To disable it, go to [1]Product Settings[/1]</source>
-        <target>To disable it, go to [1]Product Settings[/1]</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig:88</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d6df5e0f6b6204bece3852c0817420e9">
-        <source>If no carrier is selected then all the carriers will be available for customers orders.</source>
-        <target>If no carrier is selected then all the carriers will be available for customers orders.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig:148</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8597e9c43b2587a888fee6b31dad5335">
-        <source>You can't manage your stock in this shop context: select a shop instead of a group of shops.</source>
-        <target>You can't manage your stock in this shop context: select a shop instead of a group of shops.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig:35</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/cart_rules/actions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="e602c06958cd934ccc238913f51282aa">
         <source>You must select some products before</source>
         <target>You must select some products before</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:125</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4c473ee3c2de78ecaf8a5f6ce24d9b24">
-        <source>No address has been found for this brand.</source>
-        <target>No address has been found for this brand.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl:32</note>
+        <note>Line: 125</note>
       </trans-unit>
     </body>
   </file>
@@ -1113,44 +14,976 @@ File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/v
       <trans-unit id="4f11b2e8a220dab912231e74a3dfea5d">
         <source>What do you want to do with the products associated with this category?</source>
         <target>What do you want to do with the products associated with this category?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/categories/helpers/list/list_header.tpl:60</note>
+        <note>Line: 60</note>
       </trans-unit>
       <trans-unit id="f6ec5c96d6a80dad29c231e53aba0b69">
         <source>Deleting multiple categories</source>
         <target>Deleting multiple categories</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/categories/helpers/list/list_header.tpl:62</note>
+        <note>Line: 62</note>
       </trans-unit>
       <trans-unit id="764d0e955d240f946ceac8bfd3f9a83b">
         <source>I want to associate the products without other categories to the parent category, then disable these products for now. I re-enable them when they are moved in their new category.</source>
         <target>I want to associate the products without other categories to the parent category, then disable these products for now. I re-enable them when they are moved in their new category.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/categories/helpers/list/list_header.tpl:70</note>
+        <note>Line: 70</note>
       </trans-unit>
       <trans-unit id="fe8da1bad19e3e82de7c76c99c53cb27">
         <source>(Recommended)</source>
         <target>(Recommended)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/categories/helpers/list/list_header.tpl:70</note>
+        <note>Line: 70</note>
       </trans-unit>
       <trans-unit id="a9a433336c261a84c4375331e7c847a8">
         <source>I want to associate the products without other categories to the parent category, and keep them enabled.</source>
         <target>I want to associate the products without other categories to the parent category, and keep them enabled.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/categories/helpers/list/list_header.tpl:76</note>
+        <note>Line: 76</note>
       </trans-unit>
       <trans-unit id="b994ed2b38e35d32b51f5589794b2109">
         <source>I want to remove the products which are listed only within this category and no others.</source>
         <target>I want to remove the products which are listed only within this category and no others.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/categories/helpers/list/list_header.tpl:82</note>
+        <note>Line: 82</note>
       </trans-unit>
       <trans-unit id="6ee5d2b90cedb3573844f84c25ba194f">
         <source>Deleting this category will remove products linked only within this category and no others. Are you sure you want to continue?</source>
         <target>Deleting this category will remove products linked only within this category and no others. Are you sure you want to continue?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/categories/helpers/list/list_header.tpl:86</note>
+        <note>Line: 86</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4c473ee3c2de78ecaf8a5f6ce24d9b24">
+        <source>No address has been found for this brand.</source>
+        <target>No address has been found for this brand.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Product.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ffd818d6203d29bd38114292a759cb7d">
+        <source>You cannot set a negative position, the minimum for a position is 0.</source>
+        <target>You cannot set a negative position, the minimum for a position is 0.</target>
+        <note>Line: 5961</note>
+      </trans-unit>
+      <trans-unit id="b945599a5e11b76711dad5f1d7eba181">
+        <source>You cannot set a position greater than the total number of products in the category, minus 1 (position numbering starts at 0).</source>
+        <target>You cannot set a position greater than the total number of products in the category, minus 1 (position numbering starts at 0).</target>
+        <note>Line: 5970</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/QqUploadedFileForm.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2ddbcf3cd6846f895d2520d0227b7810">
+        <source>Error on image caption: "%1s" is not a valid caption.</source>
+        <target>Error on image caption: "%1s" is not a valid caption.</target>
+        <note>Line: 48</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fc2c8663d58c42bc29edd45a79b4358c">
+        <source>The discount was successfully generated.</source>
+        <target>The discount was successfully generated.</target>
+        <note>Line: 484</note>
+      </trans-unit>
+      <trans-unit id="801982917ddd7afd63f9e103ba4699bd">
+        <source>The root category of the shop %shop% is not associated with the current shop. You can't access this page. Please change the root category of the shop.</source>
+        <target>The root category of the shop %shop% is not associated with the current shop. You can't access this page. Please change the root category of the shop.</target>
+        <note>Line: 490</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/helper/HelperList.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="55ffa325538ec4bd188604c30b29a168">
+        <source>This will copy the images too. If you wish to proceed, click "Yes". If not, click "No".</source>
+        <target>This will copy the images too. If you wish to proceed, click "Yes". If not, click "No".</target>
+        <note>Line: 394</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/stock/StockAvailable.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7e4621194575d7804ebfbbafcae9067a">
+        <source>You cannot update the available stock when it depends on stock.</source>
+        <target>You cannot update the available stock when it depends on stock.</target>
+        <note>Line: 108</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/stock/StockManagerModule.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bc6f653d2d54db1348de50fe0b0192e9">
+        <source>Incorrect Stock Manager class [%s]</source>
+        <target>Incorrect Stock Manager class [%s]</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="65d09c7dfa652d616875eddb50c18d2b">
+        <source>Stock Manager class not found [%s]</source>
+        <target>Stock Manager class not found [%s]</target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttachmentsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="935b31f32421029fb633ead151d69d83">
+        <source>This file is associated with the following products, do you really want to  delete it?</source>
+        <target>This file is associated with the following products, do you really want to  delete it?</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="5251010ec9e364492c236bf8b9983928">
+        <source>File not found</source>
+        <target>File not found</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="8a23b9ee3a4502a0de3fc32c5ba7aa65">
+        <source>Failed to copy the file.</source>
+        <target>Failed to copy the file.</target>
+        <note>Line: 232</note>
+      </trans-unit>
+      <trans-unit id="8cb9da8e2fc65153510e4a067af0b32c">
+        <source>The file %file% exceeds the size allowed by the server. The limit is set to %size% MB.</source>
+        <target>The file %file% exceeds the size allowed by the server. The limit is set to %size% MB.</target>
+        <note>Line: 246</note>
+      </trans-unit>
+      <trans-unit id="d647666a6c4cef994b4fa1a540ba4481">
+        <source>Upload error. Please check your server configurations for the maximum upload size allowed.</source>
+        <target>Upload error. Please check your server configurations for the maximum upload size allowed.</target>
+        <note>Line: 250</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttributeGeneratorController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1ef611e55a4e10ff65c1e64f962281c8">
+        <source>Please select at least one attribute.</source>
+        <target>Please select at least one attribute.</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="6e89fd17c196488cfac8e63ec415d65f">
+        <source>Unable to initialize these parameters. A combination is missing or an object cannot be loaded.</source>
+        <target>Unable to initialize these parameters. A combination is missing or an object cannot be loaded.</target>
+        <note>Line: 171</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="815e471ea2970db0b63b9b09feacc70f">
+        <source>An error occurred while updating the status for an object.</source>
+        <target>An error occurred while updating the status for an object.</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="77ae44aa6c998166fcf1a87496278ad5">
+        <source>(cannot load object)</source>
+        <target>(cannot load object)</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="caecb49a7eec394177d054db34995bc0">
+        <source>The attribute value "%1$s" already exist for %2$s language</source>
+        <target>The attribute value "%1$s" already exist for %2$s language</target>
+        <note>Line: 411</note>
+      </trans-unit>
+      <trans-unit id="7f7cd1de48a84bc7ba0dfcde99de2604">
+        <source>Failed to delete the attribute.</source>
+        <target>Failed to delete the attribute.</target>
+        <note>Line: 767</note>
+      </trans-unit>
+      <trans-unit id="de2a79b3b161c486acb8f80861cd107c">
+        <source>This feature has been disabled. You can activate it here: %link%.</source>
+        <target>This feature has been disabled. You can activate it here: %link%.</target>
+        <note>Line: 502</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCartRulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fdf5ec6ad9d20c9985038e5d6521159f">
+        <source>The voucher cannot end before it begins.</source>
+        <target>The voucher cannot end before it begins.</target>
+        <note>Line: 211</note>
+      </trans-unit>
+      <trans-unit id="5c7f52b03569889081067d1413b5edbd">
+        <source>The minimum amount cannot be lower than zero.</source>
+        <target>The minimum amount cannot be lower than zero.</target>
+        <note>Line: 214</note>
+      </trans-unit>
+      <trans-unit id="93c331edf337bac96fcbac751a492fe1">
+        <source>Reduction percentage must be between 0% and 100%</source>
+        <target>Reduction percentage must be between 0% and 100%</target>
+        <note>Line: 217</note>
+      </trans-unit>
+      <trans-unit id="a3ad09e600d30676504b705e29be782d">
+        <source>Reduction amount cannot be lower than zero.</source>
+        <target>Reduction amount cannot be lower than zero.</target>
+        <note>Line: 220</note>
+      </trans-unit>
+      <trans-unit id="7f5ef3543345170784cc954cffa697d6">
+        <source>This cart rule code is already used (conflict with cart rule %rulename%)</source>
+        <target>This cart rule code is already used (conflict with cart rule %rulename%)</target>
+        <note>Line: 223</note>
+      </trans-unit>
+      <trans-unit id="bbc6a34f03def2d56def8e7685a3fcae">
+        <source>An action is required for this cart rule.</source>
+        <target>An action is required for this cart rule.</target>
+        <note>Line: 226</note>
+      </trans-unit>
+      <trans-unit id="b4be93136a337fcef40c9eb87004c9d0">
+        <source>No product has been found.</source>
+        <target>No product has been found.</target>
+        <note>Line: 585</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c1a4c1b929c4f5c81f80ece2d7b196aa">
+        <source>Invalid product</source>
+        <target>Invalid product</target>
+        <note>Line: 456</note>
+      </trans-unit>
+      <trans-unit id="e5b55dc69d10c8673f9d5db587591526">
+        <source>Invalid combination</source>
+        <target>Invalid combination</target>
+        <note>Line: 373</note>
+      </trans-unit>
+      <trans-unit id="7cc92687130ea12abb80556681538001">
+        <source>An error occurred during the image upload process.</source>
+        <target>An error occurred during the image upload process.</target>
+        <note>Line: 429</note>
+      </trans-unit>
+      <trans-unit id="b164de93448b61c61dd1c0f68c2c5884">
+        <source>An order has already been placed with this cart.</source>
+        <target>An order has already been placed with this cart.</target>
+        <note>Line: 454</note>
+      </trans-unit>
+      <trans-unit id="2cb44aa56605e05e0b912131875edcb7">
+        <source>There are not enough products in stock.</source>
+        <target>There are not enough products in stock.</target>
+        <note>Line: 468</note>
+      </trans-unit>
+      <trans-unit id="89ecb554b799211aca0441e691419963">
+        <source>This product cannot be added to the cart.</source>
+        <target>This product cannot be added to the cart.</target>
+        <note>Line: 475</note>
+      </trans-unit>
+      <trans-unit id="de10fc28511b894f704c1a67fcff7b4f">
+        <source>You already have the maximum quantity available for this product.</source>
+        <target>You already have the maximum quantity available for this product.</target>
+        <note>Line: 487</note>
+      </trans-unit>
+      <trans-unit id="fac7c1f73a2c97252e59cac143ae1930">
+        <source>Invalid voucher.</source>
+        <target>Invalid voucher.</target>
+        <note>Line: 630</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="535a56c364d0646b9319bafcb42a1357">
+        <source>The category cannot be moved here.</source>
+        <target>The category cannot be moved here.</target>
+        <note>Line: 800</note>
+      </trans-unit>
+      <trans-unit id="22d26a77067dac07bf2cfaf501a64870">
+        <source>The category cannot be a parent of itself.</source>
+        <target>The category cannot be a parent of itself.</target>
+        <note>Line: 803</note>
+      </trans-unit>
+      <trans-unit id="23be63a3d78c7375e59f5965f6ef9efd">
+        <source>Unknown delete mode: %s</source>
+        <target>Unknown delete mode: %s</target>
+        <note>Line: 824</note>
+      </trans-unit>
+      <trans-unit id="b50f440e3c9f14988bd0086683e77095">
+        <source>You cannot remove this category because one of your shops uses it as a root category.</source>
+        <target>You cannot remove this category because one of your shops uses it as a root category.</target>
+        <note>Line: 860</note>
+      </trans-unit>
+      <trans-unit id="1887caa83cfc66cd8ab440cf70eca40b">
+        <source>An error occurred while uploading category image.</source>
+        <target>An error occurred while uploading category image.</target>
+        <note>Line: 929</note>
+      </trans-unit>
+      <trans-unit id="87a130707b81cc037c9a95e74e7fbf37">
+        <source>An error occurred while uploading thumbnail image.</source>
+        <target>An error occurred while uploading thumbnail image.</target>
+        <note>Line: 953</note>
+      </trans-unit>
+      <trans-unit id="a874ef298164bbd4d00d55901225cd87">
+        <source>An error occurred while uploading the image:</source>
+        <target>An error occurred while uploading the image:</target>
+        <note>Line: 1054</note>
+      </trans-unit>
+      <trans-unit id="b05c3c0bfce943b86e286e8e8103b6e5">
+        <source>An error occurred while uploading the image.</source>
+        <target>An error occurred while uploading the image.</target>
+        <note>Line: 1069</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminFeaturesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8be9030c26dd464a739bd131dff74336">
+        <source>This feature has been disabled. You can activate it here: %url%.</source>
+        <target>This feature has been disabled. You can activate it here: %url%.</target>
+        <note>Line: 442</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminManufacturersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="60df675f17670057ec657783db03d35e">
+        <source>Unable to resize one or more of your pictures.</source>
+        <target>Unable to resize one or more of your pictures.</target>
+        <note>Line: 844</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminProductsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="01816dd287bcb3b88ad3f63970ce045f">
+        <source>Invalid quantity</source>
+        <target>Invalid quantity</target>
+        <note>Line: 1555</note>
+      </trans-unit>
+      <trans-unit id="99a6e6a05b8d706aeddf480c7e492949">
+        <source>Invalid description for %s language</source>
+        <target>Invalid description for %s language</target>
+        <note>Line: 428</note>
+      </trans-unit>
+      <trans-unit id="f19434225ce7712f091bcfc109413732">
+        <source>An attachment name is required.</source>
+        <target>An attachment name is required.</target>
+        <note>Line: 433</note>
+      </trans-unit>
+      <trans-unit id="34a22d134d958abd17afd6e6cd8b79e2">
+        <source>This attachment was unable to be loaded into the database.</source>
+        <target>This attachment was unable to be loaded into the database.</target>
+        <note>Line: 484</note>
+      </trans-unit>
+      <trans-unit id="64985418ce04cf0225e600592044206c">
+        <source>We were unable to associate this attachment to a product.</source>
+        <target>We were unable to associate this attachment to a product.</target>
+        <note>Line: 491</note>
+      </trans-unit>
+      <trans-unit id="c8632adcab64537747393f4d0d5d77ac">
+        <source>An error occurred while saving product attachments.</source>
+        <target>An error occurred while saving product attachments.</target>
+        <note>Line: 513</note>
+      </trans-unit>
+      <trans-unit id="da9f3aa8f8a01d2d7602ded33febacc7">
+        <source>You cannot delete this product because there is physical stock left.</source>
+        <target>You cannot delete this product because there is physical stock left.</target>
+        <note>Line: 585</note>
+      </trans-unit>
+      <trans-unit id="838f6e1109a673896b448d9fb46dea57">
+        <source>You cannot change the product's cover image.</source>
+        <target>You cannot change the product's cover image.</target>
+        <note>Line: 623</note>
+      </trans-unit>
+      <trans-unit id="b351af3dd276d0cac6594897a392e676">
+        <source>The image could not be found. </source>
+        <target>The image could not be found.</target>
+        <note>Line: 636</note>
+      </trans-unit>
+      <trans-unit id="8df641fea3a5b1d0f8318ce97ecd0fd7">
+        <source>You cannot delete the product #%d because there is physical stock left.</source>
+        <target>You cannot delete the product #%d because there is physical stock left.</target>
+        <note>Line: 675</note>
+      </trans-unit>
+      <trans-unit id="043432664c5abe8a28c4e7ad7191bccf">
+        <source>The price attribute is required.</source>
+        <target>The price attribute is required.</target>
+        <note>Line: 715</note>
+      </trans-unit>
+      <trans-unit id="251db6b140bc5b3adcbe0c5efadb3c7d">
+        <source>You must add at least one attribute.</source>
+        <target>You must add at least one attribute.</target>
+        <note>Line: 718</note>
+      </trans-unit>
+      <trans-unit id="e22a6ea51eb74bee7acaa4acf2846c7b">
+        <source>This combination already exists.</source>
+        <target>This combination already exists.</target>
+        <note>Line: 798</note>
+      </trans-unit>
+      <trans-unit id="0e461384b2f94dcd87f56a8a178fe768">
+        <source>A product must be created before adding features.</source>
+        <target>A product must be created before adding features.</target>
+        <note>Line: 891</note>
+      </trans-unit>
+      <trans-unit id="def4acf542de55ba41c7b7fde82bd5b6">
+        <source>Please specify priorities.</source>
+        <target>Please specify priorities.</target>
+        <note>Line: 1035</note>
+      </trans-unit>
+      <trans-unit id="23a15a97117c9d55d4ebda9373c8e45a">
+        <source>An error occurred while updating priorities.</source>
+        <target>An error occurred while updating priorities.</target>
+        <note>Line: 1038</note>
+      </trans-unit>
+      <trans-unit id="ce30da82a4a6b974c18780af4597c8ee">
+        <source>An error occurred while setting priorities.</source>
+        <target>An error occurred while setting priorities.</target>
+        <note>Line: 1043</note>
+      </trans-unit>
+      <trans-unit id="f100c143763d1b027a3e4cb77df9d1b7">
+        <source>An error occurred while creating customization fields.</source>
+        <target>An error occurred while creating customization fields.</target>
+        <note>Line: 1065</note>
+      </trans-unit>
+      <trans-unit id="d26c7c2a8aa5a3c082d8e710f796b918">
+        <source>An error occurred while updating customization fields.</source>
+        <target>An error occurred while updating customization fields.</target>
+        <note>Line: 1085</note>
+      </trans-unit>
+      <trans-unit id="c22861f3c2065a12f51c5f1fb2f83b54">
+        <source>An error occurred while updating the custom configuration.</source>
+        <target>An error occurred while updating the custom configuration.</target>
+        <note>Line: 1072</note>
+      </trans-unit>
+      <trans-unit id="6813b553c2718f4bf293d84d8193e6ea">
+        <source>The label fields defined are invalid.</source>
+        <target>The label fields defined are invalid.</target>
+        <note>Line: 1081</note>
+      </trans-unit>
+      <trans-unit id="c99e8eb97ae8f12508cfd24d1083b8d7">
+        <source>A product must be created before adding customization.</source>
+        <target>A product must be created before adding customization.</target>
+        <note>Line: 1091</note>
+      </trans-unit>
+      <trans-unit id="1697ca7c85db2a8aefb7190bc6d60b96">
+        <source>The uploaded file exceeds the "Maximum size for a downloadable product" set in preferences (%1$dMB) or the post_max_size/ directive in php.ini (%2$dMB).</source>
+        <target>The uploaded file exceeds the "Maximum size for a downloadable product" set in preferences (%1$dMB) or the post_max_size/ directive in php.ini (%2$dMB).</target>
+        <note>Line: 1222</note>
+      </trans-unit>
+      <trans-unit id="ed6c7c35c51ba299b38e3af151a5ec0f">
+        <source>An error occurred while attempting to associate this image with your shop. </source>
+        <target>An error occurred while attempting to associate this image with your shop.</target>
+        <note>Line: 1462</note>
+      </trans-unit>
+      <trans-unit id="3154baa59f6cfb5bb140601d79f61c84">
+        <source>An error occurred while attempting to move this picture.</source>
+        <target>An error occurred while attempting to move this picture.</target>
+        <note>Line: 1485</note>
+      </trans-unit>
+      <trans-unit id="0b4a86d617393c34bddd4367b84ddb2c">
+        <source>An error occurred while attempting to update the cover picture.</source>
+        <target>An error occurred while attempting to update the cover picture.</target>
+        <note>Line: 1504</note>
+      </trans-unit>
+      <trans-unit id="268b0ba02b8af913a35c543c793a99ef">
+        <source>An error occurred while attempting to delete the product image.</source>
+        <target>An error occurred while attempting to delete the product image.</target>
+        <note>Line: 1544</note>
+      </trans-unit>
+      <trans-unit id="c4e7595c4e8f49c80458997b912d749b">
+        <source>Wrong IDs</source>
+        <target>Wrong IDs</target>
+        <note>Line: 1551</note>
+      </trans-unit>
+      <trans-unit id="74efb694173710062ae76c1e9949817e">
+        <source>Invalid price/discount amount</source>
+        <target>Invalid price/discount amount</target>
+        <note>Line: 1553</note>
+      </trans-unit>
+      <trans-unit id="c1169398ceb716e384995717131c9ff7">
+        <source>Please select a discount type (amount or percentage).</source>
+        <target>Please select a discount type (amount or percentage).</target>
+        <note>Line: 1557</note>
+      </trans-unit>
+      <trans-unit id="78682ae939690325cf8c96e22595c06a">
+        <source>The from/to date is invalid.</source>
+        <target>The from/to date is invalid.</target>
+        <note>Line: 1559</note>
+      </trans-unit>
+      <trans-unit id="c24ed8eb6e592f766cd1d31ae49ed5b1">
+        <source>A specific price already exists for these parameters.</source>
+        <target>A specific price already exists for these parameters.</target>
+        <note>Line: 1561</note>
+      </trans-unit>
+      <trans-unit id="fba78cbc51e76234884ba4d6c232bc12">
+        <source>The name for feature %1$s is too long in %2$s.</source>
+        <target>The name for feature %1$s is too long in %2$s.</target>
+        <note>Line: 1588</note>
+      </trans-unit>
+      <trans-unit id="bd43d37e6647d4638a621aa4ccbde2ff">
+        <source>A valid name required for feature. %1$s in %2$s.</source>
+        <target>A valid name required for feature. %1$s in %2$s.</target>
+        <note>Line: 1597</note>
+      </trans-unit>
+      <trans-unit id="0c58058923630a64ce3f415a07cbb00d">
+        <source>An error occurred while adding tags.</source>
+        <target>An error occurred while adding tags.</target>
+        <note>Line: 2332</note>
+      </trans-unit>
+      <trans-unit id="32caa1cdf0ea26b2e1267d45a57beacf">
+        <source>This %1$s field is required at least in %2$s</source>
+        <target>This %1$s field is required at least in %2$s</target>
+        <note>Line: 2020</note>
+      </trans-unit>
+      <trans-unit id="0e2338b37ab3dfeed544e8233b53d4e0">
+        <source>The %1$s field is too long (%2$d chars max).</source>
+        <target>The %1$s field is too long (%2$d chars max).</target>
+        <note>Line: 2077</note>
+      </trans-unit>
+      <trans-unit id="95c0b24839f6e4ffe0e395d8d26ce4ee">
+        <source>This %1$s field (%2$s) is too long: %3$d chars max (current count %4$d).</source>
+        <target>This %1$s field (%2$s) is too long: %3$d chars max (current count %4$d).</target>
+        <note>Line: 2058</note>
+      </trans-unit>
+      <trans-unit id="2ac6fe3cbae5ffcef53a6bdddf888d70">
+        <source>The expiration-date attribute is required.</source>
+        <target>The expiration-date attribute is required.</target>
+        <note>Line: 2234</note>
+      </trans-unit>
+      <trans-unit id="5e2457ed64286c209f67a9333ed52a17">
+        <source>An error occurred while attempting to delete previous tags.</source>
+        <target>An error occurred while attempting to delete previous tags.</target>
+        <note>Line: 2322</note>
+      </trans-unit>
+      <trans-unit id="4177a725868ed37e7de5c8c65f4a8b0e">
+        <source>The selected currency is not valid</source>
+        <target>The selected currency is not valid</target>
+        <note>Line: 2514</note>
+      </trans-unit>
+      <trans-unit id="48b51a11285fae0b1f416165ae8fd489">
+        <source>An error occurred while copying image, the file does not exist anymore.</source>
+        <target>An error occurred while copying image, the file does not exist anymore.</target>
+        <note>Line: 2824</note>
+      </trans-unit>
+      <trans-unit id="9f26cf683839613815feebc0b1e1c6b9">
+        <source>An error occurred while copying image, the file width is 0px.</source>
+        <target>An error occurred while copying image, the file width is 0px.</target>
+        <note>Line: 2828</note>
+      </trans-unit>
+      <trans-unit id="de880a806b9948f168a2e70fff130160">
+        <source>An error occurred while copying image, check your memory limit.</source>
+        <target>An error occurred while copying image, check your memory limit.</target>
+        <note>Line: 2832</note>
+      </trans-unit>
+      <trans-unit id="06b778accab7c14a499bc6e7a68138ec">
+        <source>An error occurred while copying the image.</source>
+        <target>An error occurred while copying the image.</target>
+        <note>Line: 2836</note>
+      </trans-unit>
+      <trans-unit id="c88e73613e3f68ead933cd57e2828323">
+        <source>You can't add product packs into a pack</source>
+        <target>You can't add product packs into a pack</target>
+        <note>Line: 3101</note>
+      </trans-unit>
+      <trans-unit id="5de4038e3ea0841bf6179f99103fcccd">
+        <source>An error occurred while attempting to add products to the pack.</source>
+        <target>An error occurred while attempting to add products to the pack.</target>
+        <note>Line: 3103</note>
+      </trans-unit>
+      <trans-unit id="608860b0f96a18f3737756fc6b7766f9">
+        <source>Cannot add image because product creation failed.</source>
+        <target>Cannot add image because product creation failed.</target>
+        <note>Line: 2779</note>
+      </trans-unit>
+      <trans-unit id="c200140aea36e1efbf655fabf3f3b59e">
+        <source>Error while creating additional image</source>
+        <target>Error while creating additional image</target>
+        <note>Line: 2812</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSuppliersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df1124d59279d11c66e179b7c4e6d9e8">
+        <source>You do not have permission to add suppliers.</source>
+        <target>You do not have permission to add suppliers.</target>
+        <note>Line: 447</note>
+      </trans-unit>
+      <trans-unit id="216083c0ecc41612e3355db66a1d2042">
+        <source>The address is not correct. Please make sure all of the required fields are completed.</source>
+        <target>The address is not correct. Please make sure all of the required fields are completed.</target>
+        <note>Line: 484</note>
+      </trans-unit>
+      <trans-unit id="925c714b657d85c49a9718ef792fcb95">
+        <source>It is not possible to delete a supplier if there are pending supplier orders.</source>
+        <target>It is not possible to delete a supplier if there are pending supplier orders.</target>
+        <note>Line: 499</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cf4f33891a4f0566c7afed3776d55446">
+        <source>List of products without available quantities for sale are not displayed because stock management is disabled.</source>
+        <target>List of products without available quantities for sale are not displayed because stock management is disabled.</target>
+        <note>Line: 65</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cf3905df049698bb01639e4394e82048">
+        <source>It is not possible to delete a combination while it still has some quantities in the Advanced Stock Management. You must delete its stock first.</source>
+        <target>It is not possible to delete a combination while it still has some quantities in the Advanced Stock Management. You must delete its stock first.</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="66108be221251f01430ee5c2257e98ca">
+        <source>Error while deleting the stock</source>
+        <target>Error while deleting the stock</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="7173e38e8a10ed379625687638ddfe74">
+        <source>Successful deletion</source>
+        <target>Successful deletion</target>
+        <note>Line: 120</note>
+      </trans-unit>
+      <trans-unit id="160f1ab34ecfb437b1767602d5ee093f">
+        <source>You cannot delete this attribute.</source>
+        <target>You cannot delete this attribute.</target>
+        <note>Line: 127</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Order/Delivery/SlipPdfConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="afe2d0e6d792e09a2d3e6fb85a37af94">
+        <source>Invalid 'to' date</source>
+        <target>Invalid 'to' date</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="32d3b531ad19ea651820651ca9d40d05">
+        <source>Invalid 'from' date</source>
+        <target>Invalid 'from' date</target>
+        <note>Line: 74</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Product/AdminProductWrapper.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="162c051f703406dd4fab3fde66296a6e">
+        <source>Submitted reduction value (0-100) is out-of-range</source>
+        <target>Submitted reduction value (0-100) is out-of-range</target>
+        <note>Line: 284</note>
+      </trans-unit>
+      <trans-unit id="9f0a59f1609218c049435abd2351bd84">
+        <source>An error occurred while updating the specific price.</source>
+        <target>An error occurred while updating the specific price.</target>
+        <note>Line: 336</note>
+      </trans-unit>
+      <trans-unit id="22385bf735f96dbe1a4778d0b0d5345d">
+        <source>No reduction value has been submitted</source>
+        <target>No reduction value has been submitted</target>
+        <note>Line: 280</note>
+      </trans-unit>
+      <trans-unit id="184a2ae304c9a05459cca0cbf8755b3a">
+        <source>The specific price ID is invalid.</source>
+        <target>The specific price ID is invalid.</target>
+        <note>Line: 531</note>
+      </trans-unit>
+      <trans-unit id="0f8b5843f1391991d17f744ce9771e98">
+        <source>An error occurred while attempting to delete the specific price.</source>
+        <target>An error occurred while attempting to delete the specific price.</target>
+        <note>Line: 535</note>
+      </trans-unit>
+      <trans-unit id="c7e56badecce297feefe2a9b50a68794">
+        <source>Invalid date range</source>
+        <target>Invalid date range</target>
+        <note>Line: 282</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f4158fa3500ce1523a52bee74971f5f2">
+        <source>Product(s) successfully activated.</source>
+        <target>Product(s) successfully activated.</target>
+        <note>Line: 715</note>
+      </trans-unit>
+      <trans-unit id="25b325c47f9b5f88d7820b079bafa02e">
+        <source>Product(s) successfully deactivated.</source>
+        <target>Product(s) successfully deactivated.</target>
+        <note>Line: 740</note>
+      </trans-unit>
+      <trans-unit id="01996897996faf465514bdf1091b6d4d">
+        <source>Product(s) successfully deleted.</source>
+        <target>Product(s) successfully deleted.</target>
+        <note>Line: 765</note>
+      </trans-unit>
+      <trans-unit id="290ed9aa59dd098c9e112c4f9770407d">
+        <source>Product(s) successfully duplicated.</source>
+        <target>Product(s) successfully duplicated.</target>
+        <note>Line: 789</note>
+      </trans-unit>
+      <trans-unit id="c1746190e47d69ea7f0db7f098de7cab">
+        <source>Products successfully sorted.</source>
+        <target>Products successfully sorted.</target>
+        <note>Line: 886</note>
+      </trans-unit>
+      <trans-unit id="7bdb2828f248bbd55bba16dcc63223d9">
+        <source>Product successfully deleted.</source>
+        <target>Product successfully deleted.</target>
+        <note>Line: 973</note>
+      </trans-unit>
+      <trans-unit id="85d8f7e3038017826a8215396b96865b">
+        <source>Product successfully duplicated.</source>
+        <target>Product successfully duplicated.</target>
+        <note>Line: 995</note>
+      </trans-unit>
+      <trans-unit id="98434b0cd2f3cf08418ea1f0a9c55f0a">
+        <source>Product successfully activated.</source>
+        <target>Product successfully activated.</target>
+        <note>Line: 1018</note>
+      </trans-unit>
+      <trans-unit id="fd1d6d9c7d146c9f81572224bae86951">
+        <source>Product successfully deactivated.</source>
+        <target>Product successfully deactivated.</target>
+        <note>Line: 1040</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="04f6302b96c8cbaaec71cc884a6626a5">
+        <source>Cannot find specific price %price%</source>
+        <target>Cannot find specific price %price%</target>
+        <note>Line: 126</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8bc6a12d95b969fb603306eab1f0603b">
+        <source>This pack is empty. You must add at least one product item.</source>
+        <target>This pack is empty. You must add at least one product item.</target>
+        <note>Line: 326</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cf456ee90912d9e25795925d067f8952">
+        <source>This value is too long. It should have %limit% characters or less.</source>
+        <target>This value is too long. It should have %limit% characters or less.</target>
+        <note>Line: 46</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1aa1527fa7dfdbe44acb4be33af88e4c">
+        <source>There is no result for this search. Update your filters to view other products.</source>
+        <target>There is no result for this search. Update your filters to view other products.</target>
+        <note>Line: 138</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="90094f8ca4b0c893b2f7aef48fd2e73e">
+        <source>Duplication in progress...</source>
+        <target>Duplication in progress...</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="1c4a67678ffecd99e46e9686e3639789">
+        <source>Duplication failed.</source>
+        <target>Duplication failed.</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="e927fc858b3eccca1323ed79add38ed6">
+        <source>Activation in progress...</source>
+        <target>Activation in progress...</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="0eb7963a4b19bb1a361d2dfb0ef13ccf">
+        <source>Activation failed.</source>
+        <target>Activation failed.</target>
+        <note>Line: 140</note>
+      </trans-unit>
+      <trans-unit id="58b01b30d683cbdb393f9ede59bdb697">
+        <source>Deactivation in progress...</source>
+        <target>Deactivation in progress...</target>
+        <note>Line: 160</note>
+      </trans-unit>
+      <trans-unit id="036a5e2d815eaa9bddaebf0c12f94e17">
+        <source>Deactivation failed.</source>
+        <target>Deactivation failed.</target>
+        <note>Line: 162</note>
+      </trans-unit>
+      <trans-unit id="557c57932d4eb9b108efcf050b9db862">
+        <source>Deletion in progress...</source>
+        <target>Deletion in progress...</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="51d0bf7f10d8d28ecd64d2aa3a5ca141">
+        <source>Deletion failed.</source>
+        <target>Deletion failed.</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="fc483403c3f9b9aa31a570b83cdfa6f3">
+        <source>Duplicating products</source>
+        <target>Duplicating products</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="34202dac3bbd97da03f56d3b2cf1386b">
+        <source>Duplicating...</source>
+        <target>Duplicating...</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="6d7447cf0c9efdaeb3a700de594a70cf">
+        <source>Activating products</source>
+        <target>Activating products</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="b850e16adbf88a6b6cb724630eff2c97">
+        <source>Activating...</source>
+        <target>Activating...</target>
+        <note>Line: 132</note>
+      </trans-unit>
+      <trans-unit id="c1714105baaadc64c8e502f13ca10988">
+        <source>Deactivating products</source>
+        <target>Deactivating products</target>
+        <note>Line: 150</note>
+      </trans-unit>
+      <trans-unit id="fe38be28e7e43dc0fb4c4d7ca1d60f90">
+        <source>Deactivating...</source>
+        <target>Deactivating...</target>
+        <note>Line: 154</note>
+      </trans-unit>
+      <trans-unit id="ccfc7b0a56346cdac7fd40d2edd01c5a">
+        <source>Deleting products</source>
+        <target>Deleting products</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="1294e8c29fb59da902198447bd9a256c">
+        <source>Deleting...</source>
+        <target>Deleting...</target>
+        <note>Line: 176</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9909f0bb3eb94634e3f8cd0164dbacac">
+        <source>You are in a multistore context: any modification will impact all your shops, or each shop of the active group.</source>
+        <target>You are in a multistore context: any modification will impact all your shops, or each shop of the active group.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c292d80ff15bf0d38f63af320f9f7839">
+        <source>Friendly URLs are currently disabled.</source>
+        <target>Friendly URLs are currently disabled.</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="517937df76770fb3c4f9e6100ed69ce9">
+        <source>To enable it, go to [1]SEO and URLs[/1]</source>
+        <target>To enable it, go to [1]SEO and URLs[/1]</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="9bbbc84f839137c71e79f1b8eaafc5b7">
+        <source>Friendly URLs are currently enabled.</source>
+        <target>Friendly URLs are currently enabled.</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="2d1df068fb2a9a3c4d9e3c361795c59c">
+        <source>To disable it, go to [1]SEO and URLs[/1]</source>
+        <target>To disable it, go to [1]SEO and URLs[/1]</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="d7e9bf98e857f83943b3b75fce04cea9">
+        <source>The "Force update of friendly URL" option is currently enabled.</source>
+        <target>The "Force update of friendly URL" option is currently enabled.</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="87ffb4b96479e24281064ad98ddfd16f">
+        <source>To disable it, go to [1]Product Settings[/1]</source>
+        <target>To disable it, go to [1]Product Settings[/1]</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d6df5e0f6b6204bece3852c0817420e9">
+        <source>If no carrier is selected then all the carriers will be available for customers orders.</source>
+        <target>If no carrier is selected then all the carriers will be available for customers orders.</target>
+        <note>Line: 148</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d80ebf39e80e164a170987dcd4212136">
+        <source>When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.</source>
+        <target>When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.</target>
+        <note>Line: 159</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/disabled_form_alert.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e1cc7a5b4545de2fa898ab70a12e2d54">
+        <source>You can't add or edit a product in this shop context: select a shop instead of a group of shops.</source>
+        <target>You can't add or edit a product in this shop context: select a shop instead of a group of shops.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1b89ef639dabfd2f6eb19886f7c9f8c8">
+        <source>This will delete all the combinations. Do you wish to proceed?</source>
+        <target>This will delete all the combinations. Do you wish to proceed?</target>
+        <note>Line: 330</note>
+      </trans-unit>
+      <trans-unit id="ff8a012ee6cba99838a649d92ad1b34b">
+        <source>This will delete the specific price. Do you wish to proceed?</source>
+        <target>This will delete the specific price. Do you wish to proceed?</target>
+        <note>Line: 344</note>
+      </trans-unit>
+      <trans-unit id="dfd19ad4f089996c7eabcd5935f75e98">
+        <source>A pack of products can't have combinations.</source>
+        <target>A pack of products can't have combinations.</target>
+        <note>Line: 350</note>
+      </trans-unit>
+      <trans-unit id="5b75fdc0df647e8ac5275e31554dd0f9">
+        <source>A virtual product can't have combinations.</source>
+        <target>A virtual product can't have combinations.</target>
+        <note>Line: 351</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8597e9c43b2587a888fee6b31dad5335">
+        <source>You can't manage your stock in this shop context: select a shop instead of a group of shops.</source>
+        <target>You can't manage your stock in this shop context: select a shop instead of a group of shops.</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b385b71f1d14c0afa6d7ca6cb18927b3">
+        <source>There is no attachment yet.</source>
+        <target>There is no attachment yet.</target>
+        <note>Line: 352</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Translation/Api/StockApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5566045e38ed5e7bb072b8d55f3ceb2f">
+        <source>No product matches your search. Try changing search terms.</source>
+        <target>No product matches your search. Try changing search terms.</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="96d17a8fdea016168a9d506b0da23c07">
+        <source>Stock successfully updated</source>
+        <target>Stock successfully updated</target>
+        <note>Line: 66</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminDashboardFeature.xlf
+++ b/app/Resources/translations/default/AdminDashboardFeature.xlf
@@ -1,124 +1,105 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminDashboardController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2938c7f7e560ed972f8a4f68e80ff834">
-        <source>Dashboard</source>
-        <target>Dashboard</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:57</note>
-      </trans-unit>
-      <trans-unit id="948a2986c50ad6bb8c90b4d93ae5c04d">
-        <source>Demo mode</source>
-        <target>Demo mode</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:59</note>
-      </trans-unit>
-      <trans-unit id="6894510fe0d12804bb8c93f374a485c0">
-        <source>Average bank fees per payment method</source>
-        <target>Average bank fees per payment method</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:78</note>
-      </trans-unit>
-      <trans-unit id="dc04176957901a0f880e073ea5187187">
-        <source>Average shipping fees per shipping method</source>
-        <target>Average shipping fees per shipping method</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:79</note>
-      </trans-unit>
-      <trans-unit id="cb3c93351f1f20809fdd6e938a4319c7">
-        <source>Other settings</source>
-        <target>Other settings</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:80</note>
-      </trans-unit>
-      <trans-unit id="e7c89563e25ff383dddc384817a7b857">
-        <source>Average gross margin percentage</source>
-        <target>Average gross margin percentage</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:196</note>
-      </trans-unit>
-      <trans-unit id="719d7270f0014508129eecfe03ffd84e">
-        <source>Other fees per order</source>
-        <target>Other fees per order</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:206</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="2f310f524ccb95e1bf929cea106a8f24">
         <source>Add more dashboard modules</source>
         <target>Add more dashboard modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:94</note>
+        <note>Line: 94</note>
       </trans-unit>
       <trans-unit id="f87dfb10a52e92f3fc08bef2802da23d">
         <source>PrestaShop News</source>
         <target>PrestaShop News</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:100</note>
+        <note>Line: 100</note>
       </trans-unit>
       <trans-unit id="c9cd54b7c6c536dc09e7724c68412a56">
         <source>Find more news</source>
         <target>Find more news</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:102</note>
+        <note>Line: 102</note>
       </trans-unit>
       <trans-unit id="e9be76a44ba1c2521b80bc4a126e017a">
         <source>Useful links</source>
         <target>Useful links</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:108</note>
+        <note>Line: 108</note>
       </trans-unit>
       <trans-unit id="57290da4ab80180ce258e18d1a0c5abc">
         <source>Official Documentation</source>
         <target>Official Documentation</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:110</note>
+        <note>Line: 110</note>
       </trans-unit>
       <trans-unit id="560325da4b8aa781fb24499f7ff0b7d9">
         <source>User, Developer and Designer Guides</source>
         <target>User, Developer and Designer Guides</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:111</note>
+        <note>Line: 111</note>
       </trans-unit>
       <trans-unit id="01302c2b3dc304b92b75390bc76d5dcf">
         <source>PrestaShop Forum</source>
         <target>PrestaShop Forum</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:114</note>
+        <note>Line: 114</note>
       </trans-unit>
       <trans-unit id="a4a59496bd0d27dcf9b8ee74d7cceb2a">
         <source>Connect with the PrestaShop community</source>
         <target>Connect with the PrestaShop community</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:115</note>
+        <note>Line: 115</note>
       </trans-unit>
       <trans-unit id="164b7380deb0d897551d0c89c88de883">
         <source>PrestaShop Addons</source>
         <target>PrestaShop Addons</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:118</note>
+        <note>Line: 118</note>
       </trans-unit>
       <trans-unit id="6f6d2f5f73d1795f9138a74c59aaa1fb">
         <source><![CDATA[Enhance your store with templates & modules]]></source>
         <target><![CDATA[Enhance your store with templates & modules]]></target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:119</note>
+        <note>Line: 119</note>
       </trans-unit>
       <trans-unit id="13df627c018625ce68ca2200a869dd65">
         <source>Report issues in the Bug Tracker</source>
         <target>Report issues in the Bug Tracker</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:123</note>
+        <note>Line: 123</note>
       </trans-unit>
       <trans-unit id="b5425b530ea3127c2877199c5b64c956">
         <source>Contact Us!</source>
         <target>Contact Us!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:126</note>
+        <note>Line: 126</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminDashboardController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2938c7f7e560ed972f8a4f68e80ff834">
+        <source>Dashboard</source>
+        <target>Dashboard</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="948a2986c50ad6bb8c90b4d93ae5c04d">
+        <source>Demo mode</source>
+        <target>Demo mode</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="6894510fe0d12804bb8c93f374a485c0">
+        <source>Average bank fees per payment method</source>
+        <target>Average bank fees per payment method</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="dc04176957901a0f880e073ea5187187">
+        <source>Average shipping fees per shipping method</source>
+        <target>Average shipping fees per shipping method</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="cb3c93351f1f20809fdd6e938a4319c7">
+        <source>Other settings</source>
+        <target>Other settings</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="e7c89563e25ff383dddc384817a7b857">
+        <source>Average gross margin percentage</source>
+        <target>Average gross margin percentage</target>
+        <note>Line: 196</note>
+      </trans-unit>
+      <trans-unit id="719d7270f0014508129eecfe03ffd84e">
+        <source>Other fees per order</source>
+        <target>Other fees per order</target>
+        <note>Line: 206</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminDashboardHelp.xlf
+++ b/app/Resources/translations/default/AdminDashboardHelp.xlf
@@ -5,62 +5,52 @@
       <trans-unit id="b8a4e75e91526add8051444041526556">
         <source>This mode displays sample data so you can try your dashboard without real numbers.</source>
         <target>This mode displays sample data so you can try your dashboard without real numbers.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:61</note>
+        <note>Line: 61</note>
       </trans-unit>
       <trans-unit id="d43cfeee72c309dbca7926165582b977">
         <source>Choose a fixed fee for each order placed in %currency% with %module%.</source>
         <target>Choose a fixed fee for each order placed in %currency% with %module%.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:98</note>
+        <note>Line: 98</note>
       </trans-unit>
       <trans-unit id="1ebae23c433fa585b32d472c98edcbb4">
         <source>Choose a variable fee for each order placed in %currency% with %module%. It will be applied on the total paid with taxes.</source>
         <target>Choose a variable fee for each order placed in %currency% with %module%. It will be applied on the total paid with taxes.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:114</note>
+        <note>Line: 114</note>
       </trans-unit>
       <trans-unit id="cfaf4c36f59bdda6dec70aaee4f99fa5">
         <source>Choose a fixed fee for each order placed with a foreign currency with %module%.</source>
         <target>Choose a fixed fee for each order placed with a foreign currency with %module%.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:132</note>
+        <note>Line: 132</note>
       </trans-unit>
       <trans-unit id="963e569356ae2068f6b0c5a98428332a">
         <source>Choose a variable fee for each order placed with a foreign currency with %module%. It will be applied on the total paid with taxes.</source>
         <target>Choose a variable fee for each order placed with a foreign currency with %module%. It will be applied on the total paid with taxes.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:146</note>
+        <note>Line: 146</note>
       </trans-unit>
       <trans-unit id="e8ae5ad5beb4830ebe9a1a2fde5bb0cc">
         <source>For the carrier named %s, indicate the domestic delivery costs  in percentage of the price charged to customers.</source>
         <target>For the carrier named %s, indicate the domestic delivery costs  in percentage of the price charged to customers.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:164</note>
+        <note>Line: 164</note>
       </trans-unit>
       <trans-unit id="d2db76b1301441d2171ebc13b2533b95">
         <source>For the carrier named %s, indicate the overseas delivery costs in percentage of the price charged to customers.</source>
         <target>For the carrier named %s, indicate the overseas delivery costs in percentage of the price charged to customers.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:179</note>
+        <note>Line: 179</note>
       </trans-unit>
       <trans-unit id="3ca719d0b01232ba8c9a7109d8295917">
         <source>Method: Indicate the percentage of your carrier margin. For example, if you charge $10 of shipping fees to your customer for each shipment, but you really pay $4 to this carrier, then you should indicate "40" in the percentage field.</source>
         <target>Method: Indicate the percentage of your carrier margin. For example, if you charge $10 of shipping fees to your customer for each shipment, but you really pay $4 to this carrier, then you should indicate "40" in the percentage field.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:193</note>
+        <note>Line: 193</note>
       </trans-unit>
       <trans-unit id="8c7cf68cbd01d91e537b6055adf0967f">
         <source>You should calculate this percentage as follows: ((total sales revenue) - (cost of goods sold)) / (total sales revenue) * 100. This value is only used to calculate the Dashboard approximate gross margin, if you do not specify the wholesale price for each product.</source>
         <target>You should calculate this percentage as follows: ((total sales revenue) - (cost of goods sold)) / (total sales revenue) * 100. This value is only used to calculate the Dashboard approximate gross margin, if you do not specify the wholesale price for each product.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:197</note>
+        <note>Line: 197</note>
       </trans-unit>
       <trans-unit id="1b511dcde043e7a3609a669e2c34f63d">
         <source>You should calculate this value by making the sum of all of your additional costs per order.</source>
         <target>You should calculate this value by making the sum of all of your additional costs per order.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:207</note>
+        <note>Line: 207</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminDashboardNotification.xlf
+++ b/app/Resources/translations/default/AdminDashboardNotification.xlf
@@ -5,26 +5,22 @@
       <trans-unit id="54e180b1dbafcab1e37fd7f8cf5411f6">
         <source>You are currently connected under the following domain name:</source>
         <target>You are currently connected under the following domain name:</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:381</note>
+        <note>Line: 381</note>
       </trans-unit>
       <trans-unit id="98f5fdb1bf05af7241b0eb9cf8afbafa">
         <source>This is different from the shop domain name set in the Multistore settings: "%s".</source>
         <target>This is different from the shop domain name set in the Multistore settings: "%s".</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:384</note>
+        <note>Line: 384</note>
       </trans-unit>
       <trans-unit id="d8d5ce732cf78334f18c47ce0892ab2e">
         <source>If this is your main domain, please {link}change it now{/link}.</source>
         <target>If this is your main domain, please {link}change it now{/link}.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:400</note>
+        <note>Line: 400</note>
       </trans-unit>
       <trans-unit id="e3e7221b6b1d51f976fa58ec6131a2aa">
         <source><![CDATA[This is different from the domain name set in the "SEO & URLs" tab.]]></source>
         <target><![CDATA[This is different from the domain name set in the "SEO & URLs" tab.]]></target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:398</note>
+        <note>Line: 398</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminDesignFeature.xlf
+++ b/app/Resources/translations/default/AdminDesignFeature.xlf
@@ -1,42 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminCmsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/images/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="1f6162e1430a8d5020bf4c20dc02499f">
-        <source>Pages in category "%name%"</source>
-        <target>Pages in category "%name%"</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:76</note>
+      <trans-unit id="874d3deed67e503cac1d8bc00417794a">
+        <source>Move images</source>
+        <target>Move images</target>
+        <note>Line: 50</note>
       </trans-unit>
-      <trans-unit id="897b3f9a5dc0ebb8ab90e033e7ce61f3">
-        <source>Page Category</source>
-        <target>Page Category</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:131</note>
+      <trans-unit id="258606ef5a3ed5cd7e39da08435adec0">
+        <source>Regenerate thumbnails</source>
+        <target>Regenerate thumbnails</target>
+        <note>Line: 128</note>
       </trans-unit>
-      <trans-unit id="21f93401134586a6c481422bf01fccfd">
-        <source>Only letters and the hyphen (-) character are allowed.</source>
-        <target>Only letters and the hyphen (-) character are allowed.</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:183</note>
+      <trans-unit id="79750ba11832a44ccf92e15eb0e84ae4">
+        <source>Select an image</source>
+        <target>Select an image</target>
+        <note>Line: 73</note>
       </trans-unit>
-      <trans-unit id="45b1bce0ceb1e155fc99d59a21761b9e">
-        <source>Page content</source>
-        <target>Page content</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:187</note>
+      <trans-unit id="26e687808eb656fb38bd6e98f592e4f7">
+        <source>Select a format</source>
+        <target>Select a format</target>
+        <note>Line: 86</note>
       </trans-unit>
-      <trans-unit id="ce1e51212c9df52777620dc9de246da0">
-        <source>Indexation by search engines</source>
-        <target>Indexation by search engines</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:197</note>
-      </trans-unit>
-      <trans-unit id="cc4fbd30d676ea2f9994b7063a8ada15">
-        <source>Pages in this category</source>
-        <target>Pages in this category</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:275</note>
+      <trans-unit id="d379cadd41b68efe7c945b4d85c72085">
+        <source>Erase previous images</source>
+        <target>Erase previous images</target>
+        <note>Line: 107</note>
       </trans-unit>
     </body>
   </file>
@@ -45,420 +34,17 @@ File: controllers/admin/AdminCmsController.php:275</note>
       <trans-unit id="51a8b3a61ad63d4e5df2ce86870e39b8">
         <source>Transplant a module</source>
         <target>Transplant a module</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/form.tpl:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="97e34811d05eb0ee902aa3e190ea5efd">
         <source>Transplant to</source>
         <target>Transplant to</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/form.tpl:51</note>
+        <note>Line: 51</note>
       </trans-unit>
       <trans-unit id="d5f1381c5f97f928df4ef8d18c2a27c0">
         <source>Exceptions</source>
         <target>Exceptions</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/form.tpl:65</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminModulesPositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="700e2c3b7b442c597c781eac801408b6">
-        <source>___________ CUSTOM ___________</source>
-        <target>___________ CUSTOM ___________</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:438</note>
-      </trans-unit>
-      <trans-unit id="6957667301f05bce7e2c0b5cd8567df5">
-        <source>____________ CORE ____________</source>
-        <target>____________ CORE ____________</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:451</note>
-      </trans-unit>
-      <trans-unit id="1cc06efffbc5252916c871f45098a50f">
-        <source>Admin modules controller</source>
-        <target>Admin modules controller</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:457</note>
-      </trans-unit>
-      <trans-unit id="2f75fd5bb638eb1353d6941aac58700e">
-        <source>Front modules controller</source>
-        <target>Front modules controller</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:457</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCmsCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="789ca3cc9e29e7ef767619e13c6b2f9e">
-        <source>CMS Category</source>
-        <target>CMS Category</target>
-        <note>Context:
-File: controllers/admin/AdminCmsCategoriesController.php:214</note>
-      </trans-unit>
-      <trans-unit id="52b68aaa602d202c340d9e4e9157f276">
-        <source>Parent category</source>
-        <target>Parent category</target>
-        <note>Context:
-File: controllers/admin/AdminCmsCategoriesController.php:249</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cc350a9d1eabece4f9299f7bb51c3a9c">
-        <source>Images generation options</source>
-        <target>Images generation options</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:84</note>
-      </trans-unit>
-      <trans-unit id="d0efb46cfd8b126482192a343e2142b4">
-        <source>Image format</source>
-        <target>Image format</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:92</note>
-      </trans-unit>
-      <trans-unit id="92deb9e729da3800aca668de3491f0c8">
-        <source>Use JPEG.</source>
-        <target>Use JPEG.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:96</note>
-      </trans-unit>
-      <trans-unit id="6178649941eae11401f8bd95d32ad690">
-        <source>Use PNG only if the base image is in PNG format.</source>
-        <target>Use PNG only if the base image is in PNG format.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:96</note>
-      </trans-unit>
-      <trans-unit id="d40849d8da6fe69b751ebaa13595b34d">
-        <source>Use PNG for all images.</source>
-        <target>Use PNG for all images.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:96</note>
-      </trans-unit>
-      <trans-unit id="5a259e0a584d2d8f7de738689c91cb20">
-        <source>JPEG compression</source>
-        <target>JPEG compression</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:99</note>
-      </trans-unit>
-      <trans-unit id="9c4936420e1471c2233cfbb40ce49319">
-        <source>PNG compression</source>
-        <target>PNG compression</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:107</note>
-      </trans-unit>
-      <trans-unit id="2f0f4bfac8d0b89ceaf30a94f39f0d58">
-        <source>Generate images based on one side of the source image</source>
-        <target>Generate images based on one side of the source image</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:115</note>
-      </trans-unit>
-      <trans-unit id="fbd5c930381c5176afe9310becf39ee5">
-        <source>Automatic (longest side)</source>
-        <target>Automatic (longest side)</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:123</note>
-      </trans-unit>
-      <trans-unit id="9cddfad226d0bc7a731c13fbec74aca6">
-        <source>Maximum file size of product customization pictures</source>
-        <target>Maximum file size of product customization pictures</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:138</note>
-      </trans-unit>
-      <trans-unit id="4b3a6218bb3e3a7303e8a171a60fcf92">
-        <source>bytes</source>
-        <target>bytes</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:144</note>
-      </trans-unit>
-      <trans-unit id="ff534cd9270ca999a39a50a6365ff52e">
-        <source>Product picture width</source>
-        <target>Product picture width</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:148</note>
-      </trans-unit>
-      <trans-unit id="d399848208da8b80a306af0fd62bb03f">
-        <source>pixels</source>
-        <target>pixels</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:223</note>
-      </trans-unit>
-      <trans-unit id="5891a406596216c63f7a1f8f7c6a81a8">
-        <source>Product picture height</source>
-        <target>Product picture height</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:159</note>
-      </trans-unit>
-      <trans-unit id="ace52125644d273380446071bcd6d5fb">
-        <source>Generate high resolution images</source>
-        <target>Generate high resolution images</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:171</note>
-      </trans-unit>
-      <trans-unit id="b08ea6a4f29e76c9d843856917642409">
-        <source>Use the legacy image filesystem</source>
-        <target>Use the legacy image filesystem</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:185</note>
-      </trans-unit>
-      <trans-unit id="2dd1148046499f9c2422ce1045a4accf">
-        <source>Image type</source>
-        <target>Image type</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:197</note>
-      </trans-unit>
-      <trans-unit id="404dede45594c16ad5592b1091cc7ba8">
-        <source>Name for the image type</source>
-        <target>Name for the image type</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:203</note>
-      </trans-unit>
-      <trans-unit id="d1e9d1892046943ae96e613646fc0381">
-        <source>Add new image type</source>
-        <target>Add new image type</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:702</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminThemesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="36866999eeb441da24edc6fd075e1765">
-        <source>Add new theme</source>
-        <target>Add new theme</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:156</note>
-      </trans-unit>
-      <trans-unit id="3ff63fb80ae3bd04b6550282d39f674f">
-        <source>Export current theme</source>
-        <target>Export current theme</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:161</note>
-      </trans-unit>
-      <trans-unit id="b5c941eace89787ab475237451189eac">
-        <source>Import theme</source>
-        <target>Import theme</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:172</note>
-      </trans-unit>
-      <trans-unit id="f5ad3d3e217e4b7ea1729eb997dfbe1e">
-        <source>Your current theme</source>
-        <target>Your current theme</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:404</note>
-      </trans-unit>
-      <trans-unit id="410901e83305e49595778896745950a9">
-        <source><![CDATA[Invoice & Email Logos]]></source>
-        <target><![CDATA[Invoice & Email Logos]]></target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:408</note>
-      </trans-unit>
-      <trans-unit id="90dafb1cce6579655041476ab07fab90">
-        <source>Favicons</source>
-        <target>Favicons</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:409</note>
-      </trans-unit>
-      <trans-unit id="49824ed511fd64f33f2f8a1818ee8fe1">
-        <source>Header logo</source>
-        <target>Header logo</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:413</note>
-      </trans-unit>
-      <trans-unit id="358b0205fd07c94c16a82d8278bc5b76">
-        <source>Mail logo</source>
-        <target>Mail logo</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:426</note>
-      </trans-unit>
-      <trans-unit id="d84613cd39906ab9161e1ad513f8947b">
-        <source>Invoice logo</source>
-        <target>Invoice logo</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:435</note>
-      </trans-unit>
-      <trans-unit id="49e95301d8fcdbc23f623e0f2d1ed1e6">
-        <source>Favicon</source>
-        <target>Favicon</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:444</note>
-      </trans-unit>
-      <trans-unit id="859a82ffb385f9227c656960996025eb">
-        <source>Visit the theme catalog</source>
-        <target>Visit the theme catalog</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:460</note>
-      </trans-unit>
-      <trans-unit id="d1c54fe762697b168dee820490655563">
-        <source>Adaptation to Right-to-Left languages</source>
-        <target>Adaptation to Right-to-Left languages</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:480</note>
-      </trans-unit>
-      <trans-unit id="8ed22009aa8884b512b3e3a85d1aeb87">
-        <source>Theme to adapt</source>
-        <target>Theme to adapt</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:484</note>
-      </trans-unit>
-      <trans-unit id="fb3f98de7e392f98c02ba257e6c46f9a">
-        <source>Generate RTL stylesheet</source>
-        <target>Generate RTL stylesheet</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:490</note>
-      </trans-unit>
-      <trans-unit id="3388a09e80639f10038e6725fb32f444">
-        <source>Select a theme for the "%name%" shop</source>
-        <target>Select a theme for the "%name%" shop</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:507</note>
-      </trans-unit>
-      <trans-unit id="8d5cc12b0e7ecbe4e624baa345323035">
-        <source>Theme appearance</source>
-        <target>Theme appearance</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:527</note>
-      </trans-unit>
-      <trans-unit id="7961c4434751797a383d52d647e044d6">
-        <source>Import from your computer</source>
-        <target>Import from your computer</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:564</note>
-      </trans-unit>
-      <trans-unit id="6966bbbcdeb44c019201ede70e7b74b8">
-        <source>Zip file</source>
-        <target>Zip file</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:570</note>
-      </trans-unit>
-      <trans-unit id="dec0faa6eb19bd9120d12c5a876bd1cf">
-        <source>Import from the web</source>
-        <target>Import from the web</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:586</note>
-      </trans-unit>
-      <trans-unit id="a33388a338ee2b199d66112369279558">
-        <source>Archive URL</source>
-        <target>Archive URL</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:592</note>
-      </trans-unit>
-      <trans-unit id="cd8d9cc19984ccf9d314eee5eebfc2cc">
-        <source>Import from FTP</source>
-        <target>Import from FTP</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:620</note>
-      </trans-unit>
-      <trans-unit id="a5a23094873852f0c0a9e55be4f1cf1d">
-        <source>Select the archive</source>
-        <target>Select the archive</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:626</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d721757161f7f70c5b0949fdb6ec2c30">
-        <source>Theme</source>
-        <target>Theme</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:521</note>
-      </trans-unit>
-      <trans-unit id="453aceb005ceaf54a47da15fee8b2a26">
-        <source>Pages</source>
-        <target>Pages</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:538</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCmsContentController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d0d4e3688fdaee5afa292083b855e143">
-        <source>Add new category</source>
-        <target>Add new category</target>
-        <note>Context:
-File: controllers/admin/AdminCmsContentController.php:179</note>
-      </trans-unit>
-      <trans-unit id="4fb1231b615c9fc59cdb5729577b0919">
-        <source>Edit category: %name%</source>
-        <target>Edit category: %name%</target>
-        <note>Context:
-File: controllers/admin/AdminCmsContentController.php:182</note>
-      </trans-unit>
-      <trans-unit id="aa6f77f824eff8e896510f1bbaf9f8e5">
-        <source>Add new page</source>
-        <target>Add new page</target>
-        <note>Context:
-File: controllers/admin/AdminCmsContentController.php:187</note>
-      </trans-unit>
-      <trans-unit id="23b8a311aed9d1b2e76424acc4eff45f">
-        <source>Edit page: %meta_title%</source>
-        <target>Edit page: %meta_title%</target>
-        <note>Context:
-File: controllers/admin/AdminCmsContentController.php:190</note>
-      </trans-unit>
-      <trans-unit id="5aa00a736e77bff80d8a530b0522803d">
-        <source>Category: %category%</source>
-        <target>Category: %category%</target>
-        <note>Context:
-File: controllers/admin/AdminCmsContentController.php:193</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/ThemeLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="24e61dc70866cb84d375a6270035c7cf">
-        <source>Full width</source>
-        <target>Full width</target>
-        <note>Context:
-File: classes/lang/KeysReference/ThemeLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="63bd7d20cb7d515fe705bcda029ea776">
-        <source>Three columns</source>
-        <target>Three columns</target>
-        <note>Context:
-File: classes/lang/KeysReference/ThemeLang.php:27</note>
-      </trans-unit>
-      <trans-unit id="710c71f05157207e5c47015fc032564d">
-        <source>Two columns, small left column</source>
-        <target>Two columns, small left column</target>
-        <note>Context:
-File: classes/lang/KeysReference/ThemeLang.php:28</note>
-      </trans-unit>
-      <trans-unit id="4c318832b92e5f7b818aba037e1ed5ac">
-        <source>Two columns, small right column</source>
-        <target>Two columns, small right column</target>
-        <note>Context:
-File: classes/lang/KeysReference/ThemeLang.php:29</note>
-      </trans-unit>
-      <trans-unit id="05559f48f0ea41ebb03f6d08b95e1e25">
-        <source>No side columns, ideal for distraction-free pages such as product pages.</source>
-        <target>No side columns, ideal for distraction-free pages such as product pages.</target>
-        <note>Context:
-File: classes/lang/KeysReference/ThemeLang.php:31</note>
-      </trans-unit>
-      <trans-unit id="387bf9bbb8c3c3fd021aa85970554839">
-        <source>One large central column and 2 side columns.</source>
-        <target>One large central column and 2 side columns.</target>
-        <note>Context:
-File: classes/lang/KeysReference/ThemeLang.php:33</note>
-      </trans-unit>
-      <trans-unit id="74266ad9cb6f32c9da66592ca748ef8d">
-        <source>Two columns with a small left column.</source>
-        <target>Two columns with a small left column.</target>
-        <note>Context:
-File: classes/lang/KeysReference/ThemeLang.php:35</note>
-      </trans-unit>
-      <trans-unit id="fefe6a1aca554473c855e076d0376b52">
-        <source>Two columns with a small right column.</source>
-        <target>Two columns with a small right column.</target>
-        <note>Context:
-File: classes/lang/KeysReference/ThemeLang.php:37</note>
+        <note>Line: 65</note>
       </trans-unit>
     </body>
   </file>
@@ -467,78 +53,409 @@ File: classes/lang/KeysReference/ThemeLang.php:37</note>
       <trans-unit id="4ba24d91566786f5315acf453418dbb6">
         <source>All modules</source>
         <target>All modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="c2f2fa871a47fd6ab9e8442ff4dd468d">
         <source>Search for a hook</source>
         <target>Search for a hook</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="4c64748755160a1e441ed3dc34d6b827">
         <source>Display non-positionable hooks</source>
         <target>Display non-positionable hooks</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:69</note>
+        <note>Line: 69</note>
       </trans-unit>
       <trans-unit id="d97628f4b34d5ca2a77cc1bfa7914aa9">
         <source>Unhook</source>
         <target>Unhook</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:145</note>
+        <note>Line: 145</note>
       </trans-unit>
       <trans-unit id="feb6f2e19409f021e5fd65c51d21d254">
         <source>Unhook the selection</source>
         <target>Unhook the selection</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:181</note>
+        <note>Line: 181</note>
       </trans-unit>
       <trans-unit id="fdf4e26a28a557ccfae6ddea1881687e">
         <source>1 module selected</source>
         <target>1 module selected</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:175</note>
+        <note>Line: 175</note>
       </trans-unit>
       <trans-unit id="2451f8c34b91d6d3b6e7ee63c23d13fc">
         <source>modules selected</source>
         <target>modules selected</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:177</note>
+        <note>Line: 177</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/images/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/lang/KeysReference/ThemeLang.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="874d3deed67e503cac1d8bc00417794a">
-        <source>Move images</source>
-        <target>Move images</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:50</note>
+      <trans-unit id="24e61dc70866cb84d375a6270035c7cf">
+        <source>Full width</source>
+        <target>Full width</target>
+        <note>Line: 26</note>
       </trans-unit>
-      <trans-unit id="258606ef5a3ed5cd7e39da08435adec0">
-        <source>Regenerate thumbnails</source>
-        <target>Regenerate thumbnails</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:128</note>
+      <trans-unit id="63bd7d20cb7d515fe705bcda029ea776">
+        <source>Three columns</source>
+        <target>Three columns</target>
+        <note>Line: 27</note>
       </trans-unit>
-      <trans-unit id="79750ba11832a44ccf92e15eb0e84ae4">
-        <source>Select an image</source>
-        <target>Select an image</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:73</note>
+      <trans-unit id="710c71f05157207e5c47015fc032564d">
+        <source>Two columns, small left column</source>
+        <target>Two columns, small left column</target>
+        <note>Line: 28</note>
       </trans-unit>
-      <trans-unit id="26e687808eb656fb38bd6e98f592e4f7">
-        <source>Select a format</source>
-        <target>Select a format</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:86</note>
+      <trans-unit id="4c318832b92e5f7b818aba037e1ed5ac">
+        <source>Two columns, small right column</source>
+        <target>Two columns, small right column</target>
+        <note>Line: 29</note>
       </trans-unit>
-      <trans-unit id="d379cadd41b68efe7c945b4d85c72085">
-        <source>Erase previous images</source>
-        <target>Erase previous images</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:107</note>
+      <trans-unit id="05559f48f0ea41ebb03f6d08b95e1e25">
+        <source>No side columns, ideal for distraction-free pages such as product pages.</source>
+        <target>No side columns, ideal for distraction-free pages such as product pages.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="387bf9bbb8c3c3fd021aa85970554839">
+        <source>One large central column and 2 side columns.</source>
+        <target>One large central column and 2 side columns.</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="74266ad9cb6f32c9da66592ca748ef8d">
+        <source>Two columns with a small left column.</source>
+        <target>Two columns with a small left column.</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="fefe6a1aca554473c855e076d0376b52">
+        <source>Two columns with a small right column.</source>
+        <target>Two columns with a small right column.</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="789ca3cc9e29e7ef767619e13c6b2f9e">
+        <source>CMS Category</source>
+        <target>CMS Category</target>
+        <note>Line: 214</note>
+      </trans-unit>
+      <trans-unit id="52b68aaa602d202c340d9e4e9157f276">
+        <source>Parent category</source>
+        <target>Parent category</target>
+        <note>Line: 249</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsContentController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d0d4e3688fdaee5afa292083b855e143">
+        <source>Add new category</source>
+        <target>Add new category</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="4fb1231b615c9fc59cdb5729577b0919">
+        <source>Edit category: %name%</source>
+        <target>Edit category: %name%</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="aa6f77f824eff8e896510f1bbaf9f8e5">
+        <source>Add new page</source>
+        <target>Add new page</target>
+        <note>Line: 187</note>
+      </trans-unit>
+      <trans-unit id="23b8a311aed9d1b2e76424acc4eff45f">
+        <source>Edit page: %meta_title%</source>
+        <target>Edit page: %meta_title%</target>
+        <note>Line: 190</note>
+      </trans-unit>
+      <trans-unit id="5aa00a736e77bff80d8a530b0522803d">
+        <source>Category: %category%</source>
+        <target>Category: %category%</target>
+        <note>Line: 193</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1f6162e1430a8d5020bf4c20dc02499f">
+        <source>Pages in category "%name%"</source>
+        <target>Pages in category "%name%"</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="897b3f9a5dc0ebb8ab90e033e7ce61f3">
+        <source>Page Category</source>
+        <target>Page Category</target>
+        <note>Line: 158</note>
+      </trans-unit>
+      <trans-unit id="21f93401134586a6c481422bf01fccfd">
+        <source>Only letters and the hyphen (-) character are allowed.</source>
+        <target>Only letters and the hyphen (-) character are allowed.</target>
+        <note>Line: 210</note>
+      </trans-unit>
+      <trans-unit id="45b1bce0ceb1e155fc99d59a21761b9e">
+        <source>Page content</source>
+        <target>Page content</target>
+        <note>Line: 214</note>
+      </trans-unit>
+      <trans-unit id="ce1e51212c9df52777620dc9de246da0">
+        <source>Indexation by search engines</source>
+        <target>Indexation by search engines</target>
+        <note>Line: 224</note>
+      </trans-unit>
+      <trans-unit id="cc4fbd30d676ea2f9994b7063a8ada15">
+        <source>Pages in this category</source>
+        <target>Pages in this category</target>
+        <note>Line: 302</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cc350a9d1eabece4f9299f7bb51c3a9c">
+        <source>Images generation options</source>
+        <target>Images generation options</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="d0efb46cfd8b126482192a343e2142b4">
+        <source>Image format</source>
+        <target>Image format</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="92deb9e729da3800aca668de3491f0c8">
+        <source>Use JPEG.</source>
+        <target>Use JPEG.</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="6178649941eae11401f8bd95d32ad690">
+        <source>Use PNG only if the base image is in PNG format.</source>
+        <target>Use PNG only if the base image is in PNG format.</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="d40849d8da6fe69b751ebaa13595b34d">
+        <source>Use PNG for all images.</source>
+        <target>Use PNG for all images.</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="5a259e0a584d2d8f7de738689c91cb20">
+        <source>JPEG compression</source>
+        <target>JPEG compression</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="9c4936420e1471c2233cfbb40ce49319">
+        <source>PNG compression</source>
+        <target>PNG compression</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="2f0f4bfac8d0b89ceaf30a94f39f0d58">
+        <source>Generate images based on one side of the source image</source>
+        <target>Generate images based on one side of the source image</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="fbd5c930381c5176afe9310becf39ee5">
+        <source>Automatic (longest side)</source>
+        <target>Automatic (longest side)</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="9cddfad226d0bc7a731c13fbec74aca6">
+        <source>Maximum file size of product customization pictures</source>
+        <target>Maximum file size of product customization pictures</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="4b3a6218bb3e3a7303e8a171a60fcf92">
+        <source>bytes</source>
+        <target>bytes</target>
+        <note>Line: 144</note>
+      </trans-unit>
+      <trans-unit id="ff534cd9270ca999a39a50a6365ff52e">
+        <source>Product picture width</source>
+        <target>Product picture width</target>
+        <note>Line: 148</note>
+      </trans-unit>
+      <trans-unit id="d399848208da8b80a306af0fd62bb03f">
+        <source>pixels</source>
+        <target>pixels</target>
+        <note>Line: 223</note>
+      </trans-unit>
+      <trans-unit id="5891a406596216c63f7a1f8f7c6a81a8">
+        <source>Product picture height</source>
+        <target>Product picture height</target>
+        <note>Line: 159</note>
+      </trans-unit>
+      <trans-unit id="ace52125644d273380446071bcd6d5fb">
+        <source>Generate high resolution images</source>
+        <target>Generate high resolution images</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="b08ea6a4f29e76c9d843856917642409">
+        <source>Use the legacy image filesystem</source>
+        <target>Use the legacy image filesystem</target>
+        <note>Line: 185</note>
+      </trans-unit>
+      <trans-unit id="2dd1148046499f9c2422ce1045a4accf">
+        <source>Image type</source>
+        <target>Image type</target>
+        <note>Line: 197</note>
+      </trans-unit>
+      <trans-unit id="404dede45594c16ad5592b1091cc7ba8">
+        <source>Name for the image type</source>
+        <target>Name for the image type</target>
+        <note>Line: 203</note>
+      </trans-unit>
+      <trans-unit id="d1e9d1892046943ae96e613646fc0381">
+        <source>Add new image type</source>
+        <target>Add new image type</target>
+        <note>Line: 702</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminModulesPositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="700e2c3b7b442c597c781eac801408b6">
+        <source>___________ CUSTOM ___________</source>
+        <target>___________ CUSTOM ___________</target>
+        <note>Line: 438</note>
+      </trans-unit>
+      <trans-unit id="6957667301f05bce7e2c0b5cd8567df5">
+        <source>____________ CORE ____________</source>
+        <target>____________ CORE ____________</target>
+        <note>Line: 451</note>
+      </trans-unit>
+      <trans-unit id="1cc06efffbc5252916c871f45098a50f">
+        <source>Admin modules controller</source>
+        <target>Admin modules controller</target>
+        <note>Line: 457</note>
+      </trans-unit>
+      <trans-unit id="2f75fd5bb638eb1353d6941aac58700e">
+        <source>Front modules controller</source>
+        <target>Front modules controller</target>
+        <note>Line: 457</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="453aceb005ceaf54a47da15fee8b2a26">
+        <source>Pages</source>
+        <target>Pages</target>
+        <note>Line: 538</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminThemesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="36866999eeb441da24edc6fd075e1765">
+        <source>Add new theme</source>
+        <target>Add new theme</target>
+        <note>Line: 156</note>
+      </trans-unit>
+      <trans-unit id="3ff63fb80ae3bd04b6550282d39f674f">
+        <source>Export current theme</source>
+        <target>Export current theme</target>
+        <note>Line: 161</note>
+      </trans-unit>
+      <trans-unit id="b5c941eace89787ab475237451189eac">
+        <source>Import theme</source>
+        <target>Import theme</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="f5ad3d3e217e4b7ea1729eb997dfbe1e">
+        <source>Your current theme</source>
+        <target>Your current theme</target>
+        <note>Line: 405</note>
+      </trans-unit>
+      <trans-unit id="410901e83305e49595778896745950a9">
+        <source><![CDATA[Invoice & Email Logos]]></source>
+        <target><![CDATA[Invoice & Email Logos]]></target>
+        <note>Line: 409</note>
+      </trans-unit>
+      <trans-unit id="90dafb1cce6579655041476ab07fab90">
+        <source>Favicons</source>
+        <target>Favicons</target>
+        <note>Line: 410</note>
+      </trans-unit>
+      <trans-unit id="49824ed511fd64f33f2f8a1818ee8fe1">
+        <source>Header logo</source>
+        <target>Header logo</target>
+        <note>Line: 414</note>
+      </trans-unit>
+      <trans-unit id="358b0205fd07c94c16a82d8278bc5b76">
+        <source>Mail logo</source>
+        <target>Mail logo</target>
+        <note>Line: 427</note>
+      </trans-unit>
+      <trans-unit id="d84613cd39906ab9161e1ad513f8947b">
+        <source>Invoice logo</source>
+        <target>Invoice logo</target>
+        <note>Line: 436</note>
+      </trans-unit>
+      <trans-unit id="49e95301d8fcdbc23f623e0f2d1ed1e6">
+        <source>Favicon</source>
+        <target>Favicon</target>
+        <note>Line: 445</note>
+      </trans-unit>
+      <trans-unit id="859a82ffb385f9227c656960996025eb">
+        <source>Visit the theme catalog</source>
+        <target>Visit the theme catalog</target>
+        <note>Line: 461</note>
+      </trans-unit>
+      <trans-unit id="d1c54fe762697b168dee820490655563">
+        <source>Adaptation to Right-to-Left languages</source>
+        <target>Adaptation to Right-to-Left languages</target>
+        <note>Line: 481</note>
+      </trans-unit>
+      <trans-unit id="8ed22009aa8884b512b3e3a85d1aeb87">
+        <source>Theme to adapt</source>
+        <target>Theme to adapt</target>
+        <note>Line: 485</note>
+      </trans-unit>
+      <trans-unit id="fb3f98de7e392f98c02ba257e6c46f9a">
+        <source>Generate RTL stylesheet</source>
+        <target>Generate RTL stylesheet</target>
+        <note>Line: 491</note>
+      </trans-unit>
+      <trans-unit id="3388a09e80639f10038e6725fb32f444">
+        <source>Select a theme for the "%name%" shop</source>
+        <target>Select a theme for the "%name%" shop</target>
+        <note>Line: 508</note>
+      </trans-unit>
+      <trans-unit id="8d5cc12b0e7ecbe4e624baa345323035">
+        <source>Theme appearance</source>
+        <target>Theme appearance</target>
+        <note>Line: 529</note>
+      </trans-unit>
+      <trans-unit id="7961c4434751797a383d52d647e044d6">
+        <source>Import from your computer</source>
+        <target>Import from your computer</target>
+        <note>Line: 566</note>
+      </trans-unit>
+      <trans-unit id="6966bbbcdeb44c019201ede70e7b74b8">
+        <source>Zip file</source>
+        <target>Zip file</target>
+        <note>Line: 572</note>
+      </trans-unit>
+      <trans-unit id="dec0faa6eb19bd9120d12c5a876bd1cf">
+        <source>Import from the web</source>
+        <target>Import from the web</target>
+        <note>Line: 588</note>
+      </trans-unit>
+      <trans-unit id="a33388a338ee2b199d66112369279558">
+        <source>Archive URL</source>
+        <target>Archive URL</target>
+        <note>Line: 594</note>
+      </trans-unit>
+      <trans-unit id="cd8d9cc19984ccf9d314eee5eebfc2cc">
+        <source>Import from FTP</source>
+        <target>Import from FTP</target>
+        <note>Line: 622</note>
+      </trans-unit>
+      <trans-unit id="a5a23094873852f0c0a9e55be4f1cf1d">
+        <source>Select the archive</source>
+        <target>Select the archive</target>
+        <note>Line: 628</note>
+      </trans-unit>
+      <trans-unit id="d721757161f7f70c5b0949fdb6ec2c30">
+        <source>Theme</source>
+        <target>Theme</target>
+        <note>Line: 174</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminDesignHelp.xlf
+++ b/app/Resources/translations/default/AdminDesignHelp.xlf
@@ -1,290 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminCmsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2acc315907b6b57c444b1885666f5bdd">
-        <source>Used in the h1 page tag, and as the default title tag value.</source>
-        <target>Used in the h1 page tag, and as the default title tag value.</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:146</note>
-      </trans-unit>
-      <trans-unit id="27043bc0eeca71692edf6c51fef16ee0">
-        <source>Used to override the title tag value. If left blank, the default title value is used.</source>
-        <target>Used to override the title tag value. If left blank, the default title value is used.</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:156</note>
-      </trans-unit>
-      <trans-unit id="3ed349365d718a59eadb9df9d5c339f2">
-        <source>To add "tags" click in the field, write something, and then press "Enter."</source>
-        <target>To add "tags" click in the field, write something, and then press "Enter."</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:173</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminModulesPositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a06929291c19a7718975cb8c24dea961">
-        <source>E.g. address, addresses, attachment</source>
-        <target>E.g. address, addresses, attachment</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:428</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="48658689e18e12e430668e1f2419b0d0">
-        <source>JPEG images have a small file size and standard quality. PNG images have a larger file size, a higher quality and support transparency. Note that in all cases the image files will have the .jpg extension.</source>
-        <target>JPEG images have a small file size and standard quality. PNG images have a larger file size, a higher quality and support transparency. Note that in all cases the image files will have the .jpg extension.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:88</note>
-      </trans-unit>
-      <trans-unit id="c031c7c1498d22082b4dcbac4fac27d4">
-        <source>WARNING: This feature may not be compatible with your theme, or with some of your modules. In particular, PNG mode is not compatible with the Watermark module. If you encounter any issues, turn it off by selecting "Use JPEG".</source>
-        <target>WARNING: This feature may not be compatible with your theme, or with some of your modules. In particular, PNG mode is not compatible with the Watermark module. If you encounter any issues, turn it off by selecting "Use JPEG".</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:89</note>
-      </trans-unit>
-      <trans-unit id="576d1a59cae85fc41c31d27433e17d37">
-        <source>Ranges from 0 (worst quality, smallest file) to 100 (best quality, biggest file).</source>
-        <target>Ranges from 0 (worst quality, smallest file) to 100 (best quality, biggest file).</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:100</note>
-      </trans-unit>
-      <trans-unit id="49caff79e5dca417b2b2c37fc7ef61af">
-        <source>Recommended: 90.</source>
-        <target>Recommended: 90.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:100</note>
-      </trans-unit>
-      <trans-unit id="c1a1204bac358b5068446c93ec34bc87">
-        <source>PNG compression is lossless: unlike JPG, you do not lose image quality with a high compression ratio. However, photographs will compress very badly.</source>
-        <target>PNG compression is lossless: unlike JPG, you do not lose image quality with a high compression ratio. However, photographs will compress very badly.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:108</note>
-      </trans-unit>
-      <trans-unit id="ce1cd64739c592c80f58012b38f5c42f">
-        <source>Ranges from 0 (biggest file) to 9 (smallest file, slowest decompression).</source>
-        <target>Ranges from 0 (biggest file) to 9 (smallest file, slowest decompression).</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:108</note>
-      </trans-unit>
-      <trans-unit id="4b1fa40679bbc322bc244f9f09830681">
-        <source>Recommended: 7.</source>
-        <target>Recommended: 7.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:108</note>
-      </trans-unit>
-      <trans-unit id="e425d33122fa9152a34d746c60b0903b">
-        <source>The maximum file size of pictures that customers can upload to customize a product (in bytes).</source>
-        <target>The maximum file size of pictures that customers can upload to customize a product (in bytes).</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:139</note>
-      </trans-unit>
-      <trans-unit id="273ad45c9ec7fbd15b705f1d8b272bdb">
-        <source>Width of product customization pictures that customers can upload (in pixels).</source>
-        <target>Width of product customization pictures that customers can upload (in pixels).</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:149</note>
-      </trans-unit>
-      <trans-unit id="fd70ea0d8dbbe0a675d717812b3253fe">
-        <source>Height of product customization pictures that customers can upload (in pixels).</source>
-        <target>Height of product customization pictures that customers can upload (in pixels).</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:160</note>
-      </trans-unit>
-      <trans-unit id="d20e2b80b07e17b035a7c8fe09deca44">
-        <source>This will generate an additional file for each image (thus doubling your total amount of images). Resolution of these images will be twice higher.</source>
-        <target>This will generate an additional file for each image (thus doubling your total amount of images). Resolution of these images will be twice higher.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:174</note>
-      </trans-unit>
-      <trans-unit id="d869df123081c24a3d5f5145cb5368ea">
-        <source>Enable to optimize the display of your images on high pixel density screens.</source>
-        <target>Enable to optimize the display of your images on high pixel density screens.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:175</note>
-      </trans-unit>
-      <trans-unit id="bc10c6548185bd449a823faf9c171596">
-        <source>This should be set to yes unless you successfully moved images in "Images" page under the "Preferences" menu.</source>
-        <target>This should be set to yes unless you successfully moved images in "Images" page under the "Preferences" menu.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:186</note>
-      </trans-unit>
-      <trans-unit id="0e10ed6e73d3301bee138a59a23c5de9">
-        <source>Letters, underscores and hyphens only (e.g. "small_custom", "cart_medium", "large", "thickbox_extra-large").</source>
-        <target>Letters, underscores and hyphens only (e.g. "small_custom", "cart_medium", "large", "thickbox_extra-large").</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:206</note>
-      </trans-unit>
-      <trans-unit id="845d4d07d4cfe4d1ccadcbab72efe199">
-        <source>Maximum image width in pixels.</source>
-        <target>Maximum image width in pixels.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:215</note>
-      </trans-unit>
-      <trans-unit id="0afd1617fde01be0d13f62668e7ad4f1">
-        <source>Maximum image height in pixels.</source>
-        <target>Maximum image height in pixels.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:224</note>
-      </trans-unit>
-      <trans-unit id="a61f835bd3188471923b2da2717091ec">
-        <source>This type will be used for Product images.</source>
-        <target>This type will be used for Product images.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:232</note>
-      </trans-unit>
-      <trans-unit id="1ad8a6b5f7d9fc6ca597ad11103fab6e">
-        <source>This type will be used for Category images.</source>
-        <target>This type will be used for Category images.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:253</note>
-      </trans-unit>
-      <trans-unit id="f193abb289c02779dabbdae3beb6e9e1">
-        <source>This type will be used for Brand images.</source>
-        <target>This type will be used for Brand images.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:273</note>
-      </trans-unit>
-      <trans-unit id="01e1e70a11e81d8327a7a565869fb268">
-        <source>This type will be used for Supplier images.</source>
-        <target>This type will be used for Supplier images.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:293</note>
-      </trans-unit>
-      <trans-unit id="0096ae72d90ea092533743553617e0a5">
-        <source>This type will be used for Store images.</source>
-        <target>This type will be used for Store images.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:313</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminThemesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8ed0c1461337919e3cf576591d74b687">
-        <source>Will appear on main page. Recommended size for the default theme: height %height% and width %width%.</source>
-        <target>Will appear on main page. Recommended size for the default theme: height %height% and width %width%.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:414</note>
-      </trans-unit>
-      <trans-unit id="aeec498c2bb6b53e8eb24752af092828">
-        <source>Will appear on email headers. If undefined, the header logo will be used.</source>
-        <target>Will appear on email headers. If undefined, the header logo will be used.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:428</note>
-      </trans-unit>
-      <trans-unit id="544cd7788ebd8916e7191e7a8fd0db57">
-        <source>Warning: if no invoice logo is available, the main logo will be used instead.</source>
-        <target>Warning: if no invoice logo is available, the main logo will be used instead.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:436</note>
-      </trans-unit>
-      <trans-unit id="b0297d22aade28eda5efbeb5c2e21e97">
-        <source>Will appear on invoice headers.</source>
-        <target>Will appear on invoice headers.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:437</note>
-      </trans-unit>
-      <trans-unit id="d4d7bd35b17411da70ed5e76bcb4c3da">
-        <source>Warning: you can use a PNG file for transparency, but it can take up to 1 second per page for processing. Please consider using JPG instead.</source>
-        <target>Warning: you can use a PNG file for transparency, but it can take up to 1 second per page for processing. Please consider using JPG instead.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:437</note>
-      </trans-unit>
-      <trans-unit id="3fb044d8f9136df5b2f0087f8a8fb0c9">
-        <source>Use our [1]favicon generator on PrestaShop Marketplace[/1] to boost your brand image!</source>
-        <target>Use our [1]favicon generator on PrestaShop Marketplace[/1] to boost your brand image!</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:445</note>
-      </trans-unit>
-      <trans-unit id="9d365da5a530a9f2607be1d3ba79235c">
-        <source>It is the small icon that appears in browser tabs, next to the web address</source>
-        <target>It is the small icon that appears in browser tabs, next to the web address</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:446</note>
-      </trans-unit>
-      <trans-unit id="1a4e6f83162563ba06213015f4f503ed">
-        <source>Be careful! Please check your theme in an RTL language before generating the RTL stylesheet: your theme could be already adapted to RTL.\nOnce you click on "Adapt to RTL", any RTL-specific file that you might have added to your theme might be deleted by the created stylesheet.</source>
-        <target>Be careful! Please check your theme in an RTL language before generating the RTL stylesheet: your theme could be already adapted to RTL.\nOnce you click on "Adapt to RTL", any RTL-specific file that you might have added to your theme might be deleted by the created stylesheet.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:481</note>
-      </trans-unit>
-      <trans-unit id="6894e313abf58dc29e27e6aef50b2f03">
-        <source>You must select a shop from the above list if you wish to choose a theme.</source>
-        <target>You must select a shop from the above list if you wish to choose a theme.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:508</note>
-      </trans-unit>
-      <trans-unit id="0d03fc8cc7c22c4ff80c5cda6f56ce8e">
-        <source>Browse your computer files and select the Zip file for your new theme.</source>
-        <target>Browse your computer files and select the Zip file for your new theme.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:571</note>
-      </trans-unit>
-      <trans-unit id="f545e8220cd6f37617c495e59695f7f3">
-        <source>Indicate the complete URL to an online Zip file that contains your new theme. For instance, "http://example.com/files/theme.zip".</source>
-        <target>Indicate the complete URL to an online Zip file that contains your new theme. For instance, "http://example.com/files/theme.zip".</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:593</note>
-      </trans-unit>
-      <trans-unit id="87c309a4d1deb851c8522127c1aeae54">
-        <source>This selector lists the Zip files that you uploaded in the '/themes' folder.</source>
-        <target>This selector lists the Zip files that you uploaded in the '/themes' folder.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:628</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCmsContentController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cabfe7563d12c3e047000dc5703d9709">
-        <source>Add new page category</source>
-        <target>Add new page category</target>
-        <note>Context:
-File: controllers/admin/AdminCmsContentController.php:108</note>
-      </trans-unit>
-      <trans-unit id="aa6f77f824eff8e896510f1bbaf9f8e5">
-        <source>Add new page</source>
-        <target>Add new page</target>
-        <note>Context:
-File: controllers/admin/AdminCmsContentController.php:113</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/images/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="5fe1c6d39261cafbe5e6d827330d3841">
         <source>By default, all images settings are already installed in your store. Do not delete them, you will need it!</source>
         <target>By default, all images settings are already installed in your store. Do not delete them, you will need it!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="8e6cd17ee7b35531b7c17c1e1edeb548">
         <source>Regenerates thumbnails for all existing images</source>
         <target>Regenerates thumbnails for all existing images</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:67</note>
+        <note>Line: 67</note>
       </trans-unit>
       <trans-unit id="8055bf2356820e356d02127707b38d54">
         <source>Please be patient. This can take several minutes.</source>
         <target>Please be patient. This can take several minutes.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:68</note>
+        <note>Line: 68</note>
       </trans-unit>
       <trans-unit id="3bfa8daa236ed8bde7eb2179e8ee9765">
         <source>Be careful! Manually uploaded thumbnails will be erased and replaced by automatically generated thumbnails.</source>
         <target>Be careful! Manually uploaded thumbnails will be erased and replaced by automatically generated thumbnails.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:69</note>
+        <note>Line: 69</note>
       </trans-unit>
       <trans-unit id="85cf8b897040b0bc24d97db52d0922ee">
         <source>Select "No" only if your server timed out and you need to resume the regeneration.</source>
         <target>Select "No" only if your server timed out and you need to resume the regeneration.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:122</note>
+        <note>Line: 122</note>
       </trans-unit>
     </body>
   </file>
@@ -293,32 +34,242 @@ File: admin-dev/themes/default/template/controllers/images/content.tpl:122</note
       <trans-unit id="0a4dbce7e33277b97c5f5667715e0b46">
         <source>Please select a module</source>
         <target>Please select a module</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/form.tpl:42</note>
+        <note>Line: 42</note>
       </trans-unit>
       <trans-unit id="0b08e9b451b556f1bdd62b285ee2a9df">
         <source>Select a module above before choosing from available hooks</source>
         <target>Select a module above before choosing from available hooks</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/form.tpl:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="74cd700f9b419dd789dc7d8d1cbf49ef">
         <source>Please specify the files for which you do not want the module to be displayed.</source>
         <target>Please specify the files for which you do not want the module to be displayed.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/form.tpl:69</note>
+        <note>Line: 69</note>
       </trans-unit>
       <trans-unit id="07b7dbb810d745fc3891d68448f3f213">
         <source>Please input each filename, separated by a comma (",").</source>
         <target>Please input each filename, separated by a comma (",").</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/form.tpl:70</note>
+        <note>Line: 70</note>
       </trans-unit>
       <trans-unit id="804a997021a16e79a9e6ef9a2bf39e3d">
         <source>You can also click the filename in the list below, and even make a multiple selection by keeping the Ctrl key pressed while clicking, or choose a whole range of filename by keeping the Shift key pressed while clicking.</source>
         <target>You can also click the filename in the list below, and even make a multiple selection by keeping the Ctrl key pressed while clicking, or choose a whole range of filename by keeping the Shift key pressed while clicking.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/form.tpl:71</note>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsContentController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cabfe7563d12c3e047000dc5703d9709">
+        <source>Add new page category</source>
+        <target>Add new page category</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="aa6f77f824eff8e896510f1bbaf9f8e5">
+        <source>Add new page</source>
+        <target>Add new page</target>
+        <note>Line: 113</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2acc315907b6b57c444b1885666f5bdd">
+        <source>Used in the h1 page tag, and as the default title tag value.</source>
+        <target>Used in the h1 page tag, and as the default title tag value.</target>
+        <note>Line: 173</note>
+      </trans-unit>
+      <trans-unit id="27043bc0eeca71692edf6c51fef16ee0">
+        <source>Used to override the title tag value. If left blank, the default title value is used.</source>
+        <target>Used to override the title tag value. If left blank, the default title value is used.</target>
+        <note>Line: 183</note>
+      </trans-unit>
+      <trans-unit id="3ed349365d718a59eadb9df9d5c339f2">
+        <source>To add "tags" click in the field, write something, and then press "Enter."</source>
+        <target>To add "tags" click in the field, write something, and then press "Enter."</target>
+        <note>Line: 200</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="48658689e18e12e430668e1f2419b0d0">
+        <source>JPEG images have a small file size and standard quality. PNG images have a larger file size, a higher quality and support transparency. Note that in all cases the image files will have the .jpg extension.</source>
+        <target>JPEG images have a small file size and standard quality. PNG images have a larger file size, a higher quality and support transparency. Note that in all cases the image files will have the .jpg extension.</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="c031c7c1498d22082b4dcbac4fac27d4">
+        <source>WARNING: This feature may not be compatible with your theme, or with some of your modules. In particular, PNG mode is not compatible with the Watermark module. If you encounter any issues, turn it off by selecting "Use JPEG".</source>
+        <target>WARNING: This feature may not be compatible with your theme, or with some of your modules. In particular, PNG mode is not compatible with the Watermark module. If you encounter any issues, turn it off by selecting "Use JPEG".</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="576d1a59cae85fc41c31d27433e17d37">
+        <source>Ranges from 0 (worst quality, smallest file) to 100 (best quality, biggest file).</source>
+        <target>Ranges from 0 (worst quality, smallest file) to 100 (best quality, biggest file).</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="49caff79e5dca417b2b2c37fc7ef61af">
+        <source>Recommended: 90.</source>
+        <target>Recommended: 90.</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="c1a1204bac358b5068446c93ec34bc87">
+        <source>PNG compression is lossless: unlike JPG, you do not lose image quality with a high compression ratio. However, photographs will compress very badly.</source>
+        <target>PNG compression is lossless: unlike JPG, you do not lose image quality with a high compression ratio. However, photographs will compress very badly.</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="ce1cd64739c592c80f58012b38f5c42f">
+        <source>Ranges from 0 (biggest file) to 9 (smallest file, slowest decompression).</source>
+        <target>Ranges from 0 (biggest file) to 9 (smallest file, slowest decompression).</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="4b1fa40679bbc322bc244f9f09830681">
+        <source>Recommended: 7.</source>
+        <target>Recommended: 7.</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="e425d33122fa9152a34d746c60b0903b">
+        <source>The maximum file size of pictures that customers can upload to customize a product (in bytes).</source>
+        <target>The maximum file size of pictures that customers can upload to customize a product (in bytes).</target>
+        <note>Line: 139</note>
+      </trans-unit>
+      <trans-unit id="273ad45c9ec7fbd15b705f1d8b272bdb">
+        <source>Width of product customization pictures that customers can upload (in pixels).</source>
+        <target>Width of product customization pictures that customers can upload (in pixels).</target>
+        <note>Line: 149</note>
+      </trans-unit>
+      <trans-unit id="fd70ea0d8dbbe0a675d717812b3253fe">
+        <source>Height of product customization pictures that customers can upload (in pixels).</source>
+        <target>Height of product customization pictures that customers can upload (in pixels).</target>
+        <note>Line: 160</note>
+      </trans-unit>
+      <trans-unit id="d20e2b80b07e17b035a7c8fe09deca44">
+        <source>This will generate an additional file for each image (thus doubling your total amount of images). Resolution of these images will be twice higher.</source>
+        <target>This will generate an additional file for each image (thus doubling your total amount of images). Resolution of these images will be twice higher.</target>
+        <note>Line: 174</note>
+      </trans-unit>
+      <trans-unit id="d869df123081c24a3d5f5145cb5368ea">
+        <source>Enable to optimize the display of your images on high pixel density screens.</source>
+        <target>Enable to optimize the display of your images on high pixel density screens.</target>
+        <note>Line: 175</note>
+      </trans-unit>
+      <trans-unit id="bc10c6548185bd449a823faf9c171596">
+        <source>This should be set to yes unless you successfully moved images in "Images" page under the "Preferences" menu.</source>
+        <target>This should be set to yes unless you successfully moved images in "Images" page under the "Preferences" menu.</target>
+        <note>Line: 186</note>
+      </trans-unit>
+      <trans-unit id="0e10ed6e73d3301bee138a59a23c5de9">
+        <source>Letters, underscores and hyphens only (e.g. "small_custom", "cart_medium", "large", "thickbox_extra-large").</source>
+        <target>Letters, underscores and hyphens only (e.g. "small_custom", "cart_medium", "large", "thickbox_extra-large").</target>
+        <note>Line: 206</note>
+      </trans-unit>
+      <trans-unit id="845d4d07d4cfe4d1ccadcbab72efe199">
+        <source>Maximum image width in pixels.</source>
+        <target>Maximum image width in pixels.</target>
+        <note>Line: 215</note>
+      </trans-unit>
+      <trans-unit id="0afd1617fde01be0d13f62668e7ad4f1">
+        <source>Maximum image height in pixels.</source>
+        <target>Maximum image height in pixels.</target>
+        <note>Line: 224</note>
+      </trans-unit>
+      <trans-unit id="a61f835bd3188471923b2da2717091ec">
+        <source>This type will be used for Product images.</source>
+        <target>This type will be used for Product images.</target>
+        <note>Line: 232</note>
+      </trans-unit>
+      <trans-unit id="1ad8a6b5f7d9fc6ca597ad11103fab6e">
+        <source>This type will be used for Category images.</source>
+        <target>This type will be used for Category images.</target>
+        <note>Line: 253</note>
+      </trans-unit>
+      <trans-unit id="f193abb289c02779dabbdae3beb6e9e1">
+        <source>This type will be used for Brand images.</source>
+        <target>This type will be used for Brand images.</target>
+        <note>Line: 273</note>
+      </trans-unit>
+      <trans-unit id="01e1e70a11e81d8327a7a565869fb268">
+        <source>This type will be used for Supplier images.</source>
+        <target>This type will be used for Supplier images.</target>
+        <note>Line: 293</note>
+      </trans-unit>
+      <trans-unit id="0096ae72d90ea092533743553617e0a5">
+        <source>This type will be used for Store images.</source>
+        <target>This type will be used for Store images.</target>
+        <note>Line: 313</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminModulesPositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a06929291c19a7718975cb8c24dea961">
+        <source>E.g. address, addresses, attachment</source>
+        <target>E.g. address, addresses, attachment</target>
+        <note>Line: 428</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminThemesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8ed0c1461337919e3cf576591d74b687">
+        <source>Will appear on main page. Recommended size for the default theme: height %height% and width %width%.</source>
+        <target>Will appear on main page. Recommended size for the default theme: height %height% and width %width%.</target>
+        <note>Line: 415</note>
+      </trans-unit>
+      <trans-unit id="aeec498c2bb6b53e8eb24752af092828">
+        <source>Will appear on email headers. If undefined, the header logo will be used.</source>
+        <target>Will appear on email headers. If undefined, the header logo will be used.</target>
+        <note>Line: 429</note>
+      </trans-unit>
+      <trans-unit id="544cd7788ebd8916e7191e7a8fd0db57">
+        <source>Warning: if no invoice logo is available, the main logo will be used instead.</source>
+        <target>Warning: if no invoice logo is available, the main logo will be used instead.</target>
+        <note>Line: 437</note>
+      </trans-unit>
+      <trans-unit id="b0297d22aade28eda5efbeb5c2e21e97">
+        <source>Will appear on invoice headers.</source>
+        <target>Will appear on invoice headers.</target>
+        <note>Line: 438</note>
+      </trans-unit>
+      <trans-unit id="d4d7bd35b17411da70ed5e76bcb4c3da">
+        <source>Warning: you can use a PNG file for transparency, but it can take up to 1 second per page for processing. Please consider using JPG instead.</source>
+        <target>Warning: you can use a PNG file for transparency, but it can take up to 1 second per page for processing. Please consider using JPG instead.</target>
+        <note>Line: 438</note>
+      </trans-unit>
+      <trans-unit id="3fb044d8f9136df5b2f0087f8a8fb0c9">
+        <source>Use our [1]favicon generator on PrestaShop Marketplace[/1] to boost your brand image!</source>
+        <target>Use our [1]favicon generator on PrestaShop Marketplace[/1] to boost your brand image!</target>
+        <note>Line: 446</note>
+      </trans-unit>
+      <trans-unit id="9d365da5a530a9f2607be1d3ba79235c">
+        <source>It is the small icon that appears in browser tabs, next to the web address</source>
+        <target>It is the small icon that appears in browser tabs, next to the web address</target>
+        <note>Line: 447</note>
+      </trans-unit>
+      <trans-unit id="1a4e6f83162563ba06213015f4f503ed">
+        <source>Be careful! Please check your theme in an RTL language before generating the RTL stylesheet: your theme could be already adapted to RTL.\nOnce you click on "Adapt to RTL", any RTL-specific file that you might have added to your theme might be deleted by the created stylesheet.</source>
+        <target>Be careful! Please check your theme in an RTL language before generating the RTL stylesheet: your theme could be already adapted to RTL.\nOnce you click on "Adapt to RTL", any RTL-specific file that you might have added to your theme might be deleted by the created stylesheet.</target>
+        <note>Line: 482</note>
+      </trans-unit>
+      <trans-unit id="6894e313abf58dc29e27e6aef50b2f03">
+        <source>You must select a shop from the above list if you wish to choose a theme.</source>
+        <target>You must select a shop from the above list if you wish to choose a theme.</target>
+        <note>Line: 509</note>
+      </trans-unit>
+      <trans-unit id="0d03fc8cc7c22c4ff80c5cda6f56ce8e">
+        <source>Browse your computer files and select the Zip file for your new theme.</source>
+        <target>Browse your computer files and select the Zip file for your new theme.</target>
+        <note>Line: 573</note>
+      </trans-unit>
+      <trans-unit id="f545e8220cd6f37617c495e59695f7f3">
+        <source>Indicate the complete URL to an online Zip file that contains your new theme. For instance, "http://example.com/files/theme.zip".</source>
+        <target>Indicate the complete URL to an online Zip file that contains your new theme. For instance, "http://example.com/files/theme.zip".</target>
+        <note>Line: 595</note>
+      </trans-unit>
+      <trans-unit id="87c309a4d1deb851c8522127c1aeae54">
+        <source>This selector lists the Zip files that you uploaded in the '/themes' folder.</source>
+        <target>This selector lists the Zip files that you uploaded in the '/themes' folder.</target>
+        <note>Line: 630</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminDesignNotification.xlf
+++ b/app/Resources/translations/default/AdminDesignNotification.xlf
@@ -1,238 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminCmsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="5ece607071fe59ddc4c88dc6abfe2310">
-        <source>No items found</source>
-        <target>No items found</target>
-        <note>Context:
-File: controllers/admin/AdminCmsController.php:289</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCmsCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="29dae1d163226f90bb206b333bbffe1d">
-        <source>The page Category cannot be moved here.</source>
-        <target>The page Category cannot be moved here.</target>
-        <note>Context:
-File: controllers/admin/AdminCmsCategoriesController.php:106</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ffddcc65274efa9b4c624b34289c922c">
-        <source>Duplicate images were found when moving the product images. This is likely caused by unused demonstration images. Please make sure that the folder %folder% only contains demonstration images, and then delete it.</source>
-        <target>Duplicate images were found when moving the product images. This is likely caused by unused demonstration images. Please make sure that the folder %folder% only contains demonstration images, and then delete it.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:338</note>
-      </trans-unit>
-      <trans-unit id="5b8cb2aa659c7d6a98b740d2d788c69d">
-        <source>Incorrect value for the selected JPEG image compression.</source>
-        <target>Incorrect value for the selected JPEG image compression.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:361</note>
-      </trans-unit>
-      <trans-unit id="8357fadc46ff52546c4c69965de0d653">
-        <source>Incorrect value for the selected PNG image compression.</source>
-        <target>Incorrect value for the selected PNG image compression.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:364</note>
-      </trans-unit>
-      <trans-unit id="e8be55bf3a30501aef09d2e74de97976">
-        <source>This name already exists.</source>
-        <target>This name already exists.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:390</note>
-      </trans-unit>
-      <trans-unit id="b88862891dbf9c20a73bc59258407d0b">
-        <source>Source file does not exist or is empty (%filepath%)</source>
-        <target>Source file does not exist or is empty (%filepath%)</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:502</note>
-      </trans-unit>
-      <trans-unit id="985b5b995c4574ae5eba2062a13ef168">
-        <source>Failed to resize image file (%filepath%)</source>
-        <target>Failed to resize image file (%filepath%)</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:504</note>
-      </trans-unit>
-      <trans-unit id="c5e7d0c13104eed0a195c175f2edfdd2">
-        <source>Failed to resize image file to high resolution (%filepath%)</source>
-        <target>Failed to resize image file to high resolution (%filepath%)</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:509</note>
-      </trans-unit>
-      <trans-unit id="103d86044b78fa59e02ff8480a3a2f46">
-        <source>Original image is corrupt (%filename%) for product ID %id% or bad permission on folder.</source>
-        <target>Original image is corrupt (%filename%) for product ID %id% or bad permission on folder.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:541</note>
-      </trans-unit>
-      <trans-unit id="2934958a3f658892ee502aaf8258a6f7">
-        <source>Original image is missing or empty (%filename%) for product ID %id%</source>
-        <target>Original image is missing or empty (%filename%) for product ID %id%</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:554</note>
-      </trans-unit>
-      <trans-unit id="8b772dad7cc4ed15eaf0c433f861e55c">
-        <source>Cannot write images for this type: %1$s. Please check the %2$s folder's writing permissions.</source>
-        <target>Cannot write images for this type: %1$s. Please check the %2$s folder's writing permissions.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:676</note>
-      </trans-unit>
-      <trans-unit id="d4f225ec09e4b0eba6558753f4bd8edd">
-        <source>Only part of the images have been regenerated. The server timed out before finishing.</source>
-        <target>Only part of the images have been regenerated. The server timed out before finishing.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:679</note>
-      </trans-unit>
-      <trans-unit id="f2febdafe25d3517afc3c6dd3d815562">
-        <source>Server timed out. The watermark may not have been applied to all images.</source>
-        <target>Server timed out. The watermark may not have been applied to all images.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:683</note>
-      </trans-unit>
-      <trans-unit id="606495559093a136ed6f2c9daee2645f">
-        <source>Cannot write "No picture" image to %s images folder. Please check the folder's writing permissions.</source>
-        <target>Cannot write "No picture" image to %s images folder. Please check the folder's writing permissions.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:688</note>
-      </trans-unit>
-      <trans-unit id="4004c7590c68a8cbbe499736c56bc33c">
-        <source>Error: Your server configuration is not compatible with the new image system. No images were moved.</source>
-        <target>Error: Your server configuration is not compatible with the new image system. No images were moved.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:716</note>
-      </trans-unit>
-      <trans-unit id="4c9f49243d6dc02028801d9767abe3c1">
-        <source>Not all images have been moved. The server timed out before finishing. Click on "Move images" again to resume the moving process.</source>
-        <target>Not all images have been moved. The server timed out before finishing. Click on "Move images" again to resume the moving process.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:722</note>
-      </trans-unit>
-      <trans-unit id="95871efade00fbd0243355ce7937c40a">
-        <source>Error: Some -- or all -- images cannot be moved.</source>
-        <target>Error: Some -- or all -- images cannot be moved.</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:724</note>
-      </trans-unit>
-      <trans-unit id="cb2f901ceed5c3365d056794a1b5047f">
-        <source>After modification, do not forget to regenerate thumbnails</source>
-        <target>After modification, do not forget to regenerate thumbnails</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:743</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_themecusto/controllers/admin/AdminPsThemeCustoAdvanced.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6e9550e40cc317663fbe81e759d098e8">
-        <source>The uploaded file is too large.</source>
-        <target>The uploaded file is too large.</target>
-        <note>Context:
-File: modules/ps_themecusto/controllers/admin/AdminPsThemeCustoAdvanced.php:264</note>
-      </trans-unit>
-      <trans-unit id="1ecb89bb5b6dce906edaf8e12968c167">
-        <source>Invalid file format.</source>
-        <target>Invalid file format.</target>
-        <note>Context:
-File: modules/ps_themecusto/controllers/admin/AdminPsThemeCustoAdvanced.php:285</note>
-      </trans-unit>
-      <trans-unit id="d4c8009943f24c4318bef97058cc6ffa">
-        <source>Failed to move uploaded file.</source>
-        <target>Failed to move uploaded file.</target>
-        <note>Context:
-File: modules/ps_themecusto/controllers/admin/AdminPsThemeCustoAdvanced.php:298</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminThemesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3cb5c48f468125102a98fe83a277029d">
-        <source>Warning: if no email logo is available, the main logo will be used instead.</source>
-        <target>Warning: if no email logo is available, the main logo will be used instead.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:427</note>
-      </trans-unit>
-      <trans-unit id="4a9fdf95b29176bd9260016655a80852">
-        <source>Your RTL stylesheets has been generated successfully</source>
-        <target>Your RTL stylesheets has been generated successfully</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:1057</note>
-      </trans-unit>
-      <trans-unit id="9ccfef29efe298e9a48295a69436e11f">
-        <source><![CDATA[Your theme has been correctly reset to its default settings. You may want to regenerate your images. See the Improve > Design > Images Settings screen for the 'Regenerate thumbnails' button.]]></source>
-        <target><![CDATA[Your theme has been correctly reset to its default settings. You may want to regenerate your images. See the Improve > Design > Images Settings screen for the 'Regenerate thumbnails' button.]]></target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:1076</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Addon/Theme/ThemeValidator.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="832e8c53e8d05c52c824912c28933917">
-        <source>An error occurred. The information "%s" is missing.</source>
-        <target>An error occurred. The information "%s" is missing.</target>
-        <note>Context:
-File: src/Core/Addon/Theme/ThemeValidator.php:72</note>
-      </trans-unit>
-      <trans-unit id="7d88c564a7f74d56564402cd5e054b13">
-        <source>An error occurred. The template "%s" is missing.</source>
-        <target>An error occurred. The template "%s" is missing.</target>
-        <note>Context:
-File: src/Core/Addon/Theme/ThemeValidator.php:116</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Addon/Theme/ThemeManager.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="412b4a82ba6153e19f17f490b5f1aa88">
-        <source>This theme is not valid for PrestaShop 1.7</source>
-        <target>This theme is not valid for PrestaShop 1.7</target>
-        <note>Context:
-File: src/Core/Addon/Theme/ThemeManager.php:359</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Shop/LogoUploader.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f003149576f4755d74550952febe14bb">
-        <source>An error occurred while uploading the favicon: cannot copy file "%s" to folder "%s".</source>
-        <target>An error occurred while uploading the favicon: cannot copy file "%s" to folder "%s".</target>
-        <note>Context:
-File: src/Core/Shop/LogoUploader.php:170</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Command/ExportThemeCommand.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ebc7584c0a97bc4aa867c11fc4760b3f">
-        <source>Your theme has been correctly exported: %path%</source>
-        <target>Your theme has been correctly exported: %path%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Command/ExportThemeCommand.php:58</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/controller/FrontController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c402321a8e5818b776007e8a2d00474a">
-        <source>Current theme is unavailable. Please check your theme's directory name ("%s") and permissions.</source>
-        <target>Current theme is unavailable. Please check your theme's directory name ("%s") and permissions.</target>
-        <note>Context:
-File: classes/controller/FrontController.php:321</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="307cd46da080d0ad19ec342feb2aa6d6">
-        <source>If you want to order/move the following data, please select a shop from the shop list.</source>
-        <target>If you want to order/move the following data, please select a shop from the shop list.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:34</note>
+      <trans-unit id="feede4b4294c44c907966ddd76e23614">
+        <source>Your page will be saved as a draft</source>
+        <target>Your page will be saved as a draft</target>
+        <note>Line: 55</note>
       </trans-unit>
     </body>
   </file>
@@ -241,30 +14,217 @@ File: admin-dev/themes/default/template/controllers/modules_positions/list_modul
       <trans-unit id="8c9b2e81e93417bf65ee4d1c674d00e9">
         <source>You can choose to keep your images stored in the previous system. There's nothing wrong with that.</source>
         <target>You can choose to keep your images stored in the previous system. There's nothing wrong with that.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:42</note>
+        <note>Line: 42</note>
       </trans-unit>
       <trans-unit id="1f424af91db226ac46ea712713a3728e">
         <source>You can also decide to move your images to the new storage system. In this case, click on the "Move images" button below. Please be patient. This can take several minutes.</source>
         <target>You can also decide to move your images to the new storage system. In this case, click on the "Move images" button below. Please be patient. This can take several minutes.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="cde488e6010c72acfb6ff2781683b030">
         <source>After moving all of your product images, set the "Use the legacy image filesystem" option above to "No" for best performance.</source>
         <target>After moving all of your product images, set the "Use the legacy image filesystem" option above to "No" for best performance.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:46</note>
+        <note>Line: 46</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="feede4b4294c44c907966ddd76e23614">
-        <source>Your page will be saved as a draft</source>
-        <target>Your page will be saved as a draft</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl:55</note>
+      <trans-unit id="307cd46da080d0ad19ec342feb2aa6d6">
+        <source>If you want to order/move the following data, please select a shop from the shop list.</source>
+        <target>If you want to order/move the following data, please select a shop from the shop list.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/controller/FrontController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c402321a8e5818b776007e8a2d00474a">
+        <source>Current theme is unavailable. Please check your theme's directory name ("%s") and permissions.</source>
+        <target>Current theme is unavailable. Please check your theme's directory name ("%s") and permissions.</target>
+        <note>Line: 317</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="29dae1d163226f90bb206b333bbffe1d">
+        <source>The page Category cannot be moved here.</source>
+        <target>The page Category cannot be moved here.</target>
+        <note>Line: 106</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5ece607071fe59ddc4c88dc6abfe2310">
+        <source>No items found</source>
+        <target>No items found</target>
+        <note>Line: 316</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ffddcc65274efa9b4c624b34289c922c">
+        <source>Duplicate images were found when moving the product images. This is likely caused by unused demonstration images. Please make sure that the folder %folder% only contains demonstration images, and then delete it.</source>
+        <target>Duplicate images were found when moving the product images. This is likely caused by unused demonstration images. Please make sure that the folder %folder% only contains demonstration images, and then delete it.</target>
+        <note>Line: 338</note>
+      </trans-unit>
+      <trans-unit id="5b8cb2aa659c7d6a98b740d2d788c69d">
+        <source>Incorrect value for the selected JPEG image compression.</source>
+        <target>Incorrect value for the selected JPEG image compression.</target>
+        <note>Line: 361</note>
+      </trans-unit>
+      <trans-unit id="8357fadc46ff52546c4c69965de0d653">
+        <source>Incorrect value for the selected PNG image compression.</source>
+        <target>Incorrect value for the selected PNG image compression.</target>
+        <note>Line: 364</note>
+      </trans-unit>
+      <trans-unit id="e8be55bf3a30501aef09d2e74de97976">
+        <source>This name already exists.</source>
+        <target>This name already exists.</target>
+        <note>Line: 390</note>
+      </trans-unit>
+      <trans-unit id="b88862891dbf9c20a73bc59258407d0b">
+        <source>Source file does not exist or is empty (%filepath%)</source>
+        <target>Source file does not exist or is empty (%filepath%)</target>
+        <note>Line: 502</note>
+      </trans-unit>
+      <trans-unit id="985b5b995c4574ae5eba2062a13ef168">
+        <source>Failed to resize image file (%filepath%)</source>
+        <target>Failed to resize image file (%filepath%)</target>
+        <note>Line: 504</note>
+      </trans-unit>
+      <trans-unit id="c5e7d0c13104eed0a195c175f2edfdd2">
+        <source>Failed to resize image file to high resolution (%filepath%)</source>
+        <target>Failed to resize image file to high resolution (%filepath%)</target>
+        <note>Line: 509</note>
+      </trans-unit>
+      <trans-unit id="103d86044b78fa59e02ff8480a3a2f46">
+        <source>Original image is corrupt (%filename%) for product ID %id% or bad permission on folder.</source>
+        <target>Original image is corrupt (%filename%) for product ID %id% or bad permission on folder.</target>
+        <note>Line: 541</note>
+      </trans-unit>
+      <trans-unit id="2934958a3f658892ee502aaf8258a6f7">
+        <source>Original image is missing or empty (%filename%) for product ID %id%</source>
+        <target>Original image is missing or empty (%filename%) for product ID %id%</target>
+        <note>Line: 554</note>
+      </trans-unit>
+      <trans-unit id="8b772dad7cc4ed15eaf0c433f861e55c">
+        <source>Cannot write images for this type: %1$s. Please check the %2$s folder's writing permissions.</source>
+        <target>Cannot write images for this type: %1$s. Please check the %2$s folder's writing permissions.</target>
+        <note>Line: 676</note>
+      </trans-unit>
+      <trans-unit id="d4f225ec09e4b0eba6558753f4bd8edd">
+        <source>Only part of the images have been regenerated. The server timed out before finishing.</source>
+        <target>Only part of the images have been regenerated. The server timed out before finishing.</target>
+        <note>Line: 679</note>
+      </trans-unit>
+      <trans-unit id="f2febdafe25d3517afc3c6dd3d815562">
+        <source>Server timed out. The watermark may not have been applied to all images.</source>
+        <target>Server timed out. The watermark may not have been applied to all images.</target>
+        <note>Line: 683</note>
+      </trans-unit>
+      <trans-unit id="606495559093a136ed6f2c9daee2645f">
+        <source>Cannot write "No picture" image to %s images folder. Please check the folder's writing permissions.</source>
+        <target>Cannot write "No picture" image to %s images folder. Please check the folder's writing permissions.</target>
+        <note>Line: 688</note>
+      </trans-unit>
+      <trans-unit id="4004c7590c68a8cbbe499736c56bc33c">
+        <source>Error: Your server configuration is not compatible with the new image system. No images were moved.</source>
+        <target>Error: Your server configuration is not compatible with the new image system. No images were moved.</target>
+        <note>Line: 716</note>
+      </trans-unit>
+      <trans-unit id="4c9f49243d6dc02028801d9767abe3c1">
+        <source>Not all images have been moved. The server timed out before finishing. Click on "Move images" again to resume the moving process.</source>
+        <target>Not all images have been moved. The server timed out before finishing. Click on "Move images" again to resume the moving process.</target>
+        <note>Line: 722</note>
+      </trans-unit>
+      <trans-unit id="95871efade00fbd0243355ce7937c40a">
+        <source>Error: Some -- or all -- images cannot be moved.</source>
+        <target>Error: Some -- or all -- images cannot be moved.</target>
+        <note>Line: 724</note>
+      </trans-unit>
+      <trans-unit id="cb2f901ceed5c3365d056794a1b5047f">
+        <source>After modification, do not forget to regenerate thumbnails</source>
+        <target>After modification, do not forget to regenerate thumbnails</target>
+        <note>Line: 743</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminThemesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6e9550e40cc317663fbe81e759d098e8">
+        <source>The uploaded file is too large.</source>
+        <target>The uploaded file is too large.</target>
+        <note>Line: 922</note>
+      </trans-unit>
+      <trans-unit id="1ecb89bb5b6dce906edaf8e12968c167">
+        <source>Invalid file format.</source>
+        <target>Invalid file format.</target>
+        <note>Line: 366</note>
+      </trans-unit>
+      <trans-unit id="d4c8009943f24c4318bef97058cc6ffa">
+        <source>Failed to move uploaded file.</source>
+        <target>Failed to move uploaded file.</target>
+        <note>Line: 380</note>
+      </trans-unit>
+      <trans-unit id="3cb5c48f468125102a98fe83a277029d">
+        <source>Warning: if no email logo is available, the main logo will be used instead.</source>
+        <target>Warning: if no email logo is available, the main logo will be used instead.</target>
+        <note>Line: 428</note>
+      </trans-unit>
+      <trans-unit id="4a9fdf95b29176bd9260016655a80852">
+        <source>Your RTL stylesheets has been generated successfully</source>
+        <target>Your RTL stylesheets has been generated successfully</target>
+        <note>Line: 1059</note>
+      </trans-unit>
+      <trans-unit id="9ccfef29efe298e9a48295a69436e11f">
+        <source><![CDATA[Your theme has been correctly reset to its default settings. You may want to regenerate your images. See the Improve > Design > Images Settings screen for the 'Regenerate thumbnails' button.]]></source>
+        <target><![CDATA[Your theme has been correctly reset to its default settings. You may want to regenerate your images. See the Improve > Design > Images Settings screen for the 'Regenerate thumbnails' button.]]></target>
+        <note>Line: 1078</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Addon/Theme/ThemeManager.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="412b4a82ba6153e19f17f490b5f1aa88">
+        <source>This theme is not valid for PrestaShop 1.7</source>
+        <target>This theme is not valid for PrestaShop 1.7</target>
+        <note>Line: 359</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Addon/Theme/ThemeValidator.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="832e8c53e8d05c52c824912c28933917">
+        <source>An error occurred. The information "%s" is missing.</source>
+        <target>An error occurred. The information "%s" is missing.</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="7d88c564a7f74d56564402cd5e054b13">
+        <source>An error occurred. The template "%s" is missing.</source>
+        <target>An error occurred. The template "%s" is missing.</target>
+        <note>Line: 116</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Shop/LogoUploader.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f003149576f4755d74550952febe14bb">
+        <source>An error occurred while uploading the favicon: cannot copy file "%s" to folder "%s".</source>
+        <target>An error occurred while uploading the favicon: cannot copy file "%s" to folder "%s".</target>
+        <note>Line: 170</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Command/ExportThemeCommand.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ebc7584c0a97bc4aa867c11fc4760b3f">
+        <source>Your theme has been correctly exported: %path%</source>
+        <target>Your theme has been correctly exported: %path%</target>
+        <note>Line: 58</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminGlobal.xlf
+++ b/app/Resources/translations/default/AdminGlobal.xlf
@@ -1,912 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/ps_facetedsearch/views/templates/admin/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/attributes/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="b718adec73e04ce3ec720dd11a06a308">
-        <source>ID</source>
-        <target>ID</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:59</note>
-      </trans-unit>
-      <trans-unit id="49ee3087348e8d44e1feda1917443987">
-        <source>Name</source>
-        <target>Name</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:60</note>
-      </trans-unit>
-      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
-        <source>Categories</source>
-        <target>Categories</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="254f642527b45bc260048e30704edb39">
-        <source>Configuration</source>
-        <target>Configuration</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:111</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0b27918290ff5323bea1e3b78a9cf04e">
-        <source>File</source>
-        <target>File</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php:83</note>
-      </trans-unit>
-      <trans-unit id="9dffbf69ffba8bc38bc4e01abf4b1675">
-        <source>Text</source>
-        <target>Text</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php:82</note>
-      </trans-unit>
-      <trans-unit id="b021df6aac4654c454f46c77646e745f">
-        <source>Label</source>
-        <target>Label</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php:77</note>
-      </trans-unit>
-      <trans-unit id="b651efdb98a5d6bd2b3935d0c3f4a5e2">
-        <source>Required</source>
-        <target>Required</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php:91</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminAttachmentsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6f6cb72d544962fa333e2e34ce64f719">
-        <source>Size</source>
-        <target>Size</target>
-        <note>Context:
-File: controllers/admin/AdminAttachmentsController.php:67</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1351017ac6423911223bc19a8cb7c653">
-        <source>Filename</source>
-        <target>Filename</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php:94</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/themes/configurelayouts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
-        <source>Description</source>
-        <target>Description</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/configurelayouts.tpl:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca">
-        <source>Reference</source>
-        <target>Reference</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl:38</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ce26601dac0dea138b7295f02b7620a7">
-        <source>Customer</source>
-        <target>Customer</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1103</note>
-      </trans-unit>
-      <trans-unit id="065ab3a28ca4f16f55f103adc7d0226f">
-        <source>Delivery</source>
-        <target>Delivery</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1369</note>
-      </trans-unit>
-      <trans-unit id="466eadd40b3c10580e3ab4e8061161ce">
-        <source>Invoice</source>
-        <target>Invoice</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1382</note>
-      </trans-unit>
-      <trans-unit id="386c339d37e737a436499d423a77df0c">
-        <source>Currency</source>
-        <target>Currency</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1283</note>
-      </trans-unit>
-      <trans-unit id="290612199861c31d1036b185b4e69b75">
-        <source>Summary</source>
-        <target>Summary</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1477</note>
-      </trans-unit>
-      <trans-unit id="3601146c4e948c32b6424d2c0a7f0118">
-        <source>Price</source>
-        <target>Price</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1266</note>
-      </trans-unit>
-      <trans-unit id="3ec365dd533ddb7ef3d1c111186ce872">
-        <source>Details</source>
-        <target>Details</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:571</note>
-      </trans-unit>
-      <trans-unit id="47ac923d219501859fb68fed8c8db77b">
-        <source>Combination</source>
-        <target>Combination</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:643</note>
-      </trans-unit>
-      <trans-unit id="3a2d5fe857d8f9541136a124c2edec6c">
-        <source>Or</source>
-        <target>Or</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1332</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1c76cbfe21c6f44c1d1e59d54f3e4420">
-        <source>Company</source>
-        <target>Company</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:606</note>
-      </trans-unit>
-      <trans-unit id="96b0141273eabab320119c467cdcaf17">
-        <source>Total</source>
-        <target>Total</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:281</note>
-      </trans-unit>
-      <trans-unit id="c453a4b8e8d98e82f35b67f433e3b4da">
-        <source>Payment</source>
-        <target>Payment</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:243</note>
-      </trans-unit>
-      <trans-unit id="44749712dbec183e983dcd78a7736c41">
-        <source>Date</source>
-        <target>Date</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:568</note>
-      </trans-unit>
-      <trans-unit id="9f82518d468b9fee614fcc92f76bb163">
-        <source>Shop</source>
-        <target>Shop</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:570</note>
-      </trans-unit>
-      <trans-unit id="4994a8ffeba4ac3140beb89e8d41f174">
-        <source>Language</source>
-        <target>Language</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:469</note>
-      </trans-unit>
-      <trans-unit id="068f80c7519d0528fb08e82137a72131">
-        <source>Products</source>
-        <target>Products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:245</note>
-      </trans-unit>
-      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
-        <source>Addresses</source>
-        <target>Addresses</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:594</note>
-      </trans-unit>
-      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
-        <source>Quantity</source>
-        <target>Quantity</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:315</note>
-      </trans-unit>
-      <trans-unit id="dd7bf230fde8d4836917806aff6a6b27">
-        <source>Address</source>
-        <target>Address</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:608</note>
-      </trans-unit>
-      <trans-unit id="59716c97497eb9694541f7c3d37b1a4d">
-        <source>Country</source>
-        <target>Country</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:609</note>
-      </trans-unit>
-      <trans-unit id="4d3d769b812b6faa6b76e1a8abaece2d">
-        <source>Active</source>
-        <target>Active</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:152</note>
-      </trans-unit>
-      <trans-unit id="ca0dbad92a874b2f69b549293387925e">
-        <source>Code</source>
-        <target>Code</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:420</note>
-      </trans-unit>
-      <trans-unit id="6e7b34fa59e1bd229b207892956dc41c">
-        <source>Never</source>
-        <target>Never</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:78</note>
-      </trans-unit>
-      <trans-unit id="ffb7e666a70151215b4c55c6268d7d72">
-        <source>Newsletter</source>
-        <target>Newsletter</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:121</note>
-      </trans-unit>
-      <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4">
-        <source>Message</source>
-        <target>Message</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:390</note>
-      </trans-unit>
-      <trans-unit id="fc26e55e0993a75e892175deb02aae15">
-        <source>Carts</source>
-        <target>Carts</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:272</note>
-      </trans-unit>
-      <trans-unit id="06df33001c1d7187fdd81ea1f5b277aa">
-        <source>Actions</source>
-        <target>Actions</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:424</note>
-      </trans-unit>
-      <trans-unit id="c7892ebbb139886662c6f2fc8c450710">
-        <source>Subject</source>
-        <target>Subject</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:470</note>
-      </trans-unit>
-      <trans-unit id="41de6d6cfb8953c021bbe4ba0701c8a1">
-        <source>Messages</source>
-        <target>Messages</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:384</note>
-      </trans-unit>
-      <trans-unit id="544ed721c22329e581919041a14e0c72">
-        <source>Social Title</source>
-        <target>Social Title</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:52</note>
-      </trans-unit>
-      <trans-unit id="3cab03c00dbd11bc3569afa0748013f0">
-        <source>Inactive</source>
-        <target>Inactive</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:157</note>
-      </trans-unit>
-      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
-        <source>Carrier</source>
-        <target>Carrier</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:280</note>
-      </trans-unit>
-      <trans-unit id="278c491bdd8a53618c149c4ac790da34">
-        <source>Template</source>
-        <target>Template</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:471</note>
-      </trans-unit>
-      <trans-unit id="a37ede293936e29279ed543129451ec3">
-        <source>Groups</source>
-        <target>Groups</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:523</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/currencies/status.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ec53a8c4f07baed5d8825072c89799be">
-        <source>Status</source>
-        <target>Status</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/currencies/status.tpl:29</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSlipController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bcd1b68617759b1dfcff0403a6b5a8d1">
-        <source>PDF</source>
-        <target>PDF</target>
-        <note>Context:
-File: controllers/admin/AdminSlipController.php:63</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e4c3da18c66c0147144767efeb59198f">
-        <source>Conversion Rate</source>
-        <target>Conversion Rate</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:66</note>
-      </trans-unit>
-      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
-        <source>Orders</source>
-        <target>Orders</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:51</note>
-      </trans-unit>
-      <trans-unit id="d7e637a6e9ff116de2fa89551240a94d">
-        <source>Visits</source>
-        <target>Visits</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:61</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="947d8520f04473da621f2718138f3bc6">
-        <source>30 days</source>
-        <target>30 days</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:419</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="54e85d70ea67acdcc86963b14d6223a8">
-        <source>Abandoned Carts</source>
-        <target>Abandoned Carts</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:83</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminReferrersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1dd1c5fb7f25cd41b291d43a89e3aefd">
-        <source>Today</source>
-        <target>Today</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:406</note>
-      </trans-unit>
-      <trans-unit id="8ff922bbcd8ad41cdfc48d3c5163b2ab">
-        <source>Calendar</source>
-        <target>Calendar</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:405</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ffbb5322a3702b0d8d9c7f506209c540">
-        <source>Average Order Value</source>
-        <target>Average Order Value</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1644</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_facetedsearch/views/templates/hook/feature_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e6b391a8d2c4d45902a23a8b6585703d">
-        <source>URL</source>
-        <target>URL</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/feature_form.tpl:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailsubscription/views/templates/admin/list_action_enable.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="00d23a76e43b46dae9ec7aa9dcbebb32">
-        <source>Enabled</source>
-        <target>Enabled</target>
-        <note>Context:
-File: modules/ps_emailsubscription/views/templates/admin/list_action_enable.tpl:25</note>
-      </trans-unit>
-      <trans-unit id="b9f5c797ebbf55adccdd8539a65a0241">
-        <source>Disabled</source>
-        <target>Disabled</target>
-        <note>Context:
-File: modules/ps_emailsubscription/views/templates/admin/list_action_enable.tpl:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3a08e2e340ab29fd9263af48193cbf8e">
-        <source>Languages</source>
-        <target>Languages</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php:102</note>
-      </trans-unit>
-      <trans-unit id="dfcfc43722eef1eab1e4a12e50a068b1">
-        <source>Currencies</source>
-        <target>Currencies</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php:101</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_customtext/ps_customtext.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9d55fc80bbb875322aa67fd22fc98469">
-        <source>Shop association</source>
-        <target>Shop association</target>
-        <note>Context:
-File: modules/ps_customtext/ps_customtext.php:229</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0eaadb4fcb48a0a0ed7bc9868be9fbaa">
-        <source>Warning</source>
-        <target>Warning</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:405</note>
-      </trans-unit>
-      <trans-unit id="ce8ae9da5b7cd6c3df2929543a9af92d">
-        <source>Email</source>
-        <target>Email</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:608</note>
-      </trans-unit>
-      <trans-unit id="a240fa27925a635b08dc28c9e4f9216d">
-        <source>Order</source>
-        <target>Order</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="719fec04166d6fa75f89cd29ad61fa8c">
-        <source>Taxes</source>
-        <target>Taxes</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1118</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/helper/HelperList.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4e140ba723a03baa6948340bf90e2ef6">
-        <source>Name:</source>
-        <target>Name:</target>
-        <note>Context:
-File: classes/helper/HelperList.php:528</note>
-      </trans-unit>
-      <trans-unit id="7a1920d61156abc05a60135aefe8bc67">
-        <source>Default</source>
-        <target>Default</target>
-        <note>Context:
-File: classes/helper/HelperList.php:572</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="52f5e0bc3859bc5f5e25130b6c7e8881">
-        <source>Position</source>
-        <target>Position</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig:73</note>
-      </trans-unit>
-      <trans-unit id="be53a0541a6d36f6ecb879fa2c584b08">
-        <source>Image</source>
-        <target>Image</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="78d811e98514cd165dda532286610fd2">
-        <source>Min</source>
-        <target>Min</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig:139</note>
-      </trans-unit>
-      <trans-unit id="6a061313d22e51e0f25b7cd4dc065233">
-        <source>Max</source>
-        <target>Max</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig:140</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5204077231fc7164e2269e96b584dd95">
-        <source>Drop-down list</source>
-        <target>Drop-down list</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:177</note>
-      </trans-unit>
-      <trans-unit id="8bd90a6d76a77fe0b160e8abd85c8590">
-        <source>Radio buttons</source>
-        <target>Radio buttons</target>
-        <note>Context:
-File: controllers/admin/AdminAttributesGroupsController.php:181</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminFeaturesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c82a6100dace2b41087ba6cf99a5976a">
-        <source>Values</source>
-        <target>Values</target>
-        <note>Context:
-File: controllers/admin/AdminFeaturesController.php:58</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="689202409e48743b914713f96d93947c">
-        <source>Value</source>
-        <target>Value</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:198</note>
-      </trans-unit>
-      <trans-unit id="ec136b444eede3bc85639fac0dd06229">
-        <source>Supplier</source>
-        <target>Supplier</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:73</note>
-      </trans-unit>
-      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
-        <source>Brand</source>
-        <target>Brand</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:56</note>
-      </trans-unit>
-      <trans-unit id="98f770b0af18ca763421bac22b4b6805">
-        <source>Features</source>
-        <target>Features</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="f2bbdf9f72c085adc4d0404e370f0f4c">
-        <source>Attribute</source>
-        <target>Attribute</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:274</note>
-      </trans-unit>
-      <trans-unit id="287234a1ff35a314b5b6bc4e5828e745">
-        <source>Attributes</source>
-        <target>Attributes</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:90</note>
-      </trans-unit>
-      <trans-unit id="a1fa27779242b4902f7ae3bdd5c6d508">
-        <source>Type</source>
-        <target>Type</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:198</note>
-      </trans-unit>
-      <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">
-        <source>or</source>
-        <target>or</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:194</note>
-      </trans-unit>
-      <trans-unit id="be5d5d37542d75f93a87094459f76678">
-        <source>and</source>
-        <target>and</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:207</note>
-      </trans-unit>
-      <trans-unit id="21021ea0e52be8e9c599f4dff41e5be0">
-        <source>Feature</source>
-        <target>Feature</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:285</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminAttributeGeneratorController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9446a98ad14416153cc4d45ab8b531bf">
-        <source>Performance</source>
-        <target>Performance</target>
-        <note>Context:
-File: controllers/admin/AdminAttributeGeneratorController.php:237</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Translation/Api/StockApi.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f8c8b903cb2e4f297e4b96d4b9c1e98a">
-        <source>Employee</source>
-        <target>Employee</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/StockApi.php:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_facetedsearch/views/templates/admin/add.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bafd7322c6e97d25b6299b5d6fe8920b">
-        <source>No</source>
-        <target>No</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:338</note>
-      </trans-unit>
-      <trans-unit id="93cba07454f06a4a960172bbd6e2a435">
-        <source>Yes</source>
-        <target>Yes</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:337</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="003bf65ada43328a6164e2c681516a0e">
-        <source>30 day</source>
-        <target>30 day</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:575</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1dec4f55522b828fe5dacf8478021a9e">
-        <source>Friendly URL</source>
-        <target>Friendly URL</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:54</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSuppliersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3f64b2beede1082fd32ddb0bf11a641f">
-        <source>Meta description</source>
-        <target>Meta description</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:246</note>
-      </trans-unit>
-      <trans-unit id="7d7559ccac6bc30a4d985db11cb34a3a">
-        <source>Meta keywords</source>
-        <target>Meta keywords</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:254</note>
-      </trans-unit>
-      <trans-unit id="41c2fff4867cc204120f001e7af20f7a">
-        <source>Mobile phone</source>
-        <target>Mobile phone</target>
-        <note>Context:
-File: controllers/admin/AdminSuppliersController.php:164</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="54f664c70c22054ea0d8d26fc3997ce7">
-        <source>Online</source>
-        <target>Online</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:53</note>
-      </trans-unit>
-      <trans-unit id="8d9da4bc0e49a50e09ac9f7e56789d39">
-        <source>Offline</source>
-        <target>Offline</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig:55</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b9208b03bcc9eb4a336258dcdcb66207">
-        <source>Combinations</source>
-        <target>Combinations</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="887ee91702c962a70b87cbef07bbcaec">
-        <source>tax excl.</source>
-        <target>tax excl.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:56</note>
-      </trans-unit>
-      <trans-unit id="e2e79605fc9450ec17957cf0e910f5c6">
-        <source>tax incl.</source>
-        <target>tax incl.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:64</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e6d0e1c8fc6a4fcf47869df87e04cd88">
-        <source>Customers</source>
-        <target>Customers</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php:57</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="84be54bb4bd1b755a27d86388700d097">
-        <source>Brands</source>
-        <target>Brands</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl:52</note>
-      </trans-unit>
-      <trans-unit id="1814d65a76028fdfbadab64a5a8076df">
-        <source>Suppliers</source>
-        <target>Suppliers</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl:53</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_facetedsearch/views/templates/hook/attribute_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9e11e4b371570340ca07913bc4783a7a">
-        <source>Meta title</source>
-        <target>Meta title</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/attribute_form.tpl:56</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="32954654ac8fe66a1d09be19001de2d4">
-        <source>Width</source>
-        <target>Width</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:210</note>
-      </trans-unit>
-      <trans-unit id="eec6c4bdbd339edf8cbea68becb85244">
-        <source>Height</source>
-        <target>Height</target>
-        <note>Context:
-File: controllers/admin/AdminImagesController.php:219</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="675056ad1441b6375b2c5abd48c27ef1">
-        <source>Depth</source>
-        <target>Depth</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:248</note>
-      </trans-unit>
-      <trans-unit id="f54a73382e8bd64066339d60c9fc4bde">
-        <source>First name </source>
-        <target>First name</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:415</note>
-      </trans-unit>
-      <trans-unit id="5020eaae41baf0caa37bcb73b4a12934">
-        <source>Mobile Phone</source>
-        <target>Mobile Phone</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:424</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
-        <source>Weight</source>
-        <target>Weight</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_shipping.tpl:39</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/login/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dc647eb65e6711e155375218212b3964">
-        <source>Password</source>
-        <target>Password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:98</note>
-      </trans-unit>
-      <trans-unit id="b357b524e740bc85b9790a0712d84a30">
-        <source>Email address</source>
-        <target>Email address</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:127</note>
-      </trans-unit>
-      <trans-unit id="01a569ddc6cf67ddec2a683f0a5f5956">
-        <source>Forgot your password?</source>
-        <target>Forgot your password?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:123</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8d3f5eff9c40ee315d452392bed5309b">
-        <source>Last name</source>
-        <target>Last name</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:236</note>
-      </trans-unit>
-      <trans-unit id="20db0bfeecd8fe60533206a2b5e9891a">
-        <source>First name</source>
-        <target>First name</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:235</note>
-      </trans-unit>
-      <trans-unit id="5e74f2daf4ae8030571ceee5b4837579">
-        <source>Social title</source>
-        <target>Social title</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:234</note>
-      </trans-unit>
-      <trans-unit id="4965e9e891c3381d1ec7379f036131de">
-        <source>Date of birth</source>
-        <target>Date of birth</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:238</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="783cb853aae6984e51583b3bb80c09d2">
-        <source>Address (2)</source>
-        <target>Address (2)</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:177</note>
-      </trans-unit>
-      <trans-unit id="c6e2a9b2d1979c244d18c7e9fbf9a86f">
-        <source>Zip/postal code</source>
-        <target>Zip/postal code</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:471</note>
-      </trans-unit>
-      <trans-unit id="57d056ed0984166336b7879c2af3657f">
-        <source>City</source>
-        <target>City</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:476</note>
-      </trans-unit>
-      <trans-unit id="46a2a41cc6e552044816a2d04634545d">
-        <source>State</source>
-        <target>State</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:490</note>
-      </trans-unit>
-      <trans-unit id="bcc254b55c4a1babdf1dcb82c207506b">
-        <source>Phone</source>
-        <target>Phone</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:498</note>
-      </trans-unit>
-      <trans-unit id="9810aa2b9f44401be4bf73188ef2b67d">
-        <source>Fax</source>
-        <target>Fax</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:503</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6311ae17c1ee52b36e68aaf4ad066387">
-        <source>Other</source>
-        <target>Other</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig:48</note>
+      <trans-unit id="6adf97f83acf6453d4a6a4b1070f3754">
+        <source>None</source>
+        <target>None</target>
+        <note>Line: 47</note>
       </trans-unit>
     </body>
   </file>
@@ -915,8 +14,96 @@ File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.htm
       <trans-unit id="8c2857a9ad1d8f31659e35e904e20fa6">
         <source>Logo</source>
         <target>Logo</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/logo.tpl:28</note>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="06df33001c1d7187fdd81ea1f5b277aa">
+        <source>Actions</source>
+        <target>Actions</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="b55e509c697e4cca0e1d160a7806698f">
+        <source>Hour</source>
+        <target>Hour</target>
+        <note>Line: 66</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/informations.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ca0dbad92a874b2f69b549293387925e">
+        <source>Code</source>
+        <target>Code</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="502996d9790340c5fd7b86a5b93b1c9f">
+        <source>Priority</source>
+        <target>Priority</target>
+        <note>Line: 131</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
+        <source>Categories</source>
+        <target>Categories</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="84be54bb4bd1b755a27d86388700d097">
+        <source>Brands</source>
+        <target>Brands</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="1814d65a76028fdfbadab64a5a8076df">
+        <source>Suppliers</source>
+        <target>Suppliers</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule_itemlist.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="91b442d385b54e1418d81adc34871053">
+        <source>Selected</source>
+        <target>Selected</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="810460332a38c9ade69a49b057494cad">
+        <source>Unselected</source>
+        <target>Unselected</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="27ce7f8b5623b2e2df568d64cf051607">
+        <source>Stock</source>
+        <target>Stock</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="6c957f72dc8cdacc75762f2cbdcdfaf2">
+        <source>Unit price</source>
+        <target>Unit price</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="9d5bf15117441a1b52eb1f0808e4aad3">
+        <source>Discounts</source>
+        <target>Discounts</target>
+        <note>Line: 202</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/categories/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7dce122004969d56ae2e0245cb754d35">
+        <source>Edit</source>
+        <target>Edit</target>
+        <note>Line: 43</note>
       </trans-unit>
     </body>
   </file>
@@ -925,252 +112,94 @@ File: admin-dev/themes/default/template/controllers/carrier_wizard/logo.tpl:28</
       <trans-unit id="b3ff996fe5c77610359114835baf9b38">
         <source>Zone</source>
         <target>Zone</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/list/list_footer.tpl:141</note>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="dd8921b41e0279a02c6a26a509241700">
+        <source>result(s)</source>
+        <target>result(s)</target>
+        <note>Line: 75</note>
       </trans-unit>
     </body>
   </file>
-  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/currencies/conversion_rate.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="4b78ac8eb158840e9638a3aeb26c4a9d">
-        <source>Tax</source>
-        <target>Tax</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:320</note>
-      </trans-unit>
-      <trans-unit id="1778e0e8555dc044231c1d615b41ddea">
-        <source>MultiStore</source>
-        <target>MultiStore</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:89</note>
-      </trans-unit>
-      <trans-unit id="dd1f775e443ff3b9a89270713580a51b">
-        <source>Previous</source>
-        <target>Previous</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:132</note>
-      </trans-unit>
-      <trans-unit id="6f3455d187a23443796efdcbe044096b">
-        <source>No tax</source>
-        <target>No tax</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:327</note>
+      <trans-unit id="06933067aafd48425d67bcb01bba5cb6">
+        <source>Update</source>
+        <target>Update</target>
+        <note>Line: 56</note>
       </trans-unit>
     </body>
   </file>
-  <file original="controllers/admin/AdminCarriersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/message.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="7475ec0d41372a307c497acb7eeea8c4">
-        <source>No Tax</source>
-        <target>No Tax</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:276</note>
+      <trans-unit id="47a0be8d1015d526a1fbaa56c3102135">
+        <source>Subject:</source>
+        <target>Subject:</target>
+        <note>Line: 93</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/statsbestcustomers/statsbestcustomers.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="bc910f8bdf70f29374f496f05be0330c">
-        <source>First Name</source>
-        <target>First Name</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:67</note>
+      <trans-unit id="1c76cbfe21c6f44c1d1e59d54f3e4420">
+        <source>Company</source>
+        <target>Company</target>
+        <note>Line: 606</note>
       </trans-unit>
-      <trans-unit id="77587239bf4c54ea493c7033e1dbf636">
-        <source>Last Name</source>
-        <target>Last Name</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:61</note>
+      <trans-unit id="dd7bf230fde8d4836917806aff6a6b27">
+        <source>Address</source>
+        <target>Address</target>
+        <note>Line: 608</note>
       </trans-unit>
-      <trans-unit id="6602bbeb2956c035fb4cb5e844a4861b">
-        <source>Guide</source>
-        <target>Guide</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:127</note>
+      <trans-unit id="59716c97497eb9694541f7c3d37b1a4d">
+        <source>Country</source>
+        <target>Country</target>
+        <note>Line: 609</note>
       </trans-unit>
-      <trans-unit id="f5c493141bb4b2508c5938fd9353291a">
-        <source>Displaying %1$s of %2$s</source>
-        <target>Displaying %1$s of %2$s</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:54</note>
+      <trans-unit id="4d3d769b812b6faa6b76e1a8abaece2d">
+        <source>Active</source>
+        <target>Active</target>
+        <note>Line: 152</note>
       </trans-unit>
-      <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
-        <source>CSV Export</source>
-        <target>CSV Export</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:143</note>
+      <trans-unit id="6e7b34fa59e1bd229b207892956dc41c">
+        <source>Never</source>
+        <target>Never</target>
+        <note>Line: 78</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminManufacturersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fe66abce284ec8589e7d791185b5c442">
-        <source>Home phone</source>
-        <target>Home phone</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:582</note>
+      <trans-unit id="ffb7e666a70151215b4c55c6268d7d72">
+        <source>Newsletter</source>
+        <target>Newsletter</target>
+        <note>Line: 121</note>
       </trans-unit>
-      <trans-unit id="5d9eca48241c03f20f27586c1f24a4b0">
-        <source>Zip/Postal code</source>
-        <target>Zip/Postal code</target>
-        <note>Context:
-File: controllers/admin/AdminManufacturersController.php:187</note>
+      <trans-unit id="c7892ebbb139886662c6f2fc8c450710">
+        <source>Subject</source>
+        <target>Subject</target>
+        <note>Line: 470</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCmsCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="86754577897acfb25deb69039d49d9a7">
-        <source>Displayed</source>
-        <target>Displayed</target>
-        <note>Context:
-File: controllers/admin/AdminCmsCategoriesController.php:229</note>
+      <trans-unit id="544ed721c22329e581919041a14e0c72">
+        <source>Social Title</source>
+        <target>Social Title</target>
+        <note>Line: 52</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680">
-        <source>All</source>
-        <target>All</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl:453</note>
+      <trans-unit id="3cab03c00dbd11bc3569afa0748013f0">
+        <source>Inactive</source>
+        <target>Inactive</target>
+        <note>Line: 157</note>
       </trans-unit>
-      <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2">
-        <source>Modules</source>
-        <target>Modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl:462</note>
+      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
+        <source>Carrier</source>
+        <target>Carrier</target>
+        <note>Line: 280</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b78a3223503896721cca1303f776159b">
-        <source>Title</source>
-        <target>Title</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig:360</note>
+      <trans-unit id="278c491bdd8a53618c149c4ac790da34">
+        <source>Template</source>
+        <target>Template</target>
+        <note>Line: 471</note>
       </trans-unit>
-      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
-        <source>Search</source>
-        <target>Search</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig:320</note>
-      </trans-unit>
-      <trans-unit id="526d688f37a86d3c3f27d0c5016eb71d">
-        <source>Reset</source>
-        <target>Reset</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig:331</note>
-      </trans-unit>
-      <trans-unit id="34082694d21dbdcfc31e6e32d9fb2b9f">
-        <source>File name</source>
-        <target>File name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig:361</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/informations.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="502996d9790340c5fd7b86a5b93b1c9f">
-        <source>Priority</source>
-        <target>Priority</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/informations.tpl:131</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="019ec3132cdf8ee0f2e2a75cf5d3e459">
-        <source>Gender</source>
-        <target>Gender</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:204</note>
-      </trans-unit>
-      <trans-unit id="dff4bf10409100d989495c6d5486035e">
-        <source>Lastname</source>
-        <target>Lastname</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:208</note>
-      </trans-unit>
-      <trans-unit id="04176f095283bc729f1e3926967e7034">
-        <source>Firstname</source>
-        <target>Firstname</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:212</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6adf97f83acf6453d4a6a4b1070f3754">
-        <source>None</source>
-        <target>None</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:58</note>
-      </trans-unit>
-      <trans-unit id="f4a0d7cb0cd45214c8ca5912c970de13">
-        <source>Tax included</source>
-        <target>Tax included</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:44</note>
-      </trans-unit>
-      <trans-unit id="befcac0f9644a7abee43e69f49252ac4">
-        <source>Tax excluded</source>
-        <target>Tax excluded</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="3adbdb3ac060038aa0e6e6c138ef9873">
-        <source>Category</source>
-        <target>Category</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:63</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Kpi/MainCountryKpi.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9c680defe5574c8355ed9be5a3fede04">
-        <source>30 Days</source>
-        <target>30 Days</target>
-        <note>Context:
-File: src/Adapter/Kpi/MainCountryKpi.php:82</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d1457b72c3fb323a2671125aef3eab5d">
-        <source>?</source>
-        <target>?</target>
-        <note>Context:
-File: controllers/admin/AdminSearchController.php:282</note>
-      </trans-unit>
-      <trans-unit id="9c37b7b6ff829e977df287900543ea54">
-        <source>Birth date</source>
-        <target>Birth date</target>
-        <note>Context:
-File: controllers/admin/AdminSearchController.php:295</note>
-      </trans-unit>
-      <trans-unit id="eb6b06cab0dd72e04c4da68d511facf2">
-        <source>Search results</source>
-        <target>Search results</target>
-        <note>Context:
-File: controllers/admin/AdminSearchController.php:329</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6252c0f2c2ed83b7b06dfca86d4650bb">
-        <source>Invalid characters:</source>
-        <target>Invalid characters:</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:198</note>
+      <trans-unit id="a37ede293936e29279ed543129451ec3">
+        <source>Groups</source>
+        <target>Groups</target>
+        <note>Line: 523</note>
       </trans-unit>
     </body>
   </file>
@@ -1179,210 +208,92 @@ File: controllers/admin/AdminCountriesController.php:198</note>
       <trans-unit id="03727ac48595a24daed975559c944a44">
         <source>Day</source>
         <target>Day</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:52</note>
+        <note>Line: 52</note>
       </trans-unit>
       <trans-unit id="7cbb885aa1164b390a0bc050a64e1812">
         <source>Month</source>
         <target>Month</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="537c66b24ef5c83b7382cdc3f34885f2">
         <source>Year</source>
         <target>Year</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:58</note>
+        <note>Line: 58</note>
       </trans-unit>
       <trans-unit id="5da618e8e4b89c66fe86e32cdafde142">
         <source>From</source>
         <target>From</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:72</note>
+        <note>Line: 72</note>
       </trans-unit>
       <trans-unit id="e12167aa0a7698e6ebc92b4ce3909b53">
         <source>To</source>
         <target>To</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:74</note>
+        <note>Line: 74</note>
       </trans-unit>
       <trans-unit id="3e937d04c1c83492260a33d926ca587c">
         <source>Bug Tracker</source>
         <target>Bug Tracker</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:122</note>
+        <note>Line: 122</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/form_date_range_picker.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="1e6d57e813355689e9c77e947d73ad8f">
-        <source>From:</source>
-        <target>From:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/form_date_range_picker.tpl:50</note>
+      <trans-unit id="104d9898c04874d0fbac36e125fa1369">
+        <source>Discount</source>
+        <target>Discount</target>
+        <note>Line: 64</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/referrers/calendar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/login/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="33caa076f23f453dd4061726f3706325">
-        <source>To:</source>
-        <target>To:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/calendar.tpl:41</note>
+      <trans-unit id="dc647eb65e6711e155375218212b3964">
+        <source>Password</source>
+        <target>Password</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="b357b524e740bc85b9790a0712d84a30">
+        <source>Email address</source>
+        <target>Email address</target>
+        <note>Line: 127</note>
+      </trans-unit>
+      <trans-unit id="01a569ddc6cf67ddec2a683f0a5f5956">
+        <source>Forgot your password?</source>
+        <target>Forgot your password?</target>
+        <note>Line: 123</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/modules/configuration_bar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="c9cc8cce247e49bae79f15173ce97354">
-        <source>Save</source>
-        <target>Save</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/InternationalApi.php:38</note>
+      <trans-unit id="254f642527b45bc260048e30704edb39">
+        <source>Configuration</source>
+        <target>Configuration</target>
+        <note>Line: 30</note>
       </trans-unit>
     </body>
   </file>
-  <file original="controllers/admin/AdminStatsTabController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/modules/configure.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="d2ce009594dcc60befa6a4e6cbeb71fc">
-        <source>Week</source>
-        <target>Week</target>
-        <note>Context:
-File: controllers/admin/AdminStatsTabController.php:122</note>
+      <trans-unit id="0557fa923dcee4d0f86b1409f5c2167f">
+        <source>Back</source>
+        <target>Back</target>
+        <note>Line: 61</note>
       </trans-unit>
     </body>
   </file>
-  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="821b8ee6937cec96c30fdafbfe836d68">
-        <source>Stores</source>
-        <target>Stores</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:553</note>
+      <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2">
+        <source>Modules</source>
+        <target>Modules</target>
+        <note>Line: 87</note>
       </trans-unit>
-      <trans-unit id="790d59ef178acbc75d233bf4211763c6">
-        <source>Countries</source>
-        <target>Countries</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:540</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="11ff9f68afb6b8b5b8eda218d7c83a65">
-        <source>Sales</source>
-        <target>Sales</target>
-        <note>Context:
-File: modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl:67</note>
-      </trans-unit>
-      <trans-unit id="f1206f9fadc5ce41694f69129aecac26">
-        <source>Configure</source>
-        <target>Configure</target>
-        <note>Context:
-File: modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl:46</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="85fb1a46f605ba9e7738df38315e6513">
-        <source>All Time</source>
-        <target>All Time</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:659</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55">
-        <source>Next</source>
-        <target>Next</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl:74</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/statscheckup/statscheckup.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fff0d600f8a0b5e19e88bfb821dd1157">
-        <source>Images</source>
-        <target>Images</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:316</note>
-      </trans-unit>
-      <trans-unit id="7bd5825a187064017975513b95d7f7de">
-        <source>Available quantity for sale</source>
-        <target>Available quantity for sale</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:318</note>
-      </trans-unit>
-      <trans-unit id="c888438d14855d7d96a2724ee9c306bd">
-        <source>Settings updated</source>
-        <target>Settings updated</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:91</note>
-      </trans-unit>
-      <trans-unit id="7d74f3b92b19da5e606d737d339a9679">
-        <source>Item</source>
-        <target>Item</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:227</note>
-      </trans-unit>
-      <trans-unit id="59b514174bffe4ae402b3d63aad79fe0">
-        <source>images</source>
-        <target>images</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:157</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="03937134cedab9078be39a77ee3a48a0">
-        <source>Group</source>
-        <target>Group</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:154</note>
-      </trans-unit>
-      <trans-unit id="1901606ea069a83dc7beea17881ef95a">
-        <source>Period</source>
-        <target>Period</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig:158</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0db377921f4ce762c62526131097968f">
-        <source>General</source>
-        <target>General</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig:38</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_documents.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3b0649c72650c313a357338dcdfb64ec">
-        <source>Note</source>
-        <target>Note</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:141</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/referrers/form_settings.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f4f70727dc34561dfde1a3c529b6205c">
-        <source>Settings</source>
-        <target>Settings</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:56</note>
+      <trans-unit id="6ff9dd0d34f65181173c1e4bc39939de">
+        <source>Selection</source>
+        <target>Selection</target>
+        <note>Line: 173</note>
       </trans-unit>
     </body>
   </file>
@@ -1391,208 +302,836 @@ File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:
       <trans-unit id="adaaee4b22041c27198d410c68d952c9">
         <source>Percent</source>
         <target>Percent</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_discount_form.tpl:42</note>
+        <note>Line: 42</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/statsforecast/statsforecast.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/orders/_documents.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="37be07209f53a5d636d5c904ca9ae64c">
-        <source>Percentage</source>
-        <target>Percentage</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:493</note>
+      <trans-unit id="3b0649c72650c313a357338dcdfb64ec">
+        <source>Note</source>
+        <target>Note</target>
+        <note>Line: 141</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/actions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="b9208b03bcc9eb4a336258dcdcb66207">
+        <source>Combinations</source>
+        <target>Combinations</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="887ee91702c962a70b87cbef07bbcaec">
+        <source>tax excl.</source>
+        <target>tax excl.</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="e2e79605fc9450ec17957cf0e910f5c6">
+        <source>tax incl.</source>
+        <target>tax incl.</target>
+        <note>Line: 69</note>
+      </trans-unit>
       <trans-unit id="b2f40690858b404ed10e62bdf422c704">
         <source>Amount</source>
         <target>Amount</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:78</note>
+        <note>Line: 184</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
+        <source>Weight</source>
+        <target>Weight</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="49ee3087348e8d44e1feda1917443987">
+        <source>Name</source>
+        <target>Name</target>
+        <note>Line: 1345</note>
+      </trans-unit>
+      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca">
+        <source>Reference</source>
+        <target>Reference</target>
+        <note>Line: 1263</note>
+      </trans-unit>
+      <trans-unit id="ce26601dac0dea138b7295f02b7620a7">
+        <source>Customer</source>
+        <target>Customer</target>
+        <note>Line: 1103</note>
+      </trans-unit>
+      <trans-unit id="065ab3a28ca4f16f55f103adc7d0226f">
+        <source>Delivery</source>
+        <target>Delivery</target>
+        <note>Line: 1369</note>
+      </trans-unit>
+      <trans-unit id="466eadd40b3c10580e3ab4e8061161ce">
+        <source>Invoice</source>
+        <target>Invoice</target>
+        <note>Line: 1382</note>
+      </trans-unit>
+      <trans-unit id="386c339d37e737a436499d423a77df0c">
+        <source>Currency</source>
+        <target>Currency</target>
+        <note>Line: 1283</note>
+      </trans-unit>
+      <trans-unit id="290612199861c31d1036b185b4e69b75">
+        <source>Summary</source>
+        <target>Summary</target>
+        <note>Line: 1477</note>
+      </trans-unit>
+      <trans-unit id="3601146c4e948c32b6424d2c0a7f0118">
+        <source>Price</source>
+        <target>Price</target>
+        <note>Line: 1266</note>
+      </trans-unit>
+      <trans-unit id="3ec365dd533ddb7ef3d1c111186ce872">
+        <source>Details</source>
+        <target>Details</target>
+        <note>Line: 571</note>
+      </trans-unit>
+      <trans-unit id="47ac923d219501859fb68fed8c8db77b">
+        <source>Combination</source>
+        <target>Combination</target>
+        <note>Line: 643</note>
+      </trans-unit>
+      <trans-unit id="3a2d5fe857d8f9541136a124c2edec6c">
+        <source>Or</source>
+        <target>Or</target>
+        <note>Line: 1332</note>
+      </trans-unit>
+      <trans-unit id="96b0141273eabab320119c467cdcaf17">
+        <source>Total</source>
+        <target>Total</target>
+        <note>Line: 1160</note>
+      </trans-unit>
+      <trans-unit id="c453a4b8e8d98e82f35b67f433e3b4da">
+        <source>Payment</source>
+        <target>Payment</target>
+        <note>Line: 1546</note>
+      </trans-unit>
+      <trans-unit id="44749712dbec183e983dcd78a7736c41">
+        <source>Date</source>
+        <target>Date</target>
+        <note>Line: 1173</note>
+      </trans-unit>
+      <trans-unit id="4994a8ffeba4ac3140beb89e8d41f174">
+        <source>Language</source>
+        <target>Language</target>
+        <note>Line: 1300</note>
+      </trans-unit>
+      <trans-unit id="068f80c7519d0528fb08e82137a72131">
+        <source>Products</source>
+        <target>Products</target>
+        <note>Line: 1174</note>
+      </trans-unit>
+      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
+        <source>Addresses</source>
+        <target>Addresses</target>
+        <note>Line: 1361</note>
+      </trans-unit>
+      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
+        <source>Quantity</source>
+        <target>Quantity</target>
+        <note>Line: 1265</note>
+      </trans-unit>
+      <trans-unit id="fc26e55e0993a75e892175deb02aae15">
+        <source>Carts</source>
+        <target>Carts</target>
+        <note>Line: 1143</note>
+      </trans-unit>
+      <trans-unit id="ec53a8c4f07baed5d8825072c89799be">
+        <source>Status</source>
+        <target>Status</target>
+        <note>Line: 1177</note>
+      </trans-unit>
+      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
+        <source>Orders</source>
+        <target>Orders</target>
+        <note>Line: 1149</note>
+      </trans-unit>
+      <trans-unit id="689202409e48743b914713f96d93947c">
+        <source>Value</source>
+        <target>Value</target>
+        <note>Line: 1347</note>
       </trans-unit>
       <trans-unit id="deb10517653c255364175796ace3553f">
         <source>Product</source>
         <target>Product</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:132</note>
+        <note>Line: 1261</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="9c7f56d70e922a61254366964c01c64a">
-        <source>All currencies</source>
-        <target>All currencies</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:132</note>
+      <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4">
+        <source>Message</source>
+        <target>Message</target>
+        <note>Line: 862</note>
       </trans-unit>
-      <trans-unit id="c3987e4cac14a8456515f0d200da04ee">
-        <source>All countries</source>
-        <target>All countries</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:146</note>
+      <trans-unit id="41de6d6cfb8953c021bbe4ba0701c8a1">
+        <source>Messages</source>
+        <target>Messages</target>
+        <note>Line: 786</note>
       </trans-unit>
-      <trans-unit id="e4c4c68c7515704a91d90207067dcbbe">
-        <source>All groups</source>
-        <target>All groups</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:160</note>
+      <trans-unit id="0eaadb4fcb48a0a0ed7bc9868be9fbaa">
+        <source>Warning</source>
+        <target>Warning</target>
+        <note>Line: 405</note>
       </trans-unit>
-      <trans-unit id="804ccd6219996d12eda865d1c0707423">
-        <source>All shops</source>
-        <target>All shops</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:116</note>
+      <trans-unit id="ce8ae9da5b7cd6c3df2929543a9af92d">
+        <source>Email</source>
+        <target>Email</target>
+        <note>Line: 608</note>
       </trans-unit>
-      <trans-unit id="7e3a51a56ddd2846e21c33f05e0aea6f">
-        <source>All customers</source>
-        <target>All customers</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:170</note>
+      <trans-unit id="a240fa27925a635b08dc28c9e4f9216d">
+        <source>Order</source>
+        <target>Order</target>
+        <note>Line: 113</note>
       </trans-unit>
-      <trans-unit id="0bcef9c45bd8a48eda1b26eb0c61c869">
-        <source>%</source>
-        <target>%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php:256</note>
+      <trans-unit id="719fec04166d6fa75f89cd29ad61fa8c">
+        <source>Taxes</source>
+        <target>Taxes</target>
+        <note>Line: 1118</note>
+      </trans-unit>
+      <trans-unit id="f4a0d7cb0cd45214c8ca5912c970de13">
+        <source>Tax included</source>
+        <target>Tax included</target>
+        <note>Line: 911</note>
+      </trans-unit>
+      <trans-unit id="befcac0f9644a7abee43e69f49252ac4">
+        <source>Tax excluded</source>
+        <target>Tax excluded</target>
+        <note>Line: 909</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/referrers/calendar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="104d9898c04874d0fbac36e125fa1369">
-        <source>Discount</source>
-        <target>Discount</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl:107</note>
+      <trans-unit id="1e6d57e813355689e9c77e947d73ad8f">
+        <source>From:</source>
+        <target>From:</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="33caa076f23f453dd4061726f3706325">
+        <source>To:</source>
+        <target>To:</target>
+        <note>Line: 41</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/referrers/form_settings.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="b9b371458ab7c314f88b81c553f6ce51">
-        <source>Hook</source>
-        <target>Hook</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:138</note>
+      <trans-unit id="f4f70727dc34561dfde1a3c529b6205c">
+        <source>Settings</source>
+        <target>Settings</target>
+        <note>Line: 56</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_categorytree/ps_categorytree.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="54e4f98fb34254a6678f0795476811ed">
-        <source>By name</source>
-        <target>By name</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:208</note>
-      </trans-unit>
-      <trans-unit id="883f0bd41a4fcee55680446ce7bec0d9">
-        <source>By position</source>
-        <target>By position</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:213</note>
+      <trans-unit id="6a26f548831e6a8c26bfbbd9f6ec61e0">
+        <source>Help</source>
+        <target>Help</target>
+        <note>Line: 31</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/referrers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="e3cf5ac19407b1a62c6fccaff675a53b">
-        <source>Descending</source>
-        <target>Descending</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php:64</note>
-      </trans-unit>
-      <trans-unit id="cf3fb1ff52ea1eed3347ac5401ee7f0c">
-        <source>Ascending</source>
-        <target>Ascending</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php:63</note>
+      <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680">
+        <source>All</source>
+        <target>All</target>
+        <note>Line: 115</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_imageslider/ps_imageslider.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="b112d8dc41120e6d28639b7eb825f491">
-        <source>Maximum image size: %s.</source>
-        <target>Maximum image size: %s.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:746</note>
+      <trans-unit id="a1fa27779242b4902f7ae3bdd5c6d508">
+        <source>Type</source>
+        <target>Type</target>
+        <note>Line: 80</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/Adapter/Product/AdminProductWrapper.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="58ef6750a23ba432fc1377b7de085d9f">
-        <source>Tax excl.</source>
-        <target>Tax excl.</target>
-        <note>Context:
-File: src/Adapter/Product/AdminProductWrapper.php:435</note>
-      </trans-unit>
-      <trans-unit id="94dfb2009644e42ef41f47aece4c0350">
-        <source>Tax incl.</source>
-        <target>Tax incl.</target>
-        <note>Context:
-File: src/Adapter/Product/AdminProductWrapper.php:433</note>
-      </trans-unit>
-      <trans-unit id="545f6c2f382c04810103b3e5e6f7d841">
-        <source>Unlimited</source>
-        <target>Unlimited</target>
-        <note>Context:
-File: src/Adapter/Product/AdminProductWrapper.php:442</note>
+      <trans-unit id="004bf6c9a40003140292e97330236c53">
+        <source>Action</source>
+        <target>Action</target>
+        <note>Line: 56</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/statscarrier/statscarrier.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="d7778d0c64b6ba21494c97f77a66885a">
-        <source>Filter</source>
-        <target>Filter</target>
-        <note>Context:
-File: modules/statscarrier/statscarrier.php:84</note>
+      <trans-unit id="ec136b444eede3bc85639fac0dd06229">
+        <source>Supplier</source>
+        <target>Supplier</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
+        <source>Brand</source>
+        <target>Brand</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="98f770b0af18ca763421bac22b4b6805">
+        <source>Features</source>
+        <target>Features</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="f2bbdf9f72c085adc4d0404e370f0f4c">
+        <source>Attribute</source>
+        <target>Attribute</target>
+        <note>Line: 274</note>
+      </trans-unit>
+      <trans-unit id="287234a1ff35a314b5b6bc4e5828e745">
+        <source>Attributes</source>
+        <target>Attributes</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">
+        <source>or</source>
+        <target>or</target>
+        <note>Line: 194</note>
+      </trans-unit>
+      <trans-unit id="be5d5d37542d75f93a87094459f76678">
+        <source>and</source>
+        <target>and</target>
+        <note>Line: 207</note>
+      </trans-unit>
+      <trans-unit id="21021ea0e52be8e9c599f4dff41e5be0">
+        <source>Feature</source>
+        <target>Feature</target>
+        <note>Line: 285</note>
+      </trans-unit>
+      <trans-unit id="3adbdb3ac060038aa0e6e6c138ef9873">
+        <source>Category</source>
+        <target>Category</target>
+        <note>Line: 39</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/statscatalog/statscatalog.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="156e5c5872c9af24a5c982da07a883c2">
-        <source>Products bought:</source>
-        <target>Products bought:</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:203</note>
+      <trans-unit id="4493e821e06072415518bd7ae4077996">
+        <source>Shop group</source>
+        <target>Shop group</target>
+        <note>Line: 70</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/statsbestsuppliers/statsbestsuppliers.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/themes/configurelayouts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="2a0440eec72540c5b30d9199c01f348c">
-        <source>Quantity sold</source>
-        <target>Quantity sold</target>
-        <note>Context:
-File: modules/statsbestsuppliers/statsbestsuppliers.php:65</note>
+      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
+        <source>Description</source>
+        <target>Description</target>
+        <note>Line: 41</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list_quicknav.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="382b0f5185773fa0f67a8ed8056c7759">
-        <source>N/A</source>
-        <target>N/A</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list_quicknav.html.twig:70</note>
+      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55">
+        <source>Next</source>
+        <target>Next</target>
+        <note>Line: 74</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/statsstock/statsstock.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="844c29394eea07066bb2efefc35784ec">
-        <source>Average price</source>
-        <target>Average price</target>
+      <trans-unit id="e55f75a29310d7b60f7ac1d390c8ae42">
+        <source>Module</source>
+        <target>Module</target>
+        <note>Line: 179</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/form_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b718adec73e04ce3ec720dd11a06a308">
+        <source>ID</source>
+        <target>ID</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_action_duplicate.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bafd7322c6e97d25b6299b5d6fe8920b">
+        <source>No</source>
+        <target>No</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="93cba07454f06a4a960172bbd6e2a435">
+        <source>Yes</source>
+        <target>Yes</target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_action_enable.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="00d23a76e43b46dae9ec7aa9dcbebb32">
+        <source>Enabled</source>
+        <target>Enabled</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="b9f5c797ebbf55adccdd8539a65a0241">
+        <source>Disabled</source>
+        <target>Disabled</target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9ffa4765d2da990741800bbe1ad4e7f8">
+        <source>Bulk actions</source>
+        <target>Bulk actions</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9f82518d468b9fee614fcc92f76bb163">
+        <source>Shop</source>
+        <target>Shop</target>
+        <note>Line: 292</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dae8ace18bdcbcc6ae5aece263e14fe8">
+        <source>Options</source>
+        <target>Options</target>
+        <note>Line: 45</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/helper/HelperOptions.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="387baf0199e7c9cc944fae94e96448fa">
+        <source>Miscellaneous</source>
+        <target>Miscellaneous</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAddressesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="41c2fff4867cc204120f001e7af20f7a">
+        <source>Mobile phone</source>
+        <target>Mobile phone</target>
+        <note>Line: 348</note>
+      </trans-unit>
+      <trans-unit id="bc910f8bdf70f29374f496f05be0330c">
+        <source>First Name</source>
+        <target>First Name</target>
+        <note>Line: 272</note>
+      </trans-unit>
+      <trans-unit id="77587239bf4c54ea493c7033e1dbf636">
+        <source>Last Name</source>
+        <target>Last Name</target>
+        <note>Line: 253</note>
+      </trans-unit>
+      <trans-unit id="fe66abce284ec8589e7d791185b5c442">
+        <source>Home phone</source>
+        <target>Home phone</target>
+        <note>Line: 340</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttachmentsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6f6cb72d544962fa333e2e34ce64f719">
+        <source>Size</source>
+        <target>Size</target>
+        <note>Line: 67</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5204077231fc7164e2269e96b584dd95">
+        <source>Drop-down list</source>
+        <target>Drop-down list</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="8bd90a6d76a77fe0b160e8abd85c8590">
+        <source>Radio buttons</source>
+        <target>Radio buttons</target>
+        <note>Line: 181</note>
+      </trans-unit>
+      <trans-unit id="c82a6100dace2b41087ba6cf99a5976a">
+        <source>Values</source>
+        <target>Values</target>
+        <note>Line: 258</note>
+      </trans-unit>
+      <trans-unit id="9446a98ad14416153cc4d45ab8b531bf">
+        <source>Performance</source>
+        <target>Performance</target>
+        <note>Line: 501</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1778e0e8555dc044231c1d615b41ddea">
+        <source>MultiStore</source>
+        <target>MultiStore</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="dd1f775e443ff3b9a89270713580a51b">
+        <source>Previous</source>
+        <target>Previous</target>
+        <note>Line: 132</note>
+      </trans-unit>
+      <trans-unit id="6f3455d187a23443796efdcbe044096b">
+        <source>No tax</source>
+        <target>No tax</target>
+        <note>Line: 327</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCarriersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4b78ac8eb158840e9638a3aeb26c4a9d">
+        <source>Tax</source>
+        <target>Tax</target>
+        <note>Line: 269</note>
+      </trans-unit>
+      <trans-unit id="7475ec0d41372a307c497acb7eeea8c4">
+        <source>No Tax</source>
+        <target>No Tax</target>
+        <note>Line: 276</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3f64b2beede1082fd32ddb0bf11a641f">
+        <source>Meta description</source>
+        <target>Meta description</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="7d7559ccac6bc30a4d985db11cb34a3a">
+        <source>Meta keywords</source>
+        <target>Meta keywords</target>
+        <note>Line: 196</note>
+      </trans-unit>
+      <trans-unit id="86754577897acfb25deb69039d49d9a7">
+        <source>Displayed</source>
+        <target>Displayed</target>
+        <note>Line: 244</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6252c0f2c2ed83b7b06dfca86d4650bb">
+        <source>Invalid characters:</source>
+        <target>Invalid characters:</target>
+        <note>Line: 198</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="947d8520f04473da621f2718138f3bc6">
+        <source>30 days</source>
+        <target>30 days</target>
+        <note>Line: 562</note>
+      </trans-unit>
+      <trans-unit id="003bf65ada43328a6164e2c681516a0e">
+        <source>30 day</source>
+        <target>30 day</target>
+        <note>Line: 575</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="85fb1a46f605ba9e7738df38315e6513">
+        <source>All Time</source>
+        <target>All Time</target>
+        <note>Line: 662</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminEmployeesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9d55fc80bbb875322aa67fd22fc98469">
+        <source>Shop association</source>
+        <target>Shop association</target>
+        <note>Line: 401</note>
+      </trans-unit>
+      <trans-unit id="8d3f5eff9c40ee315d452392bed5309b">
+        <source>Last name</source>
+        <target>Last name</target>
+        <note>Line: 256</note>
+      </trans-unit>
+      <trans-unit id="20db0bfeecd8fe60533206a2b5e9891a">
+        <source>First name</source>
+        <target>First name</target>
+        <note>Line: 249</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminGendersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5e74f2daf4ae8030571ceee5b4837579">
+        <source>Social title</source>
+        <target>Social title</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="019ec3132cdf8ee0f2e2a75cf5d3e459">
+        <source>Gender</source>
+        <target>Gender</target>
+        <note>Line: 128</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4965e9e891c3381d1ec7379f036131de">
+        <source>Date of birth</source>
+        <target>Date of birth</target>
+        <note>Line: 259</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="32954654ac8fe66a1d09be19001de2d4">
+        <source>Width</source>
+        <target>Width</target>
+        <note>Line: 210</note>
+      </trans-unit>
+      <trans-unit id="eec6c4bdbd339edf8cbea68becb85244">
+        <source>Height</source>
+        <target>Height</target>
+        <note>Line: 219</note>
+      </trans-unit>
+      <trans-unit id="821b8ee6937cec96c30fdafbfe836d68">
+        <source>Stores</source>
+        <target>Stores</target>
+        <note>Line: 404</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="675056ad1441b6375b2c5abd48c27ef1">
+        <source>Depth</source>
+        <target>Depth</target>
+        <note>Line: 248</note>
+      </trans-unit>
+      <trans-unit id="f54a73382e8bd64066339d60c9fc4bde">
+        <source>First name </source>
+        <target>First name</target>
+        <note>Line: 415</note>
+      </trans-unit>
+      <trans-unit id="5020eaae41baf0caa37bcb73b4a12934">
+        <source>Mobile Phone</source>
+        <target>Mobile Phone</target>
+        <note>Line: 424</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminManufacturersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5d9eca48241c03f20f27586c1f24a4b0">
+        <source>Zip/Postal code</source>
+        <target>Zip/Postal code</target>
+        <note>Line: 189</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1dd1c5fb7f25cd41b291d43a89e3aefd">
+        <source>Today</source>
+        <target>Today</target>
+        <note>Line: 1631</note>
+      </trans-unit>
+      <trans-unit id="ffbb5322a3702b0d8d9c7f506209c540">
+        <source>Average Order Value</source>
+        <target>Average Order Value</target>
+        <note>Line: 1644</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReferrersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8ff922bbcd8ad41cdfc48d3c5163b2ab">
+        <source>Calendar</source>
+        <target>Calendar</target>
+        <note>Line: 405</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d1457b72c3fb323a2671125aef3eab5d">
+        <source>?</source>
+        <target>?</target>
+        <note>Line: 282</note>
+      </trans-unit>
+      <trans-unit id="9c37b7b6ff829e977df287900543ea54">
+        <source>Birth date</source>
+        <target>Birth date</target>
+        <note>Line: 295</note>
+      </trans-unit>
+      <trans-unit id="eb6b06cab0dd72e04c4da68d511facf2">
+        <source>Search results</source>
+        <target>Search results</target>
+        <note>Line: 329</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="790d59ef178acbc75d233bf4211763c6">
+        <source>Countries</source>
+        <target>Countries</target>
+        <note>Line: 540</note>
+      </trans-unit>
+      <trans-unit id="fff0d600f8a0b5e19e88bfb821dd1157">
+        <source>Images</source>
+        <target>Images</target>
+        <note>Line: 544</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopUrlController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4e140ba723a03baa6948340bf90e2ef6">
+        <source>Name:</source>
+        <target>Name:</target>
+        <note>Line: 548</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSlipController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bcd1b68617759b1dfcff0403a6b5a8d1">
+        <source>PDF</source>
+        <target>PDF</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSpecificPriceRuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="37be07209f53a5d636d5c904ca9ae64c">
+        <source>Percentage</source>
+        <target>Percentage</target>
+        <note>Line: 273</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatsTabController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d2ce009594dcc60befa6a4e6cbeb71fc">
+        <source>Week</source>
+        <target>Week</target>
+        <note>Line: 122</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="783cb853aae6984e51583b3bb80c09d2">
+        <source>Address (2)</source>
+        <target>Address (2)</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="c6e2a9b2d1979c244d18c7e9fbf9a86f">
+        <source>Zip/postal code</source>
+        <target>Zip/postal code</target>
+        <note>Line: 471</note>
+      </trans-unit>
+      <trans-unit id="57d056ed0984166336b7879c2af3657f">
+        <source>City</source>
+        <target>City</target>
+        <note>Line: 476</note>
+      </trans-unit>
+      <trans-unit id="46a2a41cc6e552044816a2d04634545d">
+        <source>State</source>
+        <target>State</target>
+        <note>Line: 490</note>
+      </trans-unit>
+      <trans-unit id="bcc254b55c4a1babdf1dcb82c207506b">
+        <source>Phone</source>
+        <target>Phone</target>
+        <note>Line: 498</note>
+      </trans-unit>
+      <trans-unit id="9810aa2b9f44401be4bf73188ef2b67d">
+        <source>Fax</source>
+        <target>Fax</target>
+        <note>Line: 503</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/autoupgrade/views/templates/block/channelInfo.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="453e6aa38d87b28ccae545967c53004f">
+        <source>Unavailable</source>
+        <target>Unavailable</target>
         <note>Context:
-File: modules/statsstock/statsstock.php:148</note>
+File: modules/autoupgrade/views/templates/block/channelInfo.twig:11</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="54e85d70ea67acdcc86963b14d6223a8">
+        <source>Abandoned Carts</source>
+        <target>Abandoned Carts</target>
+        <note>Line: 83</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f1206f9fadc5ce41694f69129aecac26">
+        <source>Configure</source>
+        <target>Configure</target>
+        <note>Line: 46</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e4c3da18c66c0147144767efeb59198f">
+        <source>Conversion Rate</source>
+        <target>Conversion Rate</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="d7e637a6e9ff116de2fa89551240a94d">
+        <source>Visits</source>
+        <target>Visits</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="11ff9f68afb6b8b5b8eda218d7c83a65">
+        <source>Sales</source>
+        <target>Sales</target>
+        <note>Line: 46</note>
       </trans-unit>
     </body>
   </file>
@@ -1603,56 +1142,6 @@ File: modules/statsstock/statsstock.php:148</note>
         <target>Settings updated.</target>
         <note>Context:
 File: modules/ps_brandlist/ps_brandlist.php:114</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/statsnewsletter/statsnewsletter.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4b6f7d34a58ba399f077685951d06738">
-        <source>customers</source>
-        <target>customers</target>
-        <note>Context:
-File: modules/statsnewsletter/statsnewsletter.php:123</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_mainmenu/ps_mainmenu.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="97e7c9a7d06eac006a28bf05467fcc8b">
-        <source>Link</source>
-        <target>Link</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1338</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/categories/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7dce122004969d56ae2e0245cb754d35">
-        <source>Edit</source>
-        <target>Edit</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/categories/helpers/list/list_header.tpl:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4351cfebe4b61d8aa5efa1d020710005">
-        <source>View</source>
-        <target>View</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php:127</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="004bf6c9a40003140292e97330236c53">
-        <source>Action</source>
-        <target>Action</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl:56</note>
       </trans-unit>
     </body>
   </file>
@@ -1672,335 +1161,45 @@ File: modules/ps_buybuttonlite/ps_buybuttonlite.php:168</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_categorytree/ps_categorytree.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="b55e509c697e4cca0e1d160a7806698f">
-        <source>Hour</source>
-        <target>Hour</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/form.tpl:66</note>
+      <trans-unit id="54e4f98fb34254a6678f0795476811ed">
+        <source>By name</source>
+        <target>By name</target>
+        <note>Line: 208</note>
+      </trans-unit>
+      <trans-unit id="883f0bd41a4fcee55680446ce7bec0d9">
+        <source>By position</source>
+        <target>By position</target>
+        <note>Line: 213</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/Core/Backup/Listing/BackupGridDataFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="6a7e73161603d87b26a8eac49dab0a9c">
-        <source>Hours</source>
-        <target>Hours</target>
-        <note>Context:
-File: src/Core/Backup/Listing/BackupGridDataFactory.php:133</note>
+      <trans-unit id="dff4bf10409100d989495c6d5486035e">
+        <source>Lastname</source>
+        <target>Lastname</target>
+        <note>Line: 208</note>
       </trans-unit>
-      <trans-unit id="e807d3ccf8d24c8c1a3d86db5da78da8">
-        <source>Days</source>
-        <target>Days</target>
-        <note>Context:
-File: src/Core/Backup/Listing/BackupGridDataFactory.php:141</note>
+      <trans-unit id="04176f095283bc729f1e3926967e7034">
+        <source>Firstname</source>
+        <target>Firstname</target>
+        <note>Line: 212</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_facetedsearch/views/templates/hook/feature_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="01b6e20344b68835c5ed1ddedf20d531">
-        <source>to</source>
-        <target>to</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig:105</note>
+      <trans-unit id="e6b391a8d2c4d45902a23a8b6585703d">
+        <source>URL</source>
+        <target>URL</target>
+        <note>Line: 27</note>
       </trans-unit>
-      <trans-unit id="39e61d57e9209611edd4f884e9e47c11">
-        <source>For</source>
-        <target>For</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig:60</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="27ce7f8b5623b2e2df568d64cf051607">
-        <source>Stock</source>
-        <target>Stock</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:91</note>
-      </trans-unit>
-      <trans-unit id="6c957f72dc8cdacc75762f2cbdcdfaf2">
-        <source>Unit price</source>
-        <target>Unit price</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:89</note>
-      </trans-unit>
-      <trans-unit id="9d5bf15117441a1b52eb1f0808e4aad3">
-        <source>Discounts</source>
-        <target>Discounts</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:202</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/autoupgrade/views/templates/block/channelInfo.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="78945de8de090e90045d299651a68a9b">
-        <source>Available</source>
-        <target>Available</target>
-        <note>Context:
-File: modules/autoupgrade/views/templates/block/channelInfo.twig:9</note>
-      </trans-unit>
-      <trans-unit id="453e6aa38d87b28ccae545967c53004f">
-        <source>Unavailable</source>
-        <target>Unavailable</target>
-        <note>Context:
-File: modules/autoupgrade/views/templates/block/channelInfo.twig:11</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="21034ae6d01a83e702839a72ba8a77b0">
-        <source>(tax excl.)</source>
-        <target>(tax excl.)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php:81</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="336d5ebc5436534e61d16e63ddfca327">
-        <source>-</source>
-        <target>-</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php:54</note>
-      </trans-unit>
-      <trans-unit id="c0cb5f0fcf239ab3d9c1fcd31fff1efc">
-        <source>,</source>
-        <target>,</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php:55</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6a26f548831e6a8c26bfbbd9f6ec61e0">
-        <source>Help</source>
-        <target>Help</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule_itemlist.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="91b442d385b54e1418d81adc34871053">
-        <source>Selected</source>
-        <target>Selected</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/product_rule_itemlist.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="810460332a38c9ade69a49b057494cad">
-        <source>Unselected</source>
-        <target>Unselected</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/product_rule_itemlist.tpl:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/helper/HelperOptions.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="387baf0199e7c9cc944fae94e96448fa">
-        <source>Miscellaneous</source>
-        <target>Miscellaneous</target>
-        <note>Context:
-File: classes/helper/HelperOptions.php:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/layout.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8524de963f07201e5c086830d370797f">
-        <source>Loading...</source>
-        <target>Loading...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/layout.html.twig:97</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9ffa4765d2da990741800bbe1ad4e7f8">
-        <source>Bulk actions</source>
-        <target>Bulk actions</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_footer.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="dd8921b41e0279a02c6a26a509241700">
-        <source>result(s)</source>
-        <target>result(s)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_footer.tpl:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dddc702fcffceb2ac77291954897d747">
-        <source>SQL query</source>
-        <target>SQL query</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig:212</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="878530871f0db73f004f5bd6591eeb76">
-        <source>Remember me</source>
-        <target>Remember me</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig:62</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e55f75a29310d7b60f7ac1d390c8ae42">
-        <source>Module</source>
-        <target>Module</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl:179</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bfab8bcc21a91d9a7e346bbe1143c3ea">
-        <source>Bulk Actions</source>
-        <target>Bulk Actions</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.twig:58</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f4554d31351189a4a1749eafc9662640">
-        <source>Not filtered</source>
-        <target>Not filtered</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="0ccb67e7eaae09d9e4078d161eeca100">
-        <source>Equals</source>
-        <target>Equals</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig:56</note>
-      </trans-unit>
-      <trans-unit id="e59dd8d25c0b6bb6697eac0617ccd412">
-        <source>Below</source>
-        <target>Below</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig:60</note>
-      </trans-unit>
-      <trans-unit id="5b469fd01889ec12f1e84c6e66829fc1">
-        <source>Above</source>
-        <target>Above</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig:64</note>
-      </trans-unit>
-      <trans-unit id="71b23c9e2f071ea3f73e35796f671f3b">
-        <source>Inside range</source>
-        <target>Inside range</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig:67</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="21d104a54fc71a19a325c7305327f1d2">
-        <source>Processing...</source>
-        <target>Processing...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2251caec60313460694521b2a0fa593f">
-        <source>Quick navigation</source>
-        <target>Quick navigation</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig:64</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dae8ace18bdcbcc6ae5aece263e14fe8">
-        <source>Options</source>
-        <target>Options</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/options/options.tpl:45</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9b6545e4cea9b4ad4979d41bb9170e2b">
-        <source>Advanced</source>
-        <target>Advanced</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6ff9dd0d34f65181173c1e4bc39939de">
-        <source>Selection</source>
-        <target>Selection</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:173</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customer_threads/message.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="47a0be8d1015d526a1fbaa56c3102135">
-        <source>Subject:</source>
-        <target>Subject:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:93</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/configure.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0557fa923dcee4d0f86b1409f5c2167f">
-        <source>Back</source>
-        <target>Back</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:61</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4493e821e06072415518bd7ae4077996">
-        <source>Shop group</source>
-        <target>Shop group</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_header.tpl:70</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/currencies/conversion_rate.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="06933067aafd48425d67bcb01bba5cb6">
-        <source>Update</source>
-        <target>Update</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/currencies/conversion_rate.tpl:56</note>
+      <trans-unit id="9e11e4b371570340ca07913bc4783a7a">
+        <source>Meta title</source>
+        <target>Meta title</target>
+        <note>Line: 56</note>
       </trans-unit>
     </body>
   </file>
@@ -2009,28 +1208,558 @@ File: admin-dev/themes/default/template/controllers/currencies/conversion_rate.t
       <trans-unit id="34b6cd75171affba6957e308dcbd92be">
         <source>Version</source>
         <target>Version</target>
-        <note>Context:
-File: modules/ps_faviconnotificationbo/views/templates/admin/menu.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_imageslider/ps_imageslider.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="06df33001c1d7187fdd81ea1f5b277aa">
-        <source>Actions</source>
-        <target>Actions</target>
-        <note>Context:
-          File: src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php:115</note>
+      <trans-unit id="b112d8dc41120e6d28639b7eb825f491">
+        <source>Maximum image size: %s.</source>
+        <target>Maximum image size: %s.</target>
+        <note>Line: 746</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b9b371458ab7c314f88b81c553f6ce51">
+        <source>Hook</source>
+        <target>Hook</target>
+        <note>Line: 138</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mainmenu/ps_mainmenu.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="97e7c9a7d06eac006a28bf05467fcc8b">
+        <source>Link</source>
+        <target>Link</target>
+        <note>Line: 1338</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/include/modal_addons_connect.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="878530871f0db73f004f5bd6591eeb76">
+        <source>Remember me</source>
+        <target>Remember me</target>
+        <note>Line: 65</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/statsbestmanufacturers/statsbestmanufacturers.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f5c493141bb4b2508c5938fd9353291a">
+        <source>Displaying %1$s of %2$s</source>
+        <target>Displaying %1$s of %2$s</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
+        <source>CSV Export</source>
+        <target>CSV Export</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="2a0440eec72540c5b30d9199c01f348c">
+        <source>Quantity sold</source>
+        <target>Quantity sold</target>
+        <note>Line: 66</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/statscatalog/statscatalog.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="156e5c5872c9af24a5c982da07a883c2">
+        <source>Products bought:</source>
+        <target>Products bought:</target>
+        <note>Line: 203</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/statscheckup/statscheckup.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c888438d14855d7d96a2724ee9c306bd">
+        <source>Settings updated</source>
+        <target>Settings updated</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="59b514174bffe4ae402b3d63aad79fe0">
+        <source>images</source>
+        <target>images</target>
+        <note>Line: 157</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/statsnewsletter/statsnewsletter.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4b6f7d34a58ba399f077685951d06738">
+        <source>customers</source>
+        <target>customers</target>
+        <note>Line: 123</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/statssales/statssales.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d7778d0c64b6ba21494c97f77a66885a">
+        <source>Filter</source>
+        <target>Filter</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/statsstock/statsstock.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7bd5825a187064017975513b95d7f7de">
+        <source>Available quantity for sale</source>
+        <target>Available quantity for sale</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="7d74f3b92b19da5e606d737d339a9679">
+        <source>Item</source>
+        <target>Item</target>
+        <note>Line: 122</note>
+      </trans-unit>
+      <trans-unit id="844c29394eea07066bb2efefc35784ec">
+        <source>Average price</source>
+        <target>Average price</target>
+        <note>Line: 148</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/statsvisits/statsvisits.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6602bbeb2956c035fb4cb5e844a4861b">
+        <source>Guide</source>
+        <target>Guide</target>
+        <note>Line: 97</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Kpi/MainCountryKpi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9c680defe5574c8355ed9be5a3fede04">
+        <source>30 Days</source>
+        <target>30 Days</target>
+        <note>Line: 82</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Product/AdminProductWrapper.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9c7f56d70e922a61254366964c01c64a">
+        <source>All currencies</source>
+        <target>All currencies</target>
+        <note>Line: 484</note>
+      </trans-unit>
+      <trans-unit id="c3987e4cac14a8456515f0d200da04ee">
+        <source>All countries</source>
+        <target>All countries</target>
+        <note>Line: 485</note>
+      </trans-unit>
+      <trans-unit id="e4c4c68c7515704a91d90207067dcbbe">
+        <source>All groups</source>
+        <target>All groups</target>
+        <note>Line: 486</note>
+      </trans-unit>
+      <trans-unit id="804ccd6219996d12eda865d1c0707423">
+        <source>All shops</source>
+        <target>All shops</target>
+        <note>Line: 483</note>
+      </trans-unit>
+      <trans-unit id="7e3a51a56ddd2846e21c33f05e0aea6f">
+        <source>All customers</source>
+        <target>All customers</target>
+        <note>Line: 487</note>
+      </trans-unit>
+      <trans-unit id="58ef6750a23ba432fc1377b7de085d9f">
+        <source>Tax excl.</source>
+        <target>Tax excl.</target>
+        <note>Line: 435</note>
+      </trans-unit>
+      <trans-unit id="94dfb2009644e42ef41f47aece4c0350">
+        <source>Tax incl.</source>
+        <target>Tax incl.</target>
+        <note>Line: 433</note>
+      </trans-unit>
+      <trans-unit id="545f6c2f382c04810103b3e5e6f7d841">
+        <source>Unlimited</source>
+        <target>Unlimited</target>
+        <note>Line: 442</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Backup/Listing/BackupGridDataFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6a7e73161603d87b26a8eac49dab0a9c">
+        <source>Hours</source>
+        <target>Hours</target>
+        <note>Line: 133</note>
+      </trans-unit>
+      <trans-unit id="e807d3ccf8d24c8c1a3d86db5da78da8">
+        <source>Days</source>
+        <target>Days</target>
+        <note>Line: 141</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/BackupDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1351017ac6423911223bc19a8cb7c653">
+        <source>Filename</source>
+        <target>Filename</target>
+        <note>Line: 86</note>
       </trans-unit>
     </body>
   </file>
   <file original="src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="b718adec73e04ce3ec720dd11a06a308">
-        <source>ID</source>
-        <target>ID</target>
-        <note>Context:
-          File: src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php:94</note>
+      <trans-unit id="f8c8b903cb2e4f297e4b96d4b9c1e98a">
+        <source>Employee</source>
+        <target>Employee</target>
+        <note>Line: 100</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4351cfebe4b61d8aa5efa1d020710005">
+        <source>View</source>
+        <target>View</target>
+        <note>Line: 127</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e6d0e1c8fc6a4fcf47869df87e04cd88">
+        <source>Customers</source>
+        <target>Customers</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="336d5ebc5436534e61d16e63ddfca327">
+        <source>-</source>
+        <target>-</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="c0cb5f0fcf239ab3d9c1fcd31fff1efc">
+        <source>,</source>
+        <target>,</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e3cf5ac19407b1a62c6fccaff675a53b">
+        <source>Descending</source>
+        <target>Descending</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="cf3fb1ff52ea1eed3347ac5401ee7f0c">
+        <source>Ascending</source>
+        <target>Ascending</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3a08e2e340ab29fd9263af48193cbf8e">
+        <source>Languages</source>
+        <target>Languages</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="dfcfc43722eef1eab1e4a12e50a068b1">
+        <source>Currencies</source>
+        <target>Currencies</target>
+        <note>Line: 101</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="21034ae6d01a83e702839a72ba8a77b0">
+        <source>(tax excl.)</source>
+        <target>(tax excl.)</target>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductAttachement.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0b27918290ff5323bea1e3b78a9cf04e">
+        <source>File</source>
+        <target>File</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9dffbf69ffba8bc38bc4e01abf4b1675">
+        <source>Text</source>
+        <target>Text</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="b021df6aac4654c454f46c77646e745f">
+        <source>Label</source>
+        <target>Label</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="b651efdb98a5d6bd2b3935d0c3f4a5e2">
+        <source>Required</source>
+        <target>Required</target>
+        <note>Line: 91</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7a1920d61156abc05a60135aefe8bc67">
+        <source>Default</source>
+        <target>Default</target>
+        <note>Line: 278</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0bcef9c45bd8a48eda1b26eb0c61c869">
+        <source>%</source>
+        <target>%</target>
+        <note>Line: 256</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/grid_actions.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dddc702fcffceb2ac77291954897d747">
+        <source>SQL query</source>
+        <target>SQL query</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1dec4f55522b828fe5dacf8478021a9e">
+        <source>Friendly URL</source>
+        <target>Friendly URL</target>
+        <note>Line: 54</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0db377921f4ce762c62526131097968f">
+        <source>General</source>
+        <target>General</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="21d104a54fc71a19a325c7305327f1d2">
+        <source>Processing...</source>
+        <target>Processing...</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f4554d31351189a4a1749eafc9662640">
+        <source>Not filtered</source>
+        <target>Not filtered</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="0ccb67e7eaae09d9e4078d161eeca100">
+        <source>Equals</source>
+        <target>Equals</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="e59dd8d25c0b6bb6697eac0617ccd412">
+        <source>Below</source>
+        <target>Below</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="5b469fd01889ec12f1e84c6e66829fc1">
+        <source>Above</source>
+        <target>Above</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="71b23c9e2f071ea3f73e35796f671f3b">
+        <source>Inside range</source>
+        <target>Inside range</target>
+        <note>Line: 67</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9b6545e4cea9b4ad4979d41bb9170e2b">
+        <source>Advanced</source>
+        <target>Advanced</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6311ae17c1ee52b36e68aaf4ad066387">
+        <source>Other</source>
+        <target>Other</target>
+        <note>Line: 48</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bfab8bcc21a91d9a7e346bbe1143c3ea">
+        <source>Bulk Actions</source>
+        <target>Bulk Actions</target>
+        <note>Line: 58</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="382b0f5185773fa0f67a8ed8056c7759">
+        <source>N/A</source>
+        <target>N/A</target>
+        <note>Line: 67</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="52f5e0bc3859bc5f5e25130b6c7e8881">
+        <source>Position</source>
+        <target>Position</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="be53a0541a6d36f6ecb879fa2c584b08">
+        <source>Image</source>
+        <target>Image</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="78d811e98514cd165dda532286610fd2">
+        <source>Min</source>
+        <target>Min</target>
+        <note>Line: 139</note>
+      </trans-unit>
+      <trans-unit id="6a061313d22e51e0f25b7cd4dc065233">
+        <source>Max</source>
+        <target>Max</target>
+        <note>Line: 140</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="54f664c70c22054ea0d8d26fc3997ce7">
+        <source>Online</source>
+        <target>Online</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="8d9da4bc0e49a50e09ac9f7e56789d39">
+        <source>Offline</source>
+        <target>Offline</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2251caec60313460694521b2a0fa593f">
+        <source>Quick navigation</source>
+        <target>Quick navigation</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="01b6e20344b68835c5ed1ddedf20d531">
+        <source>to</source>
+        <target>to</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="39e61d57e9209611edd4f884e9e47c11">
+        <source>For</source>
+        <target>For</target>
+        <note>Line: 60</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="03937134cedab9078be39a77ee3a48a0">
+        <source>Group</source>
+        <target>Group</target>
+        <note>Line: 154</note>
+      </trans-unit>
+      <trans-unit id="1901606ea069a83dc7beea17881ef95a">
+        <source>Period</source>
+        <target>Period</target>
+        <note>Line: 158</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b78a3223503896721cca1303f776159b">
+        <source>Title</source>
+        <target>Title</target>
+        <note>Line: 360</note>
+      </trans-unit>
+      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
+        <source>Search</source>
+        <target>Search</target>
+        <note>Line: 320</note>
+      </trans-unit>
+      <trans-unit id="526d688f37a86d3c3f27d0c5016eb71d">
+        <source>Reset</source>
+        <target>Reset</target>
+        <note>Line: 331</note>
+      </trans-unit>
+      <trans-unit id="34082694d21dbdcfc31e6e32d9fb2b9f">
+        <source>File name</source>
+        <target>File name</target>
+        <note>Line: 361</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/layout.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8524de963f07201e5c086830d370797f">
+        <source>Loading...</source>
+        <target>Loading...</target>
+        <note>Line: 97</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c9cc8cce247e49bae79f15173ce97354">
+        <source>Save</source>
+        <target>Save</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Translation/Api/StockApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="78945de8de090e90045d299651a68a9b">
+        <source>Available</source>
+        <target>Available</target>
+        <note>Line: 71</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminInternationalFeature.xlf
+++ b/app/Resources/translations/default/AdminInternationalFeature.xlf
@@ -1,188 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminLanguagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="c5836008c1649301e29351a55db8f65c">
-        <source>Flag</source>
-        <target>Flag</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:189</note>
+      <trans-unit id="9fc79b58296e3a108fbe2f8852b652f4">
+        <source>Required fields for the address (click for more details):</source>
+        <target>Required fields for the address (click for more details):</target>
+        <note>Line: 35</note>
       </trans-unit>
-      <trans-unit id="e59a41e120686e63cbb743f003bea4e6">
-        <source>Language code</source>
-        <target>Language code</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:161</note>
+      <trans-unit id="5dfe48d86e43b22b76d36dcaadd5caf9">
+        <source>Use the last registered format</source>
+        <target>Use the last registered format</target>
+        <note>Line: 42</note>
       </trans-unit>
-      <trans-unit id="534fd46732986cba0efeda8701592427">
-        <source>Date format</source>
-        <target>Date format</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:171</note>
+      <trans-unit id="a19ef0b0d61c6410b0c930f7164d5870">
+        <source>Use the default format</source>
+        <target>Use the default format</target>
+        <note>Line: 44</note>
       </trans-unit>
-      <trans-unit id="c11566e30920ed4786e534e5332d5b87">
-        <source>Date format (full)</source>
-        <target>Date format (full)</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:180</note>
+      <trans-unit id="a4a61fd17fd3f75cdddb53a1404d2ba4">
+        <source>Use my current modified format</source>
+        <target>Use my current modified format</target>
+        <note>Line: 46</note>
       </trans-unit>
-      <trans-unit id="f53b6aa000ea3aa0114e70c1f8737608">
-        <source>Add new language</source>
-        <target>Add new language</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:111</note>
-      </trans-unit>
-      <trans-unit id="a0978fb69022447c12c0db348ad4f00c">
-        <source>"No-picture" image</source>
-        <target>"No-picture" image</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:196</note>
-      </trans-unit>
-      <trans-unit id="57efe5623fc0d68b37628923808d15d1">
-        <source>Is RTL language</source>
-        <target>Is RTL language</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:202</note>
-      </trans-unit>
-      <trans-unit id="1e817248a18ffae64e10be49a46fa9ee">
-        <source>Activate this language.</source>
-        <target>Activate this language.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:241</note>
-      </trans-unit>
-      <trans-unit id="a4bc4ae2cbf8be348ecfc863538998bf">
-        <source>Check to see if a language pack is available for this ISO code.</source>
-        <target>Check to see if a language pack is available for this ISO code.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:246</note>
-      </trans-unit>
-      <trans-unit id="22a31963fda5661b3a0919f7bda0debc">
-        <source>Translation files</source>
-        <target>Translation files</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:277</note>
-      </trans-unit>
-      <trans-unit id="704075d95dec2f52e92cbe2c6e2f61c7">
-        <source>Theme files</source>
-        <target>Theme files</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:281</note>
-      </trans-unit>
-      <trans-unit id="37f3a51de63012d9060d5ff8ccab2b0f">
-        <source>Mail files</source>
-        <target>Mail files</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:285</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ad68f9bafd9bf2dcf3865dac55662fd5">
-        <source>ISO code</source>
-        <target>ISO code</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:202</note>
-      </trans-unit>
-      <trans-unit id="f52c1ff75f69fa46ae947f0a3f653641">
-        <source>Country options</source>
-        <target>Country options</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:59</note>
-      </trans-unit>
-      <trans-unit id="d8ec51bf63378409b1d40cc45c80f926">
-        <source>Call prefix</source>
-        <target>Call prefix</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:216</note>
-      </trans-unit>
-      <trans-unit id="21e6a1298ab4cd040464d67a19d0f957">
-        <source>Add new country</source>
-        <target>Add new country</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:124</note>
-      </trans-unit>
-      <trans-unit id="790d59ef178acbc75d233bf4211763c6">
-        <source>Countries</source>
-        <target>Countries</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:188</note>
-      </trans-unit>
-      <trans-unit id="3be0efaecb3514a14757b8beb4b5dbb3">
-        <source>Country name</source>
-        <target>Country name</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:198</note>
-      </trans-unit>
-      <trans-unit id="a4f164d8b1b72c87b8ce558827bcd423">
-        <source>Default store currency</source>
-        <target>Default store currency</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:232</note>
-      </trans-unit>
-      <trans-unit id="ecefe3def8a2d034d80f6a8876c3d4b1">
-        <source>Does it need Zip/postal code?</source>
-        <target>Does it need Zip/postal code?</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:250</note>
-      </trans-unit>
-      <trans-unit id="25d176f9d01ba273d1097ca7b298d281">
-        <source>Zip/postal code format</source>
-        <target>Zip/postal code format</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:269</note>
-      </trans-unit>
-      <trans-unit id="665e1ad1c6657791cecb5b68008c7c00">
-        <source>Address format</source>
-        <target>Address format</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:276</note>
-      </trans-unit>
-      <trans-unit id="0bd345b58335589d4c2fa1e50ae38619">
-        <source>Contains states</source>
-        <target>Contains states</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:305</note>
-      </trans-unit>
-      <trans-unit id="0c750dacc725ba4047374d2efc56ce3a">
-        <source>Do you need a tax identification number?</source>
-        <target>Do you need a tax identification number?</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:323</note>
-      </trans-unit>
-      <trans-unit id="05820ffcf621269347a1c14d81d20b77">
-        <source>Display tax label (e.g. "Tax incl.")</source>
-        <target>Display tax label (e.g. "Tax incl.")</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:341</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCurrenciesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="02c86eb2792f3262c21d030a87e19793">
-        <source>Symbol</source>
-        <target>Symbol</target>
-        <note>Context:
-File: controllers/admin/AdminCurrenciesController.php:46</note>
-      </trans-unit>
-      <trans-unit id="e75e316ab3a0a8c0c5fc4b48d1a7033f">
-        <source>Exchange rate</source>
-        <target>Exchange rate</target>
-        <note>Context:
-File: controllers/admin/AdminCurrenciesController.php:111</note>
-      </trans-unit>
-      <trans-unit id="076b68505282c6c0654708db343d6673">
-        <source>Add new currency</source>
-        <target>Add new currency</target>
-        <note>Context:
-File: controllers/admin/AdminCurrenciesController.php:294</note>
-      </trans-unit>
-      <trans-unit id="8394539f7cc6a58a1b71c2465d84644d">
-        <source>Live exchange Rate for %shop_name%</source>
-        <target>Live exchange Rate for %shop_name%</target>
-        <note>Context:
-File: controllers/admin/AdminCurrenciesController.php:325</note>
+      <trans-unit id="6b900667b4a05ffdccc0bab5a20130a7">
+        <source>Clear format</source>
+        <target>Clear format</target>
+        <note>Line: 48</note>
       </trans-unit>
     </body>
   </file>
@@ -191,820 +34,7 @@ File: controllers/admin/AdminCurrenciesController.php:325</note>
       <trans-unit id="10d30c6319cf61386c878e4d9a3e09a2">
         <source>Assign to a new zone</source>
         <target>Assign to a new zone</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/list/list_footer.tpl:148</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStatesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="71777469a202cba33a8985f7d5bf1d97">
-        <source>Add new state</source>
-        <target>Add new state</target>
-        <note>Context:
-File: controllers/admin/AdminStatesController.php:118</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b8464cdd84b5f068ad72bf5c4f32163d">
-        <source>States</source>
-        <target>States</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php:99</note>
-      </trans-unit>
-      <trans-unit id="892a326e935b414a79a1eb938afd6ba5">
-        <source>Units (e.g. weight, volume, distance)</source>
-        <target>Units (e.g. weight, volume, distance)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php:103</note>
-      </trans-unit>
-      <trans-unit id="41661d8cebe0d3d2211676fd8aaf73f7">
-        <source>Change the behavior of the price display for groups</source>
-        <target>Change the behavior of the price display for groups</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php:104</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTaxRulesGroupController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e7c7216c46ae0e04e2012a2137803cca">
-        <source>Add new tax rules group</source>
-        <target>Add new tax rules group</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:81</note>
-      </trans-unit>
-      <trans-unit id="7ec515dc1920404871d8180791d589f2">
-        <source>Add a new tax rule</source>
-        <target>Add a new tax rule</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:227</note>
-      </trans-unit>
-      <trans-unit id="b39a035a995fc6597c8eb942210d1527">
-        <source>Behavior</source>
-        <target>Behavior</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:293</note>
-      </trans-unit>
-      <trans-unit id="8d4ae51b8b5831db49a6dcde1b83e175">
-        <source>Tax Rules</source>
-        <target>Tax Rules</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:172</note>
-      </trans-unit>
-      <trans-unit id="af4a7a1f7975e2f67b0dbefb21a2a94d">
-        <source>New tax rule</source>
-        <target>New tax rule</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:245</note>
-      </trans-unit>
-      <trans-unit id="e1ec2a73deaf4b7cf2fea1d51c65ddc2">
-        <source>Zip/postal code range</source>
-        <target>Zip/postal code range</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:286</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="14e4d5e97b5a2c7780c4f23b7612a67b">
-        <source>This tax only</source>
-        <target>This tax only</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_content.tpl:91</note>
-      </trans-unit>
-      <trans-unit id="e7b3c0acb7168c7969b03e8aebc67ce7">
-        <source>Combine</source>
-        <target>Combine</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_content.tpl:93</note>
-      </trans-unit>
-      <trans-unit id="7f8f392e0c47b730d773b4ddd9448fba">
-        <source>One after another</source>
-        <target>One after another</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_content.tpl:95</note>
-      </trans-unit>
-      <trans-unit id="08a38277b0309070706f6652eeae9a53">
-        <source>Down</source>
-        <target>Down</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_content.tpl:65</note>
-      </trans-unit>
-      <trans-unit id="258f49887ef8d14ac268c92b02503aaa">
-        <source>Up</source>
-        <target>Up</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_content.tpl:69</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTranslationsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6b13904f9eecabe20d88f942e84e1cb8">
-        <source>%1$s (Language: %2$s, Theme: %3$s)</source>
-        <target>%1$s (Language: %2$s, Theme: %3$s)</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:135
- Comment: Create a title for each translation page</note>
-      </trans-unit>
-      <trans-unit id="3b54d45d2c221c50e916f3be1fc12f2a">
-        <source>Update translations</source>
-        <target>Update translations</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:175</note>
-      </trans-unit>
-      <trans-unit id="6e4fd86b4ea240672daa3c2fe1118fe0">
-        <source>Expand all fieldsets</source>
-        <target>Expand all fieldsets</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1764</note>
-      </trans-unit>
-      <trans-unit id="e1686cbdbfefdc838c58469866922b6c">
-        <source>Close all fieldsets</source>
-        <target>Close all fieldsets</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1767</note>
-      </trans-unit>
-      <trans-unit id="80ab38b942fb2da88ca496f8bbe237f7">
-        <source>Email subject</source>
-        <target>Email subject</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2521</note>
-      </trans-unit>
-      <trans-unit id="673a349a39148b988e9aabf651d31a96">
-        <source>View HTML version</source>
-        <target>View HTML version</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2544</note>
-      </trans-unit>
-      <trans-unit id="b040fe53badd6b3784735f3d102df0bd">
-        <source>Edit HTML version</source>
-        <target>Edit HTML version</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2545</note>
-      </trans-unit>
-      <trans-unit id="5f986174fa9cf6c0ddd927e11b68254a">
-        <source>View/Edit TXT version</source>
-        <target>View/Edit TXT version</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2546</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Form/ChoiceProvider/TranslationTypeChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fabfbbc841761a5621aea32aff4aa151">
-        <source>Back office translations</source>
-        <target>Back office translations</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/TranslationTypeChoiceProvider.php:56</note>
-      </trans-unit>
-      <trans-unit id="445518ee6de9f01f5203fa05e5b83236">
-        <source>Themes translations</source>
-        <target>Themes translations</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/TranslationTypeChoiceProvider.php:57</note>
-      </trans-unit>
-      <trans-unit id="3d966df0f234e9180aac80223c2a7e85">
-        <source>Installed modules translations</source>
-        <target>Installed modules translations</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/TranslationTypeChoiceProvider.php:58</note>
-      </trans-unit>
-      <trans-unit id="6df6a1378a5ddcdef978aadf494cef5d">
-        <source>Email translations</source>
-        <target>Email translations</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/TranslationTypeChoiceProvider.php:59</note>
-      </trans-unit>
-      <trans-unit id="5d1eb86e15320f5677c9502df9c97dd3">
-        <source>Other translations</source>
-        <target>Other translations</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/TranslationTypeChoiceProvider.php:60</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Kpi/EnabledLanguagesKpi.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8ed78ce61d50323c845e812aaccf247a">
-        <source>Enabled Languages</source>
-        <target>Enabled Languages</target>
-        <note>Context:
-File: src/Adapter/Kpi/EnabledLanguagesKpi.php:90</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Kpi/MainCountryKpi.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c1aaec25c6e16ac8f28fdc652f1986ec">
-        <source>Main Country</source>
-        <target>Main Country</target>
-        <note>Context:
-File: src/Adapter/Kpi/MainCountryKpi.php:81</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Kpi/TranslationsKpi.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2ffdb9f581f55fb1ae293ec48b151aad">
-        <source>Front office Translations</source>
-        <target>Front office Translations</target>
-        <note>Context:
-File: src/Adapter/Kpi/TranslationsKpi.php:81</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d43522f215ed8be730a542c8e1fdcff1">
-        <source>Core emails</source>
-        <target>Core emails</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:97</note>
-      </trans-unit>
-      <trans-unit id="fdfd8f2cb7c034aecf19844d1cf4abd0">
-        <source>Module emails</source>
-        <target>Module emails</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:158</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="94d7422ba3c5b0f2a35f50b048e51c6d">
-        <source>Default currency</source>
-        <target>Default currency</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:78</note>
-      </trans-unit>
-      <trans-unit id="c96a77fb323a41898c3b6941a58dc741">
-        <source>Default language</source>
-        <target>Default language</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="65a9e6dae82101cecd43f16583f8cd37">
-        <source>Set language from browser</source>
-        <target>Set language from browser</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:47</note>
-      </trans-unit>
-      <trans-unit id="aac4bf78b43b8b815119032038bbee97">
-        <source>Default country</source>
-        <target>Default country</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:57</note>
-      </trans-unit>
-      <trans-unit id="e93c6cb824cab26f82d9b3446dc8e563">
-        <source>Set default country from browser language</source>
-        <target>Set default country from browser language</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:66</note>
-      </trans-unit>
-      <trans-unit id="1c96489b890acf7ccbb4bd0dc306870b">
-        <source>Time zone</source>
-        <target>Time zone</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:87</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminZonesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="77f1ebd0522a27ee9502ab13a242d823">
-        <source>Add new zone</source>
-        <target>Add new zone</target>
-        <note>Context:
-File: controllers/admin/AdminZonesController.php:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dad1f8d794ee0dd7753fe75e73b78f31">
-        <source>Zones</source>
-        <target>Zones</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:562</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTaxesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dcb66ff6e4a2517ade22183779939c9d">
-        <source>Rate</source>
-        <target>Rate</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:208</note>
-      </trans-unit>
-      <trans-unit id="1c669d037f8bc785f0e1a9aeb7070367">
-        <source>Tax options</source>
-        <target>Tax options</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:65</note>
-      </trans-unit>
-      <trans-unit id="783453d461b47241396594776bef68de">
-        <source>Enable tax</source>
-        <target>Enable tax</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:68</note>
-      </trans-unit>
-      <trans-unit id="9686d924d9453d29fabc55346fc57808">
-        <source>Display tax in the shopping cart</source>
-        <target>Display tax in the shopping cart</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:72</note>
-      </trans-unit>
-      <trans-unit id="3e61afd38fcb5eca62efcfe46fc6a3c9">
-        <source>Based on</source>
-        <target>Based on</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:77</note>
-      </trans-unit>
-      <trans-unit id="601d8c4b9f72fc1862013c19b677a499">
-        <source>Invoice address</source>
-        <target>Invoice address</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:82</note>
-      </trans-unit>
-      <trans-unit id="af0f5bdc5be121b9307687aeeae38c17">
-        <source>Delivery address</source>
-        <target>Delivery address</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:86</note>
-      </trans-unit>
-      <trans-unit id="8e4157c726a8c5cf64361e2d751bc945">
-        <source>Use ecotax</source>
-        <target>Use ecotax</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:92</note>
-      </trans-unit>
-      <trans-unit id="e92cfa244b5eb9025d07522080468445">
-        <source>Ecotax</source>
-        <target>Ecotax</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:105</note>
-      </trans-unit>
-      <trans-unit id="7c545d3243860a144f6d3410fadd3c08">
-        <source>Add new tax</source>
-        <target>Add new tax</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:122</note>
-      </trans-unit>
-      <trans-unit id="0071aa279bd1583754a544277740f047">
-        <source>Delete item #</source>
-        <target>Delete item #</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:148</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Form/ChoiceProvider/LocalizationPackByIsoCodeChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="823e3e5a2bec573e4e38853822465914">
-        <source>%s (local)</source>
-        <target>%s (local)</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/LocalizationPackByIsoCodeChoiceProvider.php:114</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Form/ChoiceProvider/EmailContentTypeChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ac101b32dda4448cf13a93fe283dddd8">
-        <source>Body</source>
-        <target>Body</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/EmailContentTypeChoiceProvider.php:59</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Twig/TranslationsExtension.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c949bd6d096b356fc06f55ec5205e3b6">
-        <source>%d missing</source>
-        <target>%d missing</target>
-        <note>Context:
-File: src/PrestaShopBundle/Twig/TranslationsExtension.php:354</note>
-      </trans-unit>
-      <trans-unit id="3a8b99657fcabfc65f45cd1be2b34de9">
-        <source>%nb_translations% expressions</source>
-        <target>%nb_translations% expressions</target>
-        <note>Context:
-File: src/PrestaShopBundle/Twig/TranslationsExtension.php:422</note>
-      </trans-unit>
-      <trans-unit id="740b879fdd48f184f798b8018134f630">
-        <source>Show messages</source>
-        <target>Show messages</target>
-        <note>Context:
-File: src/PrestaShopBundle/Twig/TranslationsExtension.php:365</note>
-      </trans-unit>
-      <trans-unit id="67b6092e7137b245b034286819367669">
-        <source>Hide messages</source>
-        <target>Hide messages</target>
-        <note>Context:
-File: src/PrestaShopBundle/Twig/TranslationsExtension.php:366</note>
-      </trans-unit>
-      <trans-unit id="f5123d6dff8361ad9310560e87c220ef">
-        <source>%nb_translations% missing</source>
-        <target>%nb_translations% missing</target>
-        <note>Context:
-File: src/PrestaShopBundle/Twig/TranslationsExtension.php:465</note>
-      </trans-unit>
-      <trans-unit id="f0780b397b7190b7894af3d8d7d91a83">
-        <source>%nb_translations% translations are missing in %domain%</source>
-        <target>%nb_translations% translations are missing in %domain%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Twig/TranslationsExtension.php:474</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="16ec8a60494224f7fa891897aba8caf8">
-        <source>1 missing</source>
-        <target>1 missing</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/InternationalApi.php:46</note>
-      </trans-unit>
-      <trans-unit id="026966b734feffa2a2a7c807d268e495">
-        <source>%nb_translation% expression</source>
-        <target>%nb_translation% expression</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/InternationalApi.php:49
- Comment: nb_translations can be 0 or 1</note>
-      </trans-unit>
-      <trans-unit id="e3ee9f9a340e253eb5196ce7d53ae2d8">
-        <source>Search translations</source>
-        <target>Search translations</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/InternationalApi.php:58</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="13a596ad5071982366e29e4f3d76e366">
-        <source>Visitors cannot see your catalog.</source>
-        <target>Visitors cannot see your catalog.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php:87</note>
-      </trans-unit>
-      <trans-unit id="3850c8049741085bef77450dc5f0dc9a">
-        <source>Visitors can see your catalog but cannot place an order.</source>
-        <target>Visitors can see your catalog but cannot place an order.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php:88</note>
-      </trans-unit>
-      <trans-unit id="4609449450efd4dbe3f05ef2e9c5151d">
-        <source>All features are available</source>
-        <target>All features are available</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php:86</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="57fa5be19cbdbe09aa4f555b2ee710b3">
-        <source>Update a language</source>
-        <target>Update a language</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php:66</note>
-      </trans-unit>
-      <trans-unit id="369b8db3e9651d0b5d8a13a5f7f9a53a">
-        <source>Add a language</source>
-        <target>Add a language</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php:67</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5aca31cb4d1fbb543b716cbaaf35c65f">
-        <source>Core (no theme selected)</source>
-        <target>Core (no theme selected)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php:88</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="17812004136cffbd9c55b624f8d21557">
-        <source>The following features are only available if you enable the Geolocation by IP address feature.</source>
-        <target>The following features are only available if you enable the Geolocation by IP address feature.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig:39</note>
-      </trans-unit>
-      <trans-unit id="8beea67a449f1c8e352838c8a1a77111">
-        <source>Geolocation behavior for restricted countries</source>
-        <target>Geolocation behavior for restricted countries</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig:47</note>
-      </trans-unit>
-      <trans-unit id="dd39e763b87f78cae49e9d09b1e5e9d2">
-        <source>Geolocation behavior for other countries</source>
-        <target>Geolocation behavior for other countries</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig:57</note>
-      </trans-unit>
-      <trans-unit id="3d5428a3ea15cf231a5d0651df2452e2">
-        <source>Select the countries from which your store is accessible</source>
-        <target>Select the countries from which your store is accessible</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig:67</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="aa3b1c5568c71eb8b7a22e5f07c70cd4">
-        <source>Geolocation by IP address</source>
-        <target>Geolocation by IP address</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig:37</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b104929231738bd0699db6e6678581b8">
-        <source>IP address whitelist</source>
-        <target>IP address whitelist</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig:31</note>
-      </trans-unit>
-      <trans-unit id="f6572f026526c2b6356149d46db5f0a1">
-        <source>Whitelisted IP addresses</source>
-        <target>Whitelisted IP addresses</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig:47</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/geolocation.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d1e4ac2093276d0228ca8470e7ecbf98">
-        <source>In order to use Geolocation, please download [1]this file[/1] and extract it (using Winrar or Gzip) into the /app/Resources/geoip/ directory.</source>
-        <target>In order to use Geolocation, please download [1]this file[/1] and extract it (using Winrar or Gzip) into the /app/Resources/geoip/ directory.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/geolocation.html.twig:37</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="763d71969e7ee9bff4e5dc8976501f33">
-        <source>Add / Update a language</source>
-        <target>Add / Update a language</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig:32</note>
-      </trans-unit>
-      <trans-unit id="d92acc5a17d29f3f8b7ac58f22fe7df8">
-        <source>Please select the language you want to add or update</source>
-        <target>Please select the language you want to add or update</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig:48</note>
-      </trans-unit>
-      <trans-unit id="524d7e787cc63c50e0d1946ee8ef0bef">
-        <source>Add or update a language</source>
-        <target>Add or update a language</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig:63</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6700e23ddf33bd4421249c9ef94d6295">
-        <source>Export a language</source>
-        <target>Export a language</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="84a63a234d9b35094275bfb41ad46b47">
-        <source>Select your theme</source>
-        <target>Select your theme</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig:70</note>
-      </trans-unit>
-      <trans-unit id="021257190c6e64120915e008a94a06f8">
-        <source>Type of translation</source>
-        <target>Type of translation</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="4dca8188ef80c1e68c7cfc96fdeb3abe">
-        <source>Select the type of email content</source>
-        <target>Select the type of email content</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig:61</note>
-      </trans-unit>
-      <trans-unit id="dd317a8b9f3ecfc5317c2cb586274145">
-        <source>Select your module</source>
-        <target>Select your module</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig:79</note>
-      </trans-unit>
-      <trans-unit id="c96f531c0eda2dece593a2f8df3a58a8">
-        <source>Select your language</source>
-        <target>Select your language</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig:88</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2303c057afcbe798a5d9811d36e88050">
-        <source>Modify translations</source>
-        <target>Modify translations</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl:189</note>
-      </trans-unit>
-      <trans-unit id="a9e4402481bd9b8e36752bf731f67eb6">
-        <source>Theme:</source>
-        <target>Theme:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl:100</note>
-      </trans-unit>
-      <trans-unit id="53b3cae42737979c884275593a01f468">
-        <source>Module:</source>
-        <target>Module:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl:102</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="72388067f972c9a43b1ded59297f5b6e">
-        <source>Language identifier</source>
-        <target>Language identifier</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="a86844187775f3d99ab7bad450a61d78">
-        <source>Country identifier</source>
-        <target>Country identifier</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig:46</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1240d2eed41a0fd4e898e6aab64c6732">
-        <source>Import a localization pack</source>
-        <target>Import a localization pack</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig:32</note>
-      </trans-unit>
-      <trans-unit id="75f9936f4fef50cf05561217a24f058c">
-        <source>Localization pack you want to import</source>
-        <target>Localization pack you want to import</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig:39</note>
-      </trans-unit>
-      <trans-unit id="41b72abcfb3ec32e91e9cfa775e49cbd">
-        <source>Content to import</source>
-        <target>Content to import</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig:49</note>
-      </trans-unit>
-      <trans-unit id="345e1dd7e9d9ec15c68486caac639767">
-        <source>Download pack data</source>
-        <target>Download pack data</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig:59</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="216845c195c351faf05ff91c6411bfea">
-        <source>Local units</source>
-        <target>Local units</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig:32</note>
-      </trans-unit>
-      <trans-unit id="f489118ea95c746d648d36bb50c226f0">
-        <source>Weight unit</source>
-        <target>Weight unit</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="fff9ff80cc72d571e3d5115b421a27c3">
-        <source>Distance unit</source>
-        <target>Distance unit</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig:46</note>
-      </trans-unit>
-      <trans-unit id="bac94fdafa0ab5ce874f63b75d6d28da">
-        <source>Volume unit</source>
-        <target>Volume unit</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig:54</note>
-      </trans-unit>
-      <trans-unit id="cc13d156306185fd42a860da3049567c">
-        <source>Dimension unit</source>
-        <target>Dimension unit</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig:62</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9fc79b58296e3a108fbe2f8852b652f4">
-        <source>Required fields for the address (click for more details):</source>
-        <target>Required fields for the address (click for more details):</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="5dfe48d86e43b22b76d36dcaadd5caf9">
-        <source>Use the last registered format</source>
-        <target>Use the last registered format</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="a19ef0b0d61c6410b0c930f7164d5870">
-        <source>Use the default format</source>
-        <target>Use the default format</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl:44</note>
-      </trans-unit>
-      <trans-unit id="a4a61fd17fd3f75cdddb53a1404d2ba4">
-        <source>Use my current modified format</source>
-        <target>Use my current modified format</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="6b900667b4a05ffdccc0bab5a20130a7">
-        <source>Clear format</source>
-        <target>Clear format</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl:48</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f05b91496296629228c94a6b4b0a335f">
-        <source>Expressions to translate:</source>
-        <target>Expressions to translate:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl:51</note>
-      </trans-unit>
-      <trans-unit id="57aca76c1e8e4e4063437a931c74a0ee">
-        <source>Total missing expressions:</source>
-        <target>Total missing expressions:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl:52</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1476dfb963d54c697399a79fafa90151">
-        <source>expressions</source>
-        <target>expressions</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl:110</note>
-      </trans-unit>
-      <trans-unit id="ea21841da70e6405af19fabc4ff8bdd9">
-        <source>missing</source>
-        <target>missing</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl:111</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/currencies/status.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a0375b8965a19b59896d90e7e08041f3">
-        <source>This currency is disabled</source>
-        <target>This currency is disabled</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/currencies/status.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="5a654deb20d708c9f56c1d7bc5e35c38">
-        <source>This currency is enabled</source>
-        <target>This currency is enabled</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/currencies/status.tpl:38</note>
+        <note>Line: 148</note>
       </trans-unit>
     </body>
   </file>
@@ -1013,26 +43,843 @@ File: admin-dev/themes/default/template/controllers/currencies/status.tpl:38</no
       <trans-unit id="31b7dce9ac35e52f1c4719ac210b7419">
         <source>Live exchange rates</source>
         <target>Live exchange rates</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/currencies/conversion_rate.tpl:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="a9df98bcbe3f6c6f366c373674d5008b">
         <source>The exchange rates are not automatically updated</source>
         <target>The exchange rates are not automatically updated</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/currencies/conversion_rate.tpl:40</note>
+        <note>Line: 40</note>
       </trans-unit>
       <trans-unit id="161e96e34f07ec8c967819825f982902">
         <source>The exchange rates are automatically updated</source>
         <target>The exchange rates are automatically updated</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/currencies/conversion_rate.tpl:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="8f76a793218248d062ced130c0ffd968">
         <source>Update exchange rates</source>
         <target>Update exchange rates</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/currencies/conversion_rate.tpl:54</note>
+        <note>Line: 54</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/currencies/status.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a0375b8965a19b59896d90e7e08041f3">
+        <source>This currency is disabled</source>
+        <target>This currency is disabled</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="5a654deb20d708c9f56c1d7bc5e35c38">
+        <source>This currency is enabled</source>
+        <target>This currency is enabled</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/tax_rules/helpers/list/list_content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="14e4d5e97b5a2c7780c4f23b7612a67b">
+        <source>This tax only</source>
+        <target>This tax only</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="e7b3c0acb7168c7969b03e8aebc67ce7">
+        <source>Combine</source>
+        <target>Combine</target>
+        <note>Line: 93</note>
+      </trans-unit>
+      <trans-unit id="7f8f392e0c47b730d773b4ddd9448fba">
+        <source>One after another</source>
+        <target>One after another</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="08a38277b0309070706f6652eeae9a53">
+        <source>Down</source>
+        <target>Down</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="258f49887ef8d14ac268c92b02503aaa">
+        <source>Up</source>
+        <target>Up</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ea21841da70e6405af19fabc4ff8bdd9">
+        <source>missing</source>
+        <target>missing</target>
+        <note>Line: 111</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d43522f215ed8be730a542c8e1fdcff1">
+        <source>Core emails</source>
+        <target>Core emails</target>
+        <note>Line: 97</note>
+      </trans-unit>
+      <trans-unit id="fdfd8f2cb7c034aecf19844d1cf4abd0">
+        <source>Module emails</source>
+        <target>Module emails</target>
+        <note>Line: 158</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2303c057afcbe798a5d9811d36e88050">
+        <source>Modify translations</source>
+        <target>Modify translations</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="a9e4402481bd9b8e36752bf731f67eb6">
+        <source>Theme:</source>
+        <target>Theme:</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="53b3cae42737979c884275593a01f468">
+        <source>Module:</source>
+        <target>Module:</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="f05b91496296629228c94a6b4b0a335f">
+        <source>Expressions to translate:</source>
+        <target>Expressions to translate:</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="57aca76c1e8e4e4063437a931c74a0ee">
+        <source>Total missing expressions:</source>
+        <target>Total missing expressions:</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="1476dfb963d54c697399a79fafa90151">
+        <source>expressions</source>
+        <target>expressions</target>
+        <note>Line: 116</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f52c1ff75f69fa46ae947f0a3f653641">
+        <source>Country options</source>
+        <target>Country options</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="d8ec51bf63378409b1d40cc45c80f926">
+        <source>Call prefix</source>
+        <target>Call prefix</target>
+        <note>Line: 216</note>
+      </trans-unit>
+      <trans-unit id="21e6a1298ab4cd040464d67a19d0f957">
+        <source>Add new country</source>
+        <target>Add new country</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="790d59ef178acbc75d233bf4211763c6">
+        <source>Countries</source>
+        <target>Countries</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="3be0efaecb3514a14757b8beb4b5dbb3">
+        <source>Country name</source>
+        <target>Country name</target>
+        <note>Line: 198</note>
+      </trans-unit>
+      <trans-unit id="a4f164d8b1b72c87b8ce558827bcd423">
+        <source>Default store currency</source>
+        <target>Default store currency</target>
+        <note>Line: 232</note>
+      </trans-unit>
+      <trans-unit id="ecefe3def8a2d034d80f6a8876c3d4b1">
+        <source>Does it need Zip/postal code?</source>
+        <target>Does it need Zip/postal code?</target>
+        <note>Line: 250</note>
+      </trans-unit>
+      <trans-unit id="25d176f9d01ba273d1097ca7b298d281">
+        <source>Zip/postal code format</source>
+        <target>Zip/postal code format</target>
+        <note>Line: 269</note>
+      </trans-unit>
+      <trans-unit id="665e1ad1c6657791cecb5b68008c7c00">
+        <source>Address format</source>
+        <target>Address format</target>
+        <note>Line: 276</note>
+      </trans-unit>
+      <trans-unit id="0bd345b58335589d4c2fa1e50ae38619">
+        <source>Contains states</source>
+        <target>Contains states</target>
+        <note>Line: 305</note>
+      </trans-unit>
+      <trans-unit id="0c750dacc725ba4047374d2efc56ce3a">
+        <source>Do you need a tax identification number?</source>
+        <target>Do you need a tax identification number?</target>
+        <note>Line: 323</note>
+      </trans-unit>
+      <trans-unit id="05820ffcf621269347a1c14d81d20b77">
+        <source>Display tax label (e.g. "Tax incl.")</source>
+        <target>Display tax label (e.g. "Tax incl.")</target>
+        <note>Line: 341</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCurrenciesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="02c86eb2792f3262c21d030a87e19793">
+        <source>Symbol</source>
+        <target>Symbol</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="e75e316ab3a0a8c0c5fc4b48d1a7033f">
+        <source>Exchange rate</source>
+        <target>Exchange rate</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="076b68505282c6c0654708db343d6673">
+        <source>Add new currency</source>
+        <target>Add new currency</target>
+        <note>Line: 294</note>
+      </trans-unit>
+      <trans-unit id="8394539f7cc6a58a1b71c2465d84644d">
+        <source>Live exchange Rate for %shop_name%</source>
+        <target>Live exchange Rate for %shop_name%</target>
+        <note>Line: 325</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminLanguagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c5836008c1649301e29351a55db8f65c">
+        <source>Flag</source>
+        <target>Flag</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="e59a41e120686e63cbb743f003bea4e6">
+        <source>Language code</source>
+        <target>Language code</target>
+        <note>Line: 161</note>
+      </trans-unit>
+      <trans-unit id="534fd46732986cba0efeda8701592427">
+        <source>Date format</source>
+        <target>Date format</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="c11566e30920ed4786e534e5332d5b87">
+        <source>Date format (full)</source>
+        <target>Date format (full)</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="f53b6aa000ea3aa0114e70c1f8737608">
+        <source>Add new language</source>
+        <target>Add new language</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="a0978fb69022447c12c0db348ad4f00c">
+        <source>"No-picture" image</source>
+        <target>"No-picture" image</target>
+        <note>Line: 196</note>
+      </trans-unit>
+      <trans-unit id="57efe5623fc0d68b37628923808d15d1">
+        <source>Is RTL language</source>
+        <target>Is RTL language</target>
+        <note>Line: 202</note>
+      </trans-unit>
+      <trans-unit id="1e817248a18ffae64e10be49a46fa9ee">
+        <source>Activate this language.</source>
+        <target>Activate this language.</target>
+        <note>Line: 241</note>
+      </trans-unit>
+      <trans-unit id="a4bc4ae2cbf8be348ecfc863538998bf">
+        <source>Check to see if a language pack is available for this ISO code.</source>
+        <target>Check to see if a language pack is available for this ISO code.</target>
+        <note>Line: 246</note>
+      </trans-unit>
+      <trans-unit id="22a31963fda5661b3a0919f7bda0debc">
+        <source>Translation files</source>
+        <target>Translation files</target>
+        <note>Line: 277</note>
+      </trans-unit>
+      <trans-unit id="704075d95dec2f52e92cbe2c6e2f61c7">
+        <source>Theme files</source>
+        <target>Theme files</target>
+        <note>Line: 281</note>
+      </trans-unit>
+      <trans-unit id="37f3a51de63012d9060d5ff8ccab2b0f">
+        <source>Mail files</source>
+        <target>Mail files</target>
+        <note>Line: 285</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ad68f9bafd9bf2dcf3865dac55662fd5">
+        <source>ISO code</source>
+        <target>ISO code</target>
+        <note>Line: 153</note>
+      </trans-unit>
+      <trans-unit id="71777469a202cba33a8985f7d5bf1d97">
+        <source>Add new state</source>
+        <target>Add new state</target>
+        <note>Line: 118</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTaxRulesGroupController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e7c7216c46ae0e04e2012a2137803cca">
+        <source>Add new tax rules group</source>
+        <target>Add new tax rules group</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="7ec515dc1920404871d8180791d589f2">
+        <source>Add a new tax rule</source>
+        <target>Add a new tax rule</target>
+        <note>Line: 227</note>
+      </trans-unit>
+      <trans-unit id="b39a035a995fc6597c8eb942210d1527">
+        <source>Behavior</source>
+        <target>Behavior</target>
+        <note>Line: 293</note>
+      </trans-unit>
+      <trans-unit id="8d4ae51b8b5831db49a6dcde1b83e175">
+        <source>Tax Rules</source>
+        <target>Tax Rules</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="af4a7a1f7975e2f67b0dbefb21a2a94d">
+        <source>New tax rule</source>
+        <target>New tax rule</target>
+        <note>Line: 245</note>
+      </trans-unit>
+      <trans-unit id="e1ec2a73deaf4b7cf2fea1d51c65ddc2">
+        <source>Zip/postal code range</source>
+        <target>Zip/postal code range</target>
+        <note>Line: 286</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTaxesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dcb66ff6e4a2517ade22183779939c9d">
+        <source>Rate</source>
+        <target>Rate</target>
+        <note>Line: 208</note>
+      </trans-unit>
+      <trans-unit id="1c669d037f8bc785f0e1a9aeb7070367">
+        <source>Tax options</source>
+        <target>Tax options</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="783453d461b47241396594776bef68de">
+        <source>Enable tax</source>
+        <target>Enable tax</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="9686d924d9453d29fabc55346fc57808">
+        <source>Display tax in the shopping cart</source>
+        <target>Display tax in the shopping cart</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="3e61afd38fcb5eca62efcfe46fc6a3c9">
+        <source>Based on</source>
+        <target>Based on</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="601d8c4b9f72fc1862013c19b677a499">
+        <source>Invoice address</source>
+        <target>Invoice address</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="af0f5bdc5be121b9307687aeeae38c17">
+        <source>Delivery address</source>
+        <target>Delivery address</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="8e4157c726a8c5cf64361e2d751bc945">
+        <source>Use ecotax</source>
+        <target>Use ecotax</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="e92cfa244b5eb9025d07522080468445">
+        <source>Ecotax</source>
+        <target>Ecotax</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="7c545d3243860a144f6d3410fadd3c08">
+        <source>Add new tax</source>
+        <target>Add new tax</target>
+        <note>Line: 122</note>
+      </trans-unit>
+      <trans-unit id="0071aa279bd1583754a544277740f047">
+        <source>Delete item #</source>
+        <target>Delete item #</target>
+        <note>Line: 148</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTranslationsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6b13904f9eecabe20d88f942e84e1cb8">
+        <source>%1$s (Language: %2$s, Theme: %3$s)</source>
+        <target>%1$s (Language: %2$s, Theme: %3$s)</target>
+        <note>Line: 135
+Comment: Create a title for each translation page</note>
+      </trans-unit>
+      <trans-unit id="3b54d45d2c221c50e916f3be1fc12f2a">
+        <source>Update translations</source>
+        <target>Update translations</target>
+        <note>Line: 175</note>
+      </trans-unit>
+      <trans-unit id="6e4fd86b4ea240672daa3c2fe1118fe0">
+        <source>Expand all fieldsets</source>
+        <target>Expand all fieldsets</target>
+        <note>Line: 1764</note>
+      </trans-unit>
+      <trans-unit id="e1686cbdbfefdc838c58469866922b6c">
+        <source>Close all fieldsets</source>
+        <target>Close all fieldsets</target>
+        <note>Line: 1767</note>
+      </trans-unit>
+      <trans-unit id="80ab38b942fb2da88ca496f8bbe237f7">
+        <source>Email subject</source>
+        <target>Email subject</target>
+        <note>Line: 2521</note>
+      </trans-unit>
+      <trans-unit id="673a349a39148b988e9aabf651d31a96">
+        <source>View HTML version</source>
+        <target>View HTML version</target>
+        <note>Line: 2544</note>
+      </trans-unit>
+      <trans-unit id="b040fe53badd6b3784735f3d102df0bd">
+        <source>Edit HTML version</source>
+        <target>Edit HTML version</target>
+        <note>Line: 2545</note>
+      </trans-unit>
+      <trans-unit id="5f986174fa9cf6c0ddd927e11b68254a">
+        <source>View/Edit TXT version</source>
+        <target>View/Edit TXT version</target>
+        <note>Line: 2546</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminZonesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="77f1ebd0522a27ee9502ab13a242d823">
+        <source>Add new zone</source>
+        <target>Add new zone</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="dad1f8d794ee0dd7753fe75e73b78f31">
+        <source>Zones</source>
+        <target>Zones</target>
+        <note>Line: 95</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Kpi/EnabledLanguagesKpi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8ed78ce61d50323c845e812aaccf247a">
+        <source>Enabled Languages</source>
+        <target>Enabled Languages</target>
+        <note>Line: 90</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Kpi/MainCountryKpi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c1aaec25c6e16ac8f28fdc652f1986ec">
+        <source>Main Country</source>
+        <target>Main Country</target>
+        <note>Line: 81</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Kpi/TranslationsKpi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2ffdb9f581f55fb1ae293ec48b151aad">
+        <source>Front office Translations</source>
+        <target>Front office Translations</target>
+        <note>Line: 81</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Form/ChoiceProvider/EmailContentTypeChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ac101b32dda4448cf13a93fe283dddd8">
+        <source>Body</source>
+        <target>Body</target>
+        <note>Line: 59</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Form/ChoiceProvider/LocalizationPackByIsoCodeChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="823e3e5a2bec573e4e38853822465914">
+        <source>%s (local)</source>
+        <target>%s (local)</target>
+        <note>Line: 114</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Form/ChoiceProvider/TranslationTypeChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fabfbbc841761a5621aea32aff4aa151">
+        <source>Back office translations</source>
+        <target>Back office translations</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="445518ee6de9f01f5203fa05e5b83236">
+        <source>Themes translations</source>
+        <target>Themes translations</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="3d966df0f234e9180aac80223c2a7e85">
+        <source>Installed modules translations</source>
+        <target>Installed modules translations</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="6df6a1378a5ddcdef978aadf494cef5d">
+        <source>Email translations</source>
+        <target>Email translations</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="5d1eb86e15320f5677c9502df9c97dd3">
+        <source>Other translations</source>
+        <target>Other translations</target>
+        <note>Line: 60</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="13a596ad5071982366e29e4f3d76e366">
+        <source>Visitors cannot see your catalog.</source>
+        <target>Visitors cannot see your catalog.</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="3850c8049741085bef77450dc5f0dc9a">
+        <source>Visitors can see your catalog but cannot place an order.</source>
+        <target>Visitors can see your catalog but cannot place an order.</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="4609449450efd4dbe3f05ef2e9c5151d">
+        <source>All features are available</source>
+        <target>All features are available</target>
+        <note>Line: 86</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b8464cdd84b5f068ad72bf5c4f32163d">
+        <source>States</source>
+        <target>States</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="892a326e935b414a79a1eb938afd6ba5">
+        <source>Units (e.g. weight, volume, distance)</source>
+        <target>Units (e.g. weight, volume, distance)</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="41661d8cebe0d3d2211676fd8aaf73f7">
+        <source>Change the behavior of the price display for groups</source>
+        <target>Change the behavior of the price display for groups</target>
+        <note>Line: 104</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="57fa5be19cbdbe09aa4f555b2ee710b3">
+        <source>Update a language</source>
+        <target>Update a language</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="369b8db3e9651d0b5d8a13a5f7f9a53a">
+        <source>Add a language</source>
+        <target>Add a language</target>
+        <note>Line: 67</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5aca31cb4d1fbb543b716cbaaf35c65f">
+        <source>Core (no theme selected)</source>
+        <target>Core (no theme selected)</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="aa3b1c5568c71eb8b7a22e5f07c70cd4">
+        <source>Geolocation by IP address</source>
+        <target>Geolocation by IP address</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b104929231738bd0699db6e6678581b8">
+        <source>IP address whitelist</source>
+        <target>IP address whitelist</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="f6572f026526c2b6356149d46db5f0a1">
+        <source>Whitelisted IP addresses</source>
+        <target>Whitelisted IP addresses</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="17812004136cffbd9c55b624f8d21557">
+        <source>The following features are only available if you enable the Geolocation by IP address feature.</source>
+        <target>The following features are only available if you enable the Geolocation by IP address feature.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="8beea67a449f1c8e352838c8a1a77111">
+        <source>Geolocation behavior for restricted countries</source>
+        <target>Geolocation behavior for restricted countries</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="dd39e763b87f78cae49e9d09b1e5e9d2">
+        <source>Geolocation behavior for other countries</source>
+        <target>Geolocation behavior for other countries</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="3d5428a3ea15cf231a5d0651df2452e2">
+        <source>Select the countries from which your store is accessible</source>
+        <target>Select the countries from which your store is accessible</target>
+        <note>Line: 67</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/index.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d1e4ac2093276d0228ca8470e7ecbf98">
+        <source>In order to use Geolocation, please download [1]this file[/1] and extract it (using Winrar or Gzip) into the /app/Resources/geoip/ directory.</source>
+        <target>In order to use Geolocation, please download [1]this file[/1] and extract it (using Winrar or Gzip) into the /app/Resources/geoip/ directory.</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="72388067f972c9a43b1ded59297f5b6e">
+        <source>Language identifier</source>
+        <target>Language identifier</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="a86844187775f3d99ab7bad450a61d78">
+        <source>Country identifier</source>
+        <target>Country identifier</target>
+        <note>Line: 46</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="94d7422ba3c5b0f2a35f50b048e51c6d">
+        <source>Default currency</source>
+        <target>Default currency</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="c96a77fb323a41898c3b6941a58dc741">
+        <source>Default language</source>
+        <target>Default language</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="65a9e6dae82101cecd43f16583f8cd37">
+        <source>Set language from browser</source>
+        <target>Set language from browser</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="aac4bf78b43b8b815119032038bbee97">
+        <source>Default country</source>
+        <target>Default country</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="e93c6cb824cab26f82d9b3446dc8e563">
+        <source>Set default country from browser language</source>
+        <target>Set default country from browser language</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="1c96489b890acf7ccbb4bd0dc306870b">
+        <source>Time zone</source>
+        <target>Time zone</target>
+        <note>Line: 87</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1240d2eed41a0fd4e898e6aab64c6732">
+        <source>Import a localization pack</source>
+        <target>Import a localization pack</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="75f9936f4fef50cf05561217a24f058c">
+        <source>Localization pack you want to import</source>
+        <target>Localization pack you want to import</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="41b72abcfb3ec32e91e9cfa775e49cbd">
+        <source>Content to import</source>
+        <target>Content to import</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="345e1dd7e9d9ec15c68486caac639767">
+        <source>Download pack data</source>
+        <target>Download pack data</target>
+        <note>Line: 59</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="216845c195c351faf05ff91c6411bfea">
+        <source>Local units</source>
+        <target>Local units</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="f489118ea95c746d648d36bb50c226f0">
+        <source>Weight unit</source>
+        <target>Weight unit</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="fff9ff80cc72d571e3d5115b421a27c3">
+        <source>Distance unit</source>
+        <target>Distance unit</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="bac94fdafa0ab5ce874f63b75d6d28da">
+        <source>Volume unit</source>
+        <target>Volume unit</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="cc13d156306185fd42a860da3049567c">
+        <source>Dimension unit</source>
+        <target>Dimension unit</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="763d71969e7ee9bff4e5dc8976501f33">
+        <source>Add / Update a language</source>
+        <target>Add / Update a language</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="d92acc5a17d29f3f8b7ac58f22fe7df8">
+        <source>Please select the language you want to add or update</source>
+        <target>Please select the language you want to add or update</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="524d7e787cc63c50e0d1946ee8ef0bef">
+        <source>Add or update a language</source>
+        <target>Add or update a language</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6700e23ddf33bd4421249c9ef94d6295">
+        <source>Export a language</source>
+        <target>Export a language</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="84a63a234d9b35094275bfb41ad46b47">
+        <source>Select your theme</source>
+        <target>Select your theme</target>
+        <note>Line: 59</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="021257190c6e64120915e008a94a06f8">
+        <source>Type of translation</source>
+        <target>Type of translation</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="4dca8188ef80c1e68c7cfc96fdeb3abe">
+        <source>Select the type of email content</source>
+        <target>Select the type of email content</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="dd317a8b9f3ecfc5317c2cb586274145">
+        <source>Select your module</source>
+        <target>Select your module</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="c96f531c0eda2dece593a2f8df3a58a8">
+        <source>Select your language</source>
+        <target>Select your language</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="16ec8a60494224f7fa891897aba8caf8">
+        <source>1 missing</source>
+        <target>1 missing</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="026966b734feffa2a2a7c807d268e495">
+        <source>%nb_translation% expression</source>
+        <target>%nb_translation% expression</target>
+        <note>Line: 49
+Comment: nb_translations can be 0 or 1</note>
+      </trans-unit>
+      <trans-unit id="e3ee9f9a340e253eb5196ce7d53ae2d8">
+        <source>Search translations</source>
+        <target>Search translations</target>
+        <note>Line: 58</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Twig/TranslationsExtension.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c949bd6d096b356fc06f55ec5205e3b6">
+        <source>%d missing</source>
+        <target>%d missing</target>
+        <note>Line: 354</note>
+      </trans-unit>
+      <trans-unit id="3a8b99657fcabfc65f45cd1be2b34de9">
+        <source>%nb_translations% expressions</source>
+        <target>%nb_translations% expressions</target>
+        <note>Line: 422</note>
+      </trans-unit>
+      <trans-unit id="740b879fdd48f184f798b8018134f630">
+        <source>Show messages</source>
+        <target>Show messages</target>
+        <note>Line: 365</note>
+      </trans-unit>
+      <trans-unit id="67b6092e7137b245b034286819367669">
+        <source>Hide messages</source>
+        <target>Hide messages</target>
+        <note>Line: 366</note>
+      </trans-unit>
+      <trans-unit id="f5123d6dff8361ad9310560e87c220ef">
+        <source>%nb_translations% missing</source>
+        <target>%nb_translations% missing</target>
+        <note>Line: 465</note>
+      </trans-unit>
+      <trans-unit id="f0780b397b7190b7894af3d8d7d91a83">
+        <source>%nb_translations% translations are missing in %domain%</source>
+        <target>%nb_translations% translations are missing in %domain%</target>
+        <note>Line: 474</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminInternationalHelp.xlf
+++ b/app/Resources/translations/default/AdminInternationalHelp.xlf
@@ -1,468 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminLanguagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8ffd2caeab1261d512816def0690329d">
-        <source>Two-letter ISO code (e.g. FR, EN, DE).</source>
-        <target>Two-letter ISO code (e.g. FR, EN, DE).</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:157</note>
-      </trans-unit>
-      <trans-unit id="5b5f150ebfc12cefc4bf889c3fcb7149">
-        <source>IETF language tag (e.g. en-US, pt-BR).</source>
-        <target>IETF language tag (e.g. en-US, pt-BR).</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:165</note>
-      </trans-unit>
-      <trans-unit id="cb832fdb1310ad1cb4b36705e3e043d2">
-        <source>Short date format (e.g., Y-m-d).</source>
-        <target>Short date format (e.g., Y-m-d).</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:174</note>
-      </trans-unit>
-      <trans-unit id="11fb95583b7d678407bb64582a2ca3c6">
-        <source>Full date format (e.g., Y-m-d H:i:s).</source>
-        <target>Full date format (e.g., Y-m-d H:i:s).</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:183</note>
-      </trans-unit>
-      <trans-unit id="342634d26b64e430960c263ab202e02d">
-        <source>Upload the country flag from your computer.</source>
-        <target>Upload the country flag from your computer.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:192</note>
-      </trans-unit>
-      <trans-unit id="e63a2fc0fc5da5af27fbf5c515beb044">
-        <source>Image is displayed when "no picture is found".</source>
-        <target>Image is displayed when "no picture is found".</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:198</note>
-      </trans-unit>
-      <trans-unit id="6f570144d5f5ca1404b40cab00a9fa3f">
-        <source>Enable if this language is read from right to left.</source>
-        <target>Enable if this language is read from right to left.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:219</note>
-      </trans-unit>
-      <trans-unit id="6235bd7718134ee703c36fb7d3c78e69">
-        <source>(Experimental: your theme must be compliant with RTL languages).</source>
-        <target>(Experimental: your theme must be compliant with RTL languages).</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:220</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCurrenciesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4ef5571f164a6a7fcc9f4625d14e260b">
-        <source>ISO code (e.g. USD for Dollars, EUR for Euros, etc.).</source>
-        <target>ISO code (e.g. USD for Dollars, EUR for Euros, etc.).</target>
-        <note>Context:
-File: controllers/admin/AdminCurrenciesController.php:102</note>
-      </trans-unit>
-      <trans-unit id="0ab7db7a10b7efc8270dd215c2a4ada7">
-        <source><![CDATA[Exchange rates are calculated from one unit of your shop's default currency. For example, if the default currency is euros and your chosen currency is dollars, type "1.20" (1€ = $1.20).]]></source>
-        <target><![CDATA[Exchange rates are calculated from one unit of your shop's default currency. For example, if the default currency is euros and your chosen currency is dollars, type "1.20" (1€ = $1.20).]]></target>
-        <note>Context:
-File: controllers/admin/AdminCurrenciesController.php:116</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStatesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b6ff06f41cb66b5b89be6a3670e40d63">
-        <source>Provide the state name to be displayed in addresses and on invoices.</source>
-        <target>Provide the state name to be displayed in addresses and on invoices.</target>
-        <note>Context:
-File: controllers/admin/AdminStatesController.php:149</note>
-      </trans-unit>
-      <trans-unit id="473d5a5e7a18ca5e30b399ae0dfda18e">
-        <source>1 to 4 letter ISO code.</source>
-        <target>1 to 4 letter ISO code.</target>
-        <note>Context:
-File: controllers/admin/AdminStatesController.php:158</note>
-      </trans-unit>
-      <trans-unit id="d44080730b4d80fb65b9018d57c058b3">
-        <source>You can prefix it with the country ISO code if needed.</source>
-        <target>You can prefix it with the country ISO code if needed.</target>
-        <note>Context:
-File: controllers/admin/AdminStatesController.php:158</note>
-      </trans-unit>
-      <trans-unit id="0f6ca10753a64573af4ae286c7421e62">
-        <source>Country where the state is located.</source>
-        <target>Country where the state is located.</target>
-        <note>Context:
-File: controllers/admin/AdminStatesController.php:171</note>
-      </trans-unit>
-      <trans-unit id="68240d02aad03eed41bc52305688a035">
-        <source>Only the countries with the option "contains states" enabled are displayed.</source>
-        <target>Only the countries with the option "contains states" enabled are displayed.</target>
-        <note>Context:
-File: controllers/admin/AdminStatesController.php:171</note>
-      </trans-unit>
-      <trans-unit id="15c5d5dd58a9e70b8b86a7447dd00f70">
-        <source>Geographical region where this state is located.</source>
-        <target>Geographical region where this state is located.</target>
-        <note>Context:
-File: controllers/admin/AdminStatesController.php:184</note>
-      </trans-unit>
-      <trans-unit id="ec92dbe75bbcc2fbf4cad6302df97c19">
-        <source>Used for shipping</source>
-        <target>Used for shipping</target>
-        <note>Context:
-File: controllers/admin/AdminStatesController.php:185</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTaxRulesGroupController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8bd279ebcd912dc792663bc65a1fb499">
-        <source>You can define a range of Zip/postal codes (e.g., 75000-75015) or simply use one Zip/postal code.</source>
-        <target>You can define a range of Zip/postal codes (e.g., 75000-75015) or simply use one Zip/postal code.</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:289</note>
-      </trans-unit>
-      <trans-unit id="ce9c5fc1032ac5aa03a3d248022773df">
-        <source>You must define the behavior if an address matches multiple rules:</source>
-        <target>You must define the behavior if an address matches multiple rules:</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:315</note>
-      </trans-unit>
-      <trans-unit id="439fa6ce423495b01ffd31ea56b33335">
-        <source>- This tax only: Will apply only this tax</source>
-        <target>- This tax only: Will apply only this tax</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:316</note>
-      </trans-unit>
-      <trans-unit id="4019ba4535164cd55c61ac20379a8aa9">
-        <source>- Combine: Combine taxes (e.g.: 10% + 5% = 15%)</source>
-        <target>- Combine: Combine taxes (e.g.: 10% + 5% = 15%)</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:317</note>
-      </trans-unit>
-      <trans-unit id="dabf677c95d59c749ea5d6d6d22012c4">
-        <source><![CDATA[- One after another: Apply taxes one after another (e.g.: 100 + 10% => 110 + 5% = 115.5)]]></source>
-        <target><![CDATA[- One after another: Apply taxes one after another (e.g.: 100 + 10% => 110 + 5% = 115.5)]]></target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:318</note>
-      </trans-unit>
-      <trans-unit id="7475ec0d41372a307c497acb7eeea8c4">
-        <source>No Tax</source>
-        <target>No Tax</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:332</note>
-      </trans-unit>
-      <trans-unit id="7a3ded393734410a3d3514e10b672c92">
-        <source>(Total tax: 9%)</source>
-        <target>(Total tax: 9%)</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:335</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="abb056fd74a8bdf858dbe3e68c5ea97c">
-        <source>Restrict country selections in front office to those covered by active carriers</source>
-        <target>Restrict country selections in front office to those covered by active carriers</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:62</note>
-      </trans-unit>
-      <trans-unit id="b33aadd6763bfea56853a7ecf2176382">
-        <source>Two -- or three -- letter ISO code (e.g. "us" for United States).</source>
-        <target>Two -- or three -- letter ISO code (e.g. "us" for United States).</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:207</note>
-      </trans-unit>
-      <trans-unit id="cd2f7b9409e0f1527766ad35aa8bd3c5">
-        <source>International call prefix, (e.g. 1 for United States).</source>
-        <target>International call prefix, (e.g. 1 for United States).</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:221</note>
-      </trans-unit>
-      <trans-unit id="92de0162cbdfa60f671ba3cad1d392a1">
-        <source>Geographical region.</source>
-        <target>Geographical region.</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:246</note>
-      </trans-unit>
-      <trans-unit id="98ae2fd635525d30d2b0e8b643f9a23c">
-        <source>Indicate the format of the postal code: use L for a letter, N for a number, and C for the country's ISO 3166-1 alpha-2 code. For example, NNNNN for the United States, France, Poland and many other; LNNNNLLL for Argentina, etc. If you do not want PrestaShop to verify the postal code for this country, leave it blank.</source>
-        <target>Indicate the format of the postal code: use L for a letter, N for a number, and C for the country's ISO 3166-1 alpha-2 code. For example, NNNNN for the United States, France, Poland and many other; LNNNNLLL for Argentina, etc. If you do not want PrestaShop to verify the postal code for this country, leave it blank.</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:272</note>
-      </trans-unit>
-      <trans-unit id="a2ddbdfb29a0708bd711601f9277435c">
-        <source>Display this country to your customers (the selected country will always be displayed in the Back Office).</source>
-        <target>Display this country to your customers (the selected country will always be displayed in the Back Office).</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:301</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminZonesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f3211eeee6d9a3f9208dbf61903eaafa">
-        <source>Zone name (e.g. Africa, West Coast, Neighboring Countries).</source>
-        <target>Zone name (e.g. Africa, West Coast, Neighboring Countries).</target>
-        <note>Context:
-File: controllers/admin/AdminZonesController.php:104</note>
-      </trans-unit>
-      <trans-unit id="976bb0e0c56156bd36831e1bf244e7ed">
-        <source>Allow or disallow shipping to this zone.</source>
-        <target>Allow or disallow shipping to this zone.</target>
-        <note>Context:
-File: controllers/admin/AdminZonesController.php:124</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTaxesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9065c9561edb357b57b213c15813cb32">
-        <source>If you disable the ecotax, the ecotax for all your products will be set to 0.</source>
-        <target>If you disable the ecotax, the ecotax for all your products will be set to 0.</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:60</note>
-      </trans-unit>
-      <trans-unit id="fc6d7eca192247f8406fc4fc8ff896ef">
-        <source>Select whether or not to include tax on purchases.</source>
-        <target>Select whether or not to include tax on purchases.</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:69</note>
-      </trans-unit>
-      <trans-unit id="ea9d4f5bdfaaa411eb8c74355aec4553">
-        <source>Select whether or not to display tax on a distinct line in the cart.</source>
-        <target>Select whether or not to display tax on a distinct line in the cart.</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:73</note>
-      </trans-unit>
-      <trans-unit id="e17a0f166831874c90c9a13934c45cf7">
-        <source>Define the ecotax (e.g. French ecotax: 19.6%).</source>
-        <target>Define the ecotax (e.g. French ecotax: 19.6%).</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:106</note>
-      </trans-unit>
-      <trans-unit id="76fcfab4720e7e09c9ef0afbd9fe8ed9">
-        <source>Tax name to display in carts and on invoices (e.g. "VAT").</source>
-        <target>Tax name to display in carts and on invoices (e.g. "VAT").</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:204</note>
-      </trans-unit>
-      <trans-unit id="9441798e99bc6547fc74a158dbf119d6">
-        <source>Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)</source>
-        <target>Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:212</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="15ba451caecdf6917bcd4d150f33fb7c">
-        <source>Search a word or expression, e.g.: "Order confirmation"</source>
-        <target>Search a word or expression, e.g.: "Order confirmation"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/InternationalApi.php:59</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c12f8445861a605b788eb90e2c47f02a">
-        <source>This option allows you, among other things, to restrict access to your shop for certain countries. See below.</source>
-        <target>This option allows you, among other things, to restrict access to your shop for certain countries. See below.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig:37</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="632a9a67e93d72324b63a0d0626cd2a2">
-        <source>You can add IP addresses that will always be allowed to access your shop (e.g. Google bots' IP).</source>
-        <target>You can add IP addresses that will always be allowed to access your shop (e.g. Google bots' IP).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig:39</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9deac468eeaf8b5b0d2c4bee2857841a">
-        <source>You can add or update a language directly from the PrestaShop website here.</source>
-        <target>You can add or update a language directly from the PrestaShop website here.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a577e13cac9ee85d6f298e0a8deffeee">
-        <source>Export data from one language to a file (language pack).</source>
-        <target>Export data from one language to a file (language pack).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig:40</note>
-      </trans-unit>
-      <trans-unit id="234350fd7a2ea83720f91f40eb2985a9">
-        <source>Select which theme you would like to export your translations to.</source>
-        <target>Select which theme you would like to export your translations to.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8e67ab4e5869bb5521650ed40d448438">
-        <source>Here you can modify translations for every line of text inside PrestaShop.</source>
-        <target>Here you can modify translations for every line of text inside PrestaShop.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig:42</note>
-      </trans-unit>
-      <trans-unit id="00fd55ca2b1b20cca50d295393b32440">
-        <source>First, select a type of translation (such as "Back office" or "Installed modules"), and then select the language you want to translate strings in.</source>
-        <target>First, select a type of translation (such as "Back office" or "Installed modules"), and then select the language you want to translate strings in.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d4e007a94451a69f593c3ce0e06e08f2">
-        <source>Copies data from one language to another.</source>
-        <target>Copies data from one language to another.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig:42</note>
-      </trans-unit>
-      <trans-unit id="3cd0f0cce3990de970f803ffc19f68e1">
-        <source>Warning: This will replace all of the existing data inside the destination language.</source>
-        <target>Warning: This will replace all of the existing data inside the destination language.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig:43</note>
-      </trans-unit>
-      <trans-unit id="8a6815aee1e25633b568be3153f4e779">
-        <source>If necessary [1][2] you must first create a new language[/1].</source>
-        <target>If necessary [1][2] you must first create a new language[/1].</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c4b8d8d900acf4712d4511f6c39e6578">
-        <source>The default language used in your shop.</source>
-        <target>The default language used in your shop.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="e932e3b39aa40f0efe327c599cbd406f">
-        <source>Set browser language as default language</source>
-        <target>Set browser language as default language</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="59a0d89a785e4e00f80b5d6154a446d0">
-        <source>The default country used in your shop.</source>
-        <target>The default country used in your shop.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:57</note>
-      </trans-unit>
-      <trans-unit id="2d84287b4a1226bb820aac87116f401a">
-        <source>Set country corresponding to browser language</source>
-        <target>Set country corresponding to browser language</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:71</note>
-      </trans-unit>
-      <trans-unit id="eb99748a0429320ff7a0120625ace088">
-        <source>The default currency used in your shop.</source>
-        <target>The default currency used in your shop.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:78</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5aa30e77b6c3af8d4affb7b5162d60fb">
-        <source>The ISO 639-1 identifier for the language of the country where your web server is located (en, fr, sp, ru, pl, nl, etc.).</source>
-        <target>The ISO 639-1 identifier for the language of the country where your web server is located (en, fr, sp, ru, pl, nl, etc.).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="31de2e2af2f6b180fe4f3969affff0de">
-        <source>The ISO 3166-1 alpha-2 identifier for the country/region where your web server is located, in lowercase (us, gb, fr, sp, ru, pl, nl, etc.).</source>
-        <target>The ISO 3166-1 alpha-2 identifier for the country/region where your web server is located, in lowercase (us, gb, fr, sp, ru, pl, nl, etc.).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig:46</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bb0fa2ec7b2d1fcfc14bf6587cc51a66">
-        <source>If set to yes then the localization pack will be downloaded from prestashop.com. Otherwise the local xml file found in the localization folder of your PrestaShop installation will be used.</source>
-        <target>If set to yes then the localization pack will be downloaded from prestashop.com. Otherwise the local xml file found in the localization folder of your PrestaShop installation will be used.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig:64</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9da30b4a4eab6c20f3ba7ddc89c18d6d">
-        <source>The default weight unit for your shop (e.g. "kg" for kilograms, "lbs" for pound-mass, etc.).</source>
-        <target>The default weight unit for your shop (e.g. "kg" for kilograms, "lbs" for pound-mass, etc.).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="f7f469cfef2bd3d4d0a12cc7875df046">
-        <source>The default distance unit for your shop (e.g. "km" for kilometer, "mi" for mile, etc.).</source>
-        <target>The default distance unit for your shop (e.g. "km" for kilometer, "mi" for mile, etc.).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig:46</note>
-      </trans-unit>
-      <trans-unit id="dd82d34d95398e0fe58f9b2edfc933fa">
-        <source>The default volume unit for your shop (e.g. "L" for liter, "gal" for gallon, etc.).</source>
-        <target>The default volume unit for your shop (e.g. "L" for liter, "gal" for gallon, etc.).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig:54</note>
-      </trans-unit>
-      <trans-unit id="2bec6d5b97c142617d81b6abfd8611a1">
-        <source>The default dimension unit for your shop (e.g. "cm" for centimeter, "in" for inch, etc.).</source>
-        <target>The default dimension unit for your shop (e.g. "cm" for centimeter, "in" for inch, etc.).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig:62</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="ac42ae31827e4ce47e084ecfb68018aa">
         <source>This will restore your last registered address format.</source>
         <target>This will restore your last registered address format.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="a551db18a168f7b7af97f05f654f6ebd">
         <source>This will restore the default address format for this country.</source>
         <target>This will restore the default address format for this country.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="15103dc2a4e70c7865d2b2ed5542f7ee">
         <source>This will restore your current address format.</source>
         <target>This will restore your current address format.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="658983835e342b548674ebb6d169333f">
         <source>This will delete the current address format</source>
         <target>This will delete the current address format</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl:47</note>
+        <note>Line: 47</note>
       </trans-unit>
     </body>
   </file>
@@ -471,86 +29,7 @@ File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.
       <trans-unit id="c8177e39573538431ca4c24841ee3fbe">
         <source>Missing files are marked in red</source>
         <target>Missing files are marked in red</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/languages/helpers/form/form.tpl:86</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="013afdec32d184dc61040022a45409ca">
-        <source>Click on the title of a section to open its fieldsets.</source>
-        <target>Click on the title of a section to open its fieldsets.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl:53</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f75f58622599fa286aa5bdd94fb4404d">
-        <source>Some of these expressions use this special syntax: %s.</source>
-        <target>Some of these expressions use this special syntax: %s.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:68</note>
-      </trans-unit>
-      <trans-unit id="f324bbd9de83d61ccb5f7d5593aec5b3">
-        <source>You MUST use this syntax in your translations. Here are several examples:</source>
-        <target>You MUST use this syntax in your translations. Here are several examples:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:70</note>
-      </trans-unit>
-      <trans-unit id="919a5a4550f8f714f806f5590ed1b66a">
-        <source>There are [1]%replace%[/1] products</source>
-        <target>There are [1]%replace%[/1] products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:73</note>
-      </trans-unit>
-      <trans-unit id="06fb8ada95eab3e2b5d4a3e834a9ab10">
-        <source>"%s" will be replaced by a number.</source>
-        <target>"%s" will be replaced by a number.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:73</note>
-      </trans-unit>
-      <trans-unit id="cfe3ecf9fcc29ce36de15ee87cebd12b">
-        <source>List of pages in [1]%replace%[/1]</source>
-        <target>List of pages in [1]%replace%[/1]</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:74</note>
-      </trans-unit>
-      <trans-unit id="a24386154e350ad7c608af84cdb4be11">
-        <source>"%s" will be replaced by a string.</source>
-        <target>"%s" will be replaced by a string.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:74</note>
-      </trans-unit>
-      <trans-unit id="9b4ca9541e2c3e7215a5fac1f4cecd2f">
-        <source>Feature: [1]%1%[/1] ([1]%2%[/1] values)</source>
-        <target>Feature: [1]%1%[/1] ([1]%2%[/1] values)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:75</note>
-      </trans-unit>
-      <trans-unit id="031775df42ef41141d4b4c7d4db89d65">
-        <source>The numbers enable you to reorder the variables when necessary.</source>
-        <target>The numbers enable you to reorder the variables when necessary.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b3f4e400fe40a25d1c2b0c59e63668cf">
-        <source>Here you can modify translations for all installed module.</source>
-        <target>Here you can modify translations for all installed module.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl:173</note>
-      </trans-unit>
-      <trans-unit id="dd317a8b9f3ecfc5317c2cb586274145">
-        <source>Select your module</source>
-        <target>Select your module</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl:176</note>
+        <note>Line: 86</note>
       </trans-unit>
     </body>
   </file>
@@ -559,14 +38,458 @@ File: admin-dev/themes/default/template/controllers/translations/helpers/view/tr
       <trans-unit id="3881d16572ee3be6a8ab13f6862b3911">
         <source>You MUST use this syntax in your translations. Here are a few examples:</source>
         <target>You MUST use this syntax in your translations. Here are a few examples:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl:69</note>
+        <note>Line: 69</note>
       </trans-unit>
       <trans-unit id="7cefb4829c6de24b63f7a05716b43bec">
         <source>This expression uses a special syntax:</source>
         <target>This expression uses a special syntax:</target>
+        <note>Line: 94</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f75f58622599fa286aa5bdd94fb4404d">
+        <source>Some of these expressions use this special syntax: %s.</source>
+        <target>Some of these expressions use this special syntax: %s.</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="f324bbd9de83d61ccb5f7d5593aec5b3">
+        <source>You MUST use this syntax in your translations. Here are several examples:</source>
+        <target>You MUST use this syntax in your translations. Here are several examples:</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="919a5a4550f8f714f806f5590ed1b66a">
+        <source>There are [1]%replace%[/1] products</source>
+        <target>There are [1]%replace%[/1] products</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="06fb8ada95eab3e2b5d4a3e834a9ab10">
+        <source>"%s" will be replaced by a number.</source>
+        <target>"%s" will be replaced by a number.</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="cfe3ecf9fcc29ce36de15ee87cebd12b">
+        <source>List of pages in [1]%replace%[/1]</source>
+        <target>List of pages in [1]%replace%[/1]</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="a24386154e350ad7c608af84cdb4be11">
+        <source>"%s" will be replaced by a string.</source>
+        <target>"%s" will be replaced by a string.</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="9b4ca9541e2c3e7215a5fac1f4cecd2f">
+        <source>Feature: [1]%1%[/1] ([1]%2%[/1] values)</source>
+        <target>Feature: [1]%1%[/1] ([1]%2%[/1] values)</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="031775df42ef41141d4b4c7d4db89d65">
+        <source>The numbers enable you to reorder the variables when necessary.</source>
+        <target>The numbers enable you to reorder the variables when necessary.</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="013afdec32d184dc61040022a45409ca">
+        <source>Click on the title of a section to open its fieldsets.</source>
+        <target>Click on the title of a section to open its fieldsets.</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="b3f4e400fe40a25d1c2b0c59e63668cf">
+        <source>Here you can modify translations for all installed module.</source>
+        <target>Here you can modify translations for all installed module.</target>
+        <note>Line: 173</note>
+      </trans-unit>
+      <trans-unit id="dd317a8b9f3ecfc5317c2cb586274145">
+        <source>Select your module</source>
+        <target>Select your module</target>
+        <note>Line: 176</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="abb056fd74a8bdf858dbe3e68c5ea97c">
+        <source>Restrict country selections in front office to those covered by active carriers</source>
+        <target>Restrict country selections in front office to those covered by active carriers</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="b33aadd6763bfea56853a7ecf2176382">
+        <source>Two -- or three -- letter ISO code (e.g. "us" for United States).</source>
+        <target>Two -- or three -- letter ISO code (e.g. "us" for United States).</target>
+        <note>Line: 207</note>
+      </trans-unit>
+      <trans-unit id="cd2f7b9409e0f1527766ad35aa8bd3c5">
+        <source>International call prefix, (e.g. 1 for United States).</source>
+        <target>International call prefix, (e.g. 1 for United States).</target>
+        <note>Line: 221</note>
+      </trans-unit>
+      <trans-unit id="92de0162cbdfa60f671ba3cad1d392a1">
+        <source>Geographical region.</source>
+        <target>Geographical region.</target>
+        <note>Line: 246</note>
+      </trans-unit>
+      <trans-unit id="98ae2fd635525d30d2b0e8b643f9a23c">
+        <source>Indicate the format of the postal code: use L for a letter, N for a number, and C for the country's ISO 3166-1 alpha-2 code. For example, NNNNN for the United States, France, Poland and many other; LNNNNLLL for Argentina, etc. If you do not want PrestaShop to verify the postal code for this country, leave it blank.</source>
+        <target>Indicate the format of the postal code: use L for a letter, N for a number, and C for the country's ISO 3166-1 alpha-2 code. For example, NNNNN for the United States, France, Poland and many other; LNNNNLLL for Argentina, etc. If you do not want PrestaShop to verify the postal code for this country, leave it blank.</target>
+        <note>Line: 272</note>
+      </trans-unit>
+      <trans-unit id="a2ddbdfb29a0708bd711601f9277435c">
+        <source>Display this country to your customers (the selected country will always be displayed in the Back Office).</source>
+        <target>Display this country to your customers (the selected country will always be displayed in the Back Office).</target>
+        <note>Line: 301</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCurrenciesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4ef5571f164a6a7fcc9f4625d14e260b">
+        <source>ISO code (e.g. USD for Dollars, EUR for Euros, etc.).</source>
+        <target>ISO code (e.g. USD for Dollars, EUR for Euros, etc.).</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="c7c838899b96b2b17ea954d2578cf541">
+        <source>Exchange rates are calculated from one unit of your shop's default currency. For example, if the default currency is euros and your chosen currency is dollars, type "1.20" (1€ = $1.20).</source>
+        <target>Exchange rates are calculated from one unit of your shop's default currency. For example, if the default currency is euros and your chosen currency is dollars, type "1.20" (1€ = $1.20).</target>
         <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl:94</note>
+File: controllers/admin/AdminCurrenciesController.php:116</note>
+      </trans-unit>
+      <trans-unit id="0ab7db7a10b7efc8270dd215c2a4ada7">
+        <source><![CDATA[Exchange rates are calculated from one unit of your shop's default currency. For example, if the default currency is euros and your chosen currency is dollars, type "1.20" (1€ = $1.20).]]></source>
+        <target><![CDATA[Exchange rates are calculated from one unit of your shop's default currency. For example, if the default currency is euros and your chosen currency is dollars, type "1.20" (1€ = $1.20).]]></target>
+        <note>Line: 116</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminLanguagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8ffd2caeab1261d512816def0690329d">
+        <source>Two-letter ISO code (e.g. FR, EN, DE).</source>
+        <target>Two-letter ISO code (e.g. FR, EN, DE).</target>
+        <note>Line: 157</note>
+      </trans-unit>
+      <trans-unit id="5b5f150ebfc12cefc4bf889c3fcb7149">
+        <source>IETF language tag (e.g. en-US, pt-BR).</source>
+        <target>IETF language tag (e.g. en-US, pt-BR).</target>
+        <note>Line: 165</note>
+      </trans-unit>
+      <trans-unit id="cb832fdb1310ad1cb4b36705e3e043d2">
+        <source>Short date format (e.g., Y-m-d).</source>
+        <target>Short date format (e.g., Y-m-d).</target>
+        <note>Line: 174</note>
+      </trans-unit>
+      <trans-unit id="11fb95583b7d678407bb64582a2ca3c6">
+        <source>Full date format (e.g., Y-m-d H:i:s).</source>
+        <target>Full date format (e.g., Y-m-d H:i:s).</target>
+        <note>Line: 183</note>
+      </trans-unit>
+      <trans-unit id="342634d26b64e430960c263ab202e02d">
+        <source>Upload the country flag from your computer.</source>
+        <target>Upload the country flag from your computer.</target>
+        <note>Line: 192</note>
+      </trans-unit>
+      <trans-unit id="e63a2fc0fc5da5af27fbf5c515beb044">
+        <source>Image is displayed when "no picture is found".</source>
+        <target>Image is displayed when "no picture is found".</target>
+        <note>Line: 198</note>
+      </trans-unit>
+      <trans-unit id="6f570144d5f5ca1404b40cab00a9fa3f">
+        <source>Enable if this language is read from right to left.</source>
+        <target>Enable if this language is read from right to left.</target>
+        <note>Line: 219</note>
+      </trans-unit>
+      <trans-unit id="6235bd7718134ee703c36fb7d3c78e69">
+        <source>(Experimental: your theme must be compliant with RTL languages).</source>
+        <target>(Experimental: your theme must be compliant with RTL languages).</target>
+        <note>Line: 220</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b6ff06f41cb66b5b89be6a3670e40d63">
+        <source>Provide the state name to be displayed in addresses and on invoices.</source>
+        <target>Provide the state name to be displayed in addresses and on invoices.</target>
+        <note>Line: 149</note>
+      </trans-unit>
+      <trans-unit id="473d5a5e7a18ca5e30b399ae0dfda18e">
+        <source>1 to 4 letter ISO code.</source>
+        <target>1 to 4 letter ISO code.</target>
+        <note>Line: 158</note>
+      </trans-unit>
+      <trans-unit id="d44080730b4d80fb65b9018d57c058b3">
+        <source>You can prefix it with the country ISO code if needed.</source>
+        <target>You can prefix it with the country ISO code if needed.</target>
+        <note>Line: 158</note>
+      </trans-unit>
+      <trans-unit id="0f6ca10753a64573af4ae286c7421e62">
+        <source>Country where the state is located.</source>
+        <target>Country where the state is located.</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="68240d02aad03eed41bc52305688a035">
+        <source>Only the countries with the option "contains states" enabled are displayed.</source>
+        <target>Only the countries with the option "contains states" enabled are displayed.</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="15c5d5dd58a9e70b8b86a7447dd00f70">
+        <source>Geographical region where this state is located.</source>
+        <target>Geographical region where this state is located.</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="ec92dbe75bbcc2fbf4cad6302df97c19">
+        <source>Used for shipping</source>
+        <target>Used for shipping</target>
+        <note>Line: 185</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTaxRulesGroupController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8bd279ebcd912dc792663bc65a1fb499">
+        <source>You can define a range of Zip/postal codes (e.g., 75000-75015) or simply use one Zip/postal code.</source>
+        <target>You can define a range of Zip/postal codes (e.g., 75000-75015) or simply use one Zip/postal code.</target>
+        <note>Line: 289</note>
+      </trans-unit>
+      <trans-unit id="ce9c5fc1032ac5aa03a3d248022773df">
+        <source>You must define the behavior if an address matches multiple rules:</source>
+        <target>You must define the behavior if an address matches multiple rules:</target>
+        <note>Line: 315</note>
+      </trans-unit>
+      <trans-unit id="439fa6ce423495b01ffd31ea56b33335">
+        <source>- This tax only: Will apply only this tax</source>
+        <target>- This tax only: Will apply only this tax</target>
+        <note>Line: 316</note>
+      </trans-unit>
+      <trans-unit id="4019ba4535164cd55c61ac20379a8aa9">
+        <source>- Combine: Combine taxes (e.g.: 10% + 5% = 15%)</source>
+        <target>- Combine: Combine taxes (e.g.: 10% + 5% = 15%)</target>
+        <note>Line: 317</note>
+      </trans-unit>
+      <trans-unit id="dabf677c95d59c749ea5d6d6d22012c4">
+        <source><![CDATA[- One after another: Apply taxes one after another (e.g.: 100 + 10% => 110 + 5% = 115.5)]]></source>
+        <target><![CDATA[- One after another: Apply taxes one after another (e.g.: 100 + 10% => 110 + 5% = 115.5)]]></target>
+        <note>Line: 318</note>
+      </trans-unit>
+      <trans-unit id="7475ec0d41372a307c497acb7eeea8c4">
+        <source>No Tax</source>
+        <target>No Tax</target>
+        <note>Line: 332</note>
+      </trans-unit>
+      <trans-unit id="7a3ded393734410a3d3514e10b672c92">
+        <source>(Total tax: 9%)</source>
+        <target>(Total tax: 9%)</target>
+        <note>Line: 335</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTaxesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9065c9561edb357b57b213c15813cb32">
+        <source>If you disable the ecotax, the ecotax for all your products will be set to 0.</source>
+        <target>If you disable the ecotax, the ecotax for all your products will be set to 0.</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="fc6d7eca192247f8406fc4fc8ff896ef">
+        <source>Select whether or not to include tax on purchases.</source>
+        <target>Select whether or not to include tax on purchases.</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="ea9d4f5bdfaaa411eb8c74355aec4553">
+        <source>Select whether or not to display tax on a distinct line in the cart.</source>
+        <target>Select whether or not to display tax on a distinct line in the cart.</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="e17a0f166831874c90c9a13934c45cf7">
+        <source>Define the ecotax (e.g. French ecotax: 19.6%).</source>
+        <target>Define the ecotax (e.g. French ecotax: 19.6%).</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="76fcfab4720e7e09c9ef0afbd9fe8ed9">
+        <source>Tax name to display in carts and on invoices (e.g. "VAT").</source>
+        <target>Tax name to display in carts and on invoices (e.g. "VAT").</target>
+        <note>Line: 204</note>
+      </trans-unit>
+      <trans-unit id="9441798e99bc6547fc74a158dbf119d6">
+        <source>Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)</source>
+        <target>Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)</target>
+        <note>Line: 212</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminZonesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f3211eeee6d9a3f9208dbf61903eaafa">
+        <source>Zone name (e.g. Africa, West Coast, Neighboring Countries).</source>
+        <target>Zone name (e.g. Africa, West Coast, Neighboring Countries).</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="976bb0e0c56156bd36831e1bf244e7ed">
+        <source>Allow or disallow shipping to this zone.</source>
+        <target>Allow or disallow shipping to this zone.</target>
+        <note>Line: 124</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c12f8445861a605b788eb90e2c47f02a">
+        <source>This option allows you, among other things, to restrict access to your shop for certain countries. See below.</source>
+        <target>This option allows you, among other things, to restrict access to your shop for certain countries. See below.</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="632a9a67e93d72324b63a0d0626cd2a2">
+        <source>You can add IP addresses that will always be allowed to access your shop (e.g. Google bots' IP).</source>
+        <target>You can add IP addresses that will always be allowed to access your shop (e.g. Google bots' IP).</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5aa30e77b6c3af8d4affb7b5162d60fb">
+        <source>The ISO 639-1 identifier for the language of the country where your web server is located (en, fr, sp, ru, pl, nl, etc.).</source>
+        <target>The ISO 639-1 identifier for the language of the country where your web server is located (en, fr, sp, ru, pl, nl, etc.).</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="31de2e2af2f6b180fe4f3969affff0de">
+        <source>The ISO 3166-1 alpha-2 identifier for the country/region where your web server is located, in lowercase (us, gb, fr, sp, ru, pl, nl, etc.).</source>
+        <target>The ISO 3166-1 alpha-2 identifier for the country/region where your web server is located, in lowercase (us, gb, fr, sp, ru, pl, nl, etc.).</target>
+        <note>Line: 46</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c4b8d8d900acf4712d4511f6c39e6578">
+        <source>The default language used in your shop.</source>
+        <target>The default language used in your shop.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="e932e3b39aa40f0efe327c599cbd406f">
+        <source>Set browser language as default language</source>
+        <target>Set browser language as default language</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="59a0d89a785e4e00f80b5d6154a446d0">
+        <source>The default country used in your shop.</source>
+        <target>The default country used in your shop.</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="2d84287b4a1226bb820aac87116f401a">
+        <source>Set country corresponding to browser language</source>
+        <target>Set country corresponding to browser language</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="eb99748a0429320ff7a0120625ace088">
+        <source>The default currency used in your shop.</source>
+        <target>The default currency used in your shop.</target>
+        <note>Line: 78</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bb0fa2ec7b2d1fcfc14bf6587cc51a66">
+        <source>If set to yes then the localization pack will be downloaded from prestashop.com. Otherwise the local xml file found in the localization folder of your PrestaShop installation will be used.</source>
+        <target>If set to yes then the localization pack will be downloaded from prestashop.com. Otherwise the local xml file found in the localization folder of your PrestaShop installation will be used.</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9da30b4a4eab6c20f3ba7ddc89c18d6d">
+        <source>The default weight unit for your shop (e.g. "kg" for kilograms, "lbs" for pound-mass, etc.).</source>
+        <target>The default weight unit for your shop (e.g. "kg" for kilograms, "lbs" for pound-mass, etc.).</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="f7f469cfef2bd3d4d0a12cc7875df046">
+        <source>The default distance unit for your shop (e.g. "km" for kilometer, "mi" for mile, etc.).</source>
+        <target>The default distance unit for your shop (e.g. "km" for kilometer, "mi" for mile, etc.).</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="dd82d34d95398e0fe58f9b2edfc933fa">
+        <source>The default volume unit for your shop (e.g. "L" for liter, "gal" for gallon, etc.).</source>
+        <target>The default volume unit for your shop (e.g. "L" for liter, "gal" for gallon, etc.).</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="2bec6d5b97c142617d81b6abfd8611a1">
+        <source>The default dimension unit for your shop (e.g. "cm" for centimeter, "in" for inch, etc.).</source>
+        <target>The default dimension unit for your shop (e.g. "cm" for centimeter, "in" for inch, etc.).</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9deac468eeaf8b5b0d2c4bee2857841a">
+        <source>You can add or update a language directly from the PrestaShop website here.</source>
+        <target>You can add or update a language directly from the PrestaShop website here.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d4e007a94451a69f593c3ce0e06e08f2">
+        <source>Copies data from one language to another.</source>
+        <target>Copies data from one language to another.</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="3cd0f0cce3990de970f803ffc19f68e1">
+        <source>Warning: This will replace all of the existing data inside the destination language.</source>
+        <target>Warning: This will replace all of the existing data inside the destination language.</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="8a6815aee1e25633b568be3153f4e779">
+        <source>If necessary [1][2] you must first create a new language[/1].</source>
+        <target>If necessary [1][2] you must first create a new language[/1].</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a577e13cac9ee85d6f298e0a8deffeee">
+        <source>Export data from one language to a file (language pack).</source>
+        <target>Export data from one language to a file (language pack).</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="234350fd7a2ea83720f91f40eb2985a9">
+        <source>Select which theme you would like to export your translations to.</source>
+        <target>Select which theme you would like to export your translations to.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8e67ab4e5869bb5521650ed40d448438">
+        <source>Here you can modify translations for every line of text inside PrestaShop.</source>
+        <target>Here you can modify translations for every line of text inside PrestaShop.</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="00fd55ca2b1b20cca50d295393b32440">
+        <source>First, select a type of translation (such as "Back office" or "Installed modules"), and then select the language you want to translate strings in.</source>
+        <target>First, select a type of translation (such as "Back office" or "Installed modules"), and then select the language you want to translate strings in.</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="15ba451caecdf6917bcd4d150f33fb7c">
+        <source>Search a word or expression, e.g.: "Order confirmation"</source>
+        <target>Search a word or expression, e.g.: "Order confirmation"</target>
+        <note>Line: 59</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminInternationalNotification.xlf
+++ b/app/Resources/translations/default/AdminInternationalNotification.xlf
@@ -1,884 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminLanguagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4749a02e87a1b69cc421bf97c5353956">
-        <source>When you delete a language, all related translations in the database will be deleted. Are you sure you want to proceed?</source>
-        <target>When you delete a language, all related translations in the database will be deleted. Are you sure you want to proceed?</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:103</note>
-      </trans-unit>
-      <trans-unit id="cc83a240095b0a0b6e1840bb7d43830c">
-        <source>When you delete a language, all related translations in the database will be deleted.</source>
-        <target>When you delete a language, all related translations in the database will be deleted.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:124</note>
-      </trans-unit>
-      <trans-unit id="1214646a8e239537981e729a0f16f3e9">
-        <source>Your .htaccess file must be writable.</source>
-        <target>Your .htaccess file must be writable.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:126</note>
-      </trans-unit>
-      <trans-unit id="8bd94436fa6738863292fb9823368694">
-        <source>You cannot delete the default language.</source>
-        <target>You cannot delete the default language.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:339</note>
-      </trans-unit>
-      <trans-unit id="f25eedbf89efbd0cfce488fe01f9c4cb">
-        <source>You cannot delete the language currently in use. Please select a different language.</source>
-        <target>You cannot delete the language currently in use. Please select a different language.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:341</note>
-      </trans-unit>
-      <trans-unit id="2f236f9450ce8714611e468181064659">
-        <source>You cannot change the status of the default language.</source>
-        <target>You cannot change the status of the default language.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:363</note>
-      </trans-unit>
-      <trans-unit id="59382adebc7f0d65c42fe773d443e4c7">
-        <source>This ISO code is already linked to another language.</source>
-        <target>This ISO code is already linked to another language.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:408</note>
-      </trans-unit>
-      <trans-unit id="5c61f1e9d7d492c795142ceb39900050">
-        <source>Flag and "No picture" image fields are required.</source>
-        <target>Flag and "No picture" image fields are required.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:416</note>
-      </trans-unit>
-      <trans-unit id="8037670f9e6df1f09e040ff8ab047fac">
-        <source>An error occurred while copying "No Picture" image to your product folder.</source>
-        <target>An error occurred while copying "No Picture" image to your product folder.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:469</note>
-      </trans-unit>
-      <trans-unit id="0773497a933e6c2b618678b02cbdf7a1">
-        <source>An error occurred while copying "No picture" image to your category folder.</source>
-        <target>An error occurred while copying "No picture" image to your category folder.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:472</note>
-      </trans-unit>
-      <trans-unit id="6509c8bfa3f06725a6016e6a429dbcd9">
-        <source>An error occurred while copying "No picture" image to your brand folder.</source>
-        <target>An error occurred while copying "No picture" image to your brand folder.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:475</note>
-      </trans-unit>
-      <trans-unit id="1b3a472a4556d51d2169e947280e0400">
-        <source>An error occurred while resizing "No picture" image to your product directory.</source>
-        <target>An error occurred while resizing "No picture" image to your product directory.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:480</note>
-      </trans-unit>
-      <trans-unit id="2b9a5da945495f5101d57abbf2a7083c">
-        <source>An error occurred while resizing "No picture" image to your category directory.</source>
-        <target>An error occurred while resizing "No picture" image to your category directory.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:483</note>
-      </trans-unit>
-      <trans-unit id="fea874a66e2e09d727c76264844ff688">
-        <source>An error occurred while resizing "No picture" image to your brand directory.</source>
-        <target>An error occurred while resizing "No picture" image to your brand directory.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:486</note>
-      </trans-unit>
-      <trans-unit id="5f17acb89d2ab83c9138774bfd05ab16">
-        <source>An error occurred during image deletion process.</source>
-        <target>An error occurred during image deletion process.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:518</note>
-      </trans-unit>
-      <trans-unit id="7aa19852b281887173d096f6700cdebf">
-        <source>Iso code is not valid</source>
-        <target>Iso code is not valid</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:545</note>
-      </trans-unit>
-      <trans-unit id="da7e8b45fda5783ed027b88cc33fdfc1">
-        <source>Technical Error: ps_version is not valid</source>
-        <target>Technical Error: ps_version is not valid</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:551</note>
-      </trans-unit>
-      <trans-unit id="29298b5d89d0bbdfa92fb1d6e27188bd">
-        <source>Wrong ISO code, or the selected language pack is unavailable.</source>
-        <target>Wrong ISO code, or the selected language pack is unavailable.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:564</note>
-      </trans-unit>
-      <trans-unit id="dc2dde59d57d3bfd6881be1392c54280">
-        <source>Technical Error: translation server unreachable.</source>
-        <target>Technical Error: translation server unreachable.</target>
-        <note>Context:
-File: controllers/admin/AdminLanguagesController.php:568</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCurrenciesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8246d0c794e7db090587c4797b2a234f">
-        <source>You cannot delete the default currency</source>
-        <target>You cannot delete the default currency</target>
-        <note>Context:
-File: controllers/admin/AdminCurrenciesController.php:176</note>
-      </trans-unit>
-      <trans-unit id="7c77e53206853cb381e91e037554faa3">
-        <source>You cannot disable the default currency</source>
-        <target>You cannot disable the default currency</target>
-        <note>Context:
-File: controllers/admin/AdminCurrenciesController.php:192</note>
-      </trans-unit>
-      <trans-unit id="9289665482a13fc74be054caef49b63e">
-        <source>This currency already exists.</source>
-        <target>This currency already exists.</target>
-        <note>Context:
-File: controllers/admin/AdminCurrenciesController.php:281</note>
-      </trans-unit>
-      <trans-unit id="1a93d2c04e8276471b3c198d1ad95098">
-        <source>The currency conversion rate cannot be equal to 0.</source>
-        <target>The currency conversion rate cannot be equal to 0.</target>
-        <note>Context:
-File: controllers/admin/AdminCurrenciesController.php:284</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStatesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="aa28d701be690425c5518b723668f6f7">
-        <source>This ISO code already exists. You cannot create two states with the same ISO code.</source>
-        <target>This ISO code already exists. You cannot create two states with the same ISO code.</target>
-        <note>Context:
-File: controllers/admin/AdminStatesController.php:229</note>
-      </trans-unit>
-      <trans-unit id="dae008137b79aa8e5c0f2aed6d1db503">
-        <source>This state was used in at least one address. It cannot be removed.</source>
-        <target>This state was used in at least one address. It cannot be removed.</target>
-        <note>Context:
-File: controllers/admin/AdminStatesController.php:244</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTaxRulesGroupController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="45f3b37902e09b041709484fd75cab22">
-        <source>A tax rule already exists for this country/state with tax only behavior.</source>
-        <target>A tax rule already exists for this country/state with tax only behavior.</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:437</note>
-      </trans-unit>
-      <trans-unit id="97d8fb4588d1efe9731fd4f82e071924">
-        <source>The Zip/postal code is invalid. It must be typed as follows: %format% for %country%.</source>
-        <target>The Zip/postal code is invalid. It must be typed as follows: %format% for %country%.</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:464</note>
-      </trans-unit>
-      <trans-unit id="2ff5095fd8289ccdaeca9c5e7d379fd2">
-        <source>An error has occurred: Cannot save the current tax rule.</source>
-        <target>An error has occurred: Cannot save the current tax rule.</target>
-        <note>Context:
-File: controllers/admin/AdminTaxRulesGroupController.php:490</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Language/LanguageCopier.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4d7541fb66c9fc832a20a6f48b4d5613">
-        <source>Cannot create the folder "%folder%". Please check your directory writing permissions.</source>
-        <target>Cannot create the folder "%folder%". Please check your directory writing permissions.</target>
-        <note>Context:
-File: src/Adapter/Language/LanguageCopier.php:102</note>
-      </trans-unit>
-      <trans-unit id="102c75f83994f206179912d118b8bc3c">
-        <source>You must select two languages in order to copy data from one to another.</source>
-        <target>You must select two languages in order to copy data from one to another.</target>
-        <note>Context:
-File: src/Adapter/Language/LanguageCopier.php:173</note>
-      </trans-unit>
-      <trans-unit id="fc15f62c244c6d8035874d556e6a7f7b">
-        <source>You must select two themes in order to copy data from one to another.</source>
-        <target>You must select two themes in order to copy data from one to another.</target>
-        <note>Context:
-File: src/Adapter/Language/LanguageCopier.php:179</note>
-      </trans-unit>
-      <trans-unit id="0a7402299bf78a7624da443a12cd78ab">
-        <source>There is nothing to copy (same language and theme).</source>
-        <target>There is nothing to copy (same language and theme).</target>
-        <note>Context:
-File: src/Adapter/Language/LanguageCopier.php:188</note>
-      </trans-unit>
-      <trans-unit id="6b5324e2e711f17c4d3db1f625178e86">
-        <source>Theme(s) not found</source>
-        <target>Theme(s) not found</target>
-        <note>Context:
-File: src/Adapter/Language/LanguageCopier.php:211</note>
-      </trans-unit>
-      <trans-unit id="434464e4353199dd20af7bd3cf8e6c64">
-        <source>Impossible to copy "%source%" to "%dest%".</source>
-        <target>Impossible to copy "%source%" to "%dest%".</target>
-        <note>Context:
-File: src/Adapter/Language/LanguageCopier.php:115</note>
-      </trans-unit>
-      <trans-unit id="07b33077111c506cf81b6cc5ef42a170">
-        <source>Impossible to translate "%dest%".</source>
-        <target>Impossible to translate "%dest%".</target>
-        <note>Context:
-File: src/Adapter/Language/LanguageCopier.php:134</note>
-      </trans-unit>
-      <trans-unit id="c7254dc1193c25493aa0a09df285b43c">
-        <source>A part of the data has been copied but some of the language files could not be found.</source>
-        <target>A part of the data has been copied but some of the language files could not be found.</target>
-        <note>Context:
-File: src/Adapter/Language/LanguageCopier.php:146</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTranslationsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c4e5aa158727e2041778d545424797da">
-        <source>An error occurred while copying data.</source>
-        <target>An error occurred while copying data.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:402</note>
-      </trans-unit>
-      <trans-unit id="b5f3291b6db7481e8ca0da4a00718cf9">
-        <source>Impossible to create the directory "%folder%".</source>
-        <target>Impossible to create the directory "%folder%".</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:427</note>
-      </trans-unit>
-      <trans-unit id="ec531fd2b656df91f11e8f94b2bd2f9b">
-        <source>An error occurred while creating archive.</source>
-        <target>An error occurred while creating archive.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:546</note>
-      </trans-unit>
-      <trans-unit id="b10dfa68dec5e313508a4a55eedae7d1">
-        <source>Please select a language and a theme.</source>
-        <target>Please select a language and a theme.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:548</note>
-      </trans-unit>
-      <trans-unit id="02ae08296d544eb7c674182122645631">
-        <source>Tab "%s" is not valid</source>
-        <target>Tab "%s" is not valid</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:708</note>
-      </trans-unit>
-      <trans-unit id="737b7d8e0108e60b272f6e5a0eaf6ef2">
-        <source>Validation failed for: %file%</source>
-        <target>Validation failed for: %file%</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:788</note>
-      </trans-unit>
-      <trans-unit id="e7e5ca2e62158b89d7583ac6936830a5">
-        <source>Unidentified file found: %file%</source>
-        <target>Unidentified file found: %file%</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:791</note>
-      </trans-unit>
-      <trans-unit id="9831c9e35b4d39d939363aa5629e00f2">
-        <source>The archive cannot be extracted.</source>
-        <target>The archive cannot be extracted.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:854</note>
-      </trans-unit>
-      <trans-unit id="6f2981f3239ff532c94509a6f98e11c3">
-        <source>ISO CODE invalid "%iso_code%" for the following file: "%file%"</source>
-        <target>ISO CODE invalid "%iso_code%" for the following file: "%file%"</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:856</note>
-      </trans-unit>
-      <trans-unit id="299dd7d59920216689a1749def7fd939">
-        <source>Cannot write to the theme's language file (%s). Please check writing permissions.</source>
-        <target>Cannot write to the theme's language file (%s). Please check writing permissions.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:970</note>
-      </trans-unit>
-      <trans-unit id="78973deca6d26ce225f6f66c6c30dd54">
-        <source>Invalid theme "%theme%"</source>
-        <target>Invalid theme "%theme%"</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1811</note>
-      </trans-unit>
-      <trans-unit id="7d65d1400b9d08c5c638682170ff4d7c">
-        <source>Invalid iso code "%iso_code%"</source>
-        <target>Invalid iso code "%iso_code%"</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1416</note>
-      </trans-unit>
-      <trans-unit id="b399fb01ee4e0a8ec1681fb9bcb31ce0">
-        <source>This %type_content% file extension is not accepted.</source>
-        <target>This %type_content% file extension is not accepted.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1649</note>
-      </trans-unit>
-      <trans-unit id="1e5ec3cd42b5bac1b06b99f67cba41dd">
-        <source>Invalid module name "%module%"</source>
-        <target>Invalid module name "%module%"</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1658</note>
-      </trans-unit>
-      <trans-unit id="c68e9fe9015c5779289f32e2bdef0a7b">
-        <source>Invalid mail name "%mail%"</source>
-        <target>Invalid mail name "%mail%"</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1662</note>
-      </trans-unit>
-      <trans-unit id="40f5c232e433d178a4f912b3092d7df1">
-        <source>Directory "%folder%" cannot be created</source>
-        <target>Directory "%folder%" cannot be created</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1684</note>
-      </trans-unit>
-      <trans-unit id="ccdf1aa6f4cb029f9846e53006115905">
-        <source>Your email translations contain some invalid HTML and cannot be saved. Please check your content.</source>
-        <target>Your email translations contain some invalid HTML and cannot be saved. Please check your content.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1690</note>
-      </trans-unit>
-      <trans-unit id="f1c030f2fd8f1b382a4bffd04af59c2d">
-        <source>Your HTML email templates cannot contain JavaScript code.</source>
-        <target>Your HTML email templates cannot contain JavaScript code.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1696</note>
-      </trans-unit>
-      <trans-unit id="5dc4babbd10d00e89d8e46a12942d394">
-        <source>Empty string found, please edit: "%file%"</source>
-        <target>Empty string found, please edit: "%file%"</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1845</note>
-      </trans-unit>
-      <trans-unit id="f2aca97fb94315864fd2fa52f3100f1e">
-        <source>There is an error in template, an empty string has been found. Please edit: "%file%"</source>
-        <target>There is an error in template, an empty string has been found. Please edit: "%file%"</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2115</note>
-      </trans-unit>
-      <trans-unit id="616d8e7e6c0dc755a7e932c4db698317">
-        <source>The module directory must be writable.</source>
-        <target>The module directory must be writable.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2178</note>
-      </trans-unit>
-      <trans-unit id="1078d7e980a5a2fe78762cafd8480f0a">
-        <source>A mail directory exists for the "%iso_code%" language, but not for the default language (%language%) in %folder%</source>
-        <target>A mail directory exists for the "%iso_code%" language, but not for the default language (%language%) in %folder%</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2439</note>
-      </trans-unit>
-      <trans-unit id="7cf50c9ffecf05f3befc1134eba0ef45">
-        <source>missing translation(s)</source>
-        <target>missing translation(s)</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2500</note>
-      </trans-unit>
-      <trans-unit id="fda679a1f72b8a9676b6926a81c5e139">
-        <source>No Subject was found for %mail_name% in the database.</source>
-        <target>No Subject was found for %mail_name% in the database.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2539</note>
-      </trans-unit>
-      <trans-unit id="a662aa2e6538df75742383c7db8f3bd5">
-        <source>There was a problem getting the mail files.</source>
-        <target>There was a problem getting the mail files.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2576</note>
-      </trans-unit>
-      <trans-unit id="3eefb74a46023e6c9152c92803750f2b">
-        <source>English language files must exist in %folder% folder</source>
-        <target>English language files must exist in %folder% folder</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2577</note>
-      </trans-unit>
-      <trans-unit id="c4c005678d26a593268006bc4a44c179">
-        <source>Cannot write language file for email subjects. Path is: %folder%</source>
-        <target>Cannot write language file for email subjects. Path is: %folder%</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2974</note>
-      </trans-unit>
-      <trans-unit id="05b17ff64944116b14a3ec88f2080a5e">
-        <source>Cannot write into the "%file%"</source>
-        <target>Cannot write into the "%file%"</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:3176</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7cefb4829c6de24b63f7a05716b43bec">
-        <source>This expression uses a special syntax:</source>
-        <target>This expression uses a special syntax:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl:133</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e07a23e507642ef04f449a7a78f59d38">
-        <source>This ISO code already exists.You cannot create two countries with the same ISO code.</source>
-        <target>This ISO code already exists.You cannot create two countries with the same ISO code.</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:410</note>
-      </trans-unit>
-      <trans-unit id="28064049c0d480c2fdeafd456977da8d">
-        <source>Invalid address layout %s</source>
-        <target>Invalid address layout %s</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:445</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTaxesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3311c10f0830ae7b6ad64674777c3f34">
-        <source>This tax is currently in use as a tax rule. Are you sure you'd like to continue?</source>
-        <target>This tax is currently in use as a tax rule. Are you sure you'd like to continue?</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:152</note>
-      </trans-unit>
-      <trans-unit id="8eeccbbbc36b19ed4e82d2eca4055d4d">
-        <source>This tax is currently in use as a tax rule. If you continue, this tax will be removed from the tax rule. Are you sure you'd like to continue?</source>
-        <target>This tax is currently in use as a tax rule. If you continue, this tax will be removed from the tax rule. Are you sure you'd like to continue?</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:177</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Localization/Pack/Import/LocalizationPackImporter.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="34f9488516199cf18114f12369c71a59">
-        <source>Cannot load the localization pack.</source>
-        <target>Cannot load the localization pack.</target>
-        <note>Context:
-File: src/Core/Localization/Pack/Import/LocalizationPackImporter.php:109</note>
-      </trans-unit>
-      <trans-unit id="ecb8838ce98cd126849fc083f0070bcd">
-        <source>Please select at least one item to import.</source>
-        <target>Please select at least one item to import.</target>
-        <note>Context:
-File: src/Core/Localization/Pack/Import/LocalizationPackImporter.php:143</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Language.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="52326ecbfcdff77b4bc9dcf7f055c2eb">
-        <source>Fatal error: ISO code is not correct</source>
-        <target>Fatal error: ISO code is not correct</target>
-        <note>Context:
-File: classes/Language.php:794</note>
-      </trans-unit>
-      <trans-unit id="87c6e26b4d5c8e6c145691758c25b769">
-        <source>Fatal error: IETF code %s is not correct</source>
-        <target>Fatal error: IETF code %s is not correct</target>
-        <note>Context:
-File: classes/Language.php:803</note>
-      </trans-unit>
-      <trans-unit id="bec88b0b441e9deb3008eb5b2a57ec70">
-        <source>Sorry this language is not available</source>
-        <target>Sorry this language is not available</target>
-        <note>Context:
-File: classes/Language.php:1065</note>
-      </trans-unit>
-      <trans-unit id="edeb9e20655b946e4bee4ac44a6c0a7f">
-        <source>Server does not have permissions for writing.</source>
-        <target>Server does not have permissions for writing.</target>
-        <note>Context:
-File: classes/Language.php:1092
- Comment: @todo Throw exception</note>
-      </trans-unit>
-      <trans-unit id="19429992fd747ce8d7606c7ddb7fa272">
-        <source>Language pack unavailable.</source>
-        <target>Language pack unavailable.</target>
-        <note>Context:
-File: classes/Language.php:1122
- Comment: @todo Throw exception</note>
-      </trans-unit>
-      <trans-unit id="2e3dec4700000b6db379437f7d8d9fac">
-        <source>An error occurred while creating the language: %s</source>
-        <target>An error occurred while creating the language: %s</target>
-        <note>Context:
-File: classes/Language.php:1168</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Twig/TranslationsExtension.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="41ca3d8439f6e8beab7af312714e37f0">
-        <source>Translation successfully updated</source>
-        <target>Translation successfully updated</target>
-        <note>Context:
-File: src/PrestaShopBundle/Twig/TranslationsExtension.php:220</note>
-      </trans-unit>
-      <trans-unit id="b3991113a051bbeb759a923bc636ad8d">
-        <source>Failed to update translation</source>
-        <target>Failed to update translation</target>
-        <note>Context:
-File: src/PrestaShopBundle/Twig/TranslationsExtension.php:225</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7e093dcb7a9f75c8124b2adc265c5302">
-        <source>The geolocation database is unavailable.</source>
-        <target>The geolocation database is unavailable.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationFormDataProvider.php:105</note>
-      </trans-unit>
-      <trans-unit id="493ce56d58c4880dc32df56f12585a23">
-        <source>Country selection is invalid.</source>
-        <target>Country selection is invalid.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationFormDataProvider.php:113</note>
-      </trans-unit>
-      <trans-unit id="0861a67f819158c5690a1844d95390b4">
-        <source>Invalid whitelist</source>
-        <target>Invalid whitelist</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationFormDataProvider.php:121</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f22def68c5c456936078623b6dcd27ff">
-        <source>The translations have been successfully added.</source>
-        <target>The translations have been successfully added.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:468</note>
-      </trans-unit>
-      <trans-unit id="6cfb80c26b415f8f6467cf07b0c700dd">
-        <source>The translation was successfully copied.</source>
-        <target>The translation was successfully copied.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:467</note>
-      </trans-unit>
-      <trans-unit id="c9468b4bd45a165049277af6756db10e">
-        <source>Localization pack imported successfully.</source>
-        <target>Localization pack imported successfully.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:477</note>
-      </trans-unit>
-      <trans-unit id="bb01c8c21884e974df8517110c92b22a">
-        <source>The translation was added successfully, but the language has not been created.</source>
-        <target>The translation was added successfully, but the language has not been created.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:473</note>
-      </trans-unit>
-      <trans-unit id="ae99f365ee39176c3ab50b76a95cf629">
-        <source>Cannot add configuration %1$s for %2$s language</source>
-        <target>Cannot add configuration %1$s for %2$s language</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1495</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Improve/International/LocalizationController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="53802fa30d7e83f77eccfa376c33e6fa">
-        <source>Importing a new language may fail without the OpenSSL module. Please enable "openssl.so" on your server configuration.</source>
-        <target>Importing a new language may fail without the OpenSSL module. Please enable "openssl.so" on your server configuration.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/International/LocalizationController.php:60</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/LocalizationPack.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dd7edad69f95c053248e9b53eab73826">
-        <source>Cannot load country: %d</source>
-        <target>Cannot load country: %d</target>
-        <note>Context:
-File: classes/LocalizationPack.php:67</note>
-      </trans-unit>
-      <trans-unit id="5408a3468e366610d70dc31825b3ef3d">
-        <source>Cannot enable the associated country: %s</source>
-        <target>Cannot enable the associated country: %s</target>
-        <note>Context:
-File: classes/LocalizationPack.php:78</note>
-      </trans-unit>
-      <trans-unit id="db3f419ede0b78fcf31491509e68db40">
-        <source>Invalid Zone name.</source>
-        <target>Invalid Zone name.</target>
-        <note>Context:
-File: classes/LocalizationPack.php:168</note>
-      </trans-unit>
-      <trans-unit id="be9fddade234ff9b16a1d92d62963b8e">
-        <source>Invalid state properties.</source>
-        <target>Invalid state properties.</target>
-        <note>Context:
-File: classes/LocalizationPack.php:179</note>
-      </trans-unit>
-      <trans-unit id="b19f9ad94a42c56d4a2d89aaca63bafb">
-        <source>Cannot update the associated country: %s</source>
-        <target>Cannot update the associated country: %s</target>
-        <note>Context:
-File: classes/LocalizationPack.php:188</note>
-      </trans-unit>
-      <trans-unit id="e970d66f1c952edf7a4e5dfcf3e18958">
-        <source>An error occurred while adding the state.</source>
-        <target>An error occurred while adding the state.</target>
-        <note>Context:
-File: classes/LocalizationPack.php:193</note>
-      </trans-unit>
-      <trans-unit id="28c39342f22a394f233ec0cba0ecfa02">
-        <source>An error occurred while fetching the state.</source>
-        <target>An error occurred while fetching the state.</target>
-        <note>Context:
-File: classes/LocalizationPack.php:200</note>
-      </trans-unit>
-      <trans-unit id="37c73343e4118943bc088bb4ad94a56c">
-        <source>Invalid tax properties.</source>
-        <target>Invalid tax properties.</target>
-        <note>Context:
-File: classes/LocalizationPack.php:235</note>
-      </trans-unit>
-      <trans-unit id="da2b28e84d7f376b073d2c31b0cb937b">
-        <source>An error occurred while importing the tax: %s</source>
-        <target>An error occurred while importing the tax: %s</target>
-        <note>Context:
-File: classes/LocalizationPack.php:241</note>
-      </trans-unit>
-      <trans-unit id="36f9983aadfde9d77db0d357abe6e85e">
-        <source>This tax rule cannot be saved.</source>
-        <target>This tax rule cannot be saved.</target>
-        <note>Context:
-File: classes/LocalizationPack.php:265</note>
-      </trans-unit>
-      <trans-unit id="19f29a24f0ccb9b96b37182473b27d63">
-        <source>Invalid currency properties.</source>
-        <target>Invalid currency properties.</target>
-        <note>Context:
-File: classes/LocalizationPack.php:349</note>
-      </trans-unit>
-      <trans-unit id="0e7c10cc4eabebc9bd8f1b9cb8b81bb6">
-        <source>An error occurred while importing the currency: %s</source>
-        <target>An error occurred while importing the currency: %s</target>
-        <note>Context:
-File: classes/LocalizationPack.php:355</note>
-      </trans-unit>
-      <trans-unit id="4a11be1a3905ec59ca2d35a068de6f2e">
-        <source>Localization pack corrupted: wrong unit type.</source>
-        <target>Localization pack corrupted: wrong unit type.</target>
-        <note>Context:
-File: classes/LocalizationPack.php:423</note>
-      </trans-unit>
-      <trans-unit id="28194875b1f41da98a320b0c31e658a2">
-        <source>An error occurred while setting the units.</source>
-        <target>An error occurred while setting the units.</target>
-        <note>Context:
-File: classes/LocalizationPack.php:428</note>
-      </trans-unit>
-      <trans-unit id="0964494eb4e763fd08c6004a31b4b8a7">
-        <source>An error occurred while installing the module: %s</source>
-        <target>An error occurred while installing the module: %s</target>
-        <note>Context:
-File: classes/LocalizationPack.php:462</note>
-      </trans-unit>
-      <trans-unit id="e9b1cabd191f8141419c43cc46802e35">
-        <source>An error occurred while uninstalling the module: %s</source>
-        <target>An error occurred while uninstalling the module: %s</target>
-        <note>Context:
-File: classes/LocalizationPack.php:467</note>
-      </trans-unit>
-      <trans-unit id="962f6e835582ebb404a37893f46c60f3">
-        <source>An error has occurred, this module does not exist: %s</source>
-        <target>An error has occurred, this module does not exist: %s</target>
-        <note>Context:
-File: classes/LocalizationPack.php:473</note>
-      </trans-unit>
-      <trans-unit id="e7ae5e7fbebb7b087110d07b06bd2418">
-        <source>An error occurred during the configuration setup: %1$s</source>
-        <target>An error occurred during the configuration setup: %1$s</target>
-        <note>Context:
-File: classes/LocalizationPack.php:501</note>
-      </trans-unit>
-      <trans-unit id="b34f6454b80599ab92262b1da79a9edb">
-        <source>An error occurred during the default group update</source>
-        <target>An error occurred during the default group update</target>
-        <note>Context:
-File: classes/LocalizationPack.php:539</note>
-      </trans-unit>
-      <trans-unit id="09a0fad4c9a9702b2db457f6bff88f3d">
-        <source>An error has occurred during the default group update</source>
-        <target>An error has occurred during the default group update</target>
-        <note>Context:
-File: classes/LocalizationPack.php:543</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Translate.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="753200ddd6c25c2b4875afc70bb6d4fc">
-        <source>Invalid language ISO code (%s)</source>
-        <target>Invalid language ISO code (%s)</target>
-        <note>Context:
-File: classes/Translate.php:301</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/tax/TaxManagerModule.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="253356cdb3cd6af1a6028200326de711">
-        <source>Incorrect Tax Manager class [%s]</source>
-        <target>Incorrect Tax Manager class [%s]</target>
-        <note>Context:
-File: classes/tax/TaxManagerModule.php:40</note>
-      </trans-unit>
-      <trans-unit id="20eb7f9857d85d1d0c8a1e0ddf8545b8">
-        <source>Tax Manager class not found [%s]</source>
-        <target>Tax Manager class not found [%s]</target>
-        <note>Context:
-File: classes/tax/TaxManagerModule.php:46</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/tax/TaxRulesGroup.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6f3455d187a23443796efdcbe044096b">
-        <source>No tax</source>
-        <target>No tax</target>
-        <note>Context:
-File: classes/tax/TaxRulesGroup.php:148</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3c529160fd0337c151d35e7a3809d427">
-        <source>Language files must be complete to allow copying of translations.</source>
-        <target>Language files must be complete to allow copying of translations.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig:52</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7da16b055b9db528a9b4aa9c4ad674ca">
-        <source>Before changing the default currency, we strongly recommend that you enable maintenance mode. Indeed, any change on the default currency requires a manual adjustment of the price of each product and its combinations.</source>
-        <target>Before changing the default currency, we strongly recommend that you enable maintenance mode. Indeed, any change on the default currency requires a manual adjustment of the price of each product and its combinations.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig:76</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="708526e44bef1d8fcd0d67ddf61044d5">
         <source>Are you sure you want to restore the default address format for this country?</source>
         <target>Are you sure you want to restore the default address format for this country?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl:109</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/languages/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f1dd3f4aa197c3cb588dce3911e990b2">
-        <source>A language pack is available for this ISO.</source>
-        <target>A language pack is available for this ISO.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/languages/helpers/form/form.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="3ad7d3a0bcf9313e6efc3ef183b779d0">
-        <source>The Prestashop version compatible with this language and your system is:</source>
-        <target>The Prestashop version compatible with this language and your system is:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/languages/helpers/form/form.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="6b1fb1c361571071fe0f6e2055c39dcb">
-        <source>After creating the language, you can import the content of the language pack, which you can download under "International -- Translations."</source>
-        <target>After creating the language, you can import the content of the language pack, which you can download under "International -- Translations."</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/languages/helpers/form/form.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="a6669356dbb699457f5750c1b6e0ab0d">
-        <source>No language pack is available on prestashop.com for this ISO code</source>
-        <target>No language pack is available on prestashop.com for this ISO code</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/languages/helpers/form/form.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="2c148c0631e11553ded2c0cb527be862">
-        <source>This language pack is NOT complete and cannot be used in the front or back office because some files are missing.</source>
-        <target>This language pack is NOT complete and cannot be used in the front or back office because some files are missing.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/languages/helpers/form/form.tpl:64</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="06a92b5dc72bff3b98bf4b932ce72864">
-        <source>Apache mod_security is activated on your server. This could result in some Bad Request errors</source>
-        <target>Apache mod_security is activated on your server. This could result in some Bad Request errors</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:33</note>
-      </trans-unit>
-      <trans-unit id="1f0f8b59397f34d499b181297714713a">
-        <source>Warning! Your hosting provider is using the Suhosin patch for PHP, which limits the maximum number of fields allowed in a form:</source>
-        <target>Warning! Your hosting provider is using the Suhosin patch for PHP, which limits the maximum number of fields allowed in a form:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="bbfb7a636f839052067cc86c39fa595a">
-        <source>%limit% for suhosin.post.max_vars.</source>
-        <target>%limit% for suhosin.post.max_vars.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="e97da54b23c78752578cd7fa01e8866d">
-        <source>%limit% for suhosin.request.max_vars.</source>
-        <target>%limit% for suhosin.request.max_vars.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="308c1cf98be9973142833c9a9dbbc2ef">
-        <source>Please ask your hosting provider to increase the Suhosin limit to</source>
-        <target>Please ask your hosting provider to increase the Suhosin limit to</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:43</note>
-      </trans-unit>
-      <trans-unit id="5ad040870ae5ccaeb2d57e4d052163a4">
-        <source>Warning! Your PHP configuration limits the maximum number of fields allowed in a form:</source>
-        <target>Warning! Your PHP configuration limits the maximum number of fields allowed in a form:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="5607dc45ebdfc0baaab64d944aa88f47">
-        <source>for max_input_vars.</source>
-        <target>for max_input_vars.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="6e709babf4b5a0ed4194ad5240e1be2c">
-        <source>Please ask your hosting provider to increase this limit to</source>
-        <target>Please ask your hosting provider to increase this limit to</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:47</note>
-      </trans-unit>
-      <trans-unit id="4fb6a3beb82f8d8aa4bbdf8f5a0c35fa">
-        <source>%s at least, or you will have to edit the translation files.</source>
-        <target>%s at least, or you will have to edit the translation files.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl:49</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5d27fef01a54790de11db21f1ed47892">
-        <source>%s at least, or you will have to edit the translation files manually.</source>
-        <target>%s at least, or you will have to edit the translation files manually.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl:47</note>
+        <note>Line: 109</note>
       </trans-unit>
     </body>
   </file>
@@ -887,8 +14,758 @@ File: admin-dev/themes/default/template/controllers/translations/helpers/view/tr
       <trans-unit id="0f4a4ca4bdfda88bb59a4ba4814a5f78">
         <source>Please install the %module_name% module before using this feature.</source>
         <target>Please install the %module_name% module before using this feature.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/currencies/conversion_rate.tpl:50</note>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/languages/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f1dd3f4aa197c3cb588dce3911e990b2">
+        <source>A language pack is available for this ISO.</source>
+        <target>A language pack is available for this ISO.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="3ad7d3a0bcf9313e6efc3ef183b779d0">
+        <source>The Prestashop version compatible with this language and your system is:</source>
+        <target>The Prestashop version compatible with this language and your system is:</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="6b1fb1c361571071fe0f6e2055c39dcb">
+        <source>After creating the language, you can import the content of the language pack, which you can download under "International -- Translations."</source>
+        <target>After creating the language, you can import the content of the language pack, which you can download under "International -- Translations."</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="a6669356dbb699457f5750c1b6e0ab0d">
+        <source>No language pack is available on prestashop.com for this ISO code</source>
+        <target>No language pack is available on prestashop.com for this ISO code</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="2c148c0631e11553ded2c0cb527be862">
+        <source>This language pack is NOT complete and cannot be used in the front or back office because some files are missing.</source>
+        <target>This language pack is NOT complete and cannot be used in the front or back office because some files are missing.</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5d27fef01a54790de11db21f1ed47892">
+        <source>%s at least, or you will have to edit the translation files manually.</source>
+        <target>%s at least, or you will have to edit the translation files manually.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="06a92b5dc72bff3b98bf4b932ce72864">
+        <source>Apache mod_security is activated on your server. This could result in some Bad Request errors</source>
+        <target>Apache mod_security is activated on your server. This could result in some Bad Request errors</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="1f0f8b59397f34d499b181297714713a">
+        <source>Warning! Your hosting provider is using the Suhosin patch for PHP, which limits the maximum number of fields allowed in a form:</source>
+        <target>Warning! Your hosting provider is using the Suhosin patch for PHP, which limits the maximum number of fields allowed in a form:</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="bbfb7a636f839052067cc86c39fa595a">
+        <source>%limit% for suhosin.post.max_vars.</source>
+        <target>%limit% for suhosin.post.max_vars.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="e97da54b23c78752578cd7fa01e8866d">
+        <source>%limit% for suhosin.request.max_vars.</source>
+        <target>%limit% for suhosin.request.max_vars.</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="308c1cf98be9973142833c9a9dbbc2ef">
+        <source>Please ask your hosting provider to increase the Suhosin limit to</source>
+        <target>Please ask your hosting provider to increase the Suhosin limit to</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="5ad040870ae5ccaeb2d57e4d052163a4">
+        <source>Warning! Your PHP configuration limits the maximum number of fields allowed in a form:</source>
+        <target>Warning! Your PHP configuration limits the maximum number of fields allowed in a form:</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="5607dc45ebdfc0baaab64d944aa88f47">
+        <source>for max_input_vars.</source>
+        <target>for max_input_vars.</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="6e709babf4b5a0ed4194ad5240e1be2c">
+        <source>Please ask your hosting provider to increase this limit to</source>
+        <target>Please ask your hosting provider to increase this limit to</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="4fb6a3beb82f8d8aa4bbdf8f5a0c35fa">
+        <source>%s at least, or you will have to edit the translation files.</source>
+        <target>%s at least, or you will have to edit the translation files.</target>
+        <note>Line: 49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7cefb4829c6de24b63f7a05716b43bec">
+        <source>This expression uses a special syntax:</source>
+        <target>This expression uses a special syntax:</target>
+        <note>Line: 140</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Language.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="87c6e26b4d5c8e6c145691758c25b769">
+        <source>Fatal error: IETF code %s is not correct</source>
+        <target>Fatal error: IETF code %s is not correct</target>
+        <note>Line: 803</note>
+      </trans-unit>
+      <trans-unit id="bec88b0b441e9deb3008eb5b2a57ec70">
+        <source>Sorry this language is not available</source>
+        <target>Sorry this language is not available</target>
+        <note>Line: 1065</note>
+      </trans-unit>
+      <trans-unit id="edeb9e20655b946e4bee4ac44a6c0a7f">
+        <source>Server does not have permissions for writing.</source>
+        <target>Server does not have permissions for writing.</target>
+        <note>Line: 1092
+Comment: @todo Throw exception</note>
+      </trans-unit>
+      <trans-unit id="19429992fd747ce8d7606c7ddb7fa272">
+        <source>Language pack unavailable.</source>
+        <target>Language pack unavailable.</target>
+        <note>Line: 1122
+Comment: @todo Throw exception</note>
+      </trans-unit>
+      <trans-unit id="2e3dec4700000b6db379437f7d8d9fac">
+        <source>An error occurred while creating the language: %s</source>
+        <target>An error occurred while creating the language: %s</target>
+        <note>Line: 1168</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/LocalizationPack.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dd7edad69f95c053248e9b53eab73826">
+        <source>Cannot load country: %d</source>
+        <target>Cannot load country: %d</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="5408a3468e366610d70dc31825b3ef3d">
+        <source>Cannot enable the associated country: %s</source>
+        <target>Cannot enable the associated country: %s</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="db3f419ede0b78fcf31491509e68db40">
+        <source>Invalid Zone name.</source>
+        <target>Invalid Zone name.</target>
+        <note>Line: 168</note>
+      </trans-unit>
+      <trans-unit id="be9fddade234ff9b16a1d92d62963b8e">
+        <source>Invalid state properties.</source>
+        <target>Invalid state properties.</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="b19f9ad94a42c56d4a2d89aaca63bafb">
+        <source>Cannot update the associated country: %s</source>
+        <target>Cannot update the associated country: %s</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="e970d66f1c952edf7a4e5dfcf3e18958">
+        <source>An error occurred while adding the state.</source>
+        <target>An error occurred while adding the state.</target>
+        <note>Line: 193</note>
+      </trans-unit>
+      <trans-unit id="28c39342f22a394f233ec0cba0ecfa02">
+        <source>An error occurred while fetching the state.</source>
+        <target>An error occurred while fetching the state.</target>
+        <note>Line: 200</note>
+      </trans-unit>
+      <trans-unit id="37c73343e4118943bc088bb4ad94a56c">
+        <source>Invalid tax properties.</source>
+        <target>Invalid tax properties.</target>
+        <note>Line: 235</note>
+      </trans-unit>
+      <trans-unit id="da2b28e84d7f376b073d2c31b0cb937b">
+        <source>An error occurred while importing the tax: %s</source>
+        <target>An error occurred while importing the tax: %s</target>
+        <note>Line: 241</note>
+      </trans-unit>
+      <trans-unit id="36f9983aadfde9d77db0d357abe6e85e">
+        <source>This tax rule cannot be saved.</source>
+        <target>This tax rule cannot be saved.</target>
+        <note>Line: 265</note>
+      </trans-unit>
+      <trans-unit id="19f29a24f0ccb9b96b37182473b27d63">
+        <source>Invalid currency properties.</source>
+        <target>Invalid currency properties.</target>
+        <note>Line: 349</note>
+      </trans-unit>
+      <trans-unit id="0e7c10cc4eabebc9bd8f1b9cb8b81bb6">
+        <source>An error occurred while importing the currency: %s</source>
+        <target>An error occurred while importing the currency: %s</target>
+        <note>Line: 355</note>
+      </trans-unit>
+      <trans-unit id="4a11be1a3905ec59ca2d35a068de6f2e">
+        <source>Localization pack corrupted: wrong unit type.</source>
+        <target>Localization pack corrupted: wrong unit type.</target>
+        <note>Line: 423</note>
+      </trans-unit>
+      <trans-unit id="28194875b1f41da98a320b0c31e658a2">
+        <source>An error occurred while setting the units.</source>
+        <target>An error occurred while setting the units.</target>
+        <note>Line: 428</note>
+      </trans-unit>
+      <trans-unit id="0964494eb4e763fd08c6004a31b4b8a7">
+        <source>An error occurred while installing the module: %s</source>
+        <target>An error occurred while installing the module: %s</target>
+        <note>Line: 462</note>
+      </trans-unit>
+      <trans-unit id="e9b1cabd191f8141419c43cc46802e35">
+        <source>An error occurred while uninstalling the module: %s</source>
+        <target>An error occurred while uninstalling the module: %s</target>
+        <note>Line: 467</note>
+      </trans-unit>
+      <trans-unit id="962f6e835582ebb404a37893f46c60f3">
+        <source>An error has occurred, this module does not exist: %s</source>
+        <target>An error has occurred, this module does not exist: %s</target>
+        <note>Line: 473</note>
+      </trans-unit>
+      <trans-unit id="e7ae5e7fbebb7b087110d07b06bd2418">
+        <source>An error occurred during the configuration setup: %1$s</source>
+        <target>An error occurred during the configuration setup: %1$s</target>
+        <note>Line: 501</note>
+      </trans-unit>
+      <trans-unit id="b34f6454b80599ab92262b1da79a9edb">
+        <source>An error occurred during the default group update</source>
+        <target>An error occurred during the default group update</target>
+        <note>Line: 539</note>
+      </trans-unit>
+      <trans-unit id="09a0fad4c9a9702b2db457f6bff88f3d">
+        <source>An error has occurred during the default group update</source>
+        <target>An error has occurred during the default group update</target>
+        <note>Line: 543</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Translate.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="753200ddd6c25c2b4875afc70bb6d4fc">
+        <source>Invalid language ISO code (%s)</source>
+        <target>Invalid language ISO code (%s)</target>
+        <note>Line: 301</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bb01c8c21884e974df8517110c92b22a">
+        <source>The translation was added successfully, but the language has not been created.</source>
+        <target>The translation was added successfully, but the language has not been created.</target>
+        <note>Line: 473</note>
+      </trans-unit>
+      <trans-unit id="ae99f365ee39176c3ab50b76a95cf629">
+        <source>Cannot add configuration %1$s for %2$s language</source>
+        <target>Cannot add configuration %1$s for %2$s language</target>
+        <note>Line: 1495</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/tax/TaxManagerModule.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="253356cdb3cd6af1a6028200326de711">
+        <source>Incorrect Tax Manager class [%s]</source>
+        <target>Incorrect Tax Manager class [%s]</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="20eb7f9857d85d1d0c8a1e0ddf8545b8">
+        <source>Tax Manager class not found [%s]</source>
+        <target>Tax Manager class not found [%s]</target>
+        <note>Line: 46</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/tax/TaxRulesGroup.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6f3455d187a23443796efdcbe044096b">
+        <source>No tax</source>
+        <target>No tax</target>
+        <note>Line: 148</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e07a23e507642ef04f449a7a78f59d38">
+        <source>This ISO code already exists.You cannot create two countries with the same ISO code.</source>
+        <target>This ISO code already exists.You cannot create two countries with the same ISO code.</target>
+        <note>Line: 410</note>
+      </trans-unit>
+      <trans-unit id="28064049c0d480c2fdeafd456977da8d">
+        <source>Invalid address layout %s</source>
+        <target>Invalid address layout %s</target>
+        <note>Line: 445</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCurrenciesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8246d0c794e7db090587c4797b2a234f">
+        <source>You cannot delete the default currency</source>
+        <target>You cannot delete the default currency</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="7c77e53206853cb381e91e037554faa3">
+        <source>You cannot disable the default currency</source>
+        <target>You cannot disable the default currency</target>
+        <note>Line: 192</note>
+      </trans-unit>
+      <trans-unit id="9289665482a13fc74be054caef49b63e">
+        <source>This currency already exists.</source>
+        <target>This currency already exists.</target>
+        <note>Line: 281</note>
+      </trans-unit>
+      <trans-unit id="1a93d2c04e8276471b3c198d1ad95098">
+        <source>The currency conversion rate cannot be equal to 0.</source>
+        <target>The currency conversion rate cannot be equal to 0.</target>
+        <note>Line: 284</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminLanguagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4749a02e87a1b69cc421bf97c5353956">
+        <source>When you delete a language, all related translations in the database will be deleted. Are you sure you want to proceed?</source>
+        <target>When you delete a language, all related translations in the database will be deleted. Are you sure you want to proceed?</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="cc83a240095b0a0b6e1840bb7d43830c">
+        <source>When you delete a language, all related translations in the database will be deleted.</source>
+        <target>When you delete a language, all related translations in the database will be deleted.</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="1214646a8e239537981e729a0f16f3e9">
+        <source>Your .htaccess file must be writable.</source>
+        <target>Your .htaccess file must be writable.</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="8bd94436fa6738863292fb9823368694">
+        <source>You cannot delete the default language.</source>
+        <target>You cannot delete the default language.</target>
+        <note>Line: 339</note>
+      </trans-unit>
+      <trans-unit id="f25eedbf89efbd0cfce488fe01f9c4cb">
+        <source>You cannot delete the language currently in use. Please select a different language.</source>
+        <target>You cannot delete the language currently in use. Please select a different language.</target>
+        <note>Line: 341</note>
+      </trans-unit>
+      <trans-unit id="2f236f9450ce8714611e468181064659">
+        <source>You cannot change the status of the default language.</source>
+        <target>You cannot change the status of the default language.</target>
+        <note>Line: 363</note>
+      </trans-unit>
+      <trans-unit id="59382adebc7f0d65c42fe773d443e4c7">
+        <source>This ISO code is already linked to another language.</source>
+        <target>This ISO code is already linked to another language.</target>
+        <note>Line: 408</note>
+      </trans-unit>
+      <trans-unit id="5c61f1e9d7d492c795142ceb39900050">
+        <source>Flag and "No picture" image fields are required.</source>
+        <target>Flag and "No picture" image fields are required.</target>
+        <note>Line: 416</note>
+      </trans-unit>
+      <trans-unit id="8037670f9e6df1f09e040ff8ab047fac">
+        <source>An error occurred while copying "No Picture" image to your product folder.</source>
+        <target>An error occurred while copying "No Picture" image to your product folder.</target>
+        <note>Line: 469</note>
+      </trans-unit>
+      <trans-unit id="0773497a933e6c2b618678b02cbdf7a1">
+        <source>An error occurred while copying "No picture" image to your category folder.</source>
+        <target>An error occurred while copying "No picture" image to your category folder.</target>
+        <note>Line: 472</note>
+      </trans-unit>
+      <trans-unit id="6509c8bfa3f06725a6016e6a429dbcd9">
+        <source>An error occurred while copying "No picture" image to your brand folder.</source>
+        <target>An error occurred while copying "No picture" image to your brand folder.</target>
+        <note>Line: 475</note>
+      </trans-unit>
+      <trans-unit id="1b3a472a4556d51d2169e947280e0400">
+        <source>An error occurred while resizing "No picture" image to your product directory.</source>
+        <target>An error occurred while resizing "No picture" image to your product directory.</target>
+        <note>Line: 480</note>
+      </trans-unit>
+      <trans-unit id="2b9a5da945495f5101d57abbf2a7083c">
+        <source>An error occurred while resizing "No picture" image to your category directory.</source>
+        <target>An error occurred while resizing "No picture" image to your category directory.</target>
+        <note>Line: 483</note>
+      </trans-unit>
+      <trans-unit id="fea874a66e2e09d727c76264844ff688">
+        <source>An error occurred while resizing "No picture" image to your brand directory.</source>
+        <target>An error occurred while resizing "No picture" image to your brand directory.</target>
+        <note>Line: 486</note>
+      </trans-unit>
+      <trans-unit id="5f17acb89d2ab83c9138774bfd05ab16">
+        <source>An error occurred during image deletion process.</source>
+        <target>An error occurred during image deletion process.</target>
+        <note>Line: 518</note>
+      </trans-unit>
+      <trans-unit id="7aa19852b281887173d096f6700cdebf">
+        <source>Iso code is not valid</source>
+        <target>Iso code is not valid</target>
+        <note>Line: 545</note>
+      </trans-unit>
+      <trans-unit id="da7e8b45fda5783ed027b88cc33fdfc1">
+        <source>Technical Error: ps_version is not valid</source>
+        <target>Technical Error: ps_version is not valid</target>
+        <note>Line: 551</note>
+      </trans-unit>
+      <trans-unit id="29298b5d89d0bbdfa92fb1d6e27188bd">
+        <source>Wrong ISO code, or the selected language pack is unavailable.</source>
+        <target>Wrong ISO code, or the selected language pack is unavailable.</target>
+        <note>Line: 564</note>
+      </trans-unit>
+      <trans-unit id="dc2dde59d57d3bfd6881be1392c54280">
+        <source>Technical Error: translation server unreachable.</source>
+        <target>Technical Error: translation server unreachable.</target>
+        <note>Line: 568</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="aa28d701be690425c5518b723668f6f7">
+        <source>This ISO code already exists. You cannot create two states with the same ISO code.</source>
+        <target>This ISO code already exists. You cannot create two states with the same ISO code.</target>
+        <note>Line: 229</note>
+      </trans-unit>
+      <trans-unit id="dae008137b79aa8e5c0f2aed6d1db503">
+        <source>This state was used in at least one address. It cannot be removed.</source>
+        <target>This state was used in at least one address. It cannot be removed.</target>
+        <note>Line: 244</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTaxRulesGroupController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="45f3b37902e09b041709484fd75cab22">
+        <source>A tax rule already exists for this country/state with tax only behavior.</source>
+        <target>A tax rule already exists for this country/state with tax only behavior.</target>
+        <note>Line: 437</note>
+      </trans-unit>
+      <trans-unit id="97d8fb4588d1efe9731fd4f82e071924">
+        <source>The Zip/postal code is invalid. It must be typed as follows: %format% for %country%.</source>
+        <target>The Zip/postal code is invalid. It must be typed as follows: %format% for %country%.</target>
+        <note>Line: 464</note>
+      </trans-unit>
+      <trans-unit id="2ff5095fd8289ccdaeca9c5e7d379fd2">
+        <source>An error has occurred: Cannot save the current tax rule.</source>
+        <target>An error has occurred: Cannot save the current tax rule.</target>
+        <note>Line: 490</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTaxesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3311c10f0830ae7b6ad64674777c3f34">
+        <source>This tax is currently in use as a tax rule. Are you sure you'd like to continue?</source>
+        <target>This tax is currently in use as a tax rule. Are you sure you'd like to continue?</target>
+        <note>Line: 152</note>
+      </trans-unit>
+      <trans-unit id="8eeccbbbc36b19ed4e82d2eca4055d4d">
+        <source>This tax is currently in use as a tax rule. If you continue, this tax will be removed from the tax rule. Are you sure you'd like to continue?</source>
+        <target>This tax is currently in use as a tax rule. If you continue, this tax will be removed from the tax rule. Are you sure you'd like to continue?</target>
+        <note>Line: 177</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTranslationsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c4e5aa158727e2041778d545424797da">
+        <source>An error occurred while copying data.</source>
+        <target>An error occurred while copying data.</target>
+        <note>Line: 402</note>
+      </trans-unit>
+      <trans-unit id="b5f3291b6db7481e8ca0da4a00718cf9">
+        <source>Impossible to create the directory "%folder%".</source>
+        <target>Impossible to create the directory "%folder%".</target>
+        <note>Line: 427</note>
+      </trans-unit>
+      <trans-unit id="ec531fd2b656df91f11e8f94b2bd2f9b">
+        <source>An error occurred while creating archive.</source>
+        <target>An error occurred while creating archive.</target>
+        <note>Line: 546</note>
+      </trans-unit>
+      <trans-unit id="b10dfa68dec5e313508a4a55eedae7d1">
+        <source>Please select a language and a theme.</source>
+        <target>Please select a language and a theme.</target>
+        <note>Line: 548</note>
+      </trans-unit>
+      <trans-unit id="02ae08296d544eb7c674182122645631">
+        <source>Tab "%s" is not valid</source>
+        <target>Tab "%s" is not valid</target>
+        <note>Line: 708</note>
+      </trans-unit>
+      <trans-unit id="737b7d8e0108e60b272f6e5a0eaf6ef2">
+        <source>Validation failed for: %file%</source>
+        <target>Validation failed for: %file%</target>
+        <note>Line: 788</note>
+      </trans-unit>
+      <trans-unit id="e7e5ca2e62158b89d7583ac6936830a5">
+        <source>Unidentified file found: %file%</source>
+        <target>Unidentified file found: %file%</target>
+        <note>Line: 791</note>
+      </trans-unit>
+      <trans-unit id="9831c9e35b4d39d939363aa5629e00f2">
+        <source>The archive cannot be extracted.</source>
+        <target>The archive cannot be extracted.</target>
+        <note>Line: 854</note>
+      </trans-unit>
+      <trans-unit id="6f2981f3239ff532c94509a6f98e11c3">
+        <source>ISO CODE invalid "%iso_code%" for the following file: "%file%"</source>
+        <target>ISO CODE invalid "%iso_code%" for the following file: "%file%"</target>
+        <note>Line: 856</note>
+      </trans-unit>
+      <trans-unit id="299dd7d59920216689a1749def7fd939">
+        <source>Cannot write to the theme's language file (%s). Please check writing permissions.</source>
+        <target>Cannot write to the theme's language file (%s). Please check writing permissions.</target>
+        <note>Line: 970</note>
+      </trans-unit>
+      <trans-unit id="78973deca6d26ce225f6f66c6c30dd54">
+        <source>Invalid theme "%theme%"</source>
+        <target>Invalid theme "%theme%"</target>
+        <note>Line: 1811</note>
+      </trans-unit>
+      <trans-unit id="7d65d1400b9d08c5c638682170ff4d7c">
+        <source>Invalid iso code "%iso_code%"</source>
+        <target>Invalid iso code "%iso_code%"</target>
+        <note>Line: 1416</note>
+      </trans-unit>
+      <trans-unit id="b399fb01ee4e0a8ec1681fb9bcb31ce0">
+        <source>This %type_content% file extension is not accepted.</source>
+        <target>This %type_content% file extension is not accepted.</target>
+        <note>Line: 1649</note>
+      </trans-unit>
+      <trans-unit id="1e5ec3cd42b5bac1b06b99f67cba41dd">
+        <source>Invalid module name "%module%"</source>
+        <target>Invalid module name "%module%"</target>
+        <note>Line: 1658</note>
+      </trans-unit>
+      <trans-unit id="c68e9fe9015c5779289f32e2bdef0a7b">
+        <source>Invalid mail name "%mail%"</source>
+        <target>Invalid mail name "%mail%"</target>
+        <note>Line: 1662</note>
+      </trans-unit>
+      <trans-unit id="40f5c232e433d178a4f912b3092d7df1">
+        <source>Directory "%folder%" cannot be created</source>
+        <target>Directory "%folder%" cannot be created</target>
+        <note>Line: 1684</note>
+      </trans-unit>
+      <trans-unit id="ccdf1aa6f4cb029f9846e53006115905">
+        <source>Your email translations contain some invalid HTML and cannot be saved. Please check your content.</source>
+        <target>Your email translations contain some invalid HTML and cannot be saved. Please check your content.</target>
+        <note>Line: 1690</note>
+      </trans-unit>
+      <trans-unit id="f1c030f2fd8f1b382a4bffd04af59c2d">
+        <source>Your HTML email templates cannot contain JavaScript code.</source>
+        <target>Your HTML email templates cannot contain JavaScript code.</target>
+        <note>Line: 1696</note>
+      </trans-unit>
+      <trans-unit id="5dc4babbd10d00e89d8e46a12942d394">
+        <source>Empty string found, please edit: "%file%"</source>
+        <target>Empty string found, please edit: "%file%"</target>
+        <note>Line: 1845</note>
+      </trans-unit>
+      <trans-unit id="f2aca97fb94315864fd2fa52f3100f1e">
+        <source>There is an error in template, an empty string has been found. Please edit: "%file%"</source>
+        <target>There is an error in template, an empty string has been found. Please edit: "%file%"</target>
+        <note>Line: 2115</note>
+      </trans-unit>
+      <trans-unit id="616d8e7e6c0dc755a7e932c4db698317">
+        <source>The module directory must be writable.</source>
+        <target>The module directory must be writable.</target>
+        <note>Line: 2178</note>
+      </trans-unit>
+      <trans-unit id="1078d7e980a5a2fe78762cafd8480f0a">
+        <source>A mail directory exists for the "%iso_code%" language, but not for the default language (%language%) in %folder%</source>
+        <target>A mail directory exists for the "%iso_code%" language, but not for the default language (%language%) in %folder%</target>
+        <note>Line: 2439</note>
+      </trans-unit>
+      <trans-unit id="7cf50c9ffecf05f3befc1134eba0ef45">
+        <source>missing translation(s)</source>
+        <target>missing translation(s)</target>
+        <note>Line: 2500</note>
+      </trans-unit>
+      <trans-unit id="fda679a1f72b8a9676b6926a81c5e139">
+        <source>No Subject was found for %mail_name% in the database.</source>
+        <target>No Subject was found for %mail_name% in the database.</target>
+        <note>Line: 2539</note>
+      </trans-unit>
+      <trans-unit id="a662aa2e6538df75742383c7db8f3bd5">
+        <source>There was a problem getting the mail files.</source>
+        <target>There was a problem getting the mail files.</target>
+        <note>Line: 2576</note>
+      </trans-unit>
+      <trans-unit id="3eefb74a46023e6c9152c92803750f2b">
+        <source>English language files must exist in %folder% folder</source>
+        <target>English language files must exist in %folder% folder</target>
+        <note>Line: 2577</note>
+      </trans-unit>
+      <trans-unit id="c4c005678d26a593268006bc4a44c179">
+        <source>Cannot write language file for email subjects. Path is: %folder%</source>
+        <target>Cannot write language file for email subjects. Path is: %folder%</target>
+        <note>Line: 2974</note>
+      </trans-unit>
+      <trans-unit id="05b17ff64944116b14a3ec88f2080a5e">
+        <source>Cannot write into the "%file%"</source>
+        <target>Cannot write into the "%file%"</target>
+        <note>Line: 3176</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Language/LanguageCopier.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4d7541fb66c9fc832a20a6f48b4d5613">
+        <source>Cannot create the folder "%folder%". Please check your directory writing permissions.</source>
+        <target>Cannot create the folder "%folder%". Please check your directory writing permissions.</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="102c75f83994f206179912d118b8bc3c">
+        <source>You must select two languages in order to copy data from one to another.</source>
+        <target>You must select two languages in order to copy data from one to another.</target>
+        <note>Line: 173</note>
+      </trans-unit>
+      <trans-unit id="fc15f62c244c6d8035874d556e6a7f7b">
+        <source>You must select two themes in order to copy data from one to another.</source>
+        <target>You must select two themes in order to copy data from one to another.</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="0a7402299bf78a7624da443a12cd78ab">
+        <source>There is nothing to copy (same language and theme).</source>
+        <target>There is nothing to copy (same language and theme).</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="6b5324e2e711f17c4d3db1f625178e86">
+        <source>Theme(s) not found</source>
+        <target>Theme(s) not found</target>
+        <note>Line: 211</note>
+      </trans-unit>
+      <trans-unit id="434464e4353199dd20af7bd3cf8e6c64">
+        <source>Impossible to copy "%source%" to "%dest%".</source>
+        <target>Impossible to copy "%source%" to "%dest%".</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="07b33077111c506cf81b6cc5ef42a170">
+        <source>Impossible to translate "%dest%".</source>
+        <target>Impossible to translate "%dest%".</target>
+        <note>Line: 134</note>
+      </trans-unit>
+      <trans-unit id="c7254dc1193c25493aa0a09df285b43c">
+        <source>A part of the data has been copied but some of the language files could not be found.</source>
+        <target>A part of the data has been copied but some of the language files could not be found.</target>
+        <note>Line: 146</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Language/LanguagePackInstaller.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="52326ecbfcdff77b4bc9dcf7f055c2eb">
+        <source>Fatal error: ISO code is not correct</source>
+        <target>Fatal error: ISO code is not correct</target>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Localization/Pack/Import/LocalizationPackImporter.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="34f9488516199cf18114f12369c71a59">
+        <source>Cannot load the localization pack.</source>
+        <target>Cannot load the localization pack.</target>
+        <note>Line: 109</note>
+      </trans-unit>
+      <trans-unit id="ecb8838ce98cd126849fc083f0070bcd">
+        <source>Please select at least one item to import.</source>
+        <target>Please select at least one item to import.</target>
+        <note>Line: 143</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/International/LocalizationController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c9468b4bd45a165049277af6756db10e">
+        <source>Localization pack imported successfully.</source>
+        <target>Localization pack imported successfully.</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="53802fa30d7e83f77eccfa376c33e6fa">
+        <source>Importing a new language may fail without the OpenSSL module. Please enable "openssl.so" on your server configuration.</source>
+        <target>Importing a new language may fail without the OpenSSL module. Please enable "openssl.so" on your server configuration.</target>
+        <note>Line: 58</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/TranslationsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f22def68c5c456936078623b6dcd27ff">
+        <source>The translations have been successfully added.</source>
+        <target>The translations have been successfully added.</target>
+        <note>Line: 159</note>
+      </trans-unit>
+      <trans-unit id="6cfb80c26b415f8f6467cf07b0c700dd">
+        <source>The translation was successfully copied.</source>
+        <target>The translation was successfully copied.</target>
+        <note>Line: 241</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7e093dcb7a9f75c8124b2adc265c5302">
+        <source>The geolocation database is unavailable.</source>
+        <target>The geolocation database is unavailable.</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="493ce56d58c4880dc32df56f12585a23">
+        <source>Country selection is invalid.</source>
+        <target>Country selection is invalid.</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="0861a67f819158c5690a1844d95390b4">
+        <source>Invalid whitelist</source>
+        <target>Invalid whitelist</target>
+        <note>Line: 121</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7da16b055b9db528a9b4aa9c4ad674ca">
+        <source>Before changing the default currency, we strongly recommend that you enable maintenance mode. Indeed, any change on the default currency requires a manual adjustment of the price of each product and its combinations.</source>
+        <target>Before changing the default currency, we strongly recommend that you enable maintenance mode. Indeed, any change on the default currency requires a manual adjustment of the price of each product and its combinations.</target>
+        <note>Line: 76</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3c529160fd0337c151d35e7a3809d427">
+        <source>Language files must be complete to allow copying of translations.</source>
+        <target>Language files must be complete to allow copying of translations.</target>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Twig/TranslationsExtension.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="41ca3d8439f6e8beab7af312714e37f0">
+        <source>Translation successfully updated</source>
+        <target>Translation successfully updated</target>
+        <note>Line: 220</note>
+      </trans-unit>
+      <trans-unit id="b3991113a051bbeb759a923bc636ad8d">
+        <source>Failed to update translation</source>
+        <target>Failed to update translation</target>
+        <note>Line: 225</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminLoginFeature.xlf
+++ b/app/Resources/translations/default/AdminLoginFeature.xlf
@@ -5,56 +5,47 @@
       <trans-unit id="bffe9a3c9a7e00ba00a11749e022d911">
         <source>Log in</source>
         <target>Log in</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:73</note>
+        <note>Line: 73</note>
       </trans-unit>
       <trans-unit id="77dcc4123443269bb7d3e1e5912439df">
         <source>Stay logged in</source>
         <target>Stay logged in</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:81</note>
+        <note>Line: 81</note>
       </trans-unit>
       <trans-unit id="b05d72142020283dc6812fd3a9bc691c">
         <source>I forgot my password</source>
         <target>I forgot my password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:85</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="32fe59513f5bbdd353b4527cc6af55ce">
         <source>Reset your password</source>
         <target>Reset your password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:93</note>
+        <note>Line: 93</note>
       </trans-unit>
       <trans-unit id="3544848f820b9d94a3f3871a382cf138">
         <source>New password</source>
         <target>New password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:96</note>
+        <note>Line: 96</note>
       </trans-unit>
       <trans-unit id="6ab96a5df54aa6aae2bab9ea75ab76c9">
         <source>Confirm new password</source>
         <target>Confirm new password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:102</note>
+        <note>Line: 102</note>
       </trans-unit>
       <trans-unit id="4c231e0da3eaaa6a9752174f7f9cfb31">
         <source>Confirm password</source>
         <target>Confirm password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:104</note>
+        <note>Line: 104</note>
       </trans-unit>
       <trans-unit id="3b5b0f1e26d98a827ef82af202c2e85b">
         <source>Reset password</source>
         <target>Reset password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:109</note>
+        <note>Line: 109</note>
       </trans-unit>
       <trans-unit id="733ae3eecadd5777cea5ce9a32379d7a">
         <source>Send reset link</source>
         <target>Send reset link</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:138</note>
+        <note>Line: 138</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminLoginNotification.xlf
+++ b/app/Resources/translations/default/AdminLoginNotification.xlf
@@ -1,105 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminLoginController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/login/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="64bebbfcf422901ff5898cd0d0f92ba4">
-        <source>SSL is activated. However, your IP is allowed to enter unsecure mode for maintenance or local IP issues.</source>
-        <target>SSL is activated. However, your IP is allowed to enter unsecure mode for maintenance or local IP issues.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:72</note>
+      <trans-unit id="7860cb5f5994f37f332dda3f250e035b">
+        <source>You will be redirected to the login page in a few seconds.</source>
+        <target>You will be redirected to the login page in a few seconds.</target>
+        <note>Line: 118</note>
       </trans-unit>
-      <trans-unit id="0c38dbc5d2689404ee34e0fc2da845cf">
-        <source>SSL is activated. Please connect using the following link to [1]log in to secure mode (https://)[/1]</source>
-        <target>SSL is activated. Please connect using the following link to [1]log in to secure mode (https://)[/1]</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:76</note>
+      <trans-unit id="d2bd0a6c92a4501d3459335139825d21">
+        <source>Please, check your mailbox.</source>
+        <target>Please, check your mailbox.</target>
+        <note>Line: 145</note>
       </trans-unit>
-      <trans-unit id="1414e6b52fb36401e73871528bfb074d">
-        <source>The employee does not exist, or the password provided is incorrect.</source>
-        <target>The employee does not exist, or the password provided is incorrect.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:200</note>
+      <trans-unit id="95faaabab0eea73e0dddecfb101e9c59">
+        <source>A link to reset your password has been sent to you.</source>
+        <target>A link to reset your password has been sent to you.</target>
+        <note>Line: 145</note>
       </trans-unit>
-      <trans-unit id="54a27a9a29b0e113daa86220ba7e7880">
-        <source>This employee does not manage the shop anymore (either the shop has been deleted or permissions have been revoked).</source>
-        <target>This employee does not manage the shop anymore (either the shop has been deleted or permissions have been revoked).</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:203</note>
+      <trans-unit id="d84626aafd2ead966ff2f5c2e0bca73f">
+        <source>For security reasons, you cannot connect to the back office until you have:</source>
+        <target>For security reasons, you cannot connect to the back office until you have:</target>
+        <note>Line: 150</note>
       </trans-unit>
-      <trans-unit id="f197511588fa1467e957bf6c48539e88">
-        <source>This account does not exist.</source>
-        <target>This account does not exist.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:331
- Comment: check matching employee id with its email</note>
+      <trans-unit id="362b56674d07160fab60725a927bbf13">
+        <source>deleted the /install folder</source>
+        <target>deleted the /install folder</target>
+        <note>Line: 153</note>
       </trans-unit>
-      <trans-unit id="b2e73e907ab40d78981c8bbfd0e0881f">
-        <source>You can reset your password every %interval% minute(s) only. Please try again later.</source>
-        <target>You can reset your password every %interval% minute(s) only. Please try again later.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:333</note>
+      <trans-unit id="83c8a48abe6dd9b6fcc44986069b36dd">
+        <source>renamed the /admin folder (e.g. %s)</source>
+        <target>renamed the /admin folder (e.g. %s)</target>
+        <note>Line: 156</note>
       </trans-unit>
-      <trans-unit id="70888a5d7f35d91f8085cba884f7298e">
-        <source>Please, check your mailbox. A link to reset your password has been sent to you.</source>
-        <target>Please, check your mailbox. A link to reset your password has been sent to you.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:295</note>
-      </trans-unit>
-      <trans-unit id="61c79423624504f70ce7b16f76587aac">
-        <source>An error occurred while attempting to reset your password.</source>
-        <target>An error occurred while attempting to reset your password.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:300</note>
-      </trans-unit>
-      <trans-unit id="eed80aefc5a34c94db6274505d68d151">
-        <source>Some identification information is missing.</source>
-        <target>Some identification information is missing.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:318</note>
-      </trans-unit>
-      <trans-unit id="375dee52ced3330cd3496340b32098ca">
-        <source>The password is missing: please enter your new password.</source>
-        <target>The password is missing: please enter your new password.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:321
- Comment: password (twice)</note>
-      </trans-unit>
-      <trans-unit id="f01fb987f60542e0bff1bf7bed42d142">
-        <source>The password is not in a valid format.</source>
-        <target>The password is not in a valid format.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:323</note>
-      </trans-unit>
-      <trans-unit id="76e08a16ce116959f282955d33c51aa0">
-        <source>The confirmation is empty: please fill in the password confirmation as well.</source>
-        <target>The confirmation is empty: please fill in the password confirmation as well.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:325</note>
-      </trans-unit>
-      <trans-unit id="3b065e732222a25050ced52f7fca85c0">
-        <source>The password and its confirmation do not match. Please double check both passwords.</source>
-        <target>The password and its confirmation do not match. Please double check both passwords.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:327</note>
-      </trans-unit>
-      <trans-unit id="56f5aa17fc3a9c5d9827bb148f072cd2">
-        <source>Your password reset request expired. Please start again.</source>
-        <target>Your password reset request expired. Please start again.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:336
- Comment: To update password, we must have the temporary reset token that matches.</note>
-      </trans-unit>
-      <trans-unit id="2a8fac0ed3799588798c1b531a2b65ef">
-        <source>An error occurred while attempting to change your password.</source>
-        <target>An error occurred while attempting to change your password.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:384</note>
-      </trans-unit>
-      <trans-unit id="30d1a8e4c44146dcccec7b7a11db6d6e">
-        <source>The password has been changed successfully.</source>
-        <target>The password has been changed successfully.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:378</note>
+      <trans-unit id="1a728f70318152b93421d59a6f7b4110">
+        <source>Please then access this page by the new URL (e.g. %s)</source>
+        <target>Please then access this page by the new URL (e.g. %s)</target>
+        <note>Line: 161</note>
       </trans-unit>
     </body>
   </file>
@@ -108,54 +44,94 @@ File: controllers/admin/AdminLoginController.php:378</note>
       <trans-unit id="9ff082251dea737459c9f32e73ca7a62">
         <source>For security reasons, you must also delete the /install folder.</source>
         <target>For security reasons, you must also delete the /install folder.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:388</note>
+        <note>Line: 388</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/login/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/admin/AdminLoginController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="7860cb5f5994f37f332dda3f250e035b">
-        <source>You will be redirected to the login page in a few seconds.</source>
-        <target>You will be redirected to the login page in a few seconds.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:118</note>
+      <trans-unit id="64bebbfcf422901ff5898cd0d0f92ba4">
+        <source>SSL is activated. However, your IP is allowed to enter unsecure mode for maintenance or local IP issues.</source>
+        <target>SSL is activated. However, your IP is allowed to enter unsecure mode for maintenance or local IP issues.</target>
+        <note>Line: 72</note>
       </trans-unit>
-      <trans-unit id="d2bd0a6c92a4501d3459335139825d21">
-        <source>Please, check your mailbox.</source>
-        <target>Please, check your mailbox.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:145</note>
+      <trans-unit id="0c38dbc5d2689404ee34e0fc2da845cf">
+        <source>SSL is activated. Please connect using the following link to [1]log in to secure mode (https://)[/1]</source>
+        <target>SSL is activated. Please connect using the following link to [1]log in to secure mode (https://)[/1]</target>
+        <note>Line: 76</note>
       </trans-unit>
-      <trans-unit id="95faaabab0eea73e0dddecfb101e9c59">
-        <source>A link to reset your password has been sent to you.</source>
-        <target>A link to reset your password has been sent to you.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:145</note>
+      <trans-unit id="1414e6b52fb36401e73871528bfb074d">
+        <source>The employee does not exist, or the password provided is incorrect.</source>
+        <target>The employee does not exist, or the password provided is incorrect.</target>
+        <note>Line: 200</note>
       </trans-unit>
-      <trans-unit id="d84626aafd2ead966ff2f5c2e0bca73f">
-        <source>For security reasons, you cannot connect to the back office until you have:</source>
-        <target>For security reasons, you cannot connect to the back office until you have:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:150</note>
+      <trans-unit id="54a27a9a29b0e113daa86220ba7e7880">
+        <source>This employee does not manage the shop anymore (either the shop has been deleted or permissions have been revoked).</source>
+        <target>This employee does not manage the shop anymore (either the shop has been deleted or permissions have been revoked).</target>
+        <note>Line: 203</note>
       </trans-unit>
-      <trans-unit id="362b56674d07160fab60725a927bbf13">
-        <source>deleted the /install folder</source>
-        <target>deleted the /install folder</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:153</note>
+      <trans-unit id="f197511588fa1467e957bf6c48539e88">
+        <source>This account does not exist.</source>
+        <target>This account does not exist.</target>
+        <note>Line: 331
+Comment: check matching employee id with its email</note>
       </trans-unit>
-      <trans-unit id="83c8a48abe6dd9b6fcc44986069b36dd">
-        <source>renamed the /admin folder (e.g. %s)</source>
-        <target>renamed the /admin folder (e.g. %s)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:156</note>
+      <trans-unit id="b2e73e907ab40d78981c8bbfd0e0881f">
+        <source>You can reset your password every %interval% minute(s) only. Please try again later.</source>
+        <target>You can reset your password every %interval% minute(s) only. Please try again later.</target>
+        <note>Line: 333</note>
       </trans-unit>
-      <trans-unit id="1a728f70318152b93421d59a6f7b4110">
-        <source>Please then access this page by the new URL (e.g. %s)</source>
-        <target>Please then access this page by the new URL (e.g. %s)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:161</note>
+      <trans-unit id="70888a5d7f35d91f8085cba884f7298e">
+        <source>Please, check your mailbox. A link to reset your password has been sent to you.</source>
+        <target>Please, check your mailbox. A link to reset your password has been sent to you.</target>
+        <note>Line: 295</note>
+      </trans-unit>
+      <trans-unit id="61c79423624504f70ce7b16f76587aac">
+        <source>An error occurred while attempting to reset your password.</source>
+        <target>An error occurred while attempting to reset your password.</target>
+        <note>Line: 300</note>
+      </trans-unit>
+      <trans-unit id="eed80aefc5a34c94db6274505d68d151">
+        <source>Some identification information is missing.</source>
+        <target>Some identification information is missing.</target>
+        <note>Line: 318</note>
+      </trans-unit>
+      <trans-unit id="375dee52ced3330cd3496340b32098ca">
+        <source>The password is missing: please enter your new password.</source>
+        <target>The password is missing: please enter your new password.</target>
+        <note>Line: 321
+Comment: password (twice)</note>
+      </trans-unit>
+      <trans-unit id="f01fb987f60542e0bff1bf7bed42d142">
+        <source>The password is not in a valid format.</source>
+        <target>The password is not in a valid format.</target>
+        <note>Line: 323</note>
+      </trans-unit>
+      <trans-unit id="76e08a16ce116959f282955d33c51aa0">
+        <source>The confirmation is empty: please fill in the password confirmation as well.</source>
+        <target>The confirmation is empty: please fill in the password confirmation as well.</target>
+        <note>Line: 325</note>
+      </trans-unit>
+      <trans-unit id="3b065e732222a25050ced52f7fca85c0">
+        <source>The password and its confirmation do not match. Please double check both passwords.</source>
+        <target>The password and its confirmation do not match. Please double check both passwords.</target>
+        <note>Line: 327</note>
+      </trans-unit>
+      <trans-unit id="56f5aa17fc3a9c5d9827bb148f072cd2">
+        <source>Your password reset request expired. Please start again.</source>
+        <target>Your password reset request expired. Please start again.</target>
+        <note>Line: 336
+Comment: To update password, we must have the temporary reset token that matches.</note>
+      </trans-unit>
+      <trans-unit id="2a8fac0ed3799588798c1b531a2b65ef">
+        <source>An error occurred while attempting to change your password.</source>
+        <target>An error occurred while attempting to change your password.</target>
+        <note>Line: 384</note>
+      </trans-unit>
+      <trans-unit id="30d1a8e4c44146dcccec7b7a11db6d6e">
+        <source>The password has been changed successfully.</source>
+        <target>The password has been changed successfully.</target>
+        <note>Line: 378</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminModulesFeature.xlf
+++ b/app/Resources/translations/default/AdminModulesFeature.xlf
@@ -1,34 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list_addons.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/modules/configure.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="3aaeb3f0458cf2580c5f75fefdb86ab6">
-        <source>PrestaShop Addons Marketplace</source>
-        <target>PrestaShop Addons Marketplace</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list_addons.html.twig:32</note>
+      <trans-unit id="a785bc36e9e9468712517690ab9b95fb">
+        <source>Check update</source>
+        <target>Check update</target>
+        <note>Line: 94</note>
       </trans-unit>
-      <trans-unit id="24a25a6b874647087c51ea00b7992def">
-        <source>Exit to PrestaShop Addons Marketplace</source>
-        <target>Exit to PrestaShop Addons Marketplace</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list_addons.html.twig:29</note>
+      <trans-unit id="db7c4e6b5be6dd888962b943e77b29ee">
+        <source>RTL Module</source>
+        <target>RTL Module</target>
+        <note>Line: 102</note>
       </trans-unit>
-      <trans-unit id="754475030b0733378b9347e8f9da8bf9">
-        <source>See all results for your search on</source>
-        <target>See all results for your search on</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list_addons.html.twig:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="abfc3a65538a6ec86502b2b498b6b4a6">
-        <source>Discover</source>
-        <target>Discover</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig:36</note>
+      <trans-unit id="53103fcc4656f55c219b600ded3c7438">
+        <source>Manage hooks</source>
+        <target>Manage hooks</target>
+        <note>Line: 109</note>
       </trans-unit>
     </body>
   </file>
@@ -42,63 +29,145 @@ File: modules/ps_buybuttonlite/ps_buybuttonlite.php:167</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_mbo/views/templates/admin/include/action_menu.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="17e0ca27e686200d42e478e2457052aa">
-        <source>Module notifications</source>
-        <target>Module notifications</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php:57</note>
+      <trans-unit id="abfc3a65538a6ec86502b2b498b6b4a6">
+        <source>Discover</source>
+        <target>Discover</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="349838fb1d851d3e2014b9fe39203275">
+        <source>Install</source>
+        <target>Install</target>
+        <note>Line: 34</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_mbo/views/templates/admin/include/dropdown_categories.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="76ab1ee2aacc1b9bbc0a70bf6cca7004">
-        <source>Upload a module</source>
-        <target>Upload a module</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig:30</note>
-      </trans-unit>
-      <trans-unit id="7c8701c300f85e9799c74e83f4adea64">
-        <source>Drop your module archive here or [1]select file[/1]</source>
-        <target>Drop your module archive here or [1]select file[/1]</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig:51</note>
+      <trans-unit id="a6a2a55bea8760389dfca77132905b7c">
+        <source>All Categories</source>
+        <target>All Categories</target>
+        <note>Line: 36</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_mbo/views/templates/admin/include/menu_top.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="1c0b7f4d79e06a46c12312615fc4ab14">
-        <source>Connect to Addons marketplace</source>
-        <target>Connect to Addons marketplace</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig:30</note>
+      <trans-unit id="9adfc354d13f70ca8172da3cd2d9c06e">
+        <source>%nbModules% modules and services selected for you</source>
+        <target>%nbModules% modules and services selected for you</target>
+        <note>Line: 52</note>
       </trans-unit>
+      <trans-unit id="6ff9dd0d34f65181173c1e4bc39939de">
+        <source>Selection</source>
+        <target>Selection</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="3d7c1883e8f497290c2aafa2086f49ff">
+        <source>Increasing Price</source>
+        <target>Increasing Price</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="8e7cce37e14aea45d6d88e8c4aaa1b98">
+        <source>Decreasing Price</source>
+        <target>Decreasing Price</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="e22269bb51f9f2394e148716babbafbb">
+        <source>Popularity</source>
+        <target>Popularity</target>
+        <note>Line: 66</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/include/modal_addons_connect.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
       <trans-unit id="7234d2a9a27b5e8dba609efe02ee9548">
         <source>Link your shop to your Addons account to automatically receive important updates for the modules you purchased. Don't have an account yet?</source>
         <target>Link your shop to your Addons account to automatically receive important updates for the modules you purchased. Don't have an account yet?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig:48</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="cedcf6fe65a8f2849fe11e316d6c9923">
         <source>Sign up now</source>
         <target>Sign up now</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig:49</note>
+        <note>Line: 51</note>
       </trans-unit>
       <trans-unit id="b09249132bbed9baecd987cf73200b44">
         <source>Confirm logout</source>
         <target>Confirm logout</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig:84</note>
+        <note>Line: 88</note>
       </trans-unit>
       <trans-unit id="6be2c07aa891bbaafc828e43e336abb4">
         <source>Yes, log out</source>
         <target>Yes, log out</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig:97</note>
+        <note>Line: 102</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/include/modal_confirm_prestatrust.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="80c1f30ef63bc79dd32b654e7b85c112">
+        <source>Module verification</source>
+        <target>Module verification</target>
+        <note>Line: 5</note>
+      </trans-unit>
+      <trans-unit id="a517747c3d12f99244ae598910d979c5">
+        <source>Author</source>
+        <target>Author</target>
+        <note>Line: 21</note>
+      </trans-unit>
+      <trans-unit id="249212ebba2907c6087887db076179e6">
+        <source>Back to modules list</source>
+        <target>Back to modules list</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="34afcb42ab73990082d328d9b34811b5">
+        <source>Proceed with the installation</source>
+        <target>Proceed with the installation</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="0c18217e480e74369a0b21d29052574e">
+        <source>Buy module</source>
+        <target>Buy module</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/include/modal_import.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="76ab1ee2aacc1b9bbc0a70bf6cca7004">
+        <source>Upload a module</source>
+        <target>Upload a module</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="5d863819c3f3055dd8fca884f087caf7">
+        <source>Drop your module archive here or</source>
+        <target>Drop your module archive here or</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="ec2dab4ec46156a390cbe0652004f410">
+        <source>select file</source>
+        <target>select file</target>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/module-toolbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1c0b7f4d79e06a46c12312615fc4ab14">
+        <source>Connect to Addons marketplace</source>
+        <target>Connect to Addons marketplace</target>
+        <note>Line: 17</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/page.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="decbe415d8accca7c2c16d48a79ee934">
+        <source>Read More</source>
+        <target>Read More</target>
+        <note>Line: 106</note>
       </trans-unit>
     </body>
   </file>
@@ -107,320 +176,26 @@ File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_co
       <trans-unit id="8b1a3613ac33a07ab788b2656755110c">
         <source>Enable Mobile</source>
         <target>Enable Mobile</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:123</note>
+        <note>Line: 124</note>
       </trans-unit>
       <trans-unit id="038bd38b5172a9ba90468070bdc4d4f3">
         <source>Disable Mobile</source>
         <target>Disable Mobile</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:124</note>
+        <note>Line: 125</note>
       </trans-unit>
       <trans-unit id="e699cbe9208f8353248889781f83d636">
         <source>Module manager</source>
         <target>Module manager</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:133</note>
+        <note>Line: 134</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/alerts.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="798f81115f0cdbe07b699cdf392e9408">
-        <source>%nbModules% modules to configure</source>
-        <target>%nbModules% modules to configure</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/alerts.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="1f39a37212f03c5976e447cb62975024">
-        <source>Modules to configure</source>
-        <target>Modules to configure</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/alerts.html.twig:40</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bd166984f81578eb60b1420587dd9aeb">
-        <source>Bulk action confirmation</source>
-        <target>Bulk action confirmation</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig:30</note>
-      </trans-unit>
-      <trans-unit id="3d42b7bc80c4e9ca72b37f0796f4fe5f">
-        <source>Yes, I want to do it</source>
-        <target>Yes, I want to do it</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig:53</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="27788383c9407ea06c2c275ee21c86c5">
-        <source>Optional: delete module folder after uninstall.</source>
-        <target>Optional: delete module folder after uninstall.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:66</note>
-      </trans-unit>
-      <trans-unit id="16c65b710bd0c33e9439b2603ee6e672">
-        <source>Disable module?</source>
-        <target>Disable module?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:35</note>
-      </trans-unit>
-      <trans-unit id="10ad116a3eb7b6e5382ada40c393102c">
-        <source>Uninstall module?</source>
-        <target>Uninstall module?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="8916ba4927ba1516017e5ddb6409fac0">
-        <source>Reset module?</source>
-        <target>Reset module?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:41</note>
-      </trans-unit>
-      <trans-unit id="8ffc312c0ad3aebfa25b900f353d4650">
-        <source>Yes, disable it</source>
-        <target>Yes, disable it</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:95</note>
-      </trans-unit>
-      <trans-unit id="b8551bde0a3a5cee1ab95a3b64c09863">
-        <source>Yes, uninstall it</source>
-        <target>Yes, uninstall it</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:105</note>
-      </trans-unit>
-      <trans-unit id="ae89782365cf87322e7a400afb448cb5">
-        <source>Yes, reset it</source>
-        <target>Yes, reset it</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:115</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="031f3657c3601889e98df488db139b75">
-        <source>Service by %author%</source>
-        <target>Service by %author%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig:76</note>
-      </trans-unit>
-      <trans-unit id="decbe415d8accca7c2c16d48a79ee934">
-        <source>Read More</source>
-        <target>Read More</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig:91</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2693dd71600631eed47725291fe5da19">
-        <source>v%version% - by %author%</source>
-        <target>v%version% - by %author%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="12b67546923388cd92b5876ae067d283">
-        <source>You do not have module in « %categoryName% ».</source>
-        <target>You do not have module in « %categoryName% ».</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig:29</note>
-      </trans-unit>
-      <trans-unit id="10dc2676c1cfa668956517a07c6405bf">
-        <source>Discover the best-selling modules of this category in the %link% page.</source>
-        <target>Discover the best-selling modules of this category in the %link% page.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1ad8e342d5f04a220e73a90d33d98c2a">
-        <source>Recently Used</source>
-        <target>Recently Used</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories.html.twig:47</note>
-      </trans-unit>
-      <trans-unit id="a6a2a55bea8760389dfca77132905b7c">
-        <source>All Categories</source>
-        <target>All Categories</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories.html.twig:39</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9adfc354d13f70ca8172da3cd2d9c06e">
-        <source>%nbModules% modules and services selected for you</source>
-        <target>%nbModules% modules and services selected for you</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig:29</note>
-      </trans-unit>
-      <trans-unit id="6ff9dd0d34f65181173c1e4bc39939de">
-        <source>Selection</source>
-        <target>Selection</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig:31</note>
-      </trans-unit>
-      <trans-unit id="3d7c1883e8f497290c2aafa2086f49ff">
-        <source>Increasing Price</source>
-        <target>Increasing Price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig:41</note>
-      </trans-unit>
-      <trans-unit id="8e7cce37e14aea45d6d88e8c4aaa1b98">
-        <source>Decreasing Price</source>
-        <target>Decreasing Price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig:42</note>
-      </trans-unit>
-      <trans-unit id="e22269bb51f9f2394e148716babbafbb">
-        <source>Popularity</source>
-        <target>Popularity</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8a8efaec2f6f2bc692ad99b34e2070c9">
-        <source>Show all modules</source>
-        <target>Show all modules</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig:35</note>
-      </trans-unit>
-      <trans-unit id="dfe6e46e2d3e3ba76b5d9aee197c0747">
-        <source>Enabled Modules</source>
-        <target>Enabled Modules</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig:40</note>
-      </trans-unit>
-      <trans-unit id="a0f454ebaee933c7791ffcdda76944b3">
-        <source>Disabled Modules</source>
-        <target>Disabled Modules</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig:45</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_prestatrust.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="80c1f30ef63bc79dd32b654e7b85c112">
-        <source>Module verification</source>
-        <target>Module verification</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_prestatrust.html.twig:30</note>
-      </trans-unit>
-      <trans-unit id="a517747c3d12f99244ae598910d979c5">
-        <source>Author</source>
-        <target>Author</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_prestatrust.html.twig:46</note>
-      </trans-unit>
-      <trans-unit id="249212ebba2907c6087887db076179e6">
-        <source>Back to modules list</source>
-        <target>Back to modules list</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_prestatrust.html.twig:63</note>
-      </trans-unit>
-      <trans-unit id="34afcb42ab73990082d328d9b34811b5">
-        <source>Proceed with the installation</source>
-        <target>Proceed with the installation</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_prestatrust.html.twig:67</note>
-      </trans-unit>
-      <trans-unit id="0c18217e480e74369a0b21d29052574e">
-        <source>Buy module</source>
-        <target>Buy module</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_prestatrust.html.twig:68</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b24ce0cd392a5b0b8dedc66c25213594">
-        <source>Free</source>
-        <target>Free</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:190</note>
-      </trans-unit>
-      <trans-unit id="bc3b3665bd89d8eb6e3c7b0789fa98c5">
-        <source>v%version% by %author%</source>
-        <target>v%version% by %author%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:60</note>
-      </trans-unit>
-      <trans-unit id="3b878279a04dc47d60932cb294d96259">
-        <source>Overview</source>
-        <target>Overview</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:81</note>
-      </trans-unit>
-      <trans-unit id="0f68b904e33d9ac04605aecc958bcf52">
-        <source>Additional information</source>
-        <target>Additional information</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:85</note>
-      </trans-unit>
-      <trans-unit id="e654f7a86a4458b9cd662267e0f29b52">
-        <source>Benefits</source>
-        <target>Benefits</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:90</note>
-      </trans-unit>
-      <trans-unit id="98f770b0af18ca763421bac22b4b6805">
-        <source>Features</source>
-        <target>Features</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:95</note>
-      </trans-unit>
-      <trans-unit id="a5ad64d595144c185c9cf2065162dec3">
-        <source>Demo video</source>
-        <target>Demo video</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:100</note>
-      </trans-unit>
-      <trans-unit id="c49182dc0c7a70b9cd2e10853d9ec6c7">
-        <source>Changelog</source>
-        <target>Changelog</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:105</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="34c81422df0c92bb4d72f8629cc53f03">
-        <source>%nbModules% modules to update</source>
-        <target>%nbModules% modules to update</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="0c81f6a8e4b7b1d0a812d7285289f17d">
-        <source>Modules to update</source>
-        <target>Modules to update</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig:40</note>
-      </trans-unit>
-      <trans-unit id="910144fc8b8d5c1d2cb59cbe5c04a01b">
-        <source>Upgrade All</source>
-        <target>Upgrade All</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig:44</note>
+      <trans-unit id="17e0ca27e686200d42e478e2457052aa">
+        <source>Module notifications</source>
+        <target>Module notifications</target>
+        <note>Line: 57</note>
       </trans-unit>
     </body>
   </file>
@@ -429,112 +204,301 @@ File: src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig:44</no
       <trans-unit id="90406afefae30826692e7f7480f7467c">
         <source>Toggle Dropdown</source>
         <target>Toggle Dropdown</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_file_history.html.twig:86</note>
+        <note>Line: 86</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/configure.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="a785bc36e9e9468712517690ab9b95fb">
-        <source>Check update</source>
-        <target>Check update</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:94</note>
-      </trans-unit>
-      <trans-unit id="db7c4e6b5be6dd888962b943e77b29ee">
-        <source>RTL Module</source>
-        <target>RTL Module</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:102</note>
-      </trans-unit>
-      <trans-unit id="53103fcc4656f55c219b600ded3c7438">
-        <source>Manage hooks</source>
-        <target>Manage hooks</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:109</note>
+      <trans-unit id="2693dd71600631eed47725291fe5da19">
+        <source>v%version% - by %author%</source>
+        <target>v%version% - by %author%</target>
+        <note>Line: 41</note>
       </trans-unit>
     </body>
   </file>
-    <file original="src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_grid_addons.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="e81c2cdc82ffc65ff71448a30970bf2f">
+      <trans-unit id="3aaeb3f0458cf2580c5f75fefdb86ab6">
+        <source>PrestaShop Addons Marketplace</source>
+        <target>PrestaShop Addons Marketplace</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="24a25a6b874647087c51ea00b7992def">
+        <source>Exit to PrestaShop Addons Marketplace</source>
+        <target>Exit to PrestaShop Addons Marketplace</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="754475030b0733378b9347e8f9da8bf9">
+        <source>See all results for your search on</source>
+        <target>See all results for your search on</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="031f3657c3601889e98df488db139b75">
+        <source>Service by %author%</source>
+        <target>Service by %author%</target>
+        <note>Line: 76</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8a8efaec2f6f2bc692ad99b34e2070c9">
+        <source>Show all modules</source>
+        <target>Show all modules</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="dfe6e46e2d3e3ba76b5d9aee197c0747">
+        <source>Enabled Modules</source>
+        <target>Enabled Modules</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="a0f454ebaee933c7791ffcdda76944b3">
+        <source>Disabled Modules</source>
+        <target>Disabled Modules</target>
+        <note>Line: 45</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="12b67546923388cd92b5876ae067d283">
+        <source>You do not have module in « %categoryName% ».</source>
+        <target>You do not have module in « %categoryName% ».</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="10dc2676c1cfa668956517a07c6405bf">
+        <source>Discover the best-selling modules of this category in the %link% page.</source>
+        <target>Discover the best-selling modules of this category in the %link% page.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_recently_used.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1ad8e342d5f04a220e73a90d33d98c2a">
         <source>Recently Used</source>
         <target>Recently Used</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
+        <note>Line: 28</note>
       </trans-unit>
-      <trans-unit id="ec27083a80b8bf3fc0ed8ec10b31a337">
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="16c65b710bd0c33e9439b2603ee6e672">
+        <source>Disable module?</source>
+        <target>Disable module?</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="10ad116a3eb7b6e5382ada40c393102c">
+        <source>Uninstall module?</source>
+        <target>Uninstall module?</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="8916ba4927ba1516017e5ddb6409fac0">
+        <source>Reset module?</source>
+        <target>Reset module?</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="8ffc312c0ad3aebfa25b900f353d4650">
+        <source>Yes, disable it</source>
+        <target>Yes, disable it</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="b8551bde0a3a5cee1ab95a3b64c09863">
+        <source>Yes, uninstall it</source>
+        <target>Yes, uninstall it</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="ae89782365cf87322e7a400afb448cb5">
+        <source>Yes, reset it</source>
+        <target>Yes, reset it</target>
+        <note>Line: 115</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bd166984f81578eb60b1420587dd9aeb">
+        <source>Bulk action confirmation</source>
+        <target>Bulk action confirmation</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="3d42b7bc80c4e9ca72b37f0796f4fe5f">
+        <source>Yes, I want to do it</source>
+        <target>Yes, I want to do it</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="27788383c9407ea06c2c275ee21c86c5">
+        <source>Optional: delete module folder after uninstall.</source>
+        <target>Optional: delete module folder after uninstall.</target>
+        <note>Line: 45</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7c8701c300f85e9799c74e83f4adea64">
+        <source>Drop your module archive here or [1]select file[/1]</source>
+        <target>Drop your module archive here or [1]select file[/1]</target>
+        <note>Line: 51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b24ce0cd392a5b0b8dedc66c25213594">
+        <source>Free</source>
+        <target>Free</target>
+        <note>Line: 190</note>
+      </trans-unit>
+      <trans-unit id="bc3b3665bd89d8eb6e3c7b0789fa98c5">
+        <source>v%version% by %author%</source>
+        <target>v%version% by %author%</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="3b878279a04dc47d60932cb294d96259">
+        <source>Overview</source>
+        <target>Overview</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="0f68b904e33d9ac04605aecc958bcf52">
+        <source>Additional information</source>
+        <target>Additional information</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="e654f7a86a4458b9cd662267e0f29b52">
+        <source>Benefits</source>
+        <target>Benefits</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="98f770b0af18ca763421bac22b4b6805">
+        <source>Features</source>
+        <target>Features</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="a5ad64d595144c185c9cf2065162dec3">
+        <source>Demo video</source>
+        <target>Demo video</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="c49182dc0c7a70b9cd2e10853d9ec6c7">
+        <source>Changelog</source>
+        <target>Changelog</target>
+        <note>Line: 105</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/alerts.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="798f81115f0cdbe07b699cdf392e9408">
+        <source>%nbModules% modules to configure</source>
+        <target>%nbModules% modules to configure</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="1f39a37212f03c5976e447cb62975024">
+        <source>Modules to configure</source>
+        <target>Modules to configure</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7258e7251413465e0a3eb58094430bde">
         <source>Administration</source>
         <target>Administration</target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="e582d103bd28a074278423e12c40b22e">
+      <trans-unit id="181c576d1a34553e320762dd8387e970">
         <source><![CDATA[Design & Navigation]]></source>
         <target><![CDATA[Design & Navigation]]></target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="88239db3724f8d461639153da744d532">
+      <trans-unit id="86a632681202aa019f254fe5b07fc99c">
         <source><![CDATA[Promotions & Marketing]]></source>
         <target><![CDATA[Promotions & Marketing]]></target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="db7e79d107275d433a452ee35d25ba78">
+      <trans-unit id="235e8d1a54ecddcf1d3ff533331ed416">
         <source>Product Page</source>
         <target>Product Page</target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="274eedab4cea78918b89a144a8bb9eaa">
+      <trans-unit id="c453a4b8e8d98e82f35b67f433e3b4da">
         <source>Payment</source>
         <target>Payment</target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="dd5c51359997af51467f2415830edf01">
+      <trans-unit id="8b875b0fceeb6000f40332b9e0c8df36">
         <source><![CDATA[Shipping & Logistics]]></source>
         <target><![CDATA[Shipping & Logistics]]></target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="459fc29b4488e6dd5003189978e7d188">
+      <trans-unit id="064e7103ebd4e57d19783b09f44567fa">
         <source><![CDATA[Traffic & Marketplaces]]></source>
         <target><![CDATA[Traffic & Marketplaces]]></target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="d55c3fa1661004c89e3483e7ddfad894">
+      <trans-unit id="e6d0e1c8fc6a4fcf47869df87e04cd88">
         <source>Customers</source>
         <target>Customers</target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="cee17c454c0e482ba8aed25296acdd6e">
+      <trans-unit id="1e1fb0b2fbc7a713dff01ae9890d3315">
         <source><![CDATA[Facebook & Social Networks]]></source>
         <target><![CDATA[Facebook & Social Networks]]></target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="7db92468983b4faedadd62d4e74636e6">
+      <trans-unit id="2e670c24f60ad3b71edf290bad66ba0e">
         <source>Specialized Platforms</source>
         <target>Specialized Platforms</target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="621953a5fa1ba7aa3f4e7cf0fc46be64">
+      <trans-unit id="f44ba76b3113bb0f0fcbd52ab002e924">
         <source>Theme modules</source>
         <target>Theme modules</target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
       </trans-unit>
-      <trans-unit id="ec6fbb422f684a89c81e9522e87db426">
+      <trans-unit id="6311ae17c1ee52b36e68aaf4ad066387">
         <source>Other</source>
         <target>Other</target>
         <note>Context:
 File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:4</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="34c81422df0c92bb4d72f8629cc53f03">
+        <source>%nbModules% modules to update</source>
+        <target>%nbModules% modules to update</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="0c81f6a8e4b7b1d0a812d7285289f17d">
+        <source>Modules to update</source>
+        <target>Modules to update</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="910144fc8b8d5c1d2cb59cbe5c04a01b">
+        <source>Upgrade All</source>
+        <target>Upgrade All</target>
+        <note>Line: 44</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminModulesHelp.xlf
+++ b/app/Resources/translations/default/AdminModulesHelp.xlf
@@ -5,50 +5,35 @@
       <trans-unit id="5ea77a701ee37e948810656ccde89075">
         <source>Click here to log in.</source>
         <target>Click here to log in.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:810</note>
+        <note>Line: 810</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/alerts.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5117b40edade2ab3a4f738db0542ca03">
-        <source>These modules require your attention: you need to take some action to ensure they are fully operational.</source>
-        <target>These modules require your attention: you need to take some action to ensure they are fully operational.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/alerts.html.twig:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_mbo/views/templates/admin/include/menu_top.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="677b5abd7f9265257543a0f7258bc477">
         <source>Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules.</source>
         <target>Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig:32</note>
+        <note>Line: 55</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_mbo/views/templates/admin/include/modal_import.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="2b11276d6a162d7c1b9894abe5febfdc">
         <source>Please upload one file at a time, .zip or tarball format (.tar, .tar.gz or .tgz).</source>
         <target>Please upload one file at a time, .zip or tarball format (.tar, .tar.gz or .tgz).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig:54</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="e781acd6cefcfbbfce5aa2804d59a4c5">
         <source>Your module will be installed right after that.</source>
         <target>Your module will be installed right after that.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig:55</note>
+        <note>Line: 56</note>
       </trans-unit>
       <trans-unit id="fa692d85f08c92a585ed8b3fed7f1d52">
         <source>What happened?</source>
         <target>What happened?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig:75</note>
+        <note>Line: 78</note>
       </trans-unit>
     </body>
   </file>
@@ -57,8 +42,7 @@ File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.ht
       <trans-unit id="9e3c05bc84491dcd2464d72fae22e6b6">
         <source>Search modules: keyword, name, author...</source>
         <target>Search modules: keyword, name, author...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.twig:68</note>
+        <note>Line: 68</note>
       </trans-unit>
     </body>
   </file>
@@ -67,44 +51,46 @@ File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.t
       <trans-unit id="ba6b1bc4d8bfe5e6e835afa72f102a02">
         <source>You bought this module on PrestaShop Addons. Thank You.</source>
         <target>You bought this module on PrestaShop Addons. Thank You.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="fe5a7fc9d9c907efdf6a384a71cd53fc">
         <source>Bought</source>
         <target>Bought</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="aaf8966ccff4445461fe8bcfab2d318d">
         <source>This module is available on PrestaShop Addons.</source>
         <target>This module is available on PrestaShop Addons.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="2cc1943d4c0b46bfcf503a75c44f988b">
         <source>Popular</source>
         <target>Popular</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="f248df0d4d7e4ae98485c5df8af58945">
         <source>This module is available for free thanks to our partner.</source>
         <target>This module is available for free thanks to our partner.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="0008feba81a131902ece95d59f1b8f21">
         <source>Official</source>
         <target>Official</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="28f60d4760851bab00345a3cb86871f7">
         <source>Need update</source>
         <target>Need update</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig:52</note>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/alerts.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5117b40edade2ab3a4f738db0542ca03">
+        <source>These modules require your attention: you need to take some action to ensure they are fully operational.</source>
+        <target>These modules require your attention: you need to take some action to ensure they are fully operational.</target>
+        <note>Line: 41</note>
       </trans-unit>
     </body>
   </file>
@@ -113,8 +99,7 @@ File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line
       <trans-unit id="94fcfae9285e19b611afe17a8565a394">
         <source>Update these modules to enjoy their latest versions.</source>
         <target>Update these modules to enjoy their latest versions.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig:41</note>
+        <note>Line: 41</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminModulesNotification.xlf
+++ b/app/Resources/translations/default/AdminModulesNotification.xlf
@@ -1,944 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/modules/configuration_bar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="1c1824ce21df05df8689641c516c9d75">
-        <source>This module cannot be loaded.</source>
-        <target>This module cannot be loaded.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php:162</note>
-      </trans-unit>
-      <trans-unit id="0c01b89a049f95e9eb10cfeb2a2901f0">
-        <source>Hook cannot be loaded.</source>
-        <target>Hook cannot be loaded.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php:170</note>
-      </trans-unit>
-      <trans-unit id="c40924509e257aa0e73ccc576bd6b953">
-        <source>An error occurred while deleting the module from its hook.</source>
-        <target>An error occurred while deleting the module from its hook.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php:178</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminModulesPositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="63bc456afcd9d4c6285718e34ee8fed9">
-        <source>This module has already been transplanted to this hook.</source>
-        <target>This module has already been transplanted to this hook.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:86</note>
-      </trans-unit>
-      <trans-unit id="9ce4606635f2118f9d10d1f323f73fe2">
-        <source>This module cannot be transplanted to this hook.</source>
-        <target>This module cannot be transplanted to this hook.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:88</note>
-      </trans-unit>
-      <trans-unit id="0ce2f4a4f40a2d23525b5b02bcfe611f">
-        <source>An error occurred while transplanting the module to its hook.</source>
-        <target>An error occurred while transplanting the module to its hook.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:180</note>
-      </trans-unit>
-      <trans-unit id="b7d38f9dd64d92d6132e0c520a2d68a8">
-        <source>Please select a module to unhook.</source>
-        <target>Please select a module to unhook.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:213</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminModulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="723aac54d8b88c84ca0c9328f3912bf9">
-        <source>There was an error while extracting the module (file may be corrupted).</source>
-        <target>There was an error while extracting the module (file may be corrupted).</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:424</note>
-      </trans-unit>
-      <trans-unit id="2d2c4b710382f05c8cb697187f381f7c">
-        <source>The module %1$s that you uploaded is not a valid module.</source>
-        <target>The module %1$s that you uploaded is not a valid module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:429</note>
-      </trans-unit>
-      <trans-unit id="c09b8da183ec54308a4c59ab1f1ab792">
-        <source>You do not have the permission to use this module.</source>
-        <target>You do not have the permission to use this module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:686</note>
-      </trans-unit>
-      <trans-unit id="7cbb3ce25a6d0abd528dbd744da03e7f">
-        <source>Cannot reset this module.</source>
-        <target>Cannot reset this module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:536</note>
-      </trans-unit>
-      <trans-unit id="d765d45adba914dc9006cc7ec0b2faf5">
-        <source>Cannot install this module.</source>
-        <target>Cannot install this module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:543</note>
-      </trans-unit>
-      <trans-unit id="f973e6a744c0c50d212b7fd1430153f7">
-        <source>Cannot uninstall this module.</source>
-        <target>Cannot uninstall this module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:546</note>
-      </trans-unit>
-      <trans-unit id="08da26423466f4cadc0fd6e201711dcd">
-        <source>Cannot load the module's object.</source>
-        <target>Cannot load the module's object.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:666</note>
-      </trans-unit>
-      <trans-unit id="8969f3823d6bbf4cff9ea8118d8b3ecb">
-        <source>An error occurred while copying the archive to the module directory.</source>
-        <target>An error occurred while copying the archive to the module directory.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:603</note>
-      </trans-unit>
-      <trans-unit id="4654007119386a8ace934133208feed5">
-        <source>Sorry, the module cannot be deleted. Please check if you have the right permissions on this folder.</source>
-        <target>Sorry, the module cannot be deleted. Please check if you have the right permissions on this folder.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:700</note>
-      </trans-unit>
-      <trans-unit id="8875d822d9402acb528eb9c55401a573">
-        <source>You need to be logged in to your PrestaShop Addons account in order to update the %s module. %s</source>
-        <target>You need to be logged in to your PrestaShop Addons account in order to update the %s module. %s</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:806</note>
-      </trans-unit>
-      <trans-unit id="af67db57c79006fd9464c65865f36a44">
-        <source>Module %s cannot be upgraded: Error while downloading the latest version.</source>
-        <target>Module %s cannot be upgraded: Error while downloading the latest version.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:833</note>
-      </trans-unit>
-      <trans-unit id="e6148a0bace3c593e161009060a7da99">
-        <source>Module %s cannot be upgraded: Error while extracting the latest version.</source>
-        <target>Module %s cannot be upgraded: Error while extracting the latest version.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:835</note>
-      </trans-unit>
-      <trans-unit id="408e2019e00a54bbaace8e6ea29a736b">
-        <source>You do not have the rights to update the %s module. Please make sure you are logged in to the PrestaShop Addons account that purchased the module.</source>
-        <target>You do not have the rights to update the %s module. Please make sure you are logged in to the PrestaShop Addons account that purchased the module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:841</note>
-      </trans-unit>
-      <trans-unit id="811c568a06f4f5f038609a98512e9416">
-        <source>You do not have permission to access this module.</source>
-        <target>You do not have permission to access this module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:860</note>
-      </trans-unit>
-      <trans-unit id="81d2521b93f4b3abdc3877f76e04005a">
-        <source>You do not have permission to install this module.</source>
-        <target>You do not have permission to install this module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:864</note>
-      </trans-unit>
-      <trans-unit id="d7569980257d11fbd66deb501f5efab8">
-        <source>You do not have permission to delete this module.</source>
-        <target>You do not have permission to delete this module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:866</note>
-      </trans-unit>
-      <trans-unit id="5a69d1cb0ef4096b272b3b441555d737">
-        <source>You do not have permission to configure this module.</source>
-        <target>You do not have permission to configure this module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:868</note>
-      </trans-unit>
-      <trans-unit id="2c465b2a1769653563dcacfc83ab61d0">
-        <source>This module is already installed: %s.</source>
-        <target>This module is already installed: %s.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:870</note>
-      </trans-unit>
-      <trans-unit id="0ec73cc5b2910764fc221acb633c20bc">
-        <source>This module has already been uninstalled: %s.</source>
-        <target>This module has already been uninstalled: %s.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:872</note>
-      </trans-unit>
-      <trans-unit id="ee043fd10baac04e50a4256d7406e93c">
-        <source>This module needs to be installed in order to be updated: %s.</source>
-        <target>This module needs to be installed in order to be updated: %s.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:874</note>
-      </trans-unit>
-      <trans-unit id="4e03a50f18350f93b8ec321b488a4a8c">
-        <source>You do not have permission to uninstall this module.</source>
-        <target>You do not have permission to uninstall this module.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:898</note>
-      </trans-unit>
-      <trans-unit id="d3c1a921b833767f27ffcc401a87d93b">
-        <source>The following module(s) could not be uninstalled properly: %s.</source>
-        <target>The following module(s) could not be uninstalled properly: %s.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:1037</note>
-      </trans-unit>
-      <trans-unit id="89bbb6a140e2fc5ff52b2211083a2721">
-        <source>The following module(s) could not be installed properly: %s.</source>
-        <target>The following module(s) could not be installed properly: %s.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:1039</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Validate.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8095c31813f8e77d292bf6bec964169b">
-        <source>Unknown archive type.</source>
-        <target>Unknown archive type.</target>
-        <note>Context:
-File: classes/Validate.php:66</note>
-      </trans-unit>
-      <trans-unit id="f996dce5bdfb1b1094e41cf996c5fdae">
-        <source>Please specify module URL</source>
-        <target>Please specify module URL</target>
-        <note>Context:
-File: classes/Validate.php:64</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Addon/Module/ModuleRepository.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a3214c22fd9d21c988d9bb06748d6d9f">
-        <source>Parse error on module %module%. %error_details%</source>
-        <target>Parse error on module %module%. %error_details%</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleRepository.php:385</note>
-      </trans-unit>
-      <trans-unit id="bcc1e7daae2727b6d7a32567086cd84f">
-        <source>Unexpected exception on module %module%. %error_details%</source>
-        <target>Unexpected exception on module %module%. %error_details%</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleRepository.php:396</note>
-      </trans-unit>
-      <trans-unit id="9fcc3446d55e632b5f3ca13fc810c83b">
-        <source>Loading data from Addons failed. %error_details%</source>
-        <target>Loading data from Addons failed. %error_details%</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleRepository.php:444</note>
-      </trans-unit>
-      <trans-unit id="0554e4a4ddb313c3962088dc32647e90">
-        <source>Parse error detected in module %module%. %error_details%.</source>
-        <target>Parse error detected in module %module%. %error_details%.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleRepository.php:569</note>
-      </trans-unit>
-      <trans-unit id="40e7db035e09d8f198b96a7d5d9e821f">
-        <source>Exception detected while loading module %module%. %error_details%.</source>
-        <target>Exception detected while loading module %module%. %error_details%.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleRepository.php:577</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Addon/Module/ModuleManager.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f2715f72988009e4f50e94d88b3df89f">
-        <source>You are not allowed to install modules.</source>
-        <target>You are not allowed to install modules.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:267</note>
-      </trans-unit>
-      <trans-unit id="21f1ba3ca9bb026443f8dea1127f2f0b">
-        <source>You are not allowed to uninstall the module %module%.</source>
-        <target>You are not allowed to uninstall the module %module%.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:316</note>
-      </trans-unit>
-      <trans-unit id="ea328981d19b5b379639f915341bc4ad">
-        <source>You are not allowed to upgrade the module %module%.</source>
-        <target>You are not allowed to upgrade the module %module%.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:355</note>
-      </trans-unit>
-      <trans-unit id="87c10be2be869072e9d1e7cbca858445">
-        <source>You are not allowed to disable the module %module%.</source>
-        <target>You are not allowed to disable the module %module%.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:398</note>
-      </trans-unit>
-      <trans-unit id="b58f4b4f4f870b40e52c42c161df0d60">
-        <source>Error when disabling module %module%. %error_details%.</source>
-        <target>Error when disabling module %module%. %error_details%.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:415</note>
-      </trans-unit>
-      <trans-unit id="42874189778a946c2a51911076474ad4">
-        <source>You are not allowed to enable the module %module%.</source>
-        <target>You are not allowed to enable the module %module%.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:444</note>
-      </trans-unit>
-      <trans-unit id="fbaf1c9434442c780f3eddff4406603c">
-        <source>Error when enabling module %module%. %error_details%.</source>
-        <target>Error when enabling module %module%. %error_details%.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:461</note>
-      </trans-unit>
-      <trans-unit id="9fa7ea0487a785b31f48977415f3324a">
-        <source>You are not allowed to disable the module %module% on mobile.</source>
-        <target>You are not allowed to disable the module %module% on mobile.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:505</note>
-      </trans-unit>
-      <trans-unit id="976dc5c6fc2fe73b2c43c7776847e593">
-        <source>Error when disabling module %module% on mobile. %error_details%</source>
-        <target>Error when disabling module %module% on mobile. %error_details%</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:522</note>
-      </trans-unit>
-      <trans-unit id="c74f0e8fe4da4e6dcb5a051f0eef1ec3">
-        <source>You are not allowed to enable the module %module% on mobile.</source>
-        <target>You are not allowed to enable the module %module% on mobile.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:563</note>
-      </trans-unit>
-      <trans-unit id="416bc5074d9b9944a51797b081492442">
-        <source>Error when enabling module %module% on mobile. %error_details%</source>
-        <target>Error when enabling module %module% on mobile. %error_details%</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:580</note>
-      </trans-unit>
-      <trans-unit id="e65dccd7380f1af807453a7afdf3f427">
-        <source>You are not allowed to reset the module %module%.</source>
-        <target>You are not allowed to reset the module %module%.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:605</note>
-      </trans-unit>
-      <trans-unit id="387aeee114093679248f936ba36ee416">
-        <source>Error when resetting module %module%. %error_details%</source>
-        <target>Error when resetting module %module%. %error_details%</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:628</note>
-      </trans-unit>
-      <trans-unit id="c111e1387c9a6c5c98635ecdbbcb26af">
-        <source>The module is invalid and cannot be loaded.</source>
-        <target>The module is invalid and cannot be loaded.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:696</note>
-      </trans-unit>
-      <trans-unit id="c913de38eb118ce08ddae76f27063126">
-        <source>Unfortunately, the module did not return additional details.</source>
-        <target>Unfortunately, the module did not return additional details.</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:704</note>
-      </trans-unit>
-      <trans-unit id="83a812de8784135990c57d25d0f9b34b">
-        <source>The module %module% must be installed first</source>
-        <target>The module %module% must be installed first</target>
-        <note>Context:
-File: src/Core/Addon/Module/ModuleManager.php:729</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1ff626f78b7506f340c7b2ce3398367a">
-        <source>Cannot %action% module %module%. %error_details%</source>
-        <target>Cannot %action% module %module%. %error_details%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:400</note>
-      </trans-unit>
-      <trans-unit id="9dca2e42fe7a0db763b8737e9a8f9133">
-        <source>%action% action on module %module% succeeded.</source>
-        <target>%action% action on module %module% succeeded.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:410</note>
-      </trans-unit>
-      <trans-unit id="385b04e1b2442530341b51c2d3b216a3">
-        <source>Cannot get catalog data, please try again later. Reason: %error_details%</source>
-        <target>Cannot get catalog data, please try again later. Reason: %error_details%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:337</note>
-      </trans-unit>
-      <trans-unit id="71d827dd0d049981403f27fb7af0991c">
-        <source>%module% did not return a valid response on %action% action.</source>
-        <target>%module% did not return a valid response on %action% action.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:390</note>
-      </trans-unit>
-      <trans-unit id="8e7e1a7e5fa9edcd7139f569d07fc5b9">
-        <source>Confirmation needed by module %module% on %action% (%subject%).</source>
-        <target>Confirmation needed by module %module% on %action% (%subject%).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:582</note>
-      </trans-unit>
-      <trans-unit id="bf0edb2da5a51620141bff55d3060a63">
-        <source>Exception thrown by module %module% on %action%. %error_details%</source>
-        <target>Exception thrown by module %module% on %action%. %error_details%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:449</note>
-      </trans-unit>
-      <trans-unit id="89d371deca1b2b50a933fabc8005ccfb">
-        <source>%module% did not return a valid response on installation.</source>
-        <target>%module% did not return a valid response on installation.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:548</note>
-      </trans-unit>
-      <trans-unit id="35e839bc1864dd50a75500028c3ebb33">
-        <source>Installation of module %module% was successful.</source>
-        <target>Installation of module %module% was successful.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:554</note>
-      </trans-unit>
-      <trans-unit id="f52c6f7b6fcbd586aee22044aeb6c897">
-        <source>Installation of module %module% failed. %error%</source>
-        <target>Installation of module %module% failed. %error%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:565</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Module/ModuleZipManager.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="08859ef1a837ae429ff2e4decc952cbe">
-        <source>Unable to find uploaded module at the following path: %file%</source>
-        <target>Unable to find uploaded module at the following path: %file%</target>
-        <note>Context:
-File: src/Adapter/Module/ModuleZipManager.php:98</note>
-      </trans-unit>
-      <trans-unit id="848578a1a363f2c2443b3989154bf646">
-        <source>Cannot extract module in %path% to get its name. %error%</source>
-        <target>Cannot extract module in %path% to get its name. %error%</target>
-        <note>Context:
-File: src/Adapter/Module/ModuleZipManager.php:108</note>
-      </trans-unit>
-      <trans-unit id="a85499f3d020141df9b6203b7585a9bf">
-        <source>This file does not seem to be a valid module zip</source>
-        <target>This file does not seem to be a valid module zip</target>
-        <note>Context:
-File: src/Adapter/Module/ModuleZipManager.php:147</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Module/ModuleDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="429cc2fb9f1cb16782b0af5ba748096d">
-        <source>Parse error detected in main class of module %module%!</source>
-        <target>Parse error detected in main class of module %module%!</target>
-        <note>Context:
-File: src/Adapter/Module/ModuleDataProvider.php:213</note>
-      </trans-unit>
-      <trans-unit id="e03545a6c414502e72d232b4c30d9fdd">
-        <source>Error while loading file of module %module%. %error_message%</source>
-        <target>Error while loading file of module %module%. %error_message%</target>
-        <note>Context:
-File: src/Adapter/Module/ModuleDataProvider.php:232</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Module/Tab/ModuleTabUnregister.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e85403d2e654955b45105b9929924c89">
-        <source>Failed to uninstall admin tab "%name%".</source>
-        <target>Failed to uninstall admin tab "%name%".</target>
-        <note>Context:
-File: src/Adapter/Module/Tab/ModuleTabUnregister.php:102</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Module/Tab/ModuleTabRegister.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ee34aeaa570c9f1c206b8401d6eaa58d">
-        <source>Failed to install admin tab "%name%".</source>
-        <target>Failed to install admin tab "%name%".</target>
-        <note>Context:
-File: src/Adapter/Module/Tab/ModuleTabRegister.php:280</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Command/ModuleCommand.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6867740141667a3da88ac51e48ed1d9d">
-        <source>Unknown module action. It must be one of these values: %actions%</source>
-        <target>Unknown module action. It must be one of these values: %actions%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Command/ModuleCommand.php:98</note>
-      </trans-unit>
-      <trans-unit id="e92af04f3580fee9164214abd4b621a4">
-        <source>Validation of configuration details failed:</source>
-        <target>Validation of configuration details failed:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Command/ModuleCommand.php:128</note>
-      </trans-unit>
-      <trans-unit id="87167266fbdef818ec8508ea125915aa">
-        <source>Configuration successfully applied.</source>
-        <target>Configuration successfully applied.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Command/ModuleCommand.php:140</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fc7da9518fbe20ebcaccbf5f8fd0e7df">
-        <source>Synchronized with Addons marketplace!</source>
-        <target>Synchronized with Addons marketplace!</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php:112</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="80e868e8d753c3ec4066aab283e66cbc">
-        <source>The module was successfully removed from the hook.</source>
-        <target>The module was successfully removed from the hook.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:470</note>
-      </trans-unit>
-      <trans-unit id="980b6caee06822f8c5df45eb7db277be">
-        <source>The module transplanted successfully to the hook.</source>
-        <target>The module transplanted successfully to the hook.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:469</note>
-      </trans-unit>
-      <trans-unit id="9bbf45a624c880d590d7b6796e5a7a9c">
-        <source>The module was successfully downloaded.</source>
-        <target>The module was successfully downloaded.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:461</note>
-      </trans-unit>
-      <trans-unit id="6832d3339f3238558d9e290f4ff36bb8">
-        <source>Module(s) installed successfully.</source>
-        <target>Module(s) installed successfully.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:465</note>
-      </trans-unit>
-      <trans-unit id="0be078b247fde4986e320cd2684e7ab9">
-        <source>Module(s) uninstalled successfully.</source>
-        <target>Module(s) uninstalled successfully.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:466</note>
-      </trans-unit>
-      <trans-unit id="7f31b58c32d9112f9bb160a481f6a911">
-        <source>Module reset successfully.</source>
-        <target>Module reset successfully.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:474</note>
-      </trans-unit>
-      <trans-unit id="3270965aab0523dca0351cefc83e40b0">
-        <source>Module deleted successfully.</source>
-        <target>Module deleted successfully.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:475</note>
-      </trans-unit>
-      <trans-unit id="35a596598c0477aea67abfa33b053697">
-        <source>Successfully signed in to PrestaShop Addons.</source>
-        <target>Successfully signed in to PrestaShop Addons.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:485</note>
-      </trans-unit>
-      <trans-unit id="cf28eac3f0fdd7e3d2d705282948f2b9">
-        <source>Error found : %1$s in country_module_list.xml file.</source>
-        <target>Error found : %1$s in country_module_list.xml file.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:2229</note>
-      </trans-unit>
-      <trans-unit id="ce7d2844bfe39db351171add1d7348cd">
-        <source>Error found : %1$s in must_have_module_list.xml file.</source>
-        <target>Error found : %1$s in must_have_module_list.xml file.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:2244</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/module/ModuleGraph.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cb20447a4bf5ff9bec717ec68a357a93">
-        <source>No graph engine selected</source>
-        <target>No graph engine selected</target>
-        <note>Context:
-File: classes/module/ModuleGraph.php:278</note>
-      </trans-unit>
-      <trans-unit id="a78ac92432df02a17a667fdc15764454">
-        <source>Graph engine selected is unavailable.</source>
-        <target>Graph engine selected is unavailable.</target>
-        <note>Context:
-File: classes/module/ModuleGraph.php:284</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/module/Module.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cda10a1476bc741e9cec7b0a4fd2cb7d">
-        <source>Unable to install the module (Module name is not valid).</source>
-        <target>Unable to install the module (Module name is not valid).</target>
-        <note>Context:
-File: classes/module/Module.php:339</note>
-      </trans-unit>
-      <trans-unit id="5a6d75d2128c9e038623b0eecbf70cfb">
-        <source>The version of your module is not compliant with your PrestaShop version.</source>
-        <target>The version of your module is not compliant with your PrestaShop version.</target>
-        <note>Context:
-File: classes/module/Module.php:346</note>
-      </trans-unit>
-      <trans-unit id="bdc79db372bbf5800052e41b5dbab04c">
-        <source>Before installing this module, you have to install this/these module(s) first:</source>
-        <target>Before installing this module, you have to install this/these module(s) first:</target>
-        <note>Context:
-File: classes/module/Module.php:355</note>
-      </trans-unit>
-      <trans-unit id="7ae364c250c9b28880e13e2c4edae218">
-        <source>This module has already been installed.</source>
-        <target>This module has already been installed.</target>
-        <note>Context:
-File: classes/module/Module.php:369</note>
-      </trans-unit>
-      <trans-unit id="4c15c8d9982596e224487cab7b4d51f5">
-        <source>Could not install module controllers.</source>
-        <target>Could not install module controllers.</target>
-        <note>Context:
-File: classes/module/Module.php:375</note>
-      </trans-unit>
-      <trans-unit id="5bd632bbdcdfb6aece20bdf1ae8fea52">
-        <source>Technical error: PrestaShop could not install this module.</source>
-        <target>Technical error: PrestaShop could not install this module.</target>
-        <note>Context:
-File: classes/module/Module.php:384</note>
-      </trans-unit>
-      <trans-unit id="071fd3819a08e165553f33babf3dc334">
-        <source>Current version: %s</source>
-        <target>Current version: %s</target>
-        <note>Context:
-File: classes/module/Module.php:455</note>
-      </trans-unit>
-      <trans-unit id="05ded2ffdbd90e0471135709e1174d23">
-        <source>%d file upgrade applied</source>
-        <target>%d file upgrade applied</target>
-        <note>Context:
-File: classes/module/Module.php:456</note>
-      </trans-unit>
-      <trans-unit id="c909cdf836f5769c5ab8b709220c1488">
-        <source>No upgrade has been applied</source>
-        <target>No upgrade has been applied</target>
-        <note>Context:
-File: classes/module/Module.php:459</note>
-      </trans-unit>
-      <trans-unit id="d9ba34f2df7e39d1c5c0d8feb6fc951a">
-        <source>Upgraded from: %s to %s</source>
-        <target>Upgraded from: %s to %s</target>
-        <note>Context:
-File: classes/module/Module.php:461</note>
-      </trans-unit>
-      <trans-unit id="7a4a33538734a49e1136547dea5792df">
-        <source>%d upgrade left</source>
-        <target>%d upgrade left</target>
-        <note>Context:
-File: classes/module/Module.php:462</note>
-      </trans-unit>
-      <trans-unit id="a448cf0c04e337b9ca99cf83c5afb183">
-        <source>Module %s cannot be upgraded this time: please refresh this page to update it.</source>
-        <target>Module %s cannot be upgraded this time: please refresh this page to update it.</target>
-        <note>Context:
-File: classes/module/Module.php:466</note>
-      </trans-unit>
-      <trans-unit id="f79dcf8179bb9d8fa72d169f71702b44">
-        <source>To prevent any problem, this module has been turned off</source>
-        <target>To prevent any problem, this module has been turned off</target>
-        <note>Context:
-File: classes/module/Module.php:468</note>
-      </trans-unit>
-      <trans-unit id="4762b130ddcc0e4d2eacf0c59a8b17a2">
-        <source>The module is not installed.</source>
-        <target>The module is not installed.</target>
-        <note>Context:
-File: classes/module/Module.php:679</note>
-      </trans-unit>
-      <trans-unit id="6869dc1977dbff7c5749120241f74ff0">
-        <source>Unable to install override: %s</source>
-        <target>Unable to install override: %s</target>
-        <note>Context:
-File: classes/module/Module.php:795</note>
-      </trans-unit>
-      <trans-unit id="e8f98f4457c87a8aad1d4d625ad1a9f3">
-        <source>%1$s is not a valid module name.</source>
-        <target>%1$s is not a valid module name.</target>
-        <note>Context:
-File: classes/module/Module.php:1105</note>
-      </trans-unit>
-      <trans-unit id="8f62a26bf441ad698c2c562ec10448c4">
-        <source>All modules cannot be loaded due to memory limit restrictions, please increase your memory_limit value on your server configuration</source>
-        <target>All modules cannot be loaded due to memory limit restrictions, please increase your memory_limit value on your server configuration</target>
-        <note>Context:
-File: classes/module/Module.php:1457</note>
-      </trans-unit>
-      <trans-unit id="2cff6a926907204ad5c1916ba96ed815">
-        <source>%s could not be loaded.</source>
-        <target>%s could not be loaded.</target>
-        <note>Context:
-File: classes/module/Module.php:1295</note>
-      </trans-unit>
-      <trans-unit id="db0275528fda19c75f79d296ded0c6e7">
-        <source>Error found in config file:</source>
-        <target>Error found in config file:</target>
-        <note>Context:
-File: classes/module/Module.php:1302</note>
-      </trans-unit>
-      <trans-unit id="f9c47597596f7159815c61957f4f8ec2">
-        <source>%1$s (parse error in %2$s)</source>
-        <target>%1$s (parse error in %2$s)</target>
-        <note>Context:
-File: classes/module/Module.php:1356</note>
-      </trans-unit>
-      <trans-unit id="8014d5d92e09a563588869c623bd0abf">
-        <source>%1$s (class missing in %2$s)</source>
-        <target>%1$s (class missing in %2$s)</target>
-        <note>Context:
-File: classes/module/Module.php:1423</note>
-      </trans-unit>
-      <trans-unit id="a0b8a508d6ca8113e6439f623e7bf7cf">
-        <source>The following module(s) could not be loaded</source>
-        <target>The following module(s) could not be loaded</target>
-        <note>Context:
-File: classes/module/Module.php:1568</note>
-      </trans-unit>
-      <trans-unit id="ed6daad0747953284ea086d8cc5652de">
-        <source>Trusted and Untrusted XML have not been generated properly</source>
-        <target>Trusted and Untrusted XML have not been generated properly</target>
-        <note>Context:
-File: classes/module/Module.php:1868</note>
-      </trans-unit>
-      <trans-unit id="eddeabd79f8ca673d888fa2ffe9cf69a">
-        <source>No template found for module</source>
-        <target>No template found for module</target>
-        <note>Context:
-File: classes/module/Module.php:2363</note>
-      </trans-unit>
-      <trans-unit id="45e26faecce815f7e1ac16b32ac5278e">
-        <source>The method %1$s in the class %2$s is already overridden by the module %3$s version %4$s at %5$s.</source>
-        <target>The method %1$s in the class %2$s is already overridden by the module %3$s version %4$s at %5$s.</target>
-        <note>Context:
-File: classes/module/Module.php:2991</note>
-      </trans-unit>
-      <trans-unit id="03c32a7a2568d41e186d59293b02f662">
-        <source>The method %1$s in the class %2$s is already overridden.</source>
-        <target>The method %1$s in the class %2$s is already overridden.</target>
-        <note>Context:
-File: classes/module/Module.php:2993</note>
-      </trans-unit>
-      <trans-unit id="71bf68c93ca29a72a3a5080a30e20ecc">
-        <source>Failed to override method %1$s in class %2$s.</source>
-        <target>Failed to override method %1$s in class %2$s.</target>
-        <note>Context:
-File: classes/module/Module.php:3060</note>
-      </trans-unit>
-      <trans-unit id="a08302edbf2d9f7ddd43ae8bd1de5caa">
-        <source>The property %1$s in the class %2$s is already defined.</source>
-        <target>The property %1$s in the class %2$s is already defined.</target>
-        <note>Context:
-File: classes/module/Module.php:3005</note>
-      </trans-unit>
-      <trans-unit id="7893f5f2917811b37c628f787c83af8a">
-        <source>Failed to override property %1$s in class %2$s.</source>
-        <target>Failed to override property %1$s in class %2$s.</target>
-        <note>Context:
-File: classes/module/Module.php:3068</note>
-      </trans-unit>
-      <trans-unit id="6f89d5bc3c94e885d4a3716accc12983">
-        <source>The constant %1$s in the class %2$s is already defined.</source>
-        <target>The constant %1$s in the class %2$s is already defined.</target>
-        <note>Context:
-File: classes/module/Module.php:3016</note>
-      </trans-unit>
-      <trans-unit id="d27626d5c768d3782dcc6343e8a0c0f6">
-        <source>Failed to override constant %1$s in class %2$s.</source>
-        <target>Failed to override constant %1$s in class %2$s.</target>
-        <note>Context:
-File: classes/module/Module.php:3076</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/module/ModuleGrid.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ccacacd12f75e1ab3f9ce3e234ed5777">
-        <source>No grid engine selected</source>
-        <target>No grid engine selected</target>
-        <note>Context:
-File: classes/module/ModuleGrid.php:99</note>
-      </trans-unit>
-      <trans-unit id="b7be351a5a41ea3d022dc18f5f16239a">
-        <source>Grid engine selected is unavailable.</source>
-        <target>Grid engine selected is unavailable.</target>
-        <note>Context:
-File: classes/module/ModuleGrid.php:105</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a7f0cf21776c1a6ed951c58620b4507a">
-        <source>You are about to [1] the following modules:</source>
-        <target>You are about to [1] the following modules:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig:37</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fca2f02b01daced572256506d1054f4a">
-        <source>No changelog provided</source>
-        <target>No changelog provided</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig:47</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="df776a9024ce6c10ec1d1d763cee0301">
-        <source>You are about to log out your Addons account. You might miss important updates of Addons you've bought.</source>
-        <target>You are about to log out your Addons account. You might miss important updates of Addons you've bought.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_addons_connect.html.twig:90</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b8e063d2ad26dfc0a659410294caf74b">
-        <source>You are about to disable %moduleName% module.</source>
-        <target>You are about to disable %moduleName% module.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="c5209889e18199fb2a2c50958d3212b8">
-        <source>Your current settings will be saved, but the module will no longer be active.</source>
-        <target>Your current settings will be saved, but the module will no longer be active.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:55</note>
-      </trans-unit>
-      <trans-unit id="eb641425b425f906c54cb55319ec3e25">
-        <source>You are about to uninstall %moduleName% module.</source>
-        <target>You are about to uninstall %moduleName% module.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:58</note>
-      </trans-unit>
-      <trans-unit id="db0769970bbd476188bfc1c5d9d6a2bd">
-        <source>This will disable the module and delete all its files. For good.</source>
-        <target>This will disable the module and delete all its files. For good.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:63</note>
-      </trans-unit>
-      <trans-unit id="36fbfc01d63e4b57d18991077535c6e0">
-        <source>This action cannot be undone.</source>
-        <target>This action cannot be undone.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:80</note>
-      </trans-unit>
-      <trans-unit id="634b5d0d5ec8e481321b1d776f312388">
-        <source>You're about to reset %moduleName% module.</source>
-        <target>You're about to reset %moduleName% module.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:74</note>
-      </trans-unit>
-      <trans-unit id="58ce7123c3789e3c51cb3ffd42883df1">
-        <source>This will restore the defaults settings.</source>
-        <target>This will restore the defaults settings.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig:77</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="87ad4793c12c9f9e5d56cc81386f77b8">
-        <source>No description found for this module :(</source>
-        <target>No description found for this module :(</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:118</note>
-      </trans-unit>
-      <trans-unit id="a76e4258e8695991d6f5f62efdba70d6">
-        <source>No additional description provided for this module :(</source>
-        <target>No additional description provided for this module :(</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:128</note>
-      </trans-unit>
-      <trans-unit id="1ed02f805424aac96756b590d51e2038">
-        <source>No feature list provided for this module :(</source>
-        <target>No feature list provided for this module :(</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:138</note>
-      </trans-unit>
-      <trans-unit id="f2a854a84903f5f29c0b7a40ccbf4ee5">
-        <source>No customer benefits notes found for this module :(</source>
-        <target>No customer benefits notes found for this module :(</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:148</note>
-      </trans-unit>
-      <trans-unit id="94d27c2e2294ddfe66621b814f2ac3e0">
-        <source>No demonstration video found for this module :(</source>
-        <target>No demonstration video found for this module :(</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:158</note>
-      </trans-unit>
-      <trans-unit id="3072d199d2a0269893376e8c7d0049d6">
-        <source>No changelog provided for this module :(</source>
-        <target>No changelog provided for this module :(</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig:176</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c3dbf8925ec4c77ef5317e1e27317b70">
-        <source>Installing module...</source>
-        <target>Installing module...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig:61</note>
-      </trans-unit>
-      <trans-unit id="a26f56145fea2d3af35bf0d6ac83c28a">
-        <source>It will close as soon as the module is installed. It won't be long!</source>
-        <target>It will close as soon as the module is installed. It won't be long!</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig:63</note>
-      </trans-unit>
-      <trans-unit id="f48a5ae14fa2b0c85442d1199a08b3b4">
-        <source>Module installed!</source>
-        <target>Module installed!</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig:68</note>
-      </trans-unit>
-      <trans-unit id="824e2fcb263ee94399a6a261ee1ec7c1">
-        <source>Oops... Upload failed.</source>
-        <target>Oops... Upload failed.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig:74</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="634ec4fb81df959627996a95fa0e799c">
-        <source>You need to select at least one module to use the bulk action.</source>
-        <target>You need to select at least one module to use the bulk action.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:67</note>
-      </trans-unit>
-      <trans-unit id="09f9472ec012d502e9cc3ab0e31c24e8">
-        <source>The action "[1]" is not available, impossible to perform your request.</source>
-        <target>The action "[1]" is not available, impossible to perform your request.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:68</note>
-      </trans-unit>
-      <trans-unit id="6e37e943fed80ec5f0629bbea4c81e1a">
-        <source>The action [1] is not available for module [2]. Skipped.</source>
-        <target>The action [1] is not available for module [2]. Skipped.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:69</note>
+      <trans-unit id="74b5807fcdcf929e5f827d32e8af0524">
+        <source>Activate module for this shop context: %s.</source>
+        <target>Activate module for this shop context: %s.</target>
+        <note>Line: 33</note>
       </trans-unit>
     </body>
   </file>
@@ -947,36 +14,410 @@ File: src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig:69</not
       <trans-unit id="c0d19e251d0ff55ecb860e7349f779a4">
         <source>Confirm reset</source>
         <target>Confirm reset</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="45e06e5610d29d675a875a6f7731b73d">
         <source>Would you like to delete the content related to this module ?</source>
         <target>Would you like to delete the content related to this module ?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:51</note>
+        <note>Line: 51</note>
       </trans-unit>
       <trans-unit id="d65c99010166606287266e4af4f0b934">
         <source>No - reset only the parameters</source>
         <target>No - reset only the parameters</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:52</note>
+        <note>Line: 52</note>
       </trans-unit>
       <trans-unit id="0426ba52f94430cf093652d1ea18fedf">
         <source>Yes - reset everything</source>
         <target>Yes - reset everything</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:53</note>
+        <note>Line: 53</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/configuration_bar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/Validate.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="74b5807fcdcf929e5f827d32e8af0524">
-        <source>Activate module for this shop context: %s.</source>
-        <target>Activate module for this shop context: %s.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configuration_bar.tpl:33</note>
+      <trans-unit id="f996dce5bdfb1b1094e41cf996c5fdae">
+        <source>Please specify module URL</source>
+        <target>Please specify module URL</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9bbf45a624c880d590d7b6796e5a7a9c">
+        <source>The module was successfully downloaded.</source>
+        <target>The module was successfully downloaded.</target>
+        <note>Line: 461</note>
+      </trans-unit>
+      <trans-unit id="6832d3339f3238558d9e290f4ff36bb8">
+        <source>Module(s) installed successfully.</source>
+        <target>Module(s) installed successfully.</target>
+        <note>Line: 465</note>
+      </trans-unit>
+      <trans-unit id="0be078b247fde4986e320cd2684e7ab9">
+        <source>Module(s) uninstalled successfully.</source>
+        <target>Module(s) uninstalled successfully.</target>
+        <note>Line: 466</note>
+      </trans-unit>
+      <trans-unit id="7f31b58c32d9112f9bb160a481f6a911">
+        <source>Module reset successfully.</source>
+        <target>Module reset successfully.</target>
+        <note>Line: 474</note>
+      </trans-unit>
+      <trans-unit id="3270965aab0523dca0351cefc83e40b0">
+        <source>Module deleted successfully.</source>
+        <target>Module deleted successfully.</target>
+        <note>Line: 475</note>
+      </trans-unit>
+      <trans-unit id="35a596598c0477aea67abfa33b053697">
+        <source>Successfully signed in to PrestaShop Addons.</source>
+        <target>Successfully signed in to PrestaShop Addons.</target>
+        <note>Line: 485</note>
+      </trans-unit>
+      <trans-unit id="cf28eac3f0fdd7e3d2d705282948f2b9">
+        <source>Error found : %1$s in country_module_list.xml file.</source>
+        <target>Error found : %1$s in country_module_list.xml file.</target>
+        <note>Line: 2229</note>
+      </trans-unit>
+      <trans-unit id="ce7d2844bfe39db351171add1d7348cd">
+        <source>Error found : %1$s in must_have_module_list.xml file.</source>
+        <target>Error found : %1$s in must_have_module_list.xml file.</target>
+        <note>Line: 2244</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/module/Module.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cda10a1476bc741e9cec7b0a4fd2cb7d">
+        <source>Unable to install the module (Module name is not valid).</source>
+        <target>Unable to install the module (Module name is not valid).</target>
+        <note>Line: 339</note>
+      </trans-unit>
+      <trans-unit id="5a6d75d2128c9e038623b0eecbf70cfb">
+        <source>The version of your module is not compliant with your PrestaShop version.</source>
+        <target>The version of your module is not compliant with your PrestaShop version.</target>
+        <note>Line: 346</note>
+      </trans-unit>
+      <trans-unit id="bdc79db372bbf5800052e41b5dbab04c">
+        <source>Before installing this module, you have to install this/these module(s) first:</source>
+        <target>Before installing this module, you have to install this/these module(s) first:</target>
+        <note>Line: 355</note>
+      </trans-unit>
+      <trans-unit id="7ae364c250c9b28880e13e2c4edae218">
+        <source>This module has already been installed.</source>
+        <target>This module has already been installed.</target>
+        <note>Line: 369</note>
+      </trans-unit>
+      <trans-unit id="4c15c8d9982596e224487cab7b4d51f5">
+        <source>Could not install module controllers.</source>
+        <target>Could not install module controllers.</target>
+        <note>Line: 375</note>
+      </trans-unit>
+      <trans-unit id="5bd632bbdcdfb6aece20bdf1ae8fea52">
+        <source>Technical error: PrestaShop could not install this module.</source>
+        <target>Technical error: PrestaShop could not install this module.</target>
+        <note>Line: 384</note>
+      </trans-unit>
+      <trans-unit id="071fd3819a08e165553f33babf3dc334">
+        <source>Current version: %s</source>
+        <target>Current version: %s</target>
+        <note>Line: 455</note>
+      </trans-unit>
+      <trans-unit id="05ded2ffdbd90e0471135709e1174d23">
+        <source>%d file upgrade applied</source>
+        <target>%d file upgrade applied</target>
+        <note>Line: 456</note>
+      </trans-unit>
+      <trans-unit id="c909cdf836f5769c5ab8b709220c1488">
+        <source>No upgrade has been applied</source>
+        <target>No upgrade has been applied</target>
+        <note>Line: 459</note>
+      </trans-unit>
+      <trans-unit id="d9ba34f2df7e39d1c5c0d8feb6fc951a">
+        <source>Upgraded from: %s to %s</source>
+        <target>Upgraded from: %s to %s</target>
+        <note>Line: 461</note>
+      </trans-unit>
+      <trans-unit id="7a4a33538734a49e1136547dea5792df">
+        <source>%d upgrade left</source>
+        <target>%d upgrade left</target>
+        <note>Line: 462</note>
+      </trans-unit>
+      <trans-unit id="a448cf0c04e337b9ca99cf83c5afb183">
+        <source>Module %s cannot be upgraded this time: please refresh this page to update it.</source>
+        <target>Module %s cannot be upgraded this time: please refresh this page to update it.</target>
+        <note>Line: 466</note>
+      </trans-unit>
+      <trans-unit id="f79dcf8179bb9d8fa72d169f71702b44">
+        <source>To prevent any problem, this module has been turned off</source>
+        <target>To prevent any problem, this module has been turned off</target>
+        <note>Line: 468</note>
+      </trans-unit>
+      <trans-unit id="4762b130ddcc0e4d2eacf0c59a8b17a2">
+        <source>The module is not installed.</source>
+        <target>The module is not installed.</target>
+        <note>Line: 679</note>
+      </trans-unit>
+      <trans-unit id="6869dc1977dbff7c5749120241f74ff0">
+        <source>Unable to install override: %s</source>
+        <target>Unable to install override: %s</target>
+        <note>Line: 795</note>
+      </trans-unit>
+      <trans-unit id="e8f98f4457c87a8aad1d4d625ad1a9f3">
+        <source>%1$s is not a valid module name.</source>
+        <target>%1$s is not a valid module name.</target>
+        <note>Line: 1105</note>
+      </trans-unit>
+      <trans-unit id="8f62a26bf441ad698c2c562ec10448c4">
+        <source>All modules cannot be loaded due to memory limit restrictions, please increase your memory_limit value on your server configuration</source>
+        <target>All modules cannot be loaded due to memory limit restrictions, please increase your memory_limit value on your server configuration</target>
+        <note>Line: 1457</note>
+      </trans-unit>
+      <trans-unit id="2cff6a926907204ad5c1916ba96ed815">
+        <source>%s could not be loaded.</source>
+        <target>%s could not be loaded.</target>
+        <note>Line: 1295</note>
+      </trans-unit>
+      <trans-unit id="db0275528fda19c75f79d296ded0c6e7">
+        <source>Error found in config file:</source>
+        <target>Error found in config file:</target>
+        <note>Line: 1302</note>
+      </trans-unit>
+      <trans-unit id="f9c47597596f7159815c61957f4f8ec2">
+        <source>%1$s (parse error in %2$s)</source>
+        <target>%1$s (parse error in %2$s)</target>
+        <note>Line: 1356</note>
+      </trans-unit>
+      <trans-unit id="8014d5d92e09a563588869c623bd0abf">
+        <source>%1$s (class missing in %2$s)</source>
+        <target>%1$s (class missing in %2$s)</target>
+        <note>Line: 1423</note>
+      </trans-unit>
+      <trans-unit id="a0b8a508d6ca8113e6439f623e7bf7cf">
+        <source>The following module(s) could not be loaded</source>
+        <target>The following module(s) could not be loaded</target>
+        <note>Line: 1568</note>
+      </trans-unit>
+      <trans-unit id="ed6daad0747953284ea086d8cc5652de">
+        <source>Trusted and Untrusted XML have not been generated properly</source>
+        <target>Trusted and Untrusted XML have not been generated properly</target>
+        <note>Line: 1868</note>
+      </trans-unit>
+      <trans-unit id="eddeabd79f8ca673d888fa2ffe9cf69a">
+        <source>No template found for module</source>
+        <target>No template found for module</target>
+        <note>Line: 2363</note>
+      </trans-unit>
+      <trans-unit id="45e26faecce815f7e1ac16b32ac5278e">
+        <source>The method %1$s in the class %2$s is already overridden by the module %3$s version %4$s at %5$s.</source>
+        <target>The method %1$s in the class %2$s is already overridden by the module %3$s version %4$s at %5$s.</target>
+        <note>Line: 2991</note>
+      </trans-unit>
+      <trans-unit id="03c32a7a2568d41e186d59293b02f662">
+        <source>The method %1$s in the class %2$s is already overridden.</source>
+        <target>The method %1$s in the class %2$s is already overridden.</target>
+        <note>Line: 2993</note>
+      </trans-unit>
+      <trans-unit id="71bf68c93ca29a72a3a5080a30e20ecc">
+        <source>Failed to override method %1$s in class %2$s.</source>
+        <target>Failed to override method %1$s in class %2$s.</target>
+        <note>Line: 3060</note>
+      </trans-unit>
+      <trans-unit id="a08302edbf2d9f7ddd43ae8bd1de5caa">
+        <source>The property %1$s in the class %2$s is already defined.</source>
+        <target>The property %1$s in the class %2$s is already defined.</target>
+        <note>Line: 3005</note>
+      </trans-unit>
+      <trans-unit id="7893f5f2917811b37c628f787c83af8a">
+        <source>Failed to override property %1$s in class %2$s.</source>
+        <target>Failed to override property %1$s in class %2$s.</target>
+        <note>Line: 3068</note>
+      </trans-unit>
+      <trans-unit id="6f89d5bc3c94e885d4a3716accc12983">
+        <source>The constant %1$s in the class %2$s is already defined.</source>
+        <target>The constant %1$s in the class %2$s is already defined.</target>
+        <note>Line: 3016</note>
+      </trans-unit>
+      <trans-unit id="d27626d5c768d3782dcc6343e8a0c0f6">
+        <source>Failed to override constant %1$s in class %2$s.</source>
+        <target>Failed to override constant %1$s in class %2$s.</target>
+        <note>Line: 3076</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/module/ModuleGraph.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cb20447a4bf5ff9bec717ec68a357a93">
+        <source>No graph engine selected</source>
+        <target>No graph engine selected</target>
+        <note>Line: 278</note>
+      </trans-unit>
+      <trans-unit id="a78ac92432df02a17a667fdc15764454">
+        <source>Graph engine selected is unavailable.</source>
+        <target>Graph engine selected is unavailable.</target>
+        <note>Line: 284</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/module/ModuleGrid.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ccacacd12f75e1ab3f9ce3e234ed5777">
+        <source>No grid engine selected</source>
+        <target>No grid engine selected</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="b7be351a5a41ea3d022dc18f5f16239a">
+        <source>Grid engine selected is unavailable.</source>
+        <target>Grid engine selected is unavailable.</target>
+        <note>Line: 105</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminModulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="723aac54d8b88c84ca0c9328f3912bf9">
+        <source>There was an error while extracting the module (file may be corrupted).</source>
+        <target>There was an error while extracting the module (file may be corrupted).</target>
+        <note>Line: 424</note>
+      </trans-unit>
+      <trans-unit id="2d2c4b710382f05c8cb697187f381f7c">
+        <source>The module %1$s that you uploaded is not a valid module.</source>
+        <target>The module %1$s that you uploaded is not a valid module.</target>
+        <note>Line: 429</note>
+      </trans-unit>
+      <trans-unit id="c09b8da183ec54308a4c59ab1f1ab792">
+        <source>You do not have the permission to use this module.</source>
+        <target>You do not have the permission to use this module.</target>
+        <note>Line: 686</note>
+      </trans-unit>
+      <trans-unit id="7cbb3ce25a6d0abd528dbd744da03e7f">
+        <source>Cannot reset this module.</source>
+        <target>Cannot reset this module.</target>
+        <note>Line: 536</note>
+      </trans-unit>
+      <trans-unit id="d765d45adba914dc9006cc7ec0b2faf5">
+        <source>Cannot install this module.</source>
+        <target>Cannot install this module.</target>
+        <note>Line: 543</note>
+      </trans-unit>
+      <trans-unit id="f973e6a744c0c50d212b7fd1430153f7">
+        <source>Cannot uninstall this module.</source>
+        <target>Cannot uninstall this module.</target>
+        <note>Line: 546</note>
+      </trans-unit>
+      <trans-unit id="08da26423466f4cadc0fd6e201711dcd">
+        <source>Cannot load the module's object.</source>
+        <target>Cannot load the module's object.</target>
+        <note>Line: 666</note>
+      </trans-unit>
+      <trans-unit id="8969f3823d6bbf4cff9ea8118d8b3ecb">
+        <source>An error occurred while copying the archive to the module directory.</source>
+        <target>An error occurred while copying the archive to the module directory.</target>
+        <note>Line: 603</note>
+      </trans-unit>
+      <trans-unit id="4654007119386a8ace934133208feed5">
+        <source>Sorry, the module cannot be deleted. Please check if you have the right permissions on this folder.</source>
+        <target>Sorry, the module cannot be deleted. Please check if you have the right permissions on this folder.</target>
+        <note>Line: 700</note>
+      </trans-unit>
+      <trans-unit id="8875d822d9402acb528eb9c55401a573">
+        <source>You need to be logged in to your PrestaShop Addons account in order to update the %s module. %s</source>
+        <target>You need to be logged in to your PrestaShop Addons account in order to update the %s module. %s</target>
+        <note>Line: 806</note>
+      </trans-unit>
+      <trans-unit id="af67db57c79006fd9464c65865f36a44">
+        <source>Module %s cannot be upgraded: Error while downloading the latest version.</source>
+        <target>Module %s cannot be upgraded: Error while downloading the latest version.</target>
+        <note>Line: 833</note>
+      </trans-unit>
+      <trans-unit id="e6148a0bace3c593e161009060a7da99">
+        <source>Module %s cannot be upgraded: Error while extracting the latest version.</source>
+        <target>Module %s cannot be upgraded: Error while extracting the latest version.</target>
+        <note>Line: 835</note>
+      </trans-unit>
+      <trans-unit id="408e2019e00a54bbaace8e6ea29a736b">
+        <source>You do not have the rights to update the %s module. Please make sure you are logged in to the PrestaShop Addons account that purchased the module.</source>
+        <target>You do not have the rights to update the %s module. Please make sure you are logged in to the PrestaShop Addons account that purchased the module.</target>
+        <note>Line: 841</note>
+      </trans-unit>
+      <trans-unit id="811c568a06f4f5f038609a98512e9416">
+        <source>You do not have permission to access this module.</source>
+        <target>You do not have permission to access this module.</target>
+        <note>Line: 860</note>
+      </trans-unit>
+      <trans-unit id="81d2521b93f4b3abdc3877f76e04005a">
+        <source>You do not have permission to install this module.</source>
+        <target>You do not have permission to install this module.</target>
+        <note>Line: 864</note>
+      </trans-unit>
+      <trans-unit id="d7569980257d11fbd66deb501f5efab8">
+        <source>You do not have permission to delete this module.</source>
+        <target>You do not have permission to delete this module.</target>
+        <note>Line: 866</note>
+      </trans-unit>
+      <trans-unit id="5a69d1cb0ef4096b272b3b441555d737">
+        <source>You do not have permission to configure this module.</source>
+        <target>You do not have permission to configure this module.</target>
+        <note>Line: 868</note>
+      </trans-unit>
+      <trans-unit id="2c465b2a1769653563dcacfc83ab61d0">
+        <source>This module is already installed: %s.</source>
+        <target>This module is already installed: %s.</target>
+        <note>Line: 870</note>
+      </trans-unit>
+      <trans-unit id="0ec73cc5b2910764fc221acb633c20bc">
+        <source>This module has already been uninstalled: %s.</source>
+        <target>This module has already been uninstalled: %s.</target>
+        <note>Line: 872</note>
+      </trans-unit>
+      <trans-unit id="ee043fd10baac04e50a4256d7406e93c">
+        <source>This module needs to be installed in order to be updated: %s.</source>
+        <target>This module needs to be installed in order to be updated: %s.</target>
+        <note>Line: 874</note>
+      </trans-unit>
+      <trans-unit id="4e03a50f18350f93b8ec321b488a4a8c">
+        <source>You do not have permission to uninstall this module.</source>
+        <target>You do not have permission to uninstall this module.</target>
+        <note>Line: 898</note>
+      </trans-unit>
+      <trans-unit id="d3c1a921b833767f27ffcc401a87d93b">
+        <source>The following module(s) could not be uninstalled properly: %s.</source>
+        <target>The following module(s) could not be uninstalled properly: %s.</target>
+        <note>Line: 1037</note>
+      </trans-unit>
+      <trans-unit id="89bbb6a140e2fc5ff52b2211083a2721">
+        <source>The following module(s) could not be installed properly: %s.</source>
+        <target>The following module(s) could not be installed properly: %s.</target>
+        <note>Line: 1039</note>
+      </trans-unit>
+      <trans-unit id="8095c31813f8e77d292bf6bec964169b">
+        <source>Unknown archive type.</source>
+        <target>Unknown archive type.</target>
+        <note>Line: 601</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminModulesPositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="63bc456afcd9d4c6285718e34ee8fed9">
+        <source>This module has already been transplanted to this hook.</source>
+        <target>This module has already been transplanted to this hook.</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="9ce4606635f2118f9d10d1f323f73fe2">
+        <source>This module cannot be transplanted to this hook.</source>
+        <target>This module cannot be transplanted to this hook.</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="0ce2f4a4f40a2d23525b5b02bcfe611f">
+        <source>An error occurred while transplanting the module to its hook.</source>
+        <target>An error occurred while transplanting the module to its hook.</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="b7d38f9dd64d92d6132e0c520a2d68a8">
+        <source>Please select a module to unhook.</source>
+        <target>Please select a module to unhook.</target>
+        <note>Line: 213</note>
       </trans-unit>
     </body>
   </file>
@@ -994,6 +435,432 @@ File: admin-dev/themes/default/template/controllers/modules/configuration_bar.tp
         <target>There was an error during the uninstallation.</target>
         <note>Context:
           File: modules/ps_faviconnotificationbo/ps_faviconnotificationbo.php:101</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/include/modal_addons_connect.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df776a9024ce6c10ec1d1d763cee0301">
+        <source>You are about to log out your Addons account. You might miss important updates of Addons you've bought.</source>
+        <target>You are about to log out your Addons account. You might miss important updates of Addons you've bought.</target>
+        <note>Line: 94</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/include/modal_import.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c3dbf8925ec4c77ef5317e1e27317b70">
+        <source>Installing module...</source>
+        <target>Installing module...</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="a26f56145fea2d3af35bf0d6ac83c28a">
+        <source>It will close as soon as the module is installed. It won't be long!</source>
+        <target>It will close as soon as the module is installed. It won't be long!</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="f48a5ae14fa2b0c85442d1199a08b3b4">
+        <source>Module installed!</source>
+        <target>Module installed!</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="824e2fcb263ee94399a6a261ee1ec7c1">
+        <source>Oops... Upload failed.</source>
+        <target>Oops... Upload failed.</target>
+        <note>Line: 77</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/module-toolbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="957c752dd2c9466beff247b9cae7f715">
+        <source>Synchronized with Addons marketplace</source>
+        <target>Synchronized with Addons marketplace</target>
+        <note>Line: 10</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Module/ModuleDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="429cc2fb9f1cb16782b0af5ba748096d">
+        <source>Parse error detected in main class of module %module%!</source>
+        <target>Parse error detected in main class of module %module%!</target>
+        <note>Line: 213</note>
+      </trans-unit>
+      <trans-unit id="e03545a6c414502e72d232b4c30d9fdd">
+        <source>Error while loading file of module %module%. %error_message%</source>
+        <target>Error while loading file of module %module%. %error_message%</target>
+        <note>Line: 232</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Module/ModuleZipManager.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="08859ef1a837ae429ff2e4decc952cbe">
+        <source>Unable to find uploaded module at the following path: %file%</source>
+        <target>Unable to find uploaded module at the following path: %file%</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="848578a1a363f2c2443b3989154bf646">
+        <source>Cannot extract module in %path% to get its name. %error%</source>
+        <target>Cannot extract module in %path% to get its name. %error%</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="a85499f3d020141df9b6203b7585a9bf">
+        <source>This file does not seem to be a valid module zip</source>
+        <target>This file does not seem to be a valid module zip</target>
+        <note>Line: 147</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Module/Tab/ModuleTabRegister.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ee34aeaa570c9f1c206b8401d6eaa58d">
+        <source>Failed to install admin tab "%name%".</source>
+        <target>Failed to install admin tab "%name%".</target>
+        <note>Line: 280</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Module/Tab/ModuleTabUnregister.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e85403d2e654955b45105b9929924c89">
+        <source>Failed to uninstall admin tab "%name%".</source>
+        <target>Failed to uninstall admin tab "%name%".</target>
+        <note>Line: 102</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Addon/Module/ModuleManager.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f2715f72988009e4f50e94d88b3df89f">
+        <source>You are not allowed to install modules.</source>
+        <target>You are not allowed to install modules.</target>
+        <note>Line: 267</note>
+      </trans-unit>
+      <trans-unit id="21f1ba3ca9bb026443f8dea1127f2f0b">
+        <source>You are not allowed to uninstall the module %module%.</source>
+        <target>You are not allowed to uninstall the module %module%.</target>
+        <note>Line: 316</note>
+      </trans-unit>
+      <trans-unit id="ea328981d19b5b379639f915341bc4ad">
+        <source>You are not allowed to upgrade the module %module%.</source>
+        <target>You are not allowed to upgrade the module %module%.</target>
+        <note>Line: 355</note>
+      </trans-unit>
+      <trans-unit id="87c10be2be869072e9d1e7cbca858445">
+        <source>You are not allowed to disable the module %module%.</source>
+        <target>You are not allowed to disable the module %module%.</target>
+        <note>Line: 398</note>
+      </trans-unit>
+      <trans-unit id="b58f4b4f4f870b40e52c42c161df0d60">
+        <source>Error when disabling module %module%. %error_details%.</source>
+        <target>Error when disabling module %module%. %error_details%.</target>
+        <note>Line: 415</note>
+      </trans-unit>
+      <trans-unit id="42874189778a946c2a51911076474ad4">
+        <source>You are not allowed to enable the module %module%.</source>
+        <target>You are not allowed to enable the module %module%.</target>
+        <note>Line: 444</note>
+      </trans-unit>
+      <trans-unit id="fbaf1c9434442c780f3eddff4406603c">
+        <source>Error when enabling module %module%. %error_details%.</source>
+        <target>Error when enabling module %module%. %error_details%.</target>
+        <note>Line: 461</note>
+      </trans-unit>
+      <trans-unit id="9fa7ea0487a785b31f48977415f3324a">
+        <source>You are not allowed to disable the module %module% on mobile.</source>
+        <target>You are not allowed to disable the module %module% on mobile.</target>
+        <note>Line: 505</note>
+      </trans-unit>
+      <trans-unit id="976dc5c6fc2fe73b2c43c7776847e593">
+        <source>Error when disabling module %module% on mobile. %error_details%</source>
+        <target>Error when disabling module %module% on mobile. %error_details%</target>
+        <note>Line: 522</note>
+      </trans-unit>
+      <trans-unit id="c74f0e8fe4da4e6dcb5a051f0eef1ec3">
+        <source>You are not allowed to enable the module %module% on mobile.</source>
+        <target>You are not allowed to enable the module %module% on mobile.</target>
+        <note>Line: 563</note>
+      </trans-unit>
+      <trans-unit id="416bc5074d9b9944a51797b081492442">
+        <source>Error when enabling module %module% on mobile. %error_details%</source>
+        <target>Error when enabling module %module% on mobile. %error_details%</target>
+        <note>Line: 580</note>
+      </trans-unit>
+      <trans-unit id="e65dccd7380f1af807453a7afdf3f427">
+        <source>You are not allowed to reset the module %module%.</source>
+        <target>You are not allowed to reset the module %module%.</target>
+        <note>Line: 605</note>
+      </trans-unit>
+      <trans-unit id="387aeee114093679248f936ba36ee416">
+        <source>Error when resetting module %module%. %error_details%</source>
+        <target>Error when resetting module %module%. %error_details%</target>
+        <note>Line: 628</note>
+      </trans-unit>
+      <trans-unit id="c111e1387c9a6c5c98635ecdbbcb26af">
+        <source>The module is invalid and cannot be loaded.</source>
+        <target>The module is invalid and cannot be loaded.</target>
+        <note>Line: 696</note>
+      </trans-unit>
+      <trans-unit id="c913de38eb118ce08ddae76f27063126">
+        <source>Unfortunately, the module did not return additional details.</source>
+        <target>Unfortunately, the module did not return additional details.</target>
+        <note>Line: 704</note>
+      </trans-unit>
+      <trans-unit id="83a812de8784135990c57d25d0f9b34b">
+        <source>The module %module% must be installed first</source>
+        <target>The module %module% must be installed first</target>
+        <note>Line: 729</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Addon/Module/ModuleRepository.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a3214c22fd9d21c988d9bb06748d6d9f">
+        <source>Parse error on module %module%. %error_details%</source>
+        <target>Parse error on module %module%. %error_details%</target>
+        <note>Line: 385</note>
+      </trans-unit>
+      <trans-unit id="bcc1e7daae2727b6d7a32567086cd84f">
+        <source>Unexpected exception on module %module%. %error_details%</source>
+        <target>Unexpected exception on module %module%. %error_details%</target>
+        <note>Line: 396</note>
+      </trans-unit>
+      <trans-unit id="9fcc3446d55e632b5f3ca13fc810c83b">
+        <source>Loading data from Addons failed. %error_details%</source>
+        <target>Loading data from Addons failed. %error_details%</target>
+        <note>Line: 444</note>
+      </trans-unit>
+      <trans-unit id="0554e4a4ddb313c3962088dc32647e90">
+        <source>Parse error detected in module %module%. %error_details%.</source>
+        <target>Parse error detected in module %module%. %error_details%.</target>
+        <note>Line: 569</note>
+      </trans-unit>
+      <trans-unit id="40e7db035e09d8f198b96a7d5d9e821f">
+        <source>Exception detected while loading module %module%. %error_details%.</source>
+        <target>Exception detected while loading module %module%. %error_details%.</target>
+        <note>Line: 577</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Addon/Theme/ThemeManager.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1ff626f78b7506f340c7b2ce3398367a">
+        <source>Cannot %action% module %module%. %error_details%</source>
+        <target>Cannot %action% module %module%. %error_details%</target>
+        <note>Line: 293</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Command/ModuleCommand.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9dca2e42fe7a0db763b8737e9a8f9133">
+        <source>%action% action on module %module% succeeded.</source>
+        <target>%action% action on module %module% succeeded.</target>
+        <note>Line: 153</note>
+      </trans-unit>
+      <trans-unit id="6867740141667a3da88ac51e48ed1d9d">
+        <source>Unknown module action. It must be one of these values: %actions%</source>
+        <target>Unknown module action. It must be one of these values: %actions%</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="e92af04f3580fee9164214abd4b621a4">
+        <source>Validation of configuration details failed:</source>
+        <target>Validation of configuration details failed:</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="87167266fbdef818ec8508ea125915aa">
+        <source>Configuration successfully applied.</source>
+        <target>Configuration successfully applied.</target>
+        <note>Line: 140</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1c1824ce21df05df8689641c516c9d75">
+        <source>This module cannot be loaded.</source>
+        <target>This module cannot be loaded.</target>
+        <note>Line: 168</note>
+      </trans-unit>
+      <trans-unit id="0c01b89a049f95e9eb10cfeb2a2901f0">
+        <source>Hook cannot be loaded.</source>
+        <target>Hook cannot be loaded.</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="c40924509e257aa0e73ccc576bd6b953">
+        <source>An error occurred while deleting the module from its hook.</source>
+        <target>An error occurred while deleting the module from its hook.</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="80e868e8d753c3ec4066aab283e66cbc">
+        <source>The module was successfully removed from the hook.</source>
+        <target>The module was successfully removed from the hook.</target>
+        <note>Line: 221</note>
+      </trans-unit>
+      <trans-unit id="980b6caee06822f8c5df45eb7db277be">
+        <source>The module transplanted successfully to the hook.</source>
+        <target>The module transplanted successfully to the hook.</target>
+        <note>Line: 220</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="385b04e1b2442530341b51c2d3b216a3">
+        <source>Cannot get catalog data, please try again later. Reason: %error_details%</source>
+        <target>Cannot get catalog data, please try again later. Reason: %error_details%</target>
+        <note>Line: 338</note>
+      </trans-unit>
+      <trans-unit id="71d827dd0d049981403f27fb7af0991c">
+        <source>%module% did not return a valid response on %action% action.</source>
+        <target>%module% did not return a valid response on %action% action.</target>
+        <note>Line: 391</note>
+      </trans-unit>
+      <trans-unit id="8e7e1a7e5fa9edcd7139f569d07fc5b9">
+        <source>Confirmation needed by module %module% on %action% (%subject%).</source>
+        <target>Confirmation needed by module %module% on %action% (%subject%).</target>
+        <note>Line: 583</note>
+      </trans-unit>
+      <trans-unit id="bf0edb2da5a51620141bff55d3060a63">
+        <source>Exception thrown by module %module% on %action%. %error_details%</source>
+        <target>Exception thrown by module %module% on %action%. %error_details%</target>
+        <note>Line: 450</note>
+      </trans-unit>
+      <trans-unit id="89d371deca1b2b50a933fabc8005ccfb">
+        <source>%module% did not return a valid response on installation.</source>
+        <target>%module% did not return a valid response on installation.</target>
+        <note>Line: 549</note>
+      </trans-unit>
+      <trans-unit id="35e839bc1864dd50a75500028c3ebb33">
+        <source>Installation of module %module% was successful.</source>
+        <target>Installation of module %module% was successful.</target>
+        <note>Line: 555</note>
+      </trans-unit>
+      <trans-unit id="f52c6f7b6fcbd586aee22044aeb6c897">
+        <source>Installation of module %module% failed. %error%</source>
+        <target>Installation of module %module% failed. %error%</target>
+        <note>Line: 566</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fc7da9518fbe20ebcaccbf5f8fd0e7df">
+        <source>Synchronized with Addons marketplace!</source>
+        <target>Synchronized with Addons marketplace!</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fca2f02b01daced572256506d1054f4a">
+        <source>No changelog provided</source>
+        <target>No changelog provided</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b8e063d2ad26dfc0a659410294caf74b">
+        <source>You are about to disable %moduleName% module.</source>
+        <target>You are about to disable %moduleName% module.</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="c5209889e18199fb2a2c50958d3212b8">
+        <source>Your current settings will be saved, but the module will no longer be active.</source>
+        <target>Your current settings will be saved, but the module will no longer be active.</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="eb641425b425f906c54cb55319ec3e25">
+        <source>You are about to uninstall %moduleName% module.</source>
+        <target>You are about to uninstall %moduleName% module.</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="db0769970bbd476188bfc1c5d9d6a2bd">
+        <source>This will disable the module and delete all its files. For good.</source>
+        <target>This will disable the module and delete all its files. For good.</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="36fbfc01d63e4b57d18991077535c6e0">
+        <source>This action cannot be undone.</source>
+        <target>This action cannot be undone.</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="634b5d0d5ec8e481321b1d776f312388">
+        <source>You're about to reset %moduleName% module.</source>
+        <target>You're about to reset %moduleName% module.</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="58ce7123c3789e3c51cb3ffd42883df1">
+        <source>This will restore the defaults settings.</source>
+        <target>This will restore the defaults settings.</target>
+        <note>Line: 77</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a7f0cf21776c1a6ed951c58620b4507a">
+        <source>You are about to [1] the following modules:</source>
+        <target>You are about to [1] the following modules:</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="87ad4793c12c9f9e5d56cc81386f77b8">
+        <source>No description found for this module :(</source>
+        <target>No description found for this module :(</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="a76e4258e8695991d6f5f62efdba70d6">
+        <source>No additional description provided for this module :(</source>
+        <target>No additional description provided for this module :(</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="1ed02f805424aac96756b590d51e2038">
+        <source>No feature list provided for this module :(</source>
+        <target>No feature list provided for this module :(</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="f2a854a84903f5f29c0b7a40ccbf4ee5">
+        <source>No customer benefits notes found for this module :(</source>
+        <target>No customer benefits notes found for this module :(</target>
+        <note>Line: 148</note>
+      </trans-unit>
+      <trans-unit id="94d27c2e2294ddfe66621b814f2ac3e0">
+        <source>No demonstration video found for this module :(</source>
+        <target>No demonstration video found for this module :(</target>
+        <note>Line: 158</note>
+      </trans-unit>
+      <trans-unit id="3072d199d2a0269893376e8c7d0049d6">
+        <source>No changelog provided for this module :(</source>
+        <target>No changelog provided for this module :(</target>
+        <note>Line: 176</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="634ec4fb81df959627996a95fa0e799c">
+        <source>You need to select at least one module to use the bulk action.</source>
+        <target>You need to select at least one module to use the bulk action.</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="09f9472ec012d502e9cc3ab0e31c24e8">
+        <source>The action "[1]" is not available, impossible to perform your request.</source>
+        <target>The action "[1]" is not available, impossible to perform your request.</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="6e37e943fed80ec5f0629bbea4c81e1a">
+        <source>The action [1] is not available for module [2]. Skipped.</source>
+        <target>The action [1] is not available for module [2]. Skipped.</target>
+        <note>Line: 69</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminNavigationFooter.xlf
+++ b/app/Resources/translations/default/AdminNavigationFooter.xlf
@@ -5,44 +5,37 @@
       <trans-unit id="3dd9c50a1e72020b9cc83e92aa7d07b9">
         <source>Load time: </source>
         <target>Load time: </target>
-        <note>Context:
-File: admin-dev/themes/default/template/footer.tpl:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="bbaff12800505b22a853e8b7f4eb6a22">
         <source>Contact</source>
         <target>Contact</target>
-        <note>Context:
-File: admin-dev/themes/default/template/footer.tpl:57</note>
+        <note>Line: 57</note>
       </trans-unit>
       <trans-unit id="74baec1f24fb00ec864d0344e73347d6">
         <source>User Club</source>
         <target>User Club</target>
-        <note>Context:
-File: admin-dev/themes/default/template/footer.tpl:67</note>
+        <note>Line: 67</note>
       </trans-unit>
       <trans-unit id="a1a53ee7ff379c1df8dd0d299ee67bc6">
         <source>Feature Requests</source>
         <target>Feature Requests</target>
-        <note>Context:
-File: admin-dev/themes/default/template/footer.tpl:72</note>
+        <note>Line: 72</note>
       </trans-unit>
       <trans-unit id="e6a7f8a2f42cc35979973da8dfb10720">
         <source>Forum</source>
         <target>Forum</target>
-        <note>Context:
-File: admin-dev/themes/default/template/footer.tpl:77</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="b3f252777a69b110667756babe83a98f">
         <source>Addons</source>
         <target>Addons</target>
-        <note>Context:
-File: admin-dev/themes/default/template/footer.tpl:82</note>
+        <note>Line: 82</note>
       </trans-unit>
       <trans-unit id="cf270e40d273f9e7fd7c3061729060c3">
         <source>Training</source>
         <target>Training</target>
-        <note>Context:
-File: admin-dev/themes/default/template/footer.tpl:87</note>
+        <note>Line: 87</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminNavigationHeader.xlf
+++ b/app/Resources/translations/default/AdminNavigationHeader.xlf
@@ -1,98 +1,96 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="classes/lang/KeysReference/QuickAccessLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="e7a908d79d3758c911692ba791da9c70">
-        <source>Catalog evaluation</source>
-        <target>Catalog evaluation</target>
-        <note>Context:
-File: classes/lang/KeysReference/QuickAccessLang.php:33</note>
+      <trans-unit id="0a71c80de89d7b2d3e6b22974a4a7548">
+        <source>A new order has been placed on your shop.</source>
+        <target>A new order has been placed on your shop.</target>
+        <note>Line: 62</note>
       </trans-unit>
-      <trans-unit id="8cf04a9734132302f96da8e113e80ce5">
-        <source>Home</source>
-        <target>Home</target>
-        <note>Context:
-File: classes/lang/KeysReference/QuickAccessLang.php:26</note>
+      <trans-unit id="3df406952f3377a5e419d4d63abb1b1d">
+        <source>Order number:</source>
+        <target>Order number:</target>
+        <note>Line: 63</note>
       </trans-unit>
-      <trans-unit id="bf4e361cd7132e11e34d34124bb04291">
-        <source>My Shop</source>
-        <target>My Shop</target>
-        <note>Context:
-File: classes/lang/KeysReference/QuickAccessLang.php:27</note>
+      <trans-unit id="d2d2000f7fa636acd871f43c085a75dc">
+        <source>A new customer registered on your shop.</source>
+        <target>A new customer registered on your shop.</target>
+        <note>Line: 67</note>
       </trans-unit>
-      <trans-unit id="52015afb6ec8b940ef903ff73f4c4058">
-        <source>New category</source>
-        <target>New category</target>
-        <note>Context:
-File: classes/lang/KeysReference/QuickAccessLang.php:28</note>
+      <trans-unit id="d48549659ae6cc81e7d4729b068ba4b9">
+        <source>A new message was posted on your shop.</source>
+        <target>A new message was posted on your shop.</target>
+        <note>Line: 69</note>
       </trans-unit>
-      <trans-unit id="656c3be690ee43df4b845bd2a2ebe587">
-        <source>New product</source>
-        <target>New product</target>
-        <note>Context:
-File: classes/lang/KeysReference/QuickAccessLang.php:29</note>
+      <trans-unit id="6fab17d3dc1147f9b170fb8e1aac2fa8">
+        <source>Read this message</source>
+        <target>Read this message</target>
+        <note>Line: 70</note>
       </trans-unit>
-      <trans-unit id="a0d555e459a8227e786d2bfaf99b9974">
-        <source>New voucher</source>
-        <target>New voucher</target>
-        <note>Context:
-File: classes/lang/KeysReference/QuickAccessLang.php:30</note>
+      <trans-unit id="4f32a32dea642737580dd71cdfd8d3c0">
+        <source>Quick Access</source>
+        <target>Quick Access</target>
+        <note>Line: 127</note>
       </trans-unit>
-      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
-        <source>Orders</source>
-        <target>Orders</target>
-        <note>Context:
-File: classes/lang/KeysReference/QuickAccessLang.php:31</note>
+      <trans-unit id="f5c26758149849ee0f84a2eceaf0acfd">
+        <source>Remove from QuickAccess</source>
+        <target>Remove from QuickAccess</target>
+        <note>Line: 142</note>
       </trans-unit>
-      <trans-unit id="f388bc3eaa4b9f72756a75693a12559d">
-        <source>Installed modules</source>
-        <target>Installed modules</target>
-        <note>Context:
-File: classes/lang/KeysReference/QuickAccessLang.php:32</note>
+      <trans-unit id="383247a8cb198be4042d128986100cea">
+        <source>Add current page to QuickAccess</source>
+        <target>Add current page to QuickAccess</target>
+        <note>Line: 149</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminQuickAccessesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="97e7c9a7d06eac006a28bf05467fcc8b">
-        <source>Link</source>
-        <target>Link</target>
-        <note>Context:
-File: controllers/admin/AdminQuickAccessesController.php:66</note>
+      <trans-unit id="165122309e15dc09c30b78951e53cb5a">
+        <source>Manage quick accesses</source>
+        <target>Manage quick accesses</target>
+        <note>Line: 156</note>
       </trans-unit>
-      <trans-unit id="fe501f6dab88efcbde9b3f062a5ae781">
-        <source>Quick Access menu</source>
-        <target>Quick Access menu</target>
-        <note>Context:
-File: controllers/admin/AdminQuickAccessesController.php:79</note>
+      <trans-unit id="6f7579a25b7aba443386a5b86a7900b4">
+        <source>Please name this shortcut:</source>
+        <target>Please name this shortcut:</target>
+        <note>Line: 171</note>
       </trans-unit>
-      <trans-unit id="55e4a48ac94061c93174d67635445e69">
-        <source>If it's a URL that comes from your back office, you MUST remove the security token.</source>
-        <target>If it's a URL that comes from your back office, you MUST remove the security token.</target>
-        <note>Context:
-File: controllers/admin/AdminQuickAccessesController.php:98</note>
+      <trans-unit id="ec3028a12402ab7f43962a6f3a667b6e">
+        <source>Debug mode</source>
+        <target>Debug mode</target>
+        <note>Line: 225</note>
       </trans-unit>
-      <trans-unit id="2959ce8aed67d6b6e6f5cefd601f1091">
-        <source>Open in new window</source>
-        <target>Open in new window</target>
-        <note>Context:
-File: controllers/admin/AdminQuickAccessesController.php:102</note>
+      <trans-unit id="38a27c0c7ef7a05e13efa2798ee21533">
+        <source>Maintenance mode</source>
+        <target>Maintenance mode</target>
+        <note>Line: 240</note>
       </trans-unit>
-      <trans-unit id="35c2475e5e8a5a14f8c1d9c1238e4cef">
-        <source>Add new quick access</source>
-        <target>Add new quick access</target>
-        <note>Context:
-File: controllers/admin/AdminQuickAccessesController.php:135</note>
+      <trans-unit id="d70861cbe7f8c9a1241c39b3e7ef5ef2">
+        <source>View my shop</source>
+        <target>View my shop</target>
+        <note>Line: 264</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_mainmenu/ps_mainmenu.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e5dc8e5afea0a065948622039358de37">
-        <source>New window</source>
-        <target>New window</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1342</note>
+      <trans-unit id="1558db2a9e35b7898e0b2a4a777ed2f9">
+        <source>Latest orders</source>
+        <target>Latest orders</target>
+        <note>Line: 287</note>
+      </trans-unit>
+      <trans-unit id="3d8de6fcc09baf73f7175fe59f278ced">
+        <source>Your profile</source>
+        <target>Your profile</target>
+        <note>Line: 362</note>
+      </trans-unit>
+      <trans-unit id="65e81c540f5af5f5c59901a076f9b024">
+        <source>My PrestaShop account</source>
+        <target>My PrestaShop account</target>
+        <note>Line: 364</note>
+      </trans-unit>
+      <trans-unit id="c87aacf5673fada1108c9f809d354311">
+        <source>Sign out</source>
+        <target>Sign out</target>
+        <note>Line: 366</note>
+      </trans-unit>
+      <trans-unit id="5dc5aba5187b03594ed0512efb6a8d4f">
+        <source>New customers</source>
+        <target>New customers</target>
+        <note>Line: 293</note>
       </trans-unit>
     </body>
   </file>
@@ -101,178 +99,130 @@ File: modules/ps_mainmenu/ps_mainmenu.php:1342</note>
       <trans-unit id="2e67c0a79d35c15af2436c8d80ca072d">
         <source>What are you looking for?</source>
         <target>What are you looking for?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="13787cfb1a15ae6690a29d3895c54de9">
         <source>Everywhere</source>
         <target>Everywhere</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:36</note>
+        <note>Line: 36</note>
       </trans-unit>
       <trans-unit id="7f704ff8964f7b5f3f9a6444d450b5f7">
         <source>Product name, SKU, reference...</source>
         <target>Product name, SKU, reference...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:40</note>
+        <note>Line: 40</note>
       </trans-unit>
       <trans-unit id="a3681587c5320489b6a3dd21282e254d">
         <source>Email, name...</source>
         <target>Email, name...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="f53c56a189f5670f997915484f96f388">
         <source>Customers by name</source>
         <target>Customers by name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="627f312c03624bf40f0656d5e7da6983">
         <source>Customers by IP address</source>
         <target>Customers by IP address</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:51</note>
+        <note>Line: 51</note>
       </trans-unit>
       <trans-unit id="d79cf3f429596f77db95c65074663a54">
         <source>Order ID</source>
         <target>Order ID</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:54</note>
+        <note>Line: 54</note>
       </trans-unit>
       <trans-unit id="4e065ba1bec1d62b2d5450256612fa96">
         <source>Invoice Number</source>
         <target>Invoice Number</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:59</note>
+        <note>Line: 59</note>
       </trans-unit>
       <trans-unit id="fc6dfe4f8b07fc04c99e27425f780754">
         <source>Cart ID</source>
         <target>Cart ID</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:64</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="07403a8bc81d7865c8e040e718ec7828">
         <source>Module name</source>
         <target>Module name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:69</note>
+        <note>Line: 69</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/lang/KeysReference/QuickAccessLang.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="0a71c80de89d7b2d3e6b22974a4a7548">
-        <source>A new order has been placed on your shop.</source>
-        <target>A new order has been placed on your shop.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:62</note>
+      <trans-unit id="e7a908d79d3758c911692ba791da9c70">
+        <source>Catalog evaluation</source>
+        <target>Catalog evaluation</target>
+        <note>Line: 33</note>
       </trans-unit>
-      <trans-unit id="3df406952f3377a5e419d4d63abb1b1d">
-        <source>Order number:</source>
-        <target>Order number:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:63</note>
+      <trans-unit id="8cf04a9734132302f96da8e113e80ce5">
+        <source>Home</source>
+        <target>Home</target>
+        <note>Line: 26</note>
       </trans-unit>
-      <trans-unit id="d2d2000f7fa636acd871f43c085a75dc">
-        <source>A new customer registered on your shop.</source>
-        <target>A new customer registered on your shop.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:67</note>
+      <trans-unit id="bf4e361cd7132e11e34d34124bb04291">
+        <source>My Shop</source>
+        <target>My Shop</target>
+        <note>Line: 27</note>
       </trans-unit>
-      <trans-unit id="d48549659ae6cc81e7d4729b068ba4b9">
-        <source>A new message was posted on your shop.</source>
-        <target>A new message was posted on your shop.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:69</note>
+      <trans-unit id="52015afb6ec8b940ef903ff73f4c4058">
+        <source>New category</source>
+        <target>New category</target>
+        <note>Line: 28</note>
       </trans-unit>
-      <trans-unit id="6fab17d3dc1147f9b170fb8e1aac2fa8">
-        <source>Read this message</source>
-        <target>Read this message</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:70</note>
+      <trans-unit id="656c3be690ee43df4b845bd2a2ebe587">
+        <source>New product</source>
+        <target>New product</target>
+        <note>Line: 29</note>
       </trans-unit>
-      <trans-unit id="4f32a32dea642737580dd71cdfd8d3c0">
-        <source>Quick Access</source>
-        <target>Quick Access</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:127</note>
+      <trans-unit id="a0d555e459a8227e786d2bfaf99b9974">
+        <source>New voucher</source>
+        <target>New voucher</target>
+        <note>Line: 30</note>
       </trans-unit>
-      <trans-unit id="f5c26758149849ee0f84a2eceaf0acfd">
-        <source>Remove from QuickAccess</source>
-        <target>Remove from QuickAccess</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:142</note>
+      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
+        <source>Orders</source>
+        <target>Orders</target>
+        <note>Line: 31</note>
       </trans-unit>
-      <trans-unit id="383247a8cb198be4042d128986100cea">
-        <source>Add current page to QuickAccess</source>
-        <target>Add current page to QuickAccess</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:149</note>
-      </trans-unit>
-      <trans-unit id="165122309e15dc09c30b78951e53cb5a">
-        <source>Manage quick accesses</source>
-        <target>Manage quick accesses</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:156</note>
-      </trans-unit>
-      <trans-unit id="6f7579a25b7aba443386a5b86a7900b4">
-        <source>Please name this shortcut:</source>
-        <target>Please name this shortcut:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:171</note>
-      </trans-unit>
-      <trans-unit id="ec3028a12402ab7f43962a6f3a667b6e">
-        <source>Debug mode</source>
-        <target>Debug mode</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:225</note>
-      </trans-unit>
-      <trans-unit id="38a27c0c7ef7a05e13efa2798ee21533">
-        <source>Maintenance mode</source>
-        <target>Maintenance mode</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:240</note>
-      </trans-unit>
-      <trans-unit id="d70861cbe7f8c9a1241c39b3e7ef5ef2">
-        <source>View my shop</source>
-        <target>View my shop</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:264</note>
-      </trans-unit>
-      <trans-unit id="1558db2a9e35b7898e0b2a4a777ed2f9">
-        <source>Latest orders</source>
-        <target>Latest orders</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:287</note>
-      </trans-unit>
-      <trans-unit id="3d8de6fcc09baf73f7175fe59f278ced">
-        <source>Your profile</source>
-        <target>Your profile</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:362</note>
-      </trans-unit>
-      <trans-unit id="65e81c540f5af5f5c59901a076f9b024">
-        <source>My PrestaShop account</source>
-        <target>My PrestaShop account</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:364</note>
-      </trans-unit>
-      <trans-unit id="c87aacf5673fada1108c9f809d354311">
-        <source>Sign out</source>
-        <target>Sign out</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:366</note>
+      <trans-unit id="f388bc3eaa4b9f72756a75693a12559d">
+        <source>Installed modules</source>
+        <target>Installed modules</target>
+        <note>Line: 32</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_faviconnotificationbo/views/templates/admin/tabs/faviconConfiguration.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/admin/AdminQuickAccessesController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="5dc5aba5187b03594ed0512efb6a8d4f">
-        <source>New customers</source>
-        <target>New customers</target>
-        <note>Context:
-File: modules/ps_faviconnotificationbo/views/templates/admin/tabs/faviconConfiguration.tpl:44</note>
+      <trans-unit id="97e7c9a7d06eac006a28bf05467fcc8b">
+        <source>Link</source>
+        <target>Link</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="fe501f6dab88efcbde9b3f062a5ae781">
+        <source>Quick Access menu</source>
+        <target>Quick Access menu</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="55e4a48ac94061c93174d67635445e69">
+        <source>If it's a URL that comes from your back office, you MUST remove the security token.</source>
+        <target>If it's a URL that comes from your back office, you MUST remove the security token.</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="2959ce8aed67d6b6e6f5cefd601f1091">
+        <source>Open in new window</source>
+        <target>Open in new window</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="35c2475e5e8a5a14f8c1d9c1238e4cef">
+        <source>Add new quick access</source>
+        <target>Add new quick access</target>
+        <note>Line: 135</note>
+      </trans-unit>
+      <trans-unit id="e5dc8e5afea0a065948622039358de37">
+        <source>New window</source>
+        <target>New window</target>
+        <note>Line: 69</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminNavigationMenu.xlf
+++ b/app/Resources/translations/default/AdminNavigationMenu.xlf
@@ -1,673 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="classes/lang/KeysReference/TabLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/page_header_toolbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="27ce7f8b5623b2e2df568d64cf051607">
-        <source>Stock</source>
-        <target>Stock</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:119</note>
-      </trans-unit>
-      <trans-unit id="eb5782af6c84c44ab4147000928cbb78">
-        <source>DB Backup</source>
-        <target>DB Backup</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:58</note>
-      </trans-unit>
-      <trans-unit id="a80d5e18649d829bda78450f7c862711">
-        <source>Webservice</source>
-        <target>Webservice</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:132</note>
-      </trans-unit>
-      <trans-unit id="194506bb3f2a5aea2ced4ea98cb22fb4">
-        <source><![CDATA[SEO & URLs]]></source>
-        <target><![CDATA[SEO & URLs]]></target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:106</note>
-      </trans-unit>
-      <trans-unit id="1e884e3078d9978e216a027ecd57fb34">
-        <source>E-mail</source>
-        <target>E-mail</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:60</note>
-      </trans-unit>
-      <trans-unit id="e836c2a96e7ef38a39afe4be2beddddd">
-        <source>SQL Manager</source>
-        <target>SQL Manager</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:112</note>
-      </trans-unit>
-      <trans-unit id="b2d37ae1cedf42ff874289b721860af2">
-        <source>Logs</source>
-        <target>Logs</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:77</note>
-      </trans-unit>
-      <trans-unit id="0b8d92bc19b720bb1065649535463409">
-        <source>Translations</source>
-        <target>Translations</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:130</note>
-      </trans-unit>
-      <trans-unit id="8189ecf686157db0c0274c1f49373318">
-        <source>International</source>
-        <target>International</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:71</note>
-      </trans-unit>
-      <trans-unit id="8fddfc8225dcf89be0e15709c671af4e">
-        <source>Delivery Slips</source>
-        <target>Delivery Slips</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:59</note>
-      </trans-unit>
-      <trans-unit id="d0834fcec6337785ee749c8f5464f6f6">
-        <source>Preferences</source>
-        <target>Preferences</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:93</note>
-      </trans-unit>
-      <trans-unit id="369686331c93d55e587441143ccdf427">
-        <source>Localization</source>
-        <target>Localization</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:74</note>
-      </trans-unit>
-      <trans-unit id="323d4eb70b252acb4a04eaf9e0882597">
-        <source>Geolocation</source>
-        <target>Geolocation</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:65</note>
-      </trans-unit>
-      <trans-unit id="af01f8c298aa063d9c7490f00eddd2df">
-        <source>Payment Methods</source>
-        <target>Payment Methods</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:92</note>
-      </trans-unit>
-      <trans-unit id="3160eb21973806e4291c3979d4aa242e">
-        <source>Positions</source>
-        <target>Positions</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:97</note>
-      </trans-unit>
-      <trans-unit id="3821c92eff2643b0d1ccdce26d2e8e48">
-        <source>Product Settings</source>
-        <target>Product Settings</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:99</note>
-      </trans-unit>
-      <trans-unit id="10d0de28911c5f66463b9c8783f8148a">
-        <source>Maintenance</source>
-        <target>Maintenance</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:79</note>
-      </trans-unit>
-      <trans-unit id="e6d0e1c8fc6a4fcf47869df87e04cd88">
-        <source>Customers</source>
-        <target>Customers</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:55</note>
-      </trans-unit>
-      <trans-unit id="7258e7251413465e0a3eb58094430bde">
-        <source>Administration</source>
-        <target>Administration</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:31</note>
-      </trans-unit>
-      <trans-unit id="a82be0f551b8708bc08eb33cd9ded0cf">
-        <source>Information</source>
-        <target>Information</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:69</note>
-      </trans-unit>
-      <trans-unit id="72d6d7a1885885bb55a565fd1070581a">
-        <source>Import</source>
-        <target>Import</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:51</note>
-      </trans-unit>
-      <trans-unit id="9446a98ad14416153cc4d45ab8b531bf">
-        <source>Performance</source>
-        <target>Performance</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:95</note>
-      </trans-unit>
-      <trans-unit id="3068c5a98c003498f1fec0c489212e8b">
-        <source>Sell</source>
-        <target>Sell</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="10ac42c4d7dca450a66e8efbe8b00799">
-        <source>Improve</source>
-        <target>Improve</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:27</note>
-      </trans-unit>
-      <trans-unit id="f1206f9fadc5ce41694f69129aecac26">
-        <source>Configure</source>
-        <target>Configure</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:28</note>
-      </trans-unit>
-      <trans-unit id="d3da97e2d9aee5c8fbe03156ad051c99">
-        <source>More</source>
-        <target>More</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:29</note>
-      </trans-unit>
-      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
-        <source>Addresses</source>
-        <target>Addresses</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:30</note>
-      </trans-unit>
-      <trans-unit id="d5f0ba6e06dd63bcb2b101779a024f97">
-        <source><![CDATA[Modules & Services]]></source>
-        <target><![CDATA[Modules & Services]]></target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:32</note>
-      </trans-unit>
-      <trans-unit id="c9d7eedc8be4380c02106619824b8449">
-        <source>Advanced Parameters</source>
-        <target>Advanced Parameters</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:33</note>
-      </trans-unit>
-      <trans-unit id="91f3a2c0e4424c87689525da44c4db11">
-        <source>Files</source>
-        <target>Files</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:34</note>
-      </trans-unit>
-      <trans-unit id="20ad345341cfd791c1a3f9ef20c35577">
-        <source><![CDATA[Attributes & Features]]></source>
-        <target><![CDATA[Attributes & Features]]></target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:35</note>
-      </trans-unit>
-      <trans-unit id="287234a1ff35a314b5b6bc4e5828e745">
-        <source>Attributes</source>
-        <target>Attributes</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:36</note>
-      </trans-unit>
-      <trans-unit id="1d6af794b2599c1407a83029a09d1ecf">
-        <source>Carriers</source>
-        <target>Carriers</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:37</note>
-      </trans-unit>
-      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
-        <source>Carrier</source>
-        <target>Carrier</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:38</note>
-      </trans-unit>
-      <trans-unit id="65b7eaeb9ba4e9903f82297face9f7cd">
-        <source>Cart Rules</source>
-        <target>Cart Rules</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:39</note>
-      </trans-unit>
-      <trans-unit id="8540df06444445760abd0583233b6367">
-        <source>Catalog Price Rules</source>
-        <target>Catalog Price Rules</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:40</note>
-      </trans-unit>
-      <trans-unit id="2e0c0842b88031fa2594c2fc231a0c22">
-        <source>Module Catalog</source>
-        <target>Module Catalog</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:41</note>
-      </trans-unit>
-      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
-        <source>Categories</source>
-        <target>Categories</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:42</note>
-      </trans-unit>
-      <trans-unit id="efcf628091b527cc576784186ac97de9">
-        <source>Page Categories</source>
-        <target>Page Categories</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:43</note>
-      </trans-unit>
-      <trans-unit id="453aceb005ceaf54a47da15fee8b2a26">
-        <source>Pages</source>
-        <target>Pages</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:44</note>
-      </trans-unit>
-      <trans-unit id="f647e3f65d2df0358ad2eff6a6d85c15">
-        <source>Combinations Generator</source>
-        <target>Combinations Generator</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:45</note>
-      </trans-unit>
-      <trans-unit id="254f642527b45bc260048e30704edb39">
-        <source>Configuration</source>
-        <target>Configuration</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:46</note>
-      </trans-unit>
-      <trans-unit id="bbaff12800505b22a853e8b7f4eb6a22">
-        <source>Contact</source>
-        <target>Contact</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:47</note>
-      </trans-unit>
-      <trans-unit id="9aa698f602b1e5694855cee73a683488">
-        <source>Contacts</source>
-        <target>Contacts</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:48</note>
-      </trans-unit>
-      <trans-unit id="790d59ef178acbc75d233bf4211763c6">
-        <source>Countries</source>
-        <target>Countries</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:49</note>
-      </trans-unit>
-      <trans-unit id="33f595542d01643570908b6ecac7b521">
-        <source>Credit Slips</source>
-        <target>Credit Slips</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:50</note>
-      </trans-unit>
-      <trans-unit id="dfcfc43722eef1eab1e4a12e50a068b1">
-        <source>Currencies</source>
-        <target>Currencies</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:52</note>
-      </trans-unit>
-      <trans-unit id="d5552e0564007d93ff5937a9cb3bc491">
-        <source>Customer Service</source>
-        <target>Customer Service</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:53</note>
-      </trans-unit>
-      <trans-unit id="e693ba8db5bd43c8b27cf2eca19215ab">
-        <source>Customer Settings</source>
-        <target>Customer Settings</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:54</note>
-      </trans-unit>
-      <trans-unit id="2938c7f7e560ed972f8a4f68e80ff834">
-        <source>Dashboard</source>
-        <target>Dashboard</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:56</note>
-      </trans-unit>
-      <trans-unit id="e307db07b3975fef922a80d07455ee5e">
-        <source>Database</source>
-        <target>Database</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:57</note>
-      </trans-unit>
-      <trans-unit id="eb626c94531ec554f93b2b78a77c8b1b">
-        <source>Employees</source>
-        <target>Employees</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:61</note>
-      </trans-unit>
-      <trans-unit id="ac848fa228f49ba2b8a5fbd76596817d">
-        <source>Team</source>
-        <target>Team</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:62</note>
-      </trans-unit>
-      <trans-unit id="98f770b0af18ca763421bac22b4b6805">
-        <source>Features</source>
-        <target>Features</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:63</note>
-      </trans-unit>
-      <trans-unit id="0db377921f4ce762c62526131097968f">
-        <source>General</source>
-        <target>General</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:64</note>
-      </trans-unit>
-      <trans-unit id="a37ede293936e29279ed543129451ec3">
-        <source>Groups</source>
-        <target>Groups</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:66</note>
-      </trans-unit>
-      <trans-unit id="4c99c66c65d5cc7f1c5ef76302aa9988">
-        <source>Image Settings</source>
-        <target>Image Settings</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:67</note>
-      </trans-unit>
-      <trans-unit id="fff0d600f8a0b5e19e88bfb821dd1157">
-        <source>Images</source>
-        <target>Images</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:68</note>
-      </trans-unit>
-      <trans-unit id="b9c1c003e8bf1de207824b5766413840">
-        <source>Instant Stock Status</source>
-        <target>Instant Stock Status</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:70</note>
-      </trans-unit>
-      <trans-unit id="3a08e2e340ab29fd9263af48193cbf8e">
-        <source>Languages</source>
-        <target>Languages</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:73</note>
-      </trans-unit>
-      <trans-unit id="eebd338ddbd547e41e4a1296de82963a">
-        <source>Locations</source>
-        <target>Locations</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:75</note>
-      </trans-unit>
-      <trans-unit id="99dea78007133396a7b8ed70578ac6ae">
-        <source>Login</source>
-        <target>Login</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:76</note>
-      </trans-unit>
-      <trans-unit id="1afa74da05ca145d3418aad9af510109">
-        <source>Design</source>
-        <target>Design</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:78</note>
-      </trans-unit>
-      <trans-unit id="aa1550e5c6de2f5e7867edbf0f019118">
-        <source><![CDATA[Brands & Suppliers]]></source>
-        <target><![CDATA[Brands & Suppliers]]></target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:80</note>
-      </trans-unit>
-      <trans-unit id="84be54bb4bd1b755a27d86388700d097">
-        <source>Brands</source>
-        <target>Brands</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:81</note>
-      </trans-unit>
-      <trans-unit id="7cb15e416d62919b1b40298324fbe30b">
-        <source>Marketing</source>
-        <target>Marketing</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:82</note>
-      </trans-unit>
-      <trans-unit id="06145a21dcec7395085b033e6e169b61">
-        <source>Menus</source>
-        <target>Menus</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:83</note>
-      </trans-unit>
-      <trans-unit id="979640f579db842e61902ca061153965">
-        <source>Merchandise Returns</source>
-        <target>Merchandise Returns</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:84</note>
-      </trans-unit>
-      <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2">
-        <source>Modules</source>
-        <target>Modules</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:138
- Comment: subtab</note>
-      </trans-unit>
-      <trans-unit id="423e555c5ec3885f2bb5d9d2d6627f63">
-        <source>Monitoring</source>
-        <target>Monitoring</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:86</note>
-      </trans-unit>
-      <trans-unit id="c103bafd6451f1f08200bebff539606f">
-        <source>Multistore</source>
-        <target>Multistore</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:87</note>
-      </trans-unit>
-      <trans-unit id="127458a6096e6f3224228922cfd45c49">
-        <source>Order Messages</source>
-        <target>Order Messages</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:88</note>
-      </trans-unit>
-      <trans-unit id="d72eaa592e6b1b6f30787d67a70422b7">
-        <source>Order Settings</source>
-        <target>Order Settings</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:89</note>
-      </trans-unit>
-      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
-        <source>Orders</source>
-        <target>Orders</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:90</note>
-      </trans-unit>
-      <trans-unit id="a860ed9926b241b7d4dca2d00610ab2c">
-        <source>Outstanding</source>
-        <target>Outstanding</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:91</note>
-      </trans-unit>
-      <trans-unit id="c453a4b8e8d98e82f35b67f433e3b4da">
-        <source>Payment</source>
-        <target>Payment</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:94</note>
-      </trans-unit>
-      <trans-unit id="d08ccf52b4cdd08e41cfb99ec42e0b29">
-        <source>Permissions</source>
-        <target>Permissions</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:96</note>
-      </trans-unit>
-      <trans-unit id="9d5bf15117441a1b52eb1f0808e4aad3">
-        <source>Discounts</source>
-        <target>Discounts</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:98</note>
-      </trans-unit>
-      <trans-unit id="068f80c7519d0528fb08e82137a72131">
-        <source>Products</source>
-        <target>Products</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:100</note>
-      </trans-unit>
-      <trans-unit id="d0f25115288c15321ecf672f0d6a83ea">
-        <source>Profiles</source>
-        <target>Profiles</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:101</note>
-      </trans-unit>
-      <trans-unit id="4f32a32dea642737580dd71cdfd8d3c0">
-        <source>Quick Access</source>
-        <target>Quick Access</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:102</note>
-      </trans-unit>
-      <trans-unit id="ff398a1c3434e160c655aa1613e0eace">
-        <source>Referrers</source>
-        <target>Referrers</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:103</note>
-      </trans-unit>
-      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
-        <source>Search</source>
-        <target>Search</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:104</note>
-      </trans-unit>
-      <trans-unit id="60d744a6a3775f721ca67718b9c38295">
-        <source>Search Engines</source>
-        <target>Search Engines</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:105</note>
-      </trans-unit>
-      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
-        <source>Shipping</source>
-        <target>Shipping</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:107</note>
-      </trans-unit>
-      <trans-unit id="cf39aaa3dadb081e301236a4abf5e5f4">
-        <source>Shop Parameters</source>
-        <target>Shop Parameters</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:108</note>
-      </trans-unit>
-      <trans-unit id="ae92e4c41ccb386880cda8880c64c6f5">
-        <source>Shop URLs</source>
-        <target>Shop URLs</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:109</note>
-      </trans-unit>
-      <trans-unit id="2c3a8560142d9921c9de12d0a9403fa4">
-        <source>Shopping Carts</source>
-        <target>Shopping Carts</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:110</note>
-      </trans-unit>
-      <trans-unit id="12a521af593422cd508f7707662c9eb2">
-        <source>Shops</source>
-        <target>Shops</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:111</note>
-      </trans-unit>
-      <trans-unit id="b8464cdd84b5f068ad72bf5c4f32163d">
-        <source>States</source>
-        <target>States</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:113</note>
-      </trans-unit>
-      <trans-unit id="452a7601dbc6f2c38aa89e68bda8b603">
-        <source>Stats</source>
-        <target>Stats</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:114</note>
-      </trans-unit>
-      <trans-unit id="61fe9018991004014d12b8d81568df90">
-        <source>Statuses</source>
-        <target>Statuses</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:115</note>
-      </trans-unit>
-      <trans-unit id="89de17fb747c585a81e444f70312de3f">
-        <source>Stock Coverage</source>
-        <target>Stock Coverage</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:116</note>
-      </trans-unit>
-      <trans-unit id="491b992b9b809f4b8797ad1d5e89c93f">
-        <source>Stock Management</source>
-        <target>Stock Management</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:117</note>
-      </trans-unit>
-      <trans-unit id="7a88c0e00abd9ea4220cc8fd00892306">
-        <source>Stock Movement</source>
-        <target>Stock Movement</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:118</note>
-      </trans-unit>
-      <trans-unit id="821b8ee6937cec96c30fdafbfe836d68">
-        <source>Stores</source>
-        <target>Stores</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:120</note>
-      </trans-unit>
-      <trans-unit id="1814d65a76028fdfbadab64a5a8076df">
-        <source>Suppliers</source>
-        <target>Suppliers</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:121</note>
-      </trans-unit>
-      <trans-unit id="570f64eae55bf16de04f20757969d5cf">
-        <source>Supply orders</source>
-        <target>Supply orders</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:122</note>
-      </trans-unit>
-      <trans-unit id="189f63f277cd73395561651753563065">
-        <source>Tags</source>
-        <target>Tags</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:123</note>
-      </trans-unit>
-      <trans-unit id="719fec04166d6fa75f89cd29ad61fa8c">
-        <source>Taxes</source>
-        <target>Taxes</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:124</note>
-      </trans-unit>
-      <trans-unit id="8d4ae51b8b5831db49a6dcde1b83e175">
-        <source>Tax Rules</source>
-        <target>Tax Rules</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:125</note>
-      </trans-unit>
-      <trans-unit id="6ab9fb0c40f36bc078afaacf74c91215">
-        <source>Theme Catalog</source>
-        <target>Theme Catalog</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:126</note>
-      </trans-unit>
-      <trans-unit id="fcf3b725bb6ebb0e635b0f0902ade451">
-        <source><![CDATA[Theme & Logo]]></source>
-        <target><![CDATA[Theme & Logo]]></target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:127</note>
-      </trans-unit>
-      <trans-unit id="8612579044efe457f11398b5a2377226">
-        <source>Titles</source>
-        <target>Titles</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:128</note>
-      </trans-unit>
-      <trans-unit id="c11004c9bfd6ca3b95f052f0df3e8f21">
-        <source><![CDATA[Traffic & SEO]]></source>
-        <target><![CDATA[Traffic & SEO]]></target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:129</note>
-      </trans-unit>
-      <trans-unit id="3020c78ae45aff9a35b95856af076765">
-        <source>Warehouses</source>
-        <target>Warehouses</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:131</note>
-      </trans-unit>
-      <trans-unit id="dad1f8d794ee0dd7753fe75e73b78f31">
-        <source>Zones</source>
-        <target>Zones</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:133</note>
-      </trans-unit>
-      <trans-unit id="58366edba8b92e2955f237fe5897dad5">
-        <source>Modules Catalog</source>
-        <target>Modules Catalog</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:134</note>
-      </trans-unit>
-      <trans-unit id="e699cbe9208f8353248889781f83d636">
-        <source>Module manager</source>
-        <target>Module manager</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:135</note>
-      </trans-unit>
-      <trans-unit id="9ac41b6a577daadd588f0fcde0071e8b">
-        <source>Updates</source>
-        <target>Updates</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:139</note>
-      </trans-unit>
-      <trans-unit id="df583ae7ba964fd4806b55904da81813">
-        <source>Alerts</source>
-        <target>Alerts</target>
-        <note>Context:
-File: classes/lang/KeysReference/TabLang.php:140</note>
+      <trans-unit id="b61541208db7fa7dba42c85224405911">
+        <source>Menu</source>
+        <target>Menu</target>
+        <note>Line: 81</note>
       </trans-unit>
     </body>
   </file>
@@ -676,44 +14,575 @@ File: classes/lang/KeysReference/TabLang.php:140</note>
       <trans-unit id="c32516babc5b6c47eb8ce1bfc223253c">
         <source>Catalog</source>
         <target>Catalog</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="fce9a6a1bd2a2050eb86d33103f46fd3">
         <source>Invoices</source>
         <target>Invoices</target>
-        <note>Context:
-File: admin-dev/themes/default/template/search_form.tpl:60</note>
+        <note>Line: 60</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/lang/KeysReference/TabLang.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="8e750875217fe72ff73cda7e57e4d61f">
-        <source>Module selection</source>
-        <target>Module selection</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php:52</note>
+      <trans-unit id="27ce7f8b5623b2e2df568d64cf051607">
+        <source>Stock</source>
+        <target>Stock</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="3068c5a98c003498f1fec0c489212e8b">
+        <source>Sell</source>
+        <target>Sell</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="10ac42c4d7dca450a66e8efbe8b00799">
+        <source>Improve</source>
+        <target>Improve</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="f1206f9fadc5ce41694f69129aecac26">
+        <source>Configure</source>
+        <target>Configure</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="d3da97e2d9aee5c8fbe03156ad051c99">
+        <source>More</source>
+        <target>More</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
+        <source>Addresses</source>
+        <target>Addresses</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="d5f0ba6e06dd63bcb2b101779a024f97">
+        <source><![CDATA[Modules & Services]]></source>
+        <target><![CDATA[Modules & Services]]></target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="c9d7eedc8be4380c02106619824b8449">
+        <source>Advanced Parameters</source>
+        <target>Advanced Parameters</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="91f3a2c0e4424c87689525da44c4db11">
+        <source>Files</source>
+        <target>Files</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="20ad345341cfd791c1a3f9ef20c35577">
+        <source><![CDATA[Attributes & Features]]></source>
+        <target><![CDATA[Attributes & Features]]></target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="287234a1ff35a314b5b6bc4e5828e745">
+        <source>Attributes</source>
+        <target>Attributes</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="1d6af794b2599c1407a83029a09d1ecf">
+        <source>Carriers</source>
+        <target>Carriers</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
+        <source>Carrier</source>
+        <target>Carrier</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="65b7eaeb9ba4e9903f82297face9f7cd">
+        <source>Cart Rules</source>
+        <target>Cart Rules</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="8540df06444445760abd0583233b6367">
+        <source>Catalog Price Rules</source>
+        <target>Catalog Price Rules</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="2e0c0842b88031fa2594c2fc231a0c22">
+        <source>Module Catalog</source>
+        <target>Module Catalog</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
+        <source>Categories</source>
+        <target>Categories</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="efcf628091b527cc576784186ac97de9">
+        <source>Page Categories</source>
+        <target>Page Categories</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="453aceb005ceaf54a47da15fee8b2a26">
+        <source>Pages</source>
+        <target>Pages</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="f647e3f65d2df0358ad2eff6a6d85c15">
+        <source>Combinations Generator</source>
+        <target>Combinations Generator</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="254f642527b45bc260048e30704edb39">
+        <source>Configuration</source>
+        <target>Configuration</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="bbaff12800505b22a853e8b7f4eb6a22">
+        <source>Contact</source>
+        <target>Contact</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="9aa698f602b1e5694855cee73a683488">
+        <source>Contacts</source>
+        <target>Contacts</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="790d59ef178acbc75d233bf4211763c6">
+        <source>Countries</source>
+        <target>Countries</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="33f595542d01643570908b6ecac7b521">
+        <source>Credit Slips</source>
+        <target>Credit Slips</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="dfcfc43722eef1eab1e4a12e50a068b1">
+        <source>Currencies</source>
+        <target>Currencies</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="d5552e0564007d93ff5937a9cb3bc491">
+        <source>Customer Service</source>
+        <target>Customer Service</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="e693ba8db5bd43c8b27cf2eca19215ab">
+        <source>Customer Settings</source>
+        <target>Customer Settings</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="2938c7f7e560ed972f8a4f68e80ff834">
+        <source>Dashboard</source>
+        <target>Dashboard</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="e307db07b3975fef922a80d07455ee5e">
+        <source>Database</source>
+        <target>Database</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="eb626c94531ec554f93b2b78a77c8b1b">
+        <source>Employees</source>
+        <target>Employees</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="ac848fa228f49ba2b8a5fbd76596817d">
+        <source>Team</source>
+        <target>Team</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="98f770b0af18ca763421bac22b4b6805">
+        <source>Features</source>
+        <target>Features</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="0db377921f4ce762c62526131097968f">
+        <source>General</source>
+        <target>General</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="a37ede293936e29279ed543129451ec3">
+        <source>Groups</source>
+        <target>Groups</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="4c99c66c65d5cc7f1c5ef76302aa9988">
+        <source>Image Settings</source>
+        <target>Image Settings</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="fff0d600f8a0b5e19e88bfb821dd1157">
+        <source>Images</source>
+        <target>Images</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="b9c1c003e8bf1de207824b5766413840">
+        <source>Instant Stock Status</source>
+        <target>Instant Stock Status</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="3a08e2e340ab29fd9263af48193cbf8e">
+        <source>Languages</source>
+        <target>Languages</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="eebd338ddbd547e41e4a1296de82963a">
+        <source>Locations</source>
+        <target>Locations</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="99dea78007133396a7b8ed70578ac6ae">
+        <source>Login</source>
+        <target>Login</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="1afa74da05ca145d3418aad9af510109">
+        <source>Design</source>
+        <target>Design</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="aa1550e5c6de2f5e7867edbf0f019118">
+        <source><![CDATA[Brands & Suppliers]]></source>
+        <target><![CDATA[Brands & Suppliers]]></target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="84be54bb4bd1b755a27d86388700d097">
+        <source>Brands</source>
+        <target>Brands</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="7cb15e416d62919b1b40298324fbe30b">
+        <source>Marketing</source>
+        <target>Marketing</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="06145a21dcec7395085b033e6e169b61">
+        <source>Menus</source>
+        <target>Menus</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="979640f579db842e61902ca061153965">
+        <source>Merchandise Returns</source>
+        <target>Merchandise Returns</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2">
+        <source>Modules</source>
+        <target>Modules</target>
+        <note>Line: 138
+Comment: subtab</note>
+      </trans-unit>
+      <trans-unit id="423e555c5ec3885f2bb5d9d2d6627f63">
+        <source>Monitoring</source>
+        <target>Monitoring</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="c103bafd6451f1f08200bebff539606f">
+        <source>Multistore</source>
+        <target>Multistore</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="127458a6096e6f3224228922cfd45c49">
+        <source>Order Messages</source>
+        <target>Order Messages</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="d72eaa592e6b1b6f30787d67a70422b7">
+        <source>Order Settings</source>
+        <target>Order Settings</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
+        <source>Orders</source>
+        <target>Orders</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="a860ed9926b241b7d4dca2d00610ab2c">
+        <source>Outstanding</source>
+        <target>Outstanding</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="c453a4b8e8d98e82f35b67f433e3b4da">
+        <source>Payment</source>
+        <target>Payment</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="d08ccf52b4cdd08e41cfb99ec42e0b29">
+        <source>Permissions</source>
+        <target>Permissions</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="9d5bf15117441a1b52eb1f0808e4aad3">
+        <source>Discounts</source>
+        <target>Discounts</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="068f80c7519d0528fb08e82137a72131">
+        <source>Products</source>
+        <target>Products</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="d0f25115288c15321ecf672f0d6a83ea">
+        <source>Profiles</source>
+        <target>Profiles</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="4f32a32dea642737580dd71cdfd8d3c0">
+        <source>Quick Access</source>
+        <target>Quick Access</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="ff398a1c3434e160c655aa1613e0eace">
+        <source>Referrers</source>
+        <target>Referrers</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
+        <source>Search</source>
+        <target>Search</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="60d744a6a3775f721ca67718b9c38295">
+        <source>Search Engines</source>
+        <target>Search Engines</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
+        <source>Shipping</source>
+        <target>Shipping</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="cf39aaa3dadb081e301236a4abf5e5f4">
+        <source>Shop Parameters</source>
+        <target>Shop Parameters</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="ae92e4c41ccb386880cda8880c64c6f5">
+        <source>Shop URLs</source>
+        <target>Shop URLs</target>
+        <note>Line: 109</note>
+      </trans-unit>
+      <trans-unit id="2c3a8560142d9921c9de12d0a9403fa4">
+        <source>Shopping Carts</source>
+        <target>Shopping Carts</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="12a521af593422cd508f7707662c9eb2">
+        <source>Shops</source>
+        <target>Shops</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="b8464cdd84b5f068ad72bf5c4f32163d">
+        <source>States</source>
+        <target>States</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="452a7601dbc6f2c38aa89e68bda8b603">
+        <source>Stats</source>
+        <target>Stats</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="61fe9018991004014d12b8d81568df90">
+        <source>Statuses</source>
+        <target>Statuses</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="89de17fb747c585a81e444f70312de3f">
+        <source>Stock Coverage</source>
+        <target>Stock Coverage</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="491b992b9b809f4b8797ad1d5e89c93f">
+        <source>Stock Management</source>
+        <target>Stock Management</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="7a88c0e00abd9ea4220cc8fd00892306">
+        <source>Stock Movement</source>
+        <target>Stock Movement</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="821b8ee6937cec96c30fdafbfe836d68">
+        <source>Stores</source>
+        <target>Stores</target>
+        <note>Line: 120</note>
+      </trans-unit>
+      <trans-unit id="1814d65a76028fdfbadab64a5a8076df">
+        <source>Suppliers</source>
+        <target>Suppliers</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="570f64eae55bf16de04f20757969d5cf">
+        <source>Supply orders</source>
+        <target>Supply orders</target>
+        <note>Line: 122</note>
+      </trans-unit>
+      <trans-unit id="189f63f277cd73395561651753563065">
+        <source>Tags</source>
+        <target>Tags</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="719fec04166d6fa75f89cd29ad61fa8c">
+        <source>Taxes</source>
+        <target>Taxes</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="8d4ae51b8b5831db49a6dcde1b83e175">
+        <source>Tax Rules</source>
+        <target>Tax Rules</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="6ab9fb0c40f36bc078afaacf74c91215">
+        <source>Theme Catalog</source>
+        <target>Theme Catalog</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="fcf3b725bb6ebb0e635b0f0902ade451">
+        <source><![CDATA[Theme & Logo]]></source>
+        <target><![CDATA[Theme & Logo]]></target>
+        <note>Line: 127</note>
+      </trans-unit>
+      <trans-unit id="8612579044efe457f11398b5a2377226">
+        <source>Titles</source>
+        <target>Titles</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="c11004c9bfd6ca3b95f052f0df3e8f21">
+        <source><![CDATA[Traffic & SEO]]></source>
+        <target><![CDATA[Traffic & SEO]]></target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="3020c78ae45aff9a35b95856af076765">
+        <source>Warehouses</source>
+        <target>Warehouses</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="dad1f8d794ee0dd7753fe75e73b78f31">
+        <source>Zones</source>
+        <target>Zones</target>
+        <note>Line: 133</note>
+      </trans-unit>
+      <trans-unit id="58366edba8b92e2955f237fe5897dad5">
+        <source>Modules Catalog</source>
+        <target>Modules Catalog</target>
+        <note>Line: 134</note>
+      </trans-unit>
+      <trans-unit id="e699cbe9208f8353248889781f83d636">
+        <source>Module manager</source>
+        <target>Module manager</target>
+        <note>Line: 135</note>
+      </trans-unit>
+      <trans-unit id="9ac41b6a577daadd588f0fcde0071e8b">
+        <source>Updates</source>
+        <target>Updates</target>
+        <note>Line: 139</note>
+      </trans-unit>
+      <trans-unit id="df583ae7ba964fd4806b55904da81813">
+        <source>Alerts</source>
+        <target>Alerts</target>
+        <note>Line: 140</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/Core/Grid/Definition/Factory/BackupDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="e407e3879ca4125520f85ab0c57c3a5c">
-        <source>Themes Catalog</source>
-        <target>Themes Catalog</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php:51</note>
+      <trans-unit id="eb5782af6c84c44ab4147000928cbb78">
+        <source>DB Backup</source>
+        <target>DB Backup</target>
+        <note>Line: 57</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="6ea7071301eeb50e00bf88f5a46ded8e">
-        <source>Modules catalog</source>
-        <target>Modules catalog</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:70</note>
+      <trans-unit id="1e884e3078d9978e216a027ecd57fb34">
+        <source>E-mail</source>
+        <target>E-mail</target>
+        <note>Line: 93</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b2d37ae1cedf42ff874289b721860af2">
+        <source>Logs</source>
+        <target>Logs</target>
+        <note>Line: 84</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="194506bb3f2a5aea2ced4ea98cb22fb4">
+        <source><![CDATA[SEO & URLs]]></source>
+        <target><![CDATA[SEO & URLs]]></target>
+        <note>Line: 87</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e836c2a96e7ef38a39afe4be2beddddd">
+        <source>SQL Manager</source>
+        <target>SQL Manager</target>
+        <note>Line: 82</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a80d5e18649d829bda78450f7c862711">
+        <source>Webservice</source>
+        <target>Webservice</target>
+        <note>Line: 97</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7258e7251413465e0a3eb58094430bde">
+        <source>Administration</source>
+        <target>Administration</target>
+        <note>Line: 60</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="72d6d7a1885885bb55a565fd1070581a">
+        <source>Import</source>
+        <target>Import</target>
+        <note>Line: 275</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9446a98ad14416153cc4d45ab8b531bf">
+        <source>Performance</source>
+        <target>Performance</target>
+        <note>Line: 68</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a82be0f551b8708bc08eb33cd9ded0cf">
+        <source>Information</source>
+        <target>Information</target>
+        <note>Line: 56</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e6d0e1c8fc6a4fcf47869df87e04cd88">
+        <source>Customers</source>
+        <target>Customers</target>
+        <note>Line: 58</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MaintenanceController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="10d0de28911c5f66463b9c8783f8148a">
+        <source>Maintenance</source>
+        <target>Maintenance</target>
+        <note>Line: 58</note>
       </trans-unit>
     </body>
   </file>
@@ -722,18 +591,115 @@ File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:70</not
       <trans-unit id="6f23811c1a55219e38a63b7a8520f842">
         <source>Order settings</source>
         <target>Order settings</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderPreferencesController.php:56</note>
+        <note>Line: 56</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/page_header_toolbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="b61541208db7fa7dba42c85224405911">
-        <source>Menu</source>
-        <target>Menu</target>
-        <note>Context:
-File: admin-dev/themes/default/template/page_header_toolbar.tpl:81</note>
+      <trans-unit id="3821c92eff2643b0d1ccdce26d2e8e48">
+        <source>Product Settings</source>
+        <target>Product Settings</target>
+        <note>Line: 70</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3160eb21973806e4291c3979d4aa242e">
+        <source>Positions</source>
+        <target>Positions</target>
+        <note>Line: 124</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e407e3879ca4125520f85ab0c57c3a5c">
+        <source>Themes Catalog</source>
+        <target>Themes Catalog</target>
+        <note>Line: 51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/International/GeolocationController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="323d4eb70b252acb4a04eaf9e0882597">
+        <source>Geolocation</source>
+        <target>Geolocation</target>
+        <note>Line: 59</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/International/LocalizationController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="369686331c93d55e587441143ccdf427">
+        <source>Localization</source>
+        <target>Localization</target>
+        <note>Line: 66</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6ea7071301eeb50e00bf88f5a46ded8e">
+        <source>Modules catalog</source>
+        <target>Modules catalog</target>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8e750875217fe72ff73cda7e57e4d61f">
+        <source>Module selection</source>
+        <target>Module selection</target>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Payment/PaymentMethodsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="af01f8c298aa063d9c7490f00eddd2df">
+        <source>Payment Methods</source>
+        <target>Payment Methods</target>
+        <note>Line: 61</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d0834fcec6337785ee749c8f5464f6f6">
+        <source>Preferences</source>
+        <target>Preferences</target>
+        <note>Line: 56</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8fddfc8225dcf89be0e15709c671af4e">
+        <source>Delivery Slips</source>
+        <target>Delivery Slips</target>
+        <note>Line: 78</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/TranslationsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0b8d92bc19b720bb1065649535463409">
+        <source>Translations</source>
+        <target>Translations</target>
+        <note>Line: 106</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8189ecf686157db0c0274c1f49373318">
+        <source>International</source>
+        <target>International</target>
+        <note>Line: 50</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminNavigationNotification.xlf
+++ b/app/Resources/translations/default/AdminNavigationNotification.xlf
@@ -1,18 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminQuickAccessesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="c059561b30601ffaf8759ae84f2b44b9">
-        <source>An error occurred while updating new window property.</source>
-        <target>An error occurred while updating new window property.</target>
-        <note>Context:
-File: controllers/admin/AdminQuickAccessesController.php:241</note>
+      <trans-unit id="a2b8ed9c305b8ea86116b603cca78a97">
+        <source>registered</source>
+        <target>registered</target>
+        <note>Line: 68</note>
       </trans-unit>
-      <trans-unit id="aeaf2891ec065451798dc21794358950">
-        <source>An error occurred while updating the new window property for this object.</source>
-        <target>An error occurred while updating the new window property for this object.</target>
-        <note>Context:
-File: controllers/admin/AdminQuickAccessesController.php:244</note>
+      <trans-unit id="91a52a2a855d5abd5597a481c20f3972">
+        <source>No new order for now :(</source>
+        <target>No new order for now :(</target>
+        <note>Line: 311</note>
+      </trans-unit>
+      <trans-unit id="235a11509f6bd6143ddf165affbf7dad">
+        <source>No new customer for now :(</source>
+        <target>No new customer for now :(</target>
+        <note>Line: 321</note>
+      </trans-unit>
+      <trans-unit id="b7c3bb1b80422ee7587d604b1a97ce3c">
+        <source>No new message for now.</source>
+        <target>No new message for now.</target>
+        <note>Line: 331</note>
+      </trans-unit>
+      <trans-unit id="c821206b336b401bccf058f664f8255d">
+        <source>Your shop is in debug mode.</source>
+        <target>Your shop is in debug mode.</target>
+        <note>Line: 221</note>
+      </trans-unit>
+      <trans-unit id="13886bc255a80b7c11e0585013feeb30">
+        <source>All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.</source>
+        <target>All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.</target>
+        <note>Line: 221</note>
+      </trans-unit>
+      <trans-unit id="67a33d40bef41c3b79d6b973bfcbc89a">
+        <source>Your shop is in maintenance.</source>
+        <target>Your shop is in maintenance.</target>
+        <note>Line: 237</note>
+      </trans-unit>
+      <trans-unit id="929f5283d0fa1e9eecf20cc294f981e5">
+        <source><![CDATA[Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.]]></source>
+        <target><![CDATA[Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.]]></target>
+        <note>Line: 237</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="00843f41bd87586508e233b4b4947cf2">
+        <source>Orders[1][/1]</source>
+        <target>Orders[1][/1]</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="6ff813b90fea117cb8981d26b0df548c">
+        <source>Customers[1][/1]</source>
+        <target>Customers[1][/1]</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="ced94ea851437be7264f84648dbe3c7d">
+        <source>Messages[1][/1]</source>
+        <target>Messages[1][/1]</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="d98a07f84921b24ee30f86fd8cd85c3c">
+        <source>from</source>
+        <target>from</target>
+        <note>Line: 123</note>
       </trans-unit>
     </body>
   </file>
@@ -21,136 +73,61 @@ File: controllers/admin/AdminQuickAccessesController.php:244</note>
       <trans-unit id="7338d1654d0dd5e156c4ad6d2a6a80a5">
         <source>Did you check your conversion rate lately?</source>
         <target>Did you check your conversion rate lately?</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1962</note>
+        <note>Line: 1962</note>
       </trans-unit>
       <trans-unit id="2e93cdcdff918d01a48fa1f1fdd7d0cd">
         <source>How about some seasonal discounts?</source>
         <target>How about some seasonal discounts?</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1963</note>
+        <note>Line: 1963</note>
       </trans-unit>
       <trans-unit id="7c56f525288d680c6efa0c2d07d79d13">
         <source>Have you checked your [1][2]abandoned carts[/2][/1]?[3]Your next order could be hiding there!</source>
         <target>Have you checked your [1][2]abandoned carts[/2][/1]?[3]Your next order could be hiding there!</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1965</note>
+        <note>Line: 1965</note>
       </trans-unit>
       <trans-unit id="164458d092e10375ec3068e610fe5d10">
         <source>Have you sent any acquisition email lately?</source>
         <target>Have you sent any acquisition email lately?</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1977</note>
+        <note>Line: 1977</note>
       </trans-unit>
       <trans-unit id="70821661a53b31c40fdd6c9f3bbff741">
         <source>Are you active on social media these days?</source>
         <target>Are you active on social media these days?</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1978</note>
+        <note>Line: 1978</note>
       </trans-unit>
       <trans-unit id="f588a396cc917d42d3dc0dd61d9e339b">
         <source>Have you considered selling on marketplaces?</source>
         <target>Have you considered selling on marketplaces?</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1979</note>
+        <note>Line: 1979</note>
       </trans-unit>
       <trans-unit id="e0b6918caa922c992efb3343d11470c9">
         <source>That's more time for something else!</source>
         <target>That's more time for something else!</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1982</note>
+        <note>Line: 1982</note>
       </trans-unit>
       <trans-unit id="9a6493e17f94595cb54a16f60866d9fd">
         <source>No news is good news, isn't it?</source>
         <target>No news is good news, isn't it?</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1983</note>
+        <note>Line: 1983</note>
       </trans-unit>
       <trans-unit id="b5ffb1ab1fe4ad00831c65b8dab60c0c">
         <source>Seems like all your customers are happy :)</source>
         <target>Seems like all your customers are happy :)</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1984</note>
+        <note>Line: 1984</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/admin/AdminQuickAccessesController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="a2b8ed9c305b8ea86116b603cca78a97">
-        <source>registered</source>
-        <target>registered</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl:132</note>
+      <trans-unit id="c059561b30601ffaf8759ae84f2b44b9">
+        <source>An error occurred while updating new window property.</source>
+        <target>An error occurred while updating new window property.</target>
+        <note>Line: 241</note>
       </trans-unit>
-      <trans-unit id="91a52a2a855d5abd5597a481c20f3972">
-        <source>No new order for now :(</source>
-        <target>No new order for now :(</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl:87</note>
-      </trans-unit>
-      <trans-unit id="235a11509f6bd6143ddf165affbf7dad">
-        <source>No new customer for now :(</source>
-        <target>No new customer for now :(</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl:97</note>
-      </trans-unit>
-      <trans-unit id="b7c3bb1b80422ee7587d604b1a97ce3c">
-        <source>No new message for now.</source>
-        <target>No new message for now.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl:107</note>
-      </trans-unit>
-      <trans-unit id="00843f41bd87586508e233b4b4947cf2">
-        <source>Orders[1][/1]</source>
-        <target>Orders[1][/1]</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl:44</note>
-      </trans-unit>
-      <trans-unit id="6ff813b90fea117cb8981d26b0df548c">
-        <source>Customers[1][/1]</source>
-        <target>Customers[1][/1]</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl:59</note>
-      </trans-unit>
-      <trans-unit id="ced94ea851437be7264f84648dbe3c7d">
-        <source>Messages[1][/1]</source>
-        <target>Messages[1][/1]</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl:74</note>
-      </trans-unit>
-      <trans-unit id="d98a07f84921b24ee30f86fd8cd85c3c">
-        <source>from</source>
-        <target>from</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/notifications_center.tpl:123</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c821206b336b401bccf058f664f8255d">
-        <source>Your shop is in debug mode.</source>
-        <target>Your shop is in debug mode.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:221</note>
-      </trans-unit>
-      <trans-unit id="13886bc255a80b7c11e0585013feeb30">
-        <source>All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.</source>
-        <target>All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:221</note>
-      </trans-unit>
-      <trans-unit id="67a33d40bef41c3b79d6b973bfcbc89a">
-        <source>Your shop is in maintenance.</source>
-        <target>Your shop is in maintenance.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:237</note>
-      </trans-unit>
-      <trans-unit id="929f5283d0fa1e9eecf20cc294f981e5">
-        <source><![CDATA[Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.]]></source>
-        <target><![CDATA[Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.]]></target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:237</note>
+      <trans-unit id="aeaf2891ec065451798dc21794358950">
+        <source>An error occurred while updating the new window property for this object.</source>
+        <target>An error occurred while updating the new window property for this object.</target>
+        <note>Line: 244</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminNavigationSearch.xlf
+++ b/app/Resources/translations/default/AdminNavigationSearch.xlf
@@ -5,146 +5,122 @@
       <trans-unit id="1eafe1bac879d838ee6d25eccfc9cb35">
         <source>There are no results matching your query "%s".</source>
         <target>There are no results matching your query "%s".</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="71eb31b250c9248c64a08e1efad5f6d9">
         <source>%d results match your query "%s".</source>
         <target>%d results match your query "%s".</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:39</note>
+        <note>Line: 39</note>
       </trans-unit>
       <trans-unit id="7728ad63f14ad095862fd765b7a74fe6">
         <source>1 result matches your query "%s".</source>
         <target>1 result matches your query "%s".</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:37</note>
+        <note>Line: 37</note>
       </trans-unit>
       <trans-unit id="81609118f8ea6dc02664998181345416">
         <source>1 feature</source>
         <target>1 feature</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="6827f95aead7a463cac2c673591edf7e">
         <source>%d features</source>
         <target>%d features</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:52</note>
+        <note>Line: 52</note>
       </trans-unit>
       <trans-unit id="c4a6a84a33c055a2f92c8f3d52718100">
         <source>1 module</source>
         <target>1 module</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:74</note>
+        <note>Line: 74</note>
       </trans-unit>
       <trans-unit id="d64f66187ca2535e8aa5eccac54e7013">
         <source>%d modules</source>
         <target>%d modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:76</note>
+        <note>Line: 76</note>
       </trans-unit>
       <trans-unit id="59a2104ef3237945cd8378a51f853ca8">
         <source>1 category</source>
         <target>1 category</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:96</note>
+        <note>Line: 96</note>
       </trans-unit>
       <trans-unit id="593dafa821d7cebf6e76bf592110ba32">
         <source>%d categories</source>
         <target>%d categories</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:98</note>
+        <note>Line: 98</note>
       </trans-unit>
       <trans-unit id="702085cd8b96c1e778c9e59ffba0394d">
         <source>1 product</source>
         <target>1 product</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:116</note>
+        <note>Line: 116</note>
       </trans-unit>
       <trans-unit id="864c665aea5e824772fda0e678c3ac4d">
         <source>%d products</source>
         <target>%d products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:118</note>
+        <note>Line: 118</note>
       </trans-unit>
       <trans-unit id="f08f35ebaebc5e5037a0b2a3474de8c4">
         <source>1 customer</source>
         <target>1 customer</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:130</note>
+        <note>Line: 130</note>
       </trans-unit>
       <trans-unit id="d5865d192ae31edead7bdea6ed1c85d9">
         <source>%d customers</source>
         <target>%d customers</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:132</note>
+        <note>Line: 132</note>
       </trans-unit>
       <trans-unit id="6febfe29360949ae825d828fa095b6df">
         <source>1 order</source>
         <target>1 order</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:143</note>
+        <note>Line: 143</note>
       </trans-unit>
       <trans-unit id="c0115153d45d00a4510d71e2605196a3">
         <source>%d orders</source>
         <target>%d orders</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:145</note>
+        <note>Line: 145</note>
       </trans-unit>
       <trans-unit id="1b339eb691ebd4d2103b8b76de41d321">
         <source>1 addon</source>
         <target>1 addon</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:156</note>
+        <note>Line: 156</note>
       </trans-unit>
       <trans-unit id="0cbcb09148c0538edfccc2b40d606ae7">
         <source>%d addons</source>
         <target>%d addons</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:158</note>
+        <note>Line: 158</note>
       </trans-unit>
       <trans-unit id="e77449fd1e8fd61e78e99eac35791ed7">
         <source>Show more results...</source>
         <target>Show more results...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:172</note>
+        <note>Line: 172</note>
       </trans-unit>
       <trans-unit id="fdbb3dd95d543d67dc19d9fb3f6c46f4">
         <source>Search doc.prestashop.com</source>
         <target>Search doc.prestashop.com</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:183</note>
+        <note>Line: 183</note>
       </trans-unit>
       <trans-unit id="14bd5dfadc5c57da66495ebc2c8c020b">
         <source>Go to the documentation</source>
         <target>Go to the documentation</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:184</note>
+        <note>Line: 184</note>
       </trans-unit>
       <trans-unit id="9d6f008f9c1e0446e23b253ecc7b311a">
         <source>Search addons.prestashop.com</source>
         <target>Search addons.prestashop.com</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:189</note>
+        <note>Line: 189</note>
       </trans-unit>
       <trans-unit id="a68b46728e83ba2fd535a25e8216bdb7">
         <source>Go to Addons</source>
         <target>Go to Addons</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:190</note>
+        <note>Line: 190</note>
       </trans-unit>
       <trans-unit id="96b65991d3a699bf3e83cec22339b620">
         <source>Search prestashop.com forum</source>
         <target>Search prestashop.com forum</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:195</note>
+        <note>Line: 195</note>
       </trans-unit>
       <trans-unit id="550b342104e3b39d04e56c346bc6f014">
         <source>Go to the Forum</source>
         <target>Go to the Forum</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl:196</note>
+        <note>Line: 196</note>
       </trans-unit>
     </body>
   </file>
@@ -153,9 +129,8 @@ File: admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
       <trans-unit id="75d3b3db03124cd6196c021686bda791">
         <source>%d result matches your query "%s".</source>
         <target>%d result matches your query "%s".</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/InternationalApi.php:57
- Comment: %d can be 0 or 1</note>
+        <note>Line: 57
+Comment: %d can be 0 or 1</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminNotificationsError.xlf
+++ b/app/Resources/translations/default/AdminNotificationsError.xlf
@@ -1,1360 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a7eca295291f53a23ab7ba0a9c7fd9de">
-        <source>This functionality has been disabled.</source>
-        <target>This functionality has been disabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php:159</note>
-      </trans-unit>
-      <trans-unit id="df3c280f0aaf0cb0d5c25ab322a8bcf9">
-        <source>You do not have permission to update this.</source>
-        <target>You do not have permission to update this.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php:169</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminAttachmentsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1f66f9472666b18b19c22fd0f1a6a07b">
-        <source>The file is too large. Maximum size allowed is: %1$d kB. The file you are trying to upload is %2$d kB.</source>
-        <target>The file is too large. Maximum size allowed is: %1$d kB. The file you are trying to upload is %2$d kB.</target>
-        <note>Context:
-File: controllers/admin/AdminAttachmentsController.php:220</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1bdd228669c9dd995eb664737e60786e">
-        <source>You do not have permission to edit this.</source>
-        <target>You do not have permission to edit this.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:3069</note>
-      </trans-unit>
-      <trans-unit id="11a257a80f8c8d76132470b171de6795">
-        <source>You do not have permission to delete this.</source>
-        <target>You do not have permission to delete this.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:3062</note>
-      </trans-unit>
-      <trans-unit id="d8d4c3b79181fdcca8cb5159208fa56a">
-        <source>You do not have permission to add this.</source>
-        <target>You do not have permission to add this.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:2985</note>
-      </trans-unit>
-      <trans-unit id="d9b5b2302d57f3d13d5387ba9c99daae">
-        <source>An error occurred while creating an object.</source>
-        <target>An error occurred while creating an object.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1151</note>
-      </trans-unit>
-      <trans-unit id="77ae44aa6c998166fcf1a87496278ad5">
-        <source>(cannot load object)</source>
-        <target>(cannot load object)</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1344</note>
-      </trans-unit>
-      <trans-unit id="7f290594963a303db17a5e21dc4cf0b7">
-        <source>An error occurred while deleting the object.</source>
-        <target>An error occurred while deleting the object.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1107</note>
-      </trans-unit>
-      <trans-unit id="815e471ea2970db0b63b9b09feacc70f">
-        <source>An error occurred while updating the status for an object.</source>
-        <target>An error occurred while updating the status for an object.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1343</note>
-      </trans-unit>
-      <trans-unit id="1b0cc7183377b461e298d0ebcf5f8548">
-        <source>An error occurred while updating the status.</source>
-        <target>An error occurred while updating the status.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1324</note>
-      </trans-unit>
-      <trans-unit id="45ebc64529137a007889ee445d64611c">
-        <source>Failed to update the position.</source>
-        <target>Failed to update the position.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1346</note>
-      </trans-unit>
-      <trans-unit id="1d5dfad5ac415b412c20a05a89d43db6">
-        <source>An error occurred while deleting this selection.</source>
-        <target>An error occurred while deleting this selection.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4040</note>
-      </trans-unit>
-      <trans-unit id="ddd4e7f16c2032d59cb4fb4b86576bc5">
-        <source>You must select at least one element to delete.</source>
-        <target>You must select at least one element to delete.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4043</note>
-      </trans-unit>
-      <trans-unit id="b1367942aa02ea8c9d4aa07cdf5e473c">
-        <source>You need at least one object.</source>
-        <target>You need at least one object.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4010</note>
-      </trans-unit>
-      <trans-unit id="ec5f6f7f65190788d12ef16ab6135009">
-        <source>You cannot delete all of the items.</source>
-        <target>You cannot delete all of the items.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4012</note>
-      </trans-unit>
-      <trans-unit id="bc33aa1314e7dcd3472db72472b909b2">
-        <source>An error occurred during deletion.</source>
-        <target>An error occurred during deletion.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1101</note>
-      </trans-unit>
-      <trans-unit id="954b49d26a3a0986aca720a7095f2aa9">
-        <source>An error occurred while updating an object.</source>
-        <target>An error occurred while updating an object.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1256</note>
-      </trans-unit>
-      <trans-unit id="b42cd3af71fc00ef268910709255320a">
-        <source>You do not have permission to view this.</source>
-        <target>You do not have permission to view this.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:3004</note>
-      </trans-unit>
-      <trans-unit id="3452da55a90ccedd184c7ba264b2afd5">
-        <source>Due to memory limit restrictions, this image cannot be loaded. Please increase your memory_limit value via your server's configuration settings. </source>
-        <target>Due to memory limit restrictions, this image cannot be loaded. Please increase your memory_limit value via your server's configuration settings.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:3972</note>
-      </trans-unit>
-      <trans-unit id="7c422404cb037e6781b5a553060670a6">
-        <source>Can't delete #%id%</source>
-        <target>Can't delete #%id%</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4034</note>
-      </trans-unit>
-      <trans-unit id="fa4611fb85bb8f118f562d107ab790d4">
-        <source>The object cannot be loaded (or found)</source>
-        <target>The object cannot be loaded (or found)</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1670
- Comment: throw exception</note>
-      </trans-unit>
-      <trans-unit id="df2751083713a6a971814c07d88c3eb5">
-        <source>The 'From' date format is invalid (YYYY-MM-DD)</source>
-        <target>The 'From' date format is invalid (YYYY-MM-DD)</target>
-        <note>Context:
-File: classes/controller/AdminController.php:881</note>
-      </trans-unit>
-      <trans-unit id="f500b8d6f94abcca48cda7c033c64996">
-        <source>The 'To' date format is invalid (YYYY-MM-DD)</source>
-        <target>The 'To' date format is invalid (YYYY-MM-DD)</target>
-        <note>Context:
-File: classes/controller/AdminController.php:889</note>
-      </trans-unit>
-      <trans-unit id="83379252d4737a0b2a63a9388bb36890">
-        <source>An error occurred while attempting to delete the image. (cannot load object).</source>
-        <target>An error occurred while attempting to delete the image. (cannot load object).</target>
-        <note>Context:
-File: classes/controller/AdminController.php:996</note>
-      </trans-unit>
-      <trans-unit id="2a0c56d5a5183a9b65b8e2817f75ded2">
-        <source>You cannot delete this item.</source>
-        <target>You cannot delete this item.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1083
- Comment: check if some ids are in list_skip_actions and forbid deletion</note>
-      </trans-unit>
-      <trans-unit id="10f97f4fea6d1ff9ffd1ed3260d6220d">
-        <source>Unable to delete associated images.</source>
-        <target>Unable to delete associated images.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1091</note>
-      </trans-unit>
-      <trans-unit id="efb49241363bce74c7d7899333cdebb5">
-        <source>An error occurred when attempting to update the required fields.</source>
-        <target>An error occurred when attempting to update the required fields.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1291</note>
-      </trans-unit>
-      <trans-unit id="204c3558e41366f3d558ce8e01426a22">
-        <source>field %s is required.</source>
-        <target>field %s is required.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1444</note>
-      </trans-unit>
-      <trans-unit id="c2c0e06097c62422199e29a5574e9fc4">
-        <source>Cannot add configuration %s</source>
-        <target>Cannot add configuration %s</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1506</note>
-      </trans-unit>
-      <trans-unit id="a62d7ffa591311c930a2017b07e55394">
-        <source>The object cannot be loaded (the identifier is missing or invalid)</source>
-        <target>The object cannot be loaded (the identifier is missing or invalid)</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1680</note>
-      </trans-unit>
-      <trans-unit id="2782e6f430c2658c79aecfcecdc0d0e8">
-        <source>The field %field_name% is required at least in %lang%.</source>
-        <target>The field %field_name% is required at least in %lang%.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:3658</note>
-      </trans-unit>
-      <trans-unit id="114eadc70de249729e9287a6b450c6e0">
-        <source>The %field_name% field (%lang%) is invalid.</source>
-        <target>The %field_name% field (%lang%) is invalid.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:3691</note>
-      </trans-unit>
-      <trans-unit id="b4186b9ed7c957a1cd9f4e7ce916e603">
-        <source>%s: Incorrect value</source>
-        <target>%s: Incorrect value</target>
-        <note>Context:
-File: classes/controller/AdminController.php:3896</note>
-      </trans-unit>
-      <trans-unit id="c87956ad745e55231c633c03fe0f0d5b">
-        <source>An error occurred while assigning a zone to the selection.</source>
-        <target>An error occurred while assigning a zone to the selection.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4140</note>
-      </trans-unit>
-      <trans-unit id="93463ceee9a3d376b18ee618bc2fffe4">
-        <source>You must select at least one element to assign a new zone.</source>
-        <target>You must select at least one element to assign a new zone.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4142</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/ObjectModel.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0e2338b37ab3dfeed544e8233b53d4e0">
-        <source>The %1$s field is too long (%2$d chars max).</source>
-        <target>The %1$s field is too long (%2$d chars max).</target>
-        <note>Context:
-File: classes/ObjectModel.php:1114</note>
-      </trans-unit>
-      <trans-unit id="5cd8dc8a58702a63e79af3ad9de16d7a">
-        <source>The %s field is invalid.</source>
-        <target>The %s field is invalid.</target>
-        <note>Context:
-File: classes/ObjectModel.php:1155</note>
-      </trans-unit>
-      <trans-unit id="02af8c16ef4efa9fa9e2142372b0b90d">
-        <source>The %s field is required.</source>
-        <target>The %s field is required.</target>
-        <note>Context:
-File: classes/ObjectModel.php:1080</note>
-      </trans-unit>
-      <trans-unit id="fed3c8d832129d27b64c34fe410e7346">
-        <source>Property %s is empty.</source>
-        <target>Property %s is empty.</target>
-        <note>Context:
-File: classes/ObjectModel.php:1082</note>
-      </trans-unit>
-      <trans-unit id="872d428c40b36bba9fc5fafaa76c6f22">
-        <source>Property %1$s has a bad value (allowed values are: %2$s).</source>
-        <target>Property %1$s has a bad value (allowed values are: %2$s).</target>
-        <note>Context:
-File: classes/ObjectModel.php:1096</note>
-      </trans-unit>
-      <trans-unit id="9599d22695068a773c0f10ea1fd26a74">
-        <source>Your entry in field %1$s (language %2$s) exceeds max length %3$d chars (incl. html tags).</source>
-        <target>Your entry in field %1$s (language %2$s) exceeds max length %3$d chars (incl. html tags).</target>
-        <note>Context:
-File: classes/ObjectModel.php:1112</note>
-      </trans-unit>
-      <trans-unit id="2674ff1d6f5ff826dae13cd4db1ca9b0">
-        <source>The length of property %1$s is currently %2$d chars. It must be between %3$d and %4$d chars.</source>
-        <target>The length of property %1$s is currently %2$d chars. It must be between %3$d and %4$d chars.</target>
-        <note>Context:
-File: classes/ObjectModel.php:1117</note>
-      </trans-unit>
-      <trans-unit id="1448270fc6dbabe70584c87fa27cc96f">
-        <source>Validation function not found: %s.</source>
-        <target>Validation function not found: %s.</target>
-        <note>Context:
-File: classes/ObjectModel.php:1135</note>
-      </trans-unit>
-      <trans-unit id="6938fc7c0e5b0b07a6ba370bcb84bbd3">
-        <source>Property %s is not valid</source>
-        <target>Property %s is not valid</target>
-        <note>Context:
-File: classes/ObjectModel.php:1157</note>
-      </trans-unit>
-      <trans-unit id="ee66f9c9930cb33d2a5dde9b240d3f7e">
-        <source>is required.</source>
-        <target>is required.</target>
-        <note>Context:
-File: classes/ObjectModel.php:1215</note>
-      </trans-unit>
-      <trans-unit id="0fec856489067e4d21aa315324c441dc">
-        <source>%1$s is too long. Maximum length: %2$d</source>
-        <target>%1$s is too long. Maximum length: %2$d</target>
-        <note>Context:
-File: classes/ObjectModel.php:1222</note>
-      </trans-unit>
-      <trans-unit id="87ecb83d305a6af0e0438a0587e31de8">
-        <source>%s is invalid.</source>
-        <target>%s is invalid.</target>
-        <note>Context:
-File: classes/ObjectModel.php:1233</note>
-      </trans-unit>
-      <trans-unit id="2deae2efe4b65df80c188a31fed3cc17">
-        <source>The field %s is required.</source>
-        <target>The field %s is required.</target>
-        <note>Context:
-File: classes/ObjectModel.php:1432</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="055cca15dfe5fb74bde56d7331fff449">
-        <source>An error occurred while saving the message.</source>
-        <target>An error occurred while saving the message.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:627</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminNotFoundController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d0fbda9855d118740f1105334305c126">
-        <source>Page not found</source>
-        <target>Page not found</target>
-        <note>Context:
-File: controllers/admin/AdminNotFoundController.php:46</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopUrlController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fd44c173b6a7897151a978b9015fec76">
-        <source>You cannot disable the Main URL.</source>
-        <target>You cannot disable the Main URL.</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:508</note>
-      </trans-unit>
-      <trans-unit id="d2de9e264ff4f0e711d809f00da76e45">
-        <source>You cannot change a main URL to a non-main URL. You have to set another URL as your Main URL for the selected shop.</source>
-        <target>You cannot change a main URL to a non-main URL. You have to set another URL as your Main URL for the selected shop.</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:504</note>
-      </trans-unit>
-      <trans-unit id="aee1f34d776c8cc3401cac254299e6f9">
-        <source>A shop URL that uses this domain already exists.</source>
-        <target>A shop URL that uses this domain already exists.</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:482</note>
-      </trans-unit>
-      <trans-unit id="deb836e0c149bb47a1d86eabe4b2f7db">
-        <source>A shop virtual URL cannot be "%URL%"</source>
-        <target>A shop virtual URL cannot be "%URL%"</target>
-        <note>Context:
-File: controllers/admin/AdminShopUrlController.php:459</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="84e4970c5c35731ac7084f09ca0a77cd">
-        <source>The email address is invalid.</source>
-        <target>The email address is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:414</note>
-      </trans-unit>
-      <trans-unit id="62867691cceb8f8a7e7683b924cc20c5">
-        <source>An error occurred during the file upload process.</source>
-        <target>An error occurred during the file upload process.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:430</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminMetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="efd4ed1ed0d97b89a65880765028933e">
-        <source>The URL rewrite field must be filled in either the default or English language.</source>
-        <target>The URL rewrite field must be filled in either the default or English language.</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:418</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e31f2dac034e1437efa1dbf499509963">
-        <source>Cannot write into file: %filename%. Please check write permissions.</source>
-        <target>Cannot write into file: %filename%. Please check write permissions.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php:275</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8fb7465fec179740502812519d1a8182">
-        <source>This domain is not valid.</source>
-        <target>This domain is not valid.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsFormDataProvider.php:208</note>
-      </trans-unit>
-      <trans-unit id="d2d0c6d9bcc804f2c59b8fc228dc671e">
-        <source>The SSL domain is not valid.</source>
-        <target>The SSL domain is not valid.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsFormDataProvider.php:216</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="959c96ec640d353311dd9763d57daad6">
-        <source>Please fill in all the required fields.</source>
-        <target>Please fill in all the required fields.</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:471</note>
-      </trans-unit>
-      <trans-unit id="dd6b089a49908d671c3e9cc8dc5899ae">
-        <source>Invalid message</source>
-        <target>Invalid message</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:407</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/helper/HelperList.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ee77ea46b0c548ed60eadf31bdd68613">
-        <source>Bad SQL query</source>
-        <target>Bad SQL query</target>
-        <note>Context:
-File: classes/helper/HelperList.php:141</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e96814b3d9ff9ae65c8f2be2ee3e0555">
-        <source>Invalid tag(s) (%s)</source>
-        <target>Invalid tag(s) (%s)</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2113</note>
-      </trans-unit>
-      <trans-unit id="3d52f8b2b1a67aa8740b72b3752d54f3">
-        <source>Incorrect value for "Depends on stock" for product %name% </source>
-        <target>Incorrect value for "Depends on stock" for product %name%</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:2786</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminProductsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="527d23f49ced7a14e50546e1b90672e7">
-        <source>Cannot retrieve file.</source>
-        <target>Cannot retrieve file.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:362</note>
-      </trans-unit>
-      <trans-unit id="fb86a99edb05e880b59843698a2fafbd">
-        <source>Cannot delete file</source>
-        <target>Cannot delete file</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1125</note>
-      </trans-unit>
-      <trans-unit id="abf6e66f4a0b444dbcb1a626e88cd973">
-        <source>Invalid name for %s language</source>
-        <target>Invalid name for %s language</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:418</note>
-      </trans-unit>
-      <trans-unit id="572f072ea1a00ba0470ec3e5f4b80e24">
-        <source>The name for %1s language is too long (%2d chars max).</source>
-        <target>The name for %1s language is too long (%2d chars max).</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:420</note>
-      </trans-unit>
-      <trans-unit id="370835a4106d1c7860f2fbb5daabd050">
-        <source>The file is missing.</source>
-        <target>The file is missing.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:454</note>
-      </trans-unit>
-      <trans-unit id="611d3495c1e0dad701d535ccafd84330">
-        <source>Invalid file extension</source>
-        <target>Invalid file extension</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:473</note>
-      </trans-unit>
-      <trans-unit id="6292d73b79fd27bdc4c7d8a7ce2c79b4">
-        <source>The file name is too long.</source>
-        <target>The file name is too long.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:479</note>
-      </trans-unit>
-      <trans-unit id="bbced877c13c763f0141ff906c8ed0e5">
-        <source>Invalid file</source>
-        <target>Invalid file</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:495</note>
-      </trans-unit>
-      <trans-unit id="505bbc38260c669d0793757e414caecc">
-        <source>The %s field is not valid</source>
-        <target>The %s field is not valid</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:740</note>
-      </trans-unit>
-      <trans-unit id="e267d34972b3ab66b987fbad59fba513">
-        <source>Invalid date format.</source>
-        <target>Invalid date format.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:765</note>
-      </trans-unit>
-      <trans-unit id="c7e56badecce297feefe2a9b50a68794">
-        <source>Invalid date range</source>
-        <target>Invalid date range</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:973</note>
-      </trans-unit>
-      <trans-unit id="be67fb2de5962acd123edaeeed6d4488">
-        <source>An error occurred while updating the image.</source>
-        <target>An error occurred while updating the image.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1641</note>
-      </trans-unit>
-      <trans-unit id="46d431810202adee8bca6b13a5ebd0d9">
-        <source>An error occurred while linking the object %table_name% to categories.</source>
-        <target>An error occurred while linking the object %table_name% to categories.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1938</note>
-      </trans-unit>
-      <trans-unit id="723b4a80bd8ae233c9fcde1e5bd55436">
-        <source>The object cannot be loaded. </source>
-        <target>The object cannot be loaded.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:1985</note>
-      </trans-unit>
-      <trans-unit id="9ca63429d31c3e720001675dd8535a9d">
-        <source>The %name% field is required.</source>
-        <target>The %name% field is required.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2012</note>
-      </trans-unit>
-      <trans-unit id="172dfd675cd344c66724042519cc4df1">
-        <source>The %1$s field (%2$s) is invalid.</source>
-        <target>The %1$s field (%2$s) is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2121</note>
-      </trans-unit>
-      <trans-unit id="787acc7a9d39b98fac309cf303f518d3">
-        <source>The tags list (%s) is invalid.</source>
-        <target>The tags list (%s) is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2147</note>
-      </trans-unit>
-      <trans-unit id="cbecc45ae8ccf1234657bd40ee4c55dd">
-        <source>An error occurred while copying this image:</source>
-        <target>An error occurred while copying this image:</target>
-        <note>Context:
-File: controllers/admin/AdminProductsController.php:2852</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Uploader.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="be694d5db9d32c43014995441a5939c4">
-        <source>Invalid file name</source>
-        <target>Invalid file name</target>
-        <note>Context:
-File: classes/Uploader.php:349</note>
-      </trans-unit>
-      <trans-unit id="a5a6e6da29a779cece21518a4ba337e2">
-        <source>The uploaded file exceeds the post_max_size directive in php.ini</source>
-        <target>The uploaded file exceeds the post_max_size directive in php.ini</target>
-        <note>Context:
-File: classes/Uploader.php:343</note>
-      </trans-unit>
-      <trans-unit id="0bff5a3a7cc19937dd97b8a995915222">
-        <source>File is too big. Current size is %1s, maximum size is %2s.</source>
-        <target>File is too big. Current size is %1s, maximum size is %2s.</target>
-        <note>Context:
-File: classes/Uploader.php:364</note>
-      </trans-unit>
-      <trans-unit id="fb0e0badcf5ac5c98f791447646f5ac8">
-        <source>Server file size is different from local file size</source>
-        <target>Server file size is different from local file size</target>
-        <note>Context:
-File: classes/Uploader.php:287</note>
-      </trans-unit>
-      <trans-unit id="ae8e757923a42d666e5c0fdf59fda545">
-        <source>The uploaded file exceeds %s</source>
-        <target>The uploaded file exceeds %s</target>
-        <note>Context:
-File: classes/Uploader.php:307</note>
-      </trans-unit>
-      <trans-unit id="f8fe8cba1625eaf8e5c253b041d57dbd">
-        <source>The uploaded file was only partially uploaded</source>
-        <target>The uploaded file was only partially uploaded</target>
-        <note>Context:
-File: classes/Uploader.php:310</note>
-      </trans-unit>
-      <trans-unit id="298883b17e36ee3a18d73e835c0b44fc">
-        <source>No file was uploaded</source>
-        <target>No file was uploaded</target>
-        <note>Context:
-File: classes/Uploader.php:313</note>
-      </trans-unit>
-      <trans-unit id="c6de8e792d7423f52f3108b197f87738">
-        <source>Missing temporary folder</source>
-        <target>Missing temporary folder</target>
-        <note>Context:
-File: classes/Uploader.php:316</note>
-      </trans-unit>
-      <trans-unit id="f5985b2c059d5cc36968baab7585baba">
-        <source>Failed to write file to disk</source>
-        <target>Failed to write file to disk</target>
-        <note>Context:
-File: classes/Uploader.php:319</note>
-      </trans-unit>
-      <trans-unit id="b2b0bd0f32c2dcb52c3e2feb24f33a31">
-        <source>A PHP extension stopped the file upload</source>
-        <target>A PHP extension stopped the file upload</target>
-        <note>Context:
-File: classes/Uploader.php:322</note>
-      </trans-unit>
-      <trans-unit id="85fb1cf47b9543043438ba7ed901b626">
-        <source>Filetype not allowed</source>
-        <target>Filetype not allowed</target>
-        <note>Context:
-File: classes/Uploader.php:358</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/QqUploadedFileForm.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="06b778accab7c14a499bc6e7a68138ec">
-        <source>An error occurred while copying the image.</source>
-        <target>An error occurred while copying the image.</target>
-        <note>Context:
-File: classes/QqUploadedFileForm.php:78</note>
-      </trans-unit>
-      <trans-unit id="b05c3c0bfce943b86e286e8e8103b6e5">
-        <source>An error occurred while uploading the image.</source>
-        <target>An error occurred while uploading the image.</target>
-        <note>Context:
-File: classes/QqUploadedFileForm.php:76</note>
-      </trans-unit>
-      <trans-unit id="dc0614532e2b908e6c2d82cc0972af9d">
-        <source>An error occurred while attempting to create a new folder.</source>
-        <target>An error occurred while attempting to create a new folder.</target>
-        <note>Context:
-File: classes/QqUploadedFileForm.php:73</note>
-      </trans-unit>
-      <trans-unit id="6c3609de8769a4456305ec22e764573d">
-        <source>An error occurred while copying this image: %s</source>
-        <target>An error occurred while copying this image: %s</target>
-        <note>Context:
-File: classes/QqUploadedFileForm.php:83</note>
-      </trans-unit>
-      <trans-unit id="211ff814e7bf91c4548a61ba1c427c15">
-        <source>Error while updating the status.</source>
-        <target>Error while updating the status.</target>
-        <note>Context:
-File: classes/QqUploadedFileForm.php:91</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="574af21ff5cd555457e49205287f7e9b">
-        <source>The object cannot be loaded.</source>
-        <target>The object cannot be loaded.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:898</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f9f47dee59a41f69369745b42136b14e">
-        <source>Your Zip/postal code is incorrect.</source>
-        <target>Your Zip/postal code is incorrect.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:368</note>
-      </trans-unit>
-      <trans-unit id="6660b316abc0970476a09df63028d553">
-        <source>It must be entered as follows:</source>
-        <target>It must be entered as follows:</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:368</note>
-      </trans-unit>
-      <trans-unit id="d57c64abf56d22df05f34e473b3879ad">
-        <source>A Zip/postal code is required.</source>
-        <target>A Zip/postal code is required.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:370</note>
-      </trans-unit>
-      <trans-unit id="5b0e7a50bbe35d2e59dc92c7ba9b369a">
-        <source>The Zip/postal code is invalid.</source>
-        <target>The Zip/postal code is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:372</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3fe46a677aa76978d058880999b3fffb">
-        <source>Error while delete</source>
-        <target>Error while delete</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:735</note>
-      </trans-unit>
-      <trans-unit id="f86f7b91afe27e79305a6b07bdb0d3c0">
-        <source>Failed to update the status</source>
-        <target>Failed to update the status</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:1018</note>
-      </trans-unit>
-      <trans-unit id="2b4de48b49648d3323f20b6371f7e3c1">
-        <source>You cannot upload more files</source>
-        <target>You cannot upload more files</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:1055</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminModulesPositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="aeca1e74dd7d86d85886996651937da9">
-        <source>No valid value for field exceptions has been defined.</source>
-        <target>No valid value for field exceptions has been defined.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:174</note>
-      </trans-unit>
-      <trans-unit id="0ce2f4a4f40a2d23525b5b02bcfe611f">
-        <source>An error occurred while transplanting the module to its hook.</source>
-        <target>An error occurred while transplanting the module to its hook.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesPositionsController.php:107</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminModulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5dcea1234ac01d22f40ffc81d0bc4c2f">
-        <source>File too large (limit of %s bytes).</source>
-        <target>File too large (limit of %s bytes).</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:585</note>
-      </trans-unit>
-      <trans-unit id="c9b70823c0ee73b2ce964dfd16a10ddc">
-        <source>File upload was not completed.</source>
-        <target>File upload was not completed.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:588</note>
-      </trans-unit>
-      <trans-unit id="8c9067e52e4440d8a20e74fdc745b0c6">
-        <source>No file was uploaded.</source>
-        <target>No file was uploaded.</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:591</note>
-      </trans-unit>
-      <trans-unit id="acdcc688155bd653f51eaf710cac8af5">
-        <source>Internal error #%s</source>
-        <target>Internal error #%s</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:594</note>
-      </trans-unit>
-      <trans-unit id="5569135c321c16866b524ec82dcd2b2a">
-        <source>No file has been selected</source>
-        <target>No file has been selected</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:598</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTranslationsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e298a0bc9a35d45798e28c082dfc1dfa">
-        <source>"%type%" does not exist.</source>
-        <target>"%type%" does not exist.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:113</note>
-      </trans-unit>
-      <trans-unit id="40f5c232e433d178a4f912b3092d7df1">
-        <source>Directory "%folder%" cannot be created</source>
-        <target>Directory "%folder%" cannot be created</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:339</note>
-      </trans-unit>
-      <trans-unit id="80034ab2323115584ed4c5b05e222f60">
-        <source>File "%file%" cannot be created</source>
-        <target>File "%file%" cannot be created</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:341</note>
-      </trans-unit>
-      <trans-unit id="6b12f160f2bb3c7dea01bd96a223d80e">
-        <source>Cannot write this file: "%folder%"</source>
-        <target>Cannot write this file: "%folder%"</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:391</note>
-      </trans-unit>
-      <trans-unit id="f0566c73cce29920f99fda8819745804">
-        <source>This file must be writable: %file%</source>
-        <target>This file must be writable: %file%</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:520</note>
-      </trans-unit>
-      <trans-unit id="bb5ef82c8be2494c733ac77920bc5c72">
-        <source>No file has been selected.</source>
-        <target>No file has been selected.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:766</note>
-      </trans-unit>
-      <trans-unit id="e594c33758771c458a7f80e9afdf7e55">
-        <source>The server does not have permissions for writing.</source>
-        <target>The server does not have permissions for writing.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:802</note>
-      </trans-unit>
-      <trans-unit id="65dd53e33c17621f58bcc99be967814a">
-        <source>Please check rights for %file%</source>
-        <target>Please check rights for %file%</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:802</note>
-      </trans-unit>
-      <trans-unit id="e0a602c130d12d57cd4ca2a8b9240917">
-        <source>This file must be writable:</source>
-        <target>This file must be writable:</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:1747</note>
-      </trans-unit>
-      <trans-unit id="bcfa9fd034fffbe5aa1a9c9e306386f1">
-        <source>Fatal error: The module directory does not exist.</source>
-        <target>Fatal error: The module directory does not exist.</target>
-        <note>Context:
-File: controllers/admin/AdminTranslationsController.php:2175</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminLoginController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d3338ce970be43e586e64e0a41dc01e2">
-        <source>There is one error.</source>
-        <target>There is one error.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:53</note>
-      </trans-unit>
-      <trans-unit id="c7da8f310b3b53c7c3529517860b7ecc">
-        <source>There are several errors.</source>
-        <target>There are several errors.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:54</note>
-      </trans-unit>
-      <trans-unit id="becfb58422969ec127b4bf1af46650ab">
-        <source>Email is empty.</source>
-        <target>Email is empty.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:248</note>
-      </trans-unit>
-      <trans-unit id="e267e2be02cf3e29f4ba53b5d97cf78a">
-        <source>Invalid email address.</source>
-        <target>Invalid email address.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:250</note>
-      </trans-unit>
-      <trans-unit id="5ee800d2d30225decb5b057d846103b7">
-        <source>The password field is blank.</source>
-        <target>The password field is blank.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:189</note>
-      </trans-unit>
-      <trans-unit id="855eb8db89b4921c42072832d33d2dc2">
-        <source>Invalid password.</source>
-        <target>Invalid password.</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:191</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminDashboardController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8f29c70fd66f50ce28b727cd40c6a3a3">
-        <source>The selected date range is not valid.</source>
-        <target>The selected date range is not valid.</target>
-        <note>Context:
-File: controllers/admin/AdminDashboardController.php:346</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="01e93e9457d86c646965decd586dc5ea">
-        <source>Address format invalid</source>
-        <target>Address format invalid</target>
-        <note>Context:
-File: controllers/admin/AdminCountriesController.php:434</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminEmployeesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1f0e23c8f9563f28107b313ca812f3c3">
-        <source>No profile.</source>
-        <target>No profile.</target>
-        <note>Context:
-File: controllers/admin/AdminEmployeesController.php:76</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_themecusto/controllers/admin/AdminPsThemeCustoAdvanced.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="109715467b74bd66639faa5673f707c1">
-        <source>Unknown error.</source>
-        <target>Unknown error.</target>
-        <note>Context:
-File: modules/ps_themecusto/controllers/admin/AdminPsThemeCustoAdvanced.php:305</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminThemesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9f4c1b4b9bcf088c9d32e74b7f542a77">
-        <source>You do not have permission to upload this.</source>
-        <target>You do not have permission to upload this.</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:315</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/SqlManager/SqlQueryValidator.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0b5512610b0c8548345f37a58bf51360">
-        <source>"%key%" does not exist.</source>
-        <target>"%key%" does not exist.</target>
-        <note>Context:
-File: src/Adapter/SqlManager/SqlQueryValidator.php:389</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopGroupController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f1534de7e6636fdfedf7aea238841b24">
-        <source>You cannot delete or disable the last shop group.</source>
-        <target>You cannot delete or disable the last shop group.</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:323</note>
-      </trans-unit>
-      <trans-unit id="e91077be3c46fd0d3fd8e972e8ca1e48">
-        <source>You cannot delete or disable a shop group in use.</source>
-        <target>You cannot delete or disable a shop group in use.</target>
-        <note>Context:
-File: controllers/admin/AdminShopGroupController.php:325</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_banner/ps_banner.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="df7859ac16e724c9b1fba0a364503d72">
-        <source>An error occurred while attempting to upload the file.</source>
-        <target>An error occurred while attempting to upload the file.</target>
-        <note>Context:
-File: modules/ps_banner/ps_banner.php:118</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_categorytree/ps_categorytree.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="23e0d4ecc25de9b2777fdaca3e2f3193">
-        <source>Maximum depth: Invalid number.</source>
-        <target>Maximum depth: Invalid number.</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_imageslider/ps_imageslider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7cc92687130ea12abb80556681538001">
-        <source>An error occurred during the image upload process.</source>
-        <target>An error occurred during the image upload process.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:484</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_customtext/ps_customtext.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="abb1f006957d2d4002cc1d49c63a0fad">
-        <source>Please fill out all fields.</source>
-        <target>Please fill out all fields.</target>
-        <note>Context:
-File: modules/ps_customtext/ps_customtext.php:151</note>
-      </trans-unit>
-      <trans-unit id="3fa720301fb9c9badc23c00c1e88b4f7">
-        <source>An error occurred on saving.</source>
-        <target>An error occurred on saving.</target>
-        <note>Context:
-File: modules/ps_customtext/ps_customtext.php:157</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/blockreassurance/blockreassurance.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d52eaeff31af37a4a7e0550008aff5df">
-        <source>An error occurred while attempting to save.</source>
-        <target>An error occurred while attempting to save.</target>
-        <note>Context:
-File: modules/blockreassurance/blockreassurance.php:226</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="417d63b1effb110e438d4b4b9f0fbd95">
-        <source>The voucher code is invalid.</source>
-        <target>The voucher code is invalid.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:158</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Localization/Pack/Import/LocalizationPackImporter.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0bd212ed072143f56147f2f119892d03">
-        <source>Invalid selection</source>
-        <target>Invalid selection</target>
-        <note>Context:
-File: src/Core/Localization/Pack/Import/LocalizationPackImporter.php:159</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ddb7f719baea8c9f335937b683e8f155">
-        <source>Invalid data supplied.</source>
-        <target>Invalid data supplied.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestFormDataProvider.php:191</note>
-      </trans-unit>
-      <trans-unit id="777e4c7c4a3cc47eb332a7a4022c983e">
-        <source>Unexpected error occurred.</source>
-        <target>Unexpected error occurred.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestFormDataProvider.php:231</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/AddonsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="358cc9ee3a3d23d3390e5043122d9bea">
-        <source>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</source>
-        <target>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/AddonsController.php:80</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e8ae00af8575f645bf6e4358f120cba3">
-        <source>An unexpected error occurred. [%type% code %code%]</source>
-        <target>An unexpected error occurred. [%type% code %code%]</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php:366</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dbf373dd3565accf2d2fd19700f6a5ae">
-        <source>Invalid action</source>
-        <target>Invalid action</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php:380</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bf413509dac07690b304373338fc1149">
-        <source>Cannot open export file for writing</source>
-        <target>Cannot open export file for writing</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php:543</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b07242082d4a24b63951185a1bae15bb">
-        <source>You do not have permission to create this.</source>
-        <target>You do not have permission to create this.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php:94</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/controller/Controller.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="652122103181aa2752efaecab300edf0">
-        <source>Access denied.</source>
-        <target>Access denied.</target>
-        <note>Context:
-File: classes/controller/Controller.php:283</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/module/Module.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fdc746e5693df31cf4f6ef789a8846c5">
-        <source>file (%s) not writable</source>
-        <target>file (%s) not writable</target>
-        <note>Context:
-File: classes/module/Module.php:2967</note>
-      </trans-unit>
-      <trans-unit id="a9de928286071f457fcbc45656353761">
-        <source>directory (%s) not writable</source>
-        <target>directory (%s) not writable</target>
-        <note>Context:
-File: classes/module/Module.php:3044</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/FileUploader.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="20c6125376d8de28149d655c7cc25e32">
-        <source>No files were uploaded.</source>
-        <target>No files were uploaded.</target>
-        <note>Context:
-File: classes/FileUploader.php:74</note>
-      </trans-unit>
-      <trans-unit id="e1a0a773bd7a52245c9a25d45dc6d807">
-        <source>Source file does not exist or is empty.</source>
-        <target>Source file does not exist or is empty.</target>
-        <note>Context:
-File: classes/FileUploader.php:80</note>
-      </trans-unit>
-      <trans-unit id="6e9550e40cc317663fbe81e759d098e8">
-        <source>The uploaded file is too large.</source>
-        <target>The uploaded file is too large.</target>
-        <note>Context:
-File: classes/FileUploader.php:83</note>
-      </trans-unit>
-      <trans-unit id="9269d66af1c332a48a9e3f5b2284be09">
-        <source>File has an invalid extension, it should be one of these: %s.</source>
-        <target>File has an invalid extension, it should be one of these: %s.</target>
-        <note>Context:
-File: classes/FileUploader.php:93</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Customization.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="95013b94140e1438329efc8a39352f4b">
-        <source>Could not load cart id=%s</source>
-        <target>Could not load cart id=%s</target>
-        <note>Context:
-File: classes/Customization.php:384</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Meta.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="36757394a699878de6f0e51f203d1ee7">
-        <source>Cannot scan root directory</source>
-        <target>Cannot scan root directory</target>
-        <note>Context:
-File: classes/Meta.php:72</note>
-      </trans-unit>
-      <trans-unit id="c0c29d8902aa2cb256ea9eaefe307bf5">
-        <source>Cannot scan "override" directory</source>
-        <target>Cannot scan "override" directory</target>
-        <note>Context:
-File: classes/Meta.php:76</note>
-      </trans-unit>
-      <trans-unit id="b1ea648f9b7634752699f28ec9897b1a">
-        <source>File %2$s (in directory %1$s)</source>
-        <target>File %2$s (in directory %1$s)</target>
-        <note>Context:
-File: classes/Meta.php:104</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Validate.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f9c7939a8397ee022fefee2bdb3407af">
-        <source>Invalid URL</source>
-        <target>Invalid URL</target>
-        <note>Context:
-File: classes/Validate.php:72</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Currency.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e07269088946aa33a280b8c05529b46c">
-        <source>Cannot parse feed.</source>
-        <target>Cannot parse feed.</target>
-        <note>Context:
-File: classes/Currency.php:583</note>
-      </trans-unit>
-      <trans-unit id="6f775dff2aa88bce2301e5d5309c5f7e">
-        <source>No default currency</source>
-        <target>No default currency</target>
-        <note>Context:
-File: classes/Currency.php:590</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/helper/HelperImageUploader.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2368e33e3e01d53abb9b60061ab83903">
-        <source>The uploaded file exceeds the upload_max_filesize directive in php.ini</source>
-        <target>The uploaded file exceeds the upload_max_filesize directive in php.ini</target>
-        <note>Context:
-File: classes/helper/HelperImageUploader.php:59</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/QqUploadedFileXhr.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2ddbcf3cd6846f895d2520d0227b7810">
-        <source>Error on image caption: "%1s" is not a valid caption.</source>
-        <target>Error on image caption: "%1s" is not a valid caption.</target>
-        <note>Context:
-File: classes/QqUploadedFileXhr.php:68</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/ImageManager.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="30fb35f3cf2b6e6e599b30dacc6c19c8">
-        <source>Image is too large (%1$d kB). Maximum allowed: %2$d kB</source>
-        <target>Image is too large (%1$d kB). Maximum allowed: %2$d kB</target>
-        <note>Context:
-File: classes/ImageManager.php:469</note>
-      </trans-unit>
-      <trans-unit id="c4ae3afc5d4c01919142f8b39cc5c1c5">
-        <source>Image format not recognized, allowed formats are: .gif, .jpg, .png</source>
-        <target>Image format not recognized, allowed formats are: .gif, .jpg, .png</target>
-        <note>Context:
-File: classes/ImageManager.php:449</note>
-      </trans-unit>
-      <trans-unit id="198dabd328b3e93b2eec2f6d76ab3eb1">
-        <source>Error while uploading image; please change your server's settings. (Error code: %s)</source>
-        <target>Error while uploading image; please change your server's settings. (Error code: %s)</target>
-        <note>Context:
-File: classes/ImageManager.php:452</note>
-      </trans-unit>
-      <trans-unit id="2ab146a83f61d2896a472f52f353b321">
-        <source>Image format not recognized, allowed formats are: .ico</source>
-        <target>Image format not recognized, allowed formats are: .ico</target>
-        <note>Context:
-File: classes/ImageManager.php:472</note>
-      </trans-unit>
-      <trans-unit id="da819cb8d5fcace59e5ec77b43b12b0a">
-        <source>Error while uploading image; please change your server's settings.</source>
-        <target>Error while uploading image; please change your server's settings.</target>
-        <note>Context:
-File: classes/ImageManager.php:475</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/AddressFormat.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="47be00818e1acd46db0092d6586204cf">
-        <source>This class name does not exist.</source>
-        <target>This class name does not exist.</target>
-        <note>Context:
-File: classes/AddressFormat.php:132</note>
-      </trans-unit>
-      <trans-unit id="388ed04607290133b78adf251a3e17ed">
-        <source>This property does not exist in the class or is forbidden.</source>
-        <target>This property does not exist in the class or is forbidden.</target>
-        <note>Context:
-File: classes/AddressFormat.php:149</note>
-      </trans-unit>
-      <trans-unit id="48524477f4f52618e4ab9f1f6fb1d1a8">
-        <source>This association has too many elements.</source>
-        <target>This association has too many elements.</target>
-        <note>Context:
-File: classes/AddressFormat.php:176</note>
-      </trans-unit>
-      <trans-unit id="46e6c4977ebd38ff176e68481ab04275">
-        <source>This name is not allowed.</source>
-        <target>This name is not allowed.</target>
-        <note>Context:
-File: classes/AddressFormat.php:192</note>
-      </trans-unit>
-      <trans-unit id="6b6a27e705469286cb83d20ec8e1b885">
-        <source>Syntax error with this pattern.</source>
-        <target>Syntax error with this pattern.</target>
-        <note>Context:
-File: classes/AddressFormat.php:186</note>
-      </trans-unit>
-      <trans-unit id="a3084b5f93d22e573824af3ca8f58b73">
-        <source>This key has already been used.</source>
-        <target>This key has already been used.</target>
-        <note>Context:
-File: classes/AddressFormat.php:228</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Configuration.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="05c210d25ce1e9ad49a27d570f82b090">
-        <source>[%s] is not a valid configuration key</source>
-        <target>[%s] is not a valid configuration key</target>
-        <note>Context:
-File: classes/Configuration.php:428</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/Tools.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="355f26b47eff3302c93a1c49676f078e">
-        <source>Fatal error</source>
-        <target>Fatal error</target>
-        <note>Context:
-File: classes/Tools.php:1101</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="5d1994bf28899a87795983875a98c2e1">
         <source>Unable to update settings.</source>
         <target>Unable to update settings.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl:230</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a9e0d1b71fb7197367e0518bb6b34fdd">
-        <source>The file is too large. Maximum size allowed is: [1]. The file you are trying to upload is [2].</source>
-        <target>The file is too large. Maximum size allowed is: [1]. The file you are trying to upload is [2].</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:337</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/error.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ecdb1f330299c20ac9897cd73f92c8cd">
-        <source>%1$s on line %2$s in file %3$s</source>
-        <target>%1$s on line %2$s in file %3$s</target>
-        <note>Context:
-File: admin-dev/themes/default/template/error.tpl:31</note>
+        <note>Line: 230</note>
       </trans-unit>
     </body>
   </file>
@@ -1363,24 +14,1212 @@ File: admin-dev/themes/default/template/error.tpl:31</note>
       <trans-unit id="1e460c9780e870a025de51dbac61eeae">
         <source>There are %d errors.</source>
         <target>There are %d errors.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="e1ca36437c42dca0886afdc7d463b012">
         <source>There is %d error.</source>
         <target>There is %d error.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:37</note>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/error.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ecdb1f330299c20ac9897cd73f92c8cd">
+        <source>%1$s on line %2$s in file %3$s</source>
+        <target>%1$s on line %2$s in file %3$s</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/AddressFormat.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="47be00818e1acd46db0092d6586204cf">
+        <source>This class name does not exist.</source>
+        <target>This class name does not exist.</target>
+        <note>Line: 132</note>
+      </trans-unit>
+      <trans-unit id="388ed04607290133b78adf251a3e17ed">
+        <source>This property does not exist in the class or is forbidden.</source>
+        <target>This property does not exist in the class or is forbidden.</target>
+        <note>Line: 149</note>
+      </trans-unit>
+      <trans-unit id="48524477f4f52618e4ab9f1f6fb1d1a8">
+        <source>This association has too many elements.</source>
+        <target>This association has too many elements.</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="46e6c4977ebd38ff176e68481ab04275">
+        <source>This name is not allowed.</source>
+        <target>This name is not allowed.</target>
+        <note>Line: 192</note>
+      </trans-unit>
+      <trans-unit id="6b6a27e705469286cb83d20ec8e1b885">
+        <source>Syntax error with this pattern.</source>
+        <target>Syntax error with this pattern.</target>
+        <note>Line: 186</note>
+      </trans-unit>
+      <trans-unit id="a3084b5f93d22e573824af3ca8f58b73">
+        <source>This key has already been used.</source>
+        <target>This key has already been used.</target>
+        <note>Line: 228</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Configuration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="05c210d25ce1e9ad49a27d570f82b090">
+        <source>[%s] is not a valid configuration key</source>
+        <target>[%s] is not a valid configuration key</target>
+        <note>Line: 428</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Currency.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e07269088946aa33a280b8c05529b46c">
+        <source>Cannot parse feed.</source>
+        <target>Cannot parse feed.</target>
+        <note>Line: 583</note>
+      </trans-unit>
+      <trans-unit id="6f775dff2aa88bce2301e5d5309c5f7e">
+        <source>No default currency</source>
+        <target>No default currency</target>
+        <note>Line: 590</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Customization.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="95013b94140e1438329efc8a39352f4b">
+        <source>Could not load cart id=%s</source>
+        <target>Could not load cart id=%s</target>
+        <note>Line: 384</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/FileUploader.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="20c6125376d8de28149d655c7cc25e32">
+        <source>No files were uploaded.</source>
+        <target>No files were uploaded.</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="e1a0a773bd7a52245c9a25d45dc6d807">
+        <source>Source file does not exist or is empty.</source>
+        <target>Source file does not exist or is empty.</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="6e9550e40cc317663fbe81e759d098e8">
+        <source>The uploaded file is too large.</source>
+        <target>The uploaded file is too large.</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="9269d66af1c332a48a9e3f5b2284be09">
+        <source>File has an invalid extension, it should be one of these: %s.</source>
+        <target>File has an invalid extension, it should be one of these: %s.</target>
+        <note>Line: 93</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/ImageManager.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="30fb35f3cf2b6e6e599b30dacc6c19c8">
+        <source>Image is too large (%1$d kB). Maximum allowed: %2$d kB</source>
+        <target>Image is too large (%1$d kB). Maximum allowed: %2$d kB</target>
+        <note>Line: 469</note>
+      </trans-unit>
+      <trans-unit id="c4ae3afc5d4c01919142f8b39cc5c1c5">
+        <source>Image format not recognized, allowed formats are: .gif, .jpg, .png</source>
+        <target>Image format not recognized, allowed formats are: .gif, .jpg, .png</target>
+        <note>Line: 449</note>
+      </trans-unit>
+      <trans-unit id="198dabd328b3e93b2eec2f6d76ab3eb1">
+        <source>Error while uploading image; please change your server's settings. (Error code: %s)</source>
+        <target>Error while uploading image; please change your server's settings. (Error code: %s)</target>
+        <note>Line: 452</note>
+      </trans-unit>
+      <trans-unit id="2ab146a83f61d2896a472f52f353b321">
+        <source>Image format not recognized, allowed formats are: .ico</source>
+        <target>Image format not recognized, allowed formats are: .ico</target>
+        <note>Line: 472</note>
+      </trans-unit>
+      <trans-unit id="da819cb8d5fcace59e5ec77b43b12b0a">
+        <source>Error while uploading image; please change your server's settings.</source>
+        <target>Error while uploading image; please change your server's settings.</target>
+        <note>Line: 475</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Meta.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="36757394a699878de6f0e51f203d1ee7">
+        <source>Cannot scan root directory</source>
+        <target>Cannot scan root directory</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="c0c29d8902aa2cb256ea9eaefe307bf5">
+        <source>Cannot scan "override" directory</source>
+        <target>Cannot scan "override" directory</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="b1ea648f9b7634752699f28ec9897b1a">
+        <source>File %2$s (in directory %1$s)</source>
+        <target>File %2$s (in directory %1$s)</target>
+        <note>Line: 104</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/ObjectModel.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="02af8c16ef4efa9fa9e2142372b0b90d">
+        <source>The %s field is required.</source>
+        <target>The %s field is required.</target>
+        <note>Line: 1080</note>
+      </trans-unit>
+      <trans-unit id="fed3c8d832129d27b64c34fe410e7346">
+        <source>Property %s is empty.</source>
+        <target>Property %s is empty.</target>
+        <note>Line: 1082</note>
+      </trans-unit>
+      <trans-unit id="872d428c40b36bba9fc5fafaa76c6f22">
+        <source>Property %1$s has a bad value (allowed values are: %2$s).</source>
+        <target>Property %1$s has a bad value (allowed values are: %2$s).</target>
+        <note>Line: 1096</note>
+      </trans-unit>
+      <trans-unit id="9599d22695068a773c0f10ea1fd26a74">
+        <source>Your entry in field %1$s (language %2$s) exceeds max length %3$d chars (incl. html tags).</source>
+        <target>Your entry in field %1$s (language %2$s) exceeds max length %3$d chars (incl. html tags).</target>
+        <note>Line: 1112</note>
+      </trans-unit>
+      <trans-unit id="2674ff1d6f5ff826dae13cd4db1ca9b0">
+        <source>The length of property %1$s is currently %2$d chars. It must be between %3$d and %4$d chars.</source>
+        <target>The length of property %1$s is currently %2$d chars. It must be between %3$d and %4$d chars.</target>
+        <note>Line: 1117</note>
+      </trans-unit>
+      <trans-unit id="1448270fc6dbabe70584c87fa27cc96f">
+        <source>Validation function not found: %s.</source>
+        <target>Validation function not found: %s.</target>
+        <note>Line: 1135</note>
+      </trans-unit>
+      <trans-unit id="6938fc7c0e5b0b07a6ba370bcb84bbd3">
+        <source>Property %s is not valid</source>
+        <target>Property %s is not valid</target>
+        <note>Line: 1157</note>
+      </trans-unit>
+      <trans-unit id="ee66f9c9930cb33d2a5dde9b240d3f7e">
+        <source>is required.</source>
+        <target>is required.</target>
+        <note>Line: 1215</note>
+      </trans-unit>
+      <trans-unit id="0fec856489067e4d21aa315324c441dc">
+        <source>%1$s is too long. Maximum length: %2$d</source>
+        <target>%1$s is too long. Maximum length: %2$d</target>
+        <note>Line: 1222</note>
+      </trans-unit>
+      <trans-unit id="87ecb83d305a6af0e0438a0587e31de8">
+        <source>%s is invalid.</source>
+        <target>%s is invalid.</target>
+        <note>Line: 1233</note>
+      </trans-unit>
+      <trans-unit id="2deae2efe4b65df80c188a31fed3cc17">
+        <source>The field %s is required.</source>
+        <target>The field %s is required.</target>
+        <note>Line: 1432</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/QqUploadedFileXhr.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2ddbcf3cd6846f895d2520d0227b7810">
+        <source>Error on image caption: "%1s" is not a valid caption.</source>
+        <target>Error on image caption: "%1s" is not a valid caption.</target>
+        <note>Line: 68</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Tools.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="355f26b47eff3302c93a1c49676f078e">
+        <source>Fatal error</source>
+        <target>Fatal error</target>
+        <note>Line: 1105</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Uploader.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fb0e0badcf5ac5c98f791447646f5ac8">
+        <source>Server file size is different from local file size</source>
+        <target>Server file size is different from local file size</target>
+        <note>Line: 287</note>
+      </trans-unit>
+      <trans-unit id="ae8e757923a42d666e5c0fdf59fda545">
+        <source>The uploaded file exceeds %s</source>
+        <target>The uploaded file exceeds %s</target>
+        <note>Line: 307</note>
+      </trans-unit>
+      <trans-unit id="f8fe8cba1625eaf8e5c253b041d57dbd">
+        <source>The uploaded file was only partially uploaded</source>
+        <target>The uploaded file was only partially uploaded</target>
+        <note>Line: 310</note>
+      </trans-unit>
+      <trans-unit id="298883b17e36ee3a18d73e835c0b44fc">
+        <source>No file was uploaded</source>
+        <target>No file was uploaded</target>
+        <note>Line: 313</note>
+      </trans-unit>
+      <trans-unit id="c6de8e792d7423f52f3108b197f87738">
+        <source>Missing temporary folder</source>
+        <target>Missing temporary folder</target>
+        <note>Line: 316</note>
+      </trans-unit>
+      <trans-unit id="f5985b2c059d5cc36968baab7585baba">
+        <source>Failed to write file to disk</source>
+        <target>Failed to write file to disk</target>
+        <note>Line: 319</note>
+      </trans-unit>
+      <trans-unit id="b2b0bd0f32c2dcb52c3e2feb24f33a31">
+        <source>A PHP extension stopped the file upload</source>
+        <target>A PHP extension stopped the file upload</target>
+        <note>Line: 322</note>
+      </trans-unit>
+      <trans-unit id="85fb1cf47b9543043438ba7ed901b626">
+        <source>Filetype not allowed</source>
+        <target>Filetype not allowed</target>
+        <note>Line: 358</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/Validate.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f9c7939a8397ee022fefee2bdb3407af">
+        <source>Invalid URL</source>
+        <target>Invalid URL</target>
+        <note>Line: 72</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df2751083713a6a971814c07d88c3eb5">
+        <source>The 'From' date format is invalid (YYYY-MM-DD)</source>
+        <target>The 'From' date format is invalid (YYYY-MM-DD)</target>
+        <note>Line: 881</note>
+      </trans-unit>
+      <trans-unit id="f500b8d6f94abcca48cda7c033c64996">
+        <source>The 'To' date format is invalid (YYYY-MM-DD)</source>
+        <target>The 'To' date format is invalid (YYYY-MM-DD)</target>
+        <note>Line: 889</note>
+      </trans-unit>
+      <trans-unit id="83379252d4737a0b2a63a9388bb36890">
+        <source>An error occurred while attempting to delete the image. (cannot load object).</source>
+        <target>An error occurred while attempting to delete the image. (cannot load object).</target>
+        <note>Line: 996</note>
+      </trans-unit>
+      <trans-unit id="2a0c56d5a5183a9b65b8e2817f75ded2">
+        <source>You cannot delete this item.</source>
+        <target>You cannot delete this item.</target>
+        <note>Line: 1083
+Comment: check if some ids are in list_skip_actions and forbid deletion</note>
+      </trans-unit>
+      <trans-unit id="10f97f4fea6d1ff9ffd1ed3260d6220d">
+        <source>Unable to delete associated images.</source>
+        <target>Unable to delete associated images.</target>
+        <note>Line: 1091</note>
+      </trans-unit>
+      <trans-unit id="efb49241363bce74c7d7899333cdebb5">
+        <source>An error occurred when attempting to update the required fields.</source>
+        <target>An error occurred when attempting to update the required fields.</target>
+        <note>Line: 1291</note>
+      </trans-unit>
+      <trans-unit id="204c3558e41366f3d558ce8e01426a22">
+        <source>field %s is required.</source>
+        <target>field %s is required.</target>
+        <note>Line: 1444</note>
+      </trans-unit>
+      <trans-unit id="c2c0e06097c62422199e29a5574e9fc4">
+        <source>Cannot add configuration %s</source>
+        <target>Cannot add configuration %s</target>
+        <note>Line: 1506</note>
+      </trans-unit>
+      <trans-unit id="a62d7ffa591311c930a2017b07e55394">
+        <source>The object cannot be loaded (the identifier is missing or invalid)</source>
+        <target>The object cannot be loaded (the identifier is missing or invalid)</target>
+        <note>Line: 1680</note>
+      </trans-unit>
+      <trans-unit id="2782e6f430c2658c79aecfcecdc0d0e8">
+        <source>The field %field_name% is required at least in %lang%.</source>
+        <target>The field %field_name% is required at least in %lang%.</target>
+        <note>Line: 3658</note>
+      </trans-unit>
+      <trans-unit id="114eadc70de249729e9287a6b450c6e0">
+        <source>The %field_name% field (%lang%) is invalid.</source>
+        <target>The %field_name% field (%lang%) is invalid.</target>
+        <note>Line: 3691</note>
+      </trans-unit>
+      <trans-unit id="b4186b9ed7c957a1cd9f4e7ce916e603">
+        <source>%s: Incorrect value</source>
+        <target>%s: Incorrect value</target>
+        <note>Line: 3896</note>
+      </trans-unit>
+      <trans-unit id="c87956ad745e55231c633c03fe0f0d5b">
+        <source>An error occurred while assigning a zone to the selection.</source>
+        <target>An error occurred while assigning a zone to the selection.</target>
+        <note>Line: 4140</note>
+      </trans-unit>
+      <trans-unit id="93463ceee9a3d376b18ee618bc2fffe4">
+        <source>You must select at least one element to assign a new zone.</source>
+        <target>You must select at least one element to assign a new zone.</target>
+        <note>Line: 4142</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/helper/HelperImageUploader.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a5a6e6da29a779cece21518a4ba337e2">
+        <source>The uploaded file exceeds the post_max_size directive in php.ini</source>
+        <target>The uploaded file exceeds the post_max_size directive in php.ini</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="0bff5a3a7cc19937dd97b8a995915222">
+        <source>File is too big. Current size is %1s, maximum size is %2s.</source>
+        <target>File is too big. Current size is %1s, maximum size is %2s.</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="2368e33e3e01d53abb9b60061ab83903">
+        <source>The uploaded file exceeds the upload_max_filesize directive in php.ini</source>
+        <target>The uploaded file exceeds the upload_max_filesize directive in php.ini</target>
+        <note>Line: 59</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/module/Module.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fdc746e5693df31cf4f6ef789a8846c5">
+        <source>file (%s) not writable</source>
+        <target>file (%s) not writable</target>
+        <note>Line: 2967</note>
+      </trans-unit>
+      <trans-unit id="a9de928286071f457fcbc45656353761">
+        <source>directory (%s) not writable</source>
+        <target>directory (%s) not writable</target>
+        <note>Line: 3044</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttachmentsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1f66f9472666b18b19c22fd0f1a6a07b">
+        <source>The file is too large. Maximum size allowed is: %1$d kB. The file you are trying to upload is %2$d kB.</source>
+        <target>The file is too large. Maximum size allowed is: %1$d kB. The file you are trying to upload is %2$d kB.</target>
+        <note>Line: 220</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="45ebc64529137a007889ee445d64611c">
+        <source>Failed to update the position.</source>
+        <target>Failed to update the position.</target>
+        <note>Line: 761</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCarriersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="574af21ff5cd555457e49205287f7e9b">
+        <source>The object cannot be loaded.</source>
+        <target>The object cannot be loaded.</target>
+        <note>Line: 611</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="959c96ec640d353311dd9763d57daad6">
+        <source>Please fill in all the required fields.</source>
+        <target>Please fill in all the required fields.</target>
+        <note>Line: 471</note>
+      </trans-unit>
+      <trans-unit id="dd6b089a49908d671c3e9cc8dc5899ae">
+        <source>Invalid message</source>
+        <target>Invalid message</target>
+        <note>Line: 407</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3452da55a90ccedd184c7ba264b2afd5">
+        <source>Due to memory limit restrictions, this image cannot be loaded. Please increase your memory_limit value via your server's configuration settings. </source>
+        <target>Due to memory limit restrictions, this image cannot be loaded. Please increase your memory_limit value via your server's configuration settings.</target>
+        <note>Line: 1064</note>
+      </trans-unit>
+      <trans-unit id="3fe46a677aa76978d058880999b3fffb">
+        <source>Error while delete</source>
+        <target>Error while delete</target>
+        <note>Line: 735</note>
+      </trans-unit>
+      <trans-unit id="f86f7b91afe27e79305a6b07bdb0d3c0">
+        <source>Failed to update the status</source>
+        <target>Failed to update the status</target>
+        <note>Line: 1018</note>
+      </trans-unit>
+      <trans-unit id="2b4de48b49648d3323f20b6371f7e3c1">
+        <source>You cannot upload more files</source>
+        <target>You cannot upload more files</target>
+        <note>Line: 1055</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCountriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="01e93e9457d86c646965decd586dc5ea">
+        <source>Address format invalid</source>
+        <target>Address format invalid</target>
+        <note>Line: 434</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="84e4970c5c35731ac7084f09ca0a77cd">
+        <source>The email address is invalid.</source>
+        <target>The email address is invalid.</target>
+        <note>Line: 414</note>
+      </trans-unit>
+      <trans-unit id="62867691cceb8f8a7e7683b924cc20c5">
+        <source>An error occurred during the file upload process.</source>
+        <target>An error occurred during the file upload process.</target>
+        <note>Line: 430</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminDashboardController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8f29c70fd66f50ce28b727cd40c6a3a3">
+        <source>The selected date range is not valid.</source>
+        <target>The selected date range is not valid.</target>
+        <note>Line: 346</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminEmployeesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1f0e23c8f9563f28107b313ca812f3c3">
+        <source>No profile.</source>
+        <target>No profile.</target>
+        <note>Line: 76</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImagesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="109715467b74bd66639faa5673f707c1">
+        <source>Unknown error.</source>
+        <target>Unknown error.</target>
+        <note>Line: 368</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e96814b3d9ff9ae65c8f2be2ee3e0555">
+        <source>Invalid tag(s) (%s)</source>
+        <target>Invalid tag(s) (%s)</target>
+        <note>Line: 2113</note>
+      </trans-unit>
+      <trans-unit id="3d52f8b2b1a67aa8740b72b3752d54f3">
+        <source>Incorrect value for "Depends on stock" for product %name% </source>
+        <target>Incorrect value for "Depends on stock" for product %name%</target>
+        <note>Line: 2786</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminLoginController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3338ce970be43e586e64e0a41dc01e2">
+        <source>There is one error.</source>
+        <target>There is one error.</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="c7da8f310b3b53c7c3529517860b7ecc">
+        <source>There are several errors.</source>
+        <target>There are several errors.</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="becfb58422969ec127b4bf1af46650ab">
+        <source>Email is empty.</source>
+        <target>Email is empty.</target>
+        <note>Line: 248</note>
+      </trans-unit>
+      <trans-unit id="e267e2be02cf3e29f4ba53b5d97cf78a">
+        <source>Invalid email address.</source>
+        <target>Invalid email address.</target>
+        <note>Line: 250</note>
+      </trans-unit>
+      <trans-unit id="5ee800d2d30225decb5b057d846103b7">
+        <source>The password field is blank.</source>
+        <target>The password field is blank.</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="855eb8db89b4921c42072832d33d2dc2">
+        <source>Invalid password.</source>
+        <target>Invalid password.</target>
+        <note>Line: 191</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminMetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="efd4ed1ed0d97b89a65880765028933e">
+        <source>The URL rewrite field must be filled in either the default or English language.</source>
+        <target>The URL rewrite field must be filled in either the default or English language.</target>
+        <note>Line: 418</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminModulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5dcea1234ac01d22f40ffc81d0bc4c2f">
+        <source>File too large (limit of %s bytes).</source>
+        <target>File too large (limit of %s bytes).</target>
+        <note>Line: 585</note>
+      </trans-unit>
+      <trans-unit id="c9b70823c0ee73b2ce964dfd16a10ddc">
+        <source>File upload was not completed.</source>
+        <target>File upload was not completed.</target>
+        <note>Line: 588</note>
+      </trans-unit>
+      <trans-unit id="8c9067e52e4440d8a20e74fdc745b0c6">
+        <source>No file was uploaded.</source>
+        <target>No file was uploaded.</target>
+        <note>Line: 591</note>
+      </trans-unit>
+      <trans-unit id="acdcc688155bd653f51eaf710cac8af5">
+        <source>Internal error #%s</source>
+        <target>Internal error #%s</target>
+        <note>Line: 594</note>
+      </trans-unit>
+      <trans-unit id="5569135c321c16866b524ec82dcd2b2a">
+        <source>No file has been selected</source>
+        <target>No file has been selected</target>
+        <note>Line: 598</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminModulesPositionsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="aeca1e74dd7d86d85886996651937da9">
+        <source>No valid value for field exceptions has been defined.</source>
+        <target>No valid value for field exceptions has been defined.</target>
+        <note>Line: 174</note>
+      </trans-unit>
+      <trans-unit id="0ce2f4a4f40a2d23525b5b02bcfe611f">
+        <source>An error occurred while transplanting the module to its hook.</source>
+        <target>An error occurred while transplanting the module to its hook.</target>
+        <note>Line: 107</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminNotFoundController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d0fbda9855d118740f1105334305c126">
+        <source>Page not found</source>
+        <target>Page not found</target>
+        <note>Line: 46</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0e2338b37ab3dfeed544e8233b53d4e0">
+        <source>The %1$s field is too long (%2$d chars max).</source>
+        <target>The %1$s field is too long (%2$d chars max).</target>
+        <note>Line: 585</note>
+      </trans-unit>
+      <trans-unit id="055cca15dfe5fb74bde56d7331fff449">
+        <source>An error occurred while saving the message.</source>
+        <target>An error occurred while saving the message.</target>
+        <note>Line: 627</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminProductsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b1367942aa02ea8c9d4aa07cdf5e473c">
+        <source>You need at least one object.</source>
+        <target>You need at least one object.</target>
+        <note>Line: 649</note>
+      </trans-unit>
+      <trans-unit id="ec5f6f7f65190788d12ef16ab6135009">
+        <source>You cannot delete all of the items.</source>
+        <target>You cannot delete all of the items.</target>
+        <note>Line: 649</note>
+      </trans-unit>
+      <trans-unit id="527d23f49ced7a14e50546e1b90672e7">
+        <source>Cannot retrieve file.</source>
+        <target>Cannot retrieve file.</target>
+        <note>Line: 362</note>
+      </trans-unit>
+      <trans-unit id="fb86a99edb05e880b59843698a2fafbd">
+        <source>Cannot delete file</source>
+        <target>Cannot delete file</target>
+        <note>Line: 1125</note>
+      </trans-unit>
+      <trans-unit id="abf6e66f4a0b444dbcb1a626e88cd973">
+        <source>Invalid name for %s language</source>
+        <target>Invalid name for %s language</target>
+        <note>Line: 418</note>
+      </trans-unit>
+      <trans-unit id="572f072ea1a00ba0470ec3e5f4b80e24">
+        <source>The name for %1s language is too long (%2d chars max).</source>
+        <target>The name for %1s language is too long (%2d chars max).</target>
+        <note>Line: 420</note>
+      </trans-unit>
+      <trans-unit id="370835a4106d1c7860f2fbb5daabd050">
+        <source>The file is missing.</source>
+        <target>The file is missing.</target>
+        <note>Line: 454</note>
+      </trans-unit>
+      <trans-unit id="611d3495c1e0dad701d535ccafd84330">
+        <source>Invalid file extension</source>
+        <target>Invalid file extension</target>
+        <note>Line: 473</note>
+      </trans-unit>
+      <trans-unit id="6292d73b79fd27bdc4c7d8a7ce2c79b4">
+        <source>The file name is too long.</source>
+        <target>The file name is too long.</target>
+        <note>Line: 479</note>
+      </trans-unit>
+      <trans-unit id="bbced877c13c763f0141ff906c8ed0e5">
+        <source>Invalid file</source>
+        <target>Invalid file</target>
+        <note>Line: 495</note>
+      </trans-unit>
+      <trans-unit id="505bbc38260c669d0793757e414caecc">
+        <source>The %s field is not valid</source>
+        <target>The %s field is not valid</target>
+        <note>Line: 740</note>
+      </trans-unit>
+      <trans-unit id="e267d34972b3ab66b987fbad59fba513">
+        <source>Invalid date format.</source>
+        <target>Invalid date format.</target>
+        <note>Line: 765</note>
+      </trans-unit>
+      <trans-unit id="c7e56badecce297feefe2a9b50a68794">
+        <source>Invalid date range</source>
+        <target>Invalid date range</target>
+        <note>Line: 973</note>
+      </trans-unit>
+      <trans-unit id="be67fb2de5962acd123edaeeed6d4488">
+        <source>An error occurred while updating the image.</source>
+        <target>An error occurred while updating the image.</target>
+        <note>Line: 1641</note>
+      </trans-unit>
+      <trans-unit id="46d431810202adee8bca6b13a5ebd0d9">
+        <source>An error occurred while linking the object %table_name% to categories.</source>
+        <target>An error occurred while linking the object %table_name% to categories.</target>
+        <note>Line: 1938</note>
+      </trans-unit>
+      <trans-unit id="723b4a80bd8ae233c9fcde1e5bd55436">
+        <source>The object cannot be loaded. </source>
+        <target>The object cannot be loaded.</target>
+        <note>Line: 1985</note>
+      </trans-unit>
+      <trans-unit id="9ca63429d31c3e720001675dd8535a9d">
+        <source>The %name% field is required.</source>
+        <target>The %name% field is required.</target>
+        <note>Line: 2012</note>
+      </trans-unit>
+      <trans-unit id="172dfd675cd344c66724042519cc4df1">
+        <source>The %1$s field (%2$s) is invalid.</source>
+        <target>The %1$s field (%2$s) is invalid.</target>
+        <note>Line: 2121</note>
+      </trans-unit>
+      <trans-unit id="787acc7a9d39b98fac309cf303f518d3">
+        <source>The tags list (%s) is invalid.</source>
+        <target>The tags list (%s) is invalid.</target>
+        <note>Line: 2147</note>
+      </trans-unit>
+      <trans-unit id="cbecc45ae8ccf1234657bd40ee4c55dd">
+        <source>An error occurred while copying this image:</source>
+        <target>An error occurred while copying this image:</target>
+        <note>Line: 2852</note>
+      </trans-unit>
+      <trans-unit id="be694d5db9d32c43014995441a5939c4">
+        <source>Invalid file name</source>
+        <target>Invalid file name</target>
+        <note>Line: 476</note>
+      </trans-unit>
+      <trans-unit id="06b778accab7c14a499bc6e7a68138ec">
+        <source>An error occurred while copying the image.</source>
+        <target>An error occurred while copying the image.</target>
+        <note>Line: 1686</note>
+      </trans-unit>
+      <trans-unit id="b05c3c0bfce943b86e286e8e8103b6e5">
+        <source>An error occurred while uploading the image.</source>
+        <target>An error occurred while uploading the image.</target>
+        <note>Line: 1684</note>
+      </trans-unit>
+      <trans-unit id="dc0614532e2b908e6c2d82cc0972af9d">
+        <source>An error occurred while attempting to create a new folder.</source>
+        <target>An error occurred while attempting to create a new folder.</target>
+        <note>Line: 2815</note>
+      </trans-unit>
+      <trans-unit id="6c3609de8769a4456305ec22e764573d">
+        <source>An error occurred while copying this image: %s</source>
+        <target>An error occurred while copying this image: %s</target>
+        <note>Line: 1691</note>
+      </trans-unit>
+      <trans-unit id="211ff814e7bf91c4548a61ba1c427c15">
+        <source>Error while updating the status.</source>
+        <target>Error while updating the status.</target>
+        <note>Line: 2865</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopGroupController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f1534de7e6636fdfedf7aea238841b24">
+        <source>You cannot delete or disable the last shop group.</source>
+        <target>You cannot delete or disable the last shop group.</target>
+        <note>Line: 323</note>
+      </trans-unit>
+      <trans-unit id="e91077be3c46fd0d3fd8e972e8ca1e48">
+        <source>You cannot delete or disable a shop group in use.</source>
+        <target>You cannot delete or disable a shop group in use.</target>
+        <note>Line: 325</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopUrlController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fd44c173b6a7897151a978b9015fec76">
+        <source>You cannot disable the Main URL.</source>
+        <target>You cannot disable the Main URL.</target>
+        <note>Line: 508</note>
+      </trans-unit>
+      <trans-unit id="d2de9e264ff4f0e711d809f00da76e45">
+        <source>You cannot change a main URL to a non-main URL. You have to set another URL as your Main URL for the selected shop.</source>
+        <target>You cannot change a main URL to a non-main URL. You have to set another URL as your Main URL for the selected shop.</target>
+        <note>Line: 504</note>
+      </trans-unit>
+      <trans-unit id="aee1f34d776c8cc3401cac254299e6f9">
+        <source>A shop URL that uses this domain already exists.</source>
+        <target>A shop URL that uses this domain already exists.</target>
+        <note>Line: 482</note>
+      </trans-unit>
+      <trans-unit id="deb836e0c149bb47a1d86eabe4b2f7db">
+        <source>A shop virtual URL cannot be "%URL%"</source>
+        <target>A shop virtual URL cannot be "%URL%"</target>
+        <note>Line: 459</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bc33aa1314e7dcd3472db72472b909b2">
+        <source>An error occurred during deletion.</source>
+        <target>An error occurred during deletion.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f9f47dee59a41f69369745b42136b14e">
+        <source>Your Zip/postal code is incorrect.</source>
+        <target>Your Zip/postal code is incorrect.</target>
+        <note>Line: 368</note>
+      </trans-unit>
+      <trans-unit id="6660b316abc0970476a09df63028d553">
+        <source>It must be entered as follows:</source>
+        <target>It must be entered as follows:</target>
+        <note>Line: 368</note>
+      </trans-unit>
+      <trans-unit id="d57c64abf56d22df05f34e473b3879ad">
+        <source>A Zip/postal code is required.</source>
+        <target>A Zip/postal code is required.</target>
+        <note>Line: 370</note>
+      </trans-unit>
+      <trans-unit id="5b0e7a50bbe35d2e59dc92c7ba9b369a">
+        <source>The Zip/postal code is invalid.</source>
+        <target>The Zip/postal code is invalid.</target>
+        <note>Line: 372</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminThemesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b42cd3af71fc00ef268910709255320a">
+        <source>You do not have permission to view this.</source>
+        <target>You do not have permission to view this.</target>
+        <note>Line: 909</note>
+      </trans-unit>
+      <trans-unit id="9f4c1b4b9bcf088c9d32e74b7f542a77">
+        <source>You do not have permission to upload this.</source>
+        <target>You do not have permission to upload this.</target>
+        <note>Line: 316</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTranslationsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e298a0bc9a35d45798e28c082dfc1dfa">
+        <source>"%type%" does not exist.</source>
+        <target>"%type%" does not exist.</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="40f5c232e433d178a4f912b3092d7df1">
+        <source>Directory "%folder%" cannot be created</source>
+        <target>Directory "%folder%" cannot be created</target>
+        <note>Line: 339</note>
+      </trans-unit>
+      <trans-unit id="80034ab2323115584ed4c5b05e222f60">
+        <source>File "%file%" cannot be created</source>
+        <target>File "%file%" cannot be created</target>
+        <note>Line: 341</note>
+      </trans-unit>
+      <trans-unit id="6b12f160f2bb3c7dea01bd96a223d80e">
+        <source>Cannot write this file: "%folder%"</source>
+        <target>Cannot write this file: "%folder%"</target>
+        <note>Line: 391</note>
+      </trans-unit>
+      <trans-unit id="f0566c73cce29920f99fda8819745804">
+        <source>This file must be writable: %file%</source>
+        <target>This file must be writable: %file%</target>
+        <note>Line: 520</note>
+      </trans-unit>
+      <trans-unit id="bb5ef82c8be2494c733ac77920bc5c72">
+        <source>No file has been selected.</source>
+        <target>No file has been selected.</target>
+        <note>Line: 766</note>
+      </trans-unit>
+      <trans-unit id="e594c33758771c458a7f80e9afdf7e55">
+        <source>The server does not have permissions for writing.</source>
+        <target>The server does not have permissions for writing.</target>
+        <note>Line: 802</note>
+      </trans-unit>
+      <trans-unit id="65dd53e33c17621f58bcc99be967814a">
+        <source>Please check rights for %file%</source>
+        <target>Please check rights for %file%</target>
+        <note>Line: 802</note>
+      </trans-unit>
+      <trans-unit id="e0a602c130d12d57cd4ca2a8b9240917">
+        <source>This file must be writable:</source>
+        <target>This file must be writable:</target>
+        <note>Line: 1747</note>
+      </trans-unit>
+      <trans-unit id="bcfa9fd034fffbe5aa1a9c9e306386f1">
+        <source>Fatal error: The module directory does not exist.</source>
+        <target>Fatal error: The module directory does not exist.</target>
+        <note>Line: 2175</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/blockreassurance/blockreassurance.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d52eaeff31af37a4a7e0550008aff5df">
+        <source>An error occurred while attempting to save.</source>
+        <target>An error occurred while attempting to save.</target>
+        <note>Line: 226</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_banner/ps_banner.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df7859ac16e724c9b1fba0a364503d72">
+        <source>An error occurred while attempting to upload the file.</source>
+        <target>An error occurred while attempting to upload the file.</target>
+        <note>Line: 118</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_categorytree/ps_categorytree.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="23e0d4ecc25de9b2777fdaca3e2f3193">
+        <source>Maximum depth: Invalid number.</source>
+        <target>Maximum depth: Invalid number.</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_customtext/ps_customtext.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="abb1f006957d2d4002cc1d49c63a0fad">
+        <source>Please fill out all fields.</source>
+        <target>Please fill out all fields.</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="3fa720301fb9c9badc23c00c1e88b4f7">
+        <source>An error occurred on saving.</source>
+        <target>An error occurred on saving.</target>
+        <note>Line: 157</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="417d63b1effb110e438d4b4b9f0fbd95">
+        <source>The voucher code is invalid.</source>
+        <target>The voucher code is invalid.</target>
+        <note>Line: 158</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_imageslider/ps_imageslider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7cc92687130ea12abb80556681538001">
+        <source>An error occurred during the image upload process.</source>
+        <target>An error occurred during the image upload process.</target>
+        <note>Line: 484</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Email/EmailLogEraser.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ddd4e7f16c2032d59cb4fb4b86576bc5">
+        <source>You must select at least one element to delete.</source>
+        <target>You must select at least one element to delete.</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="7c422404cb037e6781b5a553060670a6">
+        <source>Can't delete #%id%</source>
+        <target>Can't delete #%id%</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/SqlManager/SqlQueryValidator.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ee77ea46b0c548ed60eadf31bdd68613">
+        <source>Bad SQL query</source>
+        <target>Bad SQL query</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="0b5512610b0c8548345f37a58bf51360">
+        <source>"%key%" does not exist.</source>
+        <target>"%key%" does not exist.</target>
+        <note>Line: 389</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Webservice/WebserviceKeyStatusModifier.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="77ae44aa6c998166fcf1a87496278ad5">
+        <source>(cannot load object)</source>
+        <target>(cannot load object)</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="815e471ea2970db0b63b9b09feacc70f">
+        <source>An error occurred while updating the status for an object.</source>
+        <target>An error occurred while updating the status for an object.</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="1b0cc7183377b461e298d0ebcf5f8548">
+        <source>An error occurred while updating the status.</source>
+        <target>An error occurred while updating the status.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Localization/Pack/Import/LocalizationPackImporter.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0bd212ed072143f56147f2f119892d03">
+        <source>Invalid selection</source>
+        <target>Invalid selection</target>
+        <note>Line: 159</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/SqlManager/Configuration/SqlRequestConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5cd8dc8a58702a63e79af3ad9de16d7a">
+        <source>The %s field is invalid.</source>
+        <target>The %s field is invalid.</target>
+        <note>Line: 123</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/AddonsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="358cc9ee3a3d23d3390e5043122d9bea">
+        <source>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</source>
+        <target>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</target>
+        <note>Line: 80</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1d5dfad5ac415b412c20a05a89d43db6">
+        <source>An error occurred while deleting this selection.</source>
+        <target>An error occurred while deleting this selection.</target>
+        <note>Line: 252</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="652122103181aa2752efaecab300edf0">
+        <source>Access denied.</source>
+        <target>Access denied.</target>
+        <note>Line: 249</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b07242082d4a24b63951185a1bae15bb">
+        <source>You do not have permission to create this.</source>
+        <target>You do not have permission to create this.</target>
+        <note>Line: 94</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7f290594963a303db17a5e21dc4cf0b7">
+        <source>An error occurred while deleting the object.</source>
+        <target>An error occurred while deleting the object.</target>
+        <note>Line: 474</note>
+      </trans-unit>
+      <trans-unit id="fa4611fb85bb8f118f562d107ab790d4">
+        <source>The object cannot be loaded (or found)</source>
+        <target>The object cannot be loaded (or found)</target>
+        <note>Line: 563</note>
+      </trans-unit>
+      <trans-unit id="bf413509dac07690b304373338fc1149">
+        <source>Cannot open export file for writing</source>
+        <target>Cannot open export file for writing</target>
+        <note>Line: 543</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e31f2dac034e1437efa1dbf499509963">
+        <source>Cannot write into file: %filename%. Please check write permissions.</source>
+        <target>Cannot write into file: %filename%. Please check write permissions.</target>
+        <note>Line: 268</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/PreferencesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df3c280f0aaf0cb0d5c25ab322a8bcf9">
+        <source>You do not have permission to update this.</source>
+        <target>You do not have permission to update this.</target>
+        <note>Line: 109</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a7eca295291f53a23ab7ba0a9c7fd9de">
+        <source>This functionality has been disabled.</source>
+        <target>This functionality has been disabled.</target>
+        <note>Line: 229</note>
+      </trans-unit>
+      <trans-unit id="11a257a80f8c8d76132470b171de6795">
+        <source>You do not have permission to delete this.</source>
+        <target>You do not have permission to delete this.</target>
+        <note>Line: 341</note>
+      </trans-unit>
+      <trans-unit id="e8ae00af8575f645bf6e4358f120cba3">
+        <source>An unexpected error occurred. [%type% code %code%]</source>
+        <target>An unexpected error occurred. [%type% code %code%]</target>
+        <note>Line: 366</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dbf373dd3565accf2d2fd19700f6a5ae">
+        <source>Invalid action</source>
+        <target>Invalid action</target>
+        <note>Line: 381</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d8d4c3b79181fdcca8cb5159208fa56a">
+        <source>You do not have permission to add this.</source>
+        <target>You do not have permission to add this.</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5a6013a735465600cb2b695361009999">
+        <source>You do not have permission to edit this</source>
+        <target>You do not have permission to edit this</target>
+        <note>Line: 85</note>
       </trans-unit>
     </body>
   </file>
   <file original="src/PrestaShopBundle/Controller/Admin/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="1bdd228669c9dd995eb664737e60786e">
+        <source>You do not have permission to edit this.</source>
+        <target>You do not have permission to edit this.</target>
+        <note>Line: 837</note>
+      </trans-unit>
       <trans-unit id="d3ee9a41133f8fc3c83c91d09053f249">
         <source>The value of the PHP.ini setting "max_input_vars" must be increased to %value% in order to be able to submit the product form.</source>
         <target>The value of the PHP.ini setting "max_input_vars" must be increased to %value% in order to be able to submit the product form.</target>
-        <note>Context:
-          File: src/PrestaShopBundle/Controller/Admin/ProductController.php:648</note>
+        <note>Line: 649</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d9b5b2302d57f3d13d5387ba9c99daae">
+        <source>An error occurred while creating an object.</source>
+        <target>An error occurred while creating an object.</target>
+        <note>Line: 213</note>
+      </trans-unit>
+      <trans-unit id="954b49d26a3a0986aca720a7095f2aa9">
+        <source>An error occurred while updating an object.</source>
+        <target>An error occurred while updating an object.</target>
+        <note>Line: 218</note>
+      </trans-unit>
+      <trans-unit id="ddb7f719baea8c9f335937b683e8f155">
+        <source>Invalid data supplied.</source>
+        <target>Invalid data supplied.</target>
+        <note>Line: 191</note>
+      </trans-unit>
+      <trans-unit id="777e4c7c4a3cc47eb332a7a4022c983e">
+        <source>Unexpected error occurred.</source>
+        <target>Unexpected error occurred.</target>
+        <note>Line: 231</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8fb7465fec179740502812519d1a8182">
+        <source>This domain is not valid.</source>
+        <target>This domain is not valid.</target>
+        <note>Line: 208</note>
+      </trans-unit>
+      <trans-unit id="d2d0c6d9bcc804f2c59b8fc228dc671e">
+        <source>The SSL domain is not valid.</source>
+        <target>The SSL domain is not valid.</target>
+        <note>Line: 216</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a9e0d1b71fb7197367e0518bb6b34fdd">
+        <source>The file is too large. Maximum size allowed is: [1]. The file you are trying to upload is [2].</source>
+        <target>The file is too large. Maximum size allowed is: [1]. The file you are trying to upload is [2].</target>
+        <note>Line: 337</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminNotificationsInfo.xlf
+++ b/app/Resources/translations/default/AdminNotificationsInfo.xlf
@@ -1,54 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="d3b206d196cd6be3a2764c1fb90b200f">
-        <source>Delete selected</source>
-        <target>Delete selected</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:65</note>
+      <trans-unit id="2fc6204d2ca7e856d9e4844d2786f053">
+        <source>This field will be modified for all your shops.</source>
+        <target>This field will be modified for all your shops.</target>
+        <note>Line: 53</note>
       </trans-unit>
-      <trans-unit id="e25f0ecd41211b01c83e5fec41df4fe7">
-        <source>Delete selected items?</source>
-        <target>Delete selected items?</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:66</note>
+      <trans-unit id="7ac170f2b47dbf7d4c5cd38449093c2b">
+        <source>This field will be modified for all shops in this shop group:</source>
+        <target>This field will be modified for all shops in this shop group:</target>
+        <note>Line: 55</note>
       </trans-unit>
-      <trans-unit id="b3ebc4fbc081856600b6b9ecbb0a99fb">
-        <source>Delete the selected item?</source>
-        <target>Delete the selected item?</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:1045</note>
+      <trans-unit id="fe0ae15c8f93a5335f0991accadd13ca">
+        <source>This field will be modified for this shop:</source>
+        <target>This field will be modified for this shop:</target>
+        <note>Line: 57</note>
       </trans-unit>
     </body>
   </file>
-  <file original="controllers/admin/AdminGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3e053943605d9e4bf7dd7588ea19e9d2">
-        <source>Forbidden characters:</source>
-        <target>Forbidden characters:</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:280</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTaxesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/admin/AdminAttributesGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="6252c0f2c2ed83b7b06dfca86d4650bb">
         <source>Invalid characters:</source>
         <target>Invalid characters:</target>
-        <note>Context:
-File: controllers/admin/AdminTaxesController.php:212</note>
+        <note>Line: 280</note>
       </trans-unit>
     </body>
   </file>
-  <file original="classes/helper/HelperList.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/admin/AdminCarriersController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="d3b206d196cd6be3a2764c1fb90b200f">
+        <source>Delete selected</source>
+        <target>Delete selected</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="e25f0ecd41211b01c83e5fec41df4fe7">
+        <source>Delete selected items?</source>
+        <target>Delete selected items?</target>
+        <note>Line: 56</note>
+      </trans-unit>
       <trans-unit id="1412292b09d3cd39f32549afb1f5f102">
         <source>Delete selected item?</source>
         <target>Delete selected item?</target>
-        <note>Context:
-File: classes/helper/HelperList.php:524</note>
+        <note>Line: 703</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b3ebc4fbc081856600b6b9ecbb0a99fb">
+        <source>Delete the selected item?</source>
+        <target>Delete the selected item?</target>
+        <note>Line: 1048</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminQuickAccessesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3e053943605d9e4bf7dd7588ea19e9d2">
+        <source>Forbidden characters:</source>
+        <target>Forbidden characters:</target>
+        <note>Line: 90</note>
       </trans-unit>
     </body>
   </file>
@@ -57,8 +70,7 @@ File: classes/helper/HelperList.php:524</note>
       <trans-unit id="58ef962a87e6fbbea6027c17a954a18d">
         <source>Empty recordset returned.</source>
         <target>Empty recordset returned.</target>
-        <note>Context:
-File: modules/statsbestmanufacturers/statsbestmanufacturers.php:53</note>
+        <note>Line: 53</note>
       </trans-unit>
     </body>
   </file>
@@ -67,30 +79,7 @@ File: modules/statsbestmanufacturers/statsbestmanufacturers.php:53</note>
       <trans-unit id="4f29d8c727dcf2022ac241cb96c31083">
         <source>Empty recordset returned</source>
         <target>Empty recordset returned</target>
-        <note>Context:
-File: modules/statsbestsuppliers/statsbestsuppliers.php:53</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2fc6204d2ca7e856d9e4844d2786f053">
-        <source>This field will be modified for all your shops.</source>
-        <target>This field will be modified for all your shops.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:53</note>
-      </trans-unit>
-      <trans-unit id="7ac170f2b47dbf7d4c5cd38449093c2b">
-        <source>This field will be modified for all shops in this shop group:</source>
-        <target>This field will be modified for all shops in this shop group:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:55</note>
-      </trans-unit>
-      <trans-unit id="fe0ae15c8f93a5335f0991accadd13ca">
-        <source>This field will be modified for this shop:</source>
-        <target>This field will be modified for this shop:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:57</note>
+        <note>Line: 53</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminNotificationsSuccess.xlf
+++ b/app/Resources/translations/default/AdminNotificationsSuccess.xlf
@@ -1,98 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="79f062391903591d68e514a400e136cf">
-        <source>The status has been updated successfully.</source>
-        <target>The status has been updated successfully.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:687</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="de360c8b5dd9a9fdd592b1c08b3b4a62">
-        <source>The status has been updated successfully</source>
-        <target>The status has been updated successfully</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:1024</note>
-      </trans-unit>
-      <trans-unit id="f86f7b91afe27e79305a6b07bdb0d3c0">
-        <source>Failed to update the status</source>
-        <target>Failed to update the status</target>
-        <note>Context:
-File: controllers/admin/AdminCategoriesController.php:1025</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminThemesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ebc7584c0a97bc4aa867c11fc4760b3f">
-        <source>Your theme has been correctly exported: %path%</source>
-        <target>Your theme has been correctly exported: %path%</target>
-        <note>Context:
-File: controllers/admin/AdminThemesController.php:954</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_dataprivacy/ps_dataprivacy.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="efc226b17e0532afff43be870bff0de7">
-        <source>The settings have been updated.</source>
-        <target>The settings have been updated.</target>
-        <note>Context:
-File: modules/ps_dataprivacy/ps_dataprivacy.php:88</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_imageslider/ps_imageslider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="20015706a8cbd457cbb6ea3e7d5dc9b3">
-        <source>Configuration updated</source>
-        <target>Configuration updated</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:434</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f38f5974cdc23279ffe6d203641a8bdf">
-        <source>Settings updated.</source>
-        <target>Settings updated.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:334</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_checkpayment/ps_checkpayment.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c888438d14855d7d96a2724ee9c306bd">
-        <source>Settings updated</source>
-        <target>Settings updated</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:116</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7173e38e8a10ed379625687638ddfe74">
-        <source>Successful deletion</source>
-        <target>Successful deletion</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php:189</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="151648106e4bf98297882ea2ea1c4b0e">
         <source>Update successful</source>
         <target>Update successful</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl:228</note>
+        <note>Line: 228</note>
       </trans-unit>
     </body>
   </file>
@@ -101,102 +14,175 @@ File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl
       <trans-unit id="b4a34d3f58b039e7685c2e39b5413757">
         <source>Successful update.</source>
         <target>Successful update.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:81</note>
+        <note>Line: 81</note>
       </trans-unit>
     </body>
   </file>
   <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="149cd107b688af7a007e739fd51ac919">
-        <source>Successful deletion.</source>
-        <target>Successful deletion.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:454</note>
-      </trans-unit>
-      <trans-unit id="02d5b938505dcda41a52ef3abcbd354a">
-        <source>The selection has been successfully deleted.</source>
-        <target>The selection has been successfully deleted.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:455</note>
-      </trans-unit>
-      <trans-unit id="6483df61619946ebf2427ba360df7ce5">
-        <source>The settings have been successfully updated.</source>
-        <target>The settings have been successfully updated.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:459</note>
-      </trans-unit>
-      <trans-unit id="1802a23025825ae791c1eea0118ee5f0">
-        <source>The status has been successfully updated.</source>
-        <target>The status has been successfully updated.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:458</note>
-      </trans-unit>
-      <trans-unit id="fb52feac670f0252be93737558eebdb7">
-        <source>Successful creation.</source>
-        <target>Successful creation.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:456</note>
-      </trans-unit>
       <trans-unit id="893a9104a7f0ebd94a7f4171d1996c7d">
         <source>The image was successfully deleted.</source>
         <target>The image was successfully deleted.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:460</note>
+        <note>Line: 460</note>
       </trans-unit>
       <trans-unit id="e9d71289fdbe4799d4fe91ccc17be0af">
         <source>The thumbnails were successfully regenerated.</source>
         <target>The thumbnails were successfully regenerated.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:462</note>
+        <note>Line: 462</note>
       </trans-unit>
       <trans-unit id="4a6c326f3ec43e638da38a44a21b5eb7">
         <source>Comment successfully added.</source>
         <target>Comment successfully added.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:464</note>
+        <note>Line: 464</note>
       </trans-unit>
       <trans-unit id="1b73f0da557b7b0773d0fc6b5fd0a3b4">
         <source>Successful upload.</source>
         <target>Successful upload.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:471</note>
+        <note>Line: 471</note>
       </trans-unit>
       <trans-unit id="759d07e8bdf6d3a5863ed521009b3ac1">
         <source>Duplication was completed successfully.</source>
         <target>Duplication was completed successfully.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:472</note>
+        <note>Line: 472</note>
       </trans-unit>
       <trans-unit id="13f1ce18a02ac5293cf5a4274f9300de">
         <source>The selected images have successfully been moved.</source>
         <target>The selected images have successfully been moved.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:478</note>
+        <note>Line: 478</note>
       </trans-unit>
       <trans-unit id="714903406a224ca68890e377ea111388">
         <source>Your cover image selection has been saved.</source>
         <target>Your cover image selection has been saved.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:479</note>
+        <note>Line: 479</note>
       </trans-unit>
       <trans-unit id="b2266c7007fff254b1a9373f8a648a1c">
         <source>The image's shop association has been modified.</source>
         <target>The image's shop association has been modified.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:480</note>
+        <note>Line: 480</note>
       </trans-unit>
       <trans-unit id="3a627484fcb2a5d110b44a390d5ee7c1">
         <source>A zone has been assigned to the selection successfully.</source>
         <target>A zone has been assigned to the selection successfully.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:481</note>
+        <note>Line: 481</note>
       </trans-unit>
       <trans-unit id="be3af9d697c193da1a7dbfcf195050ea">
         <source>Successful upgrade.</source>
         <target>Successful upgrade.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:482</note>
+        <note>Line: 482</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCategoriesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="de360c8b5dd9a9fdd592b1c08b3b4a62">
+        <source>The status has been updated successfully</source>
+        <target>The status has been updated successfully</target>
+        <note>Line: 1024</note>
+      </trans-unit>
+      <trans-unit id="f86f7b91afe27e79305a6b07bdb0d3c0">
+        <source>Failed to update the status</source>
+        <target>Failed to update the status</target>
+        <note>Line: 1025</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="79f062391903591d68e514a400e136cf">
+        <source>The status has been updated successfully.</source>
+        <target>The status has been updated successfully.</target>
+        <note>Line: 687</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminThemesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ebc7584c0a97bc4aa867c11fc4760b3f">
+        <source>Your theme has been correctly exported: %path%</source>
+        <target>Your theme has been correctly exported: %path%</target>
+        <note>Line: 956</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_checkpayment/ps_checkpayment.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c888438d14855d7d96a2724ee9c306bd">
+        <source>Settings updated</source>
+        <target>Settings updated</target>
+        <note>Line: 116</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_featuredproducts/ps_featuredproducts.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="efc226b17e0532afff43be870bff0de7">
+        <source>The settings have been updated.</source>
+        <target>The settings have been updated.</target>
+        <note>Line: 152</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_imageslider/ps_imageslider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="20015706a8cbd457cbb6ea3e7d5dc9b3">
+        <source>Configuration updated</source>
+        <target>Configuration updated</target>
+        <note>Line: 434</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Product/AdminProductWrapper.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7173e38e8a10ed379625687638ddfe74">
+        <source>Successful deletion</source>
+        <target>Successful deletion</target>
+        <note>Line: 548</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fb52feac670f0252be93737558eebdb7">
+        <source>Successful creation.</source>
+        <target>Successful creation.</target>
+        <note>Line: 204</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1802a23025825ae791c1eea0118ee5f0">
+        <source>The status has been successfully updated.</source>
+        <target>The status has been successfully updated.</target>
+        <note>Line: 286</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="149cd107b688af7a007e739fd51ac919">
+        <source>Successful deletion.</source>
+        <target>Successful deletion.</target>
+        <note>Line: 181</note>
+      </trans-unit>
+      <trans-unit id="02d5b938505dcda41a52ef3abcbd354a">
+        <source>The selection has been successfully deleted.</source>
+        <target>The selection has been successfully deleted.</target>
+        <note>Line: 210</note>
+      </trans-unit>
+      <trans-unit id="6483df61619946ebf2427ba360df7ce5">
+        <source>The settings have been successfully updated.</source>
+        <target>The settings have been successfully updated.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f38f5974cdc23279ffe6d203641a8bdf">
+        <source>Settings updated.</source>
+        <target>Settings updated.</target>
+        <note>Line: 334</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminNotificationsWarning.xlf
+++ b/app/Resources/translations/default/AdminNotificationsWarning.xlf
@@ -1,60 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e25f0ecd41211b01c83e5fec41df4fe7">
-        <source>Delete selected items?</source>
-        <target>Delete selected items?</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php:206</note>
-      </trans-unit>
-      <trans-unit id="1412292b09d3cd39f32549afb1f5f102">
-        <source>Delete selected item?</source>
-        <target>Delete selected item?</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php:148</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/images/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="729a51874fe901b092899e9e8b31c97a">
         <source>Are you sure?</source>
         <target>Are you sure?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/images/content.tpl:127</note>
+        <note>Line: 48</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/stats/menu.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="6557717352c9b5d28da3b96bf546a389">
-        <source>Leave anyway</source>
-        <target>Leave anyway</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/InternationalApi.php:39</note>
-      </trans-unit>
-      <trans-unit id="f58375e52c1f1329c29c474cd8b34ec7">
-        <source>Your modifications are not saved yet. Do you wish to save it before leaving?</source>
-        <target>Your modifications are not saved yet. Do you wish to save it before leaving?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Translation/Api/InternationalApi.php:42</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="71a0384942a58e7418c2098eaea4fe0f">
-        <source>Are you sure to delete this?</source>
-        <target>Are you sure to delete this?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:343</note>
-      </trans-unit>
-      <trans-unit id="0eaadb4fcb48a0a0ed7bc9868be9fbaa">
-        <source>Warning</source>
-        <target>Warning</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig:269</note>
+      <trans-unit id="34ddce12eacd79ced0e326360863888f">
+        <source>No module has been installed.</source>
+        <target>No module has been installed.</target>
+        <note>Line: 35</note>
       </trans-unit>
     </body>
   </file>
@@ -63,8 +23,7 @@ File: src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.htm
       <trans-unit id="358cc9ee3a3d23d3390e5043122d9bea">
         <source>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</source>
         <target>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/header.tpl:82</note>
+        <note>Line: 82</note>
       </trans-unit>
     </body>
   </file>
@@ -73,30 +32,77 @@ File: admin-dev/themes/default/template/header.tpl:82</note>
       <trans-unit id="db26e10564e958809d798e8048fcbc0a">
         <source>Invalid security token</source>
         <target>Invalid security token</target>
-        <note>Context:
-File: admin-dev/themes/default/template/invalid_token.tpl:85</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="a4da6f31ab268a5310bc475e63ab92db">
         <source>I understand the risks and I really want to display this page</source>
         <target>I understand the risks and I really want to display this page</target>
-        <note>Context:
-File: admin-dev/themes/default/template/invalid_token.tpl:89</note>
+        <note>Line: 89</note>
       </trans-unit>
       <trans-unit id="5196611ad1bf27e9cef5375b038c04db">
         <source>Take me out of here!</source>
         <target>Take me out of here!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/invalid_token.tpl:92</note>
+        <note>Line: 92</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/gsitemap/gsitemap.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="34ddce12eacd79ced0e326360863888f">
-        <source>No module has been installed.</source>
-        <target>No module has been installed.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl:467</note>
+      <trans-unit id="bb8956c67b82c7444a80c6b2433dd8b4">
+        <source>Are you sure you want to uninstall this module?</source>
+        <target>Are you sure you want to uninstall this module?</target>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e25f0ecd41211b01c83e5fec41df4fe7">
+        <source>Delete selected items?</source>
+        <target>Delete selected items?</target>
+        <note>Line: 260</note>
+      </trans-unit>
+      <trans-unit id="1412292b09d3cd39f32549afb1f5f102">
+        <source>Delete selected item?</source>
+        <target>Delete selected item?</target>
+        <note>Line: 154</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a157a50f5a421a7dfbdf280f3ff9d56e">
+        <source>You can't change the value of this configuration field in the context of this shop.</source>
+        <target>You can't change the value of this configuration field in the context of this shop.</target>
+        <note>Line: 155</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="71a0384942a58e7418c2098eaea4fe0f">
+        <source>Are you sure to delete this?</source>
+        <target>Are you sure to delete this?</target>
+        <note>Line: 343</note>
+      </trans-unit>
+      <trans-unit id="0eaadb4fcb48a0a0ed7bc9868be9fbaa">
+        <source>Warning</source>
+        <target>Warning</target>
+        <note>Line: 269</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Translation/Api/InternationalApi.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6557717352c9b5d28da3b96bf546a389">
+        <source>Leave anyway</source>
+        <target>Leave anyway</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="f58375e52c1f1329c29c474cd8b34ec7">
+        <source>Your modifications are not saved yet. Do you wish to save it before leaving?</source>
+        <target>Your modifications are not saved yet. Do you wish to save it before leaving?</target>
+        <note>Line: 42</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminOrderscustomersFeature.xlf
+++ b/app/Resources/translations/default/AdminOrderscustomersFeature.xlf
@@ -1,980 +1,95 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="classes/checkout/PaymentOptionsFinder.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/addresses/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="71754079aaeefc5c6e745ddd59f8a35f">
-        <source>Free order</source>
-        <target>Free order</target>
-        <note>Context:
-File: classes/checkout/PaymentOptionsFinder.php:72</note>
+      <trans-unit id="03361eda68f746619c2ae3341eaa2f07">
+        <source>Customer email</source>
+        <target>Customer email</target>
+        <note>Line: 34</note>
       </trans-unit>
     </body>
   </file>
-  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="94003250a2187a9f51b227b490e5ab6b">
-        <source>New client</source>
-        <target>New client</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:86</note>
-      </trans-unit>
-      <trans-unit id="e13004b81566bfc42daa48372c15111b">
-        <source>Change Order Status</source>
-        <target>Change Order Status</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:183</note>
-      </trans-unit>
-      <trans-unit id="e5d61db40a917c78a9d8e821dd0dd8de">
-        <source>Add new order</source>
-        <target>Add new order</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:201</note>
-      </trans-unit>
-      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
-        <source>Orders</source>
-        <target>Orders</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:260</note>
-      </trans-unit>
-      <trans-unit id="0262a3dc4fae9adc8cb46e788806ccbf">
-        <source>Create order</source>
-        <target>Create order</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:260</note>
-      </trans-unit>
-      <trans-unit id="0f005bd8209a61e4fc96a69736eb9798">
-        <source>Order %reference% from %firstname% %lastname%</source>
-        <target>Order %reference% from %firstname% %lastname%</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:277</note>
-      </trans-unit>
-      <trans-unit id="d201284604b35aa9392cb9c1acc434a6">
-        <source>Credit slip for order #%d</source>
-        <target>Credit slip for order #%d</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:793</note>
-      </trans-unit>
-      <trans-unit id="bbee72681d2c075d95355d3d9ccefb4e">
-        <source>Credit card slip for order #%d</source>
-        <target>Credit card slip for order #%d</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1062</note>
-      </trans-unit>
-      <trans-unit id="e49701f123af735cf327227e8ab09bac">
-        <source>Manual order -- Employee:</source>
-        <target>Manual order -- Employee:</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1231</note>
-      </trans-unit>
-      <trans-unit id="1f065062cdb50b501c5cb5160cf21ab0">
-        <source>Net Profit per Visit</source>
-        <target>Net Profit per Visit</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1657</note>
-      </trans-unit>
-      <trans-unit id="947d8520f04473da621f2718138f3bc6">
-        <source>30 days</source>
-        <target>30 days</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1658</note>
-      </trans-unit>
-      <trans-unit id="52ec3221b595bb84def222e275d0152b">
-        <source>Order #%id% (%ref%) - %firstname% %lastname%</source>
-        <target>Order #%id% (%ref%) - %firstname% %lastname%</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1711</note>
-      </trans-unit>
-      <trans-unit id="95abd3be6297996994738f735a369d4a">
-        <source>Shop: %shop_name%</source>
-        <target>Shop: %shop_name%</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1722</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6a5efd211a422296eab4adc476c98f0e">
-        <source>Return products</source>
-        <target>Return products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:162</note>
-      </trans-unit>
-      <trans-unit id="4ad439b4f7069964e258259e049fa90c">
-        <source>Standard refund</source>
-        <target>Standard refund</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:164</note>
-      </trans-unit>
-      <trans-unit id="4b8def9be8f45a8d6baea36b26868965">
-        <source>Cancel products</source>
-        <target>Cancel products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:166</note>
-      </trans-unit>
-      <trans-unit id="4b6c6cda10a23d1bdc920f2e47e5f46f">
-        <source>Add a product</source>
-        <target>Add a product</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:980</note>
-      </trans-unit>
-      <trans-unit id="77fd2b4393b379bedd30efcd5df02090">
-        <source>Partial refund</source>
-        <target>Partial refund</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1242</note>
-      </trans-unit>
-      <trans-unit id="4f68183551e5dbd7c341347ffe308682">
-        <source>SIRET</source>
-        <target>SIRET</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:617</note>
-      </trans-unit>
-      <trans-unit id="85fb93a8ee9440499692da24a1621769">
-        <source>APE</source>
-        <target>APE</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:619</note>
-      </trans-unit>
-      <trans-unit id="cb8fe83175bea4ba19d633b1dc6ea656">
-        <source>View order</source>
-        <target>View order</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1310</note>
-      </trans-unit>
-      <trans-unit id="03ab340b3f99e03cff9e84314ead38c0">
-        <source>Qty</source>
-        <target>Qty</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:929</note>
-      </trans-unit>
-      <trans-unit id="f8a09f634b7b3ede2da34607da2aaebe">
-        <source>Available quantity</source>
-        <target>Available quantity</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:936</note>
-      </trans-unit>
-      <trans-unit id="01abfc750a0c942167651c40d088531d">
-        <source>#</source>
-        <target>#</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:588</note>
-      </trans-unit>
-      <trans-unit id="be4254ec37a7bf0d2babdf04bce774cf">
-        <source>Print order</source>
-        <target>Print order</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:131</note>
-      </trans-unit>
-      <trans-unit id="a6ecff447ea8327b43f5d16a924fb6be">
-        <source>View invoice</source>
-        <target>View invoice</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:137</note>
-      </trans-unit>
-      <trans-unit id="f8246f1c2cfd9a81a376223428bd09d7">
-        <source>No invoice</source>
-        <target>No invoice</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:142</note>
-      </trans-unit>
-      <trans-unit id="ddd167afc1441dcab03a9546c8ef8b51">
-        <source>View delivery slip</source>
-        <target>View delivery slip</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:149</note>
-      </trans-unit>
-      <trans-unit id="a6181ae0a3e0370de94efa64782a6e79">
-        <source>No delivery slip</source>
-        <target>No delivery slip</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:154</note>
-      </trans-unit>
-      <trans-unit id="f28128b38efbc6134dc40751ee21fd29">
-        <source>Documents</source>
-        <target>Documents</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:262</note>
-      </trans-unit>
-      <trans-unit id="d71940f24ee38ee09f6e06b908480bcf">
-        <source>Resend email</source>
-        <target>Resend email</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:231</note>
-      </trans-unit>
-      <trans-unit id="f5359d1dd07def542aa9b0577fb27068">
-        <source>Update status</source>
-        <target>Update status</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:254</note>
-      </trans-unit>
-      <trans-unit id="979640f579db842e61902ca061153965">
-        <source>Merchandise Returns</source>
-        <target>Merchandise Returns</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:328</note>
-      </trans-unit>
-      <trans-unit id="484f5a79672cebe198ebdde45a1d672f">
-        <source>Gift wrapping</source>
-        <target>Gift wrapping</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:321</note>
-      </trans-unit>
-      <trans-unit id="f0aaaae189e9c7711931a65ffcd22543">
-        <source>Payment method</source>
-        <target>Payment method</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:429</note>
-      </trans-unit>
-      <trans-unit id="88427ec035734b45aae9f7d8859a5008">
-        <source>Transaction ID</source>
-        <target>Transaction ID</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:430</note>
-      </trans-unit>
-      <trans-unit id="931d3a3ad177dd96a28c9642fec11b01">
-        <source>Card Number</source>
-        <target>Card Number</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:459</note>
-      </trans-unit>
-      <trans-unit id="f8b1369a8e9d90da0cae0b11049309af">
-        <source>Not defined</source>
-        <target>Not defined</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:487</note>
-      </trans-unit>
-      <trans-unit id="2ef876508663171dedb532b4ecdb19a1">
-        <source>Card Brand</source>
-        <target>Card Brand</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:467</note>
-      </trans-unit>
-      <trans-unit id="52aeead61e400c8faeb3c1dcb355e7a5">
-        <source>Card Expiration</source>
-        <target>Card Expiration</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:475</note>
-      </trans-unit>
-      <trans-unit id="c20497ad97022701fa9b5d3c34c0c474">
-        <source>Card Holder</source>
-        <target>Card Holder</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:483</note>
-      </trans-unit>
-      <trans-unit id="d694c11f096d5d666dde9ab8f9d9ba29">
-        <source>Change currency</source>
-        <target>Change currency</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:552</note>
-      </trans-unit>
-      <trans-unit id="f4ec5f57bd4d31b803312d873be40da9">
-        <source>Change</source>
-        <target>Change</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:752</note>
-      </trans-unit>
-      <trans-unit id="6fe50cb3c0bf60f28ac9049ae6cb8c26">
-        <source>This order has been placed by a guest.</source>
-        <target>This order has been placed by a guest.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:594</note>
-      </trans-unit>
-      <trans-unit id="6a7bac4a86e299a2718b9d2c7c8aaea9">
-        <source>Account registered</source>
-        <target>Account registered</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:610</note>
-      </trans-unit>
-      <trans-unit id="d53b54a2bdbf970c70b7de7de4f6021f">
-        <source>Valid orders placed</source>
-        <target>Valid orders placed</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:612</note>
-      </trans-unit>
-      <trans-unit id="8a8ece2eaecf6b5771d66434212e060d">
-        <source>Total spent since registration</source>
-        <target>Total spent since registration</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:614</note>
-      </trans-unit>
-      <trans-unit id="5d9fe8726be08b6e26a0c05319590b01">
-        <source>View full details...</source>
-        <target>View full details...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:628</note>
-      </trans-unit>
-      <trans-unit id="66dc0eb61ab4157d6170494e6841a77a">
-        <source>Private note</source>
-        <target>Private note</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:633</note>
-      </trans-unit>
-      <trans-unit id="0c458988127eb2150776881e2ef3f0c4">
-        <source>Shipping address</source>
-        <target>Shipping address</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:676</note>
-      </trans-unit>
-      <trans-unit id="601d8c4b9f72fc1862013c19b677a499">
-        <source>Invoice address</source>
-        <target>Invoice address</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:728</note>
-      </trans-unit>
-      <trans-unit id="47f9082fc380ca62d531096aa1d110f1">
-        <source>Private</source>
-        <target>Private</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:807</note>
-      </trans-unit>
-      <trans-unit id="2ab74fb771ac34b95b1657895282d5d9">
-        <source>Choose a standard message</source>
-        <target>Choose a standard message</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:827</note>
-      </trans-unit>
-      <trans-unit id="a76e7775f5454953c7152f5160e75182">
-        <source>Configure predefined messages</source>
-        <target>Configure predefined messages</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:837</note>
-      </trans-unit>
-      <trans-unit id="b7623e931f082f027293f27dbfe7a8ea">
-        <source>Display to customer?</source>
-        <target>Display to customer?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:845</note>
-      </trans-unit>
-      <trans-unit id="747c6a3564774149c989884e0c581d53">
-        <source>Send message</source>
-        <target>Send message</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:873</note>
-      </trans-unit>
-      <trans-unit id="a2eda4e1c4dfc9bade7150b878c57a46">
-        <source>Show all messages</source>
-        <target>Show all messages</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:876</note>
-      </trans-unit>
-      <trans-unit id="fdfac28b5ad628f25649d9c2eb4fc62e">
-        <source>Returned</source>
-        <target>Returned</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:933</note>
-      </trans-unit>
-      <trans-unit id="cdba184783a0253218efd734da81a9da">
-        <source>Stock location</source>
-        <target>Stock location</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:935</note>
-      </trans-unit>
-      <trans-unit id="988fd738de9c6d177440c5dcf69e73ce">
-        <source>Return</source>
-        <target>Return</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:946</note>
-      </trans-unit>
-      <trans-unit id="76f0ed934de85cc7131910b32ede7714">
-        <source>Refund</source>
-        <target>Refund</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:948</note>
-      </trans-unit>
-      <trans-unit id="4320b10eab24c2b8ee337355e7deb4c6">
-        <source>Add a new discount</source>
-        <target>Add a new discount</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:985</note>
-      </trans-unit>
-      <trans-unit id="f14b582c1b0eab88ed5904fb781568c0">
-        <source>Discount name</source>
-        <target>Discount name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1017</note>
-      </trans-unit>
-      <trans-unit id="689202409e48743b914713f96d93947c">
-        <source>Value</source>
-        <target>Value</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1022</note>
-      </trans-unit>
-      <trans-unit id="c990c4027126c39a93fcaaafb68732b3">
-        <source>Delete voucher</source>
-        <target>Delete voucher</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1044</note>
-      </trans-unit>
-      <trans-unit id="b52b44c9d23e141b067d7e83b44bb556">
-        <source>Products:</source>
-        <target>Products:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1076</note>
-      </trans-unit>
-      <trans-unit id="9d5bf15117441a1b52eb1f0808e4aad3">
-        <source>Discounts</source>
-        <target>Discounts</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1083</note>
-      </trans-unit>
-      <trans-unit id="ba794350deb07c0c96fe73bd12239059">
-        <source>Wrapping</source>
-        <target>Wrapping</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1090</note>
-      </trans-unit>
-      <trans-unit id="7fc63f077cf04742cf02e7c589b428e9">
-        <source>(Max %s %s)</source>
-        <target>(Max %s %s)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1108</note>
-      </trans-unit>
-      <trans-unit id="1067f7778added234b6064bc8aa0765d">
-        <source>Re-stock products</source>
-        <target>Re-stock products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1204</note>
-      </trans-unit>
-      <trans-unit id="e413f403aa8d5253b487d09fc84e47a0">
-        <source>Generate a credit slip</source>
-        <target>Generate a credit slip</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1150</note>
-      </trans-unit>
-      <trans-unit id="400264c3cd8f2e65b9f19375230b59b8">
-        <source>Generate a voucher</source>
-        <target>Generate a voucher</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1210</note>
-      </trans-unit>
-      <trans-unit id="711cb64729ed5b666cf97c01691f5806">
-        <source>Repay shipping costs</source>
-        <target>Repay shipping costs</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1162</note>
-      </trans-unit>
-      <trans-unit id="d68a1671669f7e55d73dd78c22d52dfa">
-        <source>This order has been partially paid by voucher. Choose the amount you want to refund:</source>
-        <target>This order has been partially paid by voucher. Choose the amount you want to refund:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1166</note>
-      </trans-unit>
-      <trans-unit id="6188ffe19286d3bf694160609cf15e82">
-        <source>Include amount of initial voucher: </source>
-        <target>Include amount of initial voucher: </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1170</note>
-      </trans-unit>
-      <trans-unit id="b9313ee2094019f4ee5212f784f45d65">
-        <source>Exclude amount of initial voucher: </source>
-        <target>Exclude amount of initial voucher: </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1176</note>
-      </trans-unit>
-      <trans-unit id="7731388b0fae4c0d7214f6a1f6f1771f">
-        <source>Amount of your choice: </source>
-        <target>Amount of your choice: </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1229</note>
-      </trans-unit>
-      <trans-unit id="67dd576afa3b807903e847f6ebb11f22">
-        <source>This order has been partially paid by voucher. Choose the amount you want to refund: </source>
-        <target>This order has been partially paid by voucher. Choose the amount you want to refund: </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1214</note>
-      </trans-unit>
-      <trans-unit id="8e0398b929d533c18fff7f5e21e8fcbd">
-        <source>Product(s) price: </source>
-        <target>Product(s) price: </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1218</note>
-      </trans-unit>
-      <trans-unit id="34623cd7893be21da4239d08f79aec9a">
-        <source>Product(s) price, excluding amount of initial voucher: </source>
-        <target>Product(s) price, excluding amount of initial voucher: </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1224</note>
-      </trans-unit>
-      <trans-unit id="fb61758d0f0fda4ba867c3d5a46c16a7">
-        <source>Sources</source>
-        <target>Sources</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1257</note>
-      </trans-unit>
-      <trans-unit id="5da618e8e4b89c66fe86e32cdafde142">
-        <source>From</source>
-        <target>From</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1263</note>
-      </trans-unit>
-      <trans-unit id="e12167aa0a7698e6ebc92b4ce3909b53">
-        <source>To</source>
-        <target>To</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1264</note>
-      </trans-unit>
-      <trans-unit id="010cd82f1f972dc6b720536adb555533">
-        <source>Linked orders</source>
-        <target>Linked orders</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1277</note>
-      </trans-unit>
-      <trans-unit id="0da6a00e3eb2132d5cf97463a099c49f">
-        <source>Order no. </source>
-        <target>Order no. </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1284</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="272c853e39b8c65c81afd3661a8fd17f">
-        <source>%amount% tax excl.</source>
-        <target>%amount% tax excl.</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:186</note>
-      </trans-unit>
-      <trans-unit id="90855df1b2d1240c62d81bd35d4cfb06">
-        <source>Non ordered</source>
-        <target>Non ordered</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:48</note>
-      </trans-unit>
-      <trans-unit id="121401ccf0e3e23bcefe6a454f0f0601">
-        <source>Abandoned cart</source>
-        <target>Abandoned cart</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:62</note>
-      </trans-unit>
-      <trans-unit id="f9b01554c32cc580b7380302f22613de">
-        <source>Export carts</source>
-        <target>Export carts</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:132</note>
-      </trans-unit>
-      <trans-unit id="54e85d70ea67acdcc86963b14d6223a8">
-        <source>Abandoned Carts</source>
-        <target>Abandoned Carts</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:167</note>
-      </trans-unit>
-      <trans-unit id="edeb0ec4f968653bb56eb2d7c50dab35">
-        <source>From %date1% to %date2%</source>
-        <target>From %date1% to %date2%</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:170</note>
-      </trans-unit>
-      <trans-unit id="ffbb5322a3702b0d8d9c7f506209c540">
-        <source>Average Order Value</source>
-        <target>Average Order Value</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:183</note>
-      </trans-unit>
-      <trans-unit id="4d9e1e12ad8a61ea2a5554407488d91a">
-        <source>Net Profit per Visitor</source>
-        <target>Net Profit per Visitor</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:197</note>
-      </trans-unit>
-      <trans-unit id="50cc07e9963519545552b1ac2c5f7a1e">
-        <source>Cart #%ID%</source>
-        <target>Cart #%ID%</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:284</note>
-      </trans-unit>
-      <trans-unit id="0b91ef9198a761459c595de4b12ca109">
-        <source>Total Cart</source>
-        <target>Total Cart</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:283</note>
-      </trans-unit>
-      <trans-unit id="b00b85425e74ed2c85dc3119b78ff2c3">
-        <source>Free Shipping</source>
-        <target>Free Shipping</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:601</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSlipController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d79cf3f429596f77db95c65074663a54">
-        <source>Order ID</source>
-        <target>Order ID</target>
-        <note>Context:
-File: controllers/admin/AdminSlipController.php:51</note>
-      </trans-unit>
-      <trans-unit id="446faa7da2d42ba4ffeda73cb119dd91">
-        <source>Date issued</source>
-        <target>Date issued</target>
-        <note>Context:
-File: controllers/admin/AdminSlipController.php:56</note>
-      </trans-unit>
-      <trans-unit id="c95ed58f8c9573f7d58667e6847758d9">
-        <source>Slip</source>
-        <target>Slip</target>
-        <note>Context:
-File: controllers/admin/AdminSlipController.php:72</note>
-      </trans-unit>
-      <trans-unit id="44180a771d7f3bf534550199c3293441">
-        <source>Credit slip options</source>
-        <target>Credit slip options</target>
-        <note>Context:
-File: controllers/admin/AdminSlipController.php:76</note>
-      </trans-unit>
-      <trans-unit id="d3174688da67b4530a7c8e774a7f31d5">
-        <source>Credit slip prefix</source>
-        <target>Credit slip prefix</target>
-        <note>Context:
-File: controllers/admin/AdminSlipController.php:79</note>
-      </trans-unit>
-      <trans-unit id="9a0e3730cac2d4abdda4cfa04483318e">
-        <source>Print a PDF</source>
-        <target>Print a PDF</target>
-        <note>Context:
-File: controllers/admin/AdminSlipController.php:107</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminAddressesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7cb32e708d6b961d476baced73d362bb">
-        <source>VAT number</source>
-        <target>VAT number</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:211</note>
-      </trans-unit>
-      <trans-unit id="b60bb13a87fe3ae5463aeb0980a5a8a1">
-        <source>Identification number</source>
-        <target>Identification number</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:128</note>
-      </trans-unit>
-      <trans-unit id="bed08e8af70a98c1a8361f13ec477be0">
-        <source>Add new address</source>
-        <target>Add new address</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:104</note>
-      </trans-unit>
-      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
-        <source>Addresses</source>
-        <target>Addresses</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:116</note>
-      </trans-unit>
-      <trans-unit id="e03982ee543fe69d4954d587f1f2a338">
-        <source>The national ID card number of this person, or a unique tax identification number.</source>
-        <target>The national ID card number of this person, or a unique tax identification number.</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:132</note>
-      </trans-unit>
-      <trans-unit id="baa31a65f29121c32b637bb845d41acf">
-        <source>Address alias</source>
-        <target>Address alias</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:136</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_select_payment.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="267806034cfac4481cabe7b81c81f91d">
-        <source>Back office order</source>
-        <target>Back office order</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_select_payment.tpl:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="36358a9d4d77cc110761aec78f98c945">
-        <source>Partner offers</source>
-        <target>Partner offers</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:133</note>
-      </trans-unit>
-      <trans-unit id="a82868319826fb092b73968e661b5b38">
-        <source>Vouchers</source>
-        <target>Vouchers</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:413</note>
-      </trans-unit>
-      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e">
-        <source>Unknown</source>
-        <target>Unknown</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:104</note>
-      </trans-unit>
-      <trans-unit id="9d8d2d5ab12b515182a505f54db7f538">
-        <source>Age</source>
-        <target>Age</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:58</note>
-      </trans-unit>
-      <trans-unit id="56b80d8cc0afeaff5a2e624583b976ab">
-        <source>%1$d years old (birth date: %2$s)</source>
-        <target>%1$d years old (birth date: %2$s)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="97ce2ccb5de5849fd94203a375054378">
-        <source>Registration Date</source>
-        <target>Registration Date</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:70</note>
-      </trans-unit>
-      <trans-unit id="123cdf3e99e5daa563ac54af55a158be">
-        <source>Last Visit</source>
-        <target>Last Visit</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:76</note>
-      </trans-unit>
-      <trans-unit id="eee7a325a979babb04b46b3114c005f6">
-        <source>Best Customer Rank</source>
-        <target>Best Customer Rank</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:83</note>
-      </trans-unit>
-      <trans-unit id="a28735af01fbb1e35371cb120985ac47">
-        <source>Registrations</source>
-        <target>Registrations</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:110</note>
-      </trans-unit>
-      <trans-unit id="a39ee61626da77cb9644fa972a8ac5b5">
-        <source>Latest Update</source>
-        <target>Latest Update</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:140</note>
-      </trans-unit>
-      <trans-unit id="1f8895b98efdf9e96766d39f24ec352c">
-        <source>This customer is registered as a Guest.</source>
-        <target>This customer is registered as a Guest.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:165</note>
-      </trans-unit>
-      <trans-unit id="832c2f75a0029f82a281704661b07542">
-        <source>Transform to a customer account</source>
-        <target>Transform to a customer account</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:170</note>
-      </trans-unit>
-      <trans-unit id="33c1f4de9458d31b6df40fb7fb52a180">
-        <source>for a total amount of %s</source>
-        <target>for a total amount of %s</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:194</note>
-      </trans-unit>
-      <trans-unit id="a9c74a800ed9f3d504e76d8c59acc497">
-        <source>Invalid orders:</source>
-        <target>Invalid orders:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:198</note>
-      </trans-unit>
-      <trans-unit id="25326db0dcb2cf342b3477fbdad373dc">
-        <source>Total spent</source>
-        <target>Total spent</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:246</note>
-      </trans-unit>
-      <trans-unit id="665305fedb3adcae303f3b974bc9ce08">
-        <source>%firstname% %lastname% has not placed any orders yet</source>
-        <target>%firstname% %lastname% has not placed any orders yet</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:265</note>
-      </trans-unit>
-      <trans-unit id="698e0d3e044a7ebe56308e190b82b326">
-        <source>Purchased products</source>
-        <target>Purchased products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:308</note>
-      </trans-unit>
-      <trans-unit id="43560641f91e63dc83682bc598892fa1">
-        <source>Viewed products</source>
-        <target>Viewed products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:337</note>
-      </trans-unit>
-      <trans-unit id="a7136d956fbff49c3912e44722dbf000">
-        <source>Add a private note</source>
-        <target>Add a private note</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:362</note>
-      </trans-unit>
-      <trans-unit id="abce3ef910cfc047f0721654cb71f2db">
-        <source>Sent on</source>
-        <target>Sent on</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:391</note>
-      </trans-unit>
-      <trans-unit id="e1835dc45bbdc7f7d3ca94f4ab002f84">
-        <source>%firstname% %lastname% has never contacted you</source>
-        <target>%firstname% %lastname% has never contacted you</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:407</note>
-      </trans-unit>
-      <trans-unit id="907d7000b3555d1a1b12f1fed29a9ec4">
-        <source>Qty available</source>
-        <target>Qty available</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:423</note>
-      </trans-unit>
-      <trans-unit id="c8b4c13e6ad3227e192c118261c0e179">
-        <source>%firstname% %lastname% has no discount vouchers</source>
-        <target>%firstname% %lastname% has no discount vouchers</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:455</note>
-      </trans-unit>
-      <trans-unit id="b70a3b711156c78fa558c596980b2e30">
-        <source>Last emails</source>
-        <target>Last emails</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:463</note>
-      </trans-unit>
-      <trans-unit id="93bd48ecb9c4d5c4eec7fefffbb2070f">
-        <source>Last connections</source>
-        <target>Last connections</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:491</note>
-      </trans-unit>
-      <trans-unit id="d3139f39f1ad6324c80a9ddd50cc7867">
-        <source>Pages viewed</source>
-        <target>Pages viewed</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:498</note>
-      </trans-unit>
-      <trans-unit id="c22d30084d8ddc9a571512ddee6a83e9">
-        <source>Total time</source>
-        <target>Total time</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:499</note>
-      </trans-unit>
-      <trans-unit id="3edf8ca26a1ec14dd6e91dd277ae1de6">
-        <source>Origin</source>
-        <target>Origin</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:500</note>
-      </trans-unit>
-      <trans-unit id="5b8c99dad1893a85076709b2d3c2d2d0">
-        <source>IP Address</source>
-        <target>IP Address</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:501</note>
-      </trans-unit>
-      <trans-unit id="ff398a1c3434e160c655aa1613e0eace">
-        <source>Referrers</source>
-        <target>Referrers</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:563</note>
-      </trans-unit>
-      <trans-unit id="e174c1b711f254d538c689a90c5842a5">
-        <source>Phone number(s)</source>
-        <target>Phone number(s)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:610</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0f98b7f230f3c91292f0de4c99e263f2">
-        <source>Registration</source>
-        <target>Registration</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:143</note>
-      </trans-unit>
-      <trans-unit id="5e5914912e8d2f2765525840acf98bea">
-        <source>Last visit</source>
-        <target>Last visit</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:148</note>
-      </trans-unit>
-      <trans-unit id="888d7e26fb1b4271a83269c91134ed67">
-        <source>Manage your Customers</source>
-        <target>Manage your Customers</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:245</note>
-      </trans-unit>
-      <trans-unit id="cd338983b119cf1b564b00a655751e36">
-        <source>Information about customer %name%</source>
-        <target>Information about customer %name%</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:251</note>
-      </trans-unit>
-      <trans-unit id="69ebc35efeb4f755ec3e9c44b4da635c">
-        <source>Editing customer %name%</source>
-        <target>Editing customer %name%</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:259</note>
-      </trans-unit>
-      <trans-unit id="601bcb96f0fb98dadc4dda90d98ef24d">
-        <source>Creating a new Customer</source>
-        <target>Creating a new Customer</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:261</note>
-      </trans-unit>
-      <trans-unit id="aac772216aecbeca0e86d06671fe985a">
-        <source>Birthday</source>
-        <target>Birthday</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:403</note>
-      </trans-unit>
-      <trans-unit id="920bd1fb6d54c93fca528ce941464225">
-        <source>Group access</source>
-        <target>Group access</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:473</note>
-      </trans-unit>
-      <trans-unit id="a3858e268ef19d7ec44b4e849a189a69">
-        <source>Default customer group</source>
-        <target>Default customer group</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:482</note>
-      </trans-unit>
-      <trans-unit id="15bbb9d0bbf25e8d2978de1168c749dc">
-        <source>Website</source>
-        <target>Website</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:534</note>
-      </trans-unit>
-      <trans-unit id="6e55ad8db6699476d8901b3d439963cb">
-        <source>Allowed outstanding amount</source>
-        <target>Allowed outstanding amount</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:539</note>
-      </trans-unit>
-      <trans-unit id="a7f50f36de1e47026a07b40670b50e1a">
-        <source>Maximum number of payment days</source>
-        <target>Maximum number of payment days</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:546</note>
-      </trans-unit>
-      <trans-unit id="b5228365ac1cae42b64aa5aecee6cf25">
-        <source>Risk rating</source>
-        <target>Risk rating</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:552</note>
-      </trans-unit>
-      <trans-unit id="06b7d2fbf61e5118bb87d7f561d3fa01">
-        <source>Average Age</source>
-        <target>Average Age</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:632</note>
-      </trans-unit>
-      <trans-unit id="d8f847a1f651aee93ecb6a22207e77b2">
-        <source>Orders per Customer</source>
-        <target>Orders per Customer</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:645</note>
-      </trans-unit>
-      <trans-unit id="d7eb752a5f38ab96a8dcf110aeb9f8b3">
-        <source>Newsletter Registrations</source>
-        <target>Newsletter Registrations</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:658</note>
+      <trans-unit id="1d949d2235747b894bbaae35fbf44f1d">
+        <source>Customer information</source>
+        <target>Customer information</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="ad63162d0d394b0e0daf1c30c6d77160">
+        <source>Account registration date:</source>
+        <target>Account registration date:</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="b157524c4be8c2fc80e5ef2f0b1bf1e6">
+        <source>Valid orders placed:</source>
+        <target>Valid orders placed:</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="5c63fcad7f3534fdcf4ee426a54a6e00">
+        <source>Total spent since registration:</source>
+        <target>Total spent since registration:</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="a8e3c5c577a4b885819e5ba1c785065c">
+        <source>Guest not registered</source>
+        <target>Guest not registered</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="58930025e1f95d65035e0df5d6c2ae41">
+        <source>Order information</source>
+        <target>Order information</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="18fb6221fe0d9895c2e9ba08283f00e9">
+        <source>Order #%d</source>
+        <target>Order #%d</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="f9e17adb48f78186c6bcd4bd9c08816d">
+        <source>Made on:</source>
+        <target>Made on:</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="f56d50312cd90c7dec77c0472f20fee0">
+        <source>No order was created from this cart.</source>
+        <target>No order was created from this cart.</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="4f36361240acdff526598021f5459a87">
+        <source>Create an order from this cart.</source>
+        <target>Create an order from this cart.</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="6f16ab6ec0a6064d0c8961257a3eb1f5">
+        <source>Cart summary</source>
+        <target>Cart summary</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="2fb3b950fd7711136f7f251ae5fbdbdc">
+        <source>Text #</source>
+        <target>Text #</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="0bf157acdf9fe272c1379ff0b5442372">
+        <source>Total cost of products:</source>
+        <target>Total cost of products:</target>
+        <note>Line: 168</note>
+      </trans-unit>
+      <trans-unit id="3e69f668660d41b577a8da0fb53f6fa8">
+        <source>Total value of vouchers:</source>
+        <target>Total value of vouchers:</target>
+        <note>Line: 173</note>
+      </trans-unit>
+      <trans-unit id="79e21b5609402cd57d1dec7496771df8">
+        <source>Total cost of gift wrapping:</source>
+        <target>Total cost of gift wrapping:</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="80fde97fb8929b8bea9ebcf5241be2f9">
+        <source>Total shipping costs:</source>
+        <target>Total shipping costs:</target>
+        <note>Line: 185</note>
       </trans-unit>
     </body>
   </file>
@@ -983,556 +98,1134 @@ File: controllers/admin/AdminCustomersController.php:658</note>
       <trans-unit id="c3bf447eabe632720a3aa1a7ce401274">
         <source>Open</source>
         <target>Open</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/list/list_header.tpl:67</note>
+        <note>Line: 67</note>
       </trans-unit>
       <trans-unit id="03f4a47830f97377a35321051685071e">
         <source>Closed</source>
         <target>Closed</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/list/list_header.tpl:68</note>
+        <note>Line: 68</note>
       </trans-unit>
       <trans-unit id="70e7ab74282fb27b8c100e017b037135">
         <source>Pending 1</source>
         <target>Pending 1</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/list/list_header.tpl:69</note>
+        <note>Line: 69</note>
       </trans-unit>
       <trans-unit id="1033cc268ed0919b5d4e76ea6053ed25">
         <source>Pending 2</source>
         <target>Pending 2</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/list/list_header.tpl:70</note>
+        <note>Line: 70</note>
       </trans-unit>
       <trans-unit id="6d88865acb8658a92b188e47ba03906d">
         <source>No new messages</source>
         <target>No new messages</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/list/list_header.tpl:51</note>
+        <note>Line: 51</note>
       </trans-unit>
       <trans-unit id="b55a2d6e1009d3881156a3495dd26de5">
         <source>New message</source>
         <target>New message</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/list/list_header.tpl:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="95923cff2ad4637372adcdf25e4581f8">
         <source>Meaning of status</source>
         <target>Meaning of status</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/list/list_header.tpl:64</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="c33e404a441c6ba9648f88af3c68a1ca">
         <source>Statistics</source>
         <target>Statistics</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/list/list_header.tpl:77</note>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="f08d50397194b8e1679b11fd16f60ebc">
+        <source>New messages</source>
+        <target>New messages</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d8e87c0927539672f54462c837be0b7f">
+        <source>Sync</source>
+        <target>Sync</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="2b8fa6c46485d50e476591942fc9d7ee">
+        <source>Run sync:</source>
+        <target>Run sync:</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="a19330a6fc36ebae6683cc023e295687">
+        <source>Run sync</source>
+        <target>Run sync</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="22009610f18142abea939bc2f1836a81">
+        <source>Click to synchronize mail automatically</source>
+        <target>Click to synchronize mail automatically</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="548abe251b033d863417979998dba612">
+        <source>Forward this discussion</source>
+        <target>Forward this discussion</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="42ff79fde8fc930db50949b4f700c661">
+        <source>Forward this discussion to an employee:</source>
+        <target>Forward this discussion to an employee:</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="81e053d78f01540e9cd6fb68a1c03976">
+        <source>Someone else</source>
+        <target>Someone else</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="240f3031f25601fa128bd4e15f0a37de">
+        <source>Comment:</source>
+        <target>Comment:</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="67d2f6740a8eaebf4d5c6f79be8da481">
+        <source>Forward</source>
+        <target>Forward</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/timeline_item.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d1228f5476d15142b1358ae4b5fa2454">
+        <source>Order #</source>
+        <target>Order #</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="891ad007e2e9f2d55be6669cd9abc7a0">
+        <source>See more</source>
+        <target>See more</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d97477d6d8a838ead9348185bb5b6742">
+        <source>Thread</source>
+        <target>Thread</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="3f8faa0e229dbd775fa36b8c15bf73a6">
+        <source>Forward this discussion to another employee</source>
+        <target>Forward this discussion to another employee</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="33caa076f23f453dd4061726f3706325">
+        <source>To:</source>
+        <target>To:</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="72890e9df12803a4aab17a98d1ebfd9e">
+        <source>[1]%count%[/1] order(s) validated for a total amount of [2]%total%[/2]</source>
+        <target>[1]%count%[/1] order(s) validated for a total amount of [2]%total%[/2]</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="cdd894792c37687ccbf690fcd9673a89">
+        <source>No orders validated for the moment</source>
+        <target>No orders validated for the moment</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="76a6d3995bf5a66e8c92d84401d6435e">
+        <source>Your answer to</source>
+        <target>Your answer to</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="04427d6ba3fb03f0951b27ddd7c05af5">
+        <source>Orders and messages timeline</source>
+        <target>Orders and messages timeline</target>
+        <note>Line: 130</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/message.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9788af9fa097020a285afc0651a0721c">
+        <source>View customer</source>
+        <target>View customer</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="d13d8380c3f4de07fef91a42fe6c60d7">
+        <source>Customer ID:</source>
+        <target>Customer ID:</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="385b0ac7763680e5768f3e5e866910da">
+        <source>Sent on:</source>
+        <target>Sent on:</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="d62b749697e3c1b9c26a645ad5d56656">
+        <source>Browser:</source>
+        <target>Browser:</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="bfb069b69766c9a8a1fac8aabfd970b2">
+        <source>File attachment</source>
+        <target>File attachment</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="6fe76eb16b53e5008f51db59a7dae7b3">
+        <source>View file</source>
+        <target>View file</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="c851a34d4806acb02a55df148f9d7f25">
+        <source>Product #</source>
+        <target>Product #</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="c5730b7ad58a3bad76e6b6b763521ec7">
+        <source>View this thread</source>
+        <target>View this thread</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="018d4d01cba3905ad11258518b4ea424">
+        <source>Sent by:</source>
+        <target>Sent by:</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="818d947aeb9e604f54ce4c3444cc0256">
+        <source>Thread ID:</source>
+        <target>Thread ID:</target>
+        <note>Line: 153</note>
+      </trans-unit>
+      <trans-unit id="0e2f5e3f12561ac94047979ec5406946">
+        <source>Message ID:</source>
+        <target>Message ID:</target>
+        <note>Line: 157</note>
+      </trans-unit>
+      <trans-unit id="940663fd4428d2c86f9a4780b6574028">
+        <source>Message:</source>
+        <target>Message:</target>
+        <note>Line: 162</note>
+      </trans-unit>
+      <trans-unit id="b20d33a926b1e5b39db18b2911e1c1f9">
+        <source>Reply to this message</source>
+        <target>Reply to this message</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="e8b4e59e41f890acd1d5d86d494d6d02">
+        <source>Please type your reply below:</source>
+        <target>Please type your reply below:</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="91e2e681ab0c5817498a10318df5aec9">
+        <source>Your reply will be sent to:</source>
+        <target>Your reply will be sent to:</target>
+        <note>Line: 186</note>
+      </trans-unit>
+      <trans-unit id="3d49ea2e92edbb4219d39256794525d9">
+        <source>Send my reply</source>
+        <target>Send my reply</target>
+        <note>Line: 193</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customers/helpers/required_fields.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0470d45929f27e1161330164c423b415">
+        <source>Set required fields for this section</source>
+        <target>Set required fields for this section</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="e54b38290c8bdd95e8bc10412c9cc096">
+        <source>Required Fields</source>
+        <target>Required Fields</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="ee9b2f3cf31c23c944b15fb0b33d6a77">
+        <source>Field Name</source>
+        <target>Field Name</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="36358a9d4d77cc110761aec78f98c945">
+        <source>Partner offers</source>
+        <target>Partner offers</target>
+        <note>Line: 133</note>
+      </trans-unit>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e">
+        <source>Unknown</source>
+        <target>Unknown</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="9d8d2d5ab12b515182a505f54db7f538">
+        <source>Age</source>
+        <target>Age</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="56b80d8cc0afeaff5a2e624583b976ab">
+        <source>%1$d years old (birth date: %2$s)</source>
+        <target>%1$d years old (birth date: %2$s)</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="97ce2ccb5de5849fd94203a375054378">
+        <source>Registration Date</source>
+        <target>Registration Date</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="123cdf3e99e5daa563ac54af55a158be">
+        <source>Last Visit</source>
+        <target>Last Visit</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="eee7a325a979babb04b46b3114c005f6">
+        <source>Best Customer Rank</source>
+        <target>Best Customer Rank</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="a28735af01fbb1e35371cb120985ac47">
+        <source>Registrations</source>
+        <target>Registrations</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="a39ee61626da77cb9644fa972a8ac5b5">
+        <source>Latest Update</source>
+        <target>Latest Update</target>
+        <note>Line: 140</note>
+      </trans-unit>
+      <trans-unit id="1f8895b98efdf9e96766d39f24ec352c">
+        <source>This customer is registered as a Guest.</source>
+        <target>This customer is registered as a Guest.</target>
+        <note>Line: 165</note>
+      </trans-unit>
+      <trans-unit id="832c2f75a0029f82a281704661b07542">
+        <source>Transform to a customer account</source>
+        <target>Transform to a customer account</target>
+        <note>Line: 170</note>
+      </trans-unit>
+      <trans-unit id="33c1f4de9458d31b6df40fb7fb52a180">
+        <source>for a total amount of %s</source>
+        <target>for a total amount of %s</target>
+        <note>Line: 194</note>
+      </trans-unit>
+      <trans-unit id="a9c74a800ed9f3d504e76d8c59acc497">
+        <source>Invalid orders:</source>
+        <target>Invalid orders:</target>
+        <note>Line: 198</note>
+      </trans-unit>
+      <trans-unit id="25326db0dcb2cf342b3477fbdad373dc">
+        <source>Total spent</source>
+        <target>Total spent</target>
+        <note>Line: 246</note>
+      </trans-unit>
+      <trans-unit id="665305fedb3adcae303f3b974bc9ce08">
+        <source>%firstname% %lastname% has not placed any orders yet</source>
+        <target>%firstname% %lastname% has not placed any orders yet</target>
+        <note>Line: 265</note>
+      </trans-unit>
+      <trans-unit id="698e0d3e044a7ebe56308e190b82b326">
+        <source>Purchased products</source>
+        <target>Purchased products</target>
+        <note>Line: 308</note>
+      </trans-unit>
+      <trans-unit id="43560641f91e63dc83682bc598892fa1">
+        <source>Viewed products</source>
+        <target>Viewed products</target>
+        <note>Line: 337</note>
+      </trans-unit>
+      <trans-unit id="a7136d956fbff49c3912e44722dbf000">
+        <source>Add a private note</source>
+        <target>Add a private note</target>
+        <note>Line: 362</note>
+      </trans-unit>
+      <trans-unit id="abce3ef910cfc047f0721654cb71f2db">
+        <source>Sent on</source>
+        <target>Sent on</target>
+        <note>Line: 391</note>
+      </trans-unit>
+      <trans-unit id="e1835dc45bbdc7f7d3ca94f4ab002f84">
+        <source>%firstname% %lastname% has never contacted you</source>
+        <target>%firstname% %lastname% has never contacted you</target>
+        <note>Line: 407</note>
+      </trans-unit>
+      <trans-unit id="907d7000b3555d1a1b12f1fed29a9ec4">
+        <source>Qty available</source>
+        <target>Qty available</target>
+        <note>Line: 423</note>
+      </trans-unit>
+      <trans-unit id="c8b4c13e6ad3227e192c118261c0e179">
+        <source>%firstname% %lastname% has no discount vouchers</source>
+        <target>%firstname% %lastname% has no discount vouchers</target>
+        <note>Line: 455</note>
+      </trans-unit>
+      <trans-unit id="b70a3b711156c78fa558c596980b2e30">
+        <source>Last emails</source>
+        <target>Last emails</target>
+        <note>Line: 463</note>
+      </trans-unit>
+      <trans-unit id="93bd48ecb9c4d5c4eec7fefffbb2070f">
+        <source>Last connections</source>
+        <target>Last connections</target>
+        <note>Line: 491</note>
+      </trans-unit>
+      <trans-unit id="d3139f39f1ad6324c80a9ddd50cc7867">
+        <source>Pages viewed</source>
+        <target>Pages viewed</target>
+        <note>Line: 498</note>
+      </trans-unit>
+      <trans-unit id="c22d30084d8ddc9a571512ddee6a83e9">
+        <source>Total time</source>
+        <target>Total time</target>
+        <note>Line: 499</note>
+      </trans-unit>
+      <trans-unit id="3edf8ca26a1ec14dd6e91dd277ae1de6">
+        <source>Origin</source>
+        <target>Origin</target>
+        <note>Line: 500</note>
+      </trans-unit>
+      <trans-unit id="5b8c99dad1893a85076709b2d3c2d2d0">
+        <source>IP Address</source>
+        <target>IP Address</target>
+        <note>Line: 501</note>
+      </trans-unit>
+      <trans-unit id="ff398a1c3434e160c655aa1613e0eace">
+        <source>Referrers</source>
+        <target>Referrers</target>
+        <note>Line: 563</note>
+      </trans-unit>
+      <trans-unit id="e174c1b711f254d538c689a90c5842a5">
+        <source>Phone number(s)</source>
+        <target>Phone number(s)</target>
+        <note>Line: 610</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_customized_data.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c2808546f3e14d267d798f4e0e6f102e">
+        <source>Customized</source>
+        <target>Customized</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="b9e6daaef804c01f3847f1da8b053dd1">
+        <source>Picture #</source>
+        <target>Picture #</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="4523758f4415c5b7afe9c6bd6b4917b3">
+        <source>Text #%s</source>
+        <target>Text #%s</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="3d0d1f906e27800531e054a3b6787b7c">
+        <source>Quantity:</source>
+        <target>Quantity:</target>
+        <note>Line: 207</note>
+      </trans-unit>
+      <trans-unit id="6702a6e3bc2dce95c3e3b61fe578f29c">
+        <source>Amount:</source>
+        <target>Amount:</target>
+        <note>Line: 216</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_discount_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="41953cbf836297b3c96b137a2b789ccb">
+        <source>Apply on all invoices</source>
+        <target>Apply on all invoices</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_documents.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0945359809dad1fbf3dea1c95a0da951">
+        <source>Document</source>
+        <target>Document</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="b2ee912b91d69b435159c7c3f6df7f5f">
+        <source>Number</source>
+        <target>Number</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="ee7197503a8a3820850df76fb406c224">
+        <source>Delivery slip</source>
+        <target>Delivery slip</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="f53e8d0e97c47ce70ca9c5eaa08a00d0">
+        <source>Credit Slip</source>
+        <target>Credit Slip</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="c12a553ab6ad810580afa3f07aa9f51f">
+        <source>not paid</source>
+        <target>not paid</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="8d4ac0e8c6f5900930ddfccd45d10abf">
+        <source>overpaid</source>
+        <target>overpaid</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="7fb46048bafd1294fab5c1675ef4f849">
+        <source>Enter payment</source>
+        <target>Enter payment</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="50cd1871f950375eef4e2efce35366c6">
+        <source>Add note</source>
+        <target>Add note</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="71e2851d86b252a44c658b896c486921">
+        <source>Edit note</source>
+        <target>Edit note</target>
+        <note>Line: 127</note>
+      </trans-unit>
+      <trans-unit id="80cb34a90bc2178e9219ccc4ab106867">
+        <source>Generate invoice</source>
+        <target>Generate invoice</target>
+        <note>Line: 170</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="200e62e510bab9b03c912e10a5363a7a">
+        <source>Create a new invoice</source>
+        <target>Create a new invoice</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="4800d00deaa0a28a18151d76feb858cb">
+        <source>New invoice information</source>
+        <target>New invoice information</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="f54bdce4ab4d26c259216da67b9d6431">
+        <source>Shipping Costs</source>
+        <target>Shipping Costs</target>
+        <note>Line: 114</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="03ab340b3f99e03cff9e84314ead38c0">
+        <source>Qty</source>
+        <target>Qty</target>
+        <note>Line: 250</note>
+      </trans-unit>
+      <trans-unit id="f8a09f634b7b3ede2da34607da2aaebe">
+        <source>Available quantity</source>
+        <target>Available quantity</target>
+        <note>Line: 251</note>
+      </trans-unit>
+      <trans-unit id="5e1ce9eb796081fea13e0d0dd3c3d76f">
+        <source>Reference number:</source>
+        <target>Reference number:</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="a9971a36ea6236b1577b27dba46775ed">
+        <source>Supplier reference:</source>
+        <target>Supplier reference:</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="967ad092fca7b99aa4f170ed73a6a8e1">
+        <source>%quantity_refunded% (%amount_refunded% refund)</source>
+        <target>%quantity_refunded% (%amount_refunded% refund)</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="4fdfd561c540aa5e20a9b2b9c06054bb">
+        <source>Package content</source>
+        <target>Package content</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="ce5bf551379459c1c61d2a204061c455">
+        <source>Location</source>
+        <target>Location</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="782678f4ba02feb3e9ecd51e902cd16b">
+        <source>Refund history</source>
+        <target>Refund history</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="be73df859979ad499dd484eeb187be60">
+        <source>Return history</source>
+        <target>Return history</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="ca70428d9ed105c07f40d3c21d130859">
+        <source>Package item</source>
+        <target>Package item</target>
+        <note>Line: 258</note>
+      </trans-unit>
+      <trans-unit id="dd70925db57b570bcb660d68c30d5e0b">
+        <source>Ref Supplier:</source>
+        <target>Ref Supplier:</target>
+        <note>Line: 264</note>
+      </trans-unit>
+      <trans-unit id="e78b6f4eb3be046f4d25c07ce54954d4">
+        <source>Ref:</source>
+        <target>Ref:</target>
+        <note>Line: 263</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="74b9e5d9e68f0fcc9326fab959a8ed4b">
+        <source>Edit shipping details</source>
+        <target>Edit shipping details</target>
+        <note>Line: 95</note>
       </trans-unit>
     </body>
   </file>
   <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="267806034cfac4481cabe7b81c81f91d">
+        <source>Back office order</source>
+        <target>Back office order</target>
+        <note>Line: 1554</note>
+      </trans-unit>
+      <trans-unit id="a82868319826fb092b73968e661b5b38">
+        <source>Vouchers</source>
+        <target>Vouchers</target>
+        <note>Line: 1315</note>
+      </trans-unit>
       <trans-unit id="257630448a4acd9cfc1ce6c7a5ce05f3">
         <source>Add new customer</source>
         <target>Add new customer</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1125</note>
+        <note>Line: 1125</note>
       </trans-unit>
       <trans-unit id="7bb36e0f484d91aeba5d83fe2af63d28">
         <source>Search for a product</source>
         <target>Search for a product</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1199</note>
+        <note>Line: 1199</note>
       </trans-unit>
       <trans-unit id="c112bd7d596888979be02bd780e6a94f">
         <source>View this order</source>
         <target>View this order</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:571</note>
+        <note>Line: 571</note>
       </trans-unit>
       <trans-unit id="1a747e98fba823d6be62189cbac46dcb">
         <source>Recycled packaging</source>
         <target>Recycled packaging</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1450</note>
+        <note>Line: 1450</note>
       </trans-unit>
       <trans-unit id="449fae749af1f675c63510eecb0b88c4">
         <source>View this cart</source>
         <target>View this cart</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:561</note>
+        <note>Line: 561</note>
       </trans-unit>
       <trans-unit id="0aed4e816d2ab18361bbfe990b4fdcde">
         <source>Use this cart</source>
         <target>Use this cart</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:562</note>
+        <note>Line: 562</note>
       </trans-unit>
       <trans-unit id="ad8783089f828b927473fb61d51940ec">
         <source>Use</source>
         <target>Use</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:572</note>
+        <note>Line: 572</note>
       </trans-unit>
       <trans-unit id="90bf4568676d012fc21b3556fbd0303b">
         <source>Duplicate this order</source>
         <target>Duplicate this order</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:572</note>
+        <note>Line: 572</note>
       </trans-unit>
       <trans-unit id="0d9175fe89fb80d815e7d03698b6e83a">
         <source>Gift</source>
         <target>Gift</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1461</note>
+        <note>Line: 1461</note>
       </trans-unit>
       <trans-unit id="eeddc7284795f5c71b12156c06e9e821">
         <source>Search for a customer</source>
         <target>Search for a customer</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1108</note>
+        <note>Line: 1108</note>
       </trans-unit>
       <trans-unit id="ea067eb37801c5aab1a1c685eb97d601">
         <source>Total paid</source>
         <target>Total paid</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1175</note>
+        <note>Line: 1175</note>
       </trans-unit>
       <trans-unit id="a85eba4c6c699122b2bb1387ea4813ad">
         <source>Cart</source>
         <target>Cart</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1194</note>
+        <note>Line: 1194</note>
       </trans-unit>
       <trans-unit id="fcebe56087b9373f15514831184fa572">
         <source>In stock</source>
         <target>In stock</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1239</note>
+        <note>Line: 1239</note>
       </trans-unit>
       <trans-unit id="2d0f6b8300be19cf35e89e66f0677f95">
         <source>Add to cart</source>
         <target>Add to cart</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1247</note>
+        <note>Line: 1247</note>
       </trans-unit>
       <trans-unit id="c89db248919294ef0291a6586f6e9a5b">
         <source>Search for a voucher</source>
         <target>Search for a voucher</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1319</note>
+        <note>Line: 1319</note>
       </trans-unit>
       <trans-unit id="11599f38f7ac080ae579f1bf32f08561">
         <source>Add new voucher</source>
         <target>Add new voucher</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1335</note>
+        <note>Line: 1335</note>
       </trans-unit>
       <trans-unit id="b15e1100a6196acba01ef7aaa5b2a9e5">
         <source>Add a new address</source>
         <target>Add a new address</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1397</note>
+        <note>Line: 1397</note>
       </trans-unit>
       <trans-unit id="19dfe063714422004b75043eaf74c9b8">
         <source>Delivery option</source>
         <target>Delivery option</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1411</note>
+        <note>Line: 1411</note>
       </trans-unit>
       <trans-unit id="4c15f9bb0c76e90180c701b2d39994d8">
         <source>Shipping price (Tax incl.)</source>
         <target>Shipping price (Tax incl.)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1420</note>
+        <note>Line: 1420</note>
       </trans-unit>
       <trans-unit id="0fe067d5d05655a4c80602c1d6e7d0c5">
         <source>Gift message</source>
         <target>Gift message</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1466</note>
+        <note>Line: 1466</note>
       </trans-unit>
       <trans-unit id="db205f01b4fd580fb5daa9072d96849d">
         <source>Total products</source>
         <target>Total products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1486</note>
+        <note>Line: 1486</note>
       </trans-unit>
       <trans-unit id="58a13b9a4e13f53cf70a60bf583321e1">
         <source>Total vouchers (Tax excl.)</source>
         <target>Total vouchers (Tax excl.)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1492</note>
+        <note>Line: 1492</note>
       </trans-unit>
       <trans-unit id="96a2d6388d5c73e22a1edbe506f86b17">
         <source>Total shipping (Tax excl.)</source>
         <target>Total shipping (Tax excl.)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1498</note>
+        <note>Line: 1498</note>
       </trans-unit>
       <trans-unit id="7bf753e0cbb2d38818ba2a3ee3b36f4d">
         <source>Total taxes</source>
         <target>Total taxes</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1504</note>
+        <note>Line: 1504</note>
       </trans-unit>
       <trans-unit id="b94cb106eaa958b2ab473da305e57977">
         <source>Total (Tax excl.)</source>
         <target>Total (Tax excl.)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1510</note>
+        <note>Line: 1510</note>
       </trans-unit>
       <trans-unit id="eed1808b8206c5a62cc6407f85cf95bc">
         <source>Total (Tax incl.)</source>
         <target>Total (Tax incl.)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1516</note>
+        <note>Line: 1516</note>
       </trans-unit>
       <trans-unit id="f13673c7e261fd8d00915c9cb768ad95">
         <source>Order message</source>
         <target>Order message</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1526</note>
+        <note>Line: 1526</note>
       </trans-unit>
       <trans-unit id="034d2690db87b737dd810afccbe41b7a">
         <source>Create the order</source>
         <target>Create the order</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1573</note>
+        <note>Line: 1573</note>
       </trans-unit>
     </body>
   </file>
-  <file original="controllers/admin/AdminReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="9442975514755961788cc54bf8b43ddf">
-        <source>Merchandise return (RMA) options</source>
-        <target>Merchandise return (RMA) options</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:55</note>
+      <trans-unit id="448e9885f58aad30823ddde9996114d6">
+        <source>Choose an order status</source>
+        <target>Choose an order status</target>
+        <note>Line: 32</note>
       </trans-unit>
-      <trans-unit id="f374280fc7cab62785714cfca79b85a1">
-        <source>Enable returns</source>
-        <target>Enable returns</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:58</note>
-      </trans-unit>
-      <trans-unit id="587398fde24739a1b7ecdb632e6855dd">
-        <source>Time limit of validity</source>
-        <target>Time limit of validity</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:62</note>
-      </trans-unit>
-      <trans-unit id="942fb8edc78a4c5be5b86cc4ad009538">
-        <source>Returns prefix</source>
-        <target>Returns prefix</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:68</note>
-      </trans-unit>
-      <trans-unit id="bfc23574a242be4531bcb29877ac1d8a">
-        <source>Return Merchandise Authorization (RMA)</source>
-        <target>Return Merchandise Authorization (RMA)</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:86</note>
-      </trans-unit>
-      <trans-unit id="f504da64aae2dcfd85ce565121248f93">
-        <source>Customer explanation</source>
-        <target>Customer explanation</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:114</note>
-      </trans-unit>
-      <trans-unit id="6d72e074fdface4ae892543d39434175">
-        <source>Returns form</source>
-        <target>Returns form</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:141</note>
-      </trans-unit>
-      <trans-unit id="4f3bf7771a1ecc368092d952d698c12c">
-        <source>Order #%id% from %date%</source>
-        <target>Order #%id% from %date%</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:172</note>
+      <trans-unit id="10ea517069300c23c17f113a3d084c57">
+        <source>Update Order Status</source>
+        <target>Update Order Status</target>
+        <note>Line: 61</note>
       </trans-unit>
     </body>
   </file>
-  <file original="controllers/admin/AdminOutstandingController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="59ca88f7b0e80cdd9af330af600a9ff6">
-        <source>Risk</source>
-        <target>Risk</target>
-        <note>Context:
-File: controllers/admin/AdminOutstandingController.php:81</note>
+      <trans-unit id="6a5efd211a422296eab4adc476c98f0e">
+        <source>Return products</source>
+        <target>Return products</target>
+        <note>Line: 162</note>
       </trans-unit>
-      <trans-unit id="b0135b3cb49d9fba98fc6199d4429622">
-        <source>Outstanding Allowance</source>
-        <target>Outstanding Allowance</target>
-        <note>Context:
-File: controllers/admin/AdminOutstandingController.php:91</note>
+      <trans-unit id="4ad439b4f7069964e258259e049fa90c">
+        <source>Standard refund</source>
+        <target>Standard refund</target>
+        <note>Line: 164</note>
       </trans-unit>
-      <trans-unit id="b9894a8360f66fa7c87aebe79d2f5021">
-        <source>Current Outstanding</source>
-        <target>Current Outstanding</target>
-        <note>Context:
-File: controllers/admin/AdminOutstandingController.php:98</note>
+      <trans-unit id="4b8def9be8f45a8d6baea36b26868965">
+        <source>Cancel products</source>
+        <target>Cancel products</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="4b6c6cda10a23d1bdc920f2e47e5f46f">
+        <source>Add a product</source>
+        <target>Add a product</target>
+        <note>Line: 980</note>
+      </trans-unit>
+      <trans-unit id="77fd2b4393b379bedd30efcd5df02090">
+        <source>Partial refund</source>
+        <target>Partial refund</target>
+        <note>Line: 1242</note>
+      </trans-unit>
+      <trans-unit id="4f68183551e5dbd7c341347ffe308682">
+        <source>SIRET</source>
+        <target>SIRET</target>
+        <note>Line: 617</note>
+      </trans-unit>
+      <trans-unit id="85fb93a8ee9440499692da24a1621769">
+        <source>APE</source>
+        <target>APE</target>
+        <note>Line: 619</note>
+      </trans-unit>
+      <trans-unit id="cb8fe83175bea4ba19d633b1dc6ea656">
+        <source>View order</source>
+        <target>View order</target>
+        <note>Line: 1310</note>
+      </trans-unit>
+      <trans-unit id="01abfc750a0c942167651c40d088531d">
+        <source>#</source>
+        <target>#</target>
+        <note>Line: 588</note>
+      </trans-unit>
+      <trans-unit id="be4254ec37a7bf0d2babdf04bce774cf">
+        <source>Print order</source>
+        <target>Print order</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="a6ecff447ea8327b43f5d16a924fb6be">
+        <source>View invoice</source>
+        <target>View invoice</target>
+        <note>Line: 137</note>
+      </trans-unit>
+      <trans-unit id="f8246f1c2cfd9a81a376223428bd09d7">
+        <source>No invoice</source>
+        <target>No invoice</target>
+        <note>Line: 142</note>
+      </trans-unit>
+      <trans-unit id="ddd167afc1441dcab03a9546c8ef8b51">
+        <source>View delivery slip</source>
+        <target>View delivery slip</target>
+        <note>Line: 149</note>
+      </trans-unit>
+      <trans-unit id="a6181ae0a3e0370de94efa64782a6e79">
+        <source>No delivery slip</source>
+        <target>No delivery slip</target>
+        <note>Line: 154</note>
+      </trans-unit>
+      <trans-unit id="f28128b38efbc6134dc40751ee21fd29">
+        <source>Documents</source>
+        <target>Documents</target>
+        <note>Line: 262</note>
+      </trans-unit>
+      <trans-unit id="d71940f24ee38ee09f6e06b908480bcf">
+        <source>Resend email</source>
+        <target>Resend email</target>
+        <note>Line: 231</note>
+      </trans-unit>
+      <trans-unit id="f5359d1dd07def542aa9b0577fb27068">
+        <source>Update status</source>
+        <target>Update status</target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="979640f579db842e61902ca061153965">
+        <source>Merchandise Returns</source>
+        <target>Merchandise Returns</target>
+        <note>Line: 328</note>
+      </trans-unit>
+      <trans-unit id="484f5a79672cebe198ebdde45a1d672f">
+        <source>Gift wrapping</source>
+        <target>Gift wrapping</target>
+        <note>Line: 321</note>
+      </trans-unit>
+      <trans-unit id="f0aaaae189e9c7711931a65ffcd22543">
+        <source>Payment method</source>
+        <target>Payment method</target>
+        <note>Line: 429</note>
+      </trans-unit>
+      <trans-unit id="88427ec035734b45aae9f7d8859a5008">
+        <source>Transaction ID</source>
+        <target>Transaction ID</target>
+        <note>Line: 430</note>
+      </trans-unit>
+      <trans-unit id="931d3a3ad177dd96a28c9642fec11b01">
+        <source>Card Number</source>
+        <target>Card Number</target>
+        <note>Line: 459</note>
+      </trans-unit>
+      <trans-unit id="f8b1369a8e9d90da0cae0b11049309af">
+        <source>Not defined</source>
+        <target>Not defined</target>
+        <note>Line: 487</note>
+      </trans-unit>
+      <trans-unit id="2ef876508663171dedb532b4ecdb19a1">
+        <source>Card Brand</source>
+        <target>Card Brand</target>
+        <note>Line: 467</note>
+      </trans-unit>
+      <trans-unit id="52aeead61e400c8faeb3c1dcb355e7a5">
+        <source>Card Expiration</source>
+        <target>Card Expiration</target>
+        <note>Line: 475</note>
+      </trans-unit>
+      <trans-unit id="c20497ad97022701fa9b5d3c34c0c474">
+        <source>Card Holder</source>
+        <target>Card Holder</target>
+        <note>Line: 483</note>
+      </trans-unit>
+      <trans-unit id="d694c11f096d5d666dde9ab8f9d9ba29">
+        <source>Change currency</source>
+        <target>Change currency</target>
+        <note>Line: 552</note>
+      </trans-unit>
+      <trans-unit id="f4ec5f57bd4d31b803312d873be40da9">
+        <source>Change</source>
+        <target>Change</target>
+        <note>Line: 752</note>
+      </trans-unit>
+      <trans-unit id="6fe50cb3c0bf60f28ac9049ae6cb8c26">
+        <source>This order has been placed by a guest.</source>
+        <target>This order has been placed by a guest.</target>
+        <note>Line: 594</note>
+      </trans-unit>
+      <trans-unit id="6a7bac4a86e299a2718b9d2c7c8aaea9">
+        <source>Account registered</source>
+        <target>Account registered</target>
+        <note>Line: 610</note>
+      </trans-unit>
+      <trans-unit id="d53b54a2bdbf970c70b7de7de4f6021f">
+        <source>Valid orders placed</source>
+        <target>Valid orders placed</target>
+        <note>Line: 612</note>
+      </trans-unit>
+      <trans-unit id="8a8ece2eaecf6b5771d66434212e060d">
+        <source>Total spent since registration</source>
+        <target>Total spent since registration</target>
+        <note>Line: 614</note>
+      </trans-unit>
+      <trans-unit id="5d9fe8726be08b6e26a0c05319590b01">
+        <source>View full details...</source>
+        <target>View full details...</target>
+        <note>Line: 628</note>
+      </trans-unit>
+      <trans-unit id="66dc0eb61ab4157d6170494e6841a77a">
+        <source>Private note</source>
+        <target>Private note</target>
+        <note>Line: 633</note>
+      </trans-unit>
+      <trans-unit id="0c458988127eb2150776881e2ef3f0c4">
+        <source>Shipping address</source>
+        <target>Shipping address</target>
+        <note>Line: 676</note>
+      </trans-unit>
+      <trans-unit id="601d8c4b9f72fc1862013c19b677a499">
+        <source>Invoice address</source>
+        <target>Invoice address</target>
+        <note>Line: 728</note>
+      </trans-unit>
+      <trans-unit id="47f9082fc380ca62d531096aa1d110f1">
+        <source>Private</source>
+        <target>Private</target>
+        <note>Line: 807</note>
+      </trans-unit>
+      <trans-unit id="2ab74fb771ac34b95b1657895282d5d9">
+        <source>Choose a standard message</source>
+        <target>Choose a standard message</target>
+        <note>Line: 827</note>
+      </trans-unit>
+      <trans-unit id="a76e7775f5454953c7152f5160e75182">
+        <source>Configure predefined messages</source>
+        <target>Configure predefined messages</target>
+        <note>Line: 837</note>
+      </trans-unit>
+      <trans-unit id="b7623e931f082f027293f27dbfe7a8ea">
+        <source>Display to customer?</source>
+        <target>Display to customer?</target>
+        <note>Line: 845</note>
+      </trans-unit>
+      <trans-unit id="747c6a3564774149c989884e0c581d53">
+        <source>Send message</source>
+        <target>Send message</target>
+        <note>Line: 873</note>
+      </trans-unit>
+      <trans-unit id="a2eda4e1c4dfc9bade7150b878c57a46">
+        <source>Show all messages</source>
+        <target>Show all messages</target>
+        <note>Line: 876</note>
+      </trans-unit>
+      <trans-unit id="fdfac28b5ad628f25649d9c2eb4fc62e">
+        <source>Returned</source>
+        <target>Returned</target>
+        <note>Line: 933</note>
+      </trans-unit>
+      <trans-unit id="cdba184783a0253218efd734da81a9da">
+        <source>Stock location</source>
+        <target>Stock location</target>
+        <note>Line: 935</note>
+      </trans-unit>
+      <trans-unit id="988fd738de9c6d177440c5dcf69e73ce">
+        <source>Return</source>
+        <target>Return</target>
+        <note>Line: 946</note>
+      </trans-unit>
+      <trans-unit id="76f0ed934de85cc7131910b32ede7714">
+        <source>Refund</source>
+        <target>Refund</target>
+        <note>Line: 948</note>
+      </trans-unit>
+      <trans-unit id="4320b10eab24c2b8ee337355e7deb4c6">
+        <source>Add a new discount</source>
+        <target>Add a new discount</target>
+        <note>Line: 985</note>
+      </trans-unit>
+      <trans-unit id="f14b582c1b0eab88ed5904fb781568c0">
+        <source>Discount name</source>
+        <target>Discount name</target>
+        <note>Line: 1017</note>
+      </trans-unit>
+      <trans-unit id="689202409e48743b914713f96d93947c">
+        <source>Value</source>
+        <target>Value</target>
+        <note>Line: 1022</note>
+      </trans-unit>
+      <trans-unit id="c990c4027126c39a93fcaaafb68732b3">
+        <source>Delete voucher</source>
+        <target>Delete voucher</target>
+        <note>Line: 1044</note>
+      </trans-unit>
+      <trans-unit id="b52b44c9d23e141b067d7e83b44bb556">
+        <source>Products:</source>
+        <target>Products:</target>
+        <note>Line: 1076</note>
+      </trans-unit>
+      <trans-unit id="9d5bf15117441a1b52eb1f0808e4aad3">
+        <source>Discounts</source>
+        <target>Discounts</target>
+        <note>Line: 1083</note>
+      </trans-unit>
+      <trans-unit id="ba794350deb07c0c96fe73bd12239059">
+        <source>Wrapping</source>
+        <target>Wrapping</target>
+        <note>Line: 1090</note>
+      </trans-unit>
+      <trans-unit id="7fc63f077cf04742cf02e7c589b428e9">
+        <source>(Max %s %s)</source>
+        <target>(Max %s %s)</target>
+        <note>Line: 1108</note>
+      </trans-unit>
+      <trans-unit id="1067f7778added234b6064bc8aa0765d">
+        <source>Re-stock products</source>
+        <target>Re-stock products</target>
+        <note>Line: 1204</note>
+      </trans-unit>
+      <trans-unit id="e413f403aa8d5253b487d09fc84e47a0">
+        <source>Generate a credit slip</source>
+        <target>Generate a credit slip</target>
+        <note>Line: 1150</note>
+      </trans-unit>
+      <trans-unit id="400264c3cd8f2e65b9f19375230b59b8">
+        <source>Generate a voucher</source>
+        <target>Generate a voucher</target>
+        <note>Line: 1210</note>
+      </trans-unit>
+      <trans-unit id="711cb64729ed5b666cf97c01691f5806">
+        <source>Repay shipping costs</source>
+        <target>Repay shipping costs</target>
+        <note>Line: 1162</note>
+      </trans-unit>
+      <trans-unit id="d68a1671669f7e55d73dd78c22d52dfa">
+        <source>This order has been partially paid by voucher. Choose the amount you want to refund:</source>
+        <target>This order has been partially paid by voucher. Choose the amount you want to refund:</target>
+        <note>Line: 1166</note>
+      </trans-unit>
+      <trans-unit id="6188ffe19286d3bf694160609cf15e82">
+        <source>Include amount of initial voucher: </source>
+        <target>Include amount of initial voucher: </target>
+        <note>Line: 1170</note>
+      </trans-unit>
+      <trans-unit id="b9313ee2094019f4ee5212f784f45d65">
+        <source>Exclude amount of initial voucher: </source>
+        <target>Exclude amount of initial voucher: </target>
+        <note>Line: 1176</note>
+      </trans-unit>
+      <trans-unit id="7731388b0fae4c0d7214f6a1f6f1771f">
+        <source>Amount of your choice: </source>
+        <target>Amount of your choice: </target>
+        <note>Line: 1229</note>
+      </trans-unit>
+      <trans-unit id="67dd576afa3b807903e847f6ebb11f22">
+        <source>This order has been partially paid by voucher. Choose the amount you want to refund: </source>
+        <target>This order has been partially paid by voucher. Choose the amount you want to refund: </target>
+        <note>Line: 1214</note>
+      </trans-unit>
+      <trans-unit id="8e0398b929d533c18fff7f5e21e8fcbd">
+        <source>Product(s) price: </source>
+        <target>Product(s) price: </target>
+        <note>Line: 1218</note>
+      </trans-unit>
+      <trans-unit id="34623cd7893be21da4239d08f79aec9a">
+        <source>Product(s) price, excluding amount of initial voucher: </source>
+        <target>Product(s) price, excluding amount of initial voucher: </target>
+        <note>Line: 1224</note>
+      </trans-unit>
+      <trans-unit id="fb61758d0f0fda4ba867c3d5a46c16a7">
+        <source>Sources</source>
+        <target>Sources</target>
+        <note>Line: 1257</note>
+      </trans-unit>
+      <trans-unit id="5da618e8e4b89c66fe86e32cdafde142">
+        <source>From</source>
+        <target>From</target>
+        <note>Line: 1263</note>
+      </trans-unit>
+      <trans-unit id="e12167aa0a7698e6ebc92b4ce3909b53">
+        <source>To</source>
+        <target>To</target>
+        <note>Line: 1264</note>
+      </trans-unit>
+      <trans-unit id="010cd82f1f972dc6b720536adb555533">
+        <source>Linked orders</source>
+        <target>Linked orders</target>
+        <note>Line: 1277</note>
+      </trans-unit>
+      <trans-unit id="0da6a00e3eb2132d5cf97463a099c49f">
+        <source>Order no. </source>
+        <target>Order no. </target>
+        <note>Line: 1284</note>
       </trans-unit>
     </body>
   </file>
-  <file original="controllers/admin/AdminOrderMessageController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="38d6bc03067212bb0c2633f8a57d5881">
-        <source>Order messages</source>
-        <target>Order messages</target>
-        <note>Context:
-File: controllers/admin/AdminOrderMessageController.php:74</note>
-      </trans-unit>
-      <trans-unit id="80c05dda6b88c30a777e8777e23be8d7">
-        <source>Add new order message</source>
-        <target>Add new order message</target>
-        <note>Context:
-File: controllers/admin/AdminOrderMessageController.php:105</note>
+      <trans-unit id="a8658715e6b0e879cbcbc4728a423b36">
+        <source>Text #%d</source>
+        <target>Text #%d</target>
+        <note>Line: 92</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/slip/_print_pdf_icon.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="91ee5169ce4265b5ace262d703edbb5c">
-        <source>Generate PDF</source>
-        <target>Generate PDF</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig:59</note>
-      </trans-unit>
-      <trans-unit id="afa0e443a161e904a03bbbc333506256">
-        <source>Print PDF</source>
-        <target>Print PDF</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig:36</note>
-      </trans-unit>
-      <trans-unit id="947c66d55a8038fd0c16fef605186573">
-        <source>Delivery slip options</source>
-        <target>Delivery slip options</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig:74</note>
-      </trans-unit>
-      <trans-unit id="197a830d84923ffbb79a06975380b976">
-        <source>Delivery prefix</source>
-        <target>Delivery prefix</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig:79</note>
-      </trans-unit>
-      <trans-unit id="3f921d7b2738f966c8d4d78d62f414b6">
-        <source>Delivery Number</source>
-        <target>Delivery Number</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig:86</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ffb7e666a70151215b4c55c6268d7d72">
-        <source>Newsletter</source>
-        <target>Newsletter</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1235</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fdd748833c0e80edbfe6d955a1e2bef5">
-        <source>After the sequential number</source>
-        <target>After the sequential number</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php:92</note>
-      </trans-unit>
-      <trans-unit id="2d34b4de2b2170f55f41facfbdb3684a">
-        <source>Before the sequential number</source>
-        <target>Before the sequential number</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php:93</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/RiskLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6adf97f83acf6453d4a6a4b1070f3754">
-        <source>None</source>
-        <target>None</target>
-        <note>Context:
-File: classes/lang/KeysReference/RiskLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="28d0edd045e05cf5af64e35ae0c4c6ef">
-        <source>Low</source>
-        <target>Low</target>
-        <note>Context:
-File: classes/lang/KeysReference/RiskLang.php:27</note>
-      </trans-unit>
-      <trans-unit id="87f8a6ab85c9ced3702b4ea641ad4bb5">
-        <source>Medium</source>
-        <target>Medium</target>
-        <note>Context:
-File: classes/lang/KeysReference/RiskLang.php:28</note>
-      </trans-unit>
-      <trans-unit id="655d20c1ca69519ca647684edbb2db35">
-        <source>High</source>
-        <target>High</target>
-        <note>Context:
-File: classes/lang/KeysReference/RiskLang.php:29</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/SupplyOrderStateLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="78e25fccba5eb87a2fe929e6cfa27b26">
-        <source>1 - Creation in progress</source>
-        <target>1 - Creation in progress</target>
-        <note>Context:
-File: classes/lang/KeysReference/SupplyOrderStateLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="aa92ea2c14150feacd8a38cabaf59c4b">
-        <source>2 - Order validated</source>
-        <target>2 - Order validated</target>
-        <note>Context:
-File: classes/lang/KeysReference/SupplyOrderStateLang.php:28</note>
-      </trans-unit>
-      <trans-unit id="efca1ad6911feea6ec4f5172f28ff135">
-        <source>3 - Pending receipt</source>
-        <target>3 - Pending receipt</target>
-        <note>Context:
-File: classes/lang/KeysReference/SupplyOrderStateLang.php:30</note>
-      </trans-unit>
-      <trans-unit id="0e547a2250b0531cf58a26995ba31801">
-        <source>4 - Order received in part</source>
-        <target>4 - Order received in part</target>
-        <note>Context:
-File: classes/lang/KeysReference/SupplyOrderStateLang.php:32</note>
-      </trans-unit>
-      <trans-unit id="589760755f6f33549fb31e5ab03f2676">
-        <source>5 - Order received completely</source>
-        <target>5 - Order received completely</target>
-        <note>Context:
-File: classes/lang/KeysReference/SupplyOrderStateLang.php:34</note>
-      </trans-unit>
-      <trans-unit id="817bedb8bd68b944c3fa6e231b53147d">
-        <source>6 - Order canceled</source>
-        <target>6 - Order canceled</target>
-        <note>Context:
-File: classes/lang/KeysReference/SupplyOrderStateLang.php:36</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/OrderReturnStateLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="015c603172846437ee7a569dc2c36273">
-        <source>Waiting for confirmation</source>
-        <target>Waiting for confirmation</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderReturnStateLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="7d42f56ce1d82d68f6545242ef4384a4">
-        <source>Waiting for package</source>
-        <target>Waiting for package</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderReturnStateLang.php:27</note>
-      </trans-unit>
-      <trans-unit id="b383cc6d0e4ab5bfab94b4452a916ee5">
-        <source>Package received</source>
-        <target>Package received</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderReturnStateLang.php:28</note>
-      </trans-unit>
-      <trans-unit id="03bd13f6762c099741f4934beb32b95d">
-        <source>Return denied</source>
-        <target>Return denied</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderReturnStateLang.php:29</note>
-      </trans-unit>
-      <trans-unit id="4bb0dcdb92397d6b646711d623504058">
-        <source>Return completed</source>
-        <target>Return completed</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderReturnStateLang.php:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/OrderStateLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d698e777b19f6f487ae0490950174fde">
-        <source>Awaiting check payment</source>
-        <target>Awaiting check payment</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="016e1f278eccd700eaf33f74a501d050">
-        <source>Payment accepted</source>
-        <target>Payment accepted</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:28</note>
-      </trans-unit>
-      <trans-unit id="294e143a57d178715a55e8575f8037e6">
-        <source>Processing in progress</source>
-        <target>Processing in progress</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:30</note>
-      </trans-unit>
-      <trans-unit id="747cf5c8587184b9e489ff897d97c20d">
-        <source>Shipped</source>
-        <target>Shipped</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:32</note>
-      </trans-unit>
-      <trans-unit id="67edd3b99247c9eb5884a02802a20fa7">
-        <source>Delivered</source>
-        <target>Delivered</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:34</note>
-      </trans-unit>
-      <trans-unit id="0e22fe7d45f8e5632a4abf369b24e29c">
-        <source>Canceled</source>
-        <target>Canceled</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:36</note>
-      </trans-unit>
-      <trans-unit id="cc61945cbbf46721a053467c395c666f">
-        <source>Refunded</source>
-        <target>Refunded</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:38</note>
-      </trans-unit>
-      <trans-unit id="1e97d97a923eaddd810e056c828e99ea">
-        <source>Payment error</source>
-        <target>Payment error</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:40</note>
-      </trans-unit>
-      <trans-unit id="48eac0bd985bc909fb58ccc1e1f669ed">
-        <source>On backorder (paid)</source>
-        <target>On backorder (paid)</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:42</note>
-      </trans-unit>
-      <trans-unit id="6d59fd4089482ca1a4017ca4852f8d1d">
-        <source>On backorder (not paid)</source>
-        <target>On backorder (not paid)</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:44</note>
-      </trans-unit>
-      <trans-unit id="688a337ab9864a53b41cd6ccd7f8880d">
-        <source>Awaiting bank wire payment</source>
-        <target>Awaiting bank wire payment</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:46</note>
-      </trans-unit>
-      <trans-unit id="9517f3495b0036d25cbc455c592ea868">
-        <source>Remote payment accepted</source>
-        <target>Remote payment accepted</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:48</note>
-      </trans-unit>
-      <trans-unit id="51ebf726bac579d61910a5425e3128c5">
-        <source>Awaiting Cash On Delivery validation</source>
-        <target>Awaiting Cash On Delivery validation</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderStateLang.php:50</note>
+      <trans-unit id="a4c0c09247c3e56ff08971ff5558c596">
+        <source>Download credit slip</source>
+        <target>Download credit slip</target>
+        <note>Line: 30</note>
       </trans-unit>
     </body>
   </file>
@@ -1541,8 +1234,7 @@ File: classes/lang/KeysReference/OrderStateLang.php:50</note>
       <trans-unit id="8f497c1a3d15af9e0c215019f26b887d">
         <source>Delay</source>
         <target>Delay</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderMessageLang.php:26</note>
+        <note>Line: 26</note>
       </trans-unit>
       <trans-unit id="2a442c1a811c488f4aad5d970f1047c5">
         <source>Hi,
@@ -1557,90 +1249,586 @@ Unfortunately, an item on your order is currently out of stock. This may cause a
 Please accept our apologies and rest assured that we are working hard to rectify this.
 
 Best regards,</target>
-        <note>Context:
-File: classes/lang/KeysReference/OrderMessageLang.php:27</note>
+        <note>Line: 27</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/lang/KeysReference/OrderReturnStateLang.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="015c603172846437ee7a569dc2c36273">
+        <source>Waiting for confirmation</source>
+        <target>Waiting for confirmation</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="7d42f56ce1d82d68f6545242ef4384a4">
+        <source>Waiting for package</source>
+        <target>Waiting for package</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="b383cc6d0e4ab5bfab94b4452a916ee5">
+        <source>Package received</source>
+        <target>Package received</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="03bd13f6762c099741f4934beb32b95d">
+        <source>Return denied</source>
+        <target>Return denied</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="4bb0dcdb92397d6b646711d623504058">
+        <source>Return completed</source>
+        <target>Return completed</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/OrderStateLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d698e777b19f6f487ae0490950174fde">
+        <source>Awaiting check payment</source>
+        <target>Awaiting check payment</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="016e1f278eccd700eaf33f74a501d050">
+        <source>Payment accepted</source>
+        <target>Payment accepted</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="294e143a57d178715a55e8575f8037e6">
+        <source>Processing in progress</source>
+        <target>Processing in progress</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="747cf5c8587184b9e489ff897d97c20d">
+        <source>Shipped</source>
+        <target>Shipped</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="67edd3b99247c9eb5884a02802a20fa7">
+        <source>Delivered</source>
+        <target>Delivered</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="0e22fe7d45f8e5632a4abf369b24e29c">
+        <source>Canceled</source>
+        <target>Canceled</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="cc61945cbbf46721a053467c395c666f">
+        <source>Refunded</source>
+        <target>Refunded</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="1e97d97a923eaddd810e056c828e99ea">
+        <source>Payment error</source>
+        <target>Payment error</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="48eac0bd985bc909fb58ccc1e1f669ed">
+        <source>On backorder (paid)</source>
+        <target>On backorder (paid)</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="6d59fd4089482ca1a4017ca4852f8d1d">
+        <source>On backorder (not paid)</source>
+        <target>On backorder (not paid)</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="688a337ab9864a53b41cd6ccd7f8880d">
+        <source>Awaiting bank wire payment</source>
+        <target>Awaiting bank wire payment</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="9517f3495b0036d25cbc455c592ea868">
+        <source>Remote payment accepted</source>
+        <target>Remote payment accepted</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="51ebf726bac579d61910a5425e3128c5">
+        <source>Awaiting Cash On Delivery validation</source>
+        <target>Awaiting Cash On Delivery validation</target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/RiskLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6adf97f83acf6453d4a6a4b1070f3754">
+        <source>None</source>
+        <target>None</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="28d0edd045e05cf5af64e35ae0c4c6ef">
+        <source>Low</source>
+        <target>Low</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="87f8a6ab85c9ced3702b4ea641ad4bb5">
+        <source>Medium</source>
+        <target>Medium</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="655d20c1ca69519ca647684edbb2db35">
+        <source>High</source>
+        <target>High</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/SupplyOrderStateLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="78e25fccba5eb87a2fe929e6cfa27b26">
+        <source>1 - Creation in progress</source>
+        <target>1 - Creation in progress</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="aa92ea2c14150feacd8a38cabaf59c4b">
+        <source>2 - Order validated</source>
+        <target>2 - Order validated</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="efca1ad6911feea6ec4f5172f28ff135">
+        <source>3 - Pending receipt</source>
+        <target>3 - Pending receipt</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="0e547a2250b0531cf58a26995ba31801">
+        <source>4 - Order received in part</source>
+        <target>4 - Order received in part</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="589760755f6f33549fb31e5ab03f2676">
+        <source>5 - Order received completely</source>
+        <target>5 - Order received completely</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="817bedb8bd68b944c3fa6e231b53147d">
+        <source>6 - Order canceled</source>
+        <target>6 - Order canceled</target>
+        <note>Line: 36</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAddressesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7cb32e708d6b961d476baced73d362bb">
+        <source>VAT number</source>
+        <target>VAT number</target>
+        <note>Line: 236</note>
+      </trans-unit>
+      <trans-unit id="b60bb13a87fe3ae5463aeb0980a5a8a1">
+        <source>Identification number</source>
+        <target>Identification number</target>
+        <note>Line: 153</note>
+      </trans-unit>
+      <trans-unit id="bed08e8af70a98c1a8361f13ec477be0">
+        <source>Add new address</source>
+        <target>Add new address</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
+        <source>Addresses</source>
+        <target>Addresses</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="e03982ee543fe69d4954d587f1f2a338">
+        <source>The national ID card number of this person, or a unique tax identification number.</source>
+        <target>The national ID card number of this person, or a unique tax identification number.</target>
+        <note>Line: 157</note>
+      </trans-unit>
+      <trans-unit id="baa31a65f29121c32b637bb845d41acf">
+        <source>Address alias</source>
+        <target>Address alias</target>
+        <note>Line: 161</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="90855df1b2d1240c62d81bd35d4cfb06">
+        <source>Non ordered</source>
+        <target>Non ordered</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="121401ccf0e3e23bcefe6a454f0f0601">
+        <source>Abandoned cart</source>
+        <target>Abandoned cart</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="f9b01554c32cc580b7380302f22613de">
+        <source>Export carts</source>
+        <target>Export carts</target>
+        <note>Line: 132</note>
+      </trans-unit>
+      <trans-unit id="54e85d70ea67acdcc86963b14d6223a8">
+        <source>Abandoned Carts</source>
+        <target>Abandoned Carts</target>
+        <note>Line: 167</note>
+      </trans-unit>
+      <trans-unit id="edeb0ec4f968653bb56eb2d7c50dab35">
+        <source>From %date1% to %date2%</source>
+        <target>From %date1% to %date2%</target>
+        <note>Line: 170</note>
+      </trans-unit>
+      <trans-unit id="ffbb5322a3702b0d8d9c7f506209c540">
+        <source>Average Order Value</source>
+        <target>Average Order Value</target>
+        <note>Line: 183</note>
+      </trans-unit>
+      <trans-unit id="4d9e1e12ad8a61ea2a5554407488d91a">
+        <source>Net Profit per Visitor</source>
+        <target>Net Profit per Visitor</target>
+        <note>Line: 197</note>
+      </trans-unit>
+      <trans-unit id="50cc07e9963519545552b1ac2c5f7a1e">
+        <source>Cart #%ID%</source>
+        <target>Cart #%ID%</target>
+        <note>Line: 284</note>
+      </trans-unit>
+      <trans-unit id="0b91ef9198a761459c595de4b12ca109">
+        <source>Total Cart</source>
+        <target>Total Cart</target>
+        <note>Line: 283</note>
+      </trans-unit>
+      <trans-unit id="b00b85425e74ed2c85dc3119b78ff2c3">
+        <source>Free Shipping</source>
+        <target>Free Shipping</target>
+        <note>Line: 601</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0f98b7f230f3c91292f0de4c99e263f2">
+        <source>Registration</source>
+        <target>Registration</target>
+        <note>Line: 146</note>
+      </trans-unit>
+      <trans-unit id="5e5914912e8d2f2765525840acf98bea">
+        <source>Last visit</source>
+        <target>Last visit</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="888d7e26fb1b4271a83269c91134ed67">
+        <source>Manage your Customers</source>
+        <target>Manage your Customers</target>
+        <note>Line: 248</note>
+      </trans-unit>
+      <trans-unit id="cd338983b119cf1b564b00a655751e36">
+        <source>Information about customer %name%</source>
+        <target>Information about customer %name%</target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="69ebc35efeb4f755ec3e9c44b4da635c">
+        <source>Editing customer %name%</source>
+        <target>Editing customer %name%</target>
+        <note>Line: 262</note>
+      </trans-unit>
+      <trans-unit id="601bcb96f0fb98dadc4dda90d98ef24d">
+        <source>Creating a new Customer</source>
+        <target>Creating a new Customer</target>
+        <note>Line: 264</note>
+      </trans-unit>
+      <trans-unit id="aac772216aecbeca0e86d06671fe985a">
+        <source>Birthday</source>
+        <target>Birthday</target>
+        <note>Line: 406</note>
+      </trans-unit>
+      <trans-unit id="920bd1fb6d54c93fca528ce941464225">
+        <source>Group access</source>
+        <target>Group access</target>
+        <note>Line: 476</note>
+      </trans-unit>
+      <trans-unit id="a3858e268ef19d7ec44b4e849a189a69">
+        <source>Default customer group</source>
+        <target>Default customer group</target>
+        <note>Line: 485</note>
+      </trans-unit>
+      <trans-unit id="15bbb9d0bbf25e8d2978de1168c749dc">
+        <source>Website</source>
+        <target>Website</target>
+        <note>Line: 537</note>
+      </trans-unit>
+      <trans-unit id="6e55ad8db6699476d8901b3d439963cb">
+        <source>Allowed outstanding amount</source>
+        <target>Allowed outstanding amount</target>
+        <note>Line: 542</note>
+      </trans-unit>
+      <trans-unit id="a7f50f36de1e47026a07b40670b50e1a">
+        <source>Maximum number of payment days</source>
+        <target>Maximum number of payment days</target>
+        <note>Line: 549</note>
+      </trans-unit>
+      <trans-unit id="b5228365ac1cae42b64aa5aecee6cf25">
+        <source>Risk rating</source>
+        <target>Risk rating</target>
+        <note>Line: 555</note>
+      </trans-unit>
+      <trans-unit id="06b7d2fbf61e5118bb87d7f561d3fa01">
+        <source>Average Age</source>
+        <target>Average Age</target>
+        <note>Line: 635</note>
+      </trans-unit>
+      <trans-unit id="d8f847a1f651aee93ecb6a22207e77b2">
+        <source>Orders per Customer</source>
+        <target>Orders per Customer</target>
+        <note>Line: 648</note>
+      </trans-unit>
+      <trans-unit id="d7eb752a5f38ab96a8dcf110aeb9f8b3">
+        <source>Newsletter Registrations</source>
+        <target>Newsletter Registrations</target>
+        <note>Line: 661</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminOrderMessageController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="38d6bc03067212bb0c2633f8a57d5881">
+        <source>Order messages</source>
+        <target>Order messages</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="80c05dda6b88c30a777e8777e23be8d7">
+        <source>Add new order message</source>
+        <target>Add new order message</target>
+        <note>Line: 105</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="94003250a2187a9f51b227b490e5ab6b">
+        <source>New client</source>
+        <target>New client</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="e13004b81566bfc42daa48372c15111b">
+        <source>Change Order Status</source>
+        <target>Change Order Status</target>
+        <note>Line: 183</note>
+      </trans-unit>
+      <trans-unit id="e5d61db40a917c78a9d8e821dd0dd8de">
+        <source>Add new order</source>
+        <target>Add new order</target>
+        <note>Line: 201</note>
+      </trans-unit>
+      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
+        <source>Orders</source>
+        <target>Orders</target>
+        <note>Line: 260</note>
+      </trans-unit>
+      <trans-unit id="0262a3dc4fae9adc8cb46e788806ccbf">
+        <source>Create order</source>
+        <target>Create order</target>
+        <note>Line: 260</note>
+      </trans-unit>
+      <trans-unit id="0f005bd8209a61e4fc96a69736eb9798">
+        <source>Order %reference% from %firstname% %lastname%</source>
+        <target>Order %reference% from %firstname% %lastname%</target>
+        <note>Line: 277</note>
+      </trans-unit>
+      <trans-unit id="d201284604b35aa9392cb9c1acc434a6">
+        <source>Credit slip for order #%d</source>
+        <target>Credit slip for order #%d</target>
+        <note>Line: 793</note>
+      </trans-unit>
+      <trans-unit id="bbee72681d2c075d95355d3d9ccefb4e">
+        <source>Credit card slip for order #%d</source>
+        <target>Credit card slip for order #%d</target>
+        <note>Line: 1062</note>
+      </trans-unit>
+      <trans-unit id="e49701f123af735cf327227e8ab09bac">
+        <source>Manual order -- Employee:</source>
+        <target>Manual order -- Employee:</target>
+        <note>Line: 1231</note>
+      </trans-unit>
+      <trans-unit id="1f065062cdb50b501c5cb5160cf21ab0">
+        <source>Net Profit per Visit</source>
+        <target>Net Profit per Visit</target>
+        <note>Line: 1657</note>
+      </trans-unit>
+      <trans-unit id="947d8520f04473da621f2718138f3bc6">
+        <source>30 days</source>
+        <target>30 days</target>
+        <note>Line: 1658</note>
+      </trans-unit>
+      <trans-unit id="52ec3221b595bb84def222e275d0152b">
+        <source>Order #%id% (%ref%) - %firstname% %lastname%</source>
+        <target>Order #%id% (%ref%) - %firstname% %lastname%</target>
+        <note>Line: 1711</note>
+      </trans-unit>
+      <trans-unit id="95abd3be6297996994738f735a369d4a">
+        <source>Shop: %shop_name%</source>
+        <target>Shop: %shop_name%</target>
+        <note>Line: 1722</note>
+      </trans-unit>
+      <trans-unit id="272c853e39b8c65c81afd3661a8fd17f">
+        <source>%amount% tax excl.</source>
+        <target>%amount% tax excl.</target>
+        <note>Line: 1647</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminOutstandingController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="59ca88f7b0e80cdd9af330af600a9ff6">
+        <source>Risk</source>
+        <target>Risk</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="b0135b3cb49d9fba98fc6199d4429622">
+        <source>Outstanding Allowance</source>
+        <target>Outstanding Allowance</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="b9894a8360f66fa7c87aebe79d2f5021">
+        <source>Current Outstanding</source>
+        <target>Current Outstanding</target>
+        <note>Line: 98</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9442975514755961788cc54bf8b43ddf">
+        <source>Merchandise return (RMA) options</source>
+        <target>Merchandise return (RMA) options</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="f374280fc7cab62785714cfca79b85a1">
+        <source>Enable returns</source>
+        <target>Enable returns</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="587398fde24739a1b7ecdb632e6855dd">
+        <source>Time limit of validity</source>
+        <target>Time limit of validity</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="942fb8edc78a4c5be5b86cc4ad009538">
+        <source>Returns prefix</source>
+        <target>Returns prefix</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="bfc23574a242be4531bcb29877ac1d8a">
+        <source>Return Merchandise Authorization (RMA)</source>
+        <target>Return Merchandise Authorization (RMA)</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="f504da64aae2dcfd85ce565121248f93">
+        <source>Customer explanation</source>
+        <target>Customer explanation</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="6d72e074fdface4ae892543d39434175">
+        <source>Returns form</source>
+        <target>Returns form</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="4f3bf7771a1ecc368092d952d698c12c">
+        <source>Order #%id% from %date%</source>
+        <target>Order #%id% from %date%</target>
+        <note>Line: 172</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSlipController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d79cf3f429596f77db95c65074663a54">
+        <source>Order ID</source>
+        <target>Order ID</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="446faa7da2d42ba4ffeda73cb119dd91">
+        <source>Date issued</source>
+        <target>Date issued</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="c95ed58f8c9573f7d58667e6847758d9">
+        <source>Slip</source>
+        <target>Slip</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="44180a771d7f3bf534550199c3293441">
+        <source>Credit slip options</source>
+        <target>Credit slip options</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="d3174688da67b4530a7c8e774a7f31d5">
+        <source>Credit slip prefix</source>
+        <target>Credit slip prefix</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="9a0e3730cac2d4abdda4cfa04483318e">
+        <source>Print a PDF</source>
+        <target>Print a PDF</target>
+        <note>Line: 107</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderConfirmationController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="71754079aaeefc5c6e745ddd59f8a35f">
+        <source>Free order</source>
+        <target>Free order</target>
+        <note>Line: 154</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ffb7e666a70151215b4c55c6268d7d72">
+        <source>Newsletter</source>
+        <target>Newsletter</target>
+        <note>Line: 1235</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fdd748833c0e80edbfe6d955a1e2bef5">
+        <source>After the sequential number</source>
+        <target>After the sequential number</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="2d34b4de2b2170f55f41facfbdb3684a">
+        <source>Before the sequential number</source>
+        <target>Before the sequential number</target>
+        <note>Line: 93</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="91ee5169ce4265b5ace262d703edbb5c">
+        <source>Generate PDF</source>
+        <target>Generate PDF</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="afa0e443a161e904a03bbbc333506256">
+        <source>Print PDF</source>
+        <target>Print PDF</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="947c66d55a8038fd0c16fef605186573">
+        <source>Delivery slip options</source>
+        <target>Delivery slip options</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="197a830d84923ffbb79a06975380b976">
+        <source>Delivery prefix</source>
+        <target>Delivery prefix</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="3f921d7b2738f966c8d4d78d62f414b6">
+        <source>Delivery Number</source>
+        <target>Delivery Number</target>
+        <note>Line: 86</note>
+      </trans-unit>
       <trans-unit id="133e649a7f103383bd0c9c35c40f8ce0">
         <source>Enable product image</source>
         <target>Enable product image</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:53</note>
-      </trans-unit>
-      <trans-unit id="1b107c8f50c81b4b3497765849934a1c">
-        <source>Invoice options</source>
-        <target>Invoice options</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:34</note>
-      </trans-unit>
-      <trans-unit id="916e303456985cc95e3f551665b0314f">
-        <source>Enable invoices</source>
-        <target>Enable invoices</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:39</note>
-      </trans-unit>
-      <trans-unit id="ae3a4016de0f41b2fd7a39494fb5a05a">
-        <source>Enable tax breakdown</source>
-        <target>Enable tax breakdown</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:46</note>
-      </trans-unit>
-      <trans-unit id="82c9667c9ef1dc29e479d080eaa998db">
-        <source>Invoice prefix</source>
-        <target>Invoice prefix</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:60</note>
-      </trans-unit>
-      <trans-unit id="ffd9d577464b4a615096c6d0c9c490ae">
-        <source>Add current year to invoice number</source>
-        <target>Add current year to invoice number</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:68</note>
-      </trans-unit>
-      <trans-unit id="adb5bc3c76ab4f69fc050090e05998c7">
-        <source>Reset sequential invoice number at the beginning of the year</source>
-        <target>Reset sequential invoice number at the beginning of the year</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:77</note>
-      </trans-unit>
-      <trans-unit id="e8065dc15d8cb943a6b6aa87f7b539e9">
-        <source>Position of the year date</source>
-        <target>Position of the year date</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:86</note>
-      </trans-unit>
-      <trans-unit id="8ae4286d38bb2235def98fd68d7420d2">
-        <source>Invoice number</source>
-        <target>Invoice number</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:94</note>
-      </trans-unit>
-      <trans-unit id="3dea916f8f5db8eb7167832fc3679059">
-        <source>Legal free text</source>
-        <target>Legal free text</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:101</note>
-      </trans-unit>
-      <trans-unit id="ae68c7d78a4135cf3d9790ef9f176cdf">
-        <source>Footer text</source>
-        <target>Footer text</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:108</note>
-      </trans-unit>
-      <trans-unit id="e57758881f26d49452c5ca0fd9fc140e">
-        <source>Invoice model</source>
-        <target>Invoice model</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:115</note>
-      </trans-unit>
-      <trans-unit id="57826bb01dcd3fa7c0de235ff4bb8ca3">
-        <source>Use the disk as cache for PDF invoices</source>
-        <target>Use the disk as cache for PDF invoices</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:122</note>
+        <note>Line: 93</note>
       </trans-unit>
     </body>
   </file>
@@ -1649,14 +1837,12 @@ File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invo
       <trans-unit id="9a0a4f0869ab12a21407047290750e7a">
         <source>By date</source>
         <target>By date</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="1f0a7c7f8461359ede310318e3d44cd8">
         <source>Generate PDF file by date</source>
         <target>Generate PDF file by date</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig:57</note>
+        <note>Line: 57</note>
       </trans-unit>
     </body>
   </file>
@@ -1665,626 +1851,81 @@ File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/gene
       <trans-unit id="3f02389d0dca7ed6c03edb82a0ad35cf">
         <source>By order status</source>
         <target>By order status</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig:36</note>
+        <note>Line: 36</note>
       </trans-unit>
       <trans-unit id="33af8066d3c83110d4bd897f687cedd2">
         <source>Order statuses</source>
         <target>Order statuses</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="1f5b4e1a0e2c01cf6de547861dc86cd8">
         <source>Generate PDF file by status</source>
         <target>Generate PDF file by status</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig:52</note>
+        <note>Line: 52</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="548abe251b033d863417979998dba612">
-        <source>Forward this discussion</source>
-        <target>Forward this discussion</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="42ff79fde8fc930db50949b4f700c661">
-        <source>Forward this discussion to an employee:</source>
-        <target>Forward this discussion to an employee:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="81e053d78f01540e9cd6fb68a1c03976">
-        <source>Someone else</source>
-        <target>Someone else</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="240f3031f25601fa128bd4e15f0a37de">
-        <source>Comment:</source>
-        <target>Comment:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl:54</note>
-      </trans-unit>
-      <trans-unit id="67d2f6740a8eaebf4d5c6f79be8da481">
-        <source>Forward</source>
-        <target>Forward</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl:63</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d97477d6d8a838ead9348185bb5b6742">
-        <source>Thread</source>
-        <target>Thread</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="3f8faa0e229dbd775fa36b8c15bf73a6">
-        <source>Forward this discussion to another employee</source>
-        <target>Forward this discussion to another employee</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:47</note>
-      </trans-unit>
-      <trans-unit id="33caa076f23f453dd4061726f3706325">
-        <source>To:</source>
-        <target>To:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:67</note>
-      </trans-unit>
-      <trans-unit id="72890e9df12803a4aab17a98d1ebfd9e">
-        <source>[1]%count%[/1] order(s) validated for a total amount of [2]%total%[/2]</source>
-        <target>[1]%count%[/1] order(s) validated for a total amount of [2]%total%[/2]</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:74</note>
-      </trans-unit>
-      <trans-unit id="cdd894792c37687ccbf690fcd9673a89">
-        <source>No orders validated for the moment</source>
-        <target>No orders validated for the moment</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:76</note>
-      </trans-unit>
-      <trans-unit id="76a6d3995bf5a66e8c92d84401d6435e">
-        <source>Your answer to</source>
-        <target>Your answer to</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:101</note>
-      </trans-unit>
-      <trans-unit id="04427d6ba3fb03f0951b27ddd7c05af5">
-        <source>Orders and messages timeline</source>
-        <target>Orders and messages timeline</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:130</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customer_threads/message.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d1228f5476d15142b1358ae4b5fa2454">
-        <source>Order #</source>
-        <target>Order #</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:77</note>
-      </trans-unit>
-      <trans-unit id="9788af9fa097020a285afc0651a0721c">
-        <source>View customer</source>
-        <target>View customer</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:48</note>
-      </trans-unit>
-      <trans-unit id="d13d8380c3f4de07fef91a42fe6c60d7">
-        <source>Customer ID:</source>
-        <target>Customer ID:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="385b0ac7763680e5768f3e5e866910da">
-        <source>Sent on:</source>
-        <target>Sent on:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:55</note>
-      </trans-unit>
-      <trans-unit id="d62b749697e3c1b9c26a645ad5d56656">
-        <source>Browser:</source>
-        <target>Browser:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:60</note>
-      </trans-unit>
-      <trans-unit id="bfb069b69766c9a8a1fac8aabfd970b2">
-        <source>File attachment</source>
-        <target>File attachment</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:66</note>
-      </trans-unit>
-      <trans-unit id="6fe76eb16b53e5008f51db59a7dae7b3">
-        <source>View file</source>
-        <target>View file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:69</note>
-      </trans-unit>
-      <trans-unit id="c851a34d4806acb02a55df148f9d7f25">
-        <source>Product #</source>
-        <target>Product #</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:84</note>
-      </trans-unit>
-      <trans-unit id="c5730b7ad58a3bad76e6b6b763521ec7">
-        <source>View this thread</source>
-        <target>View this thread</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:111</note>
-      </trans-unit>
-      <trans-unit id="018d4d01cba3905ad11258518b4ea424">
-        <source>Sent by:</source>
-        <target>Sent by:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:115</note>
-      </trans-unit>
-      <trans-unit id="818d947aeb9e604f54ce4c3444cc0256">
-        <source>Thread ID:</source>
-        <target>Thread ID:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:153</note>
-      </trans-unit>
-      <trans-unit id="0e2f5e3f12561ac94047979ec5406946">
-        <source>Message ID:</source>
-        <target>Message ID:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:157</note>
-      </trans-unit>
-      <trans-unit id="940663fd4428d2c86f9a4780b6574028">
-        <source>Message:</source>
-        <target>Message:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:162</note>
-      </trans-unit>
-      <trans-unit id="b20d33a926b1e5b39db18b2911e1c1f9">
-        <source>Reply to this message</source>
-        <target>Reply to this message</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:172</note>
-      </trans-unit>
-      <trans-unit id="e8b4e59e41f890acd1d5d86d494d6d02">
-        <source>Please type your reply below:</source>
-        <target>Please type your reply below:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:180</note>
-      </trans-unit>
-      <trans-unit id="91e2e681ab0c5817498a10318df5aec9">
-        <source>Your reply will be sent to:</source>
-        <target>Your reply will be sent to:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:186</note>
-      </trans-unit>
-      <trans-unit id="3d49ea2e92edbb4219d39256794525d9">
-        <source>Send my reply</source>
-        <target>Send my reply</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:193</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/timeline_item.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="891ad007e2e9f2d55be6669cd9abc7a0">
-        <source>See more</source>
-        <target>See more</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/timeline_item.tpl:35</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_faviconnotificationbo/views/templates/admin/tabs/faviconConfiguration.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f08d50397194b8e1679b11fd16f60ebc">
-        <source>New messages</source>
-        <target>New messages</target>
-        <note>Context:
-File: modules/ps_faviconnotificationbo/views/templates/admin/tabs/faviconConfiguration.tpl:60</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d8e87c0927539672f54462c837be0b7f">
-        <source>Sync</source>
-        <target>Sync</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="2b8fa6c46485d50e476591942fc9d7ee">
-        <source>Run sync:</source>
-        <target>Run sync:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="a19330a6fc36ebae6683cc023e295687">
-        <source>Run sync</source>
-        <target>Run sync</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="22009610f18142abea939bc2f1836a81">
-        <source>Click to synchronize mail automatically</source>
-        <target>Click to synchronize mail automatically</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl:33</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_discount_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="41953cbf836297b3c96b137a2b789ccb">
-        <source>Apply on all invoices</source>
-        <target>Apply on all invoices</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_discount_form.tpl:88</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_customized_data.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5e1ce9eb796081fea13e0d0dd3c3d76f">
-        <source>Reference number:</source>
-        <target>Reference number:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_customized_data.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="a9971a36ea6236b1577b27dba46775ed">
-        <source>Supplier reference:</source>
-        <target>Supplier reference:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_customized_data.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="967ad092fca7b99aa4f170ed73a6a8e1">
-        <source>%quantity_refunded% (%amount_refunded% refund)</source>
-        <target>%quantity_refunded% (%amount_refunded% refund)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_customized_data.tpl:164</note>
-      </trans-unit>
-      <trans-unit id="c2808546f3e14d267d798f4e0e6f102e">
-        <source>Customized</source>
-        <target>Customized</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_customized_data.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="b9e6daaef804c01f3847f1da8b053dd1">
-        <source>Picture #</source>
-        <target>Picture #</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_customized_data.tpl:130</note>
-      </trans-unit>
-      <trans-unit id="4523758f4415c5b7afe9c6bd6b4917b3">
-        <source>Text #%s</source>
-        <target>Text #%s</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_customized_data.tpl:141</note>
-      </trans-unit>
-      <trans-unit id="3d0d1f906e27800531e054a3b6787b7c">
-        <source>Quantity:</source>
-        <target>Quantity:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_customized_data.tpl:207</note>
-      </trans-unit>
-      <trans-unit id="6702a6e3bc2dce95c3e3b61fe578f29c">
-        <source>Amount:</source>
-        <target>Amount:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_customized_data.tpl:216</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4fdfd561c540aa5e20a9b2b9c06054bb">
-        <source>Package content</source>
-        <target>Package content</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_product_line.tpl:43</note>
-      </trans-unit>
-      <trans-unit id="ce5bf551379459c1c61d2a204061c455">
-        <source>Location</source>
-        <target>Location</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_product_line.tpl:88</note>
-      </trans-unit>
-      <trans-unit id="782678f4ba02feb3e9ecd51e902cd16b">
-        <source>Refund history</source>
-        <target>Refund history</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_product_line.tpl:103</note>
-      </trans-unit>
-      <trans-unit id="be73df859979ad499dd484eeb187be60">
-        <source>Return history</source>
-        <target>Return history</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_product_line.tpl:119</note>
-      </trans-unit>
-      <trans-unit id="ca70428d9ed105c07f40d3c21d130859">
-        <source>Package item</source>
-        <target>Package item</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_product_line.tpl:258</note>
-      </trans-unit>
-      <trans-unit id="dd70925db57b570bcb660d68c30d5e0b">
-        <source>Ref Supplier:</source>
-        <target>Ref Supplier:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_product_line.tpl:264</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e78b6f4eb3be046f4d25c07ce54954d4">
-        <source>Ref:</source>
-        <target>Ref:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:156</note>
-      </trans-unit>
-      <trans-unit id="1d949d2235747b894bbaae35fbf44f1d">
-        <source>Customer information</source>
-        <target>Customer information</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="ad63162d0d394b0e0daf1c30c6d77160">
-        <source>Account registration date:</source>
-        <target>Account registration date:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:49</note>
-      </trans-unit>
-      <trans-unit id="b157524c4be8c2fc80e5ef2f0b1bf1e6">
-        <source>Valid orders placed:</source>
-        <target>Valid orders placed:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:53</note>
-      </trans-unit>
-      <trans-unit id="5c63fcad7f3534fdcf4ee426a54a6e00">
-        <source>Total spent since registration:</source>
-        <target>Total spent since registration:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:57</note>
-      </trans-unit>
-      <trans-unit id="a8e3c5c577a4b885819e5ba1c785065c">
-        <source>Guest not registered</source>
-        <target>Guest not registered</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="58930025e1f95d65035e0df5d6c2ae41">
-        <source>Order information</source>
-        <target>Order information</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:68</note>
-      </trans-unit>
-      <trans-unit id="18fb6221fe0d9895c2e9ba08283f00e9">
-        <source>Order #%d</source>
-        <target>Order #%d</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:70</note>
-      </trans-unit>
-      <trans-unit id="f9e17adb48f78186c6bcd4bd9c08816d">
-        <source>Made on:</source>
-        <target>Made on:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:71</note>
-      </trans-unit>
-      <trans-unit id="f56d50312cd90c7dec77c0472f20fee0">
-        <source>No order was created from this cart.</source>
-        <target>No order was created from this cart.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:73</note>
-      </trans-unit>
-      <trans-unit id="4f36361240acdff526598021f5459a87">
-        <source>Create an order from this cart.</source>
-        <target>Create an order from this cart.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:75</note>
-      </trans-unit>
-      <trans-unit id="6f16ab6ec0a6064d0c8961257a3eb1f5">
-        <source>Cart summary</source>
-        <target>Cart summary</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:82</note>
-      </trans-unit>
-      <trans-unit id="2fb3b950fd7711136f7f251ae5fbdbdc">
-        <source>Text #</source>
-        <target>Text #</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:131</note>
-      </trans-unit>
-      <trans-unit id="0bf157acdf9fe272c1379ff0b5442372">
-        <source>Total cost of products:</source>
-        <target>Total cost of products:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:168</note>
-      </trans-unit>
-      <trans-unit id="3e69f668660d41b577a8da0fb53f6fa8">
-        <source>Total value of vouchers:</source>
-        <target>Total value of vouchers:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:173</note>
-      </trans-unit>
-      <trans-unit id="79e21b5609402cd57d1dec7496771df8">
-        <source>Total cost of gift wrapping:</source>
-        <target>Total cost of gift wrapping:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:179</note>
-      </trans-unit>
-      <trans-unit id="80fde97fb8929b8bea9ebcf5241be2f9">
-        <source>Total shipping costs:</source>
-        <target>Total shipping costs:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:185</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="448e9885f58aad30823ddde9996114d6">
-        <source>Choose an order status</source>
-        <target>Choose an order status</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/list/list_header.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="10ea517069300c23c17f113a3d084c57">
-        <source>Update Order Status</source>
-        <target>Update Order Status</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/list/list_header.tpl:61</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="74b9e5d9e68f0fcc9326fab959a8ed4b">
-        <source>Edit shipping details</source>
-        <target>Edit shipping details</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_shipping.tpl:95</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_documents.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0945359809dad1fbf3dea1c95a0da951">
-        <source>Document</source>
-        <target>Document</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:33</note>
-      </trans-unit>
-      <trans-unit id="b2ee912b91d69b435159c7c3f6df7f5f">
-        <source>Number</source>
-        <target>Number</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:36</note>
-      </trans-unit>
-      <trans-unit id="ee7197503a8a3820850df76fb406c224">
-        <source>Delivery slip</source>
-        <target>Delivery slip</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="f53e8d0e97c47ce70ca9c5eaa08a00d0">
-        <source>Credit Slip</source>
-        <target>Credit Slip</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:66</note>
-      </trans-unit>
-      <trans-unit id="c12a553ab6ad810580afa3f07aa9f51f">
-        <source>not paid</source>
-        <target>not paid</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:99</note>
-      </trans-unit>
-      <trans-unit id="8d4ac0e8c6f5900930ddfccd45d10abf">
-        <source>overpaid</source>
-        <target>overpaid</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:101</note>
-      </trans-unit>
-      <trans-unit id="7fb46048bafd1294fab5c1675ef4f849">
-        <source>Enter payment</source>
-        <target>Enter payment</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="50cd1871f950375eef4e2efce35366c6">
-        <source>Add note</source>
-        <target>Add note</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:124</note>
-      </trans-unit>
-      <trans-unit id="71e2851d86b252a44c658b896c486921">
-        <source>Edit note</source>
-        <target>Edit note</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:127</note>
-      </trans-unit>
-      <trans-unit id="80cb34a90bc2178e9219ccc4ab106867">
-        <source>Generate invoice</source>
-        <target>Generate invoice</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:170</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="200e62e510bab9b03c912e10a5363a7a">
-        <source>Create a new invoice</source>
-        <target>Create a new invoice</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:86</note>
-      </trans-unit>
-      <trans-unit id="4800d00deaa0a28a18151d76feb858cb">
-        <source>New invoice information</source>
-        <target>New invoice information</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:105</note>
-      </trans-unit>
-      <trans-unit id="f54bdce4ab4d26c259216da67b9d6431">
-        <source>Shipping Costs</source>
-        <target>Shipping Costs</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:114</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a8658715e6b0e879cbcbc4728a423b36">
-        <source>Text #%d</source>
-        <target>Text #%d</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl:92</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/addresses/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="03361eda68f746619c2ae3341eaa2f07">
-        <source>Customer email</source>
-        <target>Customer email</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/addresses/helpers/form/form.tpl:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/slip/_print_pdf_icon.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a4c0c09247c3e56ff08971ff5558c596">
-        <source>Download credit slip</source>
-        <target>Download credit slip</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/slip/_print_pdf_icon.tpl:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customers/helpers/required_fields.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0470d45929f27e1161330164c423b415">
-        <source>Set required fields for this section</source>
-        <target>Set required fields for this section</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/required_fields.tpl:26</note>
-      </trans-unit>
-      <trans-unit id="e54b38290c8bdd95e8bc10412c9cc096">
-        <source>Required Fields</source>
-        <target>Required Fields</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/required_fields.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="ee9b2f3cf31c23c944b15fb0b33d6a77">
-        <source>Field Name</source>
-        <target>Field Name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/required_fields.tpl:44</note>
+      <trans-unit id="1b107c8f50c81b4b3497765849934a1c">
+        <source>Invoice options</source>
+        <target>Invoice options</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="916e303456985cc95e3f551665b0314f">
+        <source>Enable invoices</source>
+        <target>Enable invoices</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="ae3a4016de0f41b2fd7a39494fb5a05a">
+        <source>Enable tax breakdown</source>
+        <target>Enable tax breakdown</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="82c9667c9ef1dc29e479d080eaa998db">
+        <source>Invoice prefix</source>
+        <target>Invoice prefix</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="ffd9d577464b4a615096c6d0c9c490ae">
+        <source>Add current year to invoice number</source>
+        <target>Add current year to invoice number</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="adb5bc3c76ab4f69fc050090e05998c7">
+        <source>Reset sequential invoice number at the beginning of the year</source>
+        <target>Reset sequential invoice number at the beginning of the year</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="e8065dc15d8cb943a6b6aa87f7b539e9">
+        <source>Position of the year date</source>
+        <target>Position of the year date</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="8ae4286d38bb2235def98fd68d7420d2">
+        <source>Invoice number</source>
+        <target>Invoice number</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="3dea916f8f5db8eb7167832fc3679059">
+        <source>Legal free text</source>
+        <target>Legal free text</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="ae68c7d78a4135cf3d9790ef9f176cdf">
+        <source>Footer text</source>
+        <target>Footer text</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="e57758881f26d49452c5ca0fd9fc140e">
+        <source>Invoice model</source>
+        <target>Invoice model</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="57826bb01dcd3fa7c0de235ff4bb8ca3">
+        <source>Use the disk as cache for PDF invoices</source>
+        <target>Use the disk as cache for PDF invoices</target>
+        <note>Line: 122</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminOrderscustomersHelp.xlf
+++ b/app/Resources/translations/default/AdminOrderscustomersHelp.xlf
@@ -1,320 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a43fd5e0338751959686921566de352e">
-        <source>Leave this field blank if there's no change.</source>
-        <target>Leave this field blank if there's no change.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:398</note>
-      </trans-unit>
-      <trans-unit id="f6916f4f1a268d4d0014ce47a2dfc3e4">
-        <source>Password should be at least %length% characters long.</source>
-        <target>Password should be at least %length% characters long.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:399</note>
-      </trans-unit>
-      <trans-unit id="6010127763b917fdc47eb0c50a86a6f6">
-        <source>Enable or disable customer login.</source>
-        <target>Enable or disable customer login.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:430</note>
-      </trans-unit>
-      <trans-unit id="8c7a8f24423b8519d38fb3ff380e020f">
-        <source>This customer will receive your ads via email.</source>
-        <target>This customer will receive your ads via email.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:452</note>
-      </trans-unit>
-      <trans-unit id="e7608efcc5a10b78e3a98c438c2a1b7f">
-        <source>Select all the groups that you would like to apply to this customer.</source>
-        <target>Select all the groups that you would like to apply to this customer.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:478</note>
-      </trans-unit>
-      <trans-unit id="395b64636636e968c756f7514313f760">
-        <source>This group will be the user's default group.</source>
-        <target>This group will be the user's default group.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:491</note>
-      </trans-unit>
-      <trans-unit id="8b7fc06b213f4fb343c72af878e5c64b">
-        <source>Only the discount for the selected group will be applied to this customer.</source>
-        <target>Only the discount for the selected group will be applied to this customer.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:492</note>
-      </trans-unit>
-      <trans-unit id="75bf7b6b951d3183f7c8f96bdb4fa74c">
-        <source>Valid characters:</source>
-        <target>Valid characters:</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:548</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ed4bfa76b661f4b6bc94d32fe6147d57">
-        <source>Would you like to allow merchandise returns in your shop?</source>
-        <target>Would you like to allow merchandise returns in your shop?</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:59</note>
-      </trans-unit>
-      <trans-unit id="c503a53add0f47d2497ca363f9ad1b76">
-        <source>How many days after the delivery date does the customer have to return a product?</source>
-        <target>How many days after the delivery date does the customer have to return a product?</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:63</note>
-      </trans-unit>
-      <trans-unit id="095fcccad5a4585fdc2fe1f97fc89561">
-        <source>Prefix used for return name (e.g. RE00001).</source>
-        <target>Prefix used for return name (e.g. RE00001).</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:69</note>
-      </trans-unit>
-      <trans-unit id="2bf0a7ee96f0cba7f7d530ff08f01bf8">
-        <source>Merchandise return (RMA) status.</source>
-        <target>Merchandise return (RMA) status.</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:129</note>
-      </trans-unit>
-      <trans-unit id="a3d008a6e1f75882761e48de1b001497">
-        <source>List of products in return package.</source>
-        <target>List of products in return package.</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:137</note>
-      </trans-unit>
-      <trans-unit id="db21428a343da97c41ced5ad9ef17d56">
-        <source>The link is only available after validation and before the parcel gets delivered.</source>
-        <target>The link is only available after validation and before the parcel gets delivered.</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:145</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSlipController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0ecbd7a341049250b3da531530e42622">
-        <source>Prefix used for credit slips.</source>
-        <target>Prefix used for credit slips.</target>
-        <note>Context:
-File: controllers/admin/AdminSlipController.php:80</note>
-      </trans-unit>
-      <trans-unit id="e07ffcdf6051874b295597fb64b62635">
-        <source>Format: 2012-12-31 (inclusive).</source>
-        <target>Format: 2012-12-31 (inclusive).</target>
-        <note>Context:
-File: controllers/admin/AdminSlipController.php:125</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8a7a048a67746f3877ab6cb1bc1d4afd">
-        <source>Format: 2011-12-31 (inclusive).</source>
-        <target>Format: 2011-12-31 (inclusive).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig:46</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3c1c7064989da051f0b4b904bcb408cf">
-        <source>This customer will receive your newsletter via email.</source>
-        <target>This customer will receive your newsletter via email.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1253</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="67342320cb8798c3a911e0c6d8bd026a">
-        <source>Prefix used for delivery slips.</source>
-        <target>Prefix used for delivery slips.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig:79</note>
-      </trans-unit>
-      <trans-unit id="6998acbd3739a7200586b4421d0ca508">
-        <source>The next delivery slip will begin with this number and then increase with each additional slip.</source>
-        <target>The next delivery slip will begin with this number and then increase with each additional slip.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig:86</note>
-      </trans-unit>
-      <trans-unit id="8cf7df5b4b5858e73a7f4e75cc658cc3">
-        <source>Adds an image before product name on Delivery-slip</source>
-        <target>Adds an image before product name on Delivery-slip</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig:93</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fef8859b22e06e4d4918f091612bf958">
-        <source>You can also export orders which have not been charged yet.</source>
-        <target>You can also export orders which have not been charged yet.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="60422879211a12247e5da14751a59ac3">
-        <source>If enabled, your customers will receive an invoice for the purchase.</source>
-        <target>If enabled, your customers will receive an invoice for the purchase.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:39</note>
-      </trans-unit>
-      <trans-unit id="afda8f59762167c6720a8afe24345df1">
-        <source>If required, show the total amount per rate of the corresponding tax.</source>
-        <target>If required, show the total amount per rate of the corresponding tax.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:46</note>
-      </trans-unit>
-      <trans-unit id="0e963c5b7a1b6bb67429c7d0e7f45741">
-        <source>Adds an image in front of the product name on the invoice</source>
-        <target>Adds an image in front of the product name on the invoice</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:53</note>
-      </trans-unit>
-      <trans-unit id="7b87585267aed27676374641013ab66e">
-        <source>Freely definable prefix for invoice number (e.g. #IN00001).</source>
-        <target>Freely definable prefix for invoice number (e.g. #IN00001).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:60</note>
-      </trans-unit>
-      <trans-unit id="a93c4ec4b8ef325acf067112d7437c59">
-        <source>The next invoice will begin with this number, and then increase with each additional invoice. Set to 0 if you want to keep the current number (which is #%number%).</source>
-        <target>The next invoice will begin with this number, and then increase with each additional invoice. Set to 0 if you want to keep the current number (which is #%number%).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:94</note>
-      </trans-unit>
-      <trans-unit id="7a490daaa2605a4a5be08b30a0c6fe24">
-        <source>Use this field to show additional information on the invoice, below the payment methods summary (like specific legal information).</source>
-        <target>Use this field to show additional information on the invoice, below the payment methods summary (like specific legal information).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:101</note>
-      </trans-unit>
-      <trans-unit id="e3501dec19c50333c49b4d7d66931abc">
-        <source>This text will appear at the bottom of the invoice, below your company details.</source>
-        <target>This text will appear at the bottom of the invoice, below your company details.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:108</note>
-      </trans-unit>
-      <trans-unit id="4e00dcdfbf2f4a6156c01fb15ded75c5">
-        <source>Choose an invoice model.</source>
-        <target>Choose an invoice model.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:115</note>
-      </trans-unit>
-      <trans-unit id="41d8a2a057a1e1b9663d49896d3162f3">
-        <source>Saves memory but slows down the PDF generation.</source>
-        <target>Saves memory but slows down the PDF generation.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig:122</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="2605a817441c19cc88eb9e5d17845dc0">
         <source>You can add a comment here.</source>
         <target>You can add a comment here.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl:56</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_discount_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="576e650084068ed747fb3b22196dcd70">
-        <source>If you chooses to create this discount for all invoices, only one discount will be created per order invoice.</source>
-        <target>If you chooses to create this discount for all invoices, only one discount will be created per order invoice.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_discount_form.tpl:92</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_customized_data.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5728ff6d5efd64ef7db72028eefc7262">
-        <source>(Max %amount_refundable% %tax_method%)</source>
-        <target>(Max %amount_refundable% %tax_method%)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_customized_data.tpl:224</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f741fe9d353085c596e3c3610101e245">
-        <source>Resend this email to the customer</source>
-        <target>Resend this email to the customer</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:229</note>
-      </trans-unit>
-      <trans-unit id="f9a5775d7def0b6c57393fc86bb7a730">
-        <source>Do not forget to update your exchange rate before making this change.</source>
-        <target>Do not forget to update your exchange rate before making this change.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:561</note>
-      </trans-unit>
-      <trans-unit id="883370e6a8360f9ffe2e658db153fd74">
-        <source>This feature will generate a random password and send an email to the customer.</source>
-        <target>This feature will generate a random password and send an email to the customer.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:599</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="28a996f23ec7c4f6cf75da6bf30670bd">
-        <source>Search for an existing customer by typing the first letters of his/her name.</source>
-        <target>Search for an existing customer by typing the first letters of his/her name.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1107</note>
-      </trans-unit>
-      <trans-unit id="73af90a8372beea9f81a3c3ca77a4aa8">
-        <source>Send an email to the customer with the link to process the payment.</source>
-        <target>Send an email to the customer with the link to process the payment.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1536</note>
-      </trans-unit>
-      <trans-unit id="9f38710d8e9ee2338dafa9ae484b0d85">
-        <source>Go on payment page to process the payment.</source>
-        <target>Go on payment page to process the payment.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1539</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dca6b819ed4897f93a1a8531df9b282a">
-        <source>If you don't select "Free shipping," the normal shipping costs will be applied.</source>
-        <target>If you don't select "Free shipping," the normal shipping costs will be applied.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:121</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d17f6ab68839ef4a39ead0638cae47a2">
-        <source>View details on the customer page</source>
-        <target>View details on the customer page</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="a901cc409fe745be1a29a311b57880ce">
-        <source>View details on the order page</source>
-        <target>View details on the order page</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl:37</note>
+        <note>Line: 56</note>
       </trans-unit>
     </body>
   </file>
@@ -323,14 +14,12 @@ File: admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl
       <trans-unit id="81f32b96f6626b8968e6a0f4a9bce62e">
         <source>Select the fields you would like to be required for this section.</source>
         <target>Select the fields you would like to be required for this section.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/required_fields.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="a75835a6fe4329ee7884694415c2d46d">
         <source>Please make sure you are complying with the opt-in legislation applicable in your country.</source>
         <target>Please make sure you are complying with the opt-in legislation applicable in your country.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/required_fields.tpl:35</note>
+        <note>Line: 35</note>
       </trans-unit>
     </body>
   </file>
@@ -339,14 +28,274 @@ File: admin-dev/themes/default/template/controllers/customers/helpers/required_f
       <trans-unit id="fef9632f39b66ba488e163a665bb0e99">
         <source>This feature generates a random password before sending an email to your customer.</source>
         <target>This feature generates a random password before sending an email to your customer.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:172</note>
+        <note>Line: 172</note>
       </trans-unit>
       <trans-unit id="566d26ec62e9c51270b7243440227dbb">
         <source>This note will be displayed to all employees but not to customers.</source>
         <target>This note will be displayed to all employees but not to customers.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:364</note>
+        <note>Line: 364</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_discount_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="576e650084068ed747fb3b22196dcd70">
+        <source>If you chooses to create this discount for all invoices, only one discount will be created per order invoice.</source>
+        <target>If you chooses to create this discount for all invoices, only one discount will be created per order invoice.</target>
+        <note>Line: 92</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dca6b819ed4897f93a1a8531df9b282a">
+        <source>If you don't select "Free shipping," the normal shipping costs will be applied.</source>
+        <target>If you don't select "Free shipping," the normal shipping costs will be applied.</target>
+        <note>Line: 121</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5728ff6d5efd64ef7db72028eefc7262">
+        <source>(Max %amount_refundable% %tax_method%)</source>
+        <target>(Max %amount_refundable% %tax_method%)</target>
+        <note>Line: 192</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="28a996f23ec7c4f6cf75da6bf30670bd">
+        <source>Search for an existing customer by typing the first letters of his/her name.</source>
+        <target>Search for an existing customer by typing the first letters of his/her name.</target>
+        <note>Line: 1107</note>
+      </trans-unit>
+      <trans-unit id="73af90a8372beea9f81a3c3ca77a4aa8">
+        <source>Send an email to the customer with the link to process the payment.</source>
+        <target>Send an email to the customer with the link to process the payment.</target>
+        <note>Line: 1536</note>
+      </trans-unit>
+      <trans-unit id="9f38710d8e9ee2338dafa9ae484b0d85">
+        <source>Go on payment page to process the payment.</source>
+        <target>Go on payment page to process the payment.</target>
+        <note>Line: 1539</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f741fe9d353085c596e3c3610101e245">
+        <source>Resend this email to the customer</source>
+        <target>Resend this email to the customer</target>
+        <note>Line: 229</note>
+      </trans-unit>
+      <trans-unit id="f9a5775d7def0b6c57393fc86bb7a730">
+        <source>Do not forget to update your exchange rate before making this change.</source>
+        <target>Do not forget to update your exchange rate before making this change.</target>
+        <note>Line: 561</note>
+      </trans-unit>
+      <trans-unit id="883370e6a8360f9ffe2e658db153fd74">
+        <source>This feature will generate a random password and send an email to the customer.</source>
+        <target>This feature will generate a random password and send an email to the customer.</target>
+        <note>Line: 599</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d17f6ab68839ef4a39ead0638cae47a2">
+        <source>View details on the customer page</source>
+        <target>View details on the customer page</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="a901cc409fe745be1a29a311b57880ce">
+        <source>View details on the order page</source>
+        <target>View details on the order page</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a43fd5e0338751959686921566de352e">
+        <source>Leave this field blank if there's no change.</source>
+        <target>Leave this field blank if there's no change.</target>
+        <note>Line: 401</note>
+      </trans-unit>
+      <trans-unit id="f6916f4f1a268d4d0014ce47a2dfc3e4">
+        <source>Password should be at least %length% characters long.</source>
+        <target>Password should be at least %length% characters long.</target>
+        <note>Line: 402</note>
+      </trans-unit>
+      <trans-unit id="6010127763b917fdc47eb0c50a86a6f6">
+        <source>Enable or disable customer login.</source>
+        <target>Enable or disable customer login.</target>
+        <note>Line: 433</note>
+      </trans-unit>
+      <trans-unit id="8c7a8f24423b8519d38fb3ff380e020f">
+        <source>This customer will receive your ads via email.</source>
+        <target>This customer will receive your ads via email.</target>
+        <note>Line: 455</note>
+      </trans-unit>
+      <trans-unit id="e7608efcc5a10b78e3a98c438c2a1b7f">
+        <source>Select all the groups that you would like to apply to this customer.</source>
+        <target>Select all the groups that you would like to apply to this customer.</target>
+        <note>Line: 481</note>
+      </trans-unit>
+      <trans-unit id="395b64636636e968c756f7514313f760">
+        <source>This group will be the user's default group.</source>
+        <target>This group will be the user's default group.</target>
+        <note>Line: 494</note>
+      </trans-unit>
+      <trans-unit id="8b7fc06b213f4fb343c72af878e5c64b">
+        <source>Only the discount for the selected group will be applied to this customer.</source>
+        <target>Only the discount for the selected group will be applied to this customer.</target>
+        <note>Line: 495</note>
+      </trans-unit>
+      <trans-unit id="75bf7b6b951d3183f7c8f96bdb4fa74c">
+        <source>Valid characters:</source>
+        <target>Valid characters:</target>
+        <note>Line: 551</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ed4bfa76b661f4b6bc94d32fe6147d57">
+        <source>Would you like to allow merchandise returns in your shop?</source>
+        <target>Would you like to allow merchandise returns in your shop?</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="c503a53add0f47d2497ca363f9ad1b76">
+        <source>How many days after the delivery date does the customer have to return a product?</source>
+        <target>How many days after the delivery date does the customer have to return a product?</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="095fcccad5a4585fdc2fe1f97fc89561">
+        <source>Prefix used for return name (e.g. RE00001).</source>
+        <target>Prefix used for return name (e.g. RE00001).</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="2bf0a7ee96f0cba7f7d530ff08f01bf8">
+        <source>Merchandise return (RMA) status.</source>
+        <target>Merchandise return (RMA) status.</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="a3d008a6e1f75882761e48de1b001497">
+        <source>List of products in return package.</source>
+        <target>List of products in return package.</target>
+        <note>Line: 137</note>
+      </trans-unit>
+      <trans-unit id="db21428a343da97c41ced5ad9ef17d56">
+        <source>The link is only available after validation and before the parcel gets delivered.</source>
+        <target>The link is only available after validation and before the parcel gets delivered.</target>
+        <note>Line: 145</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSlipController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0ecbd7a341049250b3da531530e42622">
+        <source>Prefix used for credit slips.</source>
+        <target>Prefix used for credit slips.</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="e07ffcdf6051874b295597fb64b62635">
+        <source>Format: 2012-12-31 (inclusive).</source>
+        <target>Format: 2012-12-31 (inclusive).</target>
+        <note>Line: 125</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3c1c7064989da051f0b4b904bcb408cf">
+        <source>This customer will receive your newsletter via email.</source>
+        <target>This customer will receive your newsletter via email.</target>
+        <note>Line: 1253</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8a7a048a67746f3877ab6cb1bc1d4afd">
+        <source>Format: 2011-12-31 (inclusive).</source>
+        <target>Format: 2011-12-31 (inclusive).</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="67342320cb8798c3a911e0c6d8bd026a">
+        <source>Prefix used for delivery slips.</source>
+        <target>Prefix used for delivery slips.</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="6998acbd3739a7200586b4421d0ca508">
+        <source>The next delivery slip will begin with this number and then increase with each additional slip.</source>
+        <target>The next delivery slip will begin with this number and then increase with each additional slip.</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="8cf7df5b4b5858e73a7f4e75cc658cc3">
+        <source>Adds an image before product name on Delivery-slip</source>
+        <target>Adds an image before product name on Delivery-slip</target>
+        <note>Line: 93</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fef8859b22e06e4d4918f091612bf958">
+        <source>You can also export orders which have not been charged yet.</source>
+        <target>You can also export orders which have not been charged yet.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="60422879211a12247e5da14751a59ac3">
+        <source>If enabled, your customers will receive an invoice for the purchase.</source>
+        <target>If enabled, your customers will receive an invoice for the purchase.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="afda8f59762167c6720a8afe24345df1">
+        <source>If required, show the total amount per rate of the corresponding tax.</source>
+        <target>If required, show the total amount per rate of the corresponding tax.</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="0e963c5b7a1b6bb67429c7d0e7f45741">
+        <source>Adds an image in front of the product name on the invoice</source>
+        <target>Adds an image in front of the product name on the invoice</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="7b87585267aed27676374641013ab66e">
+        <source>Freely definable prefix for invoice number (e.g. #IN00001).</source>
+        <target>Freely definable prefix for invoice number (e.g. #IN00001).</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="a93c4ec4b8ef325acf067112d7437c59">
+        <source>The next invoice will begin with this number, and then increase with each additional invoice. Set to 0 if you want to keep the current number (which is #%number%).</source>
+        <target>The next invoice will begin with this number, and then increase with each additional invoice. Set to 0 if you want to keep the current number (which is #%number%).</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="7a490daaa2605a4a5be08b30a0c6fe24">
+        <source>Use this field to show additional information on the invoice, below the payment methods summary (like specific legal information).</source>
+        <target>Use this field to show additional information on the invoice, below the payment methods summary (like specific legal information).</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="e3501dec19c50333c49b4d7d66931abc">
+        <source>This text will appear at the bottom of the invoice, below your company details.</source>
+        <target>This text will appear at the bottom of the invoice, below your company details.</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="4e00dcdfbf2f4a6156c01fb15ded75c5">
+        <source>Choose an invoice model.</source>
+        <target>Choose an invoice model.</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="41d8a2a057a1e1b9663d49896d3162f3">
+        <source>Saves memory but slows down the PDF generation.</source>
+        <target>Saves memory but slows down the PDF generation.</target>
+        <note>Line: 122</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminOrderscustomersNotification.xlf
+++ b/app/Resources/translations/default/AdminOrderscustomersNotification.xlf
@@ -1,1102 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="aea807cc550550acd7b8d9a7bc469f6a">
-        <source>You have to select a shop before creating new orders.</source>
-        <target>You have to select a shop before creating new orders.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:219</note>
-      </trans-unit>
-      <trans-unit id="accfc34fe6c65228a926b524870161ab">
-        <source>This cart does not exists</source>
-        <target>This cart does not exists</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:225</note>
-      </trans-unit>
-      <trans-unit id="3d4d2d9627d3f1b1c0d22b9e85c687d1">
-        <source>The cart must have a customer</source>
-        <target>The cart must have a customer</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:228</note>
-      </trans-unit>
-      <trans-unit id="a42a075994b3ee0f6fe5956110d85889">
-        <source>Order status #%id% cannot be loaded</source>
-        <target>Order status #%id% cannot be loaded</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:380</note>
-      </trans-unit>
-      <trans-unit id="4fe1644600a7dad640143da346a9211b">
-        <source>Order #%d cannot be loaded</source>
-        <target>Order #%d cannot be loaded</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:385</note>
-      </trans-unit>
-      <trans-unit id="409f3dfd9f910287f86fd6c25c94c4d8">
-        <source>Order #%d has already been assigned this status.</source>
-        <target>Order #%d has already been assigned this status.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:389</note>
-      </trans-unit>
-      <trans-unit id="18893a82469e2cd9492fc8d46fa8ac01">
-        <source>An error occurred while changing the status for order #%d, or we were unable to send an email to the customer.</source>
-        <target>An error occurred while changing the status for order #%d, or we were unable to send an email to the customer.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:414</note>
-      </trans-unit>
-      <trans-unit id="45d4b3afac71a54470a6cbf828e8cb0d">
-        <source>The order carrier ID is invalid.</source>
-        <target>The order carrier ID is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:468</note>
-      </trans-unit>
-      <trans-unit id="e52d022f0fb2160ec1cf7b4122ab9589">
-        <source>The tracking number is incorrect.</source>
-        <target>The tracking number is incorrect.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:470</note>
-      </trans-unit>
-      <trans-unit id="561918c3c49ff748f543e28f5c405d3c">
-        <source>An error occurred while sending an email to the customer.</source>
-        <target>An error occurred while sending an email to the customer.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:668</note>
-      </trans-unit>
-      <trans-unit id="f465ea6c7866853ecc49286449720ac9">
-        <source>The order carrier cannot be updated.</source>
-        <target>The order carrier cannot be updated.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:510</note>
-      </trans-unit>
-      <trans-unit id="c2572d1fee836c06c88e0bdc9fa7ffa1">
-        <source>The new order status is invalid.</source>
-        <target>The new order status is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:522</note>
-      </trans-unit>
-      <trans-unit id="4f51deabdeba4ee61b998d3b0cf188b4">
-        <source>An error occurred while changing order status, or we were unable to send an email to the customer.</source>
-        <target>An error occurred while changing order status, or we were unable to send an email to the customer.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:556</note>
-      </trans-unit>
-      <trans-unit id="c5e4a57d9572678ffbb124db39542928">
-        <source>The order has already been assigned this status.</source>
-        <target>The order has already been assigned this status.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:558</note>
-      </trans-unit>
-      <trans-unit id="f61c60ff8d82ebd1012606e5bc3a2002">
-        <source>The customer is invalid.</source>
-        <target>The customer is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:569</note>
-      </trans-unit>
-      <trans-unit id="3dc245110e1f3601860c20299d97c01d">
-        <source>The message cannot be blank.</source>
-        <target>The message cannot be blank.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:571</note>
-      </trans-unit>
-      <trans-unit id="204c3558e41366f3d558ce8e01426a22">
-        <source>field %s is required.</source>
-        <target>field %s is required.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:578</note>
-      </trans-unit>
-      <trans-unit id="c4d82e8095bb903683e0b0e73887aef0">
-        <source>Please enter a quantity to proceed with your refund.</source>
-        <target>Please enter a quantity to proceed with your refund.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:864</note>
-      </trans-unit>
-      <trans-unit id="8a5f368eac3aab699cf8e6e1ec28b695">
-        <source>Please enter an amount to proceed with your refund.</source>
-        <target>Please enter an amount to proceed with your refund.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:866</note>
-      </trans-unit>
-      <trans-unit id="598db0342f11f89d4268942b9491c455">
-        <source>You cannot generate a partial credit slip.</source>
-        <target>You cannot generate a partial credit slip.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:752</note>
-      </trans-unit>
-      <trans-unit id="b1db8cec4ec0de83c3934a22bc758a3b">
-        <source>You cannot generate a voucher.</source>
-        <target>You cannot generate a voucher.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1110</note>
-      </trans-unit>
-      <trans-unit id="bd4457c0f19f796f3d66726f9fadc041">
-        <source>The partial refund data is incorrect.</source>
-        <target>The partial refund data is incorrect.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:875</note>
-      </trans-unit>
-      <trans-unit id="991bbcc5660531bc1a1c8f1c235794c0">
-        <source>You must select a product.</source>
-        <target>You must select a product.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:884</note>
-      </trans-unit>
-      <trans-unit id="6d3fd0eb289900145d482634d6e86b90">
-        <source>You must enter a quantity.</source>
-        <target>You must enter a quantity.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:886</note>
-      </trans-unit>
-      <trans-unit id="8001500c3284edd9c4dd07ae508e5a95">
-        <source>No quantity has been selected for this product.</source>
-        <target>No quantity has been selected for this product.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:950</note>
-      </trans-unit>
-      <trans-unit id="38eaecfc1ef14b98b5d6e4eb77494369">
-        <source>An invalid quantity was selected for this product.</source>
-        <target>An invalid quantity was selected for this product.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:954</note>
-      </trans-unit>
-      <trans-unit id="bf772d53e730d2e0169ed2f746044606">
-        <source>An error occurred while attempting to delete the product.</source>
-        <target>An error occurred while attempting to delete the product.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:971</note>
-      </trans-unit>
-      <trans-unit id="77d97f5686dfef72ee577e779d5bb74f">
-        <source>An error occurred while attempting to delete product customization.</source>
-        <target>An error occurred while attempting to delete product customization.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:993</note>
-      </trans-unit>
-      <trans-unit id="edeff0d68d3d20ce1f6189f6070cb2ba">
-        <source>A credit slip cannot be generated.</source>
-        <target>A credit slip cannot be generated.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1031</note>
-      </trans-unit>
-      <trans-unit id="b81f0a0540938a2e7daa684f02866696">
-        <source>No product or quantity has been selected.</source>
-        <target>No product or quantity has been selected.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1140</note>
-      </trans-unit>
-      <trans-unit id="fdb259bd3d5479c25f5d23af490b5ec3">
-        <source>The order cannot be found</source>
-        <target>The order cannot be found</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1165</note>
-      </trans-unit>
-      <trans-unit id="9391de9e24bd71839f6f72a1517de2d6">
-        <source>The amount is invalid.</source>
-        <target>The amount is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1167</note>
-      </trans-unit>
-      <trans-unit id="6ab061ec12504fab2c41f0689579d623">
-        <source>The selected payment method is invalid.</source>
-        <target>The selected payment method is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1169</note>
-      </trans-unit>
-      <trans-unit id="7d0d71a3e577be4c20799b52286191d6">
-        <source>The transaction ID is invalid.</source>
-        <target>The transaction ID is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1171</note>
-      </trans-unit>
-      <trans-unit id="3b512b6c31ef4f46605159612691eb56">
-        <source>The selected currency is invalid.</source>
-        <target>The selected currency is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1173</note>
-      </trans-unit>
-      <trans-unit id="06fc8d486e9f83c5810a21857da7b656">
-        <source>The invoice is invalid.</source>
-        <target>The invoice is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1175</note>
-      </trans-unit>
-      <trans-unit id="f50c7cba4df874039d73ee480d678f5e">
-        <source>The date is invalid</source>
-        <target>The date is invalid</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1177</note>
-      </trans-unit>
-      <trans-unit id="04e3713831c71d70817d4a69eadbc53c">
-        <source>An error occurred during payment.</source>
-        <target>An error occurred during payment.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1180</note>
-      </trans-unit>
-      <trans-unit id="0d906d12a6321e5f13e69dab92e39a4e">
-        <source>The invoice note was not saved.</source>
-        <target>The invoice note was not saved.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1197</note>
-      </trans-unit>
-      <trans-unit id="7f5a75ac350db917dc60cfbd8299da5b">
-        <source>Failed to upload the invoice and edit its note.</source>
-        <target>Failed to upload the invoice and edit its note.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1203</note>
-      </trans-unit>
-      <trans-unit id="68b7afe49451dbdab7cbeff4f66be369">
-        <source>This delivery address country is not active.</source>
-        <target>This delivery address country is not active.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1223</note>
-      </trans-unit>
-      <trans-unit id="a9320eb7be798958cba0a93262521ede">
-        <source>This invoice address country is not active.</source>
-        <target>This invoice address country is not active.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1225</note>
-      </trans-unit>
-      <trans-unit id="95aa605fa7f396d370b4c87afad9201c">
-        <source>This address can't be loaded</source>
-        <target>This address can't be loaded</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1256</note>
-      </trans-unit>
-      <trans-unit id="b0535e1868ad530e5faadf295516a724">
-        <source>You cannot change the currency.</source>
-        <target>You cannot change the currency.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1351</note>
-      </trans-unit>
-      <trans-unit id="8dcb8970b8eeeac73c8d312d1db3d1f9">
-        <source>Invoice management has been disabled.</source>
-        <target>Invoice management has been disabled.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1358</note>
-      </trans-unit>
-      <trans-unit id="f98321e34948f600959c5c4200c953c8">
-        <source>This order already has an invoice.</source>
-        <target>This order already has an invoice.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1360</note>
-      </trans-unit>
-      <trans-unit id="0da1c0afe7d3d89a53a5d00998bb4295">
-        <source>You cannot edit this cart rule.</source>
-        <target>You cannot edit this cart rule.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1400</note>
-      </trans-unit>
-      <trans-unit id="db7cb022c7b6058d0f1668faa22a54fa">
-        <source>You must specify a name in order to create a new discount.</source>
-        <target>You must specify a name in order to create a new discount.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1408</note>
-      </trans-unit>
-      <trans-unit id="7b56734426bcdd50629f41c58cb1f241">
-        <source>The discount value is invalid.</source>
-        <target>The discount value is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1447</note>
-      </trans-unit>
-      <trans-unit id="8dc19f50ae30ac7d61e67c795b32fd47">
-        <source>The discount value is greater than the order invoice total.</source>
-        <target>The discount value is greater than the order invoice total.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1467</note>
-      </trans-unit>
-      <trans-unit id="574875d4553bada6682a07ae86298bc6">
-        <source>The discount value is greater than the order total.</source>
-        <target>The discount value is greater than the order total.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1478</note>
-      </trans-unit>
-      <trans-unit id="9a9d54664b6ba23a9588f6b795dc03ab">
-        <source>The discount type is invalid.</source>
-        <target>The discount type is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1514</note>
-      </trans-unit>
-      <trans-unit id="b046e96ee00ad2ef4ed135eab1c13df4">
-        <source>An error occurred during the OrderCartRule creation</source>
-        <target>An error occurred during the OrderCartRule creation</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1567</note>
-      </trans-unit>
-      <trans-unit id="0fa578512847280157dd62ae18e92979">
-        <source>An error occurred while loading order status.</source>
-        <target>An error occurred while loading order status.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1578</note>
-      </trans-unit>
-      <trans-unit id="fded441ef916f653d49abf142b535b52">
-        <source>An error occurred while sending the e-mail to the customer.</source>
-        <target>An error occurred while sending the e-mail to the customer.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1591</note>
-      </trans-unit>
-      <trans-unit id="aeddc664f1e95691c69ea44a5c1c18f5">
-        <source>This product is out of stock: </source>
-        <target>This product is out of stock:</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1784</note>
-      </trans-unit>
-      <trans-unit id="4174f012bc63b679f092acd1a933bf5c">
-        <source>The email was sent to your customer.</source>
-        <target>The email was sent to your customer.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2033</note>
-      </trans-unit>
-      <trans-unit id="773b660773e6106c248814fa87b480f7">
-        <source>Error in sending the email to your customer.</source>
-        <target>Error in sending the email to your customer.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2037</note>
-      </trans-unit>
-      <trans-unit id="4dc1c8fa2f766c5e201155ee3737ed3f">
-        <source>The order object cannot be loaded.</source>
-        <target>The order object cannot be loaded.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2789</note>
-      </trans-unit>
-      <trans-unit id="7152cf69405fd47a8bd2f7b625ce324e">
-        <source>You cannot add products to delivered orders.</source>
-        <target>You cannot add products to delivered orders.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2057</note>
-      </trans-unit>
-      <trans-unit id="9b7508b5ee1050d5c5efb9b1cf76fd36">
-        <source>The product object cannot be loaded.</source>
-        <target>The product object cannot be loaded.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2400</note>
-      </trans-unit>
-      <trans-unit id="74bd055cec720c9f41563ff6a6a40b7b">
-        <source>The combination object cannot be loaded.</source>
-        <target>The combination object cannot be loaded.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2080</note>
-      </trans-unit>
-      <trans-unit id="0d38c90d843c787c0be14f790998210c">
-        <source>You must add %d minimum quantity</source>
-        <target>You must add %d minimum quantity</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2145</note>
-      </trans-unit>
-      <trans-unit id="de10fc28511b894f704c1a67fcff7b4f">
-        <source>You already have the maximum quantity available for this product.</source>
-        <target>You already have the maximum quantity available for this product.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2147</note>
-      </trans-unit>
-      <trans-unit id="6a94d8492279c2bfd3e81f3158658980">
-        <source>[Generated] CartRule for Free Shipping</source>
-        <target>[Generated] CartRule for Free Shipping</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2162</note>
-      </trans-unit>
-      <trans-unit id="4e670964e358534a827dc7e0359281b0">
-        <source>The OrderDetail object cannot be loaded.</source>
-        <target>The OrderDetail object cannot be loaded.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2392</note>
-      </trans-unit>
-      <trans-unit id="0c8a625097a9b711bfca4724517eeb01">
-        <source>The address object cannot be loaded.</source>
-        <target>The address object cannot be loaded.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2408</note>
-      </trans-unit>
-      <trans-unit id="7da127d075ca24fec224c1d497aac11f">
-        <source>An error occurred while editing the product line.</source>
-        <target>An error occurred while editing the product line.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2598</note>
-      </trans-unit>
-      <trans-unit id="fde52aaef1e1e23770e40a458a1cac46">
-        <source>An error occurred while attempting to delete the product line.</source>
-        <target>An error occurred while attempting to delete the product line.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2667</note>
-      </trans-unit>
-      <trans-unit id="e3a212006776535d5da7d11f7c62d727">
-        <source>The Order Detail object could not be loaded.</source>
-        <target>The Order Detail object could not be loaded.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2782</note>
-      </trans-unit>
-      <trans-unit id="823eba6da615c2a384cf8e13cd70980b">
-        <source>The invoice object cannot be loaded.</source>
-        <target>The invoice object cannot be loaded.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2716</note>
-      </trans-unit>
-      <trans-unit id="0af3cc300f35caff086e21bf2f865960">
-        <source>You cannot edit the order detail for this order.</source>
-        <target>You cannot edit the order detail for this order.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2730</note>
-      </trans-unit>
-      <trans-unit id="7ea9212dcdaccc580b9e6b548609e7fd">
-        <source>You cannot edit a delivered order.</source>
-        <target>You cannot edit a delivered order.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2804</note>
-      </trans-unit>
-      <trans-unit id="675b81dace2c99f5ef5eb6ac3f69dbe4">
-        <source>You cannot use this invoice for the order</source>
-        <target>You cannot use this invoice for the order</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2745</note>
-      </trans-unit>
-      <trans-unit id="2591b6d46f45d8f60e24c6c9c96a2a11">
-        <source>Invalid price</source>
-        <target>Invalid price</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2756</note>
-      </trans-unit>
-      <trans-unit id="01816dd287bcb3b88ad3f63970ce045f">
-        <source>Invalid quantity</source>
-        <target>Invalid quantity</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2770</note>
-      </trans-unit>
-      <trans-unit id="c181d4415ea3fd71c407da3697be421f">
-        <source>You cannot delete the order detail.</source>
-        <target>You cannot delete the order detail.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2796</note>
-      </trans-unit>
-      <trans-unit id="671cd4e79283dd9931f0452000bf2744">
-        <source>This product cannot be re-stocked.</source>
-        <target>This product cannot be re-stocked.</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2951</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminPdfController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1244f34e7f971d0b80cd2fd7cbbfb22c">
-        <source>The order cannot be found within your database.</source>
-        <target>The order cannot be found within your database.</target>
-        <note>Context:
-File: controllers/admin/AdminPdfController.php:187</note>
-      </trans-unit>
-      <trans-unit id="f193c3dd6da8a06a610c632db03d55c8">
-        <source>The order ID -- or the invoice order ID -- is missing.</source>
-        <target>The order ID -- or the invoice order ID -- is missing.</target>
-        <note>Context:
-File: controllers/admin/AdminPdfController.php:89</note>
-      </trans-unit>
-      <trans-unit id="48607ff5af8c52b5efbc057b852a37ee">
-        <source>No invoice was found.</source>
-        <target>No invoice was found.</target>
-        <note>Context:
-File: controllers/admin/AdminPdfController.php:140</note>
-      </trans-unit>
-      <trans-unit id="57bf4b0dd7dd3e5af10533785a343f88">
-        <source>No order slips were found.</source>
-        <target>No order slips were found.</target>
-        <note>Context:
-File: controllers/admin/AdminPdfController.php:124</note>
-      </trans-unit>
-      <trans-unit id="f2e9d5988718c8a3dde49c6bcb55125b">
-        <source>The supply order ID is missing.</source>
-        <target>The supply order ID is missing.</target>
-        <note>Context:
-File: controllers/admin/AdminPdfController.php:149</note>
-      </trans-unit>
-      <trans-unit id="4fc152e203df7a77fa3c1bc7f1249f36">
-        <source>The supply order cannot be found within your database.</source>
-        <target>The supply order cannot be found within your database.</target>
-        <note>Context:
-File: controllers/admin/AdminPdfController.php:156</note>
-      </trans-unit>
-      <trans-unit id="d7e5dfc920c9871caaf7562d8ba9ab36">
-        <source>The order invoice cannot be found within your database.</source>
-        <target>The order invoice cannot be found within your database.</target>
-        <note>Context:
-File: controllers/admin/AdminPdfController.php:199</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="35af021c4bdb02cad86c917022e053da">
-        <source>An error has occurred: Can't save the current order's return status.</source>
-        <target>An error has occurred: Can't save the current order's return status.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:556</note>
-      </trans-unit>
-      <trans-unit id="ca215ff3d829e3a6a9c0c672987d5959">
-        <source>An error has occurred: Can't delete the current order's return status.</source>
-        <target>An error has occurred: Can't delete the current order's return status.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:576</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b3d571edf77b87b3be5cb3db48d88aa6">
-        <source>An error occurred. Your message was not sent. Please contact your system administrator.</source>
-        <target>An error occurred. Your message was not sent. Please contact your system administrator.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:482</note>
-      </trans-unit>
-      <trans-unit id="d9c93c77e4f2eb90e8457f586e0c5cb3">
-        <source>Cannot create message in a new thread.</source>
-        <target>Cannot create message in a new thread.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:1082</note>
-      </trans-unit>
-      <trans-unit id="142c7111dc9e81f5cf273851ccce9fcc">
-        <source>The message body is empty, cannot import it.</source>
-        <target>The message body is empty, cannot import it.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:1147</note>
-      </trans-unit>
-      <trans-unit id="5d1cbbd2b78574a8cfac676d8bdb9ea4">
-        <source>Invalid message content for subject: %s</source>
-        <target>Invalid message content for subject: %s</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:1154</note>
-      </trans-unit>
-      <trans-unit id="f70f856f6d471d374aaf5080afeb1e53">
-        <source>The message content is not valid, cannot import it.</source>
-        <target>The message content is not valid, cannot import it.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:1160</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="53a60d3bbec32a4bf2777704834dc35e">
-        <source>You must add a minimum quantity of %d</source>
-        <target>You must add a minimum quantity of %d</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:490</note>
-      </trans-unit>
-      <trans-unit id="996a45aa702d041706f6388d54c53b12">
-        <source>Invalid order</source>
-        <target>Invalid order</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:571</note>
-      </trans-unit>
-      <trans-unit id="5125d7cea2749d85f13a55a023a56c71">
-        <source>The order cannot be renewed.</source>
-        <target>The order cannot be renewed.</target>
-        <note>Context:
-File: controllers/admin/AdminCartsController.php:578</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminAddressesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1c623b291d95f4f1b1d0c03d0dc0ffa1">
-        <source>This email address is not registered.</source>
-        <target>This email address is not registered.</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:350</note>
-      </trans-unit>
-      <trans-unit id="a58058b92c1584b1bdc413ac3d2e6699">
-        <source>This customer ID is not recognized.</source>
-        <target>This customer ID is not recognized.</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:357</note>
-      </trans-unit>
-      <trans-unit id="02c1c5ece60602356e41d407a81cb1fe">
-        <source>This email address is not valid. Please use an address like bob@example.com.</source>
-        <target>This email address is not valid. Please use an address like bob@example.com.</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:360</note>
-      </trans-unit>
-      <trans-unit id="7c77177e0084c27161d63e7de535a1c6">
-        <source>The identification number is incorrect or has already been used.</source>
-        <target>The identification number is incorrect or has already been used.</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:363</note>
-      </trans-unit>
-      <trans-unit id="27ac5352d430b82c99157e2dc13a96e3">
-        <source>You have selected a state for a country that does not contain states.</source>
-        <target>You have selected a state for a country that does not contain states.</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:371</note>
-      </trans-unit>
-      <trans-unit id="86de674d7405670db52e79ec1665b0b1">
-        <source>An address located in a country containing states must have a state selected.</source>
-        <target>An address located in a country containing states must have a state selected.</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:376</note>
-      </trans-unit>
-      <trans-unit id="03c123f62aad70a9533f5049cf3af959">
-        <source>An error occurred while linking this address to its order.</source>
-        <target>An error occurred while linking this address to its order.</target>
-        <note>Context:
-File: controllers/admin/AdminAddressesController.php:416</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5844cf5e9f752e6eb7cc1166a3022183">
-        <source>No order was found with this ID:</source>
-        <target>No order was found with this ID:</target>
-        <note>Context:
-File: controllers/admin/AdminSearchController.php:123</note>
-      </trans-unit>
-      <trans-unit id="3b27bc623d860beacbe5d5cde18fdec0">
-        <source>No invoice was found with this ID:</source>
-        <target>No invoice was found with this ID:</target>
-        <note>Context:
-File: controllers/admin/AdminSearchController.php:133</note>
-      </trans-unit>
-      <trans-unit id="ec79affe41245b47969a2451211b263a">
-        <source>No cart was found with this ID:</source>
-        <target>No cart was found with this ID:</target>
-        <note>Context:
-File: controllers/admin/AdminSearchController.php:141</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9e2dcf2660b82a0204f668565417010a">
-        <source>An account already exists for this email address:</source>
-        <target>An account already exists for this email address:</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:920</note>
-      </trans-unit>
-      <trans-unit id="df46bf546fc69b1cda65afe1001b73fc">
-        <source>You have to select a shop if you want to create a customer.</source>
-        <target>You have to select a shop if you want to create a customer.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:206</note>
-      </trans-unit>
-      <trans-unit id="bde13610a2ae2521b30aa7821d553862">
-        <source>There is no status defined for this order.</source>
-        <target>There is no status defined for this order.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:726</note>
-      </trans-unit>
-      <trans-unit id="03552140a267acc27f494dc3ab368067">
-        <source>Unknown delete mode:</source>
-        <target>Unknown delete mode:</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:867</note>
-      </trans-unit>
-      <trans-unit id="7298a088a582ffc05f2c777afb3115cb">
-        <source>Password cannot be empty.</source>
-        <target>Password cannot be empty.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:897</note>
-      </trans-unit>
-      <trans-unit id="0a53e9e61f2a9bf59e9028b42fbd8166">
-        <source>An error occurred while loading the object.</source>
-        <target>An error occurred while loading the object.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:926</note>
-      </trans-unit>
-      <trans-unit id="77ae44aa6c998166fcf1a87496278ad5">
-        <source>(cannot load object)</source>
-        <target>(cannot load object)</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:927</note>
-      </trans-unit>
-      <trans-unit id="c0498039cc042a1109b53933dc33b2e7">
-        <source>A default customer group must be selected in group box.</source>
-        <target>A default customer group must be selected in group box.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:935</note>
-      </trans-unit>
-      <trans-unit id="8562db06e3931e51ac8c456b56088b02">
-        <source>This customer does not exist.</source>
-        <target>This customer does not exist.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:965</note>
-      </trans-unit>
-      <trans-unit id="4383b950a18d0fd893e237148f5f58ca">
-        <source>This customer already exists as a non-guest.</source>
-        <target>This customer already exists as a non-guest.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:968</note>
-      </trans-unit>
-      <trans-unit id="beaa75cbedc3443661b894ed66c76b13">
-        <source>An error occurred while updating customer information.</source>
-        <target>An error occurred while updating customer information.</target>
-        <note>Context:
-File: controllers/admin/AdminCustomersController.php:1007</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/statsorigin/statsorigin.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="14542f5997c4a02d4276da364657f501">
-        <source>Direct link</source>
-        <target>Direct link</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:57</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7582ef2f5b5de8a479994d0412986bc2">
-        <source>An error occurred while deleting the details of your order return.</source>
-        <target>An error occurred while deleting the details of your order return.</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:224</note>
-      </trans-unit>
-      <trans-unit id="d4430672c8b3c123ae5f4c2f4b5b458d">
-        <source>You need at least one product.</source>
-        <target>You need at least one product.</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:227</note>
-      </trans-unit>
-      <trans-unit id="e7a58e52e848f513c3e9185d34d61a50">
-        <source>The order return is invalid.</source>
-        <target>The order return is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:230</note>
-      </trans-unit>
-      <trans-unit id="5431bd88788ce2df4278c84f402e3cb6">
-        <source>The order return content is invalid.</source>
-        <target>The order return content is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:233</note>
-      </trans-unit>
-      <trans-unit id="16f2adf6c4fd1317acba5871267a60f2">
-        <source>No order return ID has been specified.</source>
-        <target>No order return ID has been specified.</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:281</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByDateDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9178a1a9fc82617864593a784163d86a">
-        <source>Invalid "From" date</source>
-        <target>Invalid "From" date</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByDateDataProvider.php:88</note>
-      </trans-unit>
-      <trans-unit id="915bd2c5cf6e420095a64d309e443849">
-        <source>Invalid "To" date</source>
-        <target>Invalid "To" date</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByDateDataProvider.php:96</note>
-      </trans-unit>
-      <trans-unit id="f775c161c8662af8f70a128ad5779036">
-        <source>No invoice has been found for this period.</source>
-        <target>No invoice has been found for this period.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByDateDataProvider.php:104</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSlipController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cdbb58c797028e137b1ebf1dcc9efe92">
-        <source>No order slips were found for this period.</source>
-        <target>No order slips were found for this period.</target>
-        <note>Context:
-File: controllers/admin/AdminSlipController.php:159</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Order/Delivery/SlipPdfConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3ffd1b6c5e4ab9c98104475480477307">
-        <source>No delivery slip was found for this period.</source>
-        <target>No delivery slip was found for this period.</target>
-        <note>Context:
-File: src/Adapter/Order/Delivery/SlipPdfConfiguration.php:82</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="599b433088f71a8712de225a693ce20e">
-        <source>Invalid invoice number.</source>
-        <target>Invalid invoice number.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsDataProvider.php:95</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByStatusDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="eb9173ba78d315a23d8978a2b772bd9a">
-        <source>You must select at least one order status.</source>
-        <target>You must select at least one order status.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByStatusDataProvider.php:67</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceByStatusFormHandler.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7af95cd9cbe318a15ef10e5e30000501">
-        <source>No invoice has been found for this status.</source>
-        <target>No invoice has been found for this status.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceByStatusFormHandler.php:95</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/order/OrderHistory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f22b1baf8dcfb014646921be9841cb41">
-        <source>expires on %s.</source>
-        <target>expires on %s.</target>
-        <note>Context:
-File: classes/order/OrderHistory.php:142</note>
-      </trans-unit>
-      <trans-unit id="0db24e725e6876d0fc7467554e8b6c03">
-        <source>downloadable %d time(s)</source>
-        <target>downloadable %d time(s)</target>
-        <note>Context:
-File: classes/order/OrderHistory.php:145</note>
-      </trans-unit>
-      <trans-unit id="e1e95b3cea70730a922b35808ca3dce3">
-        <source>Invalid new order status</source>
-        <target>Invalid new order status</target>
-        <note>Context:
-File: classes/order/OrderHistory.php:352</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9cdca3c7972c48111e79648c942ac672">
-        <source>The message was successfully sent to the customer.</source>
-        <target>The message was successfully sent to the customer.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:463</note>
-      </trans-unit>
-      <trans-unit id="1923e1e610686f1182bf54f573b86921">
-        <source>A partial refund was successfully created.</source>
-        <target>A partial refund was successfully created.</target>
-        <note>Context:
-File: classes/controller/AdminController.php:483</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_discount_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4d734cc32a5cac86597621969696baa8">
-        <source>This value must include taxes.</source>
-        <target>This value must include taxes.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_discount_form.tpl:62</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="65247263c6ea1d91027b28a41db8cb4b">
-        <source>Editing this product line will remove the reduction and base price.</source>
-        <target>Editing this product line will remove the reduction and base price.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_product_line.tpl:47</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e1b638a956fae226de3740f63a4e7d48">
-        <source>Are you sure you want to add this quantity?</source>
-        <target>Are you sure you want to add this quantity?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:43</note>
-      </trans-unit>
-      <trans-unit id="e2103a9e878a2280b3163e5ee098cbdf">
-        <source>Are you sure you want to create a new invoice?</source>
-        <target>Are you sure you want to create a new invoice?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:44</note>
-      </trans-unit>
-      <trans-unit id="bcab2ed7cab19f8e119317a7e59d316a">
-        <source>Error: No product has been selected</source>
-        <target>Error: No product has been selected</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="cd5cb1c932fc6f41a4fb3f6ec2f0c2da">
-        <source>Error: Quantity of products must be set</source>
-        <target>Error: Quantity of products must be set</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="894fdeeda7d3575fd6775732d026992c">
-        <source>Error: Product price must be set</source>
-        <target>Error: Product price must be set</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:47</note>
-      </trans-unit>
-      <trans-unit id="c4832c266d52c6cef340a9c656ddda26">
-        <source>Error. You cannot refund a negative amount.</source>
-        <target>Error. You cannot refund a negative amount.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="14c7a12fdbf437a0545aed3365ce3f84">
-        <source>No merchandise returned yet</source>
-        <target>No merchandise returned yet</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:380</note>
-      </trans-unit>
-      <trans-unit id="153c7809e6b00b6cbfa01b8aa9db43e3">
-        <source>paid instead of</source>
-        <target>paid instead of</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:407</note>
-      </trans-unit>
-      <trans-unit id="7137dec9b59978006f8b0ec036099346">
-        <source>This warning also concerns order </source>
-        <target>This warning also concerns order </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:412</note>
-      </trans-unit>
-      <trans-unit id="f38c718d5cc5ea7331d8acf533f9bf0d">
-        <source>This warning also concerns the next orders:</source>
-        <target>This warning also concerns the next orders:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:414</note>
-      </trans-unit>
-      <trans-unit id="de78da3154b793d64d302db27e65baec">
-        <source>No payment methods are available</source>
-        <target>No payment methods are available</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:497</note>
-      </trans-unit>
-      <trans-unit id="ecd2046a1d4a6e46c11914c04b9559e4">
-        <source>A registered customer account has already claimed this email address</source>
-        <target>A registered customer account has already claimed this email address</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:603</note>
-      </trans-unit>
-      <trans-unit id="341ee6bf57abde84135c32f55a607de2">
-        <source>Do you want to send this message to the customer?</source>
-        <target>Do you want to send this message to the customer?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:824</note>
-      </trans-unit>
-      <trans-unit id="dc8d1b4e8c9bdf1eed97eb9ed5877a43">
-        <source>Do you want to overwrite your existing message?</source>
-        <target>Do you want to overwrite your existing message?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:829</note>
-      </trans-unit>
-      <trans-unit id="44f36e0e113ab5d842c47691364f6eb4">
-        <source>This product cannot be returned.</source>
-        <target>This product cannot be returned.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:889</note>
-      </trans-unit>
-      <trans-unit id="b8d649752e2493d7d761b05cc255c3fd">
-        <source>Quantity to cancel is greater than quantity available.</source>
-        <target>Quantity to cancel is greater than quantity available.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:889</note>
-      </trans-unit>
-      <trans-unit id="49641a1085f245fe45d45881544d1cec">
-        <source>For this customer group, prices are displayed as: [1]%tax_method%[/1]</source>
-        <target>For this customer group, prices are displayed as: [1]%tax_method%[/1]</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:994</note>
-      </trans-unit>
-      <trans-unit id="ef5f330df17f8c955005c26466c2463c">
-        <source>Merchandise returns are disabled</source>
-        <target>Merchandise returns are disabled</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1004</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2e66149518ba8dc45a9e51c4f153cebf">
-        <source><![CDATA[Please note that carrier change will not recalculate your shipping costs, if you want to change this please visit Shop Parameters > Order Settings]]></source>
-        <target><![CDATA[Please note that carrier change will not recalculate your shipping costs, if you want to change this please visit Shop Parameters > Order Settings]]></target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_shipping.tpl:101</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_documents.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5db361171166373b9694fc4aeb0932b5">
-        <source>There is no available document</source>
-        <target>There is no available document</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:165</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c6ba3f7beac8724d025d570d002b1579">
-        <source>No voucher was found</source>
-        <target>No voucher was found</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:104</note>
-      </trans-unit>
-      <trans-unit id="afdbd71037839ec5a581febacab7bad7">
-        <source>No customers found</source>
-        <target>No customers found</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:509</note>
-      </trans-unit>
-      <trans-unit id="29c14e1df15d10b73ec9605fd146b9fe">
-        <source>No carrier can be applied to this order</source>
-        <target>No carrier can be applied to this order</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:606</note>
-      </trans-unit>
-      <trans-unit id="b9af8635591dc44009ccd8e5389722ec">
-        <source>No products found</source>
-        <target>No products found</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:694</note>
-      </trans-unit>
-      <trans-unit id="43c2b5547b84d3fe632a8297c27ed20e">
-        <source>You must add at least one address to process the order.</source>
-        <target>You must add at least one address to process the order.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1057</note>
-      </trans-unit>
-      <trans-unit id="453c92894f48764318534163c2bb2830">
-        <source>The prices are without taxes.</source>
-        <target>The prices are without taxes.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1277</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="764368526633c5baf14291ba7fbb9e05">
         <source>For this particular customer group, prices are displayed as:</source>
         <target>For this particular customer group, prices are displayed as:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:221</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c7b085efe30557dbc76c2ba487506049">
-        <source>A registered customer account using the defined email address already exists. </source>
-        <target>A registered customer account using the defined email address already exists. </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:176</note>
-      </trans-unit>
-      <trans-unit id="1c28cbdd010068123432a5885ebfdb65">
-        <source>No cart is available</source>
-        <target>No cart is available</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:301</note>
+        <note>Line: 221</note>
       </trans-unit>
     </body>
   </file>
@@ -1105,26 +14,947 @@ File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.
       <trans-unit id="a37bf274ad160c76e7d17b9178bc1f57">
         <source>How do you want to delete the selected customers?</source>
         <target>How do you want to delete the selected customers?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/list/list_header.tpl:40</note>
+        <note>Line: 40</note>
       </trans-unit>
       <trans-unit id="6513e5e8645f98d950d6174b30c151b8">
         <source>There are two ways of deleting a customer. Please choose your preferred method.</source>
         <target>There are two ways of deleting a customer. Please choose your preferred method.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/list/list_header.tpl:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="ecace08642e28fc9c2704b5f73605b6d">
         <source>I want my customers to be able to register again with the same email address. All data will be removed from the database.</source>
         <target>I want my customers to be able to register again with the same email address. All data will be removed from the database.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/list/list_header.tpl:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="fd5b3faeaab816c19b1337785c0b531b">
         <source>I do not want my customer(s) to register again with the same email address. All selected customer(s) will be removed from this list but their corresponding data will be kept in the database.</source>
         <target>I do not want my customer(s) to register again with the same email address. All selected customer(s) will be removed from this list but their corresponding data will be kept in the database.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/list/list_header.tpl:53</note>
+        <note>Line: 53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c7b085efe30557dbc76c2ba487506049">
+        <source>A registered customer account using the defined email address already exists. </source>
+        <target>A registered customer account using the defined email address already exists. </target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="1c28cbdd010068123432a5885ebfdb65">
+        <source>No cart is available</source>
+        <target>No cart is available</target>
+        <note>Line: 301</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_discount_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4d734cc32a5cac86597621969696baa8">
+        <source>This value must include taxes.</source>
+        <target>This value must include taxes.</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_documents.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5db361171166373b9694fc4aeb0932b5">
+        <source>There is no available document</source>
+        <target>There is no available document</target>
+        <note>Line: 165</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="65247263c6ea1d91027b28a41db8cb4b">
+        <source>Editing this product line will remove the reduction and base price.</source>
+        <target>Editing this product line will remove the reduction and base price.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2e66149518ba8dc45a9e51c4f153cebf">
+        <source><![CDATA[Please note that carrier change will not recalculate your shipping costs, if you want to change this please visit Shop Parameters > Order Settings]]></source>
+        <target><![CDATA[Please note that carrier change will not recalculate your shipping costs, if you want to change this please visit Shop Parameters > Order Settings]]></target>
+        <note>Line: 101</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c6ba3f7beac8724d025d570d002b1579">
+        <source>No voucher was found</source>
+        <target>No voucher was found</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="afdbd71037839ec5a581febacab7bad7">
+        <source>No customers found</source>
+        <target>No customers found</target>
+        <note>Line: 509</note>
+      </trans-unit>
+      <trans-unit id="29c14e1df15d10b73ec9605fd146b9fe">
+        <source>No carrier can be applied to this order</source>
+        <target>No carrier can be applied to this order</target>
+        <note>Line: 606</note>
+      </trans-unit>
+      <trans-unit id="b9af8635591dc44009ccd8e5389722ec">
+        <source>No products found</source>
+        <target>No products found</target>
+        <note>Line: 694</note>
+      </trans-unit>
+      <trans-unit id="43c2b5547b84d3fe632a8297c27ed20e">
+        <source>You must add at least one address to process the order.</source>
+        <target>You must add at least one address to process the order.</target>
+        <note>Line: 1057</note>
+      </trans-unit>
+      <trans-unit id="453c92894f48764318534163c2bb2830">
+        <source>The prices are without taxes.</source>
+        <target>The prices are without taxes.</target>
+        <note>Line: 1277</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e1b638a956fae226de3740f63a4e7d48">
+        <source>Are you sure you want to add this quantity?</source>
+        <target>Are you sure you want to add this quantity?</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="e2103a9e878a2280b3163e5ee098cbdf">
+        <source>Are you sure you want to create a new invoice?</source>
+        <target>Are you sure you want to create a new invoice?</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="bcab2ed7cab19f8e119317a7e59d316a">
+        <source>Error: No product has been selected</source>
+        <target>Error: No product has been selected</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="cd5cb1c932fc6f41a4fb3f6ec2f0c2da">
+        <source>Error: Quantity of products must be set</source>
+        <target>Error: Quantity of products must be set</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="894fdeeda7d3575fd6775732d026992c">
+        <source>Error: Product price must be set</source>
+        <target>Error: Product price must be set</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="c4832c266d52c6cef340a9c656ddda26">
+        <source>Error. You cannot refund a negative amount.</source>
+        <target>Error. You cannot refund a negative amount.</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="14c7a12fdbf437a0545aed3365ce3f84">
+        <source>No merchandise returned yet</source>
+        <target>No merchandise returned yet</target>
+        <note>Line: 380</note>
+      </trans-unit>
+      <trans-unit id="153c7809e6b00b6cbfa01b8aa9db43e3">
+        <source>paid instead of</source>
+        <target>paid instead of</target>
+        <note>Line: 407</note>
+      </trans-unit>
+      <trans-unit id="7137dec9b59978006f8b0ec036099346">
+        <source>This warning also concerns order </source>
+        <target>This warning also concerns order </target>
+        <note>Line: 412</note>
+      </trans-unit>
+      <trans-unit id="f38c718d5cc5ea7331d8acf533f9bf0d">
+        <source>This warning also concerns the next orders:</source>
+        <target>This warning also concerns the next orders:</target>
+        <note>Line: 414</note>
+      </trans-unit>
+      <trans-unit id="de78da3154b793d64d302db27e65baec">
+        <source>No payment methods are available</source>
+        <target>No payment methods are available</target>
+        <note>Line: 497</note>
+      </trans-unit>
+      <trans-unit id="ecd2046a1d4a6e46c11914c04b9559e4">
+        <source>A registered customer account has already claimed this email address</source>
+        <target>A registered customer account has already claimed this email address</target>
+        <note>Line: 603</note>
+      </trans-unit>
+      <trans-unit id="341ee6bf57abde84135c32f55a607de2">
+        <source>Do you want to send this message to the customer?</source>
+        <target>Do you want to send this message to the customer?</target>
+        <note>Line: 824</note>
+      </trans-unit>
+      <trans-unit id="dc8d1b4e8c9bdf1eed97eb9ed5877a43">
+        <source>Do you want to overwrite your existing message?</source>
+        <target>Do you want to overwrite your existing message?</target>
+        <note>Line: 829</note>
+      </trans-unit>
+      <trans-unit id="44f36e0e113ab5d842c47691364f6eb4">
+        <source>This product cannot be returned.</source>
+        <target>This product cannot be returned.</target>
+        <note>Line: 889</note>
+      </trans-unit>
+      <trans-unit id="b8d649752e2493d7d761b05cc255c3fd">
+        <source>Quantity to cancel is greater than quantity available.</source>
+        <target>Quantity to cancel is greater than quantity available.</target>
+        <note>Line: 889</note>
+      </trans-unit>
+      <trans-unit id="49641a1085f245fe45d45881544d1cec">
+        <source>For this customer group, prices are displayed as: [1]%tax_method%[/1]</source>
+        <target>For this customer group, prices are displayed as: [1]%tax_method%[/1]</target>
+        <note>Line: 994</note>
+      </trans-unit>
+      <trans-unit id="ef5f330df17f8c955005c26466c2463c">
+        <source>Merchandise returns are disabled</source>
+        <target>Merchandise returns are disabled</target>
+        <note>Line: 1004</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9cdca3c7972c48111e79648c942ac672">
+        <source>The message was successfully sent to the customer.</source>
+        <target>The message was successfully sent to the customer.</target>
+        <note>Line: 463</note>
+      </trans-unit>
+      <trans-unit id="1923e1e610686f1182bf54f573b86921">
+        <source>A partial refund was successfully created.</source>
+        <target>A partial refund was successfully created.</target>
+        <note>Line: 483</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/order/OrderHistory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f22b1baf8dcfb014646921be9841cb41">
+        <source>expires on %s.</source>
+        <target>expires on %s.</target>
+        <note>Line: 142</note>
+      </trans-unit>
+      <trans-unit id="0db24e725e6876d0fc7467554e8b6c03">
+        <source>downloadable %d time(s)</source>
+        <target>downloadable %d time(s)</target>
+        <note>Line: 145</note>
+      </trans-unit>
+      <trans-unit id="e1e95b3cea70730a922b35808ca3dce3">
+        <source>Invalid new order status</source>
+        <target>Invalid new order status</target>
+        <note>Line: 352</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAddressesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1c623b291d95f4f1b1d0c03d0dc0ffa1">
+        <source>This email address is not registered.</source>
+        <target>This email address is not registered.</target>
+        <note>Line: 375</note>
+      </trans-unit>
+      <trans-unit id="a58058b92c1584b1bdc413ac3d2e6699">
+        <source>This customer ID is not recognized.</source>
+        <target>This customer ID is not recognized.</target>
+        <note>Line: 382</note>
+      </trans-unit>
+      <trans-unit id="02c1c5ece60602356e41d407a81cb1fe">
+        <source>This email address is not valid. Please use an address like bob@example.com.</source>
+        <target>This email address is not valid. Please use an address like bob@example.com.</target>
+        <note>Line: 385</note>
+      </trans-unit>
+      <trans-unit id="7c77177e0084c27161d63e7de535a1c6">
+        <source>The identification number is incorrect or has already been used.</source>
+        <target>The identification number is incorrect or has already been used.</target>
+        <note>Line: 388</note>
+      </trans-unit>
+      <trans-unit id="27ac5352d430b82c99157e2dc13a96e3">
+        <source>You have selected a state for a country that does not contain states.</source>
+        <target>You have selected a state for a country that does not contain states.</target>
+        <note>Line: 396</note>
+      </trans-unit>
+      <trans-unit id="86de674d7405670db52e79ec1665b0b1">
+        <source>An address located in a country containing states must have a state selected.</source>
+        <target>An address located in a country containing states must have a state selected.</target>
+        <note>Line: 401</note>
+      </trans-unit>
+      <trans-unit id="03c123f62aad70a9533f5049cf3af959">
+        <source>An error occurred while linking this address to its order.</source>
+        <target>An error occurred while linking this address to its order.</target>
+        <note>Line: 441</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="53a60d3bbec32a4bf2777704834dc35e">
+        <source>You must add a minimum quantity of %d</source>
+        <target>You must add a minimum quantity of %d</target>
+        <note>Line: 490</note>
+      </trans-unit>
+      <trans-unit id="996a45aa702d041706f6388d54c53b12">
+        <source>Invalid order</source>
+        <target>Invalid order</target>
+        <note>Line: 571</note>
+      </trans-unit>
+      <trans-unit id="5125d7cea2749d85f13a55a023a56c71">
+        <source>The order cannot be renewed.</source>
+        <target>The order cannot be renewed.</target>
+        <note>Line: 578</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b3d571edf77b87b3be5cb3db48d88aa6">
+        <source>An error occurred. Your message was not sent. Please contact your system administrator.</source>
+        <target>An error occurred. Your message was not sent. Please contact your system administrator.</target>
+        <note>Line: 482</note>
+      </trans-unit>
+      <trans-unit id="d9c93c77e4f2eb90e8457f586e0c5cb3">
+        <source>Cannot create message in a new thread.</source>
+        <target>Cannot create message in a new thread.</target>
+        <note>Line: 1082</note>
+      </trans-unit>
+      <trans-unit id="142c7111dc9e81f5cf273851ccce9fcc">
+        <source>The message body is empty, cannot import it.</source>
+        <target>The message body is empty, cannot import it.</target>
+        <note>Line: 1147</note>
+      </trans-unit>
+      <trans-unit id="5d1cbbd2b78574a8cfac676d8bdb9ea4">
+        <source>Invalid message content for subject: %s</source>
+        <target>Invalid message content for subject: %s</target>
+        <note>Line: 1154</note>
+      </trans-unit>
+      <trans-unit id="f70f856f6d471d374aaf5080afeb1e53">
+        <source>The message content is not valid, cannot import it.</source>
+        <target>The message content is not valid, cannot import it.</target>
+        <note>Line: 1160</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df46bf546fc69b1cda65afe1001b73fc">
+        <source>You have to select a shop if you want to create a customer.</source>
+        <target>You have to select a shop if you want to create a customer.</target>
+        <note>Line: 209</note>
+      </trans-unit>
+      <trans-unit id="bde13610a2ae2521b30aa7821d553862">
+        <source>There is no status defined for this order.</source>
+        <target>There is no status defined for this order.</target>
+        <note>Line: 729</note>
+      </trans-unit>
+      <trans-unit id="03552140a267acc27f494dc3ab368067">
+        <source>Unknown delete mode:</source>
+        <target>Unknown delete mode:</target>
+        <note>Line: 870</note>
+      </trans-unit>
+      <trans-unit id="7298a088a582ffc05f2c777afb3115cb">
+        <source>Password cannot be empty.</source>
+        <target>Password cannot be empty.</target>
+        <note>Line: 900</note>
+      </trans-unit>
+      <trans-unit id="0a53e9e61f2a9bf59e9028b42fbd8166">
+        <source>An error occurred while loading the object.</source>
+        <target>An error occurred while loading the object.</target>
+        <note>Line: 929</note>
+      </trans-unit>
+      <trans-unit id="77ae44aa6c998166fcf1a87496278ad5">
+        <source>(cannot load object)</source>
+        <target>(cannot load object)</target>
+        <note>Line: 930</note>
+      </trans-unit>
+      <trans-unit id="c0498039cc042a1109b53933dc33b2e7">
+        <source>A default customer group must be selected in group box.</source>
+        <target>A default customer group must be selected in group box.</target>
+        <note>Line: 938</note>
+      </trans-unit>
+      <trans-unit id="8562db06e3931e51ac8c456b56088b02">
+        <source>This customer does not exist.</source>
+        <target>This customer does not exist.</target>
+        <note>Line: 968</note>
+      </trans-unit>
+      <trans-unit id="4383b950a18d0fd893e237148f5f58ca">
+        <source>This customer already exists as a non-guest.</source>
+        <target>This customer already exists as a non-guest.</target>
+        <note>Line: 971</note>
+      </trans-unit>
+      <trans-unit id="beaa75cbedc3443661b894ed66c76b13">
+        <source>An error occurred while updating customer information.</source>
+        <target>An error occurred while updating customer information.</target>
+        <note>Line: 1010</note>
+      </trans-unit>
+      <trans-unit id="14542f5997c4a02d4276da364657f501">
+        <source>Direct link</source>
+        <target>Direct link</target>
+        <note>Line: 797</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminEmployeesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9e2dcf2660b82a0204f668565417010a">
+        <source>An account already exists for this email address:</source>
+        <target>An account already exists for this email address:</target>
+        <note>Line: 435</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="aea807cc550550acd7b8d9a7bc469f6a">
+        <source>You have to select a shop before creating new orders.</source>
+        <target>You have to select a shop before creating new orders.</target>
+        <note>Line: 219</note>
+      </trans-unit>
+      <trans-unit id="accfc34fe6c65228a926b524870161ab">
+        <source>This cart does not exists</source>
+        <target>This cart does not exists</target>
+        <note>Line: 225</note>
+      </trans-unit>
+      <trans-unit id="3d4d2d9627d3f1b1c0d22b9e85c687d1">
+        <source>The cart must have a customer</source>
+        <target>The cart must have a customer</target>
+        <note>Line: 228</note>
+      </trans-unit>
+      <trans-unit id="a42a075994b3ee0f6fe5956110d85889">
+        <source>Order status #%id% cannot be loaded</source>
+        <target>Order status #%id% cannot be loaded</target>
+        <note>Line: 380</note>
+      </trans-unit>
+      <trans-unit id="4fe1644600a7dad640143da346a9211b">
+        <source>Order #%d cannot be loaded</source>
+        <target>Order #%d cannot be loaded</target>
+        <note>Line: 385</note>
+      </trans-unit>
+      <trans-unit id="409f3dfd9f910287f86fd6c25c94c4d8">
+        <source>Order #%d has already been assigned this status.</source>
+        <target>Order #%d has already been assigned this status.</target>
+        <note>Line: 389</note>
+      </trans-unit>
+      <trans-unit id="18893a82469e2cd9492fc8d46fa8ac01">
+        <source>An error occurred while changing the status for order #%d, or we were unable to send an email to the customer.</source>
+        <target>An error occurred while changing the status for order #%d, or we were unable to send an email to the customer.</target>
+        <note>Line: 414</note>
+      </trans-unit>
+      <trans-unit id="45d4b3afac71a54470a6cbf828e8cb0d">
+        <source>The order carrier ID is invalid.</source>
+        <target>The order carrier ID is invalid.</target>
+        <note>Line: 468</note>
+      </trans-unit>
+      <trans-unit id="e52d022f0fb2160ec1cf7b4122ab9589">
+        <source>The tracking number is incorrect.</source>
+        <target>The tracking number is incorrect.</target>
+        <note>Line: 470</note>
+      </trans-unit>
+      <trans-unit id="561918c3c49ff748f543e28f5c405d3c">
+        <source>An error occurred while sending an email to the customer.</source>
+        <target>An error occurred while sending an email to the customer.</target>
+        <note>Line: 668</note>
+      </trans-unit>
+      <trans-unit id="f465ea6c7866853ecc49286449720ac9">
+        <source>The order carrier cannot be updated.</source>
+        <target>The order carrier cannot be updated.</target>
+        <note>Line: 510</note>
+      </trans-unit>
+      <trans-unit id="c2572d1fee836c06c88e0bdc9fa7ffa1">
+        <source>The new order status is invalid.</source>
+        <target>The new order status is invalid.</target>
+        <note>Line: 522</note>
+      </trans-unit>
+      <trans-unit id="4f51deabdeba4ee61b998d3b0cf188b4">
+        <source>An error occurred while changing order status, or we were unable to send an email to the customer.</source>
+        <target>An error occurred while changing order status, or we were unable to send an email to the customer.</target>
+        <note>Line: 556</note>
+      </trans-unit>
+      <trans-unit id="c5e4a57d9572678ffbb124db39542928">
+        <source>The order has already been assigned this status.</source>
+        <target>The order has already been assigned this status.</target>
+        <note>Line: 558</note>
+      </trans-unit>
+      <trans-unit id="f61c60ff8d82ebd1012606e5bc3a2002">
+        <source>The customer is invalid.</source>
+        <target>The customer is invalid.</target>
+        <note>Line: 569</note>
+      </trans-unit>
+      <trans-unit id="3dc245110e1f3601860c20299d97c01d">
+        <source>The message cannot be blank.</source>
+        <target>The message cannot be blank.</target>
+        <note>Line: 571</note>
+      </trans-unit>
+      <trans-unit id="204c3558e41366f3d558ce8e01426a22">
+        <source>field %s is required.</source>
+        <target>field %s is required.</target>
+        <note>Line: 578</note>
+      </trans-unit>
+      <trans-unit id="c4d82e8095bb903683e0b0e73887aef0">
+        <source>Please enter a quantity to proceed with your refund.</source>
+        <target>Please enter a quantity to proceed with your refund.</target>
+        <note>Line: 864</note>
+      </trans-unit>
+      <trans-unit id="8a5f368eac3aab699cf8e6e1ec28b695">
+        <source>Please enter an amount to proceed with your refund.</source>
+        <target>Please enter an amount to proceed with your refund.</target>
+        <note>Line: 866</note>
+      </trans-unit>
+      <trans-unit id="598db0342f11f89d4268942b9491c455">
+        <source>You cannot generate a partial credit slip.</source>
+        <target>You cannot generate a partial credit slip.</target>
+        <note>Line: 752</note>
+      </trans-unit>
+      <trans-unit id="b1db8cec4ec0de83c3934a22bc758a3b">
+        <source>You cannot generate a voucher.</source>
+        <target>You cannot generate a voucher.</target>
+        <note>Line: 1110</note>
+      </trans-unit>
+      <trans-unit id="bd4457c0f19f796f3d66726f9fadc041">
+        <source>The partial refund data is incorrect.</source>
+        <target>The partial refund data is incorrect.</target>
+        <note>Line: 875</note>
+      </trans-unit>
+      <trans-unit id="991bbcc5660531bc1a1c8f1c235794c0">
+        <source>You must select a product.</source>
+        <target>You must select a product.</target>
+        <note>Line: 884</note>
+      </trans-unit>
+      <trans-unit id="6d3fd0eb289900145d482634d6e86b90">
+        <source>You must enter a quantity.</source>
+        <target>You must enter a quantity.</target>
+        <note>Line: 886</note>
+      </trans-unit>
+      <trans-unit id="8001500c3284edd9c4dd07ae508e5a95">
+        <source>No quantity has been selected for this product.</source>
+        <target>No quantity has been selected for this product.</target>
+        <note>Line: 950</note>
+      </trans-unit>
+      <trans-unit id="38eaecfc1ef14b98b5d6e4eb77494369">
+        <source>An invalid quantity was selected for this product.</source>
+        <target>An invalid quantity was selected for this product.</target>
+        <note>Line: 954</note>
+      </trans-unit>
+      <trans-unit id="bf772d53e730d2e0169ed2f746044606">
+        <source>An error occurred while attempting to delete the product.</source>
+        <target>An error occurred while attempting to delete the product.</target>
+        <note>Line: 971</note>
+      </trans-unit>
+      <trans-unit id="77d97f5686dfef72ee577e779d5bb74f">
+        <source>An error occurred while attempting to delete product customization.</source>
+        <target>An error occurred while attempting to delete product customization.</target>
+        <note>Line: 993</note>
+      </trans-unit>
+      <trans-unit id="edeff0d68d3d20ce1f6189f6070cb2ba">
+        <source>A credit slip cannot be generated.</source>
+        <target>A credit slip cannot be generated.</target>
+        <note>Line: 1031</note>
+      </trans-unit>
+      <trans-unit id="b81f0a0540938a2e7daa684f02866696">
+        <source>No product or quantity has been selected.</source>
+        <target>No product or quantity has been selected.</target>
+        <note>Line: 1140</note>
+      </trans-unit>
+      <trans-unit id="fdb259bd3d5479c25f5d23af490b5ec3">
+        <source>The order cannot be found</source>
+        <target>The order cannot be found</target>
+        <note>Line: 1165</note>
+      </trans-unit>
+      <trans-unit id="9391de9e24bd71839f6f72a1517de2d6">
+        <source>The amount is invalid.</source>
+        <target>The amount is invalid.</target>
+        <note>Line: 1167</note>
+      </trans-unit>
+      <trans-unit id="6ab061ec12504fab2c41f0689579d623">
+        <source>The selected payment method is invalid.</source>
+        <target>The selected payment method is invalid.</target>
+        <note>Line: 1169</note>
+      </trans-unit>
+      <trans-unit id="7d0d71a3e577be4c20799b52286191d6">
+        <source>The transaction ID is invalid.</source>
+        <target>The transaction ID is invalid.</target>
+        <note>Line: 1171</note>
+      </trans-unit>
+      <trans-unit id="3b512b6c31ef4f46605159612691eb56">
+        <source>The selected currency is invalid.</source>
+        <target>The selected currency is invalid.</target>
+        <note>Line: 1173</note>
+      </trans-unit>
+      <trans-unit id="06fc8d486e9f83c5810a21857da7b656">
+        <source>The invoice is invalid.</source>
+        <target>The invoice is invalid.</target>
+        <note>Line: 1175</note>
+      </trans-unit>
+      <trans-unit id="f50c7cba4df874039d73ee480d678f5e">
+        <source>The date is invalid</source>
+        <target>The date is invalid</target>
+        <note>Line: 1177</note>
+      </trans-unit>
+      <trans-unit id="04e3713831c71d70817d4a69eadbc53c">
+        <source>An error occurred during payment.</source>
+        <target>An error occurred during payment.</target>
+        <note>Line: 1180</note>
+      </trans-unit>
+      <trans-unit id="0d906d12a6321e5f13e69dab92e39a4e">
+        <source>The invoice note was not saved.</source>
+        <target>The invoice note was not saved.</target>
+        <note>Line: 1197</note>
+      </trans-unit>
+      <trans-unit id="7f5a75ac350db917dc60cfbd8299da5b">
+        <source>Failed to upload the invoice and edit its note.</source>
+        <target>Failed to upload the invoice and edit its note.</target>
+        <note>Line: 1203</note>
+      </trans-unit>
+      <trans-unit id="68b7afe49451dbdab7cbeff4f66be369">
+        <source>This delivery address country is not active.</source>
+        <target>This delivery address country is not active.</target>
+        <note>Line: 1223</note>
+      </trans-unit>
+      <trans-unit id="a9320eb7be798958cba0a93262521ede">
+        <source>This invoice address country is not active.</source>
+        <target>This invoice address country is not active.</target>
+        <note>Line: 1225</note>
+      </trans-unit>
+      <trans-unit id="95aa605fa7f396d370b4c87afad9201c">
+        <source>This address can't be loaded</source>
+        <target>This address can't be loaded</target>
+        <note>Line: 1256</note>
+      </trans-unit>
+      <trans-unit id="b0535e1868ad530e5faadf295516a724">
+        <source>You cannot change the currency.</source>
+        <target>You cannot change the currency.</target>
+        <note>Line: 1351</note>
+      </trans-unit>
+      <trans-unit id="8dcb8970b8eeeac73c8d312d1db3d1f9">
+        <source>Invoice management has been disabled.</source>
+        <target>Invoice management has been disabled.</target>
+        <note>Line: 1358</note>
+      </trans-unit>
+      <trans-unit id="f98321e34948f600959c5c4200c953c8">
+        <source>This order already has an invoice.</source>
+        <target>This order already has an invoice.</target>
+        <note>Line: 1360</note>
+      </trans-unit>
+      <trans-unit id="0da1c0afe7d3d89a53a5d00998bb4295">
+        <source>You cannot edit this cart rule.</source>
+        <target>You cannot edit this cart rule.</target>
+        <note>Line: 1400</note>
+      </trans-unit>
+      <trans-unit id="db7cb022c7b6058d0f1668faa22a54fa">
+        <source>You must specify a name in order to create a new discount.</source>
+        <target>You must specify a name in order to create a new discount.</target>
+        <note>Line: 1408</note>
+      </trans-unit>
+      <trans-unit id="7b56734426bcdd50629f41c58cb1f241">
+        <source>The discount value is invalid.</source>
+        <target>The discount value is invalid.</target>
+        <note>Line: 1447</note>
+      </trans-unit>
+      <trans-unit id="8dc19f50ae30ac7d61e67c795b32fd47">
+        <source>The discount value is greater than the order invoice total.</source>
+        <target>The discount value is greater than the order invoice total.</target>
+        <note>Line: 1467</note>
+      </trans-unit>
+      <trans-unit id="574875d4553bada6682a07ae86298bc6">
+        <source>The discount value is greater than the order total.</source>
+        <target>The discount value is greater than the order total.</target>
+        <note>Line: 1478</note>
+      </trans-unit>
+      <trans-unit id="9a9d54664b6ba23a9588f6b795dc03ab">
+        <source>The discount type is invalid.</source>
+        <target>The discount type is invalid.</target>
+        <note>Line: 1514</note>
+      </trans-unit>
+      <trans-unit id="b046e96ee00ad2ef4ed135eab1c13df4">
+        <source>An error occurred during the OrderCartRule creation</source>
+        <target>An error occurred during the OrderCartRule creation</target>
+        <note>Line: 1567</note>
+      </trans-unit>
+      <trans-unit id="0fa578512847280157dd62ae18e92979">
+        <source>An error occurred while loading order status.</source>
+        <target>An error occurred while loading order status.</target>
+        <note>Line: 1578</note>
+      </trans-unit>
+      <trans-unit id="fded441ef916f653d49abf142b535b52">
+        <source>An error occurred while sending the e-mail to the customer.</source>
+        <target>An error occurred while sending the e-mail to the customer.</target>
+        <note>Line: 1591</note>
+      </trans-unit>
+      <trans-unit id="aeddc664f1e95691c69ea44a5c1c18f5">
+        <source>This product is out of stock: </source>
+        <target>This product is out of stock:</target>
+        <note>Line: 1784</note>
+      </trans-unit>
+      <trans-unit id="4174f012bc63b679f092acd1a933bf5c">
+        <source>The email was sent to your customer.</source>
+        <target>The email was sent to your customer.</target>
+        <note>Line: 2033</note>
+      </trans-unit>
+      <trans-unit id="773b660773e6106c248814fa87b480f7">
+        <source>Error in sending the email to your customer.</source>
+        <target>Error in sending the email to your customer.</target>
+        <note>Line: 2037</note>
+      </trans-unit>
+      <trans-unit id="4dc1c8fa2f766c5e201155ee3737ed3f">
+        <source>The order object cannot be loaded.</source>
+        <target>The order object cannot be loaded.</target>
+        <note>Line: 2789</note>
+      </trans-unit>
+      <trans-unit id="7152cf69405fd47a8bd2f7b625ce324e">
+        <source>You cannot add products to delivered orders.</source>
+        <target>You cannot add products to delivered orders.</target>
+        <note>Line: 2057</note>
+      </trans-unit>
+      <trans-unit id="9b7508b5ee1050d5c5efb9b1cf76fd36">
+        <source>The product object cannot be loaded.</source>
+        <target>The product object cannot be loaded.</target>
+        <note>Line: 2400</note>
+      </trans-unit>
+      <trans-unit id="74bd055cec720c9f41563ff6a6a40b7b">
+        <source>The combination object cannot be loaded.</source>
+        <target>The combination object cannot be loaded.</target>
+        <note>Line: 2080</note>
+      </trans-unit>
+      <trans-unit id="0d38c90d843c787c0be14f790998210c">
+        <source>You must add %d minimum quantity</source>
+        <target>You must add %d minimum quantity</target>
+        <note>Line: 2145</note>
+      </trans-unit>
+      <trans-unit id="de10fc28511b894f704c1a67fcff7b4f">
+        <source>You already have the maximum quantity available for this product.</source>
+        <target>You already have the maximum quantity available for this product.</target>
+        <note>Line: 2147</note>
+      </trans-unit>
+      <trans-unit id="6a94d8492279c2bfd3e81f3158658980">
+        <source>[Generated] CartRule for Free Shipping</source>
+        <target>[Generated] CartRule for Free Shipping</target>
+        <note>Line: 2162</note>
+      </trans-unit>
+      <trans-unit id="4e670964e358534a827dc7e0359281b0">
+        <source>The OrderDetail object cannot be loaded.</source>
+        <target>The OrderDetail object cannot be loaded.</target>
+        <note>Line: 2392</note>
+      </trans-unit>
+      <trans-unit id="0c8a625097a9b711bfca4724517eeb01">
+        <source>The address object cannot be loaded.</source>
+        <target>The address object cannot be loaded.</target>
+        <note>Line: 2408</note>
+      </trans-unit>
+      <trans-unit id="7da127d075ca24fec224c1d497aac11f">
+        <source>An error occurred while editing the product line.</source>
+        <target>An error occurred while editing the product line.</target>
+        <note>Line: 2598</note>
+      </trans-unit>
+      <trans-unit id="fde52aaef1e1e23770e40a458a1cac46">
+        <source>An error occurred while attempting to delete the product line.</source>
+        <target>An error occurred while attempting to delete the product line.</target>
+        <note>Line: 2667</note>
+      </trans-unit>
+      <trans-unit id="e3a212006776535d5da7d11f7c62d727">
+        <source>The Order Detail object could not be loaded.</source>
+        <target>The Order Detail object could not be loaded.</target>
+        <note>Line: 2782</note>
+      </trans-unit>
+      <trans-unit id="823eba6da615c2a384cf8e13cd70980b">
+        <source>The invoice object cannot be loaded.</source>
+        <target>The invoice object cannot be loaded.</target>
+        <note>Line: 2716</note>
+      </trans-unit>
+      <trans-unit id="0af3cc300f35caff086e21bf2f865960">
+        <source>You cannot edit the order detail for this order.</source>
+        <target>You cannot edit the order detail for this order.</target>
+        <note>Line: 2730</note>
+      </trans-unit>
+      <trans-unit id="7ea9212dcdaccc580b9e6b548609e7fd">
+        <source>You cannot edit a delivered order.</source>
+        <target>You cannot edit a delivered order.</target>
+        <note>Line: 2804</note>
+      </trans-unit>
+      <trans-unit id="675b81dace2c99f5ef5eb6ac3f69dbe4">
+        <source>You cannot use this invoice for the order</source>
+        <target>You cannot use this invoice for the order</target>
+        <note>Line: 2745</note>
+      </trans-unit>
+      <trans-unit id="2591b6d46f45d8f60e24c6c9c96a2a11">
+        <source>Invalid price</source>
+        <target>Invalid price</target>
+        <note>Line: 2756</note>
+      </trans-unit>
+      <trans-unit id="01816dd287bcb3b88ad3f63970ce045f">
+        <source>Invalid quantity</source>
+        <target>Invalid quantity</target>
+        <note>Line: 2770</note>
+      </trans-unit>
+      <trans-unit id="c181d4415ea3fd71c407da3697be421f">
+        <source>You cannot delete the order detail.</source>
+        <target>You cannot delete the order detail.</target>
+        <note>Line: 2796</note>
+      </trans-unit>
+      <trans-unit id="671cd4e79283dd9931f0452000bf2744">
+        <source>This product cannot be re-stocked.</source>
+        <target>This product cannot be re-stocked.</target>
+        <note>Line: 2951</note>
+      </trans-unit>
+      <trans-unit id="1244f34e7f971d0b80cd2fd7cbbfb22c">
+        <source>The order cannot be found within your database.</source>
+        <target>The order cannot be found within your database.</target>
+        <note>Line: 1676</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminPdfController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f193c3dd6da8a06a610c632db03d55c8">
+        <source>The order ID -- or the invoice order ID -- is missing.</source>
+        <target>The order ID -- or the invoice order ID -- is missing.</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="48607ff5af8c52b5efbc057b852a37ee">
+        <source>No invoice was found.</source>
+        <target>No invoice was found.</target>
+        <note>Line: 140</note>
+      </trans-unit>
+      <trans-unit id="57bf4b0dd7dd3e5af10533785a343f88">
+        <source>No order slips were found.</source>
+        <target>No order slips were found.</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="f2e9d5988718c8a3dde49c6bcb55125b">
+        <source>The supply order ID is missing.</source>
+        <target>The supply order ID is missing.</target>
+        <note>Line: 149</note>
+      </trans-unit>
+      <trans-unit id="4fc152e203df7a77fa3c1bc7f1249f36">
+        <source>The supply order cannot be found within your database.</source>
+        <target>The supply order cannot be found within your database.</target>
+        <note>Line: 156</note>
+      </trans-unit>
+      <trans-unit id="d7e5dfc920c9871caaf7562d8ba9ab36">
+        <source>The order invoice cannot be found within your database.</source>
+        <target>The order invoice cannot be found within your database.</target>
+        <note>Line: 199</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7582ef2f5b5de8a479994d0412986bc2">
+        <source>An error occurred while deleting the details of your order return.</source>
+        <target>An error occurred while deleting the details of your order return.</target>
+        <note>Line: 224</note>
+      </trans-unit>
+      <trans-unit id="d4430672c8b3c123ae5f4c2f4b5b458d">
+        <source>You need at least one product.</source>
+        <target>You need at least one product.</target>
+        <note>Line: 227</note>
+      </trans-unit>
+      <trans-unit id="e7a58e52e848f513c3e9185d34d61a50">
+        <source>The order return is invalid.</source>
+        <target>The order return is invalid.</target>
+        <note>Line: 230</note>
+      </trans-unit>
+      <trans-unit id="5431bd88788ce2df4278c84f402e3cb6">
+        <source>The order return content is invalid.</source>
+        <target>The order return content is invalid.</target>
+        <note>Line: 233</note>
+      </trans-unit>
+      <trans-unit id="16f2adf6c4fd1317acba5871267a60f2">
+        <source>No order return ID has been specified.</source>
+        <target>No order return ID has been specified.</target>
+        <note>Line: 281</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5844cf5e9f752e6eb7cc1166a3022183">
+        <source>No order was found with this ID:</source>
+        <target>No order was found with this ID:</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="3b27bc623d860beacbe5d5cde18fdec0">
+        <source>No invoice was found with this ID:</source>
+        <target>No invoice was found with this ID:</target>
+        <note>Line: 133</note>
+      </trans-unit>
+      <trans-unit id="ec79affe41245b47969a2451211b263a">
+        <source>No cart was found with this ID:</source>
+        <target>No cart was found with this ID:</target>
+        <note>Line: 141</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSlipController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cdbb58c797028e137b1ebf1dcc9efe92">
+        <source>No order slips were found for this period.</source>
+        <target>No order slips were found for this period.</target>
+        <note>Line: 159</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="35af021c4bdb02cad86c917022e053da">
+        <source>An error has occurred: Can't save the current order's return status.</source>
+        <target>An error has occurred: Can't save the current order's return status.</target>
+        <note>Line: 556</note>
+      </trans-unit>
+      <trans-unit id="ca215ff3d829e3a6a9c0c672987d5959">
+        <source>An error has occurred: Can't delete the current order's return status.</source>
+        <target>An error has occurred: Can't delete the current order's return status.</target>
+        <note>Line: 576</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Order/Delivery/SlipPdfConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3ffd1b6c5e4ab9c98104475480477307">
+        <source>No delivery slip was found for this period.</source>
+        <target>No delivery slip was found for this period.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceByStatusFormHandler.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7af95cd9cbe318a15ef10e5e30000501">
+        <source>No invoice has been found for this status.</source>
+        <target>No invoice has been found for this status.</target>
+        <note>Line: 95</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="599b433088f71a8712de225a693ce20e">
+        <source>Invalid invoice number.</source>
+        <target>Invalid invoice number.</target>
+        <note>Line: 95</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByDateDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9178a1a9fc82617864593a784163d86a">
+        <source>Invalid "From" date</source>
+        <target>Invalid "From" date</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="915bd2c5cf6e420095a64d309e443849">
+        <source>Invalid "To" date</source>
+        <target>Invalid "To" date</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="f775c161c8662af8f70a128ad5779036">
+        <source>No invoice has been found for this period.</source>
+        <target>No invoice has been found for this period.</target>
+        <note>Line: 104</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByStatusDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="eb9173ba78d315a23d8978a2b772bd9a">
+        <source>You must select at least one order status.</source>
+        <target>You must select at least one order status.</target>
+        <note>Line: 67</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminPaymentFeature.xlf
+++ b/app/Resources/translations/default/AdminPaymentFeature.xlf
@@ -1,46 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d3f9cb6a35595b8e7d9c0cd2f5e14929">
-        <source>Currency restrictions</source>
-        <target>Currency restrictions</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="52b7e372bca509e26e66340426dc8531">
-        <source>Country restrictions</source>
-        <target>Country restrictions</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig:87</note>
-      </trans-unit>
-      <trans-unit id="442d9a7c585a4eb14334a32decaee21b">
-        <source>Group restrictions</source>
-        <target>Group restrictions</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig:60</note>
-      </trans-unit>
-      <trans-unit id="1aa915c48859b4638d4048d533bad273">
-        <source>Carrier restrictions</source>
-        <target>Carrier restrictions</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig:114</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="3e15057a39314e679d553bd9b6522ec8">
         <source>Customer currency</source>
         <target>Customer currency</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php:255</note>
+        <note>Line: 255</note>
       </trans-unit>
       <trans-unit id="cdf4c2da827655c1ea74209dd683c903">
         <source>Shop default currency</source>
         <target>Shop default currency</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php:256</note>
+        <note>Line: 256</note>
       </trans-unit>
     </body>
   </file>
@@ -49,8 +19,31 @@ File: src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModuleP
       <trans-unit id="c2aa74ac66698f48002031386e2d8776">
         <source>Active payment</source>
         <target>Active payment</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig:35</note>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3f9cb6a35595b8e7d9c0cd2f5e14929">
+        <source>Currency restrictions</source>
+        <target>Currency restrictions</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="52b7e372bca509e26e66340426dc8531">
+        <source>Country restrictions</source>
+        <target>Country restrictions</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="442d9a7c585a4eb14334a32decaee21b">
+        <source>Group restrictions</source>
+        <target>Group restrictions</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="1aa915c48859b4638d4048d533bad273">
+        <source>Carrier restrictions</source>
+        <target>Carrier restrictions</target>
+        <note>Line: 114</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminPaymentHelp.xlf
+++ b/app/Resources/translations/default/AdminPaymentHelp.xlf
@@ -5,26 +5,22 @@
       <trans-unit id="c4d74515416a5d1be75cfcd3e148e8e5">
         <source>Please mark each checkbox for the currency, or currencies, for which you want the payment module(s) to be available.</source>
         <target>Please mark each checkbox for the currency, or currencies, for which you want the payment module(s) to be available.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig:38</note>
+        <note>Line: 38</note>
       </trans-unit>
       <trans-unit id="b193f3e27f6936fd26746b39aca66587">
         <source>Please mark each checkbox for the customer group(s), for which you want the payment module(s) to be available.</source>
         <target>Please mark each checkbox for the customer group(s), for which you want the payment module(s) to be available.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig:65</note>
+        <note>Line: 65</note>
       </trans-unit>
       <trans-unit id="a8fc3e8b2c61a74ac9b50e36604525c8">
         <source>Please mark each checkbox for the country, or countries, in which you want the payment module(s) to be available.</source>
         <target>Please mark each checkbox for the country, or countries, in which you want the payment module(s) to be available.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig:92</note>
+        <note>Line: 92</note>
       </trans-unit>
       <trans-unit id="27acfbd58a7ff9f12c9ac05dd94733c5">
         <source>Please mark each checkbox for the carrier, or carrier, for which you want the payment module(s) to be available.</source>
         <target>Please mark each checkbox for the carrier, or carrier, for which you want the payment module(s) to be available.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig:119</note>
+        <note>Line: 119</note>
       </trans-unit>
     </body>
   </file>
@@ -33,20 +29,17 @@ File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blo
       <trans-unit id="bf300d92910197db357bc70d62143559">
         <source>This is where you decide what payment modules are available for different variations like your customers' currency, group, and country.</source>
         <target>This is where you decide what payment modules are available for different variations like your customers' currency, group, and country.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/payment_preferences.html.twig:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="faf0cf10ced3f7e6202c929d8633a616">
         <source>A check mark indicates you want the payment module available.</source>
         <target>A check mark indicates you want the payment module available.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/payment_preferences.html.twig:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="2bae052f842849e596b0c6bf6adec2bf">
         <source>If it is not checked then this means that the payment module is disabled.</source>
         <target>If it is not checked then this means that the payment module is disabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/payment_preferences.html.twig:51</note>
+        <note>Line: 51</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminPaymentNotification.xlf
+++ b/app/Resources/translations/default/AdminPaymentNotification.xlf
@@ -1,54 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="admin-dev/themes/default/template/controllers/payment/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6fc908ba63932d2ea0c58d994b9b6312">
+        <source>You have more than one shop and must select one to configure payment.</source>
+        <target>You have more than one shop and must select one to configure payment.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="classes/PaymentModule.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="ed9b5732158eef63ac4d236e04101d2b">
         <source>No currency mode for payment module</source>
         <target>No currency mode for payment module</target>
-        <note>Context:
-File: classes/PaymentModule.php:54</note>
+        <note>Line: 54</note>
       </trans-unit>
       <trans-unit id="3a6e70059673992f825826f7cf89278d">
         <source>The cart rule named "%1s" (ID %2s) used in this cart is not valid and has been withdrawn from cart</source>
         <target>The cart rule named "%1s" (ID %2s) used in this cart is not valid and has been withdrawn from cart</target>
-        <note>Context:
-File: classes/PaymentModule.php:303</note>
+        <note>Line: 303</note>
       </trans-unit>
       <trans-unit id="3a1048f8aa3a9f6b604fcf7982811752">
         <source>Warning: the secure key is empty, check your payment account before validation</source>
         <target>Warning: the secure key is empty, check your payment account before validation</target>
-        <note>Context:
-File: classes/PaymentModule.php:475</note>
+        <note>Line: 475</note>
       </trans-unit>
       <trans-unit id="26beb437d3323bd4bfb0811b3e891315">
         <source>%d image(s)</source>
         <target>%d image(s)</target>
-        <note>Context:
-File: classes/PaymentModule.php:538</note>
+        <note>Line: 538</note>
       </trans-unit>
       <trans-unit id="0791970c961c09eb8caaa61aba6a3ca4">
         <source>An error occurred while saving message</source>
         <target>An error occurred while saving message</target>
-        <note>Context:
-File: classes/PaymentModule.php:716</note>
+        <note>Line: 716</note>
       </trans-unit>
       <trans-unit id="ed13b3693357ebed3751cb71cb639e65">
         <source>No carrier</source>
         <target>No carrier</target>
-        <note>Context:
-File: classes/PaymentModule.php:810</note>
+        <note>Line: 810</note>
       </trans-unit>
       <trans-unit id="b08d3867be98e6fff3233cd40ab8134a">
         <source>Order creation failed</source>
         <target>Order creation failed</target>
-        <note>Context:
-File: classes/PaymentModule.php:889</note>
+        <note>Line: 889</note>
       </trans-unit>
       <trans-unit id="43423b4056880b08f2c9aa50d8670531">
         <source>Cart cannot be loaded or an order has already been placed using this cart</source>
         <target>Cart cannot be loaded or an order has already been placed using this cart</target>
-        <note>Context:
-File: classes/PaymentModule.php:906</note>
+        <note>Line: 906</note>
       </trans-unit>
     </body>
   </file>
@@ -57,18 +58,7 @@ File: classes/PaymentModule.php:906</note>
       <trans-unit id="98a52c00a9fb228601f8b423436d36e0">
         <source>It seems there are no recommended payment solutions for your country.</source>
         <target>It seems there are no recommended payment solutions for your country.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig:63</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/payment/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6fc908ba63932d2ea0c58d994b9b6312">
-        <source>You have more than one shop and must select one to configure payment.</source>
-        <target>You have more than one shop and must select one to configure payment.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/payment/helpers/view/view.tpl:29</note>
+        <note>Line: 63</note>
       </trans-unit>
     </body>
   </file>
@@ -77,8 +67,7 @@ File: admin-dev/themes/default/template/controllers/payment/helpers/view/view.tp
       <trans-unit id="cf7da676516ac041a93fd91755fa40f9">
         <source>No payment module installed</source>
         <target>No payment module installed</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/payment_preferences.html.twig:41</note>
+        <note>Line: 41</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminShippingFeature.xlf
+++ b/app/Resources/translations/default/AdminShippingFeature.xlf
@@ -1,324 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
-        <source>Carrier</source>
-        <target>Carrier</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:108</note>
+      <trans-unit id="07018153f387118b1dacafee609f13b1">
+        <source>Will be applied when the price is</source>
+        <target>Will be applied when the price is</target>
+        <note>Line: 27</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCarriersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8f497c1a3d15af9e0c215019f26b887d">
-        <source>Delay</source>
-        <target>Delay</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:84</note>
+      <trans-unit id="4c687ab170e51c6eaa65be3b621c7205">
+        <source>Will be applied when the weight is</source>
+        <target>Will be applied when the weight is</target>
+        <note>Line: 28</note>
       </trans-unit>
-      <trans-unit id="b00b85425e74ed2c85dc3119b78ff2c3">
-        <source>Free Shipping</source>
-        <target>Free Shipping</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:96</note>
-      </trans-unit>
-      <trans-unit id="c26732c157d7b353c1be9f7ba8962e57">
-        <source>Add new carrier</source>
-        <target>Add new carrier</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:128</note>
-      </trans-unit>
-      <trans-unit id="1c0e287237d8c352c6ead633b019c047">
-        <source>Apply shipping cost</source>
-        <target>Apply shipping cost</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:249</note>
-      </trans-unit>
-      <trans-unit id="7589dfa9a5a899e9701335164c9ab520">
-        <source>Shipping and handling</source>
-        <target>Shipping and handling</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:283</note>
-      </trans-unit>
-      <trans-unit id="590f6d9a5885f042982c9a911f76abda">
-        <source>Default behavior</source>
-        <target>Default behavior</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:313</note>
-      </trans-unit>
-      <trans-unit id="e3d29a6f3d7588301aa04429e686b260">
-        <source>According to total price</source>
-        <target>According to total price</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:318</note>
-      </trans-unit>
-      <trans-unit id="49fec5c86a3b43821fdf0d9aa7bbd935">
-        <source>According to total weight</source>
-        <target>According to total weight</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:323</note>
-      </trans-unit>
-      <trans-unit id="324029d06c6bfe85489099f6e69b7637">
-        <source>Maximum package height</source>
-        <target>Maximum package height</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:349</note>
-      </trans-unit>
-      <trans-unit id="3e86ececa46af50900510892f94c4ed6">
-        <source>Maximum package width</source>
-        <target>Maximum package width</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:356</note>
-      </trans-unit>
-      <trans-unit id="1935671a637346f67b485596b9fcba2c">
-        <source>Maximum package depth</source>
-        <target>Maximum package depth</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:363</note>
-      </trans-unit>
-      <trans-unit id="0cce6348a3d85f52a44d053f542afcbc">
-        <source>Maximum package weight</source>
-        <target>Maximum package weight</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:370</note>
-      </trans-unit>
-      <trans-unit id="4e140ba723a03baa6948340bf90e2ef6">
-        <source>Name:</source>
-        <target>Name:</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:707</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1d6af794b2599c1407a83029a09d1ecf">
-        <source>Carriers</source>
-        <target>Carriers</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:537</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/carriers/helpers/list/list_footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5e6b7c069d71052ffc8c4410c0c46992">
-        <source>Use one of our recommended carrier modules</source>
-        <target>Use one of our recommended carrier modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carriers/helpers/list/list_footer.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="39efbaa2f3600dd82a031d7ab5138f73">
-        <source>Do you think there should be one? Let us know!</source>
-        <target>Do you think there should be one? Let us know!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carriers/helpers/list/list_footer.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="80a305c8cb9737ef8474472aaa65026e">
-        <source>It seems there are no recommended carriers for your country.</source>
-        <target>It seems there are no recommended carriers for your country.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carriers/helpers/list/list_footer.tpl:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dde695268ea519ababd83f0ca3d274fc">
-        <source>Transit time</source>
-        <target>Transit time</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:195</note>
-      </trans-unit>
-      <trans-unit id="c8b462f779749d2e27abed2e9501b2bd">
-        <source>Speed grade</source>
-        <target>Speed grade</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:204</note>
-      </trans-unit>
-      <trans-unit id="780c462e85ba4399a5d42e88f69a15ca">
-        <source>Billing</source>
-        <target>Billing</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:300</note>
-      </trans-unit>
-      <trans-unit id="082ebbb29b5ba59c293a00a55581679b">
-        <source>Out-of-range behavior</source>
-        <target>Out-of-range behavior</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:334</note>
-      </trans-unit>
-      <trans-unit id="4f890cf6a72112cad95093baecf39831">
-        <source>Disable carrier</source>
-        <target>Disable carrier</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:344</note>
-      </trans-unit>
-      <trans-unit id="de62775a71fc2bf7a13d7530ae24a7ed">
-        <source>General settings</source>
-        <target>General settings</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:73</note>
-      </trans-unit>
-      <trans-unit id="756eb8cebeb953f5ae47235ff2e183b5">
-        <source>Shipping locations and costs</source>
-        <target>Shipping locations and costs</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:76</note>
-      </trans-unit>
-      <trans-unit id="e2fb9fa6091dd9f779b98efdf998a00a">
-        <source>Size, weight, and group access</source>
-        <target>Size, weight, and group access</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:79</note>
-      </trans-unit>
-      <trans-unit id="c91e596246bbf8fdff9dae7b349d71d9">
-        <source>Carrier name</source>
-        <target>Carrier name</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:184</note>
-      </trans-unit>
-      <trans-unit id="0979779c4569141b98591d326d343ec2">
-        <source>Tracking URL</source>
-        <target>Tracking URL</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:217</note>
-      </trans-unit>
-      <trans-unit id="829c7cc5ed48e11df7ac9b05e236a12c">
-        <source>Add handling costs</source>
-        <target>Add handling costs</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:260</note>
-      </trans-unit>
-      <trans-unit id="0f696253cf9dacf6079bf5060e60da06">
-        <source>According to total price.</source>
-        <target>According to total price.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:309</note>
-      </trans-unit>
-      <trans-unit id="a083cb6637472c81ec701d3342320adf">
-        <source>According to total weight.</source>
-        <target>According to total weight.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:314</note>
-      </trans-unit>
-      <trans-unit id="482836cce404046ca7dc34fb0a6fc526">
-        <source>Apply the cost of the highest defined range</source>
-        <target>Apply the cost of the highest defined range</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:340</note>
-      </trans-unit>
-      <trans-unit id="9c3448f86be5ee19015f4ecce4bbd6fe">
-        <source>Maximum package width (%s)</source>
-        <target>Maximum package width (%s)</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:391</note>
-      </trans-unit>
-      <trans-unit id="65a0cd2bca5d0a980a5582a548d79900">
-        <source>Maximum package height (%s)</source>
-        <target>Maximum package height (%s)</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:398</note>
-      </trans-unit>
-      <trans-unit id="8317f5bb182c1e92c11221955592b518">
-        <source>Maximum package depth (%s)</source>
-        <target>Maximum package depth (%s)</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:405</note>
-      </trans-unit>
-      <trans-unit id="da5c987cbda47de7a6b09406b0840ec4">
-        <source>Maximum package weight (%s)</source>
-        <target>Maximum package weight (%s)</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:412</note>
-      </trans-unit>
-      <trans-unit id="920bd1fb6d54c93fca528ce941464225">
-        <source>Group access</source>
-        <target>Group access</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:419</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/actions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="29aa46cc3d2677c7e0f216910df600ff">
-        <source>Free shipping</source>
-        <target>Free shipping</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:26</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1d8ca7f442e6d4ad3da5cb61b84284fc">
-        <source>Handling charges</source>
-        <target>Handling charges</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="c9722f74f95451816de0f8ca3259ae44">
-        <source>Free shipping starts at</source>
-        <target>Free shipping starts at</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig:68</note>
-      </trans-unit>
-      <trans-unit id="2605fbb693837be42d0cd0e701cb5aa3">
-        <source>Handling</source>
-        <target>Handling</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/CarrierLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a8bbb000124c9697aa5d63e7e758b64d">
-        <source>Pick up in-store</source>
-        <target>Pick up in-store</target>
-        <note>Context:
-File: classes/lang/KeysReference/CarrierLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="5d671531babe55fff4ae63b94c80ea38">
-        <source>Delivery next day!</source>
-        <target>Delivery next day!</target>
-        <note>Context:
-File: classes/lang/KeysReference/CarrierLang.php:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8430a7b1b81635e3df949c2845303303">
-        <source>Carrier options</source>
-        <target>Carrier options</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig:32</note>
-      </trans-unit>
-      <trans-unit id="bff13ed1cd5b83b03f024f1eb6524337">
-        <source>Default carrier</source>
-        <target>Default carrier</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig:37</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5068c162a60b5859f973f701333f45c5">
-        <source>Tracking number</source>
-        <target>Tracking number</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_shipping.tpl:105</note>
-      </trans-unit>
-      <trans-unit id="552a0d8c17d95d5dbdc0c28217024f5a">
-        <source>Shipping cost</source>
-        <target>Shipping cost</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_shipping.tpl:42</note>
+      <trans-unit id="574539ea519352ea60375ee0a3edbf16">
+        <source>Add new range</source>
+        <target>Add new range</target>
+        <note>Line: 40</note>
       </trans-unit>
     </body>
   </file>
@@ -327,36 +24,12 @@ File: admin-dev/themes/default/template/controllers/orders/_shipping.tpl:42</not
       <trans-unit id="92711ef5b0215a076fef4a3abbfc2258">
         <source>Ranges</source>
         <target>Ranges</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form_ranges.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="19d3894f53ce79c3f836f26cf8a3be3b">
         <source>inactive</source>
         <target>inactive</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form_ranges.tpl:98</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="07018153f387118b1dacafee609f13b1">
-        <source>Will be applied when the price is</source>
-        <target>Will be applied when the price is</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl:27</note>
-      </trans-unit>
-      <trans-unit id="4c687ab170e51c6eaa65be3b621c7205">
-        <source>Will be applied when the weight is</source>
-        <target>Will be applied when the weight is</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="574539ea519352ea60375ee0a3edbf16">
-        <source>Add new range</source>
-        <target>Add new range</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl:40</note>
+        <note>Line: 98</note>
       </trans-unit>
     </body>
   </file>
@@ -365,74 +38,333 @@ File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/
       <trans-unit id="2eee774899a3338d423fe081beea6451">
         <source>This carrier is %1$s and the transit time is %2$s.</source>
         <target>This carrier is %1$s and the transit time is %2$s.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="aa2d6e4f578eb0cfaba23beef76c2194">
         <source>free</source>
         <target>free</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
       <trans-unit id="43aca442af5353cb54151e4a94fcd0b5">
         <source>not free</source>
         <target>not free</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:30</note>
+        <note>Line: 30</note>
       </trans-unit>
       <trans-unit id="b6fbfa40ef6e8d15ec69cb2da0dcd662">
         <source>This carrier can deliver orders from %1$s to %2$s.</source>
         <target>This carrier can deliver orders from %1$s to %2$s.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="2a28ff68d6e69bd4d2ee2d8c11a78823">
         <source>If the order is out of range, the behavior is to %3$s.</source>
         <target>If the order is out of range, the behavior is to %3$s.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="343bf3bbd8b70fd2d04bb095ad2418f9">
         <source>The shipping cost is calculated %1$s and the tax rule %2$s will be applied.</source>
         <target>The shipping cost is calculated %1$s and the tax rule %2$s will be applied.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="0ea5b002f2959687c7ff926ca01a47a3">
         <source>according to the price</source>
         <target>according to the price</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="c2908ded92c5ab4bd42c02e608d0b981">
         <source>according to the weight</source>
         <target>according to the weight</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="ba44d024ba9eec02cc432a36dcffb9d9">
         <source>Carrier name:</source>
         <target>Carrier name:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:40</note>
+        <note>Line: 40</note>
       </trans-unit>
       <trans-unit id="7f9508fc09a86a59fbcea84da182b12a">
         <source>This carrier will be proposed for those delivery zones:</source>
         <target>This carrier will be proposed for those delivery zones:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="7d705fb35c90599d918e0a619c69e17b">
         <source>And it will be proposed for those client groups:</source>
         <target>And it will be proposed for those client groups:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="272175e18b4f5f142e1afc94698df9e3">
         <source>Finally, this carrier will be proposed in those shops:</source>
         <target>Finally, this carrier will be proposed in those shops:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:55</note>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/carriers/helpers/list/list_footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5e6b7c069d71052ffc8c4410c0c46992">
+        <source>Use one of our recommended carrier modules</source>
+        <target>Use one of our recommended carrier modules</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="39efbaa2f3600dd82a031d7ab5138f73">
+        <source>Do you think there should be one? Let us know!</source>
+        <target>Do you think there should be one? Let us know!</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="80a305c8cb9737ef8474472aaa65026e">
+        <source>It seems there are no recommended carriers for your country.</source>
+        <target>It seems there are no recommended carriers for your country.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="552a0d8c17d95d5dbdc0c28217024f5a">
+        <source>Shipping cost</source>
+        <target>Shipping cost</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="29aa46cc3d2677c7e0f216910df600ff">
+        <source>Free shipping</source>
+        <target>Free shipping</target>
+        <note>Line: 1428</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
+        <source>Carrier</source>
+        <target>Carrier</target>
+        <note>Line: 338</note>
+      </trans-unit>
+      <trans-unit id="5068c162a60b5859f973f701333f45c5">
+        <source>Tracking number</source>
+        <target>Tracking number</target>
+        <note>Line: 339</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/CarrierLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a8bbb000124c9697aa5d63e7e758b64d">
+        <source>Pick up in-store</source>
+        <target>Pick up in-store</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="5d671531babe55fff4ae63b94c80ea38">
+        <source>Delivery next day!</source>
+        <target>Delivery next day!</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="de62775a71fc2bf7a13d7530ae24a7ed">
+        <source>General settings</source>
+        <target>General settings</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="756eb8cebeb953f5ae47235ff2e183b5">
+        <source>Shipping locations and costs</source>
+        <target>Shipping locations and costs</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="e2fb9fa6091dd9f779b98efdf998a00a">
+        <source>Size, weight, and group access</source>
+        <target>Size, weight, and group access</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="c91e596246bbf8fdff9dae7b349d71d9">
+        <source>Carrier name</source>
+        <target>Carrier name</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="0979779c4569141b98591d326d343ec2">
+        <source>Tracking URL</source>
+        <target>Tracking URL</target>
+        <note>Line: 217</note>
+      </trans-unit>
+      <trans-unit id="829c7cc5ed48e11df7ac9b05e236a12c">
+        <source>Add handling costs</source>
+        <target>Add handling costs</target>
+        <note>Line: 260</note>
+      </trans-unit>
+      <trans-unit id="0f696253cf9dacf6079bf5060e60da06">
+        <source>According to total price.</source>
+        <target>According to total price.</target>
+        <note>Line: 309</note>
+      </trans-unit>
+      <trans-unit id="a083cb6637472c81ec701d3342320adf">
+        <source>According to total weight.</source>
+        <target>According to total weight.</target>
+        <note>Line: 314</note>
+      </trans-unit>
+      <trans-unit id="482836cce404046ca7dc34fb0a6fc526">
+        <source>Apply the cost of the highest defined range</source>
+        <target>Apply the cost of the highest defined range</target>
+        <note>Line: 340</note>
+      </trans-unit>
+      <trans-unit id="9c3448f86be5ee19015f4ecce4bbd6fe">
+        <source>Maximum package width (%s)</source>
+        <target>Maximum package width (%s)</target>
+        <note>Line: 391</note>
+      </trans-unit>
+      <trans-unit id="65a0cd2bca5d0a980a5582a548d79900">
+        <source>Maximum package height (%s)</source>
+        <target>Maximum package height (%s)</target>
+        <note>Line: 398</note>
+      </trans-unit>
+      <trans-unit id="8317f5bb182c1e92c11221955592b518">
+        <source>Maximum package depth (%s)</source>
+        <target>Maximum package depth (%s)</target>
+        <note>Line: 405</note>
+      </trans-unit>
+      <trans-unit id="da5c987cbda47de7a6b09406b0840ec4">
+        <source>Maximum package weight (%s)</source>
+        <target>Maximum package weight (%s)</target>
+        <note>Line: 412</note>
+      </trans-unit>
+      <trans-unit id="920bd1fb6d54c93fca528ce941464225">
+        <source>Group access</source>
+        <target>Group access</target>
+        <note>Line: 419</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCarriersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8f497c1a3d15af9e0c215019f26b887d">
+        <source>Delay</source>
+        <target>Delay</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="b00b85425e74ed2c85dc3119b78ff2c3">
+        <source>Free Shipping</source>
+        <target>Free Shipping</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="c26732c157d7b353c1be9f7ba8962e57">
+        <source>Add new carrier</source>
+        <target>Add new carrier</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="1c0e287237d8c352c6ead633b019c047">
+        <source>Apply shipping cost</source>
+        <target>Apply shipping cost</target>
+        <note>Line: 249</note>
+      </trans-unit>
+      <trans-unit id="7589dfa9a5a899e9701335164c9ab520">
+        <source>Shipping and handling</source>
+        <target>Shipping and handling</target>
+        <note>Line: 283</note>
+      </trans-unit>
+      <trans-unit id="590f6d9a5885f042982c9a911f76abda">
+        <source>Default behavior</source>
+        <target>Default behavior</target>
+        <note>Line: 313</note>
+      </trans-unit>
+      <trans-unit id="e3d29a6f3d7588301aa04429e686b260">
+        <source>According to total price</source>
+        <target>According to total price</target>
+        <note>Line: 318</note>
+      </trans-unit>
+      <trans-unit id="49fec5c86a3b43821fdf0d9aa7bbd935">
+        <source>According to total weight</source>
+        <target>According to total weight</target>
+        <note>Line: 323</note>
+      </trans-unit>
+      <trans-unit id="324029d06c6bfe85489099f6e69b7637">
+        <source>Maximum package height</source>
+        <target>Maximum package height</target>
+        <note>Line: 349</note>
+      </trans-unit>
+      <trans-unit id="3e86ececa46af50900510892f94c4ed6">
+        <source>Maximum package width</source>
+        <target>Maximum package width</target>
+        <note>Line: 356</note>
+      </trans-unit>
+      <trans-unit id="1935671a637346f67b485596b9fcba2c">
+        <source>Maximum package depth</source>
+        <target>Maximum package depth</target>
+        <note>Line: 363</note>
+      </trans-unit>
+      <trans-unit id="0cce6348a3d85f52a44d053f542afcbc">
+        <source>Maximum package weight</source>
+        <target>Maximum package weight</target>
+        <note>Line: 370</note>
+      </trans-unit>
+      <trans-unit id="4e140ba723a03baa6948340bf90e2ef6">
+        <source>Name:</source>
+        <target>Name:</target>
+        <note>Line: 707</note>
+      </trans-unit>
+      <trans-unit id="1d6af794b2599c1407a83029a09d1ecf">
+        <source>Carriers</source>
+        <target>Carriers</target>
+        <note>Line: 165</note>
+      </trans-unit>
+      <trans-unit id="dde695268ea519ababd83f0ca3d274fc">
+        <source>Transit time</source>
+        <target>Transit time</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="c8b462f779749d2e27abed2e9501b2bd">
+        <source>Speed grade</source>
+        <target>Speed grade</target>
+        <note>Line: 197</note>
+      </trans-unit>
+      <trans-unit id="780c462e85ba4399a5d42e88f69a15ca">
+        <source>Billing</source>
+        <target>Billing</target>
+        <note>Line: 304</note>
+      </trans-unit>
+      <trans-unit id="082ebbb29b5ba59c293a00a55581679b">
+        <source>Out-of-range behavior</source>
+        <target>Out-of-range behavior</target>
+        <note>Line: 329</note>
+      </trans-unit>
+      <trans-unit id="4f890cf6a72112cad95093baecf39831">
+        <source>Disable carrier</source>
+        <target>Disable carrier</target>
+        <note>Line: 339</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8430a7b1b81635e3df949c2845303303">
+        <source>Carrier options</source>
+        <target>Carrier options</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="bff13ed1cd5b83b03f024f1eb6524337">
+        <source>Default carrier</source>
+        <target>Default carrier</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1d8ca7f442e6d4ad3da5cb61b84284fc">
+        <source>Handling charges</source>
+        <target>Handling charges</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="c9722f74f95451816de0f8ca3259ae44">
+        <source>Free shipping starts at</source>
+        <target>Free shipping starts at</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="2605fbb693837be42d0cd0e701cb5aa3">
+        <source>Handling</source>
+        <target>Handling</target>
+        <note>Line: 32</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminShippingHelp.xlf
+++ b/app/Resources/translations/default/AdminShippingHelp.xlf
@@ -1,228 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="07b693f09040dc64d3c36b5daf95caae">
-        <source>Allowed characters: letters, spaces and "%special_chars%".</source>
-        <target>Allowed characters: letters, spaces and "%special_chars%".</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:188</note>
+      <trans-unit id="5e543256c480ac577d30f76f9120eb74">
+        <source>undefined</source>
+        <target>undefined</target>
+        <note>Line: 58</note>
       </trans-unit>
-      <trans-unit id="a788f81b3aa0ef9c9efcb1fb67708d82">
-        <source>For in-store pickup, enter 0 to replace the carrier name with your shop name.</source>
-        <target>For in-store pickup, enter 0 to replace the carrier name with your shop name.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:190</note>
+      <trans-unit id="fb2ea703b13d059f6b7ea5da806021df">
+        <source>Format:</source>
+        <target>Format:</target>
+        <note>Line: 57</note>
       </trans-unit>
-      <trans-unit id="4ca4a355318f45dac9fb0ee632d8dc3c">
-        <source>Enter "0" for a longest shipping delay, or "9" for the shortest shipping delay.</source>
-        <target>Enter "0" for a longest shipping delay, or "9" for the shortest shipping delay.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:208</note>
+      <trans-unit id="b908c2f34052b5276e0bf50f0e042211">
+        <source>Filesize:</source>
+        <target>Filesize:</target>
+        <note>Line: 57</note>
       </trans-unit>
-      <trans-unit id="d7049d8a068769eb32177e404639b8ce">
-        <source>Mark the groups that are allowed access to this carrier.</source>
-        <target>Mark the groups that are allowed access to this carrier.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:422</note>
+      <trans-unit id="2f972dbb48435d9b8087d7e3c22daa09">
+        <source>MB max.</source>
+        <target>MB max.</target>
+        <note>Line: 57</note>
       </trans-unit>
-      <trans-unit id="1c6c9d089ce4b751673e3dd09e97b935">
-        <source>Enable the carrier in the front office.</source>
-        <target>Enable the carrier in the front office.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:471</note>
-      </trans-unit>
-      <trans-unit id="95be6960ce35a5d972b7314203b312be">
-        <source>The carrier's name will be displayed during checkout.</source>
-        <target>The carrier's name will be displayed during checkout.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:189</note>
-      </trans-unit>
-      <trans-unit id="d2eee8992bbabe7e76562a015ecf0d7f">
-        <source>The delivery time will be displayed during checkout.</source>
-        <target>The delivery time will be displayed during checkout.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:200</note>
-      </trans-unit>
-      <trans-unit id="ff9058a791d671d3cb7ce3117b3f989d">
-        <source>Delivery tracking URL: Type '@' where the tracking number should appear. It will be automatically replaced by the tracking number.</source>
-        <target>Delivery tracking URL: Type '@' where the tracking number should appear. It will be automatically replaced by the tracking number.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:219</note>
-      </trans-unit>
-      <trans-unit id="e4cb2dbfdc6b5b71c8aef1b781712b03">
-        <source>For example: 'http://example.com/track.php?num=@' with '@' where the tracking number should appear.</source>
-        <target>For example: 'http://example.com/track.php?num=@' with '@' where the tracking number should appear.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:220</note>
-      </trans-unit>
-      <trans-unit id="0668ec4bb8d6bcb27d283b2af9bc5888">
-        <source><![CDATA[Include the handling costs (as set in Shipping > Preferences) in the final carrier price.]]></source>
-        <target><![CDATA[Include the handling costs (as set in Shipping > Preferences) in the final carrier price.]]></target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:277</note>
-      </trans-unit>
-      <trans-unit id="0d93d79832d9f31a18045afabb105de1">
-        <source>Out-of-range behavior occurs when no defined range matches the customer's cart (e.g. when the weight of the cart is greater than the highest weight limit defined by the weight ranges).</source>
-        <target>Out-of-range behavior occurs when no defined range matches the customer's cart (e.g. when the weight of the cart is greater than the highest weight limit defined by the weight ranges).</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:350</note>
-      </trans-unit>
-      <trans-unit id="2f79e7f703f8cd0258b0ef7e0237a4be">
-        <source>Maximum width managed by this carrier. Set the value to "0", or leave this field blank to ignore.</source>
-        <target>Maximum width managed by this carrier. Set the value to "0", or leave this field blank to ignore.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:394</note>
-      </trans-unit>
-      <trans-unit id="497876c111e98a20564817545518f829">
-        <source>The value must be an integer.</source>
-        <target>The value must be an integer.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:408</note>
-      </trans-unit>
-      <trans-unit id="5929a4e1d04d4653b6dbe2aac59d8a41">
-        <source>Maximum height managed by this carrier. Set the value to "0", or leave this field blank to ignore.</source>
-        <target>Maximum height managed by this carrier. Set the value to "0", or leave this field blank to ignore.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:401</note>
-      </trans-unit>
-      <trans-unit id="aacaecfacce577935cf83eeb01bcac40">
-        <source>Maximum depth managed by this carrier. Set the value to "0", or leave this field blank to ignore.</source>
-        <target>Maximum depth managed by this carrier. Set the value to "0", or leave this field blank to ignore.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:408</note>
-      </trans-unit>
-      <trans-unit id="82ef5a4b25d9debf587900797b0b9619">
-        <source>Maximum weight managed by this carrier. Set the value to "0", or leave this field blank to ignore.</source>
-        <target>Maximum weight managed by this carrier. Set the value to "0", or leave this field blank to ignore.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:415</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCarriersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3194ebe40c7a8c29c78ea79066b6e05c">
-        <source>Carrier name displayed during checkout</source>
-        <target>Carrier name displayed during checkout</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:176</note>
-      </trans-unit>
-      <trans-unit id="9e93aab109e30d26aa231a49385c99db">
-        <source>Upload a logo from your computer.</source>
-        <target>Upload a logo from your computer.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:184</note>
-      </trans-unit>
-      <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">
-        <source>or</source>
-        <target>or</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:184</note>
-      </trans-unit>
-      <trans-unit id="cdaa245d6e50b5647bfd9fcb77ac9a21">
-        <source>Estimated delivery time will be displayed during checkout.</source>
-        <target>Estimated delivery time will be displayed during checkout.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:193</note>
-      </trans-unit>
-      <trans-unit id="7a753d72397847025d0a91c564fa0fdc">
-        <source>Delivery tracking URL: Type '@' where the tracking number should appear. It will then be automatically replaced by the tracking number.</source>
-        <target>Delivery tracking URL: Type '@' where the tracking number should appear. It will then be automatically replaced by the tracking number.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:206</note>
-      </trans-unit>
-      <trans-unit id="f8af50e8f2eb39dc8581b4943d6ec59f">
-        <source>The zones in which this carrier will be used.</source>
-        <target>The zones in which this carrier will be used.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:217</note>
-      </trans-unit>
-      <trans-unit id="920bd1fb6d54c93fca528ce941464225">
-        <source>Group access</source>
-        <target>Group access</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:221</note>
-      </trans-unit>
-      <trans-unit id="8a52ca34a90eb8486886815e62958ac1">
-        <source>Apply both regular shipping cost and product-specific shipping costs.</source>
-        <target>Apply both regular shipping cost and product-specific shipping costs.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:265</note>
-      </trans-unit>
-      <trans-unit id="91aa2e3b1cd071ba7031bf4263e11821">
-        <source>Include the shipping and handling costs in the carrier price.</source>
-        <target>Include the shipping and handling costs in the carrier price.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:300</note>
-      </trans-unit>
-      <trans-unit id="482836cce404046ca7dc34fb0a6fc526">
-        <source>Apply the cost of the highest defined range</source>
-        <target>Apply the cost of the highest defined range</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:335</note>
-      </trans-unit>
-      <trans-unit id="b73438685f91ee3e3afbb725fb8f948a">
-        <source>Out-of-range behavior occurs when none is defined (e.g. when a customer's cart weight is greater than the highest range limit).</source>
-        <target>Out-of-range behavior occurs when none is defined (e.g. when a customer's cart weight is greater than the highest range limit).</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:345</note>
-      </trans-unit>
-      <trans-unit id="0687bb4ca6cc1c51d79684159f91ff11">
-        <source>Maximum height managed by this carrier. Set the value to "0," or leave this field blank to ignore.</source>
-        <target>Maximum height managed by this carrier. Set the value to "0," or leave this field blank to ignore.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:352</note>
-      </trans-unit>
-      <trans-unit id="ff5e2cfc010955358f7ff264d9e58398">
-        <source>Maximum width managed by this carrier. Set the value to "0," or leave this field blank to ignore.</source>
-        <target>Maximum width managed by this carrier. Set the value to "0," or leave this field blank to ignore.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:359</note>
-      </trans-unit>
-      <trans-unit id="049de64decc4aa8fa5aa89cf8b17470c">
-        <source>Maximum depth managed by this carrier. Set the value to "0," or leave this field blank to ignore.</source>
-        <target>Maximum depth managed by this carrier. Set the value to "0," or leave this field blank to ignore.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:366</note>
-      </trans-unit>
-      <trans-unit id="a414ac63c6b29218661d1fa2c6e21b5b">
-        <source>Maximum weight managed by this carrier. Set the value to "0," or leave this field blank to ignore.</source>
-        <target>Maximum weight managed by this carrier. Set the value to "0," or leave this field blank to ignore.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:373</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ece6bb2586fa84042edde479c6a6ce6b">
-        <source>Your shop's default carrier</source>
-        <target>Your shop's default carrier</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig:41</note>
-      </trans-unit>
-      <trans-unit id="4f309c91cb82ce5d20c15d015759a21e">
-        <source>This will only be visible in the front office.</source>
-        <target>This will only be visible in the front office.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig:57</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2be1ec70444ccaf2b74bd55f3aabdead">
-        <source>If you set these parameters to 0, they will be disabled.</source>
-        <target>If you set these parameters to 0, they will be disabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig:41</note>
-      </trans-unit>
-      <trans-unit id="e99c83da35c2a39bf9dc72273d350272">
-        <source>Coupons are not taken into account when calculating free shipping.</source>
-        <target>Coupons are not taken into account when calculating free shipping.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig:44</note>
+      <trans-unit id="c32587b909ccc2187659ca665dbb06be">
+        <source>Current size:</source>
+        <target>Current size:</target>
+        <note>Line: 58</note>
       </trans-unit>
     </body>
   </file>
@@ -231,60 +34,213 @@ File: src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Bl
       <trans-unit id="401c8f6635d231c5360f31ce548c4462">
         <source>Your online store needs to have a proper carrier registered in PrestaShop as soon as you start shipping your products. This means sending yours parcels using your local postal service, or having a contract with a private carrier which in turn will ship your parcels to your customers. In order to have PrestaShop suggest the most adequate carrier to your customers during their order checkout process, you need to register all the carriers with which you have chosen to work.</source>
         <target>Your online store needs to have a proper carrier registered in PrestaShop as soon as you start shipping your products. This means sending yours parcels using your local postal service, or having a contract with a private carrier which in turn will ship your parcels to your customers. In order to have PrestaShop suggest the most adequate carrier to your customers during their order checkout process, you need to register all the carriers with which you have chosen to work.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carriers/helpers/list/list_header.tpl:30</note>
+        <note>Line: 30</note>
       </trans-unit>
       <trans-unit id="c751fd51e685dd8c071f8535be0d0d8f">
         <source>PrestaShop comes with a number of carrier modules that you can activate. You can also buy carrier modules on the PrestaShop Addons marketplace. Recommended modules are listed below: install the module that matches your carrier, and configure it!</source>
         <target>PrestaShop comes with a number of carrier modules that you can activate. You can also buy carrier modules on the PrestaShop Addons marketplace. Recommended modules are listed below: install the module that matches your carrier, and configure it!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carriers/helpers/list/list_header.tpl:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="5bacfd2dc472feddb875fc29134b03bb">
         <source>If there is no existing module for your carrier, then you can register that carrier by hand using the information that it can provide you: shipping rates, regional zones, size and weight limits, etc. Click on the "Add new carrier" button below to open the Carrier Wizard, which will help you register a new carrier in a few steps.</source>
         <target>If there is no existing module for your carrier, then you can register that carrier by hand using the information that it can provide you: shipping rates, regional zones, size and weight limits, etc. Click on the "Add new carrier" button below to open the Carrier Wizard, which will help you register a new carrier in a few steps.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carriers/helpers/list/list_header.tpl:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="12a118b904361ef7a25365b2ff29cfa9">
         <source>Note: DO NOT register a new carrier if there already exists a module for it! Using a module will be much faster and more accurate!</source>
         <target>Note: DO NOT register a new carrier if there already exists a module for it! Using a module will be much faster and more accurate!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carriers/helpers/list/list_header.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="5e543256c480ac577d30f76f9120eb74">
-        <source>undefined</source>
-        <target>undefined</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl:58</note>
+      <trans-unit id="95be6960ce35a5d972b7314203b312be">
+        <source>The carrier's name will be displayed during checkout.</source>
+        <target>The carrier's name will be displayed during checkout.</target>
+        <note>Line: 189</note>
       </trans-unit>
-      <trans-unit id="fb2ea703b13d059f6b7ea5da806021df">
-        <source>Format:</source>
-        <target>Format:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl:57</note>
+      <trans-unit id="d2eee8992bbabe7e76562a015ecf0d7f">
+        <source>The delivery time will be displayed during checkout.</source>
+        <target>The delivery time will be displayed during checkout.</target>
+        <note>Line: 200</note>
       </trans-unit>
-      <trans-unit id="b908c2f34052b5276e0bf50f0e042211">
-        <source>Filesize:</source>
-        <target>Filesize:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl:57</note>
+      <trans-unit id="ff9058a791d671d3cb7ce3117b3f989d">
+        <source>Delivery tracking URL: Type '@' where the tracking number should appear. It will be automatically replaced by the tracking number.</source>
+        <target>Delivery tracking URL: Type '@' where the tracking number should appear. It will be automatically replaced by the tracking number.</target>
+        <note>Line: 219</note>
       </trans-unit>
-      <trans-unit id="2f972dbb48435d9b8087d7e3c22daa09">
-        <source>MB max.</source>
-        <target>MB max.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl:57</note>
+      <trans-unit id="e4cb2dbfdc6b5b71c8aef1b781712b03">
+        <source>For example: 'http://example.com/track.php?num=@' with '@' where the tracking number should appear.</source>
+        <target>For example: 'http://example.com/track.php?num=@' with '@' where the tracking number should appear.</target>
+        <note>Line: 220</note>
       </trans-unit>
-      <trans-unit id="c32587b909ccc2187659ca665dbb06be">
-        <source>Current size:</source>
-        <target>Current size:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl:58</note>
+      <trans-unit id="0668ec4bb8d6bcb27d283b2af9bc5888">
+        <source><![CDATA[Include the handling costs (as set in Shipping > Preferences) in the final carrier price.]]></source>
+        <target><![CDATA[Include the handling costs (as set in Shipping > Preferences) in the final carrier price.]]></target>
+        <note>Line: 277</note>
+      </trans-unit>
+      <trans-unit id="0d93d79832d9f31a18045afabb105de1">
+        <source>Out-of-range behavior occurs when no defined range matches the customer's cart (e.g. when the weight of the cart is greater than the highest weight limit defined by the weight ranges).</source>
+        <target>Out-of-range behavior occurs when no defined range matches the customer's cart (e.g. when the weight of the cart is greater than the highest weight limit defined by the weight ranges).</target>
+        <note>Line: 350</note>
+      </trans-unit>
+      <trans-unit id="2f79e7f703f8cd0258b0ef7e0237a4be">
+        <source>Maximum width managed by this carrier. Set the value to "0", or leave this field blank to ignore.</source>
+        <target>Maximum width managed by this carrier. Set the value to "0", or leave this field blank to ignore.</target>
+        <note>Line: 394</note>
+      </trans-unit>
+      <trans-unit id="497876c111e98a20564817545518f829">
+        <source>The value must be an integer.</source>
+        <target>The value must be an integer.</target>
+        <note>Line: 408</note>
+      </trans-unit>
+      <trans-unit id="5929a4e1d04d4653b6dbe2aac59d8a41">
+        <source>Maximum height managed by this carrier. Set the value to "0", or leave this field blank to ignore.</source>
+        <target>Maximum height managed by this carrier. Set the value to "0", or leave this field blank to ignore.</target>
+        <note>Line: 401</note>
+      </trans-unit>
+      <trans-unit id="aacaecfacce577935cf83eeb01bcac40">
+        <source>Maximum depth managed by this carrier. Set the value to "0", or leave this field blank to ignore.</source>
+        <target>Maximum depth managed by this carrier. Set the value to "0", or leave this field blank to ignore.</target>
+        <note>Line: 408</note>
+      </trans-unit>
+      <trans-unit id="82ef5a4b25d9debf587900797b0b9619">
+        <source>Maximum weight managed by this carrier. Set the value to "0", or leave this field blank to ignore.</source>
+        <target>Maximum weight managed by this carrier. Set the value to "0", or leave this field blank to ignore.</target>
+        <note>Line: 415</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCarriersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="07b693f09040dc64d3c36b5daf95caae">
+        <source>Allowed characters: letters, spaces and "%special_chars%".</source>
+        <target>Allowed characters: letters, spaces and "%special_chars%".</target>
+        <note>Line: 175</note>
+      </trans-unit>
+      <trans-unit id="a788f81b3aa0ef9c9efcb1fb67708d82">
+        <source>For in-store pickup, enter 0 to replace the carrier name with your shop name.</source>
+        <target>For in-store pickup, enter 0 to replace the carrier name with your shop name.</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="4ca4a355318f45dac9fb0ee632d8dc3c">
+        <source>Enter "0" for a longest shipping delay, or "9" for the shortest shipping delay.</source>
+        <target>Enter "0" for a longest shipping delay, or "9" for the shortest shipping delay.</target>
+        <note>Line: 200</note>
+      </trans-unit>
+      <trans-unit id="d7049d8a068769eb32177e404639b8ce">
+        <source>Mark the groups that are allowed access to this carrier.</source>
+        <target>Mark the groups that are allowed access to this carrier.</target>
+        <note>Line: 224</note>
+      </trans-unit>
+      <trans-unit id="1c6c9d089ce4b751673e3dd09e97b935">
+        <source>Enable the carrier in the front office.</source>
+        <target>Enable the carrier in the front office.</target>
+        <note>Line: 245</note>
+      </trans-unit>
+      <trans-unit id="3194ebe40c7a8c29c78ea79066b6e05c">
+        <source>Carrier name displayed during checkout</source>
+        <target>Carrier name displayed during checkout</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="9e93aab109e30d26aa231a49385c99db">
+        <source>Upload a logo from your computer.</source>
+        <target>Upload a logo from your computer.</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">
+        <source>or</source>
+        <target>or</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="cdaa245d6e50b5647bfd9fcb77ac9a21">
+        <source>Estimated delivery time will be displayed during checkout.</source>
+        <target>Estimated delivery time will be displayed during checkout.</target>
+        <note>Line: 193</note>
+      </trans-unit>
+      <trans-unit id="7a753d72397847025d0a91c564fa0fdc">
+        <source>Delivery tracking URL: Type '@' where the tracking number should appear. It will then be automatically replaced by the tracking number.</source>
+        <target>Delivery tracking URL: Type '@' where the tracking number should appear. It will then be automatically replaced by the tracking number.</target>
+        <note>Line: 206</note>
+      </trans-unit>
+      <trans-unit id="f8af50e8f2eb39dc8581b4943d6ec59f">
+        <source>The zones in which this carrier will be used.</source>
+        <target>The zones in which this carrier will be used.</target>
+        <note>Line: 217</note>
+      </trans-unit>
+      <trans-unit id="920bd1fb6d54c93fca528ce941464225">
+        <source>Group access</source>
+        <target>Group access</target>
+        <note>Line: 221</note>
+      </trans-unit>
+      <trans-unit id="8a52ca34a90eb8486886815e62958ac1">
+        <source>Apply both regular shipping cost and product-specific shipping costs.</source>
+        <target>Apply both regular shipping cost and product-specific shipping costs.</target>
+        <note>Line: 265</note>
+      </trans-unit>
+      <trans-unit id="91aa2e3b1cd071ba7031bf4263e11821">
+        <source>Include the shipping and handling costs in the carrier price.</source>
+        <target>Include the shipping and handling costs in the carrier price.</target>
+        <note>Line: 300</note>
+      </trans-unit>
+      <trans-unit id="482836cce404046ca7dc34fb0a6fc526">
+        <source>Apply the cost of the highest defined range</source>
+        <target>Apply the cost of the highest defined range</target>
+        <note>Line: 335</note>
+      </trans-unit>
+      <trans-unit id="b73438685f91ee3e3afbb725fb8f948a">
+        <source>Out-of-range behavior occurs when none is defined (e.g. when a customer's cart weight is greater than the highest range limit).</source>
+        <target>Out-of-range behavior occurs when none is defined (e.g. when a customer's cart weight is greater than the highest range limit).</target>
+        <note>Line: 345</note>
+      </trans-unit>
+      <trans-unit id="0687bb4ca6cc1c51d79684159f91ff11">
+        <source>Maximum height managed by this carrier. Set the value to "0," or leave this field blank to ignore.</source>
+        <target>Maximum height managed by this carrier. Set the value to "0," or leave this field blank to ignore.</target>
+        <note>Line: 352</note>
+      </trans-unit>
+      <trans-unit id="ff5e2cfc010955358f7ff264d9e58398">
+        <source>Maximum width managed by this carrier. Set the value to "0," or leave this field blank to ignore.</source>
+        <target>Maximum width managed by this carrier. Set the value to "0," or leave this field blank to ignore.</target>
+        <note>Line: 359</note>
+      </trans-unit>
+      <trans-unit id="049de64decc4aa8fa5aa89cf8b17470c">
+        <source>Maximum depth managed by this carrier. Set the value to "0," or leave this field blank to ignore.</source>
+        <target>Maximum depth managed by this carrier. Set the value to "0," or leave this field blank to ignore.</target>
+        <note>Line: 366</note>
+      </trans-unit>
+      <trans-unit id="a414ac63c6b29218661d1fa2c6e21b5b">
+        <source>Maximum weight managed by this carrier. Set the value to "0," or leave this field blank to ignore.</source>
+        <target>Maximum weight managed by this carrier. Set the value to "0," or leave this field blank to ignore.</target>
+        <note>Line: 373</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ece6bb2586fa84042edde479c6a6ce6b">
+        <source>Your shop's default carrier</source>
+        <target>Your shop's default carrier</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="4f309c91cb82ce5d20c15d015759a21e">
+        <source>This will only be visible in the front office.</source>
+        <target>This will only be visible in the front office.</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2be1ec70444ccaf2b74bd55f3aabdead">
+        <source>If you set these parameters to 0, they will be disabled.</source>
+        <target>If you set these parameters to 0, they will be disabled.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="e99c83da35c2a39bf9dc72273d350272">
+        <source>Coupons are not taken into account when calculating free shipping.</source>
+        <target>Coupons are not taken into account when calculating free shipping.</target>
+        <note>Line: 44</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminShippingNotification.xlf
+++ b/app/Resources/translations/default/AdminShippingNotification.xlf
@@ -1,80 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminCarriersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="407ec7ad396ed1f5fc78bc006946af12">
-        <source>An error occurred while updating carrier information.</source>
-        <target>An error occurred while updating carrier information.</target>
-        <note>Context:
-File: controllers/admin/AdminCarriersController.php:525</note>
+      <trans-unit id="e23375136c63fb5936352717f495bc82">
+        <source>Ranges are not correctly ordered:</source>
+        <target>Ranges are not correctly ordered:</target>
+        <note>Line: 34</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c2cbc795de8a7691ec0e4c55fd61fe43">
-        <source>You do not have permission to use this wizard.</source>
-        <target>You do not have permission to use this wizard.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:783</note>
-      </trans-unit>
-      <trans-unit id="6305822e6fd3b92120ee6f23552164c4">
-        <source>You must choose at least one shop or group shop.</source>
-        <target>You must choose at least one shop or group shop.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:649</note>
-      </trans-unit>
-      <trans-unit id="9ef70769595c35cca03dae49ac1f31d1">
-        <source>An error occurred while saving this carrier.</source>
-        <target>An error occurred while saving this carrier.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:828</note>
-      </trans-unit>
-      <trans-unit id="cfabe09befdc8289f6ca5fbc6887ffe5">
-        <source>An error occurred while saving carrier groups.</source>
-        <target>An error occurred while saving carrier groups.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:841</note>
-      </trans-unit>
-      <trans-unit id="2222c64a45d69edbf16dd5fb81db904b">
-        <source>An error occurred while saving carrier zones.</source>
-        <target>An error occurred while saving carrier zones.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:846</note>
-      </trans-unit>
-      <trans-unit id="bae6cceb9789ee48445a0ddc8c143f0b">
-        <source>An error occurred while saving carrier ranges.</source>
-        <target>An error occurred while saving carrier ranges.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:852</note>
-      </trans-unit>
-      <trans-unit id="be78233fdb6fe537e065a0d8650c0e84">
-        <source>An error occurred while saving associations of shops.</source>
-        <target>An error occurred while saving associations of shops.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:858</note>
-      </trans-unit>
-      <trans-unit id="5b26cf06b6165264574bf9e097f062bc">
-        <source>An error occurred while saving the tax rules group.</source>
-        <target>An error occurred while saving the tax rules group.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:863</note>
-      </trans-unit>
-      <trans-unit id="08c490a8c2d633b012b63dccd00cc719">
-        <source>An error occurred while saving carrier logo.</source>
-        <target>An error occurred while saving carrier logo.</target>
-        <note>Context:
-File: controllers/admin/AdminCarrierWizardController.php:873</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/logo.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b9bc8a98f12d9decfe96d41c44513157">
-        <source>Are you sure you want to delete the logo?</source>
-        <target>Are you sure you want to delete the logo?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/logo.tpl:43</note>
+      <trans-unit id="11a5324fcccfa07ed027b0226bbf5ee1">
+        <source>Reordering</source>
+        <target>Reordering</target>
+        <note>Line: 35</note>
       </trans-unit>
     </body>
   </file>
@@ -83,48 +19,94 @@ File: admin-dev/themes/default/template/controllers/carrier_wizard/logo.tpl:43</
       <trans-unit id="d6bdbfede9754a46df1a5b801f7a6c04">
         <source>Please validate the last range before creating a new one.</source>
         <target>Please validate the last range before creating a new one.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/view/view.tpl:38</note>
+        <note>Line: 38</note>
       </trans-unit>
       <trans-unit id="d9c830e9dc70798aef5634594d183f1c">
         <source>Are you sure to delete this range ?</source>
         <target>Are you sure to delete this range ?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/view/view.tpl:39</note>
+        <note>Line: 39</note>
       </trans-unit>
       <trans-unit id="8a896dc0288ba4be64367f3006d51b98">
         <source>This range is not valid</source>
         <target>This range is not valid</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/view/view.tpl:42</note>
+        <note>Line: 42</note>
       </trans-unit>
       <trans-unit id="f3fb906c0bd487b3341bc200d23e8faf">
         <source>Ranges are overlapping</source>
         <target>Ranges are overlapping</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/view/view.tpl:44</note>
+        <note>Line: 44</note>
       </trans-unit>
       <trans-unit id="1add5d6b48d9f20ab77e9900918999ff">
         <source>Please select at least one zone</source>
         <target>Please select at least one zone</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/view/view.tpl:45</note>
+        <note>Line: 45</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/logo.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="e23375136c63fb5936352717f495bc82">
-        <source>Ranges are not correctly ordered:</source>
-        <target>Ranges are not correctly ordered:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl:34</note>
+      <trans-unit id="b9bc8a98f12d9decfe96d41c44513157">
+        <source>Are you sure you want to delete the logo?</source>
+        <target>Are you sure you want to delete the logo?</target>
+        <note>Line: 43</note>
       </trans-unit>
-      <trans-unit id="11a5324fcccfa07ed027b0226bbf5ee1">
-        <source>Reordering</source>
-        <target>Reordering</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl:35</note>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCarrierWizardController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c2cbc795de8a7691ec0e4c55fd61fe43">
+        <source>You do not have permission to use this wizard.</source>
+        <target>You do not have permission to use this wizard.</target>
+        <note>Line: 783</note>
+      </trans-unit>
+      <trans-unit id="6305822e6fd3b92120ee6f23552164c4">
+        <source>You must choose at least one shop or group shop.</source>
+        <target>You must choose at least one shop or group shop.</target>
+        <note>Line: 649</note>
+      </trans-unit>
+      <trans-unit id="9ef70769595c35cca03dae49ac1f31d1">
+        <source>An error occurred while saving this carrier.</source>
+        <target>An error occurred while saving this carrier.</target>
+        <note>Line: 828</note>
+      </trans-unit>
+      <trans-unit id="cfabe09befdc8289f6ca5fbc6887ffe5">
+        <source>An error occurred while saving carrier groups.</source>
+        <target>An error occurred while saving carrier groups.</target>
+        <note>Line: 841</note>
+      </trans-unit>
+      <trans-unit id="2222c64a45d69edbf16dd5fb81db904b">
+        <source>An error occurred while saving carrier zones.</source>
+        <target>An error occurred while saving carrier zones.</target>
+        <note>Line: 846</note>
+      </trans-unit>
+      <trans-unit id="bae6cceb9789ee48445a0ddc8c143f0b">
+        <source>An error occurred while saving carrier ranges.</source>
+        <target>An error occurred while saving carrier ranges.</target>
+        <note>Line: 852</note>
+      </trans-unit>
+      <trans-unit id="be78233fdb6fe537e065a0d8650c0e84">
+        <source>An error occurred while saving associations of shops.</source>
+        <target>An error occurred while saving associations of shops.</target>
+        <note>Line: 858</note>
+      </trans-unit>
+      <trans-unit id="5b26cf06b6165264574bf9e097f062bc">
+        <source>An error occurred while saving the tax rules group.</source>
+        <target>An error occurred while saving the tax rules group.</target>
+        <note>Line: 863</note>
+      </trans-unit>
+      <trans-unit id="08c490a8c2d633b012b63dccd00cc719">
+        <source>An error occurred while saving carrier logo.</source>
+        <target>An error occurred while saving carrier logo.</target>
+        <note>Line: 873</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCarriersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="407ec7ad396ed1f5fc78bc006946af12">
+        <source>An error occurred while updating carrier information.</source>
+        <target>An error occurred while updating carrier information.</target>
+        <note>Line: 525</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminShopparametersFeature.xlf
+++ b/app/Resources/translations/default/AdminShopparametersFeature.xlf
@@ -1,27 +1,168 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="40382ca2b15ff499eb4e5c101424bc81">
+        <source>Authorized modules:</source>
+        <target>Authorized modules:</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="32da1449064b7ef38d098e8061630883">
+        <source>This category already exists for this group.</source>
+        <target>This category already exists for this group.</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="e7446ea32216e8bf4fa8cb6460b725d6">
+        <source>Add a category discount</source>
+        <target>Add a category discount</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="29ea3cf72fb288e76bc4310bffabc03e">
+        <source>New group category discount</source>
+        <target>New group category discount</target>
+        <note>Line: 150</note>
+      </trans-unit>
+      <trans-unit id="3b78dd28e2767e0e88e5591abd386d0f">
+        <source>Discount (%):</source>
+        <target>Discount (%):</target>
+        <note>Line: 157</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c20aefc1b11dc684191ded8079cedab4">
+        <source>Group information</source>
+        <target>Group information</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="2dc9a383d693a2ded8b1ef832926ea93">
+        <source>Price display method:</source>
+        <target>Price display method:</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="02d29656d8379684796b01abfd2a9a13">
+        <source>Show prices:</source>
+        <target>Show prices:</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="4845f30b0c12e9dd97246f5f443338ad">
+        <source>Current category discount</source>
+        <target>Current category discount</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="42ba7a29aa37fc2cb42f5381e71afb9f">
+        <source>Members of this customer group</source>
+        <target>Members of this customer group</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="638dab2652b5c9fec7eeee0c8a12431b">
+        <source>Limited to the first 100 customers.</source>
+        <target>Limited to the first 100 customers.</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="3744cbfc625e57d0ac639f162dba21c1">
+        <source>Please use filters to narrow your search.</source>
+        <target>Please use filters to narrow your search.</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="734d291b0d07bae874a51370a032312e">
+        <source>Discount: %.2f%%</source>
+        <target>Discount: %.2f%%</target>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="57297718fdb439175177cf6b196172d1">
+        <source>Order status</source>
+        <target>Order status</target>
+        <note>Line: 1560</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/referrers/form_settings.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="521d4edc7c22d5f63bc5912ff2afa61a">
+        <source>Indexing</source>
+        <target>Indexing</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="97b22af4c50379be3da02a0b10f13ce3">
+        <source>Refresh index</source>
+        <target>Refresh index</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="ab0cf104f39708eabd07b8cb67e149ba">
+        <source>Cache</source>
+        <target>Cache</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="1faa3e365bfe45ad8e3a6c97da5b94d1">
+        <source>Refresh cache</source>
+        <target>Refresh cache</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="7400a4d2e88ba7fe219b1e11d382f3a2">
+        <source>Save direct traffic?</source>
+        <target>Save direct traffic?</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="9e7ff803e9245919433265f5430333c9">
+        <source>Exclude taxes in sales total?</source>
+        <target>Exclude taxes in sales total?</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="9cb43fe3704c7798a2564e0d9cd16d38">
+        <source>Exclude shipping in sales total?</source>
+        <target>Exclude shipping in sales total?</target>
+        <note>Line: 100</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/referrers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c33e404a441c6ba9648f88af3c68a1ca">
+        <source>Statistics</source>
+        <target>Statistics</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="208b51d8918ba3cdd679a5ec275df129">
+        <source>Filter by product:</source>
+        <target>Filter by product:</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/stores/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ad179a1071ebd8b00e0ff4718301dcea">
+        <source>Hours:</source>
+        <target>Hours:</target>
+        <note>Line: 66</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="classes/lang/KeysReference/ConfigurationLang.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="69d08bd5f8cf4e228930935c3f13e42f">
         <source>In Stock</source>
         <target>In Stock</target>
-        <note>Context:
-File: classes/lang/KeysReference/ConfigurationLang.php:58
- Comment: PS_LABEL_IN_STOCK_PRODUCTS on configuration_lang table</note>
+        <note>Line: 58
+Comment: PS_LABEL_IN_STOCK_PRODUCTS on configuration_lang table</note>
       </trans-unit>
       <trans-unit id="43f098d58ceefef56f05ded453751319">
         <source>Product available for orders</source>
         <target>Product available for orders</target>
-        <note>Context:
-File: classes/lang/KeysReference/ConfigurationLang.php:61
- Comment: PS_LABEL_OOS_PRODUCTS_BOA on configuration_lang table</note>
+        <note>Line: 61
+Comment: PS_LABEL_OOS_PRODUCTS_BOA on configuration_lang table</note>
       </trans-unit>
       <trans-unit id="2ef464d50f6acd767fb3424910995218">
         <source>Out-of-Stock</source>
         <target>Out-of-Stock</target>
-        <note>Context:
-File: classes/lang/KeysReference/ConfigurationLang.php:64
- Comment: PS_LABEL_OOS_PRODUCTS_BOD on configuration_lang table</note>
+        <note>Line: 64
+Comment: PS_LABEL_OOS_PRODUCTS_BOD on configuration_lang table</note>
       </trans-unit>
       <trans-unit id="d2faf7873d8849348199df0e47d148ea">
         <source>Dear Customer,
@@ -32,1799 +173,44 @@ Customer service</source>
 
 Regards,
 Customer service</target>
-        <note>Context:
-File: classes/lang/KeysReference/ConfigurationLang.php:26</note>
+        <note>Line: 26</note>
       </trans-unit>
       <trans-unit id="5a88dab595c4fe254a5154bd3ee26b7f">
         <source>We are currently updating our shop and will be back really soon.
 Thanks for your patience.</source>
         <target>We are currently updating our shop and will be back really soon.
 Thanks for your patience.</target>
-        <note>Context:
-File: classes/lang/KeysReference/ConfigurationLang.php:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="d1d2f5672327bcdef75062dc70e875df">
         <source>#IN</source>
         <target>#IN</target>
-        <note>Context:
-File: classes/lang/KeysReference/ConfigurationLang.php:39
- Comment: PS_INVOICE_PREFIX on configuration_lang table</note>
+        <note>Line: 39
+Comment: PS_INVOICE_PREFIX on configuration_lang table</note>
       </trans-unit>
       <trans-unit id="b13c095eb3e41264a7b64504fa8348be">
         <source>#DE</source>
         <target>#DE</target>
-        <note>Context:
-File: classes/lang/KeysReference/ConfigurationLang.php:42
- Comment: PS_DELIVERY_PREFIX on configuration_lang table</note>
+        <note>Line: 42
+Comment: PS_DELIVERY_PREFIX on configuration_lang table</note>
       </trans-unit>
       <trans-unit id="a02341e3f02309e6a6c6832870a7e803">
         <source>#RE</source>
         <target>#RE</target>
-        <note>Context:
-File: classes/lang/KeysReference/ConfigurationLang.php:45
- Comment: PS_RETURN_PREFIX on configuration_lang table</note>
+        <note>Line: 45
+Comment: PS_RETURN_PREFIX on configuration_lang table</note>
       </trans-unit>
       <trans-unit id="4dfefaddceaa53498ee5bd840ac72692">
         <source>a|about|above|after|again|against|all|am|an|and|any|are|aren|as|at|be|because|been|before|being|below|between|both|but|by|can|cannot|could|couldn|did|didn|do|does|doesn|doing|don|down|during|each|few|for|from|further|had|hadn|has|hasn|have|haven|having|he|ll|her|here|hers|herself|him|himself|his|how|ve|if|in|into|is|isn|it|its|itself|let|me|more|most|mustn|my|myself|no|nor|not|of|off|on|once|only|or|other|ought|our|ours|ourselves|out|over|own|same|shan|she|should|shouldn|so|some|such|than|that|the|their|theirs|them|themselves|then|there|these|they|re|this|those|through|to|too|under|until|up|very|was|wasn|we|were|weren|what|when|where|which|while|who|whom|why|with|won|would|wouldn|you|your|yours|yourself|yourselves</source>
         <target>a|about|above|after|again|against|all|am|an|and|any|are|aren|as|at|be|because|been|before|being|below|between|both|but|by|can|cannot|could|couldn|did|didn|do|does|doesn|doing|don|down|during|each|few|for|from|further|had|hadn|has|hasn|have|haven|having|he|ll|her|here|hers|herself|him|himself|his|how|ve|if|in|into|is|isn|it|its|itself|let|me|more|most|mustn|my|myself|no|nor|not|of|off|on|once|only|or|other|ought|our|ours|ourselves|out|over|own|same|shan|she|should|shouldn|so|some|such|than|that|the|their|theirs|them|themselves|then|there|these|they|re|this|those|through|to|too|under|until|up|very|was|wasn|we|were|weren|what|when|where|which|while|who|whom|why|with|won|would|wouldn|you|your|yours|yourself|yourselves</target>
-        <note>Context:
-File: classes/lang/KeysReference/ConfigurationLang.php:48
- Comment: PS_RETURN_PREFIX on configuration_lang table - No translate word per word but adapting for your language</note>
+        <note>Line: 48
+Comment: PS_RETURN_PREFIX on configuration_lang table - No translate word per word but adapting for your language</note>
       </trans-unit>
       <trans-unit id="c3d67cba349c7ecb5465ae92bdb38970">
         <source>You may unsubscribe at any moment. For that purpose, please find our contact info in the legal notice.</source>
         <target>You may unsubscribe at any moment. For that purpose, please find our contact info in the legal notice.</target>
-        <note>Context:
-File: classes/lang/KeysReference/ConfigurationLang.php:53
- Comment: NW_CONDITIONS on configuration_lang table - From ps_emailsubscription module</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="817434295a673aed431435658b65d9a7">
-        <source>Icon</source>
-        <target>Icon</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:287</note>
-      </trans-unit>
-      <trans-unit id="c9f59be398981c130408612e51464e14">
-        <source>Send email to customer</source>
-        <target>Send email to customer</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:89</note>
-      </trans-unit>
-      <trans-unit id="13a44cb3c08c1c40a3c5b62152538ee8">
-        <source>Email template</source>
-        <target>Email template</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:116</note>
-      </trans-unit>
-      <trans-unit id="8b79d8d9315e50cd01d3ce641cdc61bc">
-        <source>Edit return status</source>
-        <target>Edit return status</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:184</note>
-      </trans-unit>
-      <trans-unit id="60fd39d495f2a8d0674c236c004e8f21">
-        <source>Add new order status</source>
-        <target>Add new order status</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:194</note>
-      </trans-unit>
-      <trans-unit id="f08b529034b579d49fa94abec7f93af0">
-        <source>Add new order return status</source>
-        <target>Add new order return status</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:199</note>
-      </trans-unit>
-      <trans-unit id="34499467057e6ded44fd7861eee1893b">
-        <source>Return statuses</source>
-        <target>Return statuses</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:235</note>
-      </trans-unit>
-      <trans-unit id="69a31da4cb502aa192d07ae4a8f48613">
-        <source>Status name</source>
-        <target>Status name</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:478</note>
-      </trans-unit>
-      <trans-unit id="cb5feb1b7314637725a2e73bdc9f7295">
-        <source>Color</source>
-        <target>Color</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:489</note>
-      </trans-unit>
-      <trans-unit id="192b587e5fc71cd5f25a6089c03bff87">
-        <source>Consider the associated order as validated.</source>
-        <target>Consider the associated order as validated.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:302</note>
-      </trans-unit>
-      <trans-unit id="6d6c83be0e74d3b3d041cd61fa607ede">
-        <source>Allow a customer to download and view PDF versions of his/her invoices.</source>
-        <target>Allow a customer to download and view PDF versions of his/her invoices.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:313</note>
-      </trans-unit>
-      <trans-unit id="9529bbf156fbe6c23b5fbd8b32900f68">
-        <source>Hide this status in all customer orders.</source>
-        <target>Hide this status in all customer orders.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:324</note>
-      </trans-unit>
-      <trans-unit id="a8f92721e361eceb4489636d29f56c21">
-        <source>Send an email to the customer when his/her order status has changed.</source>
-        <target>Send an email to the customer when his/her order status has changed.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:335</note>
-      </trans-unit>
-      <trans-unit id="05ffab376e5c4a64caa28a1c4bd9fc0d">
-        <source>Attach invoice PDF to email.</source>
-        <target>Attach invoice PDF to email.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:346</note>
-      </trans-unit>
-      <trans-unit id="53343ccca7ba90caa497d4c4b40f3ec7">
-        <source>Attach delivery slip PDF to email.</source>
-        <target>Attach delivery slip PDF to email.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:357</note>
-      </trans-unit>
-      <trans-unit id="5fe3d2e4d87dccabf5c9c1d81baf995c">
-        <source>Set the order as shipped.</source>
-        <target>Set the order as shipped.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:368</note>
-      </trans-unit>
-      <trans-unit id="67a8390e9643cecbac9d149da4242bf5">
-        <source>Set the order as paid.</source>
-        <target>Set the order as paid.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:379</note>
-      </trans-unit>
-      <trans-unit id="a886c3a69907e954c771aae074f24040">
-        <source>Show delivery PDF.</source>
-        <target>Show delivery PDF.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:390</note>
-      </trans-unit>
-      <trans-unit id="278c491bdd8a53618c149c4ac790da34">
-        <source>Template</source>
-        <target>Template</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:398</note>
-      </trans-unit>
-      <trans-unit id="dc4e76994fd27117c21f83d09faa0649">
-        <source>Return status</source>
-        <target>Return status</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:472</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="57297718fdb439175177cf6b196172d1">
-        <source>Order status</source>
-        <target>Order status</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1560</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="193cfc9be3b995831c6af2fea6650e60">
-        <source>Page</source>
-        <target>Page</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php:108</note>
-      </trans-unit>
-      <trans-unit id="12cb401e3a068898222575c6a5ef5ece">
-        <source>Page title</source>
-        <target>Page title</target>
-        <note>Context:
-File: src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php:114</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a7686ea311b65874a504a343c08a4341">
-        <source>Accented URL</source>
-        <target>Accented URL</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:69</note>
-      </trans-unit>
-      <trans-unit id="fb64c58d84a997e89be8de9897f36ecc">
-        <source>Redirect to the canonical URL</source>
-        <target>Redirect to the canonical URL</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:77</note>
-      </trans-unit>
-      <trans-unit id="38bada4e8300d679ea0c293a8658605a">
-        <source>Disable Apache's MultiViews option</source>
-        <target>Disable Apache's MultiViews option</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:86</note>
-      </trans-unit>
-      <trans-unit id="1260ff0747d4dbe30fcc4d360891205f">
-        <source>Disable Apache's mod_security module</source>
-        <target>Disable Apache's mod_security module</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:96</note>
-      </trans-unit>
-      <trans-unit id="3cb0403ba2ec65e9030c1013b5edb42d">
-        <source>Set up URLs</source>
-        <target>Set up URLs</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Form/ChoiceProvider/CanonicalRedirectTypeChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="720252deba3646242d7d43548bd57d78">
-        <source>No redirection (you may have duplicate content issues)</source>
-        <target>No redirection (you may have duplicate content issues)</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/CanonicalRedirectTypeChoiceProvider.php:59</note>
-      </trans-unit>
-      <trans-unit id="35df89560d52bdb19ba653e994fbb178">
-        <source>302 Moved Temporarily (recommended while setting up your store)</source>
-        <target>302 Moved Temporarily (recommended while setting up your store)</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/CanonicalRedirectTypeChoiceProvider.php:65</note>
-      </trans-unit>
-      <trans-unit id="317a1a7df329b3d6e9d7e36915ebde8c">
-        <source>301 Moved Permanently (recommended once you have gone live)</source>
-        <target>301 Moved Permanently (recommended once you have gone live)</target>
-        <note>Context:
-File: src/Core/Form/ChoiceProvider/CanonicalRedirectTypeChoiceProvider.php:71</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7959e21ff0b83542251ca0b4e9a62eea">
-        <source>Generate robots.txt file</source>
-        <target>Generate robots.txt file</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig:59</note>
-      </trans-unit>
-      <trans-unit id="345d6249c20c6319bb09edaaf536744b">
-        <source>Robots file generation</source>
-        <target>Robots file generation</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="43199543574edd476ab25337ad4a223c">
-        <source>Set shop URL</source>
-        <target>Set shop URL</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig:32</note>
-      </trans-unit>
-      <trans-unit id="db309cb65c4220d02c0fd13927d315ae">
-        <source>Shop domain</source>
-        <target>Shop domain</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig:73</note>
-      </trans-unit>
-      <trans-unit id="7efeee26d2914e586169f61213741599">
-        <source>SSL domain</source>
-        <target>SSL domain</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig:83</note>
-      </trans-unit>
-      <trans-unit id="c274743f6bf3e3682c41e9ee269913f4">
-        <source>Base URI</source>
-        <target>Base URI</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig:93</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2cb749d5ceef7acb7790bbc1703f1fbd">
-        <source>Manage domain name</source>
-        <target>Manage domain name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig:32</note>
-      </trans-unit>
-      <trans-unit id="b6a208425b55c6e53b3114212cc525b6">
-        <source>Add a domain name</source>
-        <target>Add a domain name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig:50</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0d3ed57f8fd83cc2e9cf265a18663c0a">
-        <source>Schema of URLs</source>
-        <target>Schema of URLs</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:34</note>
-      </trans-unit>
-      <trans-unit id="5575f8bf467eba7499f22e78db6f3f56">
-        <source>Route to products</source>
-        <target>Route to products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="1092637069f4ebf1bee2b02fd280888b">
-        <source>Route to category</source>
-        <target>Route to category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:65</note>
-      </trans-unit>
-      <trans-unit id="e5bcaf8cdb205e965d4ba8fdf0dc898c">
-        <source>Route to category which has the "selected_filter" attribute for the "Layered Navigation" (blocklayered) module</source>
-        <target>Route to category which has the "selected_filter" attribute for the "Layered Navigation" (blocklayered) module</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:78</note>
-      </trans-unit>
-      <trans-unit id="08a551b84112995247355daf3b5d72ba">
-        <source>Route to supplier</source>
-        <target>Route to supplier</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:91</note>
-      </trans-unit>
-      <trans-unit id="1dc5f89ed6e4425ecef2613fda85e5c0">
-        <source>Route to brand</source>
-        <target>Route to brand</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:104</note>
-      </trans-unit>
-      <trans-unit id="e175934d3418b2070a829183b2bfe294">
-        <source>Route to page</source>
-        <target>Route to page</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:117</note>
-      </trans-unit>
-      <trans-unit id="01e4fd64862371a0f532b82e302d438d">
-        <source>Route to page category</source>
-        <target>Route to page category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:130</note>
-      </trans-unit>
-      <trans-unit id="4b9a9672a96a435f1d15ad934e093104">
-        <source>Route to modules</source>
-        <target>Route to modules</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:143</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e1622ba9f41f5b695bddc69e3ceaa204">
-        <source>Add a new page</source>
-        <target>Add a new page</target>
-        <note>Context:
-File: src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php:88</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="86d314b39d91d9c8f4578c938e4401d6">
-        <source>Keywords: %keywords%</source>
-        <target>Keywords: %keywords%</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig:37</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminMetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="532a7bf10fd5a4315e0dfefe7a110d43">
-        <source>Default pages</source>
-        <target>Default pages</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:299</note>
-      </trans-unit>
-      <trans-unit id="e334486a68366ba780f5140cfe8668ac">
-        <source>Module pages</source>
-        <target>Module pages</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:303</note>
-      </trans-unit>
-      <trans-unit id="b49c4d1248da006daf31db2577b7be4a">
-        <source>Meta tags</source>
-        <target>Meta tags</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:318</note>
-      </trans-unit>
-      <trans-unit id="c0a1f9eff88edb62c46edb084004e32b">
-        <source>Page name</source>
-        <target>Page name</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:328</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="db72e24b402e8baf8df6ca786a59e4de">
-        <source>Rewritten URL</source>
-        <target>Rewritten URL</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:203</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSearchConfController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9ab81f57823f6aeb02362291f23883e6">
-        <source>Aliases</source>
-        <target>Aliases</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:340</note>
-      </trans-unit>
-      <trans-unit id="325c9099ecef84ddc2912d5f0ed3fe2f">
-        <source>The "indexed" products have been analyzed by PrestaShop and will appear in the results of a front office search.</source>
-        <target>The "indexed" products have been analyzed by PrestaShop and will appear in the results of a front office search.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:78</note>
-      </trans-unit>
-      <trans-unit id="b9a7c2c18f61b96ff75de6468d1c7519">
-        <source>Indexed products</source>
-        <target>Indexed products</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:79</note>
-      </trans-unit>
-      <trans-unit id="a1f25953ca9e49615b12a626584680c5">
-        <source>Building the product index may take a few minutes.</source>
-        <target>Building the product index may take a few minutes.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:82</note>
-      </trans-unit>
-      <trans-unit id="b90813d74ad3dc25c5b976d932fd72d7">
-        <source>If your server stops before the process ends, you can resume the indexing by clicking "Add missing products to the index".</source>
-        <target>If your server stops before the process ends, you can resume the indexing by clicking "Add missing products to the index".</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:83</note>
-      </trans-unit>
-      <trans-unit id="d86f8ed15ec7a8f87fb1b0ed501dbb6b">
-        <source>Add missing products to the index</source>
-        <target>Add missing products to the index</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:87</note>
-      </trans-unit>
-      <trans-unit id="9897b2f361910e5188f231de872d8856">
-        <source>Re-build the entire index</source>
-        <target>Re-build the entire index</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:91</note>
-      </trans-unit>
-      <trans-unit id="9ed967cf992b654e59df8663fce97d59">
-        <source>You can set a cron job that will rebuild your index using the following URL:</source>
-        <target>You can set a cron job that will rebuild your index using the following URL:</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:94</note>
-      </trans-unit>
-      <trans-unit id="f4ff8a799e3f7446a3a67254cf038e7e">
-        <source>Search within word</source>
-        <target>Search within word</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:116</note>
-      </trans-unit>
-      <trans-unit id="969e3f96787be55242155cad3cd630d3">
-        <source>Search exact end match</source>
-        <target>Search exact end match</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:144</note>
-      </trans-unit>
-      <trans-unit id="8e7ace556216459cd9197423709bdd3a">
-        <source>Minimum word length (in characters)</source>
-        <target>Minimum word length (in characters)</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:173</note>
-      </trans-unit>
-      <trans-unit id="5bff181421d95b49ad5ce5bb08f0ffbe">
-        <source>Blacklisted words</source>
-        <target>Blacklisted words</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:187</note>
-      </trans-unit>
-      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
-        <source>Weight</source>
-        <target>Weight</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:200</note>
-      </trans-unit>
-      <trans-unit id="a9f445d59022dee4cb33385aef61620f">
-        <source>The "weight" represents its importance and relevance for the ranking of the products when completing a new search.</source>
-        <target>The "weight" represents its importance and relevance for the ranking of the products when completing a new search.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:203</note>
-      </trans-unit>
-      <trans-unit id="892e1b613b7d9628760008536bdef5da">
-        <source>A word with a weight of eight will have four times more value than a word with a weight of two.</source>
-        <target>A word with a weight of eight will have four times more value than a word with a weight of two.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:208</note>
-      </trans-unit>
-      <trans-unit id="33846fa0095bd29abbc2a8b742669b25">
-        <source>We advise you to set a greater weight for words which appear in the name or reference of a product. This will allow the search results to be as precise and relevant as possible.</source>
-        <target>We advise you to set a greater weight for words which appear in the name or reference of a product. This will allow the search results to be as precise and relevant as possible.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:213</note>
-      </trans-unit>
-      <trans-unit id="15b481c8ea8041ab6000bec80b97db5a">
-        <source>Setting a weight to 0 will exclude that field from search index. Re-build of the entire index is required when changing to or from 0</source>
-        <target>Setting a weight to 0 will exclude that field from search index. Re-build of the entire index is required when changing to or from 0</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:218</note>
-      </trans-unit>
-      <trans-unit id="76a591808a254d4094e1c43f937b834f">
-        <source>Product name weight</source>
-        <target>Product name weight</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:224</note>
-      </trans-unit>
-      <trans-unit id="f391844c98222451204cbb678d591f86">
-        <source>Reference weight</source>
-        <target>Reference weight</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:230</note>
-      </trans-unit>
-      <trans-unit id="6af0a6ff1f2f2a61cbd8b98232314b03">
-        <source>Short description weight</source>
-        <target>Short description weight</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:237</note>
-      </trans-unit>
-      <trans-unit id="f90f799bc686f5d6a731b1f8074b4580">
-        <source>Description weight</source>
-        <target>Description weight</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:246</note>
-      </trans-unit>
-      <trans-unit id="05cdca5b85ff26e596c3af66ed4820d5">
-        <source>Category weight</source>
-        <target>Category weight</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:252</note>
-      </trans-unit>
-      <trans-unit id="3474b76644954c739226a10127d83329">
-        <source>Brand weight</source>
-        <target>Brand weight</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:258</note>
-      </trans-unit>
-      <trans-unit id="c152439199cebb7e1c27633efeaf1eda">
-        <source>Tags weight</source>
-        <target>Tags weight</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:264</note>
-      </trans-unit>
-      <trans-unit id="1b25f9ffbf4d185dbb985380a04732cc">
-        <source>Attributes weight</source>
-        <target>Attributes weight</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:270</note>
-      </trans-unit>
-      <trans-unit id="4871216a35362aebc0d9908e6e288765">
-        <source>Features weight</source>
-        <target>Features weight</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:276</note>
-      </trans-unit>
-      <trans-unit id="58e8dcd40d13b2c661ac86dbc9e04e02">
-        <source>Add new alias</source>
-        <target>Add new alias</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:292</note>
-      </trans-unit>
-      <trans-unit id="8eea62084ca7e541d918e823422bd82e">
-        <source>Result</source>
-        <target>Result</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:356</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/dashproducts/dashproducts.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
-        <source>Search</source>
-        <target>Search</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:383</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/referrers/form_settings.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="521d4edc7c22d5f63bc5912ff2afa61a">
-        <source>Indexing</source>
-        <target>Indexing</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="97b22af4c50379be3da02a0b10f13ce3">
-        <source>Refresh index</source>
-        <target>Refresh index</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:34</note>
-      </trans-unit>
-      <trans-unit id="ab0cf104f39708eabd07b8cb67e149ba">
-        <source>Cache</source>
-        <target>Cache</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:43</note>
-      </trans-unit>
-      <trans-unit id="1faa3e365bfe45ad8e3a6c97da5b94d1">
-        <source>Refresh cache</source>
-        <target>Refresh cache</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:47</note>
-      </trans-unit>
-      <trans-unit id="7400a4d2e88ba7fe219b1e11d382f3a2">
-        <source>Save direct traffic?</source>
-        <target>Save direct traffic?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:60</note>
-      </trans-unit>
-      <trans-unit id="9e7ff803e9245919433265f5430333c9">
-        <source>Exclude taxes in sales total?</source>
-        <target>Exclude taxes in sales total?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:80</note>
-      </trans-unit>
-      <trans-unit id="9cb43fe3704c7798a2564e0d9cd16d38">
-        <source>Exclude shipping in sales total?</source>
-        <target>Exclude shipping in sales total?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:100</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="effdb9ce6c5d44df31b89d7069c8e0fb">
-        <source>Alias</source>
-        <target>Alias</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php:61</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTagsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9fc8691fab39cc1433cd39430edb0501">
-        <source>Add new tag</source>
-        <target>Add new tag</target>
-        <note>Context:
-File: controllers/admin/AdminTagsController.php:77</note>
-      </trans-unit>
-      <trans-unit id="c101058e7ea21bbbf2a5ac893088e90b">
-        <source>Tag</source>
-        <target>Tag</target>
-        <note>Context:
-File: controllers/admin/AdminTagsController.php:135</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminGendersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5e74f2daf4ae8030571ceee5b4837579">
-        <source>Social title</source>
-        <target>Social title</target>
-        <note>Context:
-File: controllers/admin/AdminGendersController.php:70</note>
-      </trans-unit>
-      <trans-unit id="e9bb5320b3890b6747c91b5a71ae5a01">
-        <source>Neutral</source>
-        <target>Neutral</target>
-        <note>Context:
-File: controllers/admin/AdminGendersController.php:146</note>
-      </trans-unit>
-      <trans-unit id="88972b928c146c793fc9bd5c41a27b95">
-        <source>Add new social title</source>
-        <target>Add new social title</target>
-        <note>Context:
-File: controllers/admin/AdminGendersController.php:101</note>
-      </trans-unit>
-      <trans-unit id="d583f5e653e36be901f9baafc9d975b3">
-        <source>Social titles</source>
-        <target>Social titles</target>
-        <note>Context:
-File: controllers/admin/AdminGendersController.php:113</note>
-      </trans-unit>
-      <trans-unit id="6fed80a8c8ded2f5e14a687e4a443abc">
-        <source>Image width</source>
-        <target>Image width</target>
-        <note>Context:
-File: controllers/admin/AdminGendersController.php:159</note>
-      </trans-unit>
-      <trans-unit id="2aa3aa9d021c7cfffb5afa08f52fbc51">
-        <source>Image height</source>
-        <target>Image height</target>
-        <note>Context:
-File: controllers/admin/AdminGendersController.php:166</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/statspersonalinfos/statspersonalinfos.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="63889cfb9d3cbe05d1bd2be5cc9953fd">
-        <source>Male</source>
-        <target>Male</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:217</note>
-      </trans-unit>
-      <trans-unit id="b719ce180ec7bd9641fece2f920f4817">
-        <source>Female</source>
-        <target>Female</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:218</note>
-      </trans-unit>
-      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e">
-        <source>Unknown</source>
-        <target>Unknown</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:332</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminContactsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9aa698f602b1e5694855cee73a683488">
-        <source>Contacts</source>
-        <target>Contacts</target>
-        <note>Context:
-File: controllers/admin/AdminContactsController.php:63</note>
-      </trans-unit>
-      <trans-unit id="a4cd3191fdeea29906a113c78d4c0e26">
-        <source>Save messages?</source>
-        <target>Save messages?</target>
-        <note>Context:
-File: controllers/admin/AdminContactsController.php:86</note>
-      </trans-unit>
-      <trans-unit id="c41f67055a184ed2e895681336572761">
-        <source>Add new contact</source>
-        <target>Add new contact</target>
-        <note>Context:
-File: controllers/admin/AdminContactsController.php:137</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="22ffd0379431f3b615eb8292f6c31d12">
-        <source>Registration date</source>
-        <target>Registration date</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:239</note>
-      </trans-unit>
-      <trans-unit id="c6155aaecccf794cd2a00fcc35898022">
-        <source>Group name</source>
-        <target>Group name</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:66</note>
-      </trans-unit>
-      <trans-unit id="9ba58ad734a38b533febf81361bd1a4f">
-        <source>Discount (%)</source>
-        <target>Discount (%)</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:70</note>
-      </trans-unit>
-      <trans-unit id="ef53538ae41a651c7f72ab6cb1135d8c">
-        <source>Members</source>
-        <target>Members</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:75</note>
-      </trans-unit>
-      <trans-unit id="f870b8a1af52a144a646db03f6f63f7d">
-        <source>Show prices</source>
-        <target>Show prices</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:313</note>
-      </trans-unit>
-      <trans-unit id="3112209b2dd9b55cf5dbc4865dd15afd">
-        <source>Creation date</source>
-        <target>Creation date</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:86</note>
-      </trans-unit>
-      <trans-unit id="4cd6d48d0fc07ca5526fd040edc982d0">
-        <source>Default groups options</source>
-        <target>Default groups options</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:107</note>
-      </trans-unit>
-      <trans-unit id="fcd4748df327d0e328d0aef8c1d8e756">
-        <source>Visitors group</source>
-        <target>Visitors group</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:110</note>
-      </trans-unit>
-      <trans-unit id="312541921a98c69b0f3ac8f5de1b6bb3">
-        <source>Guests group</source>
-        <target>Guests group</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:118</note>
-      </trans-unit>
-      <trans-unit id="115041dc1655b3d837ac409e16c87f85">
-        <source>Customers group</source>
-        <target>Customers group</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:126</note>
-      </trans-unit>
-      <trans-unit id="f5b8916c4201d4c8c725cc105da43b9a">
-        <source>Save, then add a category reduction.</source>
-        <target>Save, then add a category reduction.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:155</note>
-      </trans-unit>
-      <trans-unit id="3bc18b9a688cd9ee9c915cb0023a8d74">
-        <source>Add new group</source>
-        <target>Add new group</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:167</note>
-      </trans-unit>
-      <trans-unit id="c38266740494aa4980d05c606fccac10">
-        <source>Customer group</source>
-        <target>Customer group</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:266</note>
-      </trans-unit>
-      <trans-unit id="e8c371079e194d26e5e912e8f5e60408">
-        <source>Price display method</source>
-        <target>Price display method</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:292</note>
-      </trans-unit>
-      <trans-unit id="c97b6c7f99c3c50efe826e657024d29b">
-        <source>Category discount</source>
-        <target>Category discount</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:334</note>
-      </trans-unit>
-      <trans-unit id="a5b82d7328e66186000f675d6618c414">
-        <source>Modules authorization</source>
-        <target>Modules authorization</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:340</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSearchEnginesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9aa1b03934893d7134a660af4204f2a9">
-        <source>Server</source>
-        <target>Server</target>
-        <note>Context:
-File: controllers/admin/AdminSearchEnginesController.php:69</note>
-      </trans-unit>
-      <trans-unit id="b864759d534539519ceaa2c03a39d4c2">
-        <source>GET variable</source>
-        <target>GET variable</target>
-        <note>Context:
-File: controllers/admin/AdminSearchEnginesController.php:59</note>
-      </trans-unit>
-      <trans-unit id="52e1c423b768c6e9850d70f3a41aca1d">
-        <source>$_GET variable</source>
-        <target>$_GET variable</target>
-        <note>Context:
-File: controllers/admin/AdminSearchEnginesController.php:76</note>
-      </trans-unit>
-      <trans-unit id="6c8b05f1f10d94ede52a64f7ab5bc5cc">
-        <source>Add new search engine</source>
-        <target>Add new search engine</target>
-        <note>Context:
-File: controllers/admin/AdminSearchEnginesController.php:93</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/statslive/statslive.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b6f05e5ddde1ec63d992d61144452dfa">
-        <source>Referrer</source>
-        <target>Referrer</target>
-        <note>Context:
-File: modules/statslive/statslive.php:198</note>
-      </trans-unit>
-      <trans-unit id="a55533db46597bee3cd16899c007257e">
-        <source>There are no visitors online.</source>
-        <target>There are no visitors online.</target>
-        <note>Context:
-File: modules/statslive/statslive.php:216</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ccf107a5d46c6501c9f2f4345400dc2e">
-        <source>Shop ID</source>
-        <target>Shop ID</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:49</note>
-      </trans-unit>
-      <trans-unit id="4493e821e06072415518bd7ae4077996">
-        <source>Shop group</source>
-        <target>Shop group</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:429</note>
-      </trans-unit>
-      <trans-unit id="09059cedfd08d6e8a12417b285a79ffd">
-        <source>Root category</source>
-        <target>Root category</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:64</note>
-      </trans-unit>
-      <trans-unit id="8849f8620b59b37526cebfb785d1df2d">
-        <source>Main URL for this shop</source>
-        <target>Main URL for this shop</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:69</note>
-      </trans-unit>
-      <trans-unit id="0fc629d52a6553e98b76fffa727ba878">
-        <source>Edit this shop group</source>
-        <target>Edit this shop group</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:99</note>
-      </trans-unit>
-      <trans-unit id="652342e19bf26f8d1b350e60aad3e3bf">
-        <source>Add new shop</source>
-        <target>Add new shop</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:126</note>
-      </trans-unit>
-      <trans-unit id="224154fa6f3601b7de4690ba6a9ad8b4">
-        <source>Multistore tree</source>
-        <target>Multistore tree</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:157</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_mainmenu/ps_mainmenu.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e93c33bd1341ab74195430daeb63db13">
-        <source>Shop name</source>
-        <target>Shop name</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1330</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="843fbaec27e324378999e09cc665a7f4">
-        <source>Round up away from zero, when it is half way there (recommended)</source>
-        <target>Round up away from zero, when it is half way there (recommended)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:70</note>
-      </trans-unit>
-      <trans-unit id="9d70eb834e3574ca07a1f28083ecba1e">
-        <source>Round down towards zero, when it is half way there</source>
-        <target>Round down towards zero, when it is half way there</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:71</note>
-      </trans-unit>
-      <trans-unit id="5f9d1d092dc5658734b8af7187460b32">
-        <source>Round towards the next even value</source>
-        <target>Round towards the next even value</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:72</note>
-      </trans-unit>
-      <trans-unit id="8700a0015f3fc1c5d96ccc5140475dc3">
-        <source>Round towards the next odd value</source>
-        <target>Round towards the next odd value</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:73</note>
-      </trans-unit>
-      <trans-unit id="6186ae4fe9ec55025a9777dd973e0af2">
-        <source>Round up to the nearest value</source>
-        <target>Round up to the nearest value</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:74</note>
-      </trans-unit>
-      <trans-unit id="35853630b5da054ef55e8e02d8df4954">
-        <source>Round down to the nearest value</source>
-        <target>Round down to the nearest value</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:75</note>
-      </trans-unit>
-      <trans-unit id="41032c67b9a3d88ff9a824a1f0845513">
-        <source>Round on each item</source>
-        <target>Round on each item</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:81</note>
-      </trans-unit>
-      <trans-unit id="a899eacfb98f1740127be5fe16bee5c7">
-        <source>Round on each line</source>
-        <target>Round on each line</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:82</note>
-      </trans-unit>
-      <trans-unit id="6d19eb8a9ca35d858824737173ebd011">
-        <source>Round on the total</source>
-        <target>Round on the total</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:83</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1656072e927c8d3acd24359cbb648bb5">
-        <source>Enable SSL</source>
-        <target>Enable SSL</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:46</note>
-      </trans-unit>
-      <trans-unit id="73369322b5e1145bb2fc2268ce4d31f0">
-        <source>Enable SSL on all pages</source>
-        <target>Enable SSL on all pages</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:66</note>
-      </trans-unit>
-      <trans-unit id="cd1b98322104dbd61ca6ae0ab16df348">
-        <source>Increase front office security</source>
-        <target>Increase front office security</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:74</note>
-      </trans-unit>
-      <trans-unit id="913d66c5648cf0317ed371371fe44534">
-        <source>Allow iframes on HTML fields</source>
-        <target>Allow iframes on HTML fields</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:82</note>
-      </trans-unit>
-      <trans-unit id="06918a784fb394b84de012810120b75c">
-        <source>Use HTMLPurifier Library</source>
-        <target>Use HTMLPurifier Library</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:90</note>
-      </trans-unit>
-      <trans-unit id="ac2021d3c67ee796d7ab20a466ebd583">
-        <source>Round mode</source>
-        <target>Round mode</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:98</note>
-      </trans-unit>
-      <trans-unit id="019e96f05f09a70e37792a04e9e78cdc">
-        <source>Round type</source>
-        <target>Round type</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:106</note>
-      </trans-unit>
-      <trans-unit id="0a1e355325f75fe4cc3bf08b0f31f1c2">
-        <source>Number of decimals</source>
-        <target>Number of decimals</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:114</note>
-      </trans-unit>
-      <trans-unit id="267b70f19458077fe93a3fd63a6a648a">
-        <source>Display brands and suppliers</source>
-        <target>Display brands and suppliers</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:122</note>
-      </trans-unit>
-      <trans-unit id="922256753aa354c111471e85d4809ec5">
-        <source>Display best sellers</source>
-        <target>Display best sellers</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:130</note>
-      </trans-unit>
-      <trans-unit id="43b266c605d67eaa27801cc5dc0b3995">
-        <source>Enable Multistore</source>
-        <target>Enable Multistore</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:138</note>
-      </trans-unit>
-      <trans-unit id="8d9da6f9870d593e6921d3b728dc0c6b">
-        <source>Main Shop Activity</source>
-        <target>Main Shop Activity</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:146</note>
-      </trans-unit>
-      <trans-unit id="ab08050bd76be6690d1beff885570dfb">
-        <source>Please click here to check if your shop supports HTTPS.</source>
-        <target>Please click here to check if your shop supports HTTPS.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:59</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="57034def557be4e71accee021e74ce5b">
-        <source>Add new store</source>
-        <target>Add new store</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:102</note>
-      </trans-unit>
-      <trans-unit id="821b8ee6937cec96c30fdafbfe836d68">
-        <source>Stores</source>
-        <target>Stores</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:153</note>
-      </trans-unit>
-      <trans-unit id="cb6fd19e08242c75f1af9f4d15be875d">
-        <source>Store name (e.g. City Center Mall Store).</source>
-        <target>Store name (e.g. City Center Mall Store).</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:164</note>
-      </trans-unit>
-      <trans-unit id="e1bcd0aa73dbc610f1fc628499244d8f">
-        <source>Allowed characters: letters, spaces and %s</source>
-        <target>Allowed characters: letters, spaces and %s</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:165</note>
-      </trans-unit>
-      <trans-unit id="6f5373ad371f50f8d9846abf459e9770">
-        <source>Latitude / Longitude</source>
-        <target>Latitude / Longitude</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:218</note>
-      </trans-unit>
-      <trans-unit id="2315a2ebf1ec2420376642ce9b792076">
-        <source>Store coordinates (e.g. 45.265469/-47.226478).</source>
-        <target>Store coordinates (e.g. 45.265469/-47.226478).</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:222</note>
-      </trans-unit>
-      <trans-unit id="8ae5811be1a55b9b8447ad2dbdadbf6e">
-        <source>Picture</source>
-        <target>Picture</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:269</note>
-      </trans-unit>
-      <trans-unit id="6f8522e0610541f1ef215a22ffa66ff6">
-        <source>Monday</source>
-        <target>Monday</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:293</note>
-      </trans-unit>
-      <trans-unit id="5792315f09a5d54fb7e3d066672b507f">
-        <source>Tuesday</source>
-        <target>Tuesday</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:294</note>
-      </trans-unit>
-      <trans-unit id="796c163589f295373e171842f37265d5">
-        <source>Wednesday</source>
-        <target>Wednesday</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:295</note>
-      </trans-unit>
-      <trans-unit id="78ae6f0cd191d25147e252dc54768238">
-        <source>Thursday</source>
-        <target>Thursday</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:296</note>
-      </trans-unit>
-      <trans-unit id="c33b138a163847cdb6caeeb7c9a126b4">
-        <source>Friday</source>
-        <target>Friday</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:297</note>
-      </trans-unit>
-      <trans-unit id="8b7051187b9191cdcdae6ed5a10e5adc">
-        <source>Saturday</source>
-        <target>Saturday</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:298</note>
-      </trans-unit>
-      <trans-unit id="9d1a0949c39e66a0cd65240bc0ac9177">
-        <source>Sunday</source>
-        <target>Sunday</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:299</note>
-      </trans-unit>
-      <trans-unit id="63406c9482c644975f227cc93788e8fb">
-        <source>Choose your country</source>
-        <target>Choose your country</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:427</note>
-      </trans-unit>
-      <trans-unit id="ffea2d321be109fc7243cfeb515fe257">
-        <source>Choose your state (if applicable)</source>
-        <target>Choose your state (if applicable)</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:432</note>
-      </trans-unit>
-      <trans-unit id="de30ac479f8a73106c51739a0bc92cdc">
-        <source>Displayed in emails and page titles.</source>
-        <target>Displayed in emails and page titles.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:440</note>
-      </trans-unit>
-      <trans-unit id="6dbec9966be60ecb814790443c2867f7">
-        <source>Shop email</source>
-        <target>Shop email</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:446</note>
-      </trans-unit>
-      <trans-unit id="17e5b9e86108a7fd53884cfaa66ddb35">
-        <source>Registration number</source>
-        <target>Registration number</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:453</note>
-      </trans-unit>
-      <trans-unit id="1b9a36c9acf2ab7a81d67a55432b6c8f">
-        <source>Shop address line 1</source>
-        <target>Shop address line 1</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:461</note>
-      </trans-unit>
-      <trans-unit id="1cdaa96d262fdea24b42a1fc28eb7564">
-        <source>Shop address line 2</source>
-        <target>Shop address line 2</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:466</note>
-      </trans-unit>
-      <trans-unit id="5dd532f0a63d89c5af0243b74732f63c">
-        <source>Contact details</source>
-        <target>Contact details</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:539</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/statsnewsletter/statsnewsletter.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ae5d01b6efa819cc7a7c05a8c57fcc2c">
-        <source>Visitors</source>
-        <target>Visitors</target>
-        <note>Context:
-File: modules/statsnewsletter/statsnewsletter.php:124</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/statsbestcustomers/statsbestcustomers.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d7e637a6e9ff116de2fa89551240a94d">
-        <source>Visits</source>
-        <target>Visits</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:79</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminReferrersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="453aceb005ceaf54a47da15fee8b2a26">
-        <source>Pages</source>
-        <target>Pages</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:91</note>
-      </trans-unit>
-      <trans-unit id="591411cc8927851db2002208676d8330">
-        <source>Reg.</source>
-        <target>Reg.</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:96</note>
-      </trans-unit>
-      <trans-unit id="4bcce22b929055c8db5204629d0a64c1">
-        <source>Avg. cart</source>
-        <target>Avg. cart</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:114</note>
-      </trans-unit>
-      <trans-unit id="43005b13d452a4ad6f2d8e29b499c55a">
-        <source>Reg. rate</source>
-        <target>Reg. rate</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:121</note>
-      </trans-unit>
-      <trans-unit id="89741aae300253f498b0993fa678fa18">
-        <source>Order rate</source>
-        <target>Order rate</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:506</note>
-      </trans-unit>
-      <trans-unit id="316853cc3718335f11c048e33b9be98a">
-        <source>Click</source>
-        <target>Click</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:131</note>
-      </trans-unit>
-      <trans-unit id="095a1b43effec73955e31e790438de49">
-        <source>Base</source>
-        <target>Base</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:138</note>
-      </trans-unit>
-      <trans-unit id="581007491cfa474c1e1c1943b4f7026e">
-        <source>Add new referrer</source>
-        <target>Add new referrer</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:173</note>
-      </trans-unit>
-      <trans-unit id="bb166feff34b74fef81127259160c93a">
-        <source>Affiliate</source>
-        <target>Affiliate</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:213</note>
-      </trans-unit>
-      <trans-unit id="467c4d2c6929de8029b216ef0c57df6a">
-        <source>Affiliates can access their data with this name and password.</source>
-        <target>Affiliates can access their data with this name and password.</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:240</note>
-      </trans-unit>
-      <trans-unit id="6d4acea4a9682c8387d2117120a060e5">
-        <source>Front access:</source>
-        <target>Front access:</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:241</note>
-      </trans-unit>
-      <trans-unit id="6691265cf8673ac521e3a1672d482723">
-        <source>Commission plan</source>
-        <target>Commission plan</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:257</note>
-      </trans-unit>
-      <trans-unit id="51d53cd2ecdae6b5dd3397875197e898">
-        <source>Click fee</source>
-        <target>Click fee</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:507</note>
-      </trans-unit>
-      <trans-unit id="2e27c4006a026eacfc1f85b41bf9bc4c">
-        <source>Base fee</source>
-        <target>Base fee</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:508</note>
-      </trans-unit>
-      <trans-unit id="86190054fc32554662ffbb12b717e8d0">
-        <source>Percent fee</source>
-        <target>Percent fee</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:509</note>
-      </trans-unit>
-      <trans-unit id="7ea17e2c839ae2f8e149a3c437773a0a">
-        <source>Technical information -- Simple mode</source>
-        <target>Technical information -- Simple mode</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:293</note>
-      </trans-unit>
-      <trans-unit id="f4d72a64acd8929c0cc9ed96a7a336cc">
-        <source>Include</source>
-        <target>Include</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:365</note>
-      </trans-unit>
-      <trans-unit id="0988f870ad8a7648219df0767f768b8d">
-        <source>HTTP referrer</source>
-        <target>HTTP referrer</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:354</note>
-      </trans-unit>
-      <trans-unit id="843f2812f595e7ec7c5036e89fde02d6">
-        <source>Exclude</source>
-        <target>Exclude</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:373</note>
-      </trans-unit>
-      <trans-unit id="efc92fb772a0037d7b1fab20dff56a85">
-        <source>Request URI</source>
-        <target>Request URI</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:369</note>
-      </trans-unit>
-      <trans-unit id="71bbbb5468f517f3508ac436977f4dd4">
-        <source>Technical information -- Expert mode</source>
-        <target>Technical information -- Expert mode</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:344</note>
-      </trans-unit>
-      <trans-unit id="10965b2740f42ad4887932c35cee26ab">
-        <source>Unique visitors</source>
-        <target>Unique visitors</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:498</note>
-      </trans-unit>
-      <trans-unit id="d3139f39f1ad6324c80a9ddd50cc7867">
-        <source>Pages viewed</source>
-        <target>Pages viewed</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:501</note>
-      </trans-unit>
-      <trans-unit id="200f5c9c419f0a53d5d361eff7b33abc">
-        <source>Registration rate</source>
-        <target>Registration rate</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:505</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/statsforecast/statsforecast.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a28735af01fbb1e35371cb120985ac47">
-        <source>Registrations</source>
-        <target>Registrations</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:222</note>
-      </trans-unit>
-      <trans-unit id="ec0fc0100c4fc1ce4eea230c3dc10360">
-        <source>Undefined</source>
-        <target>Undefined</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:529</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="df644ae155e79abf54175bd15d75f363">
-        <source>Product name</source>
-        <target>Product name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php:50</note>
-      </trans-unit>
-      <trans-unit id="290b7c47045d269e2ccfa69e6477acfe">
-        <source>Product price</source>
-        <target>Product price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php:51</note>
-      </trans-unit>
-      <trans-unit id="0cffebd3c32f4467e14759b2b7d3d515">
-        <source>Product add date</source>
-        <target>Product add date</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php:52</note>
-      </trans-unit>
-      <trans-unit id="d920ec381c352d9d92a53ed3d261e8c6">
-        <source>Product modified date</source>
-        <target>Product modified date</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php:53</note>
-      </trans-unit>
-      <trans-unit id="3cfcde53f39184634bc7b2344479fbc4">
-        <source>Position inside category</source>
-        <target>Position inside category</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php:54</note>
-      </trans-unit>
-      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
-        <source>Brand</source>
-        <target>Brand</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php:55</note>
-      </trans-unit>
-      <trans-unit id="7b541de13ca0229406e134a373dd6382">
-        <source>Product quantity</source>
-        <target>Product quantity</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php:56</note>
-      </trans-unit>
-      <trans-unit id="75ed578ac3cb02b0ba40002a25bc0403">
-        <source>Product reference</source>
-        <target>Product reference</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php:57</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="175db77b6b3ecd9633e85b5efc28bbc1">
-        <source>Decrement pack only.</source>
-        <target>Decrement pack only.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php:67</note>
-      </trans-unit>
-      <trans-unit id="1ba020dea4ce06fa139a471db21f41a7">
-        <source>Decrement products in pack only.</source>
-        <target>Decrement products in pack only.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php:68</note>
-      </trans-unit>
-      <trans-unit id="61b912928e920c280798dc648d4068fe">
-        <source>Decrement both.</source>
-        <target>Decrement both.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php:69</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="eb1cef1202fdc4d7954899fbf9f1734b">
-        <source>Number of days for which the product is considered 'new'</source>
-        <target>Number of days for which the product is considered 'new'</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:46</note>
-      </trans-unit>
-      <trans-unit id="9d980493b9016efc42443b1fdae49f33">
-        <source>Max size of product summary</source>
-        <target>Max size of product summary</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:54</note>
-      </trans-unit>
-      <trans-unit id="7dbe88f99044a2b7e37ae992b8651be4">
-        <source>Products (general)</source>
-        <target>Products (general)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="bb98eaca8d91531f4ae177c9d395f1d4">
-        <source>Catalog mode</source>
-        <target>Catalog mode</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="b5069c99813cffc6933c18ab71fd6cd9">
-        <source>Quantity discounts based on</source>
-        <target>Quantity discounts based on</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:61</note>
-      </trans-unit>
-      <trans-unit id="52be3e936f99d9746870ca7d356b3f21">
-        <source>Force update of friendly URL</source>
-        <target>Force update of friendly URL</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:68</note>
-      </trans-unit>
-      <trans-unit id="8a93e785ac0d7204479e4697cbe8696c">
-        <source>Default activation status</source>
-        <target>Default activation status</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f8f1f78351c2864c334a80b706a303b2">
-        <source>Display remaining quantities when the quantity is lower than</source>
-        <target>Display remaining quantities when the quantity is lower than</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig:47</note>
-      </trans-unit>
-      <trans-unit id="eb763a2e313718f33f55e1f0d84df6ee">
-        <source>Product page</source>
-        <target>Product page</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="b58704f2e2e18edc7c903342c2a42dfc">
-        <source>Display available quantities on the product page</source>
-        <target>Display available quantities on the product page</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig:39</note>
-      </trans-unit>
-      <trans-unit id="a2ab7db4ee7104a693358c0c9d07c6ce">
-        <source>Display unavailable product attributes on the product page</source>
-        <target>Display unavailable product attributes on the product page</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig:55</note>
-      </trans-unit>
-      <trans-unit id="01dabe7ae47f9848c5e38f353a8f866f">
-        <source>Display the "add to cart" button when a product has attributes</source>
-        <target>Display the "add to cart" button when a product has attributes</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig:63</note>
-      </trans-unit>
-      <trans-unit id="0a91cf360875af4259f26bc7e2971132">
-        <source>Separator of attribute anchor on the product links</source>
-        <target>Separator of attribute anchor on the product links</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig:71</note>
-      </trans-unit>
-      <trans-unit id="f7699b3d1af7fe3cdb3a6ff301940fdf">
-        <source>Display discounted price</source>
-        <target>Display discounted price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig:80</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7e1b4ee573c4ef023904fd90eb9ddea7">
-        <source>Products per page</source>
-        <target>Products per page</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="cbb81506a7fe3ef03f7a89c76c52131a">
-        <source>Pagination</source>
-        <target>Pagination</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="e29857ad6c4bbba99614831d7e3e5a3f">
-        <source>Default order by</source>
-        <target>Default order by</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="114a8ec626471fdc120f863a9fb25e4c">
-        <source>Default order method</source>
-        <target>Default order method</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig:52</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="640fd0cc0ffa0316ae087652871f4486">
-        <source>minutes</source>
-        <target>minutes</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php:47</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9ca2e29ab10b2046b32dea40f4e5c232">
-        <source>Password reset delay</source>
-        <target>Password reset delay</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="a7ddcecde44eba59d425762fcdeec665">
-        <source>Re-display cart at login</source>
-        <target>Re-display cart at login</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="fcae2ef516600f29ac9aa4b084981328">
-        <source>Send an email after registration</source>
-        <target>Send an email after registration</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="c760118c537146713521758269a44bd3">
-        <source>Enable B2B mode</source>
-        <target>Enable B2B mode</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:59</note>
-      </trans-unit>
-      <trans-unit id="dcc6fd9b580a958b3f42488265cb1300">
-        <source>Ask for birth date</source>
-        <target>Ask for birth date</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:66</note>
-      </trans-unit>
-      <trans-unit id="a5e968e6a3689ca07bbdbecb6b0710ff">
-        <source>Enable partner offers</source>
-        <target>Enable partner offers</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:73</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c6ca929dc4c8193ad6cd154e9e075ac9">
-        <source>Minimum purchase total required in order to validate the order</source>
-        <target>Minimum purchase total required in order to validate the order</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:59</note>
-      </trans-unit>
-      <trans-unit id="28e503c3e4f502b3631e255dfc527620">
-        <source>Enable final summary</source>
-        <target>Enable final summary</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="403e42a4b26e379cb13563c98ab63067">
-        <source>Enable guest checkout</source>
-        <target>Enable guest checkout</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="0fb43a164e61d758c5eddcceb67be0c1">
-        <source>Disable Reordering Option</source>
-        <target>Disable Reordering Option</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="f30598053df0edf94d9463a2133d7f13">
-        <source>Recalculate shipping costs after editing the order</source>
-        <target>Recalculate shipping costs after editing the order</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:66</note>
-      </trans-unit>
-      <trans-unit id="8f32f059d66d7f10db7668e75b4742e6">
-        <source>Allow multishipping</source>
-        <target>Allow multishipping</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:74</note>
-      </trans-unit>
-      <trans-unit id="cd6aaf6d8287fd5a49122d36f0ff7024">
-        <source>Delayed shipping</source>
-        <target>Delayed shipping</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:82</note>
-      </trans-unit>
-      <trans-unit id="e4045598261988d9988c594243a9434d">
-        <source>Terms of service</source>
-        <target>Terms of service</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:89</note>
-      </trans-unit>
-      <trans-unit id="960e3de6241e862401f2bd93539e0381">
-        <source>Page for the Terms and conditions</source>
-        <target>Page for the Terms and conditions</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:96</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2a0677dae563d574fb1c50badaa4eabf">
-        <source>Gift-wrapping price</source>
-        <target>Gift-wrapping price</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="bf3b3ed0e4fd43efff9c26b3d35c6c2f">
-        <source>Gift options</source>
-        <target>Gift options</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig:33</note>
-      </trans-unit>
-      <trans-unit id="d2c8471bccf2bbf30151cf50a96c3877">
-        <source>Offer gift wrapping</source>
-        <target>Offer gift wrapping</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="0d8bdbe98feb696dd76760ee1374a740">
-        <source>Gift-wrapping tax</source>
-        <target>Gift-wrapping tax</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig:54</note>
-      </trans-unit>
-      <trans-unit id="b667478ccafce4bff6d427a6bca06269">
-        <source>Offer recycled packaging</source>
-        <target>Offer recycled packaging</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig:63</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0d2054b7a56db47a97f65e3da632fe8b">
-        <source>The route %routeRule% is not valid</source>
-        <target>The route %routeRule% is not valid</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsFormDataProvider.php:164</note>
-      </trans-unit>
-      <trans-unit id="c5fe0d77ab52ead15661b37ade6a594b">
-        <source>Keyword "{%keyword%}" required for route "%routeName%" (rule: "%routeRule%")</source>
-        <target>Keyword "{%keyword%}" required for route "%routeName%" (rule: "%routeRule%")</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsFormDataProvider.php:177</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/GenderLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="127469a6b4253ebb77adccc0dd48461e">
-        <source>Mr.</source>
-        <target>Mr.</target>
-        <note>Context:
-File: classes/lang/KeysReference/GenderLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="773442a125403cbb194c24c5a8d59b88">
-        <source>Mrs.</source>
-        <target>Mrs.</target>
-        <note>Context:
-File: classes/lang/KeysReference/GenderLang.php:27</note>
+        <note>Line: 53
+Comment: NW_CONDITIONS on configuration_lang table - From ps_emailsubscription module</note>
       </trans-unit>
     </body>
   </file>
@@ -1833,26 +219,36 @@ File: classes/lang/KeysReference/GenderLang.php:27</note>
       <trans-unit id="4b220f866824d97c12e2eb9b44e3b5e6">
         <source>Webmaster</source>
         <target>Webmaster</target>
-        <note>Context:
-File: classes/lang/KeysReference/ContactLang.php:26</note>
+        <note>Line: 26</note>
       </trans-unit>
       <trans-unit id="2273d1167a6212812d95dc8fadbae78e">
         <source>Customer service</source>
         <target>Customer service</target>
-        <note>Context:
-File: classes/lang/KeysReference/ContactLang.php:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="e335310ef456f61ede772356e5ece2aa">
         <source>If a technical problem occurs on this website</source>
         <target>If a technical problem occurs on this website</target>
-        <note>Context:
-File: classes/lang/KeysReference/ContactLang.php:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="c41c56aaf2db6aadfcdbe7e46422607d">
         <source>For any question about a product, an order</source>
         <target>For any question about a product, an order</target>
-        <note>Context:
-File: classes/lang/KeysReference/ContactLang.php:30</note>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/GenderLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="127469a6b4253ebb77adccc0dd48461e">
+        <source>Mr.</source>
+        <target>Mr.</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="773442a125403cbb194c24c5a8d59b88">
+        <source>Mrs.</source>
+        <target>Mrs.</target>
+        <note>Line: 27</note>
       </trans-unit>
     </body>
   </file>
@@ -1861,42 +257,1135 @@ File: classes/lang/KeysReference/ContactLang.php:30</note>
       <trans-unit id="c9fb01bb38360f1f3f595b7ccf3d3abe">
         <source>Visitor</source>
         <target>Visitor</target>
-        <note>Context:
-File: classes/lang/KeysReference/GroupLang.php:26</note>
+        <note>Line: 26</note>
       </trans-unit>
       <trans-unit id="adb831a7fdd83dd1e2a309ce7591dff8">
         <source>Guest</source>
         <target>Guest</target>
-        <note>Context:
-File: classes/lang/KeysReference/GroupLang.php:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="ce26601dac0dea138b7295f02b7620a7">
         <source>Customer</source>
         <target>Customer</target>
-        <note>Context:
-File: classes/lang/KeysReference/GroupLang.php:28</note>
+        <note>Line: 28</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/admin/AdminContactsController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="7fe15a347d66e291d7a1375273226205">
-        <source>Enable Shop</source>
-        <target>Enable Shop</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig:43</note>
+      <trans-unit id="9aa698f602b1e5694855cee73a683488">
+        <source>Contacts</source>
+        <target>Contacts</target>
+        <note>Line: 75</note>
       </trans-unit>
-      <trans-unit id="daf835712085aaaf81818e7ebfeb66b8">
-        <source>Maintenance IP</source>
-        <target>Maintenance IP</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig:50</note>
+      <trans-unit id="a4cd3191fdeea29906a113c78d4c0e26">
+        <source>Save messages?</source>
+        <target>Save messages?</target>
+        <note>Line: 98</note>
       </trans-unit>
-      <trans-unit id="9278432c5d2aec1ac4f42c23a941af21">
-        <source>Custom maintenance text</source>
-        <target>Custom maintenance text</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig:57</note>
+      <trans-unit id="c41f67055a184ed2e895681336572761">
+        <source>Add new contact</source>
+        <target>Add new contact</target>
+        <note>Line: 149</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminGendersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5e74f2daf4ae8030571ceee5b4837579">
+        <source>Social title</source>
+        <target>Social title</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="e9bb5320b3890b6747c91b5a71ae5a01">
+        <source>Neutral</source>
+        <target>Neutral</target>
+        <note>Line: 146</note>
+      </trans-unit>
+      <trans-unit id="88972b928c146c793fc9bd5c41a27b95">
+        <source>Add new social title</source>
+        <target>Add new social title</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="d583f5e653e36be901f9baafc9d975b3">
+        <source>Social titles</source>
+        <target>Social titles</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="6fed80a8c8ded2f5e14a687e4a443abc">
+        <source>Image width</source>
+        <target>Image width</target>
+        <note>Line: 159</note>
+      </trans-unit>
+      <trans-unit id="2aa3aa9d021c7cfffb5afa08f52fbc51">
+        <source>Image height</source>
+        <target>Image height</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="63889cfb9d3cbe05d1bd2be5cc9953fd">
+        <source>Male</source>
+        <target>Male</target>
+        <note>Line: 136</note>
+      </trans-unit>
+      <trans-unit id="b719ce180ec7bd9641fece2f920f4817">
+        <source>Female</source>
+        <target>Female</target>
+        <note>Line: 141</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="22ffd0379431f3b615eb8292f6c31d12">
+        <source>Registration date</source>
+        <target>Registration date</target>
+        <note>Line: 265</note>
+      </trans-unit>
+      <trans-unit id="c6155aaecccf794cd2a00fcc35898022">
+        <source>Group name</source>
+        <target>Group name</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="9ba58ad734a38b533febf81361bd1a4f">
+        <source>Discount (%)</source>
+        <target>Discount (%)</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="ef53538ae41a651c7f72ab6cb1135d8c">
+        <source>Members</source>
+        <target>Members</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="f870b8a1af52a144a646db03f6f63f7d">
+        <source>Show prices</source>
+        <target>Show prices</target>
+        <note>Line: 352</note>
+      </trans-unit>
+      <trans-unit id="3112209b2dd9b55cf5dbc4865dd15afd">
+        <source>Creation date</source>
+        <target>Creation date</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="4cd6d48d0fc07ca5526fd040edc982d0">
+        <source>Default groups options</source>
+        <target>Default groups options</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="fcd4748df327d0e328d0aef8c1d8e756">
+        <source>Visitors group</source>
+        <target>Visitors group</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="312541921a98c69b0f3ac8f5de1b6bb3">
+        <source>Guests group</source>
+        <target>Guests group</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="115041dc1655b3d837ac409e16c87f85">
+        <source>Customers group</source>
+        <target>Customers group</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="f5b8916c4201d4c8c725cc105da43b9a">
+        <source>Save, then add a category reduction.</source>
+        <target>Save, then add a category reduction.</target>
+        <note>Line: 155</note>
+      </trans-unit>
+      <trans-unit id="3bc18b9a688cd9ee9c915cb0023a8d74">
+        <source>Add new group</source>
+        <target>Add new group</target>
+        <note>Line: 167</note>
+      </trans-unit>
+      <trans-unit id="c38266740494aa4980d05c606fccac10">
+        <source>Customer group</source>
+        <target>Customer group</target>
+        <note>Line: 305</note>
+      </trans-unit>
+      <trans-unit id="e8c371079e194d26e5e912e8f5e60408">
+        <source>Price display method</source>
+        <target>Price display method</target>
+        <note>Line: 331</note>
+      </trans-unit>
+      <trans-unit id="c97b6c7f99c3c50efe826e657024d29b">
+        <source>Category discount</source>
+        <target>Category discount</target>
+        <note>Line: 373</note>
+      </trans-unit>
+      <trans-unit id="a5b82d7328e66186000f675d6618c414">
+        <source>Modules authorization</source>
+        <target>Modules authorization</target>
+        <note>Line: 379</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="db72e24b402e8baf8df6ca786a59e4de">
+        <source>Rewritten URL</source>
+        <target>Rewritten URL</target>
+        <note>Line: 203</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminMetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="532a7bf10fd5a4315e0dfefe7a110d43">
+        <source>Default pages</source>
+        <target>Default pages</target>
+        <note>Line: 299</note>
+      </trans-unit>
+      <trans-unit id="e334486a68366ba780f5140cfe8668ac">
+        <source>Module pages</source>
+        <target>Module pages</target>
+        <note>Line: 303</note>
+      </trans-unit>
+      <trans-unit id="b49c4d1248da006daf31db2577b7be4a">
+        <source>Meta tags</source>
+        <target>Meta tags</target>
+        <note>Line: 318</note>
+      </trans-unit>
+      <trans-unit id="c0a1f9eff88edb62c46edb084004e32b">
+        <source>Page name</source>
+        <target>Page name</target>
+        <note>Line: 328</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReferrersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ae5d01b6efa819cc7a7c05a8c57fcc2c">
+        <source>Visitors</source>
+        <target>Visitors</target>
+        <note>Line: 499</note>
+      </trans-unit>
+      <trans-unit id="d7e637a6e9ff116de2fa89551240a94d">
+        <source>Visits</source>
+        <target>Visits</target>
+        <note>Line: 500</note>
+      </trans-unit>
+      <trans-unit id="453aceb005ceaf54a47da15fee8b2a26">
+        <source>Pages</source>
+        <target>Pages</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="591411cc8927851db2002208676d8330">
+        <source>Reg.</source>
+        <target>Reg.</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="4bcce22b929055c8db5204629d0a64c1">
+        <source>Avg. cart</source>
+        <target>Avg. cart</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="43005b13d452a4ad6f2d8e29b499c55a">
+        <source>Reg. rate</source>
+        <target>Reg. rate</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="89741aae300253f498b0993fa678fa18">
+        <source>Order rate</source>
+        <target>Order rate</target>
+        <note>Line: 506</note>
+      </trans-unit>
+      <trans-unit id="316853cc3718335f11c048e33b9be98a">
+        <source>Click</source>
+        <target>Click</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="095a1b43effec73955e31e790438de49">
+        <source>Base</source>
+        <target>Base</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="581007491cfa474c1e1c1943b4f7026e">
+        <source>Add new referrer</source>
+        <target>Add new referrer</target>
+        <note>Line: 173</note>
+      </trans-unit>
+      <trans-unit id="bb166feff34b74fef81127259160c93a">
+        <source>Affiliate</source>
+        <target>Affiliate</target>
+        <note>Line: 213</note>
+      </trans-unit>
+      <trans-unit id="467c4d2c6929de8029b216ef0c57df6a">
+        <source>Affiliates can access their data with this name and password.</source>
+        <target>Affiliates can access their data with this name and password.</target>
+        <note>Line: 240</note>
+      </trans-unit>
+      <trans-unit id="6d4acea4a9682c8387d2117120a060e5">
+        <source>Front access:</source>
+        <target>Front access:</target>
+        <note>Line: 241</note>
+      </trans-unit>
+      <trans-unit id="6691265cf8673ac521e3a1672d482723">
+        <source>Commission plan</source>
+        <target>Commission plan</target>
+        <note>Line: 257</note>
+      </trans-unit>
+      <trans-unit id="51d53cd2ecdae6b5dd3397875197e898">
+        <source>Click fee</source>
+        <target>Click fee</target>
+        <note>Line: 507</note>
+      </trans-unit>
+      <trans-unit id="2e27c4006a026eacfc1f85b41bf9bc4c">
+        <source>Base fee</source>
+        <target>Base fee</target>
+        <note>Line: 508</note>
+      </trans-unit>
+      <trans-unit id="86190054fc32554662ffbb12b717e8d0">
+        <source>Percent fee</source>
+        <target>Percent fee</target>
+        <note>Line: 509</note>
+      </trans-unit>
+      <trans-unit id="7ea17e2c839ae2f8e149a3c437773a0a">
+        <source>Technical information -- Simple mode</source>
+        <target>Technical information -- Simple mode</target>
+        <note>Line: 293</note>
+      </trans-unit>
+      <trans-unit id="f4d72a64acd8929c0cc9ed96a7a336cc">
+        <source>Include</source>
+        <target>Include</target>
+        <note>Line: 365</note>
+      </trans-unit>
+      <trans-unit id="0988f870ad8a7648219df0767f768b8d">
+        <source>HTTP referrer</source>
+        <target>HTTP referrer</target>
+        <note>Line: 354</note>
+      </trans-unit>
+      <trans-unit id="843f2812f595e7ec7c5036e89fde02d6">
+        <source>Exclude</source>
+        <target>Exclude</target>
+        <note>Line: 373</note>
+      </trans-unit>
+      <trans-unit id="efc92fb772a0037d7b1fab20dff56a85">
+        <source>Request URI</source>
+        <target>Request URI</target>
+        <note>Line: 369</note>
+      </trans-unit>
+      <trans-unit id="71bbbb5468f517f3508ac436977f4dd4">
+        <source>Technical information -- Expert mode</source>
+        <target>Technical information -- Expert mode</target>
+        <note>Line: 344</note>
+      </trans-unit>
+      <trans-unit id="10965b2740f42ad4887932c35cee26ab">
+        <source>Unique visitors</source>
+        <target>Unique visitors</target>
+        <note>Line: 498</note>
+      </trans-unit>
+      <trans-unit id="d3139f39f1ad6324c80a9ddd50cc7867">
+        <source>Pages viewed</source>
+        <target>Pages viewed</target>
+        <note>Line: 501</note>
+      </trans-unit>
+      <trans-unit id="200f5c9c419f0a53d5d361eff7b33abc">
+        <source>Registration rate</source>
+        <target>Registration rate</target>
+        <note>Line: 505</note>
+      </trans-unit>
+      <trans-unit id="a28735af01fbb1e35371cb120985ac47">
+        <source>Registrations</source>
+        <target>Registrations</target>
+        <note>Line: 502</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSearchConfController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9ab81f57823f6aeb02362291f23883e6">
+        <source>Aliases</source>
+        <target>Aliases</target>
+        <note>Line: 340</note>
+      </trans-unit>
+      <trans-unit id="325c9099ecef84ddc2912d5f0ed3fe2f">
+        <source>The "indexed" products have been analyzed by PrestaShop and will appear in the results of a front office search.</source>
+        <target>The "indexed" products have been analyzed by PrestaShop and will appear in the results of a front office search.</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="b9a7c2c18f61b96ff75de6468d1c7519">
+        <source>Indexed products</source>
+        <target>Indexed products</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="a1f25953ca9e49615b12a626584680c5">
+        <source>Building the product index may take a few minutes.</source>
+        <target>Building the product index may take a few minutes.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="b90813d74ad3dc25c5b976d932fd72d7">
+        <source>If your server stops before the process ends, you can resume the indexing by clicking "Add missing products to the index".</source>
+        <target>If your server stops before the process ends, you can resume the indexing by clicking "Add missing products to the index".</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="d86f8ed15ec7a8f87fb1b0ed501dbb6b">
+        <source>Add missing products to the index</source>
+        <target>Add missing products to the index</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="9897b2f361910e5188f231de872d8856">
+        <source>Re-build the entire index</source>
+        <target>Re-build the entire index</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="9ed967cf992b654e59df8663fce97d59">
+        <source>You can set a cron job that will rebuild your index using the following URL:</source>
+        <target>You can set a cron job that will rebuild your index using the following URL:</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="f4ff8a799e3f7446a3a67254cf038e7e">
+        <source>Search within word</source>
+        <target>Search within word</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="969e3f96787be55242155cad3cd630d3">
+        <source>Search exact end match</source>
+        <target>Search exact end match</target>
+        <note>Line: 144</note>
+      </trans-unit>
+      <trans-unit id="8e7ace556216459cd9197423709bdd3a">
+        <source>Minimum word length (in characters)</source>
+        <target>Minimum word length (in characters)</target>
+        <note>Line: 173</note>
+      </trans-unit>
+      <trans-unit id="5bff181421d95b49ad5ce5bb08f0ffbe">
+        <source>Blacklisted words</source>
+        <target>Blacklisted words</target>
+        <note>Line: 187</note>
+      </trans-unit>
+      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
+        <source>Weight</source>
+        <target>Weight</target>
+        <note>Line: 200</note>
+      </trans-unit>
+      <trans-unit id="a9f445d59022dee4cb33385aef61620f">
+        <source>The "weight" represents its importance and relevance for the ranking of the products when completing a new search.</source>
+        <target>The "weight" represents its importance and relevance for the ranking of the products when completing a new search.</target>
+        <note>Line: 203</note>
+      </trans-unit>
+      <trans-unit id="892e1b613b7d9628760008536bdef5da">
+        <source>A word with a weight of eight will have four times more value than a word with a weight of two.</source>
+        <target>A word with a weight of eight will have four times more value than a word with a weight of two.</target>
+        <note>Line: 208</note>
+      </trans-unit>
+      <trans-unit id="33846fa0095bd29abbc2a8b742669b25">
+        <source>We advise you to set a greater weight for words which appear in the name or reference of a product. This will allow the search results to be as precise and relevant as possible.</source>
+        <target>We advise you to set a greater weight for words which appear in the name or reference of a product. This will allow the search results to be as precise and relevant as possible.</target>
+        <note>Line: 213</note>
+      </trans-unit>
+      <trans-unit id="15b481c8ea8041ab6000bec80b97db5a">
+        <source>Setting a weight to 0 will exclude that field from search index. Re-build of the entire index is required when changing to or from 0</source>
+        <target>Setting a weight to 0 will exclude that field from search index. Re-build of the entire index is required when changing to or from 0</target>
+        <note>Line: 218</note>
+      </trans-unit>
+      <trans-unit id="76a591808a254d4094e1c43f937b834f">
+        <source>Product name weight</source>
+        <target>Product name weight</target>
+        <note>Line: 224</note>
+      </trans-unit>
+      <trans-unit id="f391844c98222451204cbb678d591f86">
+        <source>Reference weight</source>
+        <target>Reference weight</target>
+        <note>Line: 230</note>
+      </trans-unit>
+      <trans-unit id="6af0a6ff1f2f2a61cbd8b98232314b03">
+        <source>Short description weight</source>
+        <target>Short description weight</target>
+        <note>Line: 237</note>
+      </trans-unit>
+      <trans-unit id="f90f799bc686f5d6a731b1f8074b4580">
+        <source>Description weight</source>
+        <target>Description weight</target>
+        <note>Line: 246</note>
+      </trans-unit>
+      <trans-unit id="05cdca5b85ff26e596c3af66ed4820d5">
+        <source>Category weight</source>
+        <target>Category weight</target>
+        <note>Line: 252</note>
+      </trans-unit>
+      <trans-unit id="3474b76644954c739226a10127d83329">
+        <source>Brand weight</source>
+        <target>Brand weight</target>
+        <note>Line: 258</note>
+      </trans-unit>
+      <trans-unit id="c152439199cebb7e1c27633efeaf1eda">
+        <source>Tags weight</source>
+        <target>Tags weight</target>
+        <note>Line: 264</note>
+      </trans-unit>
+      <trans-unit id="1b25f9ffbf4d185dbb985380a04732cc">
+        <source>Attributes weight</source>
+        <target>Attributes weight</target>
+        <note>Line: 270</note>
+      </trans-unit>
+      <trans-unit id="4871216a35362aebc0d9908e6e288765">
+        <source>Features weight</source>
+        <target>Features weight</target>
+        <note>Line: 276</note>
+      </trans-unit>
+      <trans-unit id="58e8dcd40d13b2c661ac86dbc9e04e02">
+        <source>Add new alias</source>
+        <target>Add new alias</target>
+        <note>Line: 292</note>
+      </trans-unit>
+      <trans-unit id="8eea62084ca7e541d918e823422bd82e">
+        <source>Result</source>
+        <target>Result</target>
+        <note>Line: 356</note>
+      </trans-unit>
+      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
+        <source>Search</source>
+        <target>Search</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSearchEnginesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9aa1b03934893d7134a660af4204f2a9">
+        <source>Server</source>
+        <target>Server</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="b864759d534539519ceaa2c03a39d4c2">
+        <source>GET variable</source>
+        <target>GET variable</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="52e1c423b768c6e9850d70f3a41aca1d">
+        <source>$_GET variable</source>
+        <target>$_GET variable</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="6c8b05f1f10d94ede52a64f7ab5bc5cc">
+        <source>Add new search engine</source>
+        <target>Add new search engine</target>
+        <note>Line: 93</note>
+      </trans-unit>
+      <trans-unit id="b6f05e5ddde1ec63d992d61144452dfa">
+        <source>Referrer</source>
+        <target>Referrer</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ccf107a5d46c6501c9f2f4345400dc2e">
+        <source>Shop ID</source>
+        <target>Shop ID</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="4493e821e06072415518bd7ae4077996">
+        <source>Shop group</source>
+        <target>Shop group</target>
+        <note>Line: 429</note>
+      </trans-unit>
+      <trans-unit id="09059cedfd08d6e8a12417b285a79ffd">
+        <source>Root category</source>
+        <target>Root category</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="8849f8620b59b37526cebfb785d1df2d">
+        <source>Main URL for this shop</source>
+        <target>Main URL for this shop</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="0fc629d52a6553e98b76fffa727ba878">
+        <source>Edit this shop group</source>
+        <target>Edit this shop group</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="652342e19bf26f8d1b350e60aad3e3bf">
+        <source>Add new shop</source>
+        <target>Add new shop</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="224154fa6f3601b7de4690ba6a9ad8b4">
+        <source>Multistore tree</source>
+        <target>Multistore tree</target>
+        <note>Line: 157</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="817434295a673aed431435658b65d9a7">
+        <source>Icon</source>
+        <target>Icon</target>
+        <note>Line: 287</note>
+      </trans-unit>
+      <trans-unit id="c9f59be398981c130408612e51464e14">
+        <source>Send email to customer</source>
+        <target>Send email to customer</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="13a44cb3c08c1c40a3c5b62152538ee8">
+        <source>Email template</source>
+        <target>Email template</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="8b79d8d9315e50cd01d3ce641cdc61bc">
+        <source>Edit return status</source>
+        <target>Edit return status</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="60fd39d495f2a8d0674c236c004e8f21">
+        <source>Add new order status</source>
+        <target>Add new order status</target>
+        <note>Line: 194</note>
+      </trans-unit>
+      <trans-unit id="f08b529034b579d49fa94abec7f93af0">
+        <source>Add new order return status</source>
+        <target>Add new order return status</target>
+        <note>Line: 199</note>
+      </trans-unit>
+      <trans-unit id="34499467057e6ded44fd7861eee1893b">
+        <source>Return statuses</source>
+        <target>Return statuses</target>
+        <note>Line: 235</note>
+      </trans-unit>
+      <trans-unit id="69a31da4cb502aa192d07ae4a8f48613">
+        <source>Status name</source>
+        <target>Status name</target>
+        <note>Line: 478</note>
+      </trans-unit>
+      <trans-unit id="cb5feb1b7314637725a2e73bdc9f7295">
+        <source>Color</source>
+        <target>Color</target>
+        <note>Line: 489</note>
+      </trans-unit>
+      <trans-unit id="192b587e5fc71cd5f25a6089c03bff87">
+        <source>Consider the associated order as validated.</source>
+        <target>Consider the associated order as validated.</target>
+        <note>Line: 302</note>
+      </trans-unit>
+      <trans-unit id="6d6c83be0e74d3b3d041cd61fa607ede">
+        <source>Allow a customer to download and view PDF versions of his/her invoices.</source>
+        <target>Allow a customer to download and view PDF versions of his/her invoices.</target>
+        <note>Line: 313</note>
+      </trans-unit>
+      <trans-unit id="9529bbf156fbe6c23b5fbd8b32900f68">
+        <source>Hide this status in all customer orders.</source>
+        <target>Hide this status in all customer orders.</target>
+        <note>Line: 324</note>
+      </trans-unit>
+      <trans-unit id="a8f92721e361eceb4489636d29f56c21">
+        <source>Send an email to the customer when his/her order status has changed.</source>
+        <target>Send an email to the customer when his/her order status has changed.</target>
+        <note>Line: 335</note>
+      </trans-unit>
+      <trans-unit id="05ffab376e5c4a64caa28a1c4bd9fc0d">
+        <source>Attach invoice PDF to email.</source>
+        <target>Attach invoice PDF to email.</target>
+        <note>Line: 346</note>
+      </trans-unit>
+      <trans-unit id="53343ccca7ba90caa497d4c4b40f3ec7">
+        <source>Attach delivery slip PDF to email.</source>
+        <target>Attach delivery slip PDF to email.</target>
+        <note>Line: 357</note>
+      </trans-unit>
+      <trans-unit id="5fe3d2e4d87dccabf5c9c1d81baf995c">
+        <source>Set the order as shipped.</source>
+        <target>Set the order as shipped.</target>
+        <note>Line: 368</note>
+      </trans-unit>
+      <trans-unit id="67a8390e9643cecbac9d149da4242bf5">
+        <source>Set the order as paid.</source>
+        <target>Set the order as paid.</target>
+        <note>Line: 379</note>
+      </trans-unit>
+      <trans-unit id="a886c3a69907e954c771aae074f24040">
+        <source>Show delivery PDF.</source>
+        <target>Show delivery PDF.</target>
+        <note>Line: 390</note>
+      </trans-unit>
+      <trans-unit id="278c491bdd8a53618c149c4ac790da34">
+        <source>Template</source>
+        <target>Template</target>
+        <note>Line: 398</note>
+      </trans-unit>
+      <trans-unit id="dc4e76994fd27117c21f83d09faa0649">
+        <source>Return status</source>
+        <target>Return status</target>
+        <note>Line: 472</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e93c33bd1341ab74195430daeb63db13">
+        <source>Shop name</source>
+        <target>Shop name</target>
+        <note>Line: 439</note>
+      </trans-unit>
+      <trans-unit id="57034def557be4e71accee021e74ce5b">
+        <source>Add new store</source>
+        <target>Add new store</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="821b8ee6937cec96c30fdafbfe836d68">
+        <source>Stores</source>
+        <target>Stores</target>
+        <note>Line: 153</note>
+      </trans-unit>
+      <trans-unit id="cb6fd19e08242c75f1af9f4d15be875d">
+        <source>Store name (e.g. City Center Mall Store).</source>
+        <target>Store name (e.g. City Center Mall Store).</target>
+        <note>Line: 164</note>
+      </trans-unit>
+      <trans-unit id="e1bcd0aa73dbc610f1fc628499244d8f">
+        <source>Allowed characters: letters, spaces and %s</source>
+        <target>Allowed characters: letters, spaces and %s</target>
+        <note>Line: 165</note>
+      </trans-unit>
+      <trans-unit id="6f5373ad371f50f8d9846abf459e9770">
+        <source>Latitude / Longitude</source>
+        <target>Latitude / Longitude</target>
+        <note>Line: 218</note>
+      </trans-unit>
+      <trans-unit id="2315a2ebf1ec2420376642ce9b792076">
+        <source>Store coordinates (e.g. 45.265469/-47.226478).</source>
+        <target>Store coordinates (e.g. 45.265469/-47.226478).</target>
+        <note>Line: 222</note>
+      </trans-unit>
+      <trans-unit id="8ae5811be1a55b9b8447ad2dbdadbf6e">
+        <source>Picture</source>
+        <target>Picture</target>
+        <note>Line: 269</note>
+      </trans-unit>
+      <trans-unit id="6f8522e0610541f1ef215a22ffa66ff6">
+        <source>Monday</source>
+        <target>Monday</target>
+        <note>Line: 293</note>
+      </trans-unit>
+      <trans-unit id="5792315f09a5d54fb7e3d066672b507f">
+        <source>Tuesday</source>
+        <target>Tuesday</target>
+        <note>Line: 294</note>
+      </trans-unit>
+      <trans-unit id="796c163589f295373e171842f37265d5">
+        <source>Wednesday</source>
+        <target>Wednesday</target>
+        <note>Line: 295</note>
+      </trans-unit>
+      <trans-unit id="78ae6f0cd191d25147e252dc54768238">
+        <source>Thursday</source>
+        <target>Thursday</target>
+        <note>Line: 296</note>
+      </trans-unit>
+      <trans-unit id="c33b138a163847cdb6caeeb7c9a126b4">
+        <source>Friday</source>
+        <target>Friday</target>
+        <note>Line: 297</note>
+      </trans-unit>
+      <trans-unit id="8b7051187b9191cdcdae6ed5a10e5adc">
+        <source>Saturday</source>
+        <target>Saturday</target>
+        <note>Line: 298</note>
+      </trans-unit>
+      <trans-unit id="9d1a0949c39e66a0cd65240bc0ac9177">
+        <source>Sunday</source>
+        <target>Sunday</target>
+        <note>Line: 299</note>
+      </trans-unit>
+      <trans-unit id="63406c9482c644975f227cc93788e8fb">
+        <source>Choose your country</source>
+        <target>Choose your country</target>
+        <note>Line: 427</note>
+      </trans-unit>
+      <trans-unit id="ffea2d321be109fc7243cfeb515fe257">
+        <source>Choose your state (if applicable)</source>
+        <target>Choose your state (if applicable)</target>
+        <note>Line: 432</note>
+      </trans-unit>
+      <trans-unit id="de30ac479f8a73106c51739a0bc92cdc">
+        <source>Displayed in emails and page titles.</source>
+        <target>Displayed in emails and page titles.</target>
+        <note>Line: 440</note>
+      </trans-unit>
+      <trans-unit id="6dbec9966be60ecb814790443c2867f7">
+        <source>Shop email</source>
+        <target>Shop email</target>
+        <note>Line: 446</note>
+      </trans-unit>
+      <trans-unit id="17e5b9e86108a7fd53884cfaa66ddb35">
+        <source>Registration number</source>
+        <target>Registration number</target>
+        <note>Line: 453</note>
+      </trans-unit>
+      <trans-unit id="1b9a36c9acf2ab7a81d67a55432b6c8f">
+        <source>Shop address line 1</source>
+        <target>Shop address line 1</target>
+        <note>Line: 461</note>
+      </trans-unit>
+      <trans-unit id="1cdaa96d262fdea24b42a1fc28eb7564">
+        <source>Shop address line 2</source>
+        <target>Shop address line 2</target>
+        <note>Line: 466</note>
+      </trans-unit>
+      <trans-unit id="5dd532f0a63d89c5af0243b74732f63c">
+        <source>Contact details</source>
+        <target>Contact details</target>
+        <note>Line: 539</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTagsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9fc8691fab39cc1433cd39430edb0501">
+        <source>Add new tag</source>
+        <target>Add new tag</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="c101058e7ea21bbbf2a5ac893088e90b">
+        <source>Tag</source>
+        <target>Tag</target>
+        <note>Line: 135</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/statsforecast/statsforecast.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e">
+        <source>Unknown</source>
+        <target>Unknown</target>
+        <note>Line: 474</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/statslive/statslive.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a55533db46597bee3cd16899c007257e">
+        <source>There are no visitors online.</source>
+        <target>There are no visitors online.</target>
+        <note>Line: 216</note>
+      </trans-unit>
+      <trans-unit id="ec0fc0100c4fc1ce4eea230c3dc10360">
+        <source>Undefined</source>
+        <target>Undefined</target>
+        <note>Line: 207</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Form/ChoiceProvider/CanonicalRedirectTypeChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="720252deba3646242d7d43548bd57d78">
+        <source>No redirection (you may have duplicate content issues)</source>
+        <target>No redirection (you may have duplicate content issues)</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="35df89560d52bdb19ba653e994fbb178">
+        <source>302 Moved Temporarily (recommended while setting up your store)</source>
+        <target>302 Moved Temporarily (recommended while setting up your store)</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="317a1a7df329b3d6e9d7e36915ebde8c">
+        <source>301 Moved Permanently (recommended once you have gone live)</source>
+        <target>301 Moved Permanently (recommended once you have gone live)</target>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="193cfc9be3b995831c6af2fea6650e60">
+        <source>Page</source>
+        <target>Page</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="12cb401e3a068898222575c6a5ef5ece">
+        <source>Page title</source>
+        <target>Page title</target>
+        <note>Line: 114</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e1622ba9f41f5b695bddc69e3ceaa204">
+        <source>Add a new page</source>
+        <target>Add a new page</target>
+        <note>Line: 81</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="effdb9ce6c5d44df31b89d7069c8e0fb">
+        <source>Alias</source>
+        <target>Alias</target>
+        <note>Line: 61</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="640fd0cc0ffa0316ae087652871f4486">
+        <source>minutes</source>
+        <target>minutes</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="843fbaec27e324378999e09cc665a7f4">
+        <source>Round up away from zero, when it is half way there (recommended)</source>
+        <target>Round up away from zero, when it is half way there (recommended)</target>
+        <note>Line: 109</note>
+      </trans-unit>
+      <trans-unit id="9d70eb834e3574ca07a1f28083ecba1e">
+        <source>Round down towards zero, when it is half way there</source>
+        <target>Round down towards zero, when it is half way there</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="5f9d1d092dc5658734b8af7187460b32">
+        <source>Round towards the next even value</source>
+        <target>Round towards the next even value</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="8700a0015f3fc1c5d96ccc5140475dc3">
+        <source>Round towards the next odd value</source>
+        <target>Round towards the next odd value</target>
+        <note>Line: 112</note>
+      </trans-unit>
+      <trans-unit id="6186ae4fe9ec55025a9777dd973e0af2">
+        <source>Round up to the nearest value</source>
+        <target>Round up to the nearest value</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="35853630b5da054ef55e8e02d8df4954">
+        <source>Round down to the nearest value</source>
+        <target>Round down to the nearest value</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="41032c67b9a3d88ff9a824a1f0845513">
+        <source>Round on each item</source>
+        <target>Round on each item</target>
+        <note>Line: 120</note>
+      </trans-unit>
+      <trans-unit id="a899eacfb98f1740127be5fe16bee5c7">
+        <source>Round on each line</source>
+        <target>Round on each line</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="6d19eb8a9ca35d858824737173ebd011">
+        <source>Round on the total</source>
+        <target>Round on the total</target>
+        <note>Line: 122</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df644ae155e79abf54175bd15d75f363">
+        <source>Product name</source>
+        <target>Product name</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="290b7c47045d269e2ccfa69e6477acfe">
+        <source>Product price</source>
+        <target>Product price</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="0cffebd3c32f4467e14759b2b7d3d515">
+        <source>Product add date</source>
+        <target>Product add date</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="d920ec381c352d9d92a53ed3d261e8c6">
+        <source>Product modified date</source>
+        <target>Product modified date</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="3cfcde53f39184634bc7b2344479fbc4">
+        <source>Position inside category</source>
+        <target>Position inside category</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
+        <source>Brand</source>
+        <target>Brand</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="7b541de13ca0229406e134a373dd6382">
+        <source>Product quantity</source>
+        <target>Product quantity</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="75ed578ac3cb02b0ba40002a25bc0403">
+        <source>Product reference</source>
+        <target>Product reference</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="175db77b6b3ecd9633e85b5efc28bbc1">
+        <source>Decrement pack only.</source>
+        <target>Decrement pack only.</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="1ba020dea4ce06fa139a471db21f41a7">
+        <source>Decrement products in pack only.</source>
+        <target>Decrement products in pack only.</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="61b912928e920c280798dc648d4068fe">
+        <source>Decrement both.</source>
+        <target>Decrement both.</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0d2054b7a56db47a97f65e3da632fe8b">
+        <source>The route %routeRule% is not valid</source>
+        <target>The route %routeRule% is not valid</target>
+        <note>Line: 164</note>
+      </trans-unit>
+      <trans-unit id="c5fe0d77ab52ead15661b37ade6a594b">
+        <source>Keyword "{%keyword%}" required for route "%routeName%" (rule: "%routeRule%")</source>
+        <target>Keyword "{%keyword%}" required for route "%routeName%" (rule: "%routeRule%")</target>
+        <note>Line: 177</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9ca2e29ab10b2046b32dea40f4e5c232">
+        <source>Password reset delay</source>
+        <target>Password reset delay</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="a7ddcecde44eba59d425762fcdeec665">
+        <source>Re-display cart at login</source>
+        <target>Re-display cart at login</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="fcae2ef516600f29ac9aa4b084981328">
+        <source>Send an email after registration</source>
+        <target>Send an email after registration</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="c760118c537146713521758269a44bd3">
+        <source>Enable B2B mode</source>
+        <target>Enable B2B mode</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="dcc6fd9b580a958b3f42488265cb1300">
+        <source>Ask for birth date</source>
+        <target>Ask for birth date</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="a5e968e6a3689ca07bbdbecb6b0710ff">
+        <source>Enable partner offers</source>
+        <target>Enable partner offers</target>
+        <note>Line: 73</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="eb1cef1202fdc4d7954899fbf9f1734b">
+        <source>Number of days for which the product is considered 'new'</source>
+        <target>Number of days for which the product is considered 'new'</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="9d980493b9016efc42443b1fdae49f33">
+        <source>Max size of product summary</source>
+        <target>Max size of product summary</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="7dbe88f99044a2b7e37ae992b8651be4">
+        <source>Products (general)</source>
+        <target>Products (general)</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="bb98eaca8d91531f4ae177c9d395f1d4">
+        <source>Catalog mode</source>
+        <target>Catalog mode</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="b5069c99813cffc6933c18ab71fd6cd9">
+        <source>Quantity discounts based on</source>
+        <target>Quantity discounts based on</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="52be3e936f99d9746870ca7d356b3f21">
+        <source>Force update of friendly URL</source>
+        <target>Force update of friendly URL</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="8a93e785ac0d7204479e4697cbe8696c">
+        <source>Default activation status</source>
+        <target>Default activation status</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f8f1f78351c2864c334a80b706a303b2">
+        <source>Display remaining quantities when the quantity is lower than</source>
+        <target>Display remaining quantities when the quantity is lower than</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="eb763a2e313718f33f55e1f0d84df6ee">
+        <source>Product page</source>
+        <target>Product page</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="b58704f2e2e18edc7c903342c2a42dfc">
+        <source>Display available quantities on the product page</source>
+        <target>Display available quantities on the product page</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="a2ab7db4ee7104a693358c0c9d07c6ce">
+        <source>Display unavailable product attributes on the product page</source>
+        <target>Display unavailable product attributes on the product page</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="01dabe7ae47f9848c5e38f353a8f866f">
+        <source>Display the "add to cart" button when a product has attributes</source>
+        <target>Display the "add to cart" button when a product has attributes</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="0a91cf360875af4259f26bc7e2971132">
+        <source>Separator of attribute anchor on the product links</source>
+        <target>Separator of attribute anchor on the product links</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="f7699b3d1af7fe3cdb3a6ff301940fdf">
+        <source>Display discounted price</source>
+        <target>Display discounted price</target>
+        <note>Line: 80</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7e1b4ee573c4ef023904fd90eb9ddea7">
+        <source>Products per page</source>
+        <target>Products per page</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="cbb81506a7fe3ef03f7a89c76c52131a">
+        <source>Pagination</source>
+        <target>Pagination</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="e29857ad6c4bbba99614831d7e3e5a3f">
+        <source>Default order by</source>
+        <target>Default order by</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="114a8ec626471fdc120f863a9fb25e4c">
+        <source>Default order method</source>
+        <target>Default order method</target>
+        <note>Line: 52</note>
       </trans-unit>
     </body>
   </file>
@@ -1905,62 +1394,153 @@ File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/mainte
       <trans-unit id="ff26a60315cd84533d5339ba26617988">
         <source>Products stock</source>
         <target>Products stock</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="be6be43cab36ddf8024d237c4a2414f7">
         <source>Allow ordering of out-of-stock products</source>
         <target>Allow ordering of out-of-stock products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:38</note>
+        <note>Line: 38</note>
       </trans-unit>
       <trans-unit id="69983ae81c0090a571d3f60aedbd0d46">
         <source>Enable stock management</source>
         <target>Enable stock management</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="966c11f36eeb298187639eea581a7522">
         <source>Label of in-stock products</source>
         <target>Label of in-stock products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="3385e522bc49e8f8fcb008788bc1762d">
         <source>Label of out-of-stock products with allowed backorders</source>
         <target>Label of out-of-stock products with allowed backorders</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:64</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="d79daa535ef1e90b7b1230b501b7b6c6">
         <source>Label of out-of-stock products with denied backorders</source>
         <target>Label of out-of-stock products with denied backorders</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:73</note>
+        <note>Line: 73</note>
       </trans-unit>
       <trans-unit id="480cb944a0974a27ec0f964de23a18f4">
         <source>Delivery time of in-stock products</source>
         <target>Delivery time of in-stock products</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:81</note>
+        <note>Line: 81</note>
       </trans-unit>
       <trans-unit id="16a5534d559007de7e8f5b4f17112203">
         <source>Leave empty to disable</source>
         <target>Leave empty to disable</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:93</note>
+        <note>Line: 93</note>
       </trans-unit>
       <trans-unit id="d8b9fadcb2c1164975877a18731b1f4a">
         <source>Delivery time of out-of-stock products with allowed backorders</source>
         <target>Delivery time of out-of-stock products with allowed backorders</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:89</note>
+        <note>Line: 89</note>
       </trans-unit>
       <trans-unit id="65055b5469b4ad0c6f799ad782d1ebe5">
         <source>Default pack stock management</source>
         <target>Default pack stock management</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:97</note>
+        <note>Line: 97</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c6ca929dc4c8193ad6cd154e9e075ac9">
+        <source>Minimum purchase total required in order to validate the order</source>
+        <target>Minimum purchase total required in order to validate the order</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="28e503c3e4f502b3631e255dfc527620">
+        <source>Enable final summary</source>
+        <target>Enable final summary</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="403e42a4b26e379cb13563c98ab63067">
+        <source>Enable guest checkout</source>
+        <target>Enable guest checkout</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="0fb43a164e61d758c5eddcceb67be0c1">
+        <source>Disable Reordering Option</source>
+        <target>Disable Reordering Option</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="f30598053df0edf94d9463a2133d7f13">
+        <source>Recalculate shipping costs after editing the order</source>
+        <target>Recalculate shipping costs after editing the order</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="8f32f059d66d7f10db7668e75b4742e6">
+        <source>Allow multishipping</source>
+        <target>Allow multishipping</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="cd6aaf6d8287fd5a49122d36f0ff7024">
+        <source>Delayed shipping</source>
+        <target>Delayed shipping</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="e4045598261988d9988c594243a9434d">
+        <source>Terms of service</source>
+        <target>Terms of service</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="960e3de6241e862401f2bd93539e0381">
+        <source>Page for the Terms and conditions</source>
+        <target>Page for the Terms and conditions</target>
+        <note>Line: 96</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2a0677dae563d574fb1c50badaa4eabf">
+        <source>Gift-wrapping price</source>
+        <target>Gift-wrapping price</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="bf3b3ed0e4fd43efff9c26b3d35c6c2f">
+        <source>Gift options</source>
+        <target>Gift options</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="d2c8471bccf2bbf30151cf50a96c3877">
+        <source>Offer gift wrapping</source>
+        <target>Offer gift wrapping</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="0d8bdbe98feb696dd76760ee1374a740">
+        <source>Gift-wrapping tax</source>
+        <target>Gift-wrapping tax</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="b667478ccafce4bff6d427a6bca06269">
+        <source>Offer recycled packaging</source>
+        <target>Offer recycled packaging</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2cb749d5ceef7acb7790bbc1703f1fbd">
+        <source>Manage domain name</source>
+        <target>Manage domain name</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="b6a208425b55c6e53b3114212cc525b6">
+        <source>Add a domain name</source>
+        <target>Add a domain name</target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="86d314b39d91d9c8f4578c938e4401d6">
+        <source>Keywords: %keywords%</source>
+        <target>Keywords: %keywords%</target>
+        <note>Line: 37</note>
       </trans-unit>
     </body>
   </file>
@@ -1969,132 +1549,221 @@ File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks
       <trans-unit id="f2fa247c9f424452552992222c0b8137">
         <source>Improve your SEO</source>
         <target>Improve your SEO</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="4f43f191a80a8b1d7ee512646f98544f">
         <source>Edit information about your pages to gain visibility and therefore reach more visitors. We advise you to start with the index page, it stands for your homepage.</source>
         <target>Edit information about your pages to gain visibility and therefore reach more visitors. We advise you to start with the index page, it stands for your homepage.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="9b2028adefe19782be9eaa370a067e53">
         <source>Configure index page</source>
         <target>Configure index page</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig:38</note>
+        <note>Line: 38</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/referrers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="c33e404a441c6ba9648f88af3c68a1ca">
-        <source>Statistics</source>
-        <target>Statistics</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/view/view.tpl:99</note>
+      <trans-unit id="7959e21ff0b83542251ca0b4e9a62eea">
+        <source>Generate robots.txt file</source>
+        <target>Generate robots.txt file</target>
+        <note>Line: 59</note>
       </trans-unit>
-      <trans-unit id="208b51d8918ba3cdd679a5ec275df129">
-        <source>Filter by product:</source>
-        <target>Filter by product:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/view/view.tpl:112</note>
+      <trans-unit id="345d6249c20c6319bb09edaaf536744b">
+        <source>Robots file generation</source>
+        <target>Robots file generation</target>
+        <note>Line: 31</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/stores/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="ad179a1071ebd8b00e0ff4718301dcea">
-        <source>Hours:</source>
-        <target>Hours:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/stores/helpers/form/form.tpl:66</note>
+      <trans-unit id="a7686ea311b65874a504a343c08a4341">
+        <source>Accented URL</source>
+        <target>Accented URL</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="fb64c58d84a997e89be8de9897f36ecc">
+        <source>Redirect to the canonical URL</source>
+        <target>Redirect to the canonical URL</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="38bada4e8300d679ea0c293a8658605a">
+        <source>Disable Apache's MultiViews option</source>
+        <target>Disable Apache's MultiViews option</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="1260ff0747d4dbe30fcc4d360891205f">
+        <source>Disable Apache's mod_security module</source>
+        <target>Disable Apache's mod_security module</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="3cb0403ba2ec65e9030c1013b5edb42d">
+        <source>Set up URLs</source>
+        <target>Set up URLs</target>
+        <note>Line: 31</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="c20aefc1b11dc684191ded8079cedab4">
-        <source>Group information</source>
-        <target>Group information</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:32</note>
+      <trans-unit id="43199543574edd476ab25337ad4a223c">
+        <source>Set shop URL</source>
+        <target>Set shop URL</target>
+        <note>Line: 32</note>
       </trans-unit>
-      <trans-unit id="2dc9a383d693a2ded8b1ef832926ea93">
-        <source>Price display method:</source>
-        <target>Price display method:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:40</note>
+      <trans-unit id="db309cb65c4220d02c0fd13927d315ae">
+        <source>Shop domain</source>
+        <target>Shop domain</target>
+        <note>Line: 73</note>
       </trans-unit>
-      <trans-unit id="02d29656d8379684796b01abfd2a9a13">
-        <source>Show prices:</source>
-        <target>Show prices:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:48</note>
+      <trans-unit id="7efeee26d2914e586169f61213741599">
+        <source>SSL domain</source>
+        <target>SSL domain</target>
+        <note>Line: 83</note>
       </trans-unit>
-      <trans-unit id="4845f30b0c12e9dd97246f5f443338ad">
-        <source>Current category discount</source>
-        <target>Current category discount</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:56</note>
-      </trans-unit>
-      <trans-unit id="42ba7a29aa37fc2cb42f5381e71afb9f">
-        <source>Members of this customer group</source>
-        <target>Members of this customer group</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:82</note>
-      </trans-unit>
-      <trans-unit id="638dab2652b5c9fec7eeee0c8a12431b">
-        <source>Limited to the first 100 customers.</source>
-        <target>Limited to the first 100 customers.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:83</note>
-      </trans-unit>
-      <trans-unit id="3744cbfc625e57d0ac639f162dba21c1">
-        <source>Please use filters to narrow your search.</source>
-        <target>Please use filters to narrow your search.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:83</note>
+      <trans-unit id="c274743f6bf3e3682c41e9ee269913f4">
+        <source>Base URI</source>
+        <target>Base URI</target>
+        <note>Line: 93</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="734d291b0d07bae874a51370a032312e">
-        <source>Discount: %.2f%%</source>
-        <target>Discount: %.2f%%</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl:136</note>
+      <trans-unit id="0d3ed57f8fd83cc2e9cf265a18663c0a">
+        <source>Schema of URLs</source>
+        <target>Schema of URLs</target>
+        <note>Line: 34</note>
       </trans-unit>
-      <trans-unit id="40382ca2b15ff499eb4e5c101424bc81">
-        <source>Authorized modules:</source>
-        <target>Authorized modules:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl:31</note>
+      <trans-unit id="5575f8bf467eba7499f22e78db6f3f56">
+        <source>Route to products</source>
+        <target>Route to products</target>
+        <note>Line: 52</note>
       </trans-unit>
-      <trans-unit id="32da1449064b7ef38d098e8061630883">
-        <source>This category already exists for this group.</source>
-        <target>This category already exists for this group.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl:75</note>
+      <trans-unit id="1092637069f4ebf1bee2b02fd280888b">
+        <source>Route to category</source>
+        <target>Route to category</target>
+        <note>Line: 65</note>
       </trans-unit>
-      <trans-unit id="e7446ea32216e8bf4fa8cb6460b725d6">
-        <source>Add a category discount</source>
-        <target>Add a category discount</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl:131</note>
+      <trans-unit id="e5bcaf8cdb205e965d4ba8fdf0dc898c">
+        <source>Route to category which has the "selected_filter" attribute for the "Layered Navigation" (blocklayered) module</source>
+        <target>Route to category which has the "selected_filter" attribute for the "Layered Navigation" (blocklayered) module</target>
+        <note>Line: 78</note>
       </trans-unit>
-      <trans-unit id="29ea3cf72fb288e76bc4310bffabc03e">
-        <source>New group category discount</source>
-        <target>New group category discount</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl:150</note>
+      <trans-unit id="08a551b84112995247355daf3b5d72ba">
+        <source>Route to supplier</source>
+        <target>Route to supplier</target>
+        <note>Line: 91</note>
       </trans-unit>
-      <trans-unit id="3b78dd28e2767e0e88e5591abd386d0f">
-        <source>Discount (%):</source>
-        <target>Discount (%):</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl:157</note>
+      <trans-unit id="1dc5f89ed6e4425ecef2613fda85e5c0">
+        <source>Route to brand</source>
+        <target>Route to brand</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="e175934d3418b2070a829183b2bfe294">
+        <source>Route to page</source>
+        <target>Route to page</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="01e4fd64862371a0f532b82e302d438d">
+        <source>Route to page category</source>
+        <target>Route to page category</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="4b9a9672a96a435f1d15ad934e093104">
+        <source>Route to modules</source>
+        <target>Route to modules</target>
+        <note>Line: 143</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7fe15a347d66e291d7a1375273226205">
+        <source>Enable Shop</source>
+        <target>Enable Shop</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="daf835712085aaaf81818e7ebfeb66b8">
+        <source>Maintenance IP</source>
+        <target>Maintenance IP</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="9278432c5d2aec1ac4f42c23a941af21">
+        <source>Custom maintenance text</source>
+        <target>Custom maintenance text</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1656072e927c8d3acd24359cbb648bb5">
+        <source>Enable SSL</source>
+        <target>Enable SSL</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="73369322b5e1145bb2fc2268ce4d31f0">
+        <source>Enable SSL on all pages</source>
+        <target>Enable SSL on all pages</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="cd1b98322104dbd61ca6ae0ab16df348">
+        <source>Increase front office security</source>
+        <target>Increase front office security</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="913d66c5648cf0317ed371371fe44534">
+        <source>Allow iframes on HTML fields</source>
+        <target>Allow iframes on HTML fields</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="06918a784fb394b84de012810120b75c">
+        <source>Use HTMLPurifier Library</source>
+        <target>Use HTMLPurifier Library</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="ac2021d3c67ee796d7ab20a466ebd583">
+        <source>Round mode</source>
+        <target>Round mode</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="019e96f05f09a70e37792a04e9e78cdc">
+        <source>Round type</source>
+        <target>Round type</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="0a1e355325f75fe4cc3bf08b0f31f1c2">
+        <source>Number of decimals</source>
+        <target>Number of decimals</target>
+        <note>Line: 122</note>
+      </trans-unit>
+      <trans-unit id="267b70f19458077fe93a3fd63a6a648a">
+        <source>Display brands and suppliers</source>
+        <target>Display brands and suppliers</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="922256753aa354c111471e85d4809ec5">
+        <source>Display best sellers</source>
+        <target>Display best sellers</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="43b266c605d67eaa27801cc5dc0b3995">
+        <source>Enable Multistore</source>
+        <target>Enable Multistore</target>
+        <note>Line: 146</note>
+      </trans-unit>
+      <trans-unit id="8d9da6f9870d593e6921d3b728dc0c6b">
+        <source>Main Shop Activity</source>
+        <target>Main Shop Activity</target>
+        <note>Line: 162</note>
+      </trans-unit>
+      <trans-unit id="ab08050bd76be6690d1beff885570dfb">
+        <source>Please click here to check if your shop supports HTTPS.</source>
+        <target>Please click here to check if your shop supports HTTPS.</target>
+        <note>Line: 59</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminShopparametersHelp.xlf
+++ b/app/Resources/translations/default/AdminShopparametersHelp.xlf
@@ -1,776 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/referrers/form_settings.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="83b262520a65657b95fd686817c56a09">
-        <source>Order status (e.g. 'Pending').</source>
-        <target>Order status (e.g. 'Pending').</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:281</note>
-      </trans-unit>
-      <trans-unit id="a4bb440d400f4dc30f148b44d08680b4">
-        <source>Invalid characters: numbers and</source>
-        <target>Invalid characters: numbers and</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:484</note>
-      </trans-unit>
-      <trans-unit id="a9c2e14555131d68a4ac37b604ee52a8">
-        <source>Upload an icon from your computer (File type: .gif, suggested size: 16x16).</source>
-        <target>Upload an icon from your computer (File type: .gif, suggested size: 16x16).</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:289</note>
-      </trans-unit>
-      <trans-unit id="00b963b1cb1aad2142ae67ce65329944">
-        <source>Status will be highlighted in this color. HTML colors only.</source>
-        <target>Status will be highlighted in this color. HTML colors only.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:491</note>
-      </trans-unit>
-      <trans-unit id="f0fe1aebeace842330fb048126151e06">
-        <source>Only letters, numbers and underscores ("_") are allowed.</source>
-        <target>Only letters, numbers and underscores ("_") are allowed.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:408</note>
-      </trans-unit>
-      <trans-unit id="3d034f43e44ee495a11005507185a0a0">
-        <source>Email template for both .html and .txt.</source>
-        <target>Email template for both .html and .txt.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:409</note>
-      </trans-unit>
-      <trans-unit id="43f4ac702eaf88267f6946aeb559b251">
-        <source>Order's return status name.</source>
-        <target>Order's return status name.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:483</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3ff4fabe93bbb10c32a27c54ea13a5e1">
-        <source>Enable this option only if your server allows URL rewriting (recommended).</source>
-        <target>Enable this option only if your server allows URL rewriting (recommended).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:54</note>
-      </trans-unit>
-      <trans-unit id="6a9bb0bb3f61904834f4f436bbcaa1d2">
-        <source>URL rewriting (mod_rewrite) is not active on your server, or it is not possible to check your server configuration. If you want to use Friendly URLs, you must activate this mod.</source>
-        <target>URL rewriting (mod_rewrite) is not active on your server, or it is not possible to check your server configuration. If you want to use Friendly URLs, you must activate this mod.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:62</note>
-      </trans-unit>
-      <trans-unit id="1ccf825d454faaa7f8141830469fab8f">
-        <source>Enable this option if you want to allow accented characters in your friendly URLs.</source>
-        <target>Enable this option if you want to allow accented characters in your friendly URLs.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:69</note>
-      </trans-unit>
-      <trans-unit id="37d06ba898faba724d13f931b1642b06">
-        <source>You should only activate this option if you are using non-latin characters ; for all the latin charsets, your SEO will be better without this option.</source>
-        <target>You should only activate this option if you are using non-latin characters ; for all the latin charsets, your SEO will be better without this option.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:69</note>
-      </trans-unit>
-      <trans-unit id="7dcc0875a9e200be4d760155c09c2945">
-        <source>Enable this option only if you have problems with URL rewriting.</source>
-        <target>Enable this option only if you have problems with URL rewriting.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:86</note>
-      </trans-unit>
-      <trans-unit id="9e9ad9fb2adc8da0aaec808b3d4e73e4">
-        <source>Some of PrestaShop's features might not work correctly with a specific configuration of Apache's mod_security module. We recommend to turn it off.</source>
-        <target>Some of PrestaShop's features might not work correctly with a specific configuration of Apache's mod_security module. We recommend to turn it off.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:96</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="55ed6eb3effe909461f682de73f89f82">
-        <source>You can search for a new domain name or add a domain name that you already own. You will be redirected to your PrestaShop account.</source>
-        <target>You can search for a new domain name or add a domain name that you already own. You will be redirected to your PrestaShop account.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig:40</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminMetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="219985722a429b6aaceef7d363e6a565">
-        <source>Name of the related page.</source>
-        <target>Name of the related page.</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:342</note>
-      </trans-unit>
-      <trans-unit id="14bc1d17bbcf8fb45debf11fb7c5f80b">
-        <source>Title of this page.</source>
-        <target>Title of this page.</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:351</note>
-      </trans-unit>
-      <trans-unit id="79c06fd4269a36582767dc4525699148">
-        <source>A short description of your shop.</source>
-        <target>A short description of your shop.</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:361</note>
-      </trans-unit>
-      <trans-unit id="d9f600637f31b203b55f6c91dabd4fde">
-        <source>List of keywords for search engines.</source>
-        <target>List of keywords for search engines.</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:371</note>
-      </trans-unit>
-      <trans-unit id="0210e7a00cf2cd3cca0e4d7ed3bdf86f">
-        <source>To add tags, click in the field, write something, and then press the "Enter" key.</source>
-        <target>To add tags, click in the field, write something, and then press the "Enter" key.</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:372</note>
-      </trans-unit>
-      <trans-unit id="99de37a1ed381af8c01ccb18f70b1427">
-        <source>For instance, "contacts" for http://example.com/shop/contacts to redirect to http://example.com/shop/contact-form.php</source>
-        <target>For instance, "contacts" for http://example.com/shop/contacts to redirect to http://example.com/shop/contact-form.php</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:384</note>
-      </trans-unit>
-      <trans-unit id="7aa534250fe76a40d96078a07b6f44e8">
-        <source>Only letters and hyphens are allowed.</source>
-        <target>Only letters and hyphens are allowed.</target>
-        <note>Context:
-File: controllers/admin/AdminMetaController.php:385</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminGendersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6252c0f2c2ed83b7b06dfca86d4650bb">
-        <source>Invalid characters:</source>
-        <target>Invalid characters:</target>
-        <note>Context:
-File: controllers/admin/AdminGendersController.php:123</note>
-      </trans-unit>
-      <trans-unit id="62c7ceb6de5c4d39e49c9762af6ddb4d">
-        <source>Image width in pixels. Enter "0" to use the original size.</source>
-        <target>Image width in pixels. Enter "0" to use the original size.</target>
-        <note>Context:
-File: controllers/admin/AdminGendersController.php:162</note>
-      </trans-unit>
-      <trans-unit id="aec8651b033be4d4056785d43763d7ca">
-        <source>Image height in pixels. Enter "0" to use the original size.</source>
-        <target>Image height in pixels. Enter "0" to use the original size.</target>
-        <note>Context:
-File: controllers/admin/AdminGendersController.php:169</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSearchConfController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="12399d580627a1a5889cdc44e6e48b5a">
-        <source>Enable the automatic indexing of products. If you enable this feature, the products will be indexed in the search automatically when they are saved. If the feature is disabled, you will have to index products manually by using the links provided in the field set.</source>
-        <target>Enable the automatic indexing of products. If you enable this feature, the products will be indexed in the search automatically when they are saved. If the feature is disabled, you will have to index products manually by using the links provided in the field set.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:106</note>
-      </trans-unit>
-      <trans-unit id="a5cb89e5bcb48c0708ee6837a5944d3e">
-        <source>By default, to search for “blouse”, you have to enter “blous”, “blo”, etc (beginning of the word) – but not “lous” (within the word).</source>
-        <target>By default, to search for “blouse”, you have to enter “blous”, “blo”, etc (beginning of the word) – but not “lous” (within the word).</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:121</note>
-      </trans-unit>
-      <trans-unit id="d2e38e24e467d35cc5881e083e05b823">
-        <source>With this option enabled, it also gives the good result if you search for “lous”, “ouse”, or anything contained in the word.</source>
-        <target>With this option enabled, it also gives the good result if you search for “lous”, “ouse”, or anything contained in the word.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:126</note>
-      </trans-unit>
-      <trans-unit id="9110055bdc92744713baa237b26f8ac7">
-        <source>Enable search within a whole word, rather than from its beginning only.</source>
-        <target>Enable search within a whole word, rather than from its beginning only.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:132</note>
-      </trans-unit>
-      <trans-unit id="0e665a9cf278d49f43c4bb4cb9a7c29f">
-        <source>It checks if the searched term is contained in the indexed word. This may be resource-consuming.</source>
-        <target>It checks if the searched term is contained in the indexed word. This may be resource-consuming.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:137</note>
-      </trans-unit>
-      <trans-unit id="1122eba5946331d2709712f64fa1d66b">
-        <source>By default, if you search "book", you will have "book", "bookcase" and "bookend".</source>
-        <target>By default, if you search "book", you will have "book", "bookcase" and "bookend".</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:149</note>
-      </trans-unit>
-      <trans-unit id="0b1d71ac92f27198d2bd1e6cd49cec1b">
-        <source>With this option enabled, it only gives one result “book”, as exact end of the indexed word is matching.</source>
-        <target>With this option enabled, it only gives one result “book”, as exact end of the indexed word is matching.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:154</note>
-      </trans-unit>
-      <trans-unit id="c4474326e7d8129b7c04ada10f34f5b1">
-        <source>Enable more precise search with the end of the word.</source>
-        <target>Enable more precise search with the end of the word.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:160</note>
-      </trans-unit>
-      <trans-unit id="efb6bc8d1ee1c5527d494ba15ee3109d">
-        <source>It checks if the searched term is the exact end of the indexed word.</source>
-        <target>It checks if the searched term is the exact end of the indexed word.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:165</note>
-      </trans-unit>
-      <trans-unit id="645115aba5ef431a04da95c746477544">
-        <source>Only words this size or larger will be indexed.</source>
-        <target>Only words this size or larger will be indexed.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:178</note>
-      </trans-unit>
-      <trans-unit id="2c2666c9eee818342b0aff77dda51990">
-        <source>Please enter the index words separated by a "|".</source>
-        <target>Please enter the index words separated by a "|".</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:190</note>
-      </trans-unit>
-      <trans-unit id="786471035f60ea5955fd93f6998e8637">
-        <source>Enter each alias separated by a comma (e.g. 'prestshop,preztashop,prestasohp').</source>
-        <target>Enter each alias separated by a comma (e.g. 'prestshop,preztashop,prestasohp').</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:350</note>
-      </trans-unit>
-      <trans-unit id="88851f53412ccb796508fd5f48e7a44f">
-        <source><![CDATA[Forbidden characters: <>;=#{}]]></source>
-        <target><![CDATA[Forbidden characters: <>;=#{}]]></target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:351</note>
-      </trans-unit>
-      <trans-unit id="01d2aac5d20787a1e873f2bdc79b514a">
-        <source>Search this word instead.</source>
-        <target>Search this word instead.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:359</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminContactsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9cd9efd3eb168071eb0a199972c54aab">
-        <source>Contact name (e.g. Customer Support).</source>
-        <target>Contact name (e.g. Customer Support).</target>
-        <note>Context:
-File: controllers/admin/AdminContactsController.php:74</note>
-      </trans-unit>
-      <trans-unit id="daedf9c5c8f38ac4cf641f3fb3e1bdc4">
-        <source>Emails will be sent to this address.</source>
-        <target>Emails will be sent to this address.</target>
-        <note>Context:
-File: controllers/admin/AdminContactsController.php:82</note>
-      </trans-unit>
-      <trans-unit id="0f28459fa87b1b3ce6e8b17932f08c3a">
-        <source>If enabled, all messages will be saved in the "Customer Service" page under the "Customer" menu.</source>
-        <target>If enabled, all messages will be saved in the "Customer Service" page under the "Customer" menu.</target>
-        <note>Context:
-File: controllers/admin/AdminContactsController.php:91</note>
-      </trans-unit>
-      <trans-unit id="a2b086325f59e6c2fbd410511f4fdfb3">
-        <source>Further information regarding this contact.</source>
-        <target>Further information regarding this contact.</target>
-        <note>Context:
-File: controllers/admin/AdminContactsController.php:112</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5c85aec638229f60a035c7a6ab3623c8">
-        <source>This field does not refer to the shop name visible in the front office.</source>
-        <target>This field does not refer to the shop name visible in the front office.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:371</note>
-      </trans-unit>
-      <trans-unit id="1561fa99e3814c72f5206ab48b472335">
-        <source>Follow [1]this link[/1] to edit the shop name used on the front office.</source>
-        <target>Follow [1]this link[/1] to edit the shop name used on the front office.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:372</note>
-      </trans-unit>
-      <trans-unit id="92aaf3cf7e8f1434886a8887e102391b">
-        <source>You can't edit the shop group because the current shop belongs to a group with the "share" option enabled.</source>
-        <target>You can't edit the shop group because the current shop belongs to a group with the "share" option enabled.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:430</note>
-      </trans-unit>
-      <trans-unit id="fce5f624e66bd2e2f0296fc3bd2a8f64">
-        <source>This is the root category of the store that you've created. To define a new root category for your store, [1]please click here[/1].</source>
-        <target>This is the root category of the store that you've created. To define a new root category for your store, [1]please click here[/1].</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:440</note>
-      </trans-unit>
-      <trans-unit id="f0f7416fad0a9c9fc3163cabe68393c1">
-        <source>By selecting associated categories, you are choosing to share the categories between shops. Once associated between shops, any alteration of this category will impact every shop.</source>
-        <target>By selecting associated categories, you are choosing to share the categories between shops. Once associated between shops, any alteration of this category will impact every shop.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:494</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="500294c9fd031bb4f00a82b5d27dc22c">
-        <source>If you own an SSL certificate for your shop's domain name, you can activate SSL encryption (https://) for customer account identification and order processing.</source>
-        <target>If you own an SSL certificate for your shop's domain name, you can activate SSL encryption (https://) for customer account identification and order processing.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:53</note>
-      </trans-unit>
-      <trans-unit id="a3a0f3b2f4c12d1c11b9916c8c10c48c">
-        <source>If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.</source>
-        <target>If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:47</note>
-      </trans-unit>
-      <trans-unit id="d86a9baf93dba6b27dbbb04cef8d3aae">
-        <source>When enabled, all the pages of your shop will be SSL-secured.</source>
-        <target>When enabled, all the pages of your shop will be SSL-secured.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:70</note>
-      </trans-unit>
-      <trans-unit id="a1202480ddcd8665114515ca380c0e5b">
-        <source>Enable or disable token in the Front Office to improve PrestaShop's security.</source>
-        <target>Enable or disable token in the Front Office to improve PrestaShop's security.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:78</note>
-      </trans-unit>
-      <trans-unit id="4f70bd9998bb35643fa3dfc88d6a6373">
-        <source>Allow iframes on text fields like product description. We recommend that you leave this option disabled.</source>
-        <target>Allow iframes on text fields like product description. We recommend that you leave this option disabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:86</note>
-      </trans-unit>
-      <trans-unit id="7ba34b929c8241268ab5eac35a772ab1">
-        <source>Clean the HTML content on text fields. We recommend that you leave this option enabled.</source>
-        <target>Clean the HTML content on text fields. We recommend that you leave this option enabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:94</note>
-      </trans-unit>
-      <trans-unit id="71958504714b867b7f6f00f43b9c9bd0">
-        <source>You can choose among 6 different ways of rounding prices. "Round up away from zero ..." is the recommended behavior.</source>
-        <target>You can choose among 6 different ways of rounding prices. "Round up away from zero ..." is the recommended behavior.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:102</note>
-      </trans-unit>
-      <trans-unit id="2b116a3c74c816d853b7d86abf838ebb">
-        <source>You can choose when to round prices: either on each item, each line or the total (of an invoice, for example).</source>
-        <target>You can choose when to round prices: either on each item, each line or the total (of an invoice, for example).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:110</note>
-      </trans-unit>
-      <trans-unit id="2d21e9a3fe59f46db5ffdc26448e3ab6">
-        <source>Choose how many decimals you want to display</source>
-        <target>Choose how many decimals you want to display</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:118</note>
-      </trans-unit>
-      <trans-unit id="b6d90c5c27a4d2d48ead626c17be303c">
-        <source>Enable brands and suppliers pages on your front office even when their respective modules are disabled.</source>
-        <target>Enable brands and suppliers pages on your front office even when their respective modules are disabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:126</note>
-      </trans-unit>
-      <trans-unit id="0678cf17f202cb7fd14d79054a2e628c">
-        <source>Enable best sellers page on your front office even when its respective module is disabled.</source>
-        <target>Enable best sellers page on your front office even when its respective module is disabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:134</note>
-      </trans-unit>
-      <trans-unit id="d8942e5679a9104ae58333b9b4778b71">
-        <source>The multistore feature allows you to manage several e-shops with one Back Office. If this feature is enabled, a "Multistore" page will be available in the "Advanced Parameters" menu.</source>
-        <target>The multistore feature allows you to manage several e-shops with one Back Office. If this feature is enabled, a "Multistore" page will be available in the "Advanced Parameters" menu.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig:142</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f45ed1483cf46972b5f225656c9c8991">
-        <source>Whether or not to display this store.</source>
-        <target>Whether or not to display this store.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:265</note>
-      </trans-unit>
-      <trans-unit id="b950eb0054205bc67aa88899eadded22">
-        <source>Storefront picture.</source>
-        <target>Storefront picture.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:274</note>
-      </trans-unit>
-      <trans-unit id="d42de30e9e03274c5c83bd6ce5c27a6f">
-        <source>Displayed in emails sent to customers.</source>
-        <target>Displayed in emails sent to customers.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:447</note>
-      </trans-unit>
-      <trans-unit id="49aaf34d99febc7c13881d121288cd8a">
-        <source>Shop registration information (e.g. SIRET or RCS).</source>
-        <target>Shop registration information (e.g. SIRET or RCS).</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:454</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminReferrersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6ca725316d3577fb24218119380f38fe">
-        <source>Leave blank if no change.</source>
-        <target>Leave blank if no change.</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:228</note>
-      </trans-unit>
-      <trans-unit id="4181de604675ec0fb8d12202ec23964c">
-        <source>Fee given for each visit.</source>
-        <target>Fee given for each visit.</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:265</note>
-      </trans-unit>
-      <trans-unit id="4b11cf76a471c13ba29b799772c90ddf">
-        <source>Fee given for each order placed.</source>
-        <target>Fee given for each order placed.</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:271</note>
-      </trans-unit>
-      <trans-unit id="d3d12bc1b7512d954444ec7c368d7176">
-        <source>If you know how to use MySQL regular expressions, you can use the [1]expert mode[/1].</source>
-        <target>If you know how to use MySQL regular expressions, you can use the [1]expert mode[/1].</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:330</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0822f76515fa1d9ce38504176cb23bae">
-        <source>The group defined for your un-identified visitors.</source>
-        <target>The group defined for your un-identified visitors.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:111</note>
-      </trans-unit>
-      <trans-unit id="e3e0c764f81f1a3677d59aa238fddd14">
-        <source>The group defined for your identified guest customers (used in guest checkout).</source>
-        <target>The group defined for your identified guest customers (used in guest checkout).</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:119</note>
-      </trans-unit>
-      <trans-unit id="e820b12959b64dfff397100db68cd951">
-        <source>The group defined for your identified registered customers.</source>
-        <target>The group defined for your identified registered customers.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:127</note>
-      </trans-unit>
-      <trans-unit id="a5fa9ffd3ddf89fe263675358032e7fb">
-        <source>Automatically apply this value as a discount on all products for members of this customer group.</source>
-        <target>Automatically apply this value as a discount on all products for members of this customer group.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:288</note>
-      </trans-unit>
-      <trans-unit id="21e445ba767d4fd41332b6eceab2be1a">
-        <source>How prices are displayed in the order summary for this customer group.</source>
-        <target>How prices are displayed in the order summary for this customer group.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:295</note>
-      </trans-unit>
-      <trans-unit id="eaf74fe1658ada757063c8ddc4381ef9">
-        <source>Customers in this group can view prices.</source>
-        <target>Customers in this group can view prices.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:330</note>
-      </trans-unit>
-      <trans-unit id="d38245fbe312b2dafef8450b67e94f50">
-        <source>%group_name% - All persons without a customer account or customers that are not logged in.</source>
-        <target>%group_name% - All persons without a customer account or customers that are not logged in.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:573</note>
-      </trans-unit>
-      <trans-unit id="5125d0fd7b81fee95b7e4b7689a878a9">
-        <source>%group_name% - All persons who placed an order through Guest Checkout.</source>
-        <target>%group_name% - All persons who placed an order through Guest Checkout.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:574</note>
-      </trans-unit>
-      <trans-unit id="96f090b06e329e3d192c0ea3701f8cb5">
-        <source>%group_name% - All persons who created an account on this site.</source>
-        <target>%group_name% - All persons who created an account on this site.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:575</note>
-      </trans-unit>
-      <trans-unit id="a2ce271cf6d8afe81168fbfc4ccb492c">
-        <source>PrestaShop has three default customer groups:</source>
-        <target>PrestaShop has three default customer groups:</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:577</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2593c7ce3ff937293feb1e61c152e551">
-        <source>characters</source>
-        <target>characters</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php:55</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="23d2e4d116d9d457eed9dd3a29f7ac51">
-        <source>Activate or deactivate your shop (It is a good idea to deactivate your shop while you perform maintenance. Please note that the webservice will not be disabled).</source>
-        <target>Activate or deactivate your shop (It is a good idea to deactivate your shop while you perform maintenance. Please note that the webservice will not be disabled).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig:43</note>
-      </trans-unit>
-      <trans-unit id="c3e680954da4b0bbf8e4d380287f4a76">
-        <source>IP addresses allowed to access the front office even if the shop is disabled. Please use a comma to separate them (e.g. 42.24.4.2,127.0.0.1,99.98.97.96)</source>
-        <target>IP addresses allowed to access the front office even if the shop is disabled. Please use a comma to separate them (e.g. 42.24.4.2,127.0.0.1,99.98.97.96)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig:50</note>
-      </trans-unit>
-      <trans-unit id="c1c418380f12430665f311652395eb11">
-        <source>Custom text displayed on maintenance page while shop is deactivated.</source>
-        <target>Custom text displayed on maintenance page while shop is deactivated.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig:57</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9175b705bec9604985209d1f2d88c785">
-        <source>Set to "0" to disable this feature.</source>
-        <target>Set to "0" to disable this feature.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig:47</note>
-      </trans-unit>
-      <trans-unit id="265b491d10a9a79c9b43655659826614">
-        <source>Display or hide the "add to cart" button on category pages for products that have attributes forcing customers to see product details.</source>
-        <target>Display or hide the "add to cart" button on category pages for products that have attributes forcing customers to see product details.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig:63</note>
-      </trans-unit>
-      <trans-unit id="f70d03fbb967b69ef8222c4a2b4ab334">
-        <source>In the volume discounts board, display the new price with the applied discount instead of showing the discount (ie. "-5%").</source>
-        <target>In the volume discounts board, display the new price with the applied discount instead of showing the discount (ie. "-5%").</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig:85</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2724aaa50fa52662bc9b244cab7afcae">
-        <source>Number of products displayed per page. Default is 10.</source>
-        <target>Number of products displayed per page. Default is 10.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="c18179baaeadd4a2fc27fafd3d6f40b1">
-        <source>The order in which products are displayed in the product list.</source>
-        <target>The order in which products are displayed in the product list.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="043781290780f9b67e98fc277d7608ba">
-        <source>Default order method for product list.</source>
-        <target>Default order method for product list.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig:52</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="54ae4e3e39f5a1f636cfcf2744433678">
-        <source>The catalog mode is actually to disable products checkout (prices, add to cart, etc.) on your shop, like a retail website does.</source>
-        <target>The catalog mode is actually to disable products checkout (prices, add to cart, etc.) on your shop, like a retail website does.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="80af0f0b70143f575fdfd6fa3ca3cb89">
-        <source>Set the maximum size of the summary of your product description (in characters).</source>
-        <target>Set the maximum size of the summary of your product description (in characters).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:54</note>
-      </trans-unit>
-      <trans-unit id="fc216bdfbaab3c5e3e87c70720110a08">
-        <source>How to calculate quantity discounts.</source>
-        <target>How to calculate quantity discounts.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:61</note>
-      </trans-unit>
-      <trans-unit id="07d295aa9281a95bf9c27348393f688a">
-        <source>When active, friendly URL will be updated on every save.</source>
-        <target>When active, friendly URL will be updated on every save.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:68</note>
-      </trans-unit>
-      <trans-unit id="3f141565d26297ff4449250743dba137">
-        <source>When active, new products will be activated by default during creation.</source>
-        <target>When active, new products will be activated by default during creation.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b9716d3d87447a2275318bf88ced7bf8">
-        <source>After a customer logs in, you can recall and display the content of his/her last shopping cart.</source>
-        <target>After a customer logs in, you can recall and display the content of his/her last shopping cart.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="751e29d82b27256878d1a38f2be4e118">
-        <source>Send an email with summary of the account information (email, password) after registration.</source>
-        <target>Send an email with summary of the account information (email, password) after registration.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="59a84d54ad58aa4bea8aeacd11e47ab2">
-        <source>Minimum time required between two requests for a password reset.</source>
-        <target>Minimum time required between two requests for a password reset.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="e0cf416b39580f321e4641721698560f">
-        <source>Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.</source>
-        <target>Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:59</note>
-      </trans-unit>
-      <trans-unit id="69b3bcd0dba13c9f1188ab86480afca4">
-        <source>Display or not the birth date field.</source>
-        <target>Display or not the birth date field.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:66</note>
-      </trans-unit>
-      <trans-unit id="3bc07e4ecf0660962221cf030b935d9d">
-        <source>Display or not the partner offers tick box, to receive offers from the store's partners.</source>
-        <target>Display or not the partner offers tick box, to receive offers from the store's partners.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig:73</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="885af23392ddb34eaabf65d3b86b216c">
-        <source>By default, the Add to Cart button is hidden when a product is unavailable. You can choose to have it displayed in all cases.</source>
-        <target>By default, the Add to Cart button is hidden when a product is unavailable. You can choose to have it displayed in all cases.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="4b7f36059725914c3abe3fe69a42d860">
-        <source>Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)</source>
-        <target>Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:81</note>
-      </trans-unit>
-      <trans-unit id="29474c2b0b3e4d053abd526ed118b420">
-        <source>Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)</source>
-        <target>Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:89</note>
-      </trans-unit>
-      <trans-unit id="f9a436259aa8fcb0e45a2081a259e90d">
-        <source>When selling packs of products, how do you want your stock to be calculated?</source>
-        <target>When selling packs of products, how do you want your stock to be calculated?</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig:97</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="406fff3ade73ad2eb4c4fefa8a1c2702">
-        <source>Display an overview of the addresses, shipping method and cart just before the order button (required in some European countries).</source>
-        <target>Display an overview of the addresses, shipping method and cart just before the order button (required in some European countries).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="e7c9a42ec01114dcd98e47bb1cb1ace6">
-        <source>Allow guest visitors to place an order without registering.</source>
-        <target>Allow guest visitors to place an order without registering.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="8690429442758955469bd5eb14c3db72">
-        <source>Disable the option to allow customers to reorder in one click from the order history page (required in some European countries).</source>
-        <target>Disable the option to allow customers to reorder in one click from the order history page (required in some European countries).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:52</note>
-      </trans-unit>
-      <trans-unit id="96b2f955774aee5f11e61646b7d5ae43">
-        <source>Set to 0 to disable this feature.</source>
-        <target>Set to 0 to disable this feature.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:59</note>
-      </trans-unit>
-      <trans-unit id="5ed533875d7388ffdbb60818e9596bdc">
-        <source>Automatically updates the shipping costs when you edit an order.</source>
-        <target>Automatically updates the shipping costs when you edit an order.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:66</note>
-      </trans-unit>
-      <trans-unit id="df2a562b17ec12920cee57e20b02ab67">
-        <source>Allow the customer to ship orders to multiple addresses. This option will convert the customer's cart into one or more orders.</source>
-        <target>Allow the customer to ship orders to multiple addresses. This option will convert the customer's cart into one or more orders.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:74</note>
-      </trans-unit>
-      <trans-unit id="86d8ec764d429d4ebe6e39de9ff8c4a4">
-        <source>Allows you to delay shipping at your customers' request.</source>
-        <target>Allows you to delay shipping at your customers' request.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:82</note>
-      </trans-unit>
-      <trans-unit id="fff92cdf417b8a468af180474057a575">
-        <source>Require customers to accept or decline terms of service before processing an order.</source>
-        <target>Require customers to accept or decline terms of service before processing an order.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:89</note>
-      </trans-unit>
-      <trans-unit id="38cb366ab3534fefcbc7d051a3b122fd">
-        <source>Choose the page which contains your store's terms and conditions of use.</source>
-        <target>Choose the page which contains your store's terms and conditions of use.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig:96</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8be74244c8fe462cb6d967a5ebdc57cb">
-        <source>Suggest gift-wrapping to customers.</source>
-        <target>Suggest gift-wrapping to customers.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig:38</note>
-      </trans-unit>
-      <trans-unit id="f2e28db133063334eb23fad936947493">
-        <source>Set a price for gift wrapping.</source>
-        <target>Set a price for gift wrapping.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig:45</note>
-      </trans-unit>
-      <trans-unit id="3993942430a9f4e82e50b2c39048d6b6">
-        <source>Set a tax for gift wrapping.</source>
-        <target>Set a tax for gift wrapping.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig:54</note>
-      </trans-unit>
-      <trans-unit id="f8aacaf7661fefb62d929d691b6bcfbe">
-        <source>Suggest recycled packaging to customer.</source>
-        <target>Suggest recycled packaging to customer.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig:63</note>
+      <trans-unit id="ce162159505d90c37be3dd2b464c3360">
+        <source>There is a huge quantity of data, so each connection corresponding to a referrer is indexed. You can also refresh this index by clicking the "Refresh index" button. This process may take a while, and it's only needed if you modified or added a referrer, or if you want changes to be retroactive.</source>
+        <target>There is a huge quantity of data, so each connection corresponding to a referrer is indexed. You can also refresh this index by clicking the "Refresh index" button. This process may take a while, and it's only needed if you modified or added a referrer, or if you want changes to be retroactive.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="6c4defc21d9e7428d7fe81a81f8eb05d">
+        <source>Your data is cached in order to sort it and filter it. You can refresh the cache by clicking on the "Refresh cache" button.</source>
+        <target>Your data is cached in order to sort it and filter it. You can refresh the cache by clicking on the "Refresh cache" button.</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="42bb6e7b5d150acfa5243c250d864cbc">
+        <source>Direct traffic can be quite resource-intensive. You should consider enabling it only if you have a strong need for it.</source>
+        <target>Direct traffic can be quite resource-intensive. You should consider enabling it only if you have a strong need for it.</target>
+        <note>Line: 58</note>
       </trans-unit>
     </body>
   </file>
@@ -779,138 +24,97 @@ File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderP
       <trans-unit id="711136b10e4f46ca38be4363bfd809ce">
         <source>Show me more</source>
         <target>Show me more</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="a1b58c5793a9c4b1596f555d3c46ca7c">
         <source>Definitions:</source>
         <target>Definitions:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="b0194c3357e1b561284a08ba9c8625c7">
         <source>The "http_referer" field is the website from which your customers arrive.</source>
         <target>The "http_referer" field is the website from which your customers arrive.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:38</note>
+        <note>Line: 38</note>
       </trans-unit>
       <trans-unit id="e1bc4efa13a13333c86fdf2eb70a0c38">
         <source>For example, visitors coming from Google will have an "http_referer" value like this one: "http://www.google.com/search?q=prestashop".</source>
         <target>For example, visitors coming from Google will have an "http_referer" value like this one: "http://www.google.com/search?q=prestashop".</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:39</note>
+        <note>Line: 39</note>
       </trans-unit>
       <trans-unit id="9b3c4e3b2a8a95bcaad9b816a925fca5">
         <source>If the visitor arrives directly (by typing the URL of your shop, or by using their bookmarks, for example), the http_referer will be empty.</source>
         <target>If the visitor arrives directly (by typing the URL of your shop, or by using their bookmarks, for example), the http_referer will be empty.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:40</note>
+        <note>Line: 40</note>
       </trans-unit>
       <trans-unit id="6f0aa1b11f44e45dbbd01546e6726424">
         <source>If you'd like to view all the visitors coming from Google, you can type "%google%" in this field. Alternatively, you can type "%google.fr%" if you want to view visitors coming from Google France, only.</source>
         <target>If you'd like to view all the visitors coming from Google, you can type "%google%" in this field. Alternatively, you can type "%google.fr%" if you want to view visitors coming from Google France, only.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="41b06c521ee2d1075f9bd3b12e8758a5">
         <source>The "request_uri" field is the URL from which the customers come to your website.</source>
         <target>The "request_uri" field is the URL from which the customers come to your website.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="aa9eb9d62ab328d8da04b77469fbb6c8">
         <source>For example, if the visitor accesses a product page, the URL will be like this one: "%smusic-ipods/1-ipod-nano.html".</source>
         <target>For example, if the visitor accesses a product page, the URL will be like this one: "%smusic-ipods/1-ipod-nano.html".</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="4451a0228098136036ced8d9b7478ed9">
         <source>This is helpful because you can add tags or tokens in the links pointing to your website.</source>
         <target>This is helpful because you can add tags or tokens in the links pointing to your website.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="6ca25929481cee3aef9cda0f7d309f9d">
         <source>For example, you can post a link (such as "%sindex.php?myuniquekeyword" -- note that you added "?myuniquekeyword" at the end of the URL) in an online forum or as a blog comment, and get visitors statistics for that unique link by entering "%%myuniquekeyword" in the "request_uri" field.</source>
         <target>For example, you can post a link (such as "%sindex.php?myuniquekeyword" -- note that you added "?myuniquekeyword" at the end of the URL) in an online forum or as a blog comment, and get visitors statistics for that unique link by entering "%%myuniquekeyword" in the "request_uri" field.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="07d199fdf852bd9dc4d899b6cd2a16e7">
         <source>This method is more reliable than the "http_referer" one, but there is one disadvantage: if a search engine references a page with your link, then it will be displayed in the search results and you will not only indicate visitors from the places where you posted the link, but also those from the search engines that picked up that link.</source>
         <target>This method is more reliable than the "http_referer" one, but there is one disadvantage: if a search engine references a page with your link, then it will be displayed in the search results and you will not only indicate visitors from the places where you posted the link, but also those from the search engines that picked up that link.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="2a7510ee054a824a06c67cb30a9dc85f">
         <source>The "Include" fields indicate what has to be included in the URL.</source>
         <target>The "Include" fields indicate what has to be included in the URL.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="7047f6cd037224af5ef028de15a0b844">
         <source>The "Exclude" fields indicate what has to be excluded from the URL.</source>
         <target>The "Exclude" fields indicate what has to be excluded from the URL.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:57</note>
+        <note>Line: 57</note>
       </trans-unit>
       <trans-unit id="fec5647b486079a90ea4667d6125a03e">
         <source>When using simple mode, you can use a wide variety of generic characters to replace other characters:</source>
         <target>When using simple mode, you can use a wide variety of generic characters to replace other characters:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:61</note>
+        <note>Line: 61</note>
       </trans-unit>
       <trans-unit id="19e6272904f9f449ae490d69aa36cd6c">
         <source>"_" will replace one character. If you want to use the real "_", you should type this: "\\_".</source>
         <target>"_" will replace one character. If you want to use the real "_", you should type this: "\\_".</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:63</note>
+        <note>Line: 63</note>
       </trans-unit>
       <trans-unit id="900b3ed6d62723c673b427a3f6e66669">
         <source>"%" will replace any number of characters. If you want to use the real "%", you should type this: "\\%".</source>
         <target>"%" will replace any number of characters. If you want to use the real "%", you should type this: "\\%".</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:64</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="5d23fb29ee98e1f050bc9dabbcca667d">
         <source>The Simple mode uses the MySQL "LIKE" pattern matching, but for a higher potency you can use MySQL's regular expressions in the Expert mode.</source>
         <target>The Simple mode uses the MySQL "LIKE" pattern matching, but for a higher potency you can use MySQL's regular expressions in the Expert mode.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:69</note>
+        <note>Line: 69</note>
       </trans-unit>
       <trans-unit id="88b3441035077ae06f817c3b4afb8d2a">
         <source>Take a look at MySQL's documentation for more details.</source>
         <target>Take a look at MySQL's documentation for more details.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:70</note>
+        <note>Line: 70</note>
       </trans-unit>
       <trans-unit id="2d0c2b736fa1ab8ce149d26fc36e453a">
         <source>Get help!</source>
         <target>Get help!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/helpers/form/form.tpl:81</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/referrers/form_settings.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ce162159505d90c37be3dd2b464c3360">
-        <source>There is a huge quantity of data, so each connection corresponding to a referrer is indexed. You can also refresh this index by clicking the "Refresh index" button. This process may take a while, and it's only needed if you modified or added a referrer, or if you want changes to be retroactive.</source>
-        <target>There is a huge quantity of data, so each connection corresponding to a referrer is indexed. You can also refresh this index by clicking the "Refresh index" button. This process may take a while, and it's only needed if you modified or added a referrer, or if you want changes to be retroactive.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="6c4defc21d9e7428d7fe81a81f8eb05d">
-        <source>Your data is cached in order to sort it and filter it. You can refresh the cache by clicking on the "Refresh cache" button.</source>
-        <target>Your data is cached in order to sort it and filter it. You can refresh the cache by clicking on the "Refresh cache" button.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="42bb6e7b5d150acfa5243c250d864cbc">
-        <source>Direct traffic can be quite resource-intensive. You should consider enabling it only if you have a strong need for it.</source>
-        <target>Direct traffic can be quite resource-intensive. You should consider enabling it only if you have a strong need for it.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:58</note>
+        <note>Line: 81</note>
       </trans-unit>
     </body>
   </file>
@@ -919,8 +123,672 @@ File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:
       <trans-unit id="e734ed12d2c2026532f66e0ebeedfc8c">
         <source>e.g. 10:00AM - 9:30PM</source>
         <target>e.g. 10:00AM - 9:30PM</target>
+        <note>Line: 67</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminContactsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9cd9efd3eb168071eb0a199972c54aab">
+        <source>Contact name (e.g. Customer Support).</source>
+        <target>Contact name (e.g. Customer Support).</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="daedf9c5c8f38ac4cf641f3fb3e1bdc4">
+        <source>Emails will be sent to this address.</source>
+        <target>Emails will be sent to this address.</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="0f28459fa87b1b3ce6e8b17932f08c3a">
+        <source>If enabled, all messages will be saved in the "Customer Service" page under the "Customer" menu.</source>
+        <target>If enabled, all messages will be saved in the "Customer Service" page under the "Customer" menu.</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="a2b086325f59e6c2fbd410511f4fdfb3">
+        <source>Further information regarding this contact.</source>
+        <target>Further information regarding this contact.</target>
+        <note>Line: 124</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminGendersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6252c0f2c2ed83b7b06dfca86d4650bb">
+        <source>Invalid characters:</source>
+        <target>Invalid characters:</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="62c7ceb6de5c4d39e49c9762af6ddb4d">
+        <source>Image width in pixels. Enter "0" to use the original size.</source>
+        <target>Image width in pixels. Enter "0" to use the original size.</target>
+        <note>Line: 162</note>
+      </trans-unit>
+      <trans-unit id="aec8651b033be4d4056785d43763d7ca">
+        <source>Image height in pixels. Enter "0" to use the original size.</source>
+        <target>Image height in pixels. Enter "0" to use the original size.</target>
+        <note>Line: 169</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0822f76515fa1d9ce38504176cb23bae">
+        <source>The group defined for your un-identified visitors.</source>
+        <target>The group defined for your un-identified visitors.</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="e3e0c764f81f1a3677d59aa238fddd14">
+        <source>The group defined for your identified guest customers (used in guest checkout).</source>
+        <target>The group defined for your identified guest customers (used in guest checkout).</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="e820b12959b64dfff397100db68cd951">
+        <source>The group defined for your identified registered customers.</source>
+        <target>The group defined for your identified registered customers.</target>
+        <note>Line: 127</note>
+      </trans-unit>
+      <trans-unit id="a5fa9ffd3ddf89fe263675358032e7fb">
+        <source>Automatically apply this value as a discount on all products for members of this customer group.</source>
+        <target>Automatically apply this value as a discount on all products for members of this customer group.</target>
+        <note>Line: 327</note>
+      </trans-unit>
+      <trans-unit id="21e445ba767d4fd41332b6eceab2be1a">
+        <source>How prices are displayed in the order summary for this customer group.</source>
+        <target>How prices are displayed in the order summary for this customer group.</target>
+        <note>Line: 334</note>
+      </trans-unit>
+      <trans-unit id="eaf74fe1658ada757063c8ddc4381ef9">
+        <source>Customers in this group can view prices.</source>
+        <target>Customers in this group can view prices.</target>
+        <note>Line: 369</note>
+      </trans-unit>
+      <trans-unit id="d38245fbe312b2dafef8450b67e94f50">
+        <source>%group_name% - All persons without a customer account or customers that are not logged in.</source>
+        <target>%group_name% - All persons without a customer account or customers that are not logged in.</target>
+        <note>Line: 612</note>
+      </trans-unit>
+      <trans-unit id="5125d0fd7b81fee95b7e4b7689a878a9">
+        <source>%group_name% - All persons who placed an order through Guest Checkout.</source>
+        <target>%group_name% - All persons who placed an order through Guest Checkout.</target>
+        <note>Line: 613</note>
+      </trans-unit>
+      <trans-unit id="96f090b06e329e3d192c0ea3701f8cb5">
+        <source>%group_name% - All persons who created an account on this site.</source>
+        <target>%group_name% - All persons who created an account on this site.</target>
+        <note>Line: 614</note>
+      </trans-unit>
+      <trans-unit id="a2ce271cf6d8afe81168fbfc4ccb492c">
+        <source>PrestaShop has three default customer groups:</source>
+        <target>PrestaShop has three default customer groups:</target>
+        <note>Line: 616</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminMetaController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="219985722a429b6aaceef7d363e6a565">
+        <source>Name of the related page.</source>
+        <target>Name of the related page.</target>
+        <note>Line: 342</note>
+      </trans-unit>
+      <trans-unit id="14bc1d17bbcf8fb45debf11fb7c5f80b">
+        <source>Title of this page.</source>
+        <target>Title of this page.</target>
+        <note>Line: 351</note>
+      </trans-unit>
+      <trans-unit id="79c06fd4269a36582767dc4525699148">
+        <source>A short description of your shop.</source>
+        <target>A short description of your shop.</target>
+        <note>Line: 361</note>
+      </trans-unit>
+      <trans-unit id="d9f600637f31b203b55f6c91dabd4fde">
+        <source>List of keywords for search engines.</source>
+        <target>List of keywords for search engines.</target>
+        <note>Line: 371</note>
+      </trans-unit>
+      <trans-unit id="0210e7a00cf2cd3cca0e4d7ed3bdf86f">
+        <source>To add tags, click in the field, write something, and then press the "Enter" key.</source>
+        <target>To add tags, click in the field, write something, and then press the "Enter" key.</target>
+        <note>Line: 372</note>
+      </trans-unit>
+      <trans-unit id="99de37a1ed381af8c01ccb18f70b1427">
+        <source>For instance, "contacts" for http://example.com/shop/contacts to redirect to http://example.com/shop/contact-form.php</source>
+        <target>For instance, "contacts" for http://example.com/shop/contacts to redirect to http://example.com/shop/contact-form.php</target>
+        <note>Line: 384</note>
+      </trans-unit>
+      <trans-unit id="7aa534250fe76a40d96078a07b6f44e8">
+        <source>Only letters and hyphens are allowed.</source>
+        <target>Only letters and hyphens are allowed.</target>
+        <note>Line: 385</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReferrersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6ca725316d3577fb24218119380f38fe">
+        <source>Leave blank if no change.</source>
+        <target>Leave blank if no change.</target>
+        <note>Line: 228</note>
+      </trans-unit>
+      <trans-unit id="4181de604675ec0fb8d12202ec23964c">
+        <source>Fee given for each visit.</source>
+        <target>Fee given for each visit.</target>
+        <note>Line: 265</note>
+      </trans-unit>
+      <trans-unit id="4b11cf76a471c13ba29b799772c90ddf">
+        <source>Fee given for each order placed.</source>
+        <target>Fee given for each order placed.</target>
+        <note>Line: 271</note>
+      </trans-unit>
+      <trans-unit id="d3d12bc1b7512d954444ec7c368d7176">
+        <source>If you know how to use MySQL regular expressions, you can use the [1]expert mode[/1].</source>
+        <target>If you know how to use MySQL regular expressions, you can use the [1]expert mode[/1].</target>
+        <note>Line: 330</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSearchConfController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="12399d580627a1a5889cdc44e6e48b5a">
+        <source>Enable the automatic indexing of products. If you enable this feature, the products will be indexed in the search automatically when they are saved. If the feature is disabled, you will have to index products manually by using the links provided in the field set.</source>
+        <target>Enable the automatic indexing of products. If you enable this feature, the products will be indexed in the search automatically when they are saved. If the feature is disabled, you will have to index products manually by using the links provided in the field set.</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="a5cb89e5bcb48c0708ee6837a5944d3e">
+        <source>By default, to search for “blouse”, you have to enter “blous”, “blo”, etc (beginning of the word) – but not “lous” (within the word).</source>
+        <target>By default, to search for “blouse”, you have to enter “blous”, “blo”, etc (beginning of the word) – but not “lous” (within the word).</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="d2e38e24e467d35cc5881e083e05b823">
+        <source>With this option enabled, it also gives the good result if you search for “lous”, “ouse”, or anything contained in the word.</source>
+        <target>With this option enabled, it also gives the good result if you search for “lous”, “ouse”, or anything contained in the word.</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="9110055bdc92744713baa237b26f8ac7">
+        <source>Enable search within a whole word, rather than from its beginning only.</source>
+        <target>Enable search within a whole word, rather than from its beginning only.</target>
+        <note>Line: 132</note>
+      </trans-unit>
+      <trans-unit id="0e665a9cf278d49f43c4bb4cb9a7c29f">
+        <source>It checks if the searched term is contained in the indexed word. This may be resource-consuming.</source>
+        <target>It checks if the searched term is contained in the indexed word. This may be resource-consuming.</target>
+        <note>Line: 137</note>
+      </trans-unit>
+      <trans-unit id="1122eba5946331d2709712f64fa1d66b">
+        <source>By default, if you search "book", you will have "book", "bookcase" and "bookend".</source>
+        <target>By default, if you search "book", you will have "book", "bookcase" and "bookend".</target>
+        <note>Line: 149</note>
+      </trans-unit>
+      <trans-unit id="0b1d71ac92f27198d2bd1e6cd49cec1b">
+        <source>With this option enabled, it only gives one result “book”, as exact end of the indexed word is matching.</source>
+        <target>With this option enabled, it only gives one result “book”, as exact end of the indexed word is matching.</target>
+        <note>Line: 154</note>
+      </trans-unit>
+      <trans-unit id="c4474326e7d8129b7c04ada10f34f5b1">
+        <source>Enable more precise search with the end of the word.</source>
+        <target>Enable more precise search with the end of the word.</target>
+        <note>Line: 160</note>
+      </trans-unit>
+      <trans-unit id="efb6bc8d1ee1c5527d494ba15ee3109d">
+        <source>It checks if the searched term is the exact end of the indexed word.</source>
+        <target>It checks if the searched term is the exact end of the indexed word.</target>
+        <note>Line: 165</note>
+      </trans-unit>
+      <trans-unit id="645115aba5ef431a04da95c746477544">
+        <source>Only words this size or larger will be indexed.</source>
+        <target>Only words this size or larger will be indexed.</target>
+        <note>Line: 178</note>
+      </trans-unit>
+      <trans-unit id="2c2666c9eee818342b0aff77dda51990">
+        <source>Please enter the index words separated by a "|".</source>
+        <target>Please enter the index words separated by a "|".</target>
+        <note>Line: 190</note>
+      </trans-unit>
+      <trans-unit id="786471035f60ea5955fd93f6998e8637">
+        <source>Enter each alias separated by a comma (e.g. 'prestshop,preztashop,prestasohp').</source>
+        <target>Enter each alias separated by a comma (e.g. 'prestshop,preztashop,prestasohp').</target>
+        <note>Line: 350</note>
+      </trans-unit>
+      <trans-unit id="259b411f284388d228a30c1e2ed0c61d">
+        <source><![CDATA[Forbidden characters: <>;=#{}]]></source>
+        <target><![CDATA[Forbidden characters: <>;=#{}]]></target>
         <note>Context:
-File: admin-dev/themes/default/template/controllers/stores/helpers/form/form.tpl:67</note>
+File: controllers/admin/AdminSearchConfController.php:351</note>
+      </trans-unit>
+      <trans-unit id="01d2aac5d20787a1e873f2bdc79b514a">
+        <source>Search this word instead.</source>
+        <target>Search this word instead.</target>
+        <note>Line: 359</note>
+      </trans-unit>
+      <trans-unit id="88851f53412ccb796508fd5f48e7a44f">
+        <source><![CDATA[Forbidden characters: <>;=#{}]]></source>
+        <target><![CDATA[Forbidden characters: <>;=#{}]]></target>
+        <note>Line: 351</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5c85aec638229f60a035c7a6ab3623c8">
+        <source>This field does not refer to the shop name visible in the front office.</source>
+        <target>This field does not refer to the shop name visible in the front office.</target>
+        <note>Line: 371</note>
+      </trans-unit>
+      <trans-unit id="1561fa99e3814c72f5206ab48b472335">
+        <source>Follow [1]this link[/1] to edit the shop name used on the front office.</source>
+        <target>Follow [1]this link[/1] to edit the shop name used on the front office.</target>
+        <note>Line: 372</note>
+      </trans-unit>
+      <trans-unit id="92aaf3cf7e8f1434886a8887e102391b">
+        <source>You can't edit the shop group because the current shop belongs to a group with the "share" option enabled.</source>
+        <target>You can't edit the shop group because the current shop belongs to a group with the "share" option enabled.</target>
+        <note>Line: 430</note>
+      </trans-unit>
+      <trans-unit id="fce5f624e66bd2e2f0296fc3bd2a8f64">
+        <source>This is the root category of the store that you've created. To define a new root category for your store, [1]please click here[/1].</source>
+        <target>This is the root category of the store that you've created. To define a new root category for your store, [1]please click here[/1].</target>
+        <note>Line: 440</note>
+      </trans-unit>
+      <trans-unit id="f0f7416fad0a9c9fc3163cabe68393c1">
+        <source>By selecting associated categories, you are choosing to share the categories between shops. Once associated between shops, any alteration of this category will impact every shop.</source>
+        <target>By selecting associated categories, you are choosing to share the categories between shops. Once associated between shops, any alteration of this category will impact every shop.</target>
+        <note>Line: 494</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="83b262520a65657b95fd686817c56a09">
+        <source>Order status (e.g. 'Pending').</source>
+        <target>Order status (e.g. 'Pending').</target>
+        <note>Line: 281</note>
+      </trans-unit>
+      <trans-unit id="a4bb440d400f4dc30f148b44d08680b4">
+        <source>Invalid characters: numbers and</source>
+        <target>Invalid characters: numbers and</target>
+        <note>Line: 484</note>
+      </trans-unit>
+      <trans-unit id="a9c2e14555131d68a4ac37b604ee52a8">
+        <source>Upload an icon from your computer (File type: .gif, suggested size: 16x16).</source>
+        <target>Upload an icon from your computer (File type: .gif, suggested size: 16x16).</target>
+        <note>Line: 289</note>
+      </trans-unit>
+      <trans-unit id="00b963b1cb1aad2142ae67ce65329944">
+        <source>Status will be highlighted in this color. HTML colors only.</source>
+        <target>Status will be highlighted in this color. HTML colors only.</target>
+        <note>Line: 491</note>
+      </trans-unit>
+      <trans-unit id="f0fe1aebeace842330fb048126151e06">
+        <source>Only letters, numbers and underscores ("_") are allowed.</source>
+        <target>Only letters, numbers and underscores ("_") are allowed.</target>
+        <note>Line: 408</note>
+      </trans-unit>
+      <trans-unit id="3d034f43e44ee495a11005507185a0a0">
+        <source>Email template for both .html and .txt.</source>
+        <target>Email template for both .html and .txt.</target>
+        <note>Line: 409</note>
+      </trans-unit>
+      <trans-unit id="43f4ac702eaf88267f6946aeb559b251">
+        <source>Order's return status name.</source>
+        <target>Order's return status name.</target>
+        <note>Line: 483</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f45ed1483cf46972b5f225656c9c8991">
+        <source>Whether or not to display this store.</source>
+        <target>Whether or not to display this store.</target>
+        <note>Line: 265</note>
+      </trans-unit>
+      <trans-unit id="b950eb0054205bc67aa88899eadded22">
+        <source>Storefront picture.</source>
+        <target>Storefront picture.</target>
+        <note>Line: 274</note>
+      </trans-unit>
+      <trans-unit id="d42de30e9e03274c5c83bd6ce5c27a6f">
+        <source>Displayed in emails sent to customers.</source>
+        <target>Displayed in emails sent to customers.</target>
+        <note>Line: 447</note>
+      </trans-unit>
+      <trans-unit id="49aaf34d99febc7c13881d121288cd8a">
+        <source>Shop registration information (e.g. SIRET or RCS).</source>
+        <target>Shop registration information (e.g. SIRET or RCS).</target>
+        <note>Line: 454</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2593c7ce3ff937293feb1e61c152e551">
+        <source>characters</source>
+        <target>characters</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b9716d3d87447a2275318bf88ced7bf8">
+        <source>After a customer logs in, you can recall and display the content of his/her last shopping cart.</source>
+        <target>After a customer logs in, you can recall and display the content of his/her last shopping cart.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="751e29d82b27256878d1a38f2be4e118">
+        <source>Send an email with summary of the account information (email, password) after registration.</source>
+        <target>Send an email with summary of the account information (email, password) after registration.</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="59a84d54ad58aa4bea8aeacd11e47ab2">
+        <source>Minimum time required between two requests for a password reset.</source>
+        <target>Minimum time required between two requests for a password reset.</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="e0cf416b39580f321e4641721698560f">
+        <source>Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.</source>
+        <target>Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="69b3bcd0dba13c9f1188ab86480afca4">
+        <source>Display or not the birth date field.</source>
+        <target>Display or not the birth date field.</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="3bc07e4ecf0660962221cf030b935d9d">
+        <source>Display or not the partner offers tick box, to receive offers from the store's partners.</source>
+        <target>Display or not the partner offers tick box, to receive offers from the store's partners.</target>
+        <note>Line: 73</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="54ae4e3e39f5a1f636cfcf2744433678">
+        <source>The catalog mode is actually to disable products checkout (prices, add to cart, etc.) on your shop, like a retail website does.</source>
+        <target>The catalog mode is actually to disable products checkout (prices, add to cart, etc.) on your shop, like a retail website does.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="80af0f0b70143f575fdfd6fa3ca3cb89">
+        <source>Set the maximum size of the summary of your product description (in characters).</source>
+        <target>Set the maximum size of the summary of your product description (in characters).</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="fc216bdfbaab3c5e3e87c70720110a08">
+        <source>How to calculate quantity discounts.</source>
+        <target>How to calculate quantity discounts.</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="07d295aa9281a95bf9c27348393f688a">
+        <source>When active, friendly URL will be updated on every save.</source>
+        <target>When active, friendly URL will be updated on every save.</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="3f141565d26297ff4449250743dba137">
+        <source>When active, new products will be activated by default during creation.</source>
+        <target>When active, new products will be activated by default during creation.</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9175b705bec9604985209d1f2d88c785">
+        <source>Set to "0" to disable this feature.</source>
+        <target>Set to "0" to disable this feature.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="265b491d10a9a79c9b43655659826614">
+        <source>Display or hide the "add to cart" button on category pages for products that have attributes forcing customers to see product details.</source>
+        <target>Display or hide the "add to cart" button on category pages for products that have attributes forcing customers to see product details.</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="f70d03fbb967b69ef8222c4a2b4ab334">
+        <source>In the volume discounts board, display the new price with the applied discount instead of showing the discount (ie. "-5%").</source>
+        <target>In the volume discounts board, display the new price with the applied discount instead of showing the discount (ie. "-5%").</target>
+        <note>Line: 85</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2724aaa50fa52662bc9b244cab7afcae">
+        <source>Number of products displayed per page. Default is 10.</source>
+        <target>Number of products displayed per page. Default is 10.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="c18179baaeadd4a2fc27fafd3d6f40b1">
+        <source>The order in which products are displayed in the product list.</source>
+        <target>The order in which products are displayed in the product list.</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="043781290780f9b67e98fc277d7608ba">
+        <source>Default order method for product list.</source>
+        <target>Default order method for product list.</target>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="885af23392ddb34eaabf65d3b86b216c">
+        <source>By default, the Add to Cart button is hidden when a product is unavailable. You can choose to have it displayed in all cases.</source>
+        <target>By default, the Add to Cart button is hidden when a product is unavailable. You can choose to have it displayed in all cases.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="4b7f36059725914c3abe3fe69a42d860">
+        <source>Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)</source>
+        <target>Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="29474c2b0b3e4d053abd526ed118b420">
+        <source>Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)</source>
+        <target>Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="f9a436259aa8fcb0e45a2081a259e90d">
+        <source>When selling packs of products, how do you want your stock to be calculated?</source>
+        <target>When selling packs of products, how do you want your stock to be calculated?</target>
+        <note>Line: 97</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="406fff3ade73ad2eb4c4fefa8a1c2702">
+        <source>Display an overview of the addresses, shipping method and cart just before the order button (required in some European countries).</source>
+        <target>Display an overview of the addresses, shipping method and cart just before the order button (required in some European countries).</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="e7c9a42ec01114dcd98e47bb1cb1ace6">
+        <source>Allow guest visitors to place an order without registering.</source>
+        <target>Allow guest visitors to place an order without registering.</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="8690429442758955469bd5eb14c3db72">
+        <source>Disable the option to allow customers to reorder in one click from the order history page (required in some European countries).</source>
+        <target>Disable the option to allow customers to reorder in one click from the order history page (required in some European countries).</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="96b2f955774aee5f11e61646b7d5ae43">
+        <source>Set to 0 to disable this feature.</source>
+        <target>Set to 0 to disable this feature.</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="5ed533875d7388ffdbb60818e9596bdc">
+        <source>Automatically updates the shipping costs when you edit an order.</source>
+        <target>Automatically updates the shipping costs when you edit an order.</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="df2a562b17ec12920cee57e20b02ab67">
+        <source>Allow the customer to ship orders to multiple addresses. This option will convert the customer's cart into one or more orders.</source>
+        <target>Allow the customer to ship orders to multiple addresses. This option will convert the customer's cart into one or more orders.</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="86d8ec764d429d4ebe6e39de9ff8c4a4">
+        <source>Allows you to delay shipping at your customers' request.</source>
+        <target>Allows you to delay shipping at your customers' request.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="fff92cdf417b8a468af180474057a575">
+        <source>Require customers to accept or decline terms of service before processing an order.</source>
+        <target>Require customers to accept or decline terms of service before processing an order.</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="38cb366ab3534fefcbc7d051a3b122fd">
+        <source>Choose the page which contains your store's terms and conditions of use.</source>
+        <target>Choose the page which contains your store's terms and conditions of use.</target>
+        <note>Line: 96</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8be74244c8fe462cb6d967a5ebdc57cb">
+        <source>Suggest gift-wrapping to customers.</source>
+        <target>Suggest gift-wrapping to customers.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="f2e28db133063334eb23fad936947493">
+        <source>Set a price for gift wrapping.</source>
+        <target>Set a price for gift wrapping.</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="3993942430a9f4e82e50b2c39048d6b6">
+        <source>Set a tax for gift wrapping.</source>
+        <target>Set a tax for gift wrapping.</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="f8aacaf7661fefb62d929d691b6bcfbe">
+        <source>Suggest recycled packaging to customer.</source>
+        <target>Suggest recycled packaging to customer.</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="55ed6eb3effe909461f682de73f89f82">
+        <source>You can search for a new domain name or add a domain name that you already own. You will be redirected to your PrestaShop account.</source>
+        <target>You can search for a new domain name or add a domain name that you already own. You will be redirected to your PrestaShop account.</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3ff4fabe93bbb10c32a27c54ea13a5e1">
+        <source>Enable this option only if your server allows URL rewriting (recommended).</source>
+        <target>Enable this option only if your server allows URL rewriting (recommended).</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="6a9bb0bb3f61904834f4f436bbcaa1d2">
+        <source>URL rewriting (mod_rewrite) is not active on your server, or it is not possible to check your server configuration. If you want to use Friendly URLs, you must activate this mod.</source>
+        <target>URL rewriting (mod_rewrite) is not active on your server, or it is not possible to check your server configuration. If you want to use Friendly URLs, you must activate this mod.</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="1ccf825d454faaa7f8141830469fab8f">
+        <source>Enable this option if you want to allow accented characters in your friendly URLs.</source>
+        <target>Enable this option if you want to allow accented characters in your friendly URLs.</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="37d06ba898faba724d13f931b1642b06">
+        <source>You should only activate this option if you are using non-latin characters ; for all the latin charsets, your SEO will be better without this option.</source>
+        <target>You should only activate this option if you are using non-latin characters ; for all the latin charsets, your SEO will be better without this option.</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="7dcc0875a9e200be4d760155c09c2945">
+        <source>Enable this option only if you have problems with URL rewriting.</source>
+        <target>Enable this option only if you have problems with URL rewriting.</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="9e9ad9fb2adc8da0aaec808b3d4e73e4">
+        <source>Some of PrestaShop's features might not work correctly with a specific configuration of Apache's mod_security module. We recommend to turn it off.</source>
+        <target>Some of PrestaShop's features might not work correctly with a specific configuration of Apache's mod_security module. We recommend to turn it off.</target>
+        <note>Line: 96</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="23d2e4d116d9d457eed9dd3a29f7ac51">
+        <source>Activate or deactivate your shop (It is a good idea to deactivate your shop while you perform maintenance. Please note that the webservice will not be disabled).</source>
+        <target>Activate or deactivate your shop (It is a good idea to deactivate your shop while you perform maintenance. Please note that the webservice will not be disabled).</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="c3e680954da4b0bbf8e4d380287f4a76">
+        <source>IP addresses allowed to access the front office even if the shop is disabled. Please use a comma to separate them (e.g. 42.24.4.2,127.0.0.1,99.98.97.96)</source>
+        <target>IP addresses allowed to access the front office even if the shop is disabled. Please use a comma to separate them (e.g. 42.24.4.2,127.0.0.1,99.98.97.96)</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="c1c418380f12430665f311652395eb11">
+        <source>Custom text displayed on maintenance page while shop is deactivated.</source>
+        <target>Custom text displayed on maintenance page while shop is deactivated.</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="500294c9fd031bb4f00a82b5d27dc22c">
+        <source>If you own an SSL certificate for your shop's domain name, you can activate SSL encryption (https://) for customer account identification and order processing.</source>
+        <target>If you own an SSL certificate for your shop's domain name, you can activate SSL encryption (https://) for customer account identification and order processing.</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="a3a0f3b2f4c12d1c11b9916c8c10c48c">
+        <source>If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.</source>
+        <target>If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="d86a9baf93dba6b27dbbb04cef8d3aae">
+        <source>When enabled, all the pages of your shop will be SSL-secured.</source>
+        <target>When enabled, all the pages of your shop will be SSL-secured.</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="a1202480ddcd8665114515ca380c0e5b">
+        <source>Enable or disable token in the Front Office to improve PrestaShop's security.</source>
+        <target>Enable or disable token in the Front Office to improve PrestaShop's security.</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="4f70bd9998bb35643fa3dfc88d6a6373">
+        <source>Allow iframes on text fields like product description. We recommend that you leave this option disabled.</source>
+        <target>Allow iframes on text fields like product description. We recommend that you leave this option disabled.</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="7ba34b929c8241268ab5eac35a772ab1">
+        <source>Clean the HTML content on text fields. We recommend that you leave this option enabled.</source>
+        <target>Clean the HTML content on text fields. We recommend that you leave this option enabled.</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="71958504714b867b7f6f00f43b9c9bd0">
+        <source>You can choose among 6 different ways of rounding prices. "Round up away from zero ..." is the recommended behavior.</source>
+        <target>You can choose among 6 different ways of rounding prices. "Round up away from zero ..." is the recommended behavior.</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="2b116a3c74c816d853b7d86abf838ebb">
+        <source>You can choose when to round prices: either on each item, each line or the total (of an invoice, for example).</source>
+        <target>You can choose when to round prices: either on each item, each line or the total (of an invoice, for example).</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="2d21e9a3fe59f46db5ffdc26448e3ab6">
+        <source>Choose how many decimals you want to display</source>
+        <target>Choose how many decimals you want to display</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="b6d90c5c27a4d2d48ead626c17be303c">
+        <source>Enable brands and suppliers pages on your front office even when their respective modules are disabled.</source>
+        <target>Enable brands and suppliers pages on your front office even when their respective modules are disabled.</target>
+        <note>Line: 134</note>
+      </trans-unit>
+      <trans-unit id="0678cf17f202cb7fd14d79054a2e628c">
+        <source>Enable best sellers page on your front office even when its respective module is disabled.</source>
+        <target>Enable best sellers page on your front office even when its respective module is disabled.</target>
+        <note>Line: 142</note>
+      </trans-unit>
+      <trans-unit id="d8942e5679a9104ae58333b9b4778b71">
+        <source>The multistore feature allows you to manage several e-shops with one Back Office. If this feature is enabled, a "Multistore" page will be available in the "Advanced Parameters" menu.</source>
+        <target>The multistore feature allows you to manage several e-shops with one Back Office. If this feature is enabled, a "Multistore" page will be available in the "Advanced Parameters" menu.</target>
+        <note>Line: 150</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminShopparametersNotification.xlf
+++ b/app/Resources/translations/default/AdminShopparametersNotification.xlf
@@ -1,320 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="510f6a8fda6eb21f9ff01954e034a29a">
-        <source>For security reasons, you cannot delete default order statuses.</source>
-        <target>For security reasons, you cannot delete default order statuses.</target>
-        <note>Context:
-File: controllers/admin/AdminStatusesController.php:611</note>
+      <trans-unit id="57f51ca7c7ae71c5ac955cbce1942622">
+        <source>Caution: The discount applied to a category does not stack with the overall reduction but instead replaces it.</source>
+        <target>Caution: The discount applied to a category does not stack with the overall reduction but instead replaces it.</target>
+        <note>Line: 154</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="73ca86c0d6a5d58e868c54c3a1524c6c">
-        <source>Before you can use this tool, you need to:</source>
-        <target>Before you can use this tool, you need to:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:41</note>
-      </trans-unit>
-      <trans-unit id="636fc324804393cc1d3306a541cc871f">
-        <source>1) Create a blank .htaccess file in your root directory.</source>
-        <target>1) Create a blank .htaccess file in your root directory.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:43</note>
-      </trans-unit>
-      <trans-unit id="1a53c64bc79e181125e94976211eb401">
-        <source>2) Give it write permissions (CHMOD 666 on Unix system).</source>
-        <target>2) Give it write permissions (CHMOD 666 on Unix system).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig:45</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="10ebcb160107c452a2fc3c51804fc780">
-        <source>Your robots.txt file MUST be in your website's root directory and nowhere else (e.g. http://www.example.com/robots.txt).</source>
-        <target>Your robots.txt file MUST be in your website's root directory and nowhere else (e.g. http://www.example.com/robots.txt).</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig:40</note>
-      </trans-unit>
-      <trans-unit id="54a81582e2ea2a98cebaabab9c454957">
-        <source>Generate your "robots.txt" file by clicking on the following button (this will erase the old robots.txt file)</source>
-        <target>Generate your "robots.txt" file by clicking on the following button (this will erase the old robots.txt file)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig:43</note>
-      </trans-unit>
-      <trans-unit id="d999a32b68fd420ce389f774c231c637">
-        <source>1) Create a blank robots.txt file in your root directory.</source>
-        <target>1) Create a blank robots.txt file in your root directory.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig:47</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4836c0b3d56db59ba29844b8bcec084d">
-        <source>Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.</source>
-        <target>Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig:65</note>
-      </trans-unit>
-      <trans-unit id="117fb47c0109ce0c9415a7f60f084c39">
-        <source>The multistore option is enabled. If you want to change the URL of your shop, you must go to the "Multistore" page under the "Advanced Parameters" menu.</source>
-        <target>The multistore option is enabled. If you want to change the URL of your shop, you must go to the "Multistore" page under the "Advanced Parameters" menu.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="488acc51322abb701f50f1e753f7c19e">
-        <source>This section enables you to change the default pattern of your links. In order to use this functionality, PrestaShop's "Friendly URL" option must be enabled, and Apache's URL rewriting module (mod_rewrite) must be activated on your web server.</source>
-        <target>This section enables you to change the default pattern of your links. In order to use this functionality, PrestaShop's "Friendly URL" option must be enabled, and Apache's URL rewriting module (mod_rewrite) must be activated on your web server.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:42</note>
-      </trans-unit>
-      <trans-unit id="3ecf3d1a434ba446f75b21deb67826c6">
-        <source>There are several available keywords for each route listed below; note that keywords with * are required!</source>
-        <target>There are several available keywords for each route listed below; note that keywords with * are required!</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:43</note>
-      </trans-unit>
-      <trans-unit id="e3fc732382d81895d218614e841ea222">
-        <source>To add a keyword in your URL, use the {keyword} syntax. If the keyword is not empty, you can add text before or after the keyword with syntax {prepend:keyword:append}. For example {-hey-:meta_title} will add "-hey-my-title" in the URL if the meta title is set.</source>
-        <target>To add a keyword in your URL, use the {keyword} syntax. If the keyword is not empty, you can add text before or after the keyword with syntax {prepend:keyword:append}. For example {-hey-:meta_title} will add "-hey-my-title" in the URL if the meta title is set.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/meta.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="843afaeb1d84245d7cf7d0877a7258dd">
-        <source>You can only display the page list in a shop context.</source>
-        <target>You can only display the page list in a shop context.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/meta.html.twig:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Meta/SetUpUrlsDataConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b8a27e47e64caa3e36c8894c3745357b">
-        <source>Before being able to use this tool, you need to:</source>
-        <target>Before being able to use this tool, you need to:</target>
-        <note>Context:
-File: src/Adapter/Meta/SetUpUrlsDataConfiguration.php:104</note>
-      </trans-unit>
-      <trans-unit id="d7faa8eb2f73f2c764e387d3d7c57556">
-        <source>Create a blank .htaccess in your root directory.</source>
-        <target>Create a blank .htaccess in your root directory.</target>
-        <note>Context:
-File: src/Adapter/Meta/SetUpUrlsDataConfiguration.php:112</note>
-      </trans-unit>
-      <trans-unit id="5dab5160dfb25b3a4d6c51416dac5c87">
-        <source>Give it write permissions (CHMOD 666 on Unix system).</source>
-        <target>Give it write permissions (CHMOD 666 on Unix system).</target>
-        <note>Context:
-File: src/Adapter/Meta/SetUpUrlsDataConfiguration.php:120</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSearchConfController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d2317f906b956432eebb5c8814bfb65e">
-        <source>Aliases and results are both required.</source>
-        <target>Aliases and results are both required.</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:378</note>
-      </trans-unit>
-      <trans-unit id="a43994b123cc1e321a83cd6d10edb6a5">
-        <source>Is not a valid result</source>
-        <target>Is not a valid result</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:381</note>
-      </trans-unit>
-      <trans-unit id="3b50177d99c96fbf78912e239d59804a">
-        <source>Is not a valid alias</source>
-        <target>Is not a valid alias</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:385</note>
-      </trans-unit>
-      <trans-unit id="84b4d8c8cdd02488c0f868e97b22a3c2">
-        <source>Creation successful</source>
-        <target>Creation successful</target>
-        <note>Context:
-File: controllers/admin/AdminSearchConfController.php:397</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminGendersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f164e438206718c5539f6761d83e26b7">
-        <source>Width and height must be numeric values.</source>
-        <target>Width and height must be numeric values.</target>
-        <note>Context:
-File: controllers/admin/AdminGendersController.php:200</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminSearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ef553500695e07c58644bbdd166581be">
-        <source>This is not a valid IP address:</source>
-        <target>This is not a valid IP address:</target>
-        <note>Context:
-File: controllers/admin/AdminSearchController.php:163</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="837e57427bf283453398a561c9516398">
-        <source>You cannot delete this shop (customer and/or order dependency).</source>
-        <target>You cannot delete this shop (customer and/or order dependency).</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:272</note>
-      </trans-unit>
-      <trans-unit id="e3651705f1156de17be5bf1943c480b3">
-        <source>Please create some sub-categories for this root category.</source>
-        <target>Please create some sub-categories for this root category.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:314</note>
-      </trans-unit>
-      <trans-unit id="cf52c411b5659457074fd9962435307f">
-        <source>You need to select at least the root category.</source>
-        <target>You need to select at least the root category.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:322</note>
-      </trans-unit>
-      <trans-unit id="18f086b62387b20309c709bbf9fe4fdb">
-        <source>Warning: You won't be able to change the group of this shop if this shop belongs to a group with one of these options activated: Share Customers, Share Quantities or Share Orders.</source>
-        <target>Warning: You won't be able to change the group of this shop if this shop belongs to a group with one of these options activated: Share Customers, Share Quantities or Share Orders.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:405</note>
-      </trans-unit>
-      <trans-unit id="1ff40978236e0d196983386376b0a5e3">
-        <source>You can only move your shop to a shop group with all "share" options disabled -- or to a shop group with no customers/orders.</source>
-        <target>You can only move your shop to a shop group with all "share" options disabled -- or to a shop group with no customers/orders.</target>
-        <note>Context:
-File: controllers/admin/AdminShopController.php:407</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="86de674d7405670db52e79ec1665b0b1">
-        <source>An address located in a country containing states must have a state selected.</source>
-        <target>An address located in a country containing states must have a state selected.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:355</note>
-      </trans-unit>
-      <trans-unit id="60e8343766afd5e69c5797ea7380ce8e">
-        <source>Latitude and longitude are required.</source>
-        <target>Latitude and longitude are required.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:362</note>
-      </trans-unit>
-      <trans-unit id="1ae9a82096a0077dde65dec6b1344792">
-        <source>The specified state is not located in this country.</source>
-        <target>The specified state is not located in this country.</target>
-        <note>Context:
-File: controllers/admin/AdminStoresController.php:554</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminReferrersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="787e0ec1d05653f65a03b10c179356e1">
-        <source>Please install the "%modulename%" module in order to give your affiliates access to their own statistics.</source>
-        <target>Please install the "%modulename%" module in order to give your affiliates access to their own statistics.</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:246</note>
-      </trans-unit>
-      <trans-unit id="ab20dd433a5e44c6166509b6c0075b9d">
-        <source>Percent of the sales.</source>
-        <target>Percent of the sales.</target>
-        <note>Context:
-File: controllers/admin/AdminReferrersController.php:277</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2a266db001f17e9fdcbc17ac7f169922">
-        <source>The discount value is incorrect (must be a percentage).</source>
-        <target>The discount value is incorrect (must be a percentage).</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:485</note>
-      </trans-unit>
-      <trans-unit id="5f455758d7337262fdeedba6d54ec89f">
-        <source>Wrong category ID.</source>
-        <target>Wrong category ID.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:482</note>
-      </trans-unit>
-      <trans-unit id="14d9080664b90f7ff1bcd739aa34f5d0">
-        <source>The discount value is incorrect.</source>
-        <target>The discount value is incorrect.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:534</note>
-      </trans-unit>
-      <trans-unit id="5d4aa63b116fb3fe40589e20c1574661">
-        <source>You cannot save group reductions.</source>
-        <target>You cannot save group reductions.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:543</note>
-      </trans-unit>
-      <trans-unit id="a5ee25b466967f2e940d8c7f973a6906">
-        <source>An error occurred while updating this group.</source>
-        <target>An error occurred while updating this group.</target>
-        <note>Context:
-File: controllers/admin/AdminGroupsController.php:561</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/OrderPreferencesFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="85a1ca0031f114f8409d15c6790856f5">
-        <source>Assign a valid page if you want it to be read.</source>
-        <target>Assign a valid page if you want it to be read.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/OrderPreferencesFormDataProvider.php:140</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4f0c0475f4b0b0b2b0def4256b8e2300">
-        <source>You must define an SMTP server and an SMTP port. If you do not know it, use the PHP mail() function instead.</source>
-        <target>You must define an SMTP server and an SMTP port. If you do not know it, use the PHP mail() function instead.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationFormDataProvider.php:100</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/shop/helpers/list/list_action_delete.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b869af59d40b52d2ad275c9f5ed81461">
-        <source>You cannot delete this shop (customer and/or order dependency)</source>
-        <target>You cannot delete this shop (customer and/or order dependency)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/shop/helpers/list/list_action_delete.tpl:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/shop/helpers/list/list_content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c2cdad0778bdd9995afb2b4d27387675">
-        <source>Click here to set a URL for this shop.</source>
-        <target>Click here to set a URL for this shop.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/shop/helpers/list/list_content.tpl:41</note>
+      <trans-unit id="30de5dc59697ad3a8b60a3290a67de6c">
+        <source>Only products that have this category as the default category will be affected.</source>
+        <target>Only products that have this category as the default category will be affected.</target>
+        <note>Line: 155</note>
       </trans-unit>
     </body>
   </file>
@@ -323,24 +19,284 @@ File: admin-dev/themes/default/template/controllers/shop/helpers/list/list_conte
       <trans-unit id="60496e92d8c44007e78f095a1cb6adc2">
         <source>The module '%s' must be activated and configurated in order to have all the statistics</source>
         <target>The module '%s' must be activated and configurated in order to have all the statistics</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/referrers/form_settings.tpl:133</note>
+        <note>Line: 133</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/shop/helpers/list/list_action_delete.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="57f51ca7c7ae71c5ac955cbce1942622">
-        <source>Caution: The discount applied to a category does not stack with the overall reduction but instead replaces it.</source>
-        <target>Caution: The discount applied to a category does not stack with the overall reduction but instead replaces it.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl:154</note>
+      <trans-unit id="b869af59d40b52d2ad275c9f5ed81461">
+        <source>You cannot delete this shop (customer and/or order dependency)</source>
+        <target>You cannot delete this shop (customer and/or order dependency)</target>
+        <note>Line: 27</note>
       </trans-unit>
-      <trans-unit id="30de5dc59697ad3a8b60a3290a67de6c">
-        <source>Only products that have this category as the default category will be affected.</source>
-        <target>Only products that have this category as the default category will be affected.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl:155</note>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/shop/helpers/list/list_content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c2cdad0778bdd9995afb2b4d27387675">
+        <source>Click here to set a URL for this shop.</source>
+        <target>Click here to set a URL for this shop.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminGendersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f164e438206718c5539f6761d83e26b7">
+        <source>Width and height must be numeric values.</source>
+        <target>Width and height must be numeric values.</target>
+        <note>Line: 200</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminGroupsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2a266db001f17e9fdcbc17ac7f169922">
+        <source>The discount value is incorrect (must be a percentage).</source>
+        <target>The discount value is incorrect (must be a percentage).</target>
+        <note>Line: 524</note>
+      </trans-unit>
+      <trans-unit id="5f455758d7337262fdeedba6d54ec89f">
+        <source>Wrong category ID.</source>
+        <target>Wrong category ID.</target>
+        <note>Line: 521</note>
+      </trans-unit>
+      <trans-unit id="14d9080664b90f7ff1bcd739aa34f5d0">
+        <source>The discount value is incorrect.</source>
+        <target>The discount value is incorrect.</target>
+        <note>Line: 573</note>
+      </trans-unit>
+      <trans-unit id="5d4aa63b116fb3fe40589e20c1574661">
+        <source>You cannot save group reductions.</source>
+        <target>You cannot save group reductions.</target>
+        <note>Line: 582</note>
+      </trans-unit>
+      <trans-unit id="a5ee25b466967f2e940d8c7f973a6906">
+        <source>An error occurred while updating this group.</source>
+        <target>An error occurred while updating this group.</target>
+        <note>Line: 600</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReferrersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="787e0ec1d05653f65a03b10c179356e1">
+        <source>Please install the "%modulename%" module in order to give your affiliates access to their own statistics.</source>
+        <target>Please install the "%modulename%" module in order to give your affiliates access to their own statistics.</target>
+        <note>Line: 246</note>
+      </trans-unit>
+      <trans-unit id="ab20dd433a5e44c6166509b6c0075b9d">
+        <source>Percent of the sales.</source>
+        <target>Percent of the sales.</target>
+        <note>Line: 277</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSearchConfController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d2317f906b956432eebb5c8814bfb65e">
+        <source>Aliases and results are both required.</source>
+        <target>Aliases and results are both required.</target>
+        <note>Line: 378</note>
+      </trans-unit>
+      <trans-unit id="a43994b123cc1e321a83cd6d10edb6a5">
+        <source>Is not a valid result</source>
+        <target>Is not a valid result</target>
+        <note>Line: 381</note>
+      </trans-unit>
+      <trans-unit id="3b50177d99c96fbf78912e239d59804a">
+        <source>Is not a valid alias</source>
+        <target>Is not a valid alias</target>
+        <note>Line: 385</note>
+      </trans-unit>
+      <trans-unit id="84b4d8c8cdd02488c0f868e97b22a3c2">
+        <source>Creation successful</source>
+        <target>Creation successful</target>
+        <note>Line: 397</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ef553500695e07c58644bbdd166581be">
+        <source>This is not a valid IP address:</source>
+        <target>This is not a valid IP address:</target>
+        <note>Line: 163</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminShopController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="837e57427bf283453398a561c9516398">
+        <source>You cannot delete this shop (customer and/or order dependency).</source>
+        <target>You cannot delete this shop (customer and/or order dependency).</target>
+        <note>Line: 272</note>
+      </trans-unit>
+      <trans-unit id="e3651705f1156de17be5bf1943c480b3">
+        <source>Please create some sub-categories for this root category.</source>
+        <target>Please create some sub-categories for this root category.</target>
+        <note>Line: 314</note>
+      </trans-unit>
+      <trans-unit id="cf52c411b5659457074fd9962435307f">
+        <source>You need to select at least the root category.</source>
+        <target>You need to select at least the root category.</target>
+        <note>Line: 322</note>
+      </trans-unit>
+      <trans-unit id="18f086b62387b20309c709bbf9fe4fdb">
+        <source>Warning: You won't be able to change the group of this shop if this shop belongs to a group with one of these options activated: Share Customers, Share Quantities or Share Orders.</source>
+        <target>Warning: You won't be able to change the group of this shop if this shop belongs to a group with one of these options activated: Share Customers, Share Quantities or Share Orders.</target>
+        <note>Line: 405</note>
+      </trans-unit>
+      <trans-unit id="1ff40978236e0d196983386376b0a5e3">
+        <source>You can only move your shop to a shop group with all "share" options disabled -- or to a shop group with no customers/orders.</source>
+        <target>You can only move your shop to a shop group with all "share" options disabled -- or to a shop group with no customers/orders.</target>
+        <note>Line: 407</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="510f6a8fda6eb21f9ff01954e034a29a">
+        <source>For security reasons, you cannot delete default order statuses.</source>
+        <target>For security reasons, you cannot delete default order statuses.</target>
+        <note>Line: 611</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStoresController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="86de674d7405670db52e79ec1665b0b1">
+        <source>An address located in a country containing states must have a state selected.</source>
+        <target>An address located in a country containing states must have a state selected.</target>
+        <note>Line: 355</note>
+      </trans-unit>
+      <trans-unit id="60e8343766afd5e69c5797ea7380ce8e">
+        <source>Latitude and longitude are required.</source>
+        <target>Latitude and longitude are required.</target>
+        <note>Line: 362</note>
+      </trans-unit>
+      <trans-unit id="1ae9a82096a0077dde65dec6b1344792">
+        <source>The specified state is not located in this country.</source>
+        <target>The specified state is not located in this country.</target>
+        <note>Line: 554</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Meta/SetUpUrlsDataConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b8a27e47e64caa3e36c8894c3745357b">
+        <source>Before being able to use this tool, you need to:</source>
+        <target>Before being able to use this tool, you need to:</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="d7faa8eb2f73f2c764e387d3d7c57556">
+        <source>Create a blank .htaccess in your root directory.</source>
+        <target>Create a blank .htaccess in your root directory.</target>
+        <note>Line: 112</note>
+      </trans-unit>
+      <trans-unit id="5dab5160dfb25b3a4d6c51416dac5c87">
+        <source>Give it write permissions (CHMOD 666 on Unix system).</source>
+        <target>Give it write permissions (CHMOD 666 on Unix system).</target>
+        <note>Line: 120</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4f0c0475f4b0b0b2b0def4256b8e2300">
+        <source>You must define an SMTP server and an SMTP port. If you do not know it, use the PHP mail() function instead.</source>
+        <target>You must define an SMTP server and an SMTP port. If you do not know it, use the PHP mail() function instead.</target>
+        <note>Line: 100</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/OrderPreferencesFormDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="85a1ca0031f114f8409d15c6790856f5">
+        <source>Assign a valid page if you want it to be read.</source>
+        <target>Assign a valid page if you want it to be read.</target>
+        <note>Line: 140</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="10ebcb160107c452a2fc3c51804fc780">
+        <source>Your robots.txt file MUST be in your website's root directory and nowhere else (e.g. http://www.example.com/robots.txt).</source>
+        <target>Your robots.txt file MUST be in your website's root directory and nowhere else (e.g. http://www.example.com/robots.txt).</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="54a81582e2ea2a98cebaabab9c454957">
+        <source>Generate your "robots.txt" file by clicking on the following button (this will erase the old robots.txt file)</source>
+        <target>Generate your "robots.txt" file by clicking on the following button (this will erase the old robots.txt file)</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="d999a32b68fd420ce389f774c231c637">
+        <source>1) Create a blank robots.txt file in your root directory.</source>
+        <target>1) Create a blank robots.txt file in your root directory.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="73ca86c0d6a5d58e868c54c3a1524c6c">
+        <source>Before you can use this tool, you need to:</source>
+        <target>Before you can use this tool, you need to:</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="636fc324804393cc1d3306a541cc871f">
+        <source>1) Create a blank .htaccess file in your root directory.</source>
+        <target>1) Create a blank .htaccess file in your root directory.</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="1a53c64bc79e181125e94976211eb401">
+        <source>2) Give it write permissions (CHMOD 666 on Unix system).</source>
+        <target>2) Give it write permissions (CHMOD 666 on Unix system).</target>
+        <note>Line: 45</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4836c0b3d56db59ba29844b8bcec084d">
+        <source>Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.</source>
+        <target>Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="117fb47c0109ce0c9415a7f60f084c39">
+        <source>The multistore option is enabled. If you want to change the URL of your shop, you must go to the "Multistore" page under the "Advanced Parameters" menu.</source>
+        <target>The multistore option is enabled. If you want to change the URL of your shop, you must go to the "Multistore" page under the "Advanced Parameters" menu.</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="488acc51322abb701f50f1e753f7c19e">
+        <source>This section enables you to change the default pattern of your links. In order to use this functionality, PrestaShop's "Friendly URL" option must be enabled, and Apache's URL rewriting module (mod_rewrite) must be activated on your web server.</source>
+        <target>This section enables you to change the default pattern of your links. In order to use this functionality, PrestaShop's "Friendly URL" option must be enabled, and Apache's URL rewriting module (mod_rewrite) must be activated on your web server.</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="3ecf3d1a434ba446f75b21deb67826c6">
+        <source>There are several available keywords for each route listed below; note that keywords with * are required!</source>
+        <target>There are several available keywords for each route listed below; note that keywords with * are required!</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="e3fc732382d81895d218614e841ea222">
+        <source>To add a keyword in your URL, use the {keyword} syntax. If the keyword is not empty, you can add text before or after the keyword with syntax {prepend:keyword:append}. For example {-hey-:meta_title} will add "-hey-my-title" in the URL if the meta title is set.</source>
+        <target>To add a keyword in your URL, use the {keyword} syntax. If the keyword is not empty, you can add text before or after the keyword with syntax {prepend:keyword:append}. For example {-hey-:meta_title} will add "-hey-my-title" in the URL if the meta title is set.</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/index.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="843afaeb1d84245d7cf7d0877a7258dd">
+        <source>You can only display the page list in a shop context.</source>
+        <target>You can only display the page list in a shop context.</target>
+        <note>Line: 41</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminStatsFeature.xlf
+++ b/app/Resources/translations/default/AdminStatsFeature.xlf
@@ -5,62 +5,52 @@
       <trans-unit id="bbe8aef37d99eeb6f34a17f939ffa6f0">
         <source>%value%% of your Catalog</source>
         <target>%value%% of your Catalog</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:760</note>
+        <note>Line: 760</note>
       </trans-unit>
       <trans-unit id="82ad4f0be97f8f36d31e2540aacb155d">
         <source>No customers</source>
         <target>No customers</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:775</note>
+        <note>Line: 775</note>
       </trans-unit>
       <trans-unit id="a0e9b94006c36be97ce9fa908fdff7d8">
         <source>%percentage%% Female Customers</source>
         <target>%percentage%% Female Customers</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:777</note>
+        <note>Line: 777</note>
       </trans-unit>
       <trans-unit id="7870d39845089cddec99f55bef4ca3bb">
         <source>%percentage%% Male Customers</source>
         <target>%percentage%% Male Customers</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:779</note>
+        <note>Line: 779</note>
       </trans-unit>
       <trans-unit id="70f3bf1ba6a40018f2b5139e4721bae1">
         <source>%percentage%% Neutral Customers</source>
         <target>%percentage%% Neutral Customers</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:781</note>
+        <note>Line: 781</note>
       </trans-unit>
       <trans-unit id="ac72cc56077f4fcf5c0fd3d6e0902264">
         <source>%value% years</source>
         <target>%value% years</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:792</note>
+        <note>Line: 792</note>
       </trans-unit>
       <trans-unit id="d48e7c1fd584c90dad7cd24e8f65be6d">
         <source>%average% hours</source>
         <target>%average% hours</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:807</note>
+        <note>Line: 807</note>
       </trans-unit>
       <trans-unit id="08cfa7751d1812e961560f623e082aba">
         <source>No orders</source>
         <target>No orders</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:887</note>
+        <note>Line: 887</note>
       </trans-unit>
       <trans-unit id="9aee5f7903fbed5f7d715e4011961b59">
         <source>%d%% %s</source>
         <target>%d%% %s</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:891</note>
+        <note>Line: 891</note>
       </trans-unit>
       <trans-unit id="d79de24a931cdfd25615c068f1f2765a">
         <source>No category</source>
         <target>No category</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:987</note>
+        <note>Line: 987</note>
       </trans-unit>
     </body>
   </file>
@@ -69,8 +59,7 @@ File: controllers/admin/AdminStatsController.php:987</note>
       <trans-unit id="452a7601dbc6f2c38aa89e68bda8b603">
         <source>Stats</source>
         <target>Stats</target>
-        <note>Context:
-File: controllers/admin/AdminStatsTabController.php:43</note>
+        <note>Line: 43</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminStatsHelp.xlf
+++ b/app/Resources/translations/default/AdminStatsHelp.xlf
@@ -5,26 +5,22 @@
       <trans-unit id="9d6effc7093fb65fd4d16a6d3c38d54f">
         <source>%value% of your products for sale are out of stock.</source>
         <target>%value% of your products for sale are out of stock.</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:714</note>
+        <note>Line: 714</note>
       </trans-unit>
       <trans-unit id="599abbd2bcf079c9963669b35d9dfdd0">
         <source>Gross margin expressed in percentage assesses how cost-effectively you sell your goods. Out of $100, you will retain $%value% to cover profit and expenses.</source>
         <target>Gross margin expressed in percentage assesses how cost-effectively you sell your goods. Out of $100, you will retain $%value% to cover profit and expenses.</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:725</note>
+        <note>Line: 725</note>
       </trans-unit>
       <trans-unit id="ae77fb0c47ab2d94996be0c6c78b1951">
         <source>%value% of your products are disabled and not visible to your customers</source>
         <target>%value% of your products are disabled and not visible to your customers</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:745</note>
+        <note>Line: 745</note>
       </trans-unit>
       <trans-unit id="091c657283a379962fa01591dea197df">
         <source>Within your catalog, %value% of your products have had sales in the last 30 days</source>
         <target>Within your catalog, %value% of your products have had sales in the last 30 days</target>
-        <note>Context:
-File: controllers/admin/AdminStatsController.php:756</note>
+        <note>Line: 756</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminStatsNotification.xlf
+++ b/app/Resources/translations/default/AdminStatsNotification.xlf
@@ -1,28 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/admin/AdminStatsTabController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="afa9e719ed5259554b0647d035eaecb8">
-        <source>The specified date is invalid.</source>
-        <target>The specified date is invalid.</target>
-        <note>Context:
-File: controllers/admin/AdminStatsTabController.php:239</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="admin-dev/themes/default/template/controllers/stats/stats.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="8290fb626ffacf21450997f25967efeb">
         <source>Module not found</source>
         <target>Module not found</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/stats/stats.tpl:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="9f8ba2077f4e7338b68934afe22b4ad9">
         <source>Please select a module from the left column.</source>
         <target>Please select a module from the left column.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/stats/stats.tpl:34</note>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatsTabController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="afa9e719ed5259554b0647d035eaecb8">
+        <source>The specified date is invalid.</source>
+        <target>The specified date is invalid.</target>
+        <note>Line: 239</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/EmailsBody.xlf
+++ b/app/Resources/translations/default/EmailsBody.xlf
@@ -1,5 +1,813 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="modules/ps_emailgenerator/templates/core/account.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="22a9d6a64a74d0f58a11fa7013f4b83a">
+        <source>Thank you for creating a customer account at {shop_name}.</source>
+        <target>Thank you for creating a customer account at {shop_name}.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/account.php:7</note>
+      </trans-unit>
+      <trans-unit id="d5b14d16c4008efddbee79cb56af5455">
+        <source>Here are your login details:</source>
+        <target>Here are your login details:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/account.php:25</note>
+      </trans-unit>
+      <trans-unit id="d70650ce5612f05bfe75c1962fa1e519">
+        <source>Important Security Tips:</source>
+        <target>Important Security Tips:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/account.php:45</note>
+      </trans-unit>
+      <trans-unit id="def00214a95442dc7899951abd9a6104">
+        <source>Always keep your account details safe.</source>
+        <target>Always keep your account details safe.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/account.php:47</note>
+      </trans-unit>
+      <trans-unit id="1559b55f6ea1de9f9b8826e9be306e6f">
+        <source>Never disclose your login details to anyone.</source>
+        <target>Never disclose your login details to anyone.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/account.php:48</note>
+      </trans-unit>
+      <trans-unit id="7601ee5e7968d91a7b4f099f4b4b84d0">
+        <source>Change your password regularly.</source>
+        <target>Change your password regularly.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/account.php:49</note>
+      </trans-unit>
+      <trans-unit id="8f9011f4a1219e51c8a0638d2af3f29a">
+        <source>Should you suspect someone is using your account illegally, please notify us immediately.</source>
+        <target>Should you suspect someone is using your account illegally, please notify us immediately.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/account.php:50</note>
+      </trans-unit>
+      <trans-unit id="de421ce3bebc9b5a2ee30fcf0312cb68">
+        <source>You can now place orders on our shop:</source>
+        <target>You can now place orders on our shop:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/account.php:65</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/backoffice_order.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="abc81c0d865925584b1269c996d7b297">
+        <source>A new order has been generated on your behalf.</source>
+        <target>A new order has been generated on your behalf.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/backoffice_order.php:21</note>
+      </trans-unit>
+      <trans-unit id="bffeb374bf71938ffc4faa42afbf1679">
+        <source><![CDATA[Please go on <a href="{order_link}">{order_link}</a> to finalize the payment.]]></source>
+        <target><![CDATA[Please go on <a href="{order_link}">{order_link}</a> to finalize the payment.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/backoffice_order.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/bankwire.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9b33ea5c9409a67cb6e1f6bc3f0828f0">
+        <source>Awaiting wire payment</source>
+        <target>Awaiting wire payment</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/bankwire.php:22</note>
+      </trans-unit>
+      <trans-unit id="f4a6af01d092af11dca29cb89578b124">
+        <source>You have selected to pay by wire transfer.</source>
+        <target>You have selected to pay by wire transfer.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/bankwire.php:45</note>
+      </trans-unit>
+      <trans-unit id="fc1ae3c1dd1d9d9a44da719fa9966f0e">
+        <source>Here are the bank details for your transfer:</source>
+        <target>Here are the bank details for your transfer:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/bankwire.php:48</note>
+      </trans-unit>
+      <trans-unit id="21e4851289ecc91b65023c2563344aa7">
+        <source>Account owner:</source>
+        <target>Account owner:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/bankwire.php:50</note>
+      </trans-unit>
+      <trans-unit id="20a650d87733bd5895c979de29864a73">
+        <source>Account details:</source>
+        <target>Account details:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/bankwire.php:51</note>
+      </trans-unit>
+      <trans-unit id="312d898d92d8ba90499ef0dac27270be">
+        <source>Bank address:</source>
+        <target>Bank address:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/bankwire.php:52</note>
+      </trans-unit>
+      <trans-unit id="b8f05e3501f419f9f7ec08026a9342be">
+        <source>Please specify your order reference in the bankwire description.</source>
+        <target>Please specify your order reference in the bankwire description.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/bankwire.php:53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/cheque.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3f8b7a7948f4fd5d9bb34d63746dfd23">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been placed successfully and will be <strong>shipped as soon as we receive your payment</strong>.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been placed successfully and will be <strong>shipped as soon as we receive your payment</strong>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/cheque.php:25</note>
+      </trans-unit>
+      <trans-unit id="6702a6e3bc2dce95c3e3b61fe578f29c">
+        <source>Amount:</source>
+        <target>Amount:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/cheque.php:49</note>
+      </trans-unit>
+      <trans-unit id="a51341e25ff7710496cf86468d797169">
+        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}">"Guest Tracking"</a> section on our shop.]]></source>
+        <target><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}">"Guest Tracking"</a> section on our shop.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/cheque.php:76</note>
+      </trans-unit>
+      <trans-unit id="d698e777b19f6f487ae0490950174fde">
+        <source>Awaiting check payment</source>
+        <target>Awaiting check payment</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/cheque.php:22</note>
+      </trans-unit>
+      <trans-unit id="ecf01c46965fdfd36eb98b271276c0d5">
+        <source>You have selected to pay by check.</source>
+        <target>You have selected to pay by check.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/cheque.php:45</note>
+      </trans-unit>
+      <trans-unit id="b6592595266708e46d1d420ab7153213">
+        <source>Here are the bank details for your check:</source>
+        <target>Here are the bank details for your check:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/cheque.php:48</note>
+      </trans-unit>
+      <trans-unit id="1c3bd8f6bd066270354607c08f930baf">
+        <source>Payable to the order of:</source>
+        <target>Payable to the order of:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/cheque.php:50</note>
+      </trans-unit>
+      <trans-unit id="8f1fb2295c4289bae9fc26549b4b45f2">
+        <source>Please mail your check to:</source>
+        <target>Please mail your check to:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/cheque.php:51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/contact.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a1cee0a898793ad5101154ac97984d8a">
+        <source>Message from a {shop_name} customer</source>
+        <target>Message from a {shop_name} customer</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/contact.php:6</note>
+      </trans-unit>
+      <trans-unit id="31e15b28c2f071f74f47eb8bcd612d94">
+        <source>Customer e-mail address:</source>
+        <target>Customer e-mail address:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/contact.php:21</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/contact_form.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="83fa39a28a4d159061c408fbd6a249e7">
+        <source>Order ID:</source>
+        <target>Order ID:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/contact_form.php:22</note>
+      </trans-unit>
+      <trans-unit id="53659d236625358b98797389fd2504fa">
+        <source>Attached file:</source>
+        <target>Attached file:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/contact_form.php:24</note>
+      </trans-unit>
+      <trans-unit id="1edbec13a38606f19c0bae544a7c6552">
+        <source>Your message to {shop_name} Customer Service</source>
+        <target>Your message to {shop_name} Customer Service</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/contact_form.php:6</note>
+      </trans-unit>
+      <trans-unit id="e92ba0cecb0593f537515b2aa2d1c701">
+        <source>Your message has been sent successfully.</source>
+        <target>Your message has been sent successfully.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/contact_form.php:21</note>
+      </trans-unit>
+      <trans-unit id="465d60b936c982d7b57674f30ba022d0">
+        <source>Product:</source>
+        <target>Product:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/contact_form.php:23</note>
+      </trans-unit>
+      <trans-unit id="76890cf906149b370ea6f7d1bd8eaf9a">
+        <source>We will answer as soon as possible.</source>
+        <target>We will answer as soon as possible.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/contact_form.php:40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/credit_slip.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="72dbe899c04eb3875b29b5b274340dac">
+        <source>Credit slip created</source>
+        <target>Credit slip created</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/credit_slip.php:21</note>
+      </trans-unit>
+      <trans-unit id="b1c95c88d55558a6c04dea50425199df">
+        <source><![CDATA[We have generated a credit slip in your name for order with the reference <span><strong>{order_name}</strong></span>.]]></source>
+        <target><![CDATA[We have generated a credit slip in your name for order with the reference <span><strong>{order_name}</strong></span>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/credit_slip.php:24</note>
+      </trans-unit>
+      <trans-unit id="99f89e9a116e1c07f62ba17fb0312db6">
+        <source><![CDATA[You can review this credit slip and download your invoice from the <a href="{history_url}">"My credit slips"</a> section of your account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></source>
+        <target><![CDATA[You can review this credit slip and download your invoice from the <a href="{history_url}">"My credit slips"</a> section of your account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/credit_slip.php:40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/download_product.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5f55a607fea61a402ceac66cc99f1e9e">
+        <source><![CDATA[Thank you for your order with the reference {order_name} from <strong>{shop_name}</strong>]]></source>
+        <target><![CDATA[Thank you for your order with the reference {order_name} from <strong>{shop_name}</strong>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/download_product.php:7</note>
+      </trans-unit>
+      <trans-unit id="30acb55a5efc4a32a30a0c3db85f37d1">
+        <source>Product(s) now available for download</source>
+        <target>Product(s) now available for download</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/download_product.php:22</note>
+      </trans-unit>
+      <trans-unit id="afae9cdc5d9b4583915a579cb0c67788">
+        <source><![CDATA[You have <span><strong>{nbProducts}</strong></span> product(s) now available for download using the following link(s):]]></source>
+        <target><![CDATA[You have <span><strong>{nbProducts}</strong></span> product(s) now available for download using the following link(s):]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/download_product.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/employee_password.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4785f7efb27f2905a05564903db18b23">
+        <source>Your {shop_name} login information</source>
+        <target>Your {shop_name} login information</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/employee_password.php:21</note>
+      </trans-unit>
+      <trans-unit id="a1fd16fcb98f1a6ec4312a10e6a3acba">
+        <source><![CDATA[Here is your personal login information for <span><strong>{shop_name}</strong></span>:]]></source>
+        <target><![CDATA[Here is your personal login information for <span><strong>{shop_name}</strong></span>:]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/employee_password.php:24</note>
+      </trans-unit>
+      <trans-unit id="668a8d8d7ffe5da112b266e46b79b685">
+        <source>First name:</source>
+        <target>First name:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/employee_password.php:25</note>
+      </trans-unit>
+      <trans-unit id="be5e0b5d50d48b049bd0f7b57cd163f9">
+        <source>Last name:</source>
+        <target>Last name:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/employee_password.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/footer.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e1c65ac2c128f4835c77d0c7aefccb7e">
+        <source><![CDATA[<a href="{shop_url}">{shop_name}</a> powered by <a href="http://www.prestashop.com/">PrestaShop™</a>]]></source>
+        <target><![CDATA[<a href="{shop_url}">{shop_name}</a> powered by <a href="http://www.prestashop.com/">PrestaShop™</a>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/footer.php:6</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/forward_msg.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8595a98bbe6d6b0e3b9b0681b3b4aa71">
+        <source>Customer service - Forwarded discussion</source>
+        <target>Customer service - Forwarded discussion</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/forward_msg.php:21</note>
+      </trans-unit>
+      <trans-unit id="85ae5cfc68837cc8e50609b84babba09">
+        <source><![CDATA[<span><strong>{employee}</strong></span> wanted to forward this discussion to you.]]></source>
+        <target><![CDATA[<span><strong>{employee}</strong></span> wanted to forward this discussion to you.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/forward_msg.php:24</note>
+      </trans-unit>
+      <trans-unit id="a9854b516855755f7a9246d781d4f57b">
+        <source>Discussion history:</source>
+        <target>Discussion history:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/forward_msg.php:25</note>
+      </trans-unit>
+      <trans-unit id="f4df87e5e465151ae8d5954bec01d9ec">
+        <source><![CDATA[<span><strong>{employee}</strong></span> added <span><strong>"{comment}"</strong></span>]]></source>
+        <target><![CDATA[<span><strong>{employee}</strong></span> added <span><strong>"{comment}"</strong></span>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/forward_msg.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/guest_to_customer.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9893de883531529d4a66a3851265f02e">
+        <source>Your customer account creation</source>
+        <target>Your customer account creation</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/guest_to_customer.php:21</note>
+      </trans-unit>
+      <trans-unit id="499e229d39934f1a36f3f48718cc19cc">
+        <source><![CDATA[Your guest account for <span><strong>{shop_name}</strong></span> has been transformed into a customer account.]]></source>
+        <target><![CDATA[Your guest account for <span><strong>{shop_name}</strong></span> has been transformed into a customer account.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/guest_to_customer.php:24</note>
+      </trans-unit>
+      <trans-unit id="49bea2c7e271e5cd440a295dd6fadc72">
+        <source>Please be careful when sharing these login details with others.</source>
+        <target>Please be careful when sharing these login details with others.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/guest_to_customer.php:41</note>
+      </trans-unit>
+      <trans-unit id="b75184fa489c948c6debc4d635fefa5a">
+        <source>You can access your customer account on our shop:</source>
+        <target>You can access your customer account on our shop:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/guest_to_customer.php:50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/header_order_conf.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2769d37f4eb00f2c9b940ee928f1b426">
+        <source>Message from {shop_name}</source>
+        <target>Message from {shop_name}</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/header_order_conf.php:6</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/import.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a218495ad30949e8ea1f64a261e37463">
+        <source>Import complete</source>
+        <target>Import complete</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/import.php:21</note>
+      </trans-unit>
+      <trans-unit id="293a2b3dd4b7fb2d950c8128be6d14f7">
+        <source>The file {filename} has been successfully imported to your shop.</source>
+        <target>The file {filename} has been successfully imported to your shop.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/import.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/in_transit.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7ec4f8b296984ffe6ea829b7e1743577">
+        <source>In transit</source>
+        <target>In transit</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/in_transit.php:46</note>
+      </trans-unit>
+      <trans-unit id="873a6c9ce4b0711161105e4a6d943bb6">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> is currently in transit.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> is currently in transit.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/in_transit.php:49</note>
+      </trans-unit>
+      <trans-unit id="34f49f671cedfb2d5f8080ec14120281">
+        <source>You can track your package using the following link:</source>
+        <target>You can track your package using the following link:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/in_transit.php:50</note>
+      </trans-unit>
+      <trans-unit id="1b0d1cd23421d9cea08507e950e87094">
+        <source>{followup}</source>
+        <target>{followup}</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/in_transit.php:50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/log_alert.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="07e3b33fd6a9b33d3d9cacea26dc1899">
+        <source>You have received a new log alert</source>
+        <target>You have received a new log alert</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/log_alert.php:21</note>
+      </trans-unit>
+      <trans-unit id="17357f0ed7c82a1620f4311667886a63">
+        <source><![CDATA[<span><strong>Warning:</strong></span> you have received a new log alert in your Back Office.]]></source>
+        <target><![CDATA[<span><strong>Warning:</strong></span> you have received a new log alert in your Back Office.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/log_alert.php:24</note>
+      </trans-unit>
+      <trans-unit id="ba00a1816b599684def5ff1d312ef5ed">
+        <source><![CDATA[You can check for it in the <span><strong>"Tools" > "Logs"</strong></span> section of your Back Office.]]></source>
+        <target><![CDATA[You can check for it in the <span><strong>"Tools" > "Logs"</strong></span> section of your Back Office.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/log_alert.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_canceled.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3baf03ed2980c9f339731f052c12b37d">
+        <source>Order canceled</source>
+        <target>Order canceled</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_canceled.php:21</note>
+      </trans-unit>
+      <trans-unit id="50651089ed12eb33b55394a0a17618de">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been canceled.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been canceled.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_canceled.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_changed.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ac32eb3619340a6b6aff41d9797665d4">
+        <source>Order changed</source>
+        <target>Order changed</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_changed.php:21</note>
+      </trans-unit>
+      <trans-unit id="0e6321e9d36186e957652f07d88116a5">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been changed by the merchant.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been changed by the merchant.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_changed.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_conf.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b4556791acee238c77be9ed338a29e80">
+        <source>Thank you for shopping with {shop_name}!</source>
+        <target>Thank you for shopping with {shop_name}!</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_conf.php:7</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_customer_comment.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="381fc38b470ed543424afbd43f224453">
+        <source>Message from a customer</source>
+        <target>Message from a customer</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_customer_comment.php:21</note>
+      </trans-unit>
+      <trans-unit id="1607c3534ee9bdb8638858fa4bb9261b">
+        <source>You have received a new message regarding order with the reference</source>
+        <target>You have received a new message regarding order with the reference</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_customer_comment.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_merchant_comment.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ad9fd7d0fe973ddaef093d912d0b57e2">
+        <source><![CDATA[You have received a new message from <span><strong>{shop_name}</strong></span> regarding order with the reference <span><strong>{order_name}</strong></span>.]]></source>
+        <target><![CDATA[You have received a new message from <span><strong>{shop_name}</strong></span> regarding order with the reference <span><strong>{order_name}</strong></span>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_merchant_comment.php:24</note>
+      </trans-unit>
+      <trans-unit id="940663fd4428d2c86f9a4780b6574028">
+        <source>Message:</source>
+        <target>Message:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_merchant_comment.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_return_state.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="34d125dc458bced25eaf5e2e272c0d75">
+        <source>Return #{id_order_return} - update</source>
+        <target>Return #{id_order_return} - update</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_return_state.php:21</note>
+      </trans-unit>
+      <trans-unit id="96aac675caae8b0ca0a5227ce8a6a7c6">
+        <source>We have updated the progress on your return #{id_order_return}, the new status is:</source>
+        <target>We have updated the progress on your return #{id_order_return}, the new status is:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_return_state.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/outofstock.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="be07158cdaa6c7244af799f3cdd6dad5">
+        <source>Thanks for your order with the reference {order_name} from {shop_name}.</source>
+        <target>Thanks for your order with the reference {order_name} from {shop_name}.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/outofstock.php:7</note>
+      </trans-unit>
+      <trans-unit id="e25d137c27dca2618629678d2df71113">
+        <source>Item(s) out of stock</source>
+        <target>Item(s) out of stock</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/outofstock.php:22</note>
+      </trans-unit>
+      <trans-unit id="5468cd18ba24d269db5ebe9177abca4a">
+        <source>Unfortunately, one or more items are currently out of stock. This may cause a slight delay in your delivery. Please accept our apologies and rest assured that we are working hard to rectify this.</source>
+        <target>Unfortunately, one or more items are currently out of stock. This may cause a slight delay in your delivery. Please accept our apologies and rest assured that we are working hard to rectify this.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/outofstock.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/password.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="78e365acb087fd1f8d494dae0001de10">
+        <source>E-mail address:</source>
+        <target>E-mail address:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/password.php:24</note>
+      </trans-unit>
+      <trans-unit id="53423ed6d9f522de8d41539456628786">
+        <source>Your new {shop_name} login details</source>
+        <target>Your new {shop_name} login details</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/password.php:21</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/password_query.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="280f51a8705636bd7e7ba595529411d4">
+        <source>Password reset request for {shop_name}</source>
+        <target>Password reset request for {shop_name}</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/password_query.php:21</note>
+      </trans-unit>
+      <trans-unit id="18f3152ffe51f0d446558f666dc8d5ea">
+        <source><![CDATA[You have requested to reset your <span><strong>{shop_name}</strong></span> login details.]]></source>
+        <target><![CDATA[You have requested to reset your <span><strong>{shop_name}</strong></span> login details.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/password_query.php:24</note>
+      </trans-unit>
+      <trans-unit id="09ce893cc7228918df5657665b899249">
+        <source>Please note that this will change your current password.</source>
+        <target>Please note that this will change your current password.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/password_query.php:25</note>
+      </trans-unit>
+      <trans-unit id="278b2a400e176e90d476fb69cb881f59">
+        <source>To confirm this action, please use the following link:</source>
+        <target>To confirm this action, please use the following link:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/password_query.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/payment.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6daabaab43cdbd67346ae71828b1710c">
+        <source>Payment processed</source>
+        <target>Payment processed</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/payment.php:22</note>
+      </trans-unit>
+      <trans-unit id="2762264cddd3133c3486886e31681873">
+        <source><![CDATA[Your payment for order with the reference <strong><span>{order_name}</span></strong> was successfully processed.]]></source>
+        <target><![CDATA[Your payment for order with the reference <strong><span>{order_name}</span></strong> was successfully processed.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/payment.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/payment_error.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3dd0be333980f0b0f0895cdb6322d117">
+        <source>Payment processing error</source>
+        <target>Payment processing error</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/payment_error.php:21</note>
+      </trans-unit>
+      <trans-unit id="96c8c962f040049e80bccbea08e2d776">
+        <source><![CDATA[There is a problem with your payment for <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>. Please contact us at your earliest convenience.]]></source>
+        <target><![CDATA[There is a problem with your payment for <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>. Please contact us at your earliest convenience.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/payment_error.php:24</note>
+      </trans-unit>
+      <trans-unit id="5f2142258e3f214d12efeb927f2a7aef">
+        <source>We cannot ship your order until we receive your payment.</source>
+        <target>We cannot ship your order until we receive your payment.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/payment_error.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/preparation.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="643562a9ae7099c8aabfdc93478db117">
+        <source>Processing</source>
+        <target>Processing</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/preparation.php:21</note>
+      </trans-unit>
+      <trans-unit id="d87f9ab0faa0b39a5240d1ce19529905">
+        <source><![CDATA[We are currently processing your <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>.]]></source>
+        <target><![CDATA[We are currently processing your <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/preparation.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/refund.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9b45ae8a346e0587013cdb1494e113d8">
+        <source>Refund processed</source>
+        <target>Refund processed</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/refund.php:21</note>
+      </trans-unit>
+      <trans-unit id="b3e67c974cc0ca43712679a17bedf6db">
+        <source><![CDATA[We have processed your <strong><span>{shop_name}</span></strong> refund for order with the reference <strong><span>{order_name}</span></strong>.]]></source>
+        <target><![CDATA[We have processed your <strong><span>{shop_name}</span></strong> refund for order with the reference <strong><span>{order_name}</span></strong>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/refund.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/reply_msg.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2ddbd3a9b06eadccdea8e1b372830d69">
+        <source>Please do not reply directly to this email, we will not receive it.</source>
+        <target>Please do not reply directly to this email, we will not receive it.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/reply_msg.php:22</note>
+      </trans-unit>
+      <trans-unit id="95d1732a1f5200c8e176bea0a5562804">
+        <source><![CDATA[In order to reply, please use the following link: <a href="{link}">{link}</a>]]></source>
+        <target><![CDATA[In order to reply, please use the following link: <a href="{link}">{link}</a>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/reply_msg.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/shipped.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d0cc952b66ca292a2e4a1bc53453b287">
+        <source>Your order has been shipped</source>
+        <target>Your order has been shipped</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/shipped.php:7</note>
+      </trans-unit>
+      <trans-unit id="747cf5c8587184b9e489ff897d97c20d">
+        <source>Shipped</source>
+        <target>Shipped</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/shipped.php:22</note>
+      </trans-unit>
+      <trans-unit id="e9933131bfeef332fc84561f8e23aeba">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been shipped.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been shipped.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/shipped.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/test.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8b1a9953c4611296a827abf8c47804d7">
+        <source>Hello</source>
+        <target>Hello</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/test.php:5</note>
+      </trans-unit>
+      <trans-unit id="0afa69e0eb948ce9fb81e14cc0c7cf0b">
+        <source><![CDATA[This is a <strong>test e-mail</strong> from your shop.<br /><br /> If you can read this, the test was successful!]]></source>
+        <target><![CDATA[This is a <strong>test e-mail</strong> from your shop.<br /><br /> If you can read this, the test was successful!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/test.php:14</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/voucher.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6edfaaf163aab585fb50f909e6f2cadf">
+        <source>Voucher created</source>
+        <target>Voucher created</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/voucher.php:21</note>
+      </trans-unit>
+      <trans-unit id="17ab9221f0e6cb342a02d31c56c79c2b">
+        <source><![CDATA[A voucher has been created in your name as a result of your order with the reference <span><strong>{order_name}</strong></span>.]]></source>
+        <target><![CDATA[A voucher has been created in your name as a result of your order with the reference <span><strong>{order_name}</strong></span>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/voucher.php:24</note>
+      </trans-unit>
+      <trans-unit id="25cecf399c0cd872952ced4a7d150e0d">
+        <source><![CDATA[<span><strong>Voucher code: {voucher_num}</strong></span> in the amount of <span><strong>{voucher_amount}</strong></span>]]></source>
+        <target><![CDATA[<span><strong>Voucher code: {voucher_num}</strong></span> in the amount of <span><strong>{voucher_amount}</strong></span>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/voucher.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/voucher_new.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5bb0c38774ca650d9548d682e175dc75">
+        <source>This is to inform you about the creation of a voucher.</source>
+        <target>This is to inform you about the creation of a voucher.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/voucher_new.php:21</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_1.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a037426f7ede13b30759469aaca5ad91">
+        <source>Your {shop_name} login details</source>
+        <target>Your {shop_name} login details</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_1.php:46</note>
+      </trans-unit>
+      <trans-unit id="ca0c09ad63f8cd2f732058be8d2b3a97">
+        <source>We noticed that during your last visit on {shop_name}, you did not complete the order you had started.</source>
+        <target>We noticed that during your last visit on {shop_name}, you did not complete the order you had started.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_1.php:24</note>
+      </trans-unit>
+      <trans-unit id="2213ab34c63663d94f96efdb6a9be339">
+        <source><![CDATA[As an incentive, we can give you a discount of {amount}% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target><![CDATA[As an incentive, we can give you a discount of {amount}% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_1.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_2.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="212dcee7c3ca3ee5fbae444b2f07c62d">
+        <source>Thank you for your order at {shop_name}.</source>
+        <target>Thank you for your order at {shop_name}.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_2.php:7</note>
+      </trans-unit>
+      <trans-unit id="3a5fa552bd31ebcceae0973cd384406b">
+        <source><![CDATA[As our way of saying thanks, we want to give you a discount of <span><strong>{amount}</strong></span>% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target><![CDATA[As our way of saying thanks, we want to give you a discount of <span><strong>{amount}</strong></span>% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_2.php:22</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_3.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="66472df69ec288388183a74a6e34e942">
+        <source>Thanks for your trust.</source>
+        <target>Thanks for your trust.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_3.php:7</note>
+      </trans-unit>
+      <trans-unit id="5a230b8b0490a33cf1fa3a577e1b4ef3">
+        <source>You are one of our best customers and as such we want to thank you for your continued patronage.</source>
+        <target>You are one of our best customers and as such we want to thank you for your continued patronage.</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_3.php:22</note>
+      </trans-unit>
+      <trans-unit id="86736a3055a9913b2c64671cd333e159">
+        <source><![CDATA[As appreciation for your loyalty, we want to give you a discount of <span><strong>{amount}</strong></span>% valid on your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target><![CDATA[As appreciation for your loyalty, we want to give you a discount of <span><strong>{amount}</strong></span>% valid on your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_3.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="modules/ps_emailgenerator/templates/modules/followup/followup_4.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="31ee1241ee08294dfc2ca85698fda2a1">
@@ -46,127 +854,31 @@ File: modules/ps_emailgenerator/templates/modules/followup/followup_4.php:26</no
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_emailgenerator/templates/core/order_return_state.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/customer_qty.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="34d125dc458bced25eaf5e2e272c0d75">
-        <source>Return #{id_order_return} - update</source>
-        <target>Return #{id_order_return} - update</target>
+      <trans-unit id="9b096ae55ce4d2bb889392144c104069">
+        <source>{product} is now available.</source>
+        <target>{product} is now available.</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_return_state.php:21</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/customer_qty.php:21</note>
       </trans-unit>
-      <trans-unit id="96aac675caae8b0ca0a5227ce8a6a7c6">
-        <source>We have updated the progress on your return #{id_order_return}, the new status is:</source>
-        <target>We have updated the progress on your return #{id_order_return}, the new status is:</target>
+      <trans-unit id="5b736bebe50e10240ff58d486494dc7b">
+        <source>This item is once again in-stock.</source>
+        <target>This item is once again in-stock.</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_return_state.php:24</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/customer_qty.php:24</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fce4d5217e51f199cfbd10ae913cc5dd">
-        <source><![CDATA[You can review your order and download your invoice from the <a href="{history_url}">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></source>
-        <target><![CDATA[You can review your order and download your invoice from the <a href="{history_url}">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></target>
+      <trans-unit id="16ce091d5fafd5b92941221eab85f3af">
+        <source>You can access the product page by clicking on the link:</source>
+        <target>You can access the product page by clicking on the link:</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:40</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/customer_qty.php:25</note>
       </trans-unit>
-      <trans-unit id="008400d8db73946ba53b2d7f091eb845">
-        <source>Order {order_name}</source>
-        <target>Order {order_name}</target>
+      <trans-unit id="d5c8de069674d35946f2e88642635485">
+        <source>You can order it right now from our online shop.</source>
+        <target>You can order it right now from our online shop.</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:21</note>
-      </trans-unit>
-      <trans-unit id="992ed3f1f7ce7be683fd4051138b693e">
-        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}">"Guest Tracking"</a> section on our shop.]]></source>
-        <target><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}">"Guest Tracking"</a> section on our shop.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:49</note>
-      </trans-unit>
-      <trans-unit id="6eaf1dae59f88437851d95f504f9cb3c">
-        <source>Order edited</source>
-        <target>Order edited</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:21</note>
-      </trans-unit>
-      <trans-unit id="fe61da38922f840543c9f7a4f5dc8140">
-        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been modified.]]></source>
-        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been modified.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:24</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/footer.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2ef8544a3e6d7f08ce2cadc006bd1bf0">
-        <source><![CDATA[<a href="{shop_url}">{shop_name}</a> powered by <a href="http://www.prestashop.com/">PrestaShop™</a>]]></source>
-        <target><![CDATA[<a href="{shop_url}">{shop_name}</a> powered by <a href="http://www.prestashop.com/">PrestaShop™</a>]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/footer.php:6</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/outofstock.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="be07158cdaa6c7244af799f3cdd6dad5">
-        <source>Thanks for your order with the reference {order_name} from {shop_name}.</source>
-        <target>Thanks for your order with the reference {order_name} from {shop_name}.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/outofstock.php:7</note>
-      </trans-unit>
-      <trans-unit id="e25d137c27dca2618629678d2df71113">
-        <source>Item(s) out of stock</source>
-        <target>Item(s) out of stock</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/outofstock.php:22</note>
-      </trans-unit>
-      <trans-unit id="5468cd18ba24d269db5ebe9177abca4a">
-        <source>Unfortunately, one or more items are currently out of stock. This may cause a slight delay in your delivery. Please accept our apologies and rest assured that we are working hard to rectify this.</source>
-        <target>Unfortunately, one or more items are currently out of stock. This may cause a slight delay in your delivery. Please accept our apologies and rest assured that we are working hard to rectify this.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/outofstock.php:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/backoffice_order.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="abc81c0d865925584b1269c996d7b297">
-        <source>A new order has been generated on your behalf.</source>
-        <target>A new order has been generated on your behalf.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/backoffice_order.php:21</note>
-      </trans-unit>
-      <trans-unit id="bffeb374bf71938ffc4faa42afbf1679">
-        <source><![CDATA[Please go on <a href="{order_link}">{order_link}</a> to finalize the payment.]]></source>
-        <target><![CDATA[Please go on <a href="{order_link}">{order_link}</a> to finalize the payment.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/backoffice_order.php:24</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/header_order_conf.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2769d37f4eb00f2c9b940ee928f1b426">
-        <source>Message from {shop_name}</source>
-        <target>Message from {shop_name}</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/header_order_conf.php:6</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/contact.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a1cee0a898793ad5101154ac97984d8a">
-        <source>Message from a {shop_name} customer</source>
-        <target>Message from a {shop_name} customer</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/contact.php:6</note>
-      </trans-unit>
-      <trans-unit id="31e15b28c2f071f74f47eb8bcd612d94">
-        <source>Customer e-mail address:</source>
-        <target>Customer e-mail address:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/contact.php:21</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/customer_qty.php:26</note>
       </trans-unit>
     </body>
   </file>
@@ -300,729 +1012,59 @@ File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/new_order.php:1
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_emailgenerator/templates/core/contact_form.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="83fa39a28a4d159061c408fbd6a249e7">
-        <source>Order ID:</source>
-        <target>Order ID:</target>
+      <trans-unit id="fce4d5217e51f199cfbd10ae913cc5dd">
+        <source><![CDATA[You can review your order and download your invoice from the <a href="{history_url}">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></source>
+        <target><![CDATA[You can review your order and download your invoice from the <a href="{history_url}">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/contact_form.php:22</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:40</note>
       </trans-unit>
-      <trans-unit id="53659d236625358b98797389fd2504fa">
-        <source>Attached file:</source>
-        <target>Attached file:</target>
+      <trans-unit id="008400d8db73946ba53b2d7f091eb845">
+        <source>Order {order_name}</source>
+        <target>Order {order_name}</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/contact_form.php:24</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:21</note>
       </trans-unit>
-      <trans-unit id="1edbec13a38606f19c0bae544a7c6552">
-        <source>Your message to {shop_name} Customer Service</source>
-        <target>Your message to {shop_name} Customer Service</target>
+      <trans-unit id="992ed3f1f7ce7be683fd4051138b693e">
+        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}">"Guest Tracking"</a> section on our shop.]]></source>
+        <target><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}">"Guest Tracking"</a> section on our shop.]]></target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/contact_form.php:6</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:49</note>
       </trans-unit>
-      <trans-unit id="e92ba0cecb0593f537515b2aa2d1c701">
-        <source>Your message has been sent successfully.</source>
-        <target>Your message has been sent successfully.</target>
+      <trans-unit id="6eaf1dae59f88437851d95f504f9cb3c">
+        <source>Order edited</source>
+        <target>Order edited</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/contact_form.php:21</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:21</note>
       </trans-unit>
-      <trans-unit id="465d60b936c982d7b57674f30ba022d0">
-        <source>Product:</source>
-        <target>Product:</target>
+      <trans-unit id="fe61da38922f840543c9f7a4f5dc8140">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been modified.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been modified.]]></target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/contact_form.php:23</note>
-      </trans-unit>
-      <trans-unit id="76890cf906149b370ea6f7d1bd8eaf9a">
-        <source>We will answer as soon as possible.</source>
-        <target>We will answer as soon as possible.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/contact_form.php:40</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:24</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_emailgenerator/templates/core/employee_password.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/productcoverage.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="4785f7efb27f2905a05564903db18b23">
-        <source>Your {shop_name} login information</source>
-        <target>Your {shop_name} login information</target>
+      <trans-unit id="6983ddb3442f4ad4a3b94e94a1ebd3dc">
+        <source>{product} is almost out of stock.</source>
+        <target>{product} is almost out of stock.</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/employee_password.php:21</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/productcoverage.php:21</note>
       </trans-unit>
-      <trans-unit id="a1fd16fcb98f1a6ec4312a10e6a3acba">
-        <source><![CDATA[Here is your personal login information for <span><strong>{shop_name}</strong></span>:]]></source>
-        <target><![CDATA[Here is your personal login information for <span><strong>{shop_name}</strong></span>:]]></target>
+      <trans-unit id="22609de33e6e9ee1be5b2bf9ae16514c">
+        <source>The stock cover is now less than the specified minimum of:</source>
+        <target>The stock cover is now less than the specified minimum of:</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/employee_password.php:24</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/productcoverage.php:24</note>
       </trans-unit>
-      <trans-unit id="668a8d8d7ffe5da112b266e46b79b685">
-        <source>First name:</source>
-        <target>First name:</target>
+      <trans-unit id="81899e9a62d3f952e81d5f72437470f9">
+        <source>Current stock cover:</source>
+        <target>Current stock cover:</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/employee_password.php:25</note>
-      </trans-unit>
-      <trans-unit id="be5e0b5d50d48b049bd0f7b57cd163f9">
-        <source>Last name:</source>
-        <target>Last name:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/employee_password.php:26</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/password.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="78e365acb087fd1f8d494dae0001de10">
-        <source>E-mail address:</source>
-        <target>E-mail address:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/password.php:24</note>
-      </trans-unit>
-      <trans-unit id="53423ed6d9f522de8d41539456628786">
-        <source>Your new {shop_name} login details</source>
-        <target>Your new {shop_name} login details</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/password.php:21</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_voucher.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bb372ddf88ad8fcc480f7a8599a92abc">
-        <source>Hi,</source>
-        <target>Hi,</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_voucher.php:6</note>
-      </trans-unit>
-      <trans-unit id="7bf7f18afabb5122fa68fbab617e509b">
-        <source>Newsletter subscription</source>
-        <target>Newsletter subscription</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_voucher.php:21</note>
-      </trans-unit>
-      <trans-unit id="289f1fb0b0a7ed1c03d1f1f597666f67">
-        <source>Regarding your newsletter subscription, we are pleased to offer you the following voucher:</source>
-        <target>Regarding your newsletter subscription, we are pleased to offer you the following voucher:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_voucher.php:24</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/order_customer_comment.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="381fc38b470ed543424afbd43f224453">
-        <source>Message from a customer</source>
-        <target>Message from a customer</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_customer_comment.php:21</note>
-      </trans-unit>
-      <trans-unit id="1607c3534ee9bdb8638858fa4bb9261b">
-        <source>You have received a new message regarding order with the reference</source>
-        <target>You have received a new message regarding order with the reference</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_customer_comment.php:24</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/return_slip.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5eea367ea73b909880393bd1ae79fc67">
-        <source>Customer:</source>
-        <target>Customer:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/return_slip.php:28</note>
-      </trans-unit>
-      <trans-unit id="f285446f60a203b0f7c3ad0b14d13d29">
-        <source>You have received a new return request for {shop_name}.</source>
-        <target>You have received a new return request for {shop_name}.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/return_slip.php:15</note>
-      </trans-unit>
-      <trans-unit id="cd8ee64ef80cd6bb4e320a7d0563b56f">
-        <source>Return details</source>
-        <target>Return details</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/return_slip.php:24</note>
-      </trans-unit>
-      <trans-unit id="f2d476bf166cc31b450908f8606b0fd5">
-        <source>{order_name} Placed on {date}</source>
-        <target>{order_name} Placed on {date}</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/return_slip.php:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/account.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="22a9d6a64a74d0f58a11fa7013f4b83a">
-        <source>Thank you for creating a customer account at {shop_name}.</source>
-        <target>Thank you for creating a customer account at {shop_name}.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/account.php:7</note>
-      </trans-unit>
-      <trans-unit id="d5b14d16c4008efddbee79cb56af5455">
-        <source>Here are your login details:</source>
-        <target>Here are your login details:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/account.php:25</note>
-      </trans-unit>
-      <trans-unit id="d70650ce5612f05bfe75c1962fa1e519">
-        <source>Important Security Tips:</source>
-        <target>Important Security Tips:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/account.php:45</note>
-      </trans-unit>
-      <trans-unit id="def00214a95442dc7899951abd9a6104">
-        <source>Always keep your account details safe.</source>
-        <target>Always keep your account details safe.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/account.php:47</note>
-      </trans-unit>
-      <trans-unit id="1559b55f6ea1de9f9b8826e9be306e6f">
-        <source>Never disclose your login details to anyone.</source>
-        <target>Never disclose your login details to anyone.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/account.php:48</note>
-      </trans-unit>
-      <trans-unit id="7601ee5e7968d91a7b4f099f4b4b84d0">
-        <source>Change your password regularly.</source>
-        <target>Change your password regularly.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/account.php:49</note>
-      </trans-unit>
-      <trans-unit id="8f9011f4a1219e51c8a0638d2af3f29a">
-        <source>Should you suspect someone is using your account illegally, please notify us immediately.</source>
-        <target>Should you suspect someone is using your account illegally, please notify us immediately.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/account.php:50</note>
-      </trans-unit>
-      <trans-unit id="de421ce3bebc9b5a2ee30fcf0312cb68">
-        <source>You can now place orders on our shop:</source>
-        <target>You can now place orders on our shop:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/account.php:65</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_1.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a037426f7ede13b30759469aaca5ad91">
-        <source>Your {shop_name} login details</source>
-        <target>Your {shop_name} login details</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/followup/followup_1.php:46</note>
-      </trans-unit>
-      <trans-unit id="ca0c09ad63f8cd2f732058be8d2b3a97">
-        <source>We noticed that during your last visit on {shop_name}, you did not complete the order you had started.</source>
-        <target>We noticed that during your last visit on {shop_name}, you did not complete the order you had started.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/followup/followup_1.php:24</note>
-      </trans-unit>
-      <trans-unit id="2213ab34c63663d94f96efdb6a9be339">
-        <source><![CDATA[As an incentive, we can give you a discount of {amount}% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
-        <target><![CDATA[As an incentive, we can give you a discount of {amount}% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/followup/followup_1.php:26</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/order_changed.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ac32eb3619340a6b6aff41d9797665d4">
-        <source>Order changed</source>
-        <target>Order changed</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_changed.php:21</note>
-      </trans-unit>
-      <trans-unit id="0e6321e9d36186e957652f07d88116a5">
-        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been changed by the merchant.]]></source>
-        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been changed by the merchant.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_changed.php:24</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/refund.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9b45ae8a346e0587013cdb1494e113d8">
-        <source>Refund processed</source>
-        <target>Refund processed</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/refund.php:21</note>
-      </trans-unit>
-      <trans-unit id="b3e67c974cc0ca43712679a17bedf6db">
-        <source><![CDATA[We have processed your <strong><span>{shop_name}</span></strong> refund for order with the reference <strong><span>{order_name}</span></strong>.]]></source>
-        <target><![CDATA[We have processed your <strong><span>{shop_name}</span></strong> refund for order with the reference <strong><span>{order_name}</span></strong>.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/refund.php:24</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/voucher.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6edfaaf163aab585fb50f909e6f2cadf">
-        <source>Voucher created</source>
-        <target>Voucher created</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/voucher.php:21</note>
-      </trans-unit>
-      <trans-unit id="17ab9221f0e6cb342a02d31c56c79c2b">
-        <source><![CDATA[A voucher has been created in your name as a result of your order with the reference <span><strong>{order_name}</strong></span>.]]></source>
-        <target><![CDATA[A voucher has been created in your name as a result of your order with the reference <span><strong>{order_name}</strong></span>.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/voucher.php:24</note>
-      </trans-unit>
-      <trans-unit id="25cecf399c0cd872952ced4a7d150e0d">
-        <source><![CDATA[<span><strong>Voucher code: {voucher_num}</strong></span> in the amount of <span><strong>{voucher_amount}</strong></span>]]></source>
-        <target><![CDATA[<span><strong>Voucher code: {voucher_num}</strong></span> in the amount of <span><strong>{voucher_amount}</strong></span>]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/voucher.php:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f4f614c22d9d2cbd0f9aa08cd59600d2">
-        <source>Simply copy/paste this code during the payment process for your next order.</source>
-        <target>Simply copy/paste this code during the payment process for your next order.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php:24</note>
-      </trans-unit>
-      <trans-unit id="abe1585bf97403d8a9a01a272183585a">
-        <source>Here is the code of your voucher:</source>
-        <target>Here is the code of your voucher:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php:23</note>
-      </trans-unit>
-      <trans-unit id="6540b502e953f4c05abeb8f234cd50bf">
-        <source>Referral Program</source>
-        <target>Referral Program</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php:19</note>
-      </trans-unit>
-      <trans-unit id="dd863685846fc4eddcc9d6d09ddd5264">
-        <source>We have created a voucher in your name for referring a friend.</source>
-        <target>We have created a voucher in your name for referring a friend.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php:22</note>
-      </trans-unit>
-      <trans-unit id="389df865c60c8fc7b86bf773eb5b121c">
-        <source>, with an amount of</source>
-        <target>, with an amount of</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php:23</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/guest_to_customer.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9893de883531529d4a66a3851265f02e">
-        <source>Your customer account creation</source>
-        <target>Your customer account creation</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/guest_to_customer.php:21</note>
-      </trans-unit>
-      <trans-unit id="499e229d39934f1a36f3f48718cc19cc">
-        <source><![CDATA[Your guest account for <span><strong>{shop_name}</strong></span> has been transformed into a customer account.]]></source>
-        <target><![CDATA[Your guest account for <span><strong>{shop_name}</strong></span> has been transformed into a customer account.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/guest_to_customer.php:24</note>
-      </trans-unit>
-      <trans-unit id="49bea2c7e271e5cd440a295dd6fadc72">
-        <source>Please be careful when sharing these login details with others.</source>
-        <target>Please be careful when sharing these login details with others.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/guest_to_customer.php:41</note>
-      </trans-unit>
-      <trans-unit id="b75184fa489c948c6debc4d635fefa5a">
-        <source>You can access your customer account on our shop:</source>
-        <target>You can access your customer account on our shop:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/guest_to_customer.php:50</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/credit_slip.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="72dbe899c04eb3875b29b5b274340dac">
-        <source>Credit slip created</source>
-        <target>Credit slip created</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/credit_slip.php:21</note>
-      </trans-unit>
-      <trans-unit id="b1c95c88d55558a6c04dea50425199df">
-        <source><![CDATA[We have generated a credit slip in your name for order with the reference <span><strong>{order_name}</strong></span>.]]></source>
-        <target><![CDATA[We have generated a credit slip in your name for order with the reference <span><strong>{order_name}</strong></span>.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/credit_slip.php:24</note>
-      </trans-unit>
-      <trans-unit id="99f89e9a116e1c07f62ba17fb0312db6">
-        <source><![CDATA[You can review this credit slip and download your invoice from the <a href="{history_url}">"My credit slips"</a> section of your account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></source>
-        <target><![CDATA[You can review this credit slip and download your invoice from the <a href="{history_url}">"My credit slips"</a> section of your account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/credit_slip.php:40</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/order_merchant_comment.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ad9fd7d0fe973ddaef093d912d0b57e2">
-        <source><![CDATA[You have received a new message from <span><strong>{shop_name}</strong></span> regarding order with the reference <span><strong>{order_name}</strong></span>.]]></source>
-        <target><![CDATA[You have received a new message from <span><strong>{shop_name}</strong></span> regarding order with the reference <span><strong>{order_name}</strong></span>.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_merchant_comment.php:24</note>
-      </trans-unit>
-      <trans-unit id="940663fd4428d2c86f9a4780b6574028">
-        <source>Message:</source>
-        <target>Message:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_merchant_comment.php:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/reply_msg.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2ddbd3a9b06eadccdea8e1b372830d69">
-        <source>Please do not reply directly to this email, we will not receive it.</source>
-        <target>Please do not reply directly to this email, we will not receive it.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/reply_msg.php:22</note>
-      </trans-unit>
-      <trans-unit id="95d1732a1f5200c8e176bea0a5562804">
-        <source><![CDATA[In order to reply, please use the following link: <a href="{link}">{link}</a>]]></source>
-        <target><![CDATA[In order to reply, please use the following link: <a href="{link}">{link}</a>]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/reply_msg.php:24</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/preparation.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="643562a9ae7099c8aabfdc93478db117">
-        <source>Processing</source>
-        <target>Processing</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/preparation.php:21</note>
-      </trans-unit>
-      <trans-unit id="d87f9ab0faa0b39a5240d1ce19529905">
-        <source><![CDATA[We are currently processing your <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>.]]></source>
-        <target><![CDATA[We are currently processing your <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/preparation.php:24</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/voucher_new.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5bb0c38774ca650d9548d682e175dc75">
-        <source>This is to inform you about the creation of a voucher.</source>
-        <target>This is to inform you about the creation of a voucher.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/voucher_new.php:21</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/order_conf.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b4556791acee238c77be9ed338a29e80">
-        <source>Thank you for shopping with {shop_name}!</source>
-        <target>Thank you for shopping with {shop_name}!</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_conf.php:7</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/bankwire.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9b33ea5c9409a67cb6e1f6bc3f0828f0">
-        <source>Awaiting wire payment</source>
-        <target>Awaiting wire payment</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/bankwire.php:22</note>
-      </trans-unit>
-      <trans-unit id="f4a6af01d092af11dca29cb89578b124">
-        <source>You have selected to pay by wire transfer.</source>
-        <target>You have selected to pay by wire transfer.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/bankwire.php:45</note>
-      </trans-unit>
-      <trans-unit id="fc1ae3c1dd1d9d9a44da719fa9966f0e">
-        <source>Here are the bank details for your transfer:</source>
-        <target>Here are the bank details for your transfer:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/bankwire.php:48</note>
-      </trans-unit>
-      <trans-unit id="21e4851289ecc91b65023c2563344aa7">
-        <source>Account owner:</source>
-        <target>Account owner:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/bankwire.php:50</note>
-      </trans-unit>
-      <trans-unit id="20a650d87733bd5895c979de29864a73">
-        <source>Account details:</source>
-        <target>Account details:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/bankwire.php:51</note>
-      </trans-unit>
-      <trans-unit id="312d898d92d8ba90499ef0dac27270be">
-        <source>Bank address:</source>
-        <target>Bank address:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/bankwire.php:52</note>
-      </trans-unit>
-      <trans-unit id="b8f05e3501f419f9f7ec08026a9342be">
-        <source>Please specify your order reference in the bankwire description.</source>
-        <target>Please specify your order reference in the bankwire description.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/bankwire.php:53</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/cheque.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3f8b7a7948f4fd5d9bb34d63746dfd23">
-        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been placed successfully and will be <strong>shipped as soon as we receive your payment</strong>.]]></source>
-        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been placed successfully and will be <strong>shipped as soon as we receive your payment</strong>.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/cheque.php:25</note>
-      </trans-unit>
-      <trans-unit id="6702a6e3bc2dce95c3e3b61fe578f29c">
-        <source>Amount:</source>
-        <target>Amount:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/cheque.php:49</note>
-      </trans-unit>
-      <trans-unit id="a51341e25ff7710496cf86468d797169">
-        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}">"Guest Tracking"</a> section on our shop.]]></source>
-        <target><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}">"Guest Tracking"</a> section on our shop.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/cheque.php:76</note>
-      </trans-unit>
-      <trans-unit id="d698e777b19f6f487ae0490950174fde">
-        <source>Awaiting check payment</source>
-        <target>Awaiting check payment</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/cheque.php:22</note>
-      </trans-unit>
-      <trans-unit id="ecf01c46965fdfd36eb98b271276c0d5">
-        <source>You have selected to pay by check.</source>
-        <target>You have selected to pay by check.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/cheque.php:45</note>
-      </trans-unit>
-      <trans-unit id="b6592595266708e46d1d420ab7153213">
-        <source>Here are the bank details for your check:</source>
-        <target>Here are the bank details for your check:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/cheque.php:48</note>
-      </trans-unit>
-      <trans-unit id="1c3bd8f6bd066270354607c08f930baf">
-        <source>Payable to the order of:</source>
-        <target>Payable to the order of:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/cheque.php:50</note>
-      </trans-unit>
-      <trans-unit id="8f1fb2295c4289bae9fc26549b4b45f2">
-        <source>Please mail your check to:</source>
-        <target>Please mail your check to:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/cheque.php:51</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/test.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8b1a9953c4611296a827abf8c47804d7">
-        <source>Hello</source>
-        <target>Hello</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/test.php:5</note>
-      </trans-unit>
-      <trans-unit id="0afa69e0eb948ce9fb81e14cc0c7cf0b">
-        <source><![CDATA[This is a <strong>test e-mail</strong> from your shop.<br /><br /> If you can read this, the test was successful!]]></source>
-        <target><![CDATA[This is a <strong>test e-mail</strong> from your shop.<br /><br /> If you can read this, the test was successful!]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/test.php:14</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/payment.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6daabaab43cdbd67346ae71828b1710c">
-        <source>Payment processed</source>
-        <target>Payment processed</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/payment.php:22</note>
-      </trans-unit>
-      <trans-unit id="2762264cddd3133c3486886e31681873">
-        <source><![CDATA[Your payment for order with the reference <strong><span>{order_name}</span></strong> was successfully processed.]]></source>
-        <target><![CDATA[Your payment for order with the reference <strong><span>{order_name}</span></strong> was successfully processed.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/payment.php:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/import.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a218495ad30949e8ea1f64a261e37463">
-        <source>Import complete</source>
-        <target>Import complete</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/import.php:21</note>
-      </trans-unit>
-      <trans-unit id="293a2b3dd4b7fb2d950c8128be6d14f7">
-        <source>The file {filename} has been successfully imported to your shop.</source>
-        <target>The file {filename} has been successfully imported to your shop.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/import.php:24</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/password_query.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="280f51a8705636bd7e7ba595529411d4">
-        <source>Password reset request for {shop_name}</source>
-        <target>Password reset request for {shop_name}</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/password_query.php:21</note>
-      </trans-unit>
-      <trans-unit id="18f3152ffe51f0d446558f666dc8d5ea">
-        <source><![CDATA[You have requested to reset your <span><strong>{shop_name}</strong></span> login details.]]></source>
-        <target><![CDATA[You have requested to reset your <span><strong>{shop_name}</strong></span> login details.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/password_query.php:24</note>
-      </trans-unit>
-      <trans-unit id="09ce893cc7228918df5657665b899249">
-        <source>Please note that this will change your current password.</source>
-        <target>Please note that this will change your current password.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/password_query.php:25</note>
-      </trans-unit>
-      <trans-unit id="278b2a400e176e90d476fb69cb881f59">
-        <source>To confirm this action, please use the following link:</source>
-        <target>To confirm this action, please use the following link:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/password_query.php:26</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/in_transit.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7ec4f8b296984ffe6ea829b7e1743577">
-        <source>In transit</source>
-        <target>In transit</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/in_transit.php:46</note>
-      </trans-unit>
-      <trans-unit id="873a6c9ce4b0711161105e4a6d943bb6">
-        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> is currently in transit.]]></source>
-        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> is currently in transit.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/in_transit.php:49</note>
-      </trans-unit>
-      <trans-unit id="34f49f671cedfb2d5f8080ec14120281">
-        <source>You can track your package using the following link:</source>
-        <target>You can track your package using the following link:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/in_transit.php:50</note>
-      </trans-unit>
-      <trans-unit id="1b0d1cd23421d9cea08507e950e87094">
-        <source>{followup}</source>
-        <target>{followup}</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/in_transit.php:50</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/shipped.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d0cc952b66ca292a2e4a1bc53453b287">
-        <source>Your order has been shipped</source>
-        <target>Your order has been shipped</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/shipped.php:7</note>
-      </trans-unit>
-      <trans-unit id="747cf5c8587184b9e489ff897d97c20d">
-        <source>Shipped</source>
-        <target>Shipped</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/shipped.php:22</note>
-      </trans-unit>
-      <trans-unit id="e9933131bfeef332fc84561f8e23aeba">
-        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been shipped.]]></source>
-        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been shipped.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/shipped.php:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/download_product.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5f55a607fea61a402ceac66cc99f1e9e">
-        <source><![CDATA[Thank you for your order with the reference {order_name} from <strong>{shop_name}</strong>]]></source>
-        <target><![CDATA[Thank you for your order with the reference {order_name} from <strong>{shop_name}</strong>]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/download_product.php:7</note>
-      </trans-unit>
-      <trans-unit id="30acb55a5efc4a32a30a0c3db85f37d1">
-        <source>Product(s) now available for download</source>
-        <target>Product(s) now available for download</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/download_product.php:22</note>
-      </trans-unit>
-      <trans-unit id="afae9cdc5d9b4583915a579cb0c67788">
-        <source><![CDATA[You have <span><strong>{nbProducts}</strong></span> product(s) now available for download using the following link(s):]]></source>
-        <target><![CDATA[You have <span><strong>{nbProducts}</strong></span> product(s) now available for download using the following link(s):]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/download_product.php:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/log_alert.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="07e3b33fd6a9b33d3d9cacea26dc1899">
-        <source>You have received a new log alert</source>
-        <target>You have received a new log alert</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/log_alert.php:21</note>
-      </trans-unit>
-      <trans-unit id="17357f0ed7c82a1620f4311667886a63">
-        <source><![CDATA[<span><strong>Warning:</strong></span> you have received a new log alert in your Back Office.]]></source>
-        <target><![CDATA[<span><strong>Warning:</strong></span> you have received a new log alert in your Back Office.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/log_alert.php:24</note>
-      </trans-unit>
-      <trans-unit id="32ef0cc5af8577c12e075c3cb285a786">
-        <source><![CDATA[You can check for it in the <span><strong>"Tools" > "Logs"</strong></span> section of your Back Office.]]></source>
-        <target><![CDATA[You can check for it in the <span><strong>"Tools" > "Logs"</strong></span> section of your Back Office.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/log_alert.php:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/core/forward_msg.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8595a98bbe6d6b0e3b9b0681b3b4aa71">
-        <source>Customer service - Forwarded discussion</source>
-        <target>Customer service - Forwarded discussion</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/forward_msg.php:21</note>
-      </trans-unit>
-      <trans-unit id="85ae5cfc68837cc8e50609b84babba09">
-        <source><![CDATA[<span><strong>{employee}</strong></span> wanted to forward this discussion to you.]]></source>
-        <target><![CDATA[<span><strong>{employee}</strong></span> wanted to forward this discussion to you.]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/forward_msg.php:24</note>
-      </trans-unit>
-      <trans-unit id="a9854b516855755f7a9246d781d4f57b">
-        <source>Discussion history:</source>
-        <target>Discussion history:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/forward_msg.php:25</note>
-      </trans-unit>
-      <trans-unit id="f4df87e5e465151ae8d5954bec01d9ec">
-        <source><![CDATA[<span><strong>{employee}</strong></span> added <span><strong>"{comment}"</strong></span>]]></source>
-        <target><![CDATA[<span><strong>{employee}</strong></span> added <span><strong>"{comment}"</strong></span>]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/core/forward_msg.php:26</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/productcoverage.php:25</note>
       </trans-unit>
     </body>
   </file>
@@ -1054,41 +1096,95 @@ File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/productoutofsto
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_emailgenerator/templates/core/order_canceled.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/return_slip.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="3baf03ed2980c9f339731f052c12b37d">
-        <source>Order canceled</source>
-        <target>Order canceled</target>
+      <trans-unit id="5eea367ea73b909880393bd1ae79fc67">
+        <source>Customer:</source>
+        <target>Customer:</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_canceled.php:21</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/return_slip.php:28</note>
       </trans-unit>
-      <trans-unit id="50651089ed12eb33b55394a0a17618de">
-        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been canceled.]]></source>
-        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been canceled.]]></target>
+      <trans-unit id="f285446f60a203b0f7c3ad0b14d13d29">
+        <source>You have received a new return request for {shop_name}.</source>
+        <target>You have received a new return request for {shop_name}.</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/order_canceled.php:24</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/return_slip.php:15</note>
+      </trans-unit>
+      <trans-unit id="cd8ee64ef80cd6bb4e320a7d0563b56f">
+        <source>Return details</source>
+        <target>Return details</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/return_slip.php:24</note>
+      </trans-unit>
+      <trans-unit id="f2d476bf166cc31b450908f8606b0fd5">
+        <source>{order_name} Placed on {date}</source>
+        <target>{order_name} Placed on {date}</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/return_slip.php:27</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_emailgenerator/templates/core/payment_error.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_conf.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="3dd0be333980f0b0f0895cdb6322d117">
-        <source>Payment processing error</source>
-        <target>Payment processing error</target>
+      <trans-unit id="4e1c51e233f1ed368c58db9ef09010ba">
+        <source>Thank you for subscribing to our newsletter.</source>
+        <target>Thank you for subscribing to our newsletter.</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/payment_error.php:21</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_conf.php:22</note>
       </trans-unit>
-      <trans-unit id="96c8c962f040049e80bccbea08e2d776">
-        <source><![CDATA[There is a problem with your payment for <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>. Please contact us at your earliest convenience.]]></source>
-        <target><![CDATA[There is a problem with your payment for <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>. Please contact us at your earliest convenience.]]></target>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_verif.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3f796454690dc2d7f26db5d45c48b187">
+        <source>Thank you for subscribing to our newsletter, please confirm your request by clicking the link below :</source>
+        <target>Thank you for subscribing to our newsletter, please confirm your request by clicking the link below :</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/payment_error.php:24</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_verif.php:21</note>
       </trans-unit>
-      <trans-unit id="5f2142258e3f214d12efeb927f2a7aef">
-        <source>We cannot ship your order until we receive your payment.</source>
-        <target>We cannot ship your order until we receive your payment.</target>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_voucher.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bb372ddf88ad8fcc480f7a8599a92abc">
+        <source>Hi,</source>
+        <target>Hi,</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/core/payment_error.php:25</note>
+File: modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_voucher.php:6</note>
+      </trans-unit>
+      <trans-unit id="7bf7f18afabb5122fa68fbab617e509b">
+        <source>Newsletter subscription</source>
+        <target>Newsletter subscription</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_voucher.php:21</note>
+      </trans-unit>
+      <trans-unit id="289f1fb0b0a7ed1c03d1f1f597666f67">
+        <source>Regarding your newsletter subscription, we are pleased to offer you the following voucher:</source>
+        <target>Regarding your newsletter subscription, we are pleased to offer you the following voucher:</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_voucher.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="677182971924ee6799eb365f688c5572">
+        <source>Best regards,</source>
+        <target>Best regards,</target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php:37</note>
+      </trans-unit>
+      <trans-unit id="90e0a7c3c7230e2188794af89350ea7b">
+        <source><![CDATA[Your referred friend <span><strong>{sponsored_firstname} {sponsored_lastname}</strong></span> has placed his or her first order on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target><![CDATA[Your referred friend <span><strong>{sponsored_firstname} {sponsored_lastname}</strong></span> has placed his or her first order on <a href="{shop_url}">{shop_name}</a>!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php:21</note>
+      </trans-unit>
+      <trans-unit id="eb7c04362c657d5651703a43307e61c2">
+        <source><![CDATA[We are pleased to offer you a voucher worth <span><strong>{discount_display} (voucher # {discount_name})</strong></span> that you can use on your next order.]]></source>
+        <target><![CDATA[We are pleased to offer you a voucher worth <span><strong>{discount_display} (voucher # {discount_name})</strong></span> that you can use on your next order.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php:22</note>
       </trans-unit>
     </body>
   </file>
@@ -1132,133 +1228,37 @@ File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogra
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="677182971924ee6799eb365f688c5572">
-        <source>Best regards,</source>
-        <target>Best regards,</target>
+      <trans-unit id="f4f614c22d9d2cbd0f9aa08cd59600d2">
+        <source>Simply copy/paste this code during the payment process for your next order.</source>
+        <target>Simply copy/paste this code during the payment process for your next order.</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php:37</note>
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php:24</note>
       </trans-unit>
-      <trans-unit id="90e0a7c3c7230e2188794af89350ea7b">
-        <source><![CDATA[Your referred friend <span><strong>{sponsored_firstname} {sponsored_lastname}</strong></span> has placed his or her first order on <a href="{shop_url}">{shop_name}</a>!]]></source>
-        <target><![CDATA[Your referred friend <span><strong>{sponsored_firstname} {sponsored_lastname}</strong></span> has placed his or her first order on <a href="{shop_url}">{shop_name}</a>!]]></target>
+      <trans-unit id="abe1585bf97403d8a9a01a272183585a">
+        <source>Here is the code of your voucher:</source>
+        <target>Here is the code of your voucher:</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php:21</note>
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php:23</note>
       </trans-unit>
-      <trans-unit id="eb7c04362c657d5651703a43307e61c2">
-        <source><![CDATA[We are pleased to offer you a voucher worth <span><strong>{discount_display} (voucher # {discount_name})</strong></span> that you can use on your next order.]]></source>
-        <target><![CDATA[We are pleased to offer you a voucher worth <span><strong>{discount_display} (voucher # {discount_name})</strong></span> that you can use on your next order.]]></target>
+      <trans-unit id="6540b502e953f4c05abeb8f234cd50bf">
+        <source>Referral Program</source>
+        <target>Referral Program</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php:22</note>
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php:19</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/productcoverage.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6983ddb3442f4ad4a3b94e94a1ebd3dc">
-        <source>{product} is almost out of stock.</source>
-        <target>{product} is almost out of stock.</target>
+      <trans-unit id="dd863685846fc4eddcc9d6d09ddd5264">
+        <source>We have created a voucher in your name for referring a friend.</source>
+        <target>We have created a voucher in your name for referring a friend.</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/productcoverage.php:21</note>
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php:22</note>
       </trans-unit>
-      <trans-unit id="22609de33e6e9ee1be5b2bf9ae16514c">
-        <source>The stock cover is now less than the specified minimum of:</source>
-        <target>The stock cover is now less than the specified minimum of:</target>
+      <trans-unit id="389df865c60c8fc7b86bf773eb5b121c">
+        <source>, with an amount of</source>
+        <target>, with an amount of</target>
         <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/productcoverage.php:24</note>
-      </trans-unit>
-      <trans-unit id="81899e9a62d3f952e81d5f72437470f9">
-        <source>Current stock cover:</source>
-        <target>Current stock cover:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/productcoverage.php:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/customer_qty.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9b096ae55ce4d2bb889392144c104069">
-        <source>{product} is now available.</source>
-        <target>{product} is now available.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/customer_qty.php:21</note>
-      </trans-unit>
-      <trans-unit id="5b736bebe50e10240ff58d486494dc7b">
-        <source>This item is once again in-stock.</source>
-        <target>This item is once again in-stock.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/customer_qty.php:24</note>
-      </trans-unit>
-      <trans-unit id="16ce091d5fafd5b92941221eab85f3af">
-        <source>You can access the product page by clicking on the link:</source>
-        <target>You can access the product page by clicking on the link:</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/customer_qty.php:25</note>
-      </trans-unit>
-      <trans-unit id="d5c8de069674d35946f2e88642635485">
-        <source>You can order it right now from our online shop.</source>
-        <target>You can order it right now from our online shop.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/customer_qty.php:26</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_2.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="212dcee7c3ca3ee5fbae444b2f07c62d">
-        <source>Thank you for your order at {shop_name}.</source>
-        <target>Thank you for your order at {shop_name}.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/followup/followup_2.php:7</note>
-      </trans-unit>
-      <trans-unit id="3a5fa552bd31ebcceae0973cd384406b">
-        <source><![CDATA[As our way of saying thanks, we want to give you a discount of <span><strong>{amount}</strong></span>% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
-        <target><![CDATA[As our way of saying thanks, we want to give you a discount of <span><strong>{amount}</strong></span>% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/followup/followup_2.php:22</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_3.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="66472df69ec288388183a74a6e34e942">
-        <source>Thanks for your trust.</source>
-        <target>Thanks for your trust.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/followup/followup_3.php:7</note>
-      </trans-unit>
-      <trans-unit id="5a230b8b0490a33cf1fa3a577e1b4ef3">
-        <source>You are one of our best customers and as such we want to thank you for your continued patronage.</source>
-        <target>You are one of our best customers and as such we want to thank you for your continued patronage.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/followup/followup_3.php:22</note>
-      </trans-unit>
-      <trans-unit id="86736a3055a9913b2c64671cd333e159">
-        <source><![CDATA[As appreciation for your loyalty, we want to give you a discount of <span><strong>{amount}</strong></span>% valid on your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
-        <target><![CDATA[As appreciation for your loyalty, we want to give you a discount of <span><strong>{amount}</strong></span>% valid on your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/followup/followup_3.php:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_conf.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4e1c51e233f1ed368c58db9ef09010ba">
-        <source>Thank you for subscribing to our newsletter.</source>
-        <target>Thank you for subscribing to our newsletter.</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_conf.php:22</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_verif.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3f796454690dc2d7f26db5d45c48b187">
-        <source>Thank you for subscribing to our newsletter, please confirm your request by clicking the link below :</source>
-        <target>Thank you for subscribing to our newsletter, please confirm your request by clicking the link below :</target>
-        <note>Context:
-File: modules/ps_emailgenerator/templates/modules/ps_emailsubscription/newsletter_verif.php:21</note>
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-voucher.php:23</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/EmailsSubject.xlf
+++ b/app/Resources/translations/default/EmailsSubject.xlf
@@ -1,170 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/front/OrderDetailController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/Customer.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="381fc38b470ed543424afbd43f224453">
-        <source>Message from a customer</source>
-        <target>Message from a customer</target>
-        <note>Context:
-File: controllers/front/OrderDetailController.php:108</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/PasswordController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="61afad00abe3639b3ead655a1e8696d9">
-        <source>Password query confirmation</source>
-        <target>Password query confirmation</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:90</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminLoginController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c5f4622e4a63b41e7c0ddc100583ee6b">
-        <source>Your new password</source>
-        <target>Your new password</target>
-        <note>Context:
-File: controllers/admin/AdminLoginController.php:357</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="abe01af80b6bc9f1fa34feaa068336b2">
-        <source>New message regarding your order</source>
-        <target>New message regarding your order</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:650</note>
-      </trans-unit>
-      <trans-unit id="10e7889bf2e6fd95e25936d2c11e92be">
-        <source>New credit slip regarding your order</source>
-        <target>New credit slip regarding your order</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1039</note>
-      </trans-unit>
-      <trans-unit id="b360ddde7a5a70304c005e45e141cf9d">
-        <source>New voucher for your order #%s</source>
-        <target>New voucher for your order #%s</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:1120</note>
-      </trans-unit>
-      <trans-unit id="cad374f43e79ca774b2e8e00dcd8b842">
-        <source>Process the payment of your order</source>
-        <target>Process the payment of your order</target>
-        <note>Context:
-File: controllers/admin/AdminOrdersController.php:2017</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4f55e8d67e33d354a5273eb87c903980">
-        <source>Fwd: Customer message</source>
-        <target>Fwd: Customer message</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:402</note>
-      </trans-unit>
-      <trans-unit id="26fabd8660373b86b9288dd72fd40e13">
-        <source>An answer to your message is available #ct%thread_id% #tc%thread_token%</source>
-        <target>An answer to your message is available #ct%thread_id% #tc%thread_token%</target>
-        <note>Context:
-File: controllers/admin/AdminCustomerThreadsController.php:465</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a218495ad30949e8ea1f64a261e37463">
-        <source>Import complete</source>
-        <target>Import complete</target>
-        <note>Context:
-File: controllers/admin/AdminImportController.php:4667</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f2328a3f139e31d53016f94ea9477124">
-        <source>Your order return status has changed</source>
-        <target>Your order return status has changed</target>
-        <note>Context:
-File: controllers/admin/AdminReturnController.php:257</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/contactform/contactform.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9e03c4150db1c72add84ba520ee589aa">
-        <source>Message from contact form</source>
-        <target>Message from contact form</target>
-        <note>Context:
-File: modules/contactform/contactform.php:614</note>
-      </trans-unit>
-      <trans-unit id="55c19f9aec68a1a320cbeba663f1e4c0">
-        <source>Your message has been correctly sent #ct%thread_id% #tc%thread_token%</source>
-        <target>Your message has been correctly sent #ct%thread_id% #tc%thread_token%</target>
-        <note>Context:
-File: modules/contactform/contactform.php:643</note>
-      </trans-unit>
-      <trans-unit id="d40cb87db94e750405e7b20a8a043d81">
-        <source>Your message has been correctly sent</source>
-        <target>Your message has been correctly sent</target>
-        <note>Context:
-File: modules/contactform/contactform.php:649</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a95bc59685fb4546de3884a5fbe474ea">
-        <source>Newsletter voucher</source>
-        <target>Newsletter voucher</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:661</note>
-      </trans-unit>
-      <trans-unit id="efabbb0eb84d3c8e487a72e879953673">
-        <source>Newsletter confirmation</source>
-        <target>Newsletter confirmation</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:695</note>
-      </trans-unit>
-      <trans-unit id="732f1aa49f17856ff55a5aa0a88374d9">
-        <source>Email verification</source>
-        <target>Email verification</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:734</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/PrestaShopLogger.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="caedcb9e2005bf6e522cf4536a1885bd">
-        <source>Log: You have a new alert from your shop</source>
-        <target>Log: You have a new alert from your shop</target>
-        <note>Context:
-File: classes/PrestaShopLogger.php:93</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/order/OrderHistory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3cf100d3725155b75779945680651f3d">
-        <source>The virtual product that you bought is available for download</source>
-        <target>The virtual product that you bought is available for download</target>
-        <note>Context:
-File: classes/order/OrderHistory.php:165</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/order/OrderCarrier.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="87405e011a2c4166bb685336827fbe81">
-        <source>Package in transit</source>
-        <target>Package in transit</target>
-        <note>Context:
-File: classes/order/OrderCarrier.php:149</note>
+      <trans-unit id="32e8a8d9ed872f16d6dae0dc5fd4bb71">
+        <source>Your guest account has been transformed into a customer account</source>
+        <target>Your guest account has been transformed into a customer account</target>
+        <note>Line: 1112</note>
       </trans-unit>
     </body>
   </file>
@@ -173,24 +14,21 @@ File: classes/order/OrderCarrier.php:149</note>
       <trans-unit id="fca7e8d1c86db11246e429e40aa10c81">
         <source>New voucher for your order %s</source>
         <target>New voucher for your order %s</target>
-        <note>Context:
-File: classes/PaymentModule.php:644</note>
+        <note>Line: 644</note>
       </trans-unit>
       <trans-unit id="fb077ecba55e5552916bde26d8b9e794">
         <source>Order confirmation</source>
         <target>Order confirmation</target>
-        <note>Context:
-File: classes/PaymentModule.php:850</note>
+        <note>Line: 850</note>
       </trans-unit>
     </body>
   </file>
-  <file original="classes/Customer.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/PrestaShopLogger.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="32e8a8d9ed872f16d6dae0dc5fd4bb71">
-        <source>Your guest account has been transformed into a customer account</source>
-        <target>Your guest account has been transformed into a customer account</target>
-        <note>Context:
-File: classes/Customer.php:1112</note>
+      <trans-unit id="caedcb9e2005bf6e522cf4536a1885bd">
+        <source>Log: You have a new alert from your shop</source>
+        <target>Log: You have a new alert from your shop</target>
+        <note>Line: 93</note>
       </trans-unit>
     </body>
   </file>
@@ -199,8 +37,142 @@ File: classes/Customer.php:1112</note>
       <trans-unit id="9a843f20677a52ca79af903123147af0">
         <source>Welcome!</source>
         <target>Welcome!</target>
-        <note>Context:
-File: classes/form/CustomerPersister.php:215</note>
+        <note>Line: 215</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/order/OrderCarrier.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="87405e011a2c4166bb685336827fbe81">
+        <source>Package in transit</source>
+        <target>Package in transit</target>
+        <note>Line: 149</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/order/OrderHistory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3cf100d3725155b75779945680651f3d">
+        <source>The virtual product that you bought is available for download</source>
+        <target>The virtual product that you bought is available for download</target>
+        <note>Line: 165</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4f55e8d67e33d354a5273eb87c903980">
+        <source>Fwd: Customer message</source>
+        <target>Fwd: Customer message</target>
+        <note>Line: 402</note>
+      </trans-unit>
+      <trans-unit id="26fabd8660373b86b9288dd72fd40e13">
+        <source>An answer to your message is available #ct%thread_id% #tc%thread_token%</source>
+        <target>An answer to your message is available #ct%thread_id% #tc%thread_token%</target>
+        <note>Line: 465</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a218495ad30949e8ea1f64a261e37463">
+        <source>Import complete</source>
+        <target>Import complete</target>
+        <note>Line: 4667</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="abe01af80b6bc9f1fa34feaa068336b2">
+        <source>New message regarding your order</source>
+        <target>New message regarding your order</target>
+        <note>Line: 650</note>
+      </trans-unit>
+      <trans-unit id="10e7889bf2e6fd95e25936d2c11e92be">
+        <source>New credit slip regarding your order</source>
+        <target>New credit slip regarding your order</target>
+        <note>Line: 1039</note>
+      </trans-unit>
+      <trans-unit id="b360ddde7a5a70304c005e45e141cf9d">
+        <source>New voucher for your order #%s</source>
+        <target>New voucher for your order #%s</target>
+        <note>Line: 1120</note>
+      </trans-unit>
+      <trans-unit id="cad374f43e79ca774b2e8e00dcd8b842">
+        <source>Process the payment of your order</source>
+        <target>Process the payment of your order</target>
+        <note>Line: 2017</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f2328a3f139e31d53016f94ea9477124">
+        <source>Your order return status has changed</source>
+        <target>Your order return status has changed</target>
+        <note>Line: 257</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderDetailController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="381fc38b470ed543424afbd43f224453">
+        <source>Message from a customer</source>
+        <target>Message from a customer</target>
+        <note>Line: 108</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/PasswordController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="61afad00abe3639b3ead655a1e8696d9">
+        <source>Password query confirmation</source>
+        <target>Password query confirmation</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="c5f4622e4a63b41e7c0ddc100583ee6b">
+        <source>Your new password</source>
+        <target>Your new password</target>
+        <note>Line: 168</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/contactform/contactform.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9e03c4150db1c72add84ba520ee589aa">
+        <source>Message from contact form</source>
+        <target>Message from contact form</target>
+        <note>Line: 614</note>
+      </trans-unit>
+      <trans-unit id="55c19f9aec68a1a320cbeba663f1e4c0">
+        <source>Your message has been correctly sent #ct%thread_id% #tc%thread_token%</source>
+        <target>Your message has been correctly sent #ct%thread_id% #tc%thread_token%</target>
+        <note>Line: 643</note>
+      </trans-unit>
+      <trans-unit id="d40cb87db94e750405e7b20a8a043d81">
+        <source>Your message has been correctly sent</source>
+        <target>Your message has been correctly sent</target>
+        <note>Line: 649</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a95bc59685fb4546de3884a5fbe474ea">
+        <source>Newsletter voucher</source>
+        <target>Newsletter voucher</target>
+        <note>Line: 661</note>
+      </trans-unit>
+      <trans-unit id="efabbb0eb84d3c8e487a72e879953673">
+        <source>Newsletter confirmation</source>
+        <target>Newsletter confirmation</target>
+        <note>Line: 695</note>
+      </trans-unit>
+      <trans-unit id="732f1aa49f17856ff55a5aa0a88374d9">
+        <source>Email verification</source>
+        <target>Email verification</target>
+        <note>Line: 734</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/Install.xlf
+++ b/app/Resources/translations/default/Install.xlf
@@ -1,232 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="install-dev/controllers/http/system.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="install-dev/classes/controllerHttp.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="5a0f8c7d1f0c12dd0d41abe3b5b6e29d">
-        <source>Required PHP parameters</source>
-        <target>Required PHP parameters</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:92</note>
+      <trans-unit id="fa6724c724e5524034b09c9bbac81f07">
+        <source>Choose your language</source>
+        <target>Choose your language</target>
+        <note>Line: 98</note>
       </trans-unit>
-      <trans-unit id="8e5a027b55c03eddcbe0209009f831c8">
-        <source>PHP 5.6 or later is not enabled</source>
-        <target>PHP 5.6 or later is not enabled</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:95</note>
+      <trans-unit id="13e582c97044bf8680de63c6bdb41c18">
+        <source>License agreements</source>
+        <target>License agreements</target>
+        <note>Line: 103</note>
       </trans-unit>
-      <trans-unit id="6619b8629c4ea12c29f929402071ddf1">
-        <source>Cannot upload files</source>
-        <target>Cannot upload files</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:96</note>
+      <trans-unit id="d13e189d15c36f1ec8ff701cce809b4d">
+        <source>System compatibility</source>
+        <target>System compatibility</target>
+        <note>Line: 108</note>
       </trans-unit>
-      <trans-unit id="077486357155a0ea1d3d24a534625020">
-        <source>Cannot create new files and folders</source>
-        <target>Cannot create new files and folders</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:97</note>
+      <trans-unit id="3aea774cdcd8f2c45549f10758a71323">
+        <source>Store information</source>
+        <target>Store information</target>
+        <note>Line: 113</note>
       </trans-unit>
-      <trans-unit id="8edddbd91415fa92ce68a7601116e39d">
-        <source>cURL extension is not enabled</source>
-        <target>cURL extension is not enabled</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:98</note>
+      <trans-unit id="3c4e32d95f12c00d16a76057a7af18f6">
+        <source>System configuration</source>
+        <target>System configuration</target>
+        <note>Line: 118</note>
       </trans-unit>
-      <trans-unit id="d482b958dcd96bf9219f5039afae2dde">
-        <source>GD library is not installed</source>
-        <target>GD library is not installed</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:99</note>
+      <trans-unit id="b68b681631a5198ce1120f9ffd06f77a">
+        <source>Store installation</source>
+        <target>Store installation</target>
+        <note>Line: 123</note>
       </trans-unit>
-      <trans-unit id="53451c05d2a863bad2f972f2a423ca78">
-        <source>JSON extension is not loaded</source>
-        <target>JSON extension is not loaded</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:100</note>
+      <trans-unit id="9fca14e649c0c0615185b971b85b4348">
+        <source>http://doc.prestashop.com/display/PS17/Installing+PrestaShop</source>
+        <target>http://doc.prestashop.com/display/PS17/Installing+PrestaShop</target>
+        <note>Line: 369
+Comment: Link to translated documentation (if available)</note>
       </trans-unit>
-      <trans-unit id="8e36201b3398a5af1e571037b16cb7cc">
-        <source>PHP OpenSSL extension is not loaded</source>
-        <target>PHP OpenSSL extension is not loaded</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:101</note>
+      <trans-unit id="2a173fecdfb07ae87233530178309208">
+        <source>https://www.youtube.com/watch?v=cANFwuJqdgM</source>
+        <target>https://www.youtube.com/watch?v=cANFwuJqdgM</target>
+        <note>Line: 380
+Comment: Link to localized video tutorial (if available)</note>
       </trans-unit>
-      <trans-unit id="0e359a480284508d7d9c7a90a9c94b57">
-        <source>PDO MySQL extension is not loaded</source>
-        <target>PDO MySQL extension is not loaded</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:102</note>
+      <trans-unit id="ff029af54cc9cb942c8fce1a59663cb6">
+        <source>https://addons.prestashop.com/en/388-support</source>
+        <target>https://addons.prestashop.com/en/388-support</target>
+        <note>Line: 391
+Comment: Link to support on addons</note>
       </trans-unit>
-      <trans-unit id="f37d70acdd46c99aa2738a9b9c6a4484">
-        <source>SimpleXML extension is not loaded</source>
-        <target>SimpleXML extension is not loaded</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:103</note>
+      <trans-unit id="bef52e1b984549863546726aae19ffba">
+        <source>http://www.prestashop.com/forums/</source>
+        <target>http://www.prestashop.com/forums/</target>
+        <note>Line: 402
+Comment: Link to localized forum</note>
       </trans-unit>
-      <trans-unit id="88ab0c1cce0f8be93e9cef2d42d47f97">
-        <source>ZIP extension is not enabled</source>
-        <target>ZIP extension is not enabled</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:104</note>
+      <trans-unit id="8b867f185f486735e7be5006d903114d">
+        <source>http://www.prestashop.com/blog/</source>
+        <target>http://www.prestashop.com/blog/</target>
+        <note>Line: 412</note>
       </trans-unit>
-      <trans-unit id="110b26012a01ad5604e5b9ac39b585ba">
-        <source>Fileinfo extension is not enabled</source>
-        <target>Fileinfo extension is not enabled</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:105</note>
+      <trans-unit id="c1cd9c13737881d797b2efd168a2df8c">
+        <source>https://www.prestashop.com/en/support</source>
+        <target>https://www.prestashop.com/en/support</target>
+        <note>Line: 422</note>
       </trans-unit>
-      <trans-unit id="9985ec427b90450fffe50ef87916f316">
-        <source>Required Apache configuration</source>
-        <target>Required Apache configuration</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:109</note>
-      </trans-unit>
-      <trans-unit id="0b9193ca4af6867c1f50a07097254b62">
-        <source>Enable the Apache mod_rewrite module</source>
-        <target>Enable the Apache mod_rewrite module</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:112</note>
-      </trans-unit>
-      <trans-unit id="91f3a2c0e4424c87689525da44c4db11">
-        <source>Files</source>
-        <target>Files</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:116</note>
-      </trans-unit>
-      <trans-unit id="65c896ec6e9dd47cfc8498d0554e50ae">
-        <source>Not all files were successfully uploaded on your server</source>
-        <target>Not all files were successfully uploaded on your server</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:119</note>
-      </trans-unit>
-      <trans-unit id="0b7a9eb57523a26174e9ba358ced79a6">
-        <source>Permissions on files and folders</source>
-        <target>Permissions on files and folders</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:123</note>
-      </trans-unit>
-      <trans-unit id="9fa7c3c4ae8d448c7536e98947b51d75">
-        <source>Recursive write permissions for %user% user on %folder%</source>
-        <target>Recursive write permissions for %user% user on %folder%</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:137</note>
-      </trans-unit>
-      <trans-unit id="4b3fafb5b9b053c5d3d39d5af60a5154">
-        <source>Write permissions for %user% user on %folder%</source>
-        <target>Write permissions for %user% user on %folder%</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:139</note>
-      </trans-unit>
-      <trans-unit id="cae2fd0d1edf2730523324e86f4113d0">
-        <source>Recommended PHP parameters</source>
-        <target>Recommended PHP parameters</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:145</note>
-      </trans-unit>
-      <trans-unit id="5b845252f12353a62a52a120f1613f1c">
-        <source>GZIP compression is not activated</source>
-        <target>GZIP compression is not activated</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:148</note>
-      </trans-unit>
-      <trans-unit id="250ca84e0a4b02ebcfe7b99dfba30f00">
-        <source>Mbstring extension is not enabled</source>
-        <target>Mbstring extension is not enabled</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:149</note>
-      </trans-unit>
-      <trans-unit id="14bab7de5cc2553ed7686416eda1b1dd">
-        <source>Dom extension is not loaded</source>
-        <target>Dom extension is not loaded</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:150</note>
-      </trans-unit>
-      <trans-unit id="a69c52258e44151f43f0d4bf17526d3e">
-        <source>Cannot open external URLs (requires allow_url_fopen as On)</source>
-        <target>Cannot open external URLs (requires allow_url_fopen as On)</target>
-        <note>Context:
-File: install-dev/controllers/http/system.php:151</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/controllers/http/process.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cdc5a0619e8dadc368c1d5feb2d83986">
-        <source>Create file parameters</source>
-        <target>Create file parameters</target>
-        <note>Context:
-File: install-dev/controllers/http/process.php:306
- Comment: We fill the process step used for Ajax queries</note>
-      </trans-unit>
-      <trans-unit id="0b1b557a66c34f8467d364c5f6ac36a5">
-        <source>Create database tables</source>
-        <target>Create database tables</target>
-        <note>Context:
-File: install-dev/controllers/http/process.php:307</note>
-      </trans-unit>
-      <trans-unit id="22242e741d52f57289ac8b72b9e8c96d">
-        <source>Create default shop and languages</source>
-        <target>Create default shop and languages</target>
-        <note>Context:
-File: install-dev/controllers/http/process.php:308</note>
-      </trans-unit>
-      <trans-unit id="33f1b48d4dac0408b87bb952b6b0799f">
-        <source>Populate database tables</source>
-        <target>Populate database tables</target>
-        <note>Context:
-File: install-dev/controllers/http/process.php:311
- Comment: If low memory or big fixtures, create subtasks for populateDatabase step (entity per entity)</note>
-      </trans-unit>
-      <trans-unit id="039c15f5a6879d4a65fb0f67f8f90f09">
-        <source>Configure shop information</source>
-        <target>Configure shop information</target>
-        <note>Context:
-File: install-dev/controllers/http/process.php:323</note>
-      </trans-unit>
-      <trans-unit id="23de8b7f5abcac68c426e405975411bb">
-        <source>Install demonstration data</source>
-        <target>Install demonstration data</target>
-        <note>Context:
-File: install-dev/controllers/http/process.php:326</note>
-      </trans-unit>
-      <trans-unit id="e819ad111fcd4023d34b419946936265">
-        <source>Install modules</source>
-        <target>Install modules</target>
-        <note>Context:
-File: install-dev/controllers/http/process.php:340</note>
-      </trans-unit>
-      <trans-unit id="fe931ab87bd95a63a886c40e311ab838">
-        <source>Install Addons modules</source>
-        <target>Install Addons modules</target>
-        <note>Context:
-File: install-dev/controllers/http/process.php:348</note>
-      </trans-unit>
-      <trans-unit id="7ad8960b5505289cf368e247f7ac72ef">
-        <source>Install theme</source>
-        <target>Install theme</target>
-        <note>Context:
-File: install-dev/controllers/http/process.php:366</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/controllers/http/database.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ebbc6b4a57ddc7935d5e230782152a28">
-        <source>Database is connected</source>
-        <target>Database is connected</target>
-        <note>Context:
-File: install-dev/controllers/http/database.php:113</note>
-      </trans-unit>
-      <trans-unit id="b5ffef0333cad914f58876eeb1e334af">
-        <source>Database is created</source>
-        <target>Database is created</target>
-        <note>Context:
-File: install-dev/controllers/http/database.php:131</note>
-      </trans-unit>
-      <trans-unit id="8532ab270c96503d3d646da3485c251a">
-        <source>Cannot create the database automatically</source>
-        <target>Cannot create the database automatically</target>
-        <note>Context:
-File: install-dev/controllers/http/database.php:131</note>
+      <trans-unit id="22ab9d3f09c6d941d171590a6c8079fd">
+        <source>http://docs.prestashop.com/display/PS16/Updating+PrestaShop</source>
+        <target>http://docs.prestashop.com/display/PS16/Updating+PrestaShop</target>
+        <note>Line: 427</note>
       </trans-unit>
     </body>
   </file>
@@ -235,97 +78,778 @@ File: install-dev/controllers/http/database.php:131</note>
       <trans-unit id="5ad366cc586498f65b4f18a9a87bb1ed">
         <source>Field required</source>
         <target>Field required</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:85</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="ab141dcb233ea3357d0a86584ff65a49">
         <source>shop name</source>
         <target>shop name</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:93</note>
+        <note>Line: 93</note>
       </trans-unit>
       <trans-unit id="96f52200c7a597ff32a0bb66f794d183">
         <source>The field %field% is limited to %limit% characters</source>
         <target>The field %field% is limited to %limit% characters</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:106</note>
+        <note>Line: 106</note>
       </trans-unit>
       <trans-unit id="342f5c77ed008542e78094607ce1f7f3">
         <source>firstname</source>
         <target>firstname</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:100</note>
+        <note>Line: 100</note>
       </trans-unit>
       <trans-unit id="2399cf4ca7b49f2706f6e147a32efa78">
         <source>Your lastname contains some invalid characters</source>
         <target>Your lastname contains some invalid characters</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:104</note>
+        <note>Line: 104</note>
       </trans-unit>
       <trans-unit id="8ad75c5a8821cc294f189181722acb56">
         <source>lastname</source>
         <target>lastname</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:106</note>
+        <note>Line: 106</note>
       </trans-unit>
       <trans-unit id="74d36cb95a84f88728b3d69678aba185">
         <source>The password and its confirmation are different</source>
         <target>The password and its confirmation are different</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:114</note>
+        <note>Line: 114</note>
       </trans-unit>
       <trans-unit id="3d282d50434c9dee33c39a09d5283406">
         <source>This e-mail address is invalid</source>
         <target>This e-mail address is invalid</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:120</note>
+        <note>Line: 120</note>
       </trans-unit>
       <trans-unit id="316ec028b21331289425813b583e4b8f">
         <source>Image folder %s is not writable</source>
         <target>Image folder %s is not writable</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:158</note>
+        <note>Line: 158</note>
       </trans-unit>
       <trans-unit id="aa2154c174605e6c5bae0daa7ea56352">
         <source>An error occurred during logo copy.</source>
         <target>An error occurred during logo copy.</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:168</note>
+        <note>Line: 168</note>
       </trans-unit>
       <trans-unit id="6b6ab7122be1b8361066f56eed537aab">
         <source>An error occurred during logo upload.</source>
         <target>An error occurred during logo upload.</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:175</note>
+        <note>Line: 175</note>
       </trans-unit>
       <trans-unit id="496d2fd133e6dd3ffcf1d92b77807751">
         <source>Sports and Entertainment</source>
         <target>Sports and Entertainment</target>
-        <note>Context:
-File: install-dev/controllers/http/configure.php:263</note>
+        <note>Line: 263</note>
+      </trans-unit>
+      <trans-unit id="989a45a4ca01ee222f4370172bf8850d">
+        <source>Invalid shop name</source>
+        <target>Invalid shop name</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="68499acecfba9d3bf0ca8711f300d3ed">
+        <source>Your firstname contains some invalid characters</source>
+        <target>Your firstname contains some invalid characters</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="89605cda87edd2daeebbe3534b7beb0d">
+        <source>The password is incorrect (must be alphanumeric string with at least 8 characters)</source>
+        <target>The password is incorrect (must be alphanumeric string with at least 8 characters)</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/controllers/http/database.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ebbc6b4a57ddc7935d5e230782152a28">
+        <source>Database is connected</source>
+        <target>Database is connected</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="b5ffef0333cad914f58876eeb1e334af">
+        <source>Database is created</source>
+        <target>Database is created</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="8532ab270c96503d3d646da3485c251a">
+        <source>Cannot create the database automatically</source>
+        <target>Cannot create the database automatically</target>
+        <note>Line: 131</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/controllers/http/process.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cdc5a0619e8dadc368c1d5feb2d83986">
+        <source>Create file parameters</source>
+        <target>Create file parameters</target>
+        <note>Line: 306
+Comment: We fill the process step used for Ajax queries</note>
+      </trans-unit>
+      <trans-unit id="0b1b557a66c34f8467d364c5f6ac36a5">
+        <source>Create database tables</source>
+        <target>Create database tables</target>
+        <note>Line: 307</note>
+      </trans-unit>
+      <trans-unit id="22242e741d52f57289ac8b72b9e8c96d">
+        <source>Create default shop and languages</source>
+        <target>Create default shop and languages</target>
+        <note>Line: 308</note>
+      </trans-unit>
+      <trans-unit id="33f1b48d4dac0408b87bb952b6b0799f">
+        <source>Populate database tables</source>
+        <target>Populate database tables</target>
+        <note>Line: 311
+Comment: If low memory or big fixtures, create subtasks for populateDatabase step (entity per entity)</note>
+      </trans-unit>
+      <trans-unit id="039c15f5a6879d4a65fb0f67f8f90f09">
+        <source>Configure shop information</source>
+        <target>Configure shop information</target>
+        <note>Line: 323</note>
+      </trans-unit>
+      <trans-unit id="23de8b7f5abcac68c426e405975411bb">
+        <source>Install demonstration data</source>
+        <target>Install demonstration data</target>
+        <note>Line: 326</note>
+      </trans-unit>
+      <trans-unit id="e819ad111fcd4023d34b419946936265">
+        <source>Install modules</source>
+        <target>Install modules</target>
+        <note>Line: 340</note>
+      </trans-unit>
+      <trans-unit id="fe931ab87bd95a63a886c40e311ab838">
+        <source>Install Addons modules</source>
+        <target>Install Addons modules</target>
+        <note>Line: 348</note>
+      </trans-unit>
+      <trans-unit id="7ad8960b5505289cf368e247f7ac72ef">
+        <source>Install theme</source>
+        <target>Install theme</target>
+        <note>Line: 366</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/controllers/http/system.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5a0f8c7d1f0c12dd0d41abe3b5b6e29d">
+        <source>Required PHP parameters</source>
+        <target>Required PHP parameters</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="8e5a027b55c03eddcbe0209009f831c8">
+        <source>PHP 5.6 or later is not enabled</source>
+        <target>PHP 5.6 or later is not enabled</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="6619b8629c4ea12c29f929402071ddf1">
+        <source>Cannot upload files</source>
+        <target>Cannot upload files</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="077486357155a0ea1d3d24a534625020">
+        <source>Cannot create new files and folders</source>
+        <target>Cannot create new files and folders</target>
+        <note>Line: 97</note>
+      </trans-unit>
+      <trans-unit id="8edddbd91415fa92ce68a7601116e39d">
+        <source>cURL extension is not enabled</source>
+        <target>cURL extension is not enabled</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="d482b958dcd96bf9219f5039afae2dde">
+        <source>GD library is not installed</source>
+        <target>GD library is not installed</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="53451c05d2a863bad2f972f2a423ca78">
+        <source>JSON extension is not loaded</source>
+        <target>JSON extension is not loaded</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="8e36201b3398a5af1e571037b16cb7cc">
+        <source>PHP OpenSSL extension is not loaded</source>
+        <target>PHP OpenSSL extension is not loaded</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="0e359a480284508d7d9c7a90a9c94b57">
+        <source>PDO MySQL extension is not loaded</source>
+        <target>PDO MySQL extension is not loaded</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="f37d70acdd46c99aa2738a9b9c6a4484">
+        <source>SimpleXML extension is not loaded</source>
+        <target>SimpleXML extension is not loaded</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="88ab0c1cce0f8be93e9cef2d42d47f97">
+        <source>ZIP extension is not enabled</source>
+        <target>ZIP extension is not enabled</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="110b26012a01ad5604e5b9ac39b585ba">
+        <source>Fileinfo extension is not enabled</source>
+        <target>Fileinfo extension is not enabled</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="9985ec427b90450fffe50ef87916f316">
+        <source>Required Apache configuration</source>
+        <target>Required Apache configuration</target>
+        <note>Line: 109</note>
+      </trans-unit>
+      <trans-unit id="0b9193ca4af6867c1f50a07097254b62">
+        <source>Enable the Apache mod_rewrite module</source>
+        <target>Enable the Apache mod_rewrite module</target>
+        <note>Line: 112</note>
+      </trans-unit>
+      <trans-unit id="91f3a2c0e4424c87689525da44c4db11">
+        <source>Files</source>
+        <target>Files</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="65c896ec6e9dd47cfc8498d0554e50ae">
+        <source>Not all files were successfully uploaded on your server</source>
+        <target>Not all files were successfully uploaded on your server</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="0b7a9eb57523a26174e9ba358ced79a6">
+        <source>Permissions on files and folders</source>
+        <target>Permissions on files and folders</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="9fa7c3c4ae8d448c7536e98947b51d75">
+        <source>Recursive write permissions for %user% user on %folder%</source>
+        <target>Recursive write permissions for %user% user on %folder%</target>
+        <note>Line: 137</note>
+      </trans-unit>
+      <trans-unit id="4b3fafb5b9b053c5d3d39d5af60a5154">
+        <source>Write permissions for %user% user on %folder%</source>
+        <target>Write permissions for %user% user on %folder%</target>
+        <note>Line: 139</note>
+      </trans-unit>
+      <trans-unit id="cae2fd0d1edf2730523324e86f4113d0">
+        <source>Recommended PHP parameters</source>
+        <target>Recommended PHP parameters</target>
+        <note>Line: 145</note>
+      </trans-unit>
+      <trans-unit id="5b845252f12353a62a52a120f1613f1c">
+        <source>GZIP compression is not activated</source>
+        <target>GZIP compression is not activated</target>
+        <note>Line: 148</note>
+      </trans-unit>
+      <trans-unit id="250ca84e0a4b02ebcfe7b99dfba30f00">
+        <source>Mbstring extension is not enabled</source>
+        <target>Mbstring extension is not enabled</target>
+        <note>Line: 149</note>
+      </trans-unit>
+      <trans-unit id="14bab7de5cc2553ed7686416eda1b1dd">
+        <source>Dom extension is not loaded</source>
+        <target>Dom extension is not loaded</target>
+        <note>Line: 150</note>
+      </trans-unit>
+      <trans-unit id="a69c52258e44151f43f0d4bf17526d3e">
+        <source>Cannot open external URLs (requires allow_url_fopen as On)</source>
+        <target>Cannot open external URLs (requires allow_url_fopen as On)</target>
+        <note>Line: 151</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/theme/views/configure.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c075a7d57ac5f08683a1a0a1d3425e94">
+        <source>Information about your Store</source>
+        <target>Information about your Store</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="e93c33bd1341ab74195430daeb63db13">
+        <source>Shop name</source>
+        <target>Shop name</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="98360f1ae89a205da2d571f1503729db">
+        <source>Main activity</source>
+        <target>Main activity</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="eebdd5f4803a884624a2d99b16c783a4">
+        <source>Please choose your main activity</source>
+        <target>Please choose your main activity</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="bc350ae6b31fefb88adaee19a9f4e912">
+        <source>Other activity...</source>
+        <target>Other activity...</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="038b579adc8560b4903395edc67c580b">
+        <source>Help us learn more about your store so we can offer you optimal guidance and the best features for your business!</source>
+        <target>Help us learn more about your store so we can offer you optimal guidance and the best features for your business!</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="87b616fe8f0a5ee54271f2eae643c069">
+        <source>Install demo products</source>
+        <target>Install demo products</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="93cba07454f06a4a960172bbd6e2a435">
+        <source>Yes</source>
+        <target>Yes</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="bafd7322c6e97d25b6299b5d6fe8920b">
+        <source>No</source>
+        <target>No</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="75b105f67d0774e4bb7b69de06d20dbb">
+        <source>Demo products are a good way to learn how to use PrestaShop. You should install them if you are not familiar with it.</source>
+        <target>Demo products are a good way to learn how to use PrestaShop. You should install them if you are not familiar with it.</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="59716c97497eb9694541f7c3d37b1a4d">
+        <source>Country</source>
+        <target>Country</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="a7bb58222222b064f0721e6e0fe4c486">
+        <source>Select your country</source>
+        <target>Select your country</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="65d03d6bab79cbe2135c384592e70715">
+        <source>Shop timezone</source>
+        <target>Shop timezone</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="5a9d7616b5690c569919362f77dc9ec5">
+        <source>Select your timezone</source>
+        <target>Select your timezone</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="97e0d62d1db5473366dd6e7ebd56f596">
+        <source>Shop logo</source>
+        <target>Shop logo</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="65ff4245dba0a751bdd9f2530cb8788b">
+        <source>Optional - You can add you logo at a later time.</source>
+        <target>Optional - You can add you logo at a later time.</target>
+        <note>Line: 118</note>
+      </trans-unit>
+      <trans-unit id="a0623b78a5f2cfe415d9dbbd4428ea40">
+        <source>Your Account</source>
+        <target>Your Account</target>
+        <note>Line: 127</note>
+      </trans-unit>
+      <trans-unit id="20db0bfeecd8fe60533206a2b5e9891a">
+        <source>First name</source>
+        <target>First name</target>
+        <note>Line: 131</note>
+      </trans-unit>
+      <trans-unit id="8d3f5eff9c40ee315d452392bed5309b">
+        <source>Last name</source>
+        <target>Last name</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="8b5dd64ab8d0b8158906796b53a200e2">
+        <source>E-mail address</source>
+        <target>E-mail address</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="a838dd011a3bb99084a43912a71cdc46">
+        <source>This email address will be your username to access your store's back office.</source>
+        <target>This email address will be your username to access your store's back office.</target>
+        <note>Line: 156</note>
+      </trans-unit>
+      <trans-unit id="ecb77be87bda4dd34d51cfedbef9b6c3">
+        <source>Shop password</source>
+        <target>Shop password</target>
+        <note>Line: 162</note>
+      </trans-unit>
+      <trans-unit id="af2d11e28485cf3841ea367fdcdb4713">
+        <source>Must be at least 8 characters</source>
+        <target>Must be at least 8 characters</target>
+        <note>Line: 170</note>
+      </trans-unit>
+      <trans-unit id="540155f9adc935c8f3a9d8a77beb8860">
+        <source>Re-type to confirm</source>
+        <target>Re-type to confirm</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="6794fece26df4610c0523bffd7a45231">
+        <source><![CDATA[All information you give us is collected by us and is subject to data processing and statistics, it is necessary for the members of the PrestaShop company in order to respond to your requests. Your personal data may be communicated to service providers and partners as part of partner relationships. Under the current "Act on Data Processing, Data Files and Individual Liberties" you have the right to access, rectify and oppose to the processing of your personal data through this <a href="%s" onclick="return !window.open(this.href)">link</a>.]]></source>
+        <target><![CDATA[All information you give us is collected by us and is subject to data processing and statistics, it is necessary for the members of the PrestaShop company in order to respond to your requests. Your personal data may be communicated to service providers and partners as part of partner relationships. Under the current "Act on Data Processing, Data Files and Individual Liberties" you have the right to access, rectify and oppose to the processing of your personal data through this <a href="%s" onclick="return !window.open(this.href)">link</a>.]]></target>
+        <note>Line: 184</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/theme/views/database.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b66ad3bc67c20939fb6f5c8f866ce366">
+        <source>Configure your database by filling out the following fields</source>
+        <target>Configure your database by filling out the following fields</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="74987401b3b33cc9542cd8585c08de98">
+        <source><![CDATA[To use PrestaShop, you must <a href="http://doc.prestashop.com/display/PS16/Installing+PrestaShop#InstallingPrestaShop-Creatingadatabaseforyourshop" target="_blank">create a database</a> to collect all of your store's data-related activities.]]></source>
+        <target><![CDATA[To use PrestaShop, you must <a href="http://doc.prestashop.com/display/PS16/Installing+PrestaShop#InstallingPrestaShop-Creatingadatabaseforyourshop" target="_blank">create a database</a> to collect all of your store's data-related activities.]]></target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="3b4db494bf9473e98bf8106d3fb381a7">
+        <source>Please complete the fields below in order for PrestaShop to connect to your database.</source>
+        <target>Please complete the fields below in order for PrestaShop to connect to your database.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="52a372f1b2b0ce0f9a3789a9ae9e6ef8">
+        <source>Database server address</source>
+        <target>Database server address</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="bc4b85255c14de3bf09748a093c63529">
+        <source>The default port is 3306. To use a different port, add the port number at the end of your server's address i.e ":4242".</source>
+        <target>The default port is 3306. To use a different port, add the port number at the end of your server's address i.e ":4242".</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="9e362f7bde93fb1a52dea86534d5be9c">
+        <source>Database name</source>
+        <target>Database name</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="4ed2e481694680d735fa1d9b47a27822">
+        <source>Database login</source>
+        <target>Database login</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="60f5beb4715bf84676dfc7ac7f3649da">
+        <source>Database password</source>
+        <target>Database password</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="d07e3cfba4c070cf15423fd0462ba6b9">
+        <source>Database Engine</source>
+        <target>Database Engine</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="8eb2ccdf1b2566fb1ce7fe1545dadbe1">
+        <source>Tables prefix</source>
+        <target>Tables prefix</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="9b8fe6ffb270752db0cffd410e5a7aa2">
+        <source>Drop existing tables (mode dev)</source>
+        <target>Drop existing tables (mode dev)</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="4a8b0cfe8f2ecd6b3b34b2ed853f02a8">
+        <source>Test your database connection now!</source>
+        <target>Test your database connection now!</target>
+        <note>Line: 74</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/theme/views/footer.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55">
+        <source>Next</source>
+        <target>Next</target>
+        <note>Line: 9</note>
+      </trans-unit>
+      <trans-unit id="0557fa923dcee4d0f86b1409f5c2167f">
+        <source>Back</source>
+        <target>Back</target>
+        <note>Line: 14</note>
+      </trans-unit>
+      <trans-unit id="51743fbddca2031100b6145fd5b06f52">
+        <source><![CDATA[If you need some assistance, you can <a href="%help%" onclick="return !window.open(this.href);">get tailored help</a> from our support team. <a href="%doc%" onclick="return !window.open(this.href);">The official documentation</a> is also here to guide you.]]></source>
+        <target><![CDATA[If you need some assistance, you can <a href="%help%" onclick="return !window.open(this.href);">get tailored help</a> from our support team. <a href="%doc%" onclick="return !window.open(this.href);">The official documentation</a> is also here to guide you.]]></target>
+        <note>Line: 19</note>
+      </trans-unit>
+      <trans-unit id="92042416ac115fb6dd71a9f09c711625">
+        <source>Official forum</source>
+        <target>Official forum</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="02d4482d332e1aef3437cd61c9bcc624">
+        <source>Contact us</source>
+        <target>Contact us</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="db5eb84117d06047c97c9a0191b5fffe">
+        <source>Support</source>
+        <target>Support</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="5b6cf869265c13af8566f192b4ab3d2a">
+        <source>Documentation</source>
+        <target>Documentation</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/theme/views/header.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5baf40a1b7c7500b92aff1c73d88a579">
+        <source>PrestaShop Installation Assistant</source>
+        <target>PrestaShop Installation Assistant</target>
+        <note>Line: 4</note>
+      </trans-unit>
+      <trans-unit id="e6a7f8a2f42cc35979973da8dfb10720">
+        <source>Forum</source>
+        <target>Forum</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="be8df1f28c0abc85a0ed0c6860e5d832">
+        <source>Blog</source>
+        <target>Blog</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="83b14f196cda2257c76ef2fa682893ca">
+        <source>Contact us!</source>
+        <target>Contact us!</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="301fedbe35369c411966a9e6a396ee95">
+        <source>Installation Assistant</source>
+        <target>Installation Assistant</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="bf66566854c3a0177681632a7839105d">
+        <source>To install PrestaShop, you need to have JavaScript enabled in your browser.</source>
+        <target>To install PrestaShop, you need to have JavaScript enabled in your browser.</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="9d90b6827ed904399354488b99074a4b">
+        <source>https://enable-javascript.com/</source>
+        <target>https://enable-javascript.com/</target>
+        <note>Line: 96</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/theme/views/license.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dea48ade3500772702e1fc82c6b0e7a2">
+        <source>License Agreements</source>
+        <target>License Agreements</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="0ac0a81ca1509342742c589072f5c235">
+        <source>To enjoy the many features that are offered for free by PrestaShop, please read the license terms below. PrestaShop core is licensed under OSL 3.0, while the modules and themes are licensed under AFL 3.0.</source>
+        <target>To enjoy the many features that are offered for free by PrestaShop, please read the license terms below. PrestaShop core is licensed under OSL 3.0, while the modules and themes are licensed under AFL 3.0.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="8de3e515f8a43bf8de5d2ae37a7d6c42">
+        <source>I agree to the above terms and conditions.</source>
+        <target>I agree to the above terms and conditions.</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="7df3195a4bfdf4456ec2d51c8559bb17">
+        <source>I agree to participate in improving the solution by sending anonymous information about my configuration.</source>
+        <target>I agree to participate in improving the solution by sending anonymous information about my configuration.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/theme/views/process.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3de52109c609784f2e4a28d0e9fdb97">
+        <source>Done!</source>
+        <target>Done!</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="1f8fed56213622fdd4444d8707440ef6">
+        <source>An error occurred during installation...</source>
+        <target>An error occurred during installation...</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="6a44fd63f5cc2e5d0565d4c106280a3c">
+        <source><![CDATA[You can use the links on the left column to go back to the previous steps, or restart the installation process by <a href="%link%">clicking here</a>.]]></source>
+        <target><![CDATA[You can use the links on the left column to go back to the previous steps, or restart the installation process by <a href="%link%">clicking here</a>.]]></target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="7f3475513f7ba2a7c36fb507d60db6a5">
+        <source>Your installation is finished!</source>
+        <target>Your installation is finished!</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="95d8b8f9b89717f8e58b5e9df21eab6b">
+        <source>You have just finished installing your shop. Thank you for using PrestaShop!</source>
+        <target>You have just finished installing your shop. Thank you for using PrestaShop!</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="08c51a1149fb9402773557f678cad130">
+        <source>Please remember your login information:</source>
+        <target>Please remember your login information:</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="1e884e3078d9978e216a027ecd57fb34">
+        <source>E-mail</source>
+        <target>E-mail</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="638c31b20cf4a67654c049ca9cf92a99">
+        <source>Print my login information</source>
+        <target>Print my login information</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="dc647eb65e6711e155375218212b3964">
+        <source>Password</source>
+        <target>Password</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="b9987a246a537f4fe86f1f2e3d10dbdb">
+        <source>Display</source>
+        <target>Display</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="1725f045dbcb8e6e77a7ade8c476a879">
+        <source>For security purposes, you must delete the "install" folder.</source>
+        <target>For security purposes, you must delete the "install" folder.</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="c9cb297f6c4491751bc2849409e37535">
+        <source>http://doc.prestashop.com/display/PS17/Installing+PrestaShop#InstallingPrestaShop-Completingtheinstallation</source>
+        <target>http://doc.prestashop.com/display/PS17/Installing+PrestaShop#InstallingPrestaShop-Completingtheinstallation</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="eed2839c1e3e5f7069ed03b2f6d4c6dd">
+        <source>Back Office</source>
+        <target>Back Office</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="450abc1417292c60121dd3dfde9c9b23">
+        <source>Manage your store using your Back Office. Manage your orders and customers, add modules, change themes, etc.</source>
+        <target>Manage your store using your Back Office. Manage your orders and customers, add modules, change themes, etc.</target>
+        <note>Line: 93</note>
+      </trans-unit>
+      <trans-unit id="39b5e23e409fa9f6f67e984c1bedf6ae">
+        <source>Manage your store</source>
+        <target>Manage your store</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="0558c4724c1321605189662a0e3f66f6">
+        <source>Front Office</source>
+        <target>Front Office</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="f3669ee3bb5b38eebcb9d619511ff771">
+        <source>Discover your store as your future customers will see it!</source>
+        <target>Discover your store as your future customers will see it!</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="d502268208857835192e375383bd1a94">
+        <source>Discover your store</source>
+        <target>Discover your store</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="643d415c09f1eae4e639af61cf01079e">
+        <source>Share your experience with your friends!</source>
+        <target>Share your experience with your friends!</target>
+        <note>Line: 109</note>
+      </trans-unit>
+      <trans-unit id="3090d414525dcb37e3f8a14b94453a26">
+        <source>I just built an online store with PrestaShop!</source>
+        <target>I just built an online store with PrestaShop!</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="eb0fec563c30847715617ad08218ccfd">
+        <source>Watch this exhilarating experience: http://vimeo.com/89298199</source>
+        <target>Watch this exhilarating experience: http://vimeo.com/89298199</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="3746d4aa96f19672260a424d76729dd1">
+        <source>Tweet</source>
+        <target>Tweet</target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="5a95a425f74314a96f13a2f136992178">
+        <source>Share</source>
+        <target>Share</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="5b2c8bfd1bc974966209b7be1cb51a72">
+        <source>Google+</source>
+        <target>Google+</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="86709a608bd914b28221164e6680ebf7">
+        <source>Pinterest</source>
+        <target>Pinterest</target>
+        <note>Line: 120</note>
+      </trans-unit>
+      <trans-unit id="e884c507c5198a4578a84498f7a323e2">
+        <source>LinkedIn</source>
+        <target>LinkedIn</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="ea4384b22e2a5e24600efedd7b0bc09a">
+        <source>Check out PrestaShop Addons to add that little something extra to your store!</source>
+        <target>Check out PrestaShop Addons to add that little something extra to your store!</target>
+        <note>Line: 130</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/theme/views/system.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ec71bc993640f8f32baa7e64c78d53b2">
+        <source>We are currently checking PrestaShop compatibility with your system environment</source>
+        <target>We are currently checking PrestaShop compatibility with your system environment</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="4f169bcfd81c2ab2d6b49883160d70c7">
+        <source><![CDATA[If you have any questions, please visit our <a href="%doc%" target="_blank">documentation</a> and <a href="%forum%" target="_blank">community forum</a>.]]></source>
+        <target><![CDATA[If you have any questions, please visit our <a href="%doc%" target="_blank">documentation</a> and <a href="%forum%" target="_blank">community forum</a>.]]></target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="156f1b458dd064de3dde4b69f03d89f9">
+        <source>PrestaShop compatibility with your system environment has been verified!</source>
+        <target>PrestaShop compatibility with your system environment has been verified!</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="133732c8a39c2002228f938d06768531">
+        <source>Oops! Please correct the item(s) below, and then click "Refresh information" to test the compatibility of your new system.</source>
+        <target>Oops! Please correct the item(s) below, and then click "Refresh information" to test the compatibility of your new system.</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="63a6a88c066880c5ac42394a22803ca6">
+        <source>Refresh</source>
+        <target>Refresh</target>
+        <note>Line: 51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="install-dev/theme/views/welcome.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d51066397d7cbedc122457c9479f6fb2">
+        <source>PrestaShop requires at least 32 MB of memory to run: please check the memory_limit directive in your php.ini file or contact your host provider about this.</source>
+        <target>PrestaShop requires at least 32 MB of memory to run: please check the memory_limit directive in your php.ini file or contact your host provider about this.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="c8c27951cbaf7da257e6af50a6fc4116">
+        <source><![CDATA[<b>Warning: You cannot use this tool to upgrade your store anymore.</b><br /><br />You already have <b>PrestaShop version %version% installed</b>.<br /><br />If you want to upgrade to the latest version, please read our documentation: <a href="%doc%">%doc%</a>]]></source>
+        <target><![CDATA[<b>Warning: You cannot use this tool to upgrade your store anymore.</b><br /><br />You already have <b>PrestaShop version %version% installed</b>.<br /><br />If you want to upgrade to the latest version, please read our documentation: <a href="%doc%">%doc%</a>]]></target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="bcc5d67b4832784ca5e4f09a40b28bb2">
+        <source>Welcome to the PrestaShop %version% Installer</source>
+        <target>Welcome to the PrestaShop %version% Installer</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="78a57ffff28849e5627e564bc055acea">
+        <source>Installing PrestaShop is quick and easy. In just a few moments, you will become part of a community consisting of more than 250,000 merchants. You are on the way to creating your own unique online store that you can manage easily every day.</source>
+        <target>Installing PrestaShop is quick and easy. In just a few moments, you will become part of a community consisting of more than 250,000 merchants. You are on the way to creating your own unique online store that you can manage easily every day.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="d9b205f1e80dee567296d14611add4a2">
+        <source><![CDATA[If you need help, do not hesitate to <a href="%tutoriellink%" target="_blank">watch this short tutorial</a>, or check <a href="%linkdoc%" target="_blank">our documentation</a>.]]></source>
+        <target><![CDATA[If you need help, do not hesitate to <a href="%tutoriellink%" target="_blank">watch this short tutorial</a>, or check <a href="%linkdoc%" target="_blank">our documentation</a>.]]></target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="edbaa44341f3064baa5a5676aabc91e5">
+        <source>Continue the installation in:</source>
+        <target>Continue the installation in:</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="239e971a06ff313e2b8aafa9b51286c9">
+        <source>The language selection above only applies to the Installation Assistant. Once your store is installed, you can choose the language of your store from over %d% translations, all for free!</source>
+        <target>The language selection above only applies to the Installation Assistant. Once your store is installed, you can choose the language of your store from over %d% translations, all for free!</target>
+        <note>Line: 56</note>
       </trans-unit>
     </body>
   </file>
   <file original="modules/autoupgrade/classes/UpgradePage.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="989a45a4ca01ee222f4370172bf8850d">
-        <source>Invalid shop name</source>
-        <target>Invalid shop name</target>
-        <note>Context:
-File: modules/autoupgrade/classes/UpgradePage.php:413</note>
-      </trans-unit>
-      <trans-unit id="68499acecfba9d3bf0ca8711f300d3ed">
-        <source>Your firstname contains some invalid characters</source>
-        <target>Your firstname contains some invalid characters</target>
-        <note>Context:
-File: modules/autoupgrade/classes/UpgradePage.php:412</note>
-      </trans-unit>
-      <trans-unit id="89605cda87edd2daeebbe3534b7beb0d">
-        <source>The password is incorrect (must be alphanumeric string with at least 8 characters)</source>
-        <target>The password is incorrect (must be alphanumeric string with at least 8 characters)</target>
-        <note>Context:
-File: modules/autoupgrade/classes/UpgradePage.php:391</note>
-      </trans-unit>
       <trans-unit id="7d72600fcff52fb3a2d2f73572117311">
         <source>Your database server does not support the utf-8 charset.</source>
         <target>Your database server does not support the utf-8 charset.</target>
@@ -339,810 +863,107 @@ File: modules/autoupgrade/classes/UpgradePage.php:414</note>
       <trans-unit id="21084da7c0a49b229bd7f905e93d4aaa">
         <source>Lingerie and Adult</source>
         <target>Lingerie and Adult</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:113</note>
+        <note>Line: 154</note>
       </trans-unit>
       <trans-unit id="0fe4ca3df29658482098bb33a2ff66e5">
         <source>Animals and Pets</source>
         <target>Animals and Pets</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:99</note>
+        <note>Line: 140</note>
       </trans-unit>
       <trans-unit id="9e4359f35054190eba36e09466e39d01">
         <source>Art and Culture</source>
         <target>Art and Culture</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:100</note>
+        <note>Line: 141</note>
       </trans-unit>
       <trans-unit id="066cd752c82ddc6231a9723b5822a945">
         <source>Babies</source>
         <target>Babies</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:101</note>
+        <note>Line: 142</note>
       </trans-unit>
       <trans-unit id="41a081c3f3042ac40117cf295350870d">
         <source>Beauty and Personal Care</source>
         <target>Beauty and Personal Care</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:102</note>
+        <note>Line: 143</note>
       </trans-unit>
       <trans-unit id="f2b545a8abb14f8706f808a79277c061">
         <source>Cars</source>
         <target>Cars</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:103</note>
+        <note>Line: 144</note>
       </trans-unit>
       <trans-unit id="39bb2fdc532f8984d8348863c86ebfca">
         <source>Computer Hardware and Software</source>
         <target>Computer Hardware and Software</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:104</note>
+        <note>Line: 145</note>
       </trans-unit>
       <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d">
         <source>Download</source>
         <target>Download</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:105</note>
+        <note>Line: 146</note>
       </trans-unit>
       <trans-unit id="8bdd8b2357d516da5b81eb16746ba9a9">
         <source>Fashion and accessories</source>
         <target>Fashion and accessories</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:106</note>
+        <note>Line: 147</note>
       </trans-unit>
       <trans-unit id="33cb31c5505618a808d3bcd7490a793c">
         <source>Flowers, Gifts and Crafts</source>
         <target>Flowers, Gifts and Crafts</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:107</note>
+        <note>Line: 148</note>
       </trans-unit>
       <trans-unit id="0570b6d9de5c37a026e69c6987fc27f6">
         <source>Food and beverage</source>
         <target>Food and beverage</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:108</note>
+        <note>Line: 149</note>
       </trans-unit>
       <trans-unit id="4b73b8913afcdf06d9f49c176306d950">
         <source>HiFi, Photo and Video</source>
         <target>HiFi, Photo and Video</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:109</note>
+        <note>Line: 150</note>
       </trans-unit>
       <trans-unit id="2e9d6500d9b2a65985a621f0f0afdeb3">
         <source>Home and Garden</source>
         <target>Home and Garden</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:110</note>
+        <note>Line: 151</note>
       </trans-unit>
       <trans-unit id="83dd3493957bcd92a37bc39111f670b8">
         <source>Home Appliances</source>
         <target>Home Appliances</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:111</note>
+        <note>Line: 152</note>
       </trans-unit>
       <trans-unit id="565631402af79df42f22a117b0d6f1a5">
         <source>Jewelry</source>
         <target>Jewelry</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:112</note>
+        <note>Line: 153</note>
       </trans-unit>
       <trans-unit id="18848d605251b3627014c6a58c14c449">
         <source>Mobile and Telecom</source>
         <target>Mobile and Telecom</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:114</note>
+        <note>Line: 155</note>
       </trans-unit>
       <trans-unit id="992a0f0542384f1ee5ef51b7cf4ae6c4">
         <source>Services</source>
         <target>Services</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:115</note>
+        <note>Line: 156</note>
       </trans-unit>
       <trans-unit id="4ef7205b13f6821177d0dbc2fb90f79e">
         <source>Shoes and accessories</source>
         <target>Shoes and accessories</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:116</note>
+        <note>Line: 157</note>
       </trans-unit>
       <trans-unit id="1fb0f99b55e6c2be35aed72ebe38c245">
         <source>Travel</source>
         <target>Travel</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:118</note>
+        <note>Line: 159</note>
       </trans-unit>
       <trans-unit id="4d0a6a9777a818ecc3b59b9a8ecd0c43">
         <source>-- Please choose your main activity --</source>
         <target>-- Please choose your main activity --</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:97</note>
+        <note>Line: 138</note>
       </trans-unit>
       <trans-unit id="9503054261b8aeed48e0a3902019b579">
         <source>Sport and Entertainment</source>
         <target>Sport and Entertainment</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php:117</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/classes/controllerHttp.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fa6724c724e5524034b09c9bbac81f07">
-        <source>Choose your language</source>
-        <target>Choose your language</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:98</note>
-      </trans-unit>
-      <trans-unit id="13e582c97044bf8680de63c6bdb41c18">
-        <source>License agreements</source>
-        <target>License agreements</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:103</note>
-      </trans-unit>
-      <trans-unit id="d13e189d15c36f1ec8ff701cce809b4d">
-        <source>System compatibility</source>
-        <target>System compatibility</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:108</note>
-      </trans-unit>
-      <trans-unit id="3aea774cdcd8f2c45549f10758a71323">
-        <source>Store information</source>
-        <target>Store information</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:113</note>
-      </trans-unit>
-      <trans-unit id="3c4e32d95f12c00d16a76057a7af18f6">
-        <source>System configuration</source>
-        <target>System configuration</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:118</note>
-      </trans-unit>
-      <trans-unit id="b68b681631a5198ce1120f9ffd06f77a">
-        <source>Store installation</source>
-        <target>Store installation</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:123</note>
-      </trans-unit>
-      <trans-unit id="9fca14e649c0c0615185b971b85b4348">
-        <source>http://doc.prestashop.com/display/PS17/Installing+PrestaShop</source>
-        <target>http://doc.prestashop.com/display/PS17/Installing+PrestaShop</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:369
- Comment: Link to translated documentation (if available)</note>
-      </trans-unit>
-      <trans-unit id="2a173fecdfb07ae87233530178309208">
-        <source>https://www.youtube.com/watch?v=cANFwuJqdgM</source>
-        <target>https://www.youtube.com/watch?v=cANFwuJqdgM</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:380
- Comment: Link to localized video tutorial (if available)</note>
-      </trans-unit>
-      <trans-unit id="ff029af54cc9cb942c8fce1a59663cb6">
-        <source>https://addons.prestashop.com/en/388-support</source>
-        <target>https://addons.prestashop.com/en/388-support</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:391
- Comment: Link to support on addons</note>
-      </trans-unit>
-      <trans-unit id="bef52e1b984549863546726aae19ffba">
-        <source>http://www.prestashop.com/forums/</source>
-        <target>http://www.prestashop.com/forums/</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:402
- Comment: Link to localized forum</note>
-      </trans-unit>
-      <trans-unit id="8b867f185f486735e7be5006d903114d">
-        <source>http://www.prestashop.com/blog/</source>
-        <target>http://www.prestashop.com/blog/</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:412</note>
-      </trans-unit>
-      <trans-unit id="c1cd9c13737881d797b2efd168a2df8c">
-        <source>https://www.prestashop.com/en/support</source>
-        <target>https://www.prestashop.com/en/support</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:422</note>
-      </trans-unit>
-      <trans-unit id="22ab9d3f09c6d941d171590a6c8079fd">
-        <source>http://docs.prestashop.com/display/PS16/Updating+PrestaShop</source>
-        <target>http://docs.prestashop.com/display/PS16/Updating+PrestaShop</target>
-        <note>Context:
-File: install-dev/classes/controllerHttp.php:427</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/theme/views/footer.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55">
-        <source>Next</source>
-        <target>Next</target>
-        <note>Context:
-File: install-dev/theme/views/footer.php:9</note>
-      </trans-unit>
-      <trans-unit id="0557fa923dcee4d0f86b1409f5c2167f">
-        <source>Back</source>
-        <target>Back</target>
-        <note>Context:
-File: install-dev/theme/views/footer.php:14</note>
-      </trans-unit>
-      <trans-unit id="51743fbddca2031100b6145fd5b06f52">
-        <source><![CDATA[If you need some assistance, you can <a href="%help%" onclick="return !window.open(this.href);">get tailored help</a> from our support team. <a href="%doc%" onclick="return !window.open(this.href);">The official documentation</a> is also here to guide you.]]></source>
-        <target><![CDATA[If you need some assistance, you can <a href="%help%" onclick="return !window.open(this.href);">get tailored help</a> from our support team. <a href="%doc%" onclick="return !window.open(this.href);">The official documentation</a> is also here to guide you.]]></target>
-        <note>Context:
-File: install-dev/theme/views/footer.php:19</note>
-      </trans-unit>
-      <trans-unit id="92042416ac115fb6dd71a9f09c711625">
-        <source>Official forum</source>
-        <target>Official forum</target>
-        <note>Context:
-File: install-dev/theme/views/footer.php:24</note>
-      </trans-unit>
-      <trans-unit id="02d4482d332e1aef3437cd61c9bcc624">
-        <source>Contact us</source>
-        <target>Contact us</target>
-        <note>Context:
-File: install-dev/theme/views/footer.php:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/theme/views/header.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="db5eb84117d06047c97c9a0191b5fffe">
-        <source>Support</source>
-        <target>Support</target>
-        <note>Context:
-File: install-dev/theme/views/header.php:38</note>
-      </trans-unit>
-      <trans-unit id="5b6cf869265c13af8566f192b4ab3d2a">
-        <source>Documentation</source>
-        <target>Documentation</target>
-        <note>Context:
-File: install-dev/theme/views/header.php:39</note>
-      </trans-unit>
-      <trans-unit id="5baf40a1b7c7500b92aff1c73d88a579">
-        <source>PrestaShop Installation Assistant</source>
-        <target>PrestaShop Installation Assistant</target>
-        <note>Context:
-File: install-dev/theme/views/header.php:4</note>
-      </trans-unit>
-      <trans-unit id="e6a7f8a2f42cc35979973da8dfb10720">
-        <source>Forum</source>
-        <target>Forum</target>
-        <note>Context:
-File: install-dev/theme/views/header.php:37</note>
-      </trans-unit>
-      <trans-unit id="be8df1f28c0abc85a0ed0c6860e5d832">
-        <source>Blog</source>
-        <target>Blog</target>
-        <note>Context:
-File: install-dev/theme/views/header.php:40</note>
-      </trans-unit>
-      <trans-unit id="83b14f196cda2257c76ef2fa682893ca">
-        <source>Contact us!</source>
-        <target>Contact us!</target>
-        <note>Context:
-File: install-dev/theme/views/header.php:76</note>
-      </trans-unit>
-      <trans-unit id="301fedbe35369c411966a9e6a396ee95">
-        <source>Installation Assistant</source>
-        <target>Installation Assistant</target>
-        <note>Context:
-File: install-dev/theme/views/header.php:86</note>
-      </trans-unit>
-      <trans-unit id="bf66566854c3a0177681632a7839105d">
-        <source>To install PrestaShop, you need to have JavaScript enabled in your browser.</source>
-        <target>To install PrestaShop, you need to have JavaScript enabled in your browser.</target>
-        <note>Context:
-File: install-dev/theme/views/header.php:95</note>
-      </trans-unit>
-      <trans-unit id="9d90b6827ed904399354488b99074a4b">
-        <source>https://enable-javascript.com/</source>
-        <target>https://enable-javascript.com/</target>
-        <note>Context:
-File: install-dev/theme/views/header.php:96</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/theme/views/system.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ec71bc993640f8f32baa7e64c78d53b2">
-        <source>We are currently checking PrestaShop compatibility with your system environment</source>
-        <target>We are currently checking PrestaShop compatibility with your system environment</target>
-        <note>Context:
-File: install-dev/theme/views/system.php:28</note>
-      </trans-unit>
-      <trans-unit id="4f169bcfd81c2ab2d6b49883160d70c7">
-        <source><![CDATA[If you have any questions, please visit our <a href="%doc%" target="_blank">documentation</a> and <a href="%forum%" target="_blank">community forum</a>.]]></source>
-        <target><![CDATA[If you have any questions, please visit our <a href="%doc%" target="_blank">documentation</a> and <a href="%forum%" target="_blank">community forum</a>.]]></target>
-        <note>Context:
-File: install-dev/theme/views/system.php:30</note>
-      </trans-unit>
-      <trans-unit id="156f1b458dd064de3dde4b69f03d89f9">
-        <source>PrestaShop compatibility with your system environment has been verified!</source>
-        <target>PrestaShop compatibility with your system environment has been verified!</target>
-        <note>Context:
-File: install-dev/theme/views/system.php:33</note>
-      </trans-unit>
-      <trans-unit id="133732c8a39c2002228f938d06768531">
-        <source>Oops! Please correct the item(s) below, and then click "Refresh information" to test the compatibility of your new system.</source>
-        <target>Oops! Please correct the item(s) below, and then click "Refresh information" to test the compatibility of your new system.</target>
-        <note>Context:
-File: install-dev/theme/views/system.php:35</note>
-      </trans-unit>
-      <trans-unit id="63a6a88c066880c5ac42394a22803ca6">
-        <source>Refresh</source>
-        <target>Refresh</target>
-        <note>Context:
-File: install-dev/theme/views/system.php:51</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/theme/views/license.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dea48ade3500772702e1fc82c6b0e7a2">
-        <source>License Agreements</source>
-        <target>License Agreements</target>
-        <note>Context:
-File: install-dev/theme/views/license.php:29</note>
-      </trans-unit>
-      <trans-unit id="0ac0a81ca1509342742c589072f5c235">
-        <source>To enjoy the many features that are offered for free by PrestaShop, please read the license terms below. PrestaShop core is licensed under OSL 3.0, while the modules and themes are licensed under AFL 3.0.</source>
-        <target>To enjoy the many features that are offered for free by PrestaShop, please read the license terms below. PrestaShop core is licensed under OSL 3.0, while the modules and themes are licensed under AFL 3.0.</target>
-        <note>Context:
-File: install-dev/theme/views/license.php:30</note>
-      </trans-unit>
-      <trans-unit id="8de3e515f8a43bf8de5d2ae37a7d6c42">
-        <source>I agree to the above terms and conditions.</source>
-        <target>I agree to the above terms and conditions.</target>
-        <note>Context:
-File: install-dev/theme/views/license.php:37</note>
-      </trans-unit>
-      <trans-unit id="7df3195a4bfdf4456ec2d51c8559bb17">
-        <source>I agree to participate in improving the solution by sending anonymous information about my configuration.</source>
-        <target>I agree to participate in improving the solution by sending anonymous information about my configuration.</target>
-        <note>Context:
-File: install-dev/theme/views/license.php:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/theme/views/process.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d3de52109c609784f2e4a28d0e9fdb97">
-        <source>Done!</source>
-        <target>Done!</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:30</note>
-      </trans-unit>
-      <trans-unit id="1f8fed56213622fdd4444d8707440ef6">
-        <source>An error occurred during installation...</source>
-        <target>An error occurred during installation...</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:54</note>
-      </trans-unit>
-      <trans-unit id="6a44fd63f5cc2e5d0565d4c106280a3c">
-        <source><![CDATA[You can use the links on the left column to go back to the previous steps, or restart the installation process by <a href="%link%">clicking here</a>.]]></source>
-        <target><![CDATA[You can use the links on the left column to go back to the previous steps, or restart the installation process by <a href="%link%">clicking here</a>.]]></target>
-        <note>Context:
-File: install-dev/theme/views/process.php:55</note>
-      </trans-unit>
-      <trans-unit id="7f3475513f7ba2a7c36fb507d60db6a5">
-        <source>Your installation is finished!</source>
-        <target>Your installation is finished!</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:62</note>
-      </trans-unit>
-      <trans-unit id="95d8b8f9b89717f8e58b5e9df21eab6b">
-        <source>You have just finished installing your shop. Thank you for using PrestaShop!</source>
-        <target>You have just finished installing your shop. Thank you for using PrestaShop!</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:63</note>
-      </trans-unit>
-      <trans-unit id="08c51a1149fb9402773557f678cad130">
-        <source>Please remember your login information:</source>
-        <target>Please remember your login information:</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:64</note>
-      </trans-unit>
-      <trans-unit id="1e884e3078d9978e216a027ecd57fb34">
-        <source>E-mail</source>
-        <target>E-mail</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:67</note>
-      </trans-unit>
-      <trans-unit id="638c31b20cf4a67654c049ca9cf92a99">
-        <source>Print my login information</source>
-        <target>Print my login information</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:71</note>
-      </trans-unit>
-      <trans-unit id="dc647eb65e6711e155375218212b3964">
-        <source>Password</source>
-        <target>Password</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:75</note>
-      </trans-unit>
-      <trans-unit id="b9987a246a537f4fe86f1f2e3d10dbdb">
-        <source>Display</source>
-        <target>Display</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:79</note>
-      </trans-unit>
-      <trans-unit id="1725f045dbcb8e6e77a7ade8c476a879">
-        <source>For security purposes, you must delete the "install" folder.</source>
-        <target>For security purposes, you must delete the "install" folder.</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:86</note>
-      </trans-unit>
-      <trans-unit id="c9cb297f6c4491751bc2849409e37535">
-        <source>http://doc.prestashop.com/display/PS17/Installing+PrestaShop#InstallingPrestaShop-Completingtheinstallation</source>
-        <target>http://doc.prestashop.com/display/PS17/Installing+PrestaShop#InstallingPrestaShop-Completingtheinstallation</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:87</note>
-      </trans-unit>
-      <trans-unit id="eed2839c1e3e5f7069ed03b2f6d4c6dd">
-        <source>Back Office</source>
-        <target>Back Office</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:92</note>
-      </trans-unit>
-      <trans-unit id="450abc1417292c60121dd3dfde9c9b23">
-        <source>Manage your store using your Back Office. Manage your orders and customers, add modules, change themes, etc.</source>
-        <target>Manage your store using your Back Office. Manage your orders and customers, add modules, change themes, etc.</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:93</note>
-      </trans-unit>
-      <trans-unit id="39b5e23e409fa9f6f67e984c1bedf6ae">
-        <source>Manage your store</source>
-        <target>Manage your store</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:95</note>
-      </trans-unit>
-      <trans-unit id="0558c4724c1321605189662a0e3f66f6">
-        <source>Front Office</source>
-        <target>Front Office</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:100</note>
-      </trans-unit>
-      <trans-unit id="f3669ee3bb5b38eebcb9d619511ff771">
-        <source>Discover your store as your future customers will see it!</source>
-        <target>Discover your store as your future customers will see it!</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:101</note>
-      </trans-unit>
-      <trans-unit id="d502268208857835192e375383bd1a94">
-        <source>Discover your store</source>
-        <target>Discover your store</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:103</note>
-      </trans-unit>
-      <trans-unit id="643d415c09f1eae4e639af61cf01079e">
-        <source>Share your experience with your friends!</source>
-        <target>Share your experience with your friends!</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:109</note>
-      </trans-unit>
-      <trans-unit id="3090d414525dcb37e3f8a14b94453a26">
-        <source>I just built an online store with PrestaShop!</source>
-        <target>I just built an online store with PrestaShop!</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:110</note>
-      </trans-unit>
-      <trans-unit id="eb0fec563c30847715617ad08218ccfd">
-        <source>Watch this exhilarating experience: http://vimeo.com/89298199</source>
-        <target>Watch this exhilarating experience: http://vimeo.com/89298199</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:110</note>
-      </trans-unit>
-      <trans-unit id="3746d4aa96f19672260a424d76729dd1">
-        <source>Tweet</source>
-        <target>Tweet</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:111</note>
-      </trans-unit>
-      <trans-unit id="5a95a425f74314a96f13a2f136992178">
-        <source>Share</source>
-        <target>Share</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:114</note>
-      </trans-unit>
-      <trans-unit id="5b2c8bfd1bc974966209b7be1cb51a72">
-        <source>Google+</source>
-        <target>Google+</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:117</note>
-      </trans-unit>
-      <trans-unit id="86709a608bd914b28221164e6680ebf7">
-        <source>Pinterest</source>
-        <target>Pinterest</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:120</note>
-      </trans-unit>
-      <trans-unit id="e884c507c5198a4578a84498f7a323e2">
-        <source>LinkedIn</source>
-        <target>LinkedIn</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:123</note>
-      </trans-unit>
-      <trans-unit id="ea4384b22e2a5e24600efedd7b0bc09a">
-        <source>Check out PrestaShop Addons to add that little something extra to your store!</source>
-        <target>Check out PrestaShop Addons to add that little something extra to your store!</target>
-        <note>Context:
-File: install-dev/theme/views/process.php:130</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/theme/views/welcome.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d51066397d7cbedc122457c9479f6fb2">
-        <source>PrestaShop requires at least 32 MB of memory to run: please check the memory_limit directive in your php.ini file or contact your host provider about this.</source>
-        <target>PrestaShop requires at least 32 MB of memory to run: please check the memory_limit directive in your php.ini file or contact your host provider about this.</target>
-        <note>Context:
-File: install-dev/theme/views/welcome.php:29</note>
-      </trans-unit>
-      <trans-unit id="c8c27951cbaf7da257e6af50a6fc4116">
-        <source><![CDATA[<b>Warning: You cannot use this tool to upgrade your store anymore.</b><br /><br />You already have <b>PrestaShop version %version% installed</b>.<br /><br />If you want to upgrade to the latest version, please read our documentation: <a href="%doc%">%doc%</a>]]></source>
-        <target><![CDATA[<b>Warning: You cannot use this tool to upgrade your store anymore.</b><br /><br />You already have <b>PrestaShop version %version% installed</b>.<br /><br />If you want to upgrade to the latest version, please read our documentation: <a href="%doc%">%doc%</a>]]></target>
-        <note>Context:
-File: install-dev/theme/views/welcome.php:36</note>
-      </trans-unit>
-      <trans-unit id="bcc5d67b4832784ca5e4f09a40b28bb2">
-        <source>Welcome to the PrestaShop %version% Installer</source>
-        <target>Welcome to the PrestaShop %version% Installer</target>
-        <note>Context:
-File: install-dev/theme/views/welcome.php:40</note>
-      </trans-unit>
-      <trans-unit id="78a57ffff28849e5627e564bc055acea">
-        <source>Installing PrestaShop is quick and easy. In just a few moments, you will become part of a community consisting of more than 250,000 merchants. You are on the way to creating your own unique online store that you can manage easily every day.</source>
-        <target>Installing PrestaShop is quick and easy. In just a few moments, you will become part of a community consisting of more than 250,000 merchants. You are on the way to creating your own unique online store that you can manage easily every day.</target>
-        <note>Context:
-File: install-dev/theme/views/welcome.php:41</note>
-      </trans-unit>
-      <trans-unit id="d9b205f1e80dee567296d14611add4a2">
-        <source><![CDATA[If you need help, do not hesitate to <a href="%tutoriellink%" target="_blank">watch this short tutorial</a>, or check <a href="%linkdoc%" target="_blank">our documentation</a>.]]></source>
-        <target><![CDATA[If you need help, do not hesitate to <a href="%tutoriellink%" target="_blank">watch this short tutorial</a>, or check <a href="%linkdoc%" target="_blank">our documentation</a>.]]></target>
-        <note>Context:
-File: install-dev/theme/views/welcome.php:42</note>
-      </trans-unit>
-      <trans-unit id="edbaa44341f3064baa5a5676aabc91e5">
-        <source>Continue the installation in:</source>
-        <target>Continue the installation in:</target>
-        <note>Context:
-File: install-dev/theme/views/welcome.php:46</note>
-      </trans-unit>
-      <trans-unit id="239e971a06ff313e2b8aafa9b51286c9">
-        <source>The language selection above only applies to the Installation Assistant. Once your store is installed, you can choose the language of your store from over %d% translations, all for free!</source>
-        <target>The language selection above only applies to the Installation Assistant. Once your store is installed, you can choose the language of your store from over %d% translations, all for free!</target>
-        <note>Context:
-File: install-dev/theme/views/welcome.php:56</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/theme/views/database.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b66ad3bc67c20939fb6f5c8f866ce366">
-        <source>Configure your database by filling out the following fields</source>
-        <target>Configure your database by filling out the following fields</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:30</note>
-      </trans-unit>
-      <trans-unit id="74987401b3b33cc9542cd8585c08de98">
-        <source><![CDATA[To use PrestaShop, you must <a href="http://doc.prestashop.com/display/PS16/Installing+PrestaShop#InstallingPrestaShop-Creatingadatabaseforyourshop" target="_blank">create a database</a> to collect all of your store's data-related activities.]]></source>
-        <target><![CDATA[To use PrestaShop, you must <a href="http://doc.prestashop.com/display/PS16/Installing+PrestaShop#InstallingPrestaShop-Creatingadatabaseforyourshop" target="_blank">create a database</a> to collect all of your store's data-related activities.]]></target>
-        <note>Context:
-File: install-dev/theme/views/database.php:32</note>
-      </trans-unit>
-      <trans-unit id="3b4db494bf9473e98bf8106d3fb381a7">
-        <source>Please complete the fields below in order for PrestaShop to connect to your database.</source>
-        <target>Please complete the fields below in order for PrestaShop to connect to your database.</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:34</note>
-      </trans-unit>
-      <trans-unit id="52a372f1b2b0ce0f9a3789a9ae9e6ef8">
-        <source>Database server address</source>
-        <target>Database server address</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:39</note>
-      </trans-unit>
-      <trans-unit id="bc4b85255c14de3bf09748a093c63529">
-        <source>The default port is 3306. To use a different port, add the port number at the end of your server's address i.e ":4242".</source>
-        <target>The default port is 3306. To use a different port, add the port number at the end of your server's address i.e ":4242".</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:41</note>
-      </trans-unit>
-      <trans-unit id="9e362f7bde93fb1a52dea86534d5be9c">
-        <source>Database name</source>
-        <target>Database name</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:44</note>
-      </trans-unit>
-      <trans-unit id="4ed2e481694680d735fa1d9b47a27822">
-        <source>Database login</source>
-        <target>Database login</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:48</note>
-      </trans-unit>
-      <trans-unit id="60f5beb4715bf84676dfc7ac7f3649da">
-        <source>Database password</source>
-        <target>Database password</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:52</note>
-      </trans-unit>
-      <trans-unit id="d07e3cfba4c070cf15423fd0462ba6b9">
-        <source>Database Engine</source>
-        <target>Database Engine</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:57</note>
-      </trans-unit>
-      <trans-unit id="8eb2ccdf1b2566fb1ce7fe1545dadbe1">
-        <source>Tables prefix</source>
-        <target>Tables prefix</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:64</note>
-      </trans-unit>
-      <trans-unit id="9b8fe6ffb270752db0cffd410e5a7aa2">
-        <source>Drop existing tables (mode dev)</source>
-        <target>Drop existing tables (mode dev)</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:69</note>
-      </trans-unit>
-      <trans-unit id="4a8b0cfe8f2ecd6b3b34b2ed853f02a8">
-        <source>Test your database connection now!</source>
-        <target>Test your database connection now!</target>
-        <note>Context:
-File: install-dev/theme/views/database.php:74</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="install-dev/theme/views/configure.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c075a7d57ac5f08683a1a0a1d3425e94">
-        <source>Information about your Store</source>
-        <target>Information about your Store</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:36</note>
-      </trans-unit>
-      <trans-unit id="e93c33bd1341ab74195430daeb63db13">
-        <source>Shop name</source>
-        <target>Shop name</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:40</note>
-      </trans-unit>
-      <trans-unit id="98360f1ae89a205da2d571f1503729db">
-        <source>Main activity</source>
-        <target>Main activity</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:49</note>
-      </trans-unit>
-      <trans-unit id="eebdd5f4803a884624a2d99b16c783a4">
-        <source>Please choose your main activity</source>
-        <target>Please choose your main activity</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:52</note>
-      </trans-unit>
-      <trans-unit id="bc350ae6b31fefb88adaee19a9f4e912">
-        <source>Other activity...</source>
-        <target>Other activity...</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:56</note>
-      </trans-unit>
-      <trans-unit id="038b579adc8560b4903395edc67c580b">
-        <source>Help us learn more about your store so we can offer you optimal guidance and the best features for your business!</source>
-        <target>Help us learn more about your store so we can offer you optimal guidance and the best features for your business!</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:59</note>
-      </trans-unit>
-      <trans-unit id="87b616fe8f0a5ee54271f2eae643c069">
-        <source>Install demo products</source>
-        <target>Install demo products</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:65</note>
-      </trans-unit>
-      <trans-unit id="93cba07454f06a4a960172bbd6e2a435">
-        <source>Yes</source>
-        <target>Yes</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:69</note>
-      </trans-unit>
-      <trans-unit id="bafd7322c6e97d25b6299b5d6fe8920b">
-        <source>No</source>
-        <target>No</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:73</note>
-      </trans-unit>
-      <trans-unit id="75b105f67d0774e4bb7b69de06d20dbb">
-        <source>Demo products are a good way to learn how to use PrestaShop. You should install them if you are not familiar with it.</source>
-        <target>Demo products are a good way to learn how to use PrestaShop. You should install them if you are not familiar with it.</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:76</note>
-      </trans-unit>
-      <trans-unit id="59716c97497eb9694541f7c3d37b1a4d">
-        <source>Country</source>
-        <target>Country</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:84</note>
-      </trans-unit>
-      <trans-unit id="a7bb58222222b064f0721e6e0fe4c486">
-        <source>Select your country</source>
-        <target>Select your country</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:87</note>
-      </trans-unit>
-      <trans-unit id="65d03d6bab79cbe2135c384592e70715">
-        <source>Shop timezone</source>
-        <target>Shop timezone</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:99</note>
-      </trans-unit>
-      <trans-unit id="5a9d7616b5690c569919362f77dc9ec5">
-        <source>Select your timezone</source>
-        <target>Select your timezone</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:102</note>
-      </trans-unit>
-      <trans-unit id="97e0d62d1db5473366dd6e7ebd56f596">
-        <source>Shop logo</source>
-        <target>Shop logo</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:114</note>
-      </trans-unit>
-      <trans-unit id="65ff4245dba0a751bdd9f2530cb8788b">
-        <source>Optional - You can add you logo at a later time.</source>
-        <target>Optional - You can add you logo at a later time.</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:118</note>
-      </trans-unit>
-      <trans-unit id="a0623b78a5f2cfe415d9dbbd4428ea40">
-        <source>Your Account</source>
-        <target>Your Account</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:127</note>
-      </trans-unit>
-      <trans-unit id="20db0bfeecd8fe60533206a2b5e9891a">
-        <source>First name</source>
-        <target>First name</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:131</note>
-      </trans-unit>
-      <trans-unit id="8d3f5eff9c40ee315d452392bed5309b">
-        <source>Last name</source>
-        <target>Last name</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:141</note>
-      </trans-unit>
-      <trans-unit id="8b5dd64ab8d0b8158906796b53a200e2">
-        <source>E-mail address</source>
-        <target>E-mail address</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:151</note>
-      </trans-unit>
-      <trans-unit id="a838dd011a3bb99084a43912a71cdc46">
-        <source>This email address will be your username to access your store's back office.</source>
-        <target>This email address will be your username to access your store's back office.</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:156</note>
-      </trans-unit>
-      <trans-unit id="ecb77be87bda4dd34d51cfedbef9b6c3">
-        <source>Shop password</source>
-        <target>Shop password</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:162</note>
-      </trans-unit>
-      <trans-unit id="af2d11e28485cf3841ea367fdcdb4713">
-        <source>Must be at least 8 characters</source>
-        <target>Must be at least 8 characters</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:170</note>
-      </trans-unit>
-      <trans-unit id="540155f9adc935c8f3a9d8a77beb8860">
-        <source>Re-type to confirm</source>
-        <target>Re-type to confirm</target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:176</note>
-      </trans-unit>
-      <trans-unit id="6794fece26df4610c0523bffd7a45231">
-        <source><![CDATA[All information you give us is collected by us and is subject to data processing and statistics, it is necessary for the members of the PrestaShop company in order to respond to your requests. Your personal data may be communicated to service providers and partners as part of partner relationships. Under the current "Act on Data Processing, Data Files and Individual Liberties" you have the right to access, rectify and oppose to the processing of your personal data through this <a href="%s" onclick="return !window.open(this.href)">link</a>.]]></source>
-        <target><![CDATA[All information you give us is collected by us and is subject to data processing and statistics, it is necessary for the members of the PrestaShop company in order to respond to your requests. Your personal data may be communicated to service providers and partners as part of partner relationships. Under the current "Act on Data Processing, Data Files and Individual Liberties" you have the right to access, rectify and oppose to the processing of your personal data through this <a href="%s" onclick="return !window.open(this.href)">link</a>.]]></target>
-        <note>Context:
-File: install-dev/theme/views/configure.php:184</note>
+        <note>Line: 158</note>
       </trans-unit>
     </body>
   </file>
@@ -1151,68 +972,57 @@ File: install-dev/theme/views/configure.php:184</note>
       <trans-unit id="7433acfc71c103b95ddc7f861ecd55ee">
         <source>At least one table with same prefix was already found, please change your prefix or drop your database</source>
         <target>At least one table with same prefix was already found, please change your prefix or drop your database</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:79</note>
+        <note>Line: 79</note>
       </trans-unit>
       <trans-unit id="0e29192ae1f901f7c586dbe2e163324e">
         <source>Server name is not valid</source>
         <target>Server name is not valid</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="432b416ae18332365f49829f82d8e522">
         <source>You must enter a database name</source>
         <target>You must enter a database name</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:57</note>
+        <note>Line: 57</note>
       </trans-unit>
       <trans-unit id="eb6e8b3fa25d57b419896d6f8b3609da">
         <source>You must enter a database login</source>
         <target>You must enter a database login</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:61</note>
+        <note>Line: 61</note>
       </trans-unit>
       <trans-unit id="5ed7d7dbcbdd7f2ed850627bdc97945b">
         <source>Tables prefix is invalid</source>
         <target>Tables prefix is invalid</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:65</note>
+        <note>Line: 65</note>
       </trans-unit>
       <trans-unit id="2f866a47ae9b2bffaca244ccd79d4ea7">
         <source>Cannot convert database data to utf-8</source>
         <target>Cannot convert database data to utf-8</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:74</note>
+        <note>Line: 74</note>
       </trans-unit>
       <trans-unit id="00151f099adaa8a1ad25dff0862b121b">
         <source>The values of auto_increment increment and offset must be set to 1</source>
         <target>The values of auto_increment increment and offset must be set to 1</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:82</note>
+        <note>Line: 82</note>
       </trans-unit>
       <trans-unit id="2c3fc7088c5715d31d1f0a33d1e7c79c">
         <source>Your database login does not have the privileges to create table on the database "%s". Ask your hosting provider:</source>
         <target>Your database login does not have the privileges to create table on the database "%s". Ask your hosting provider:</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:85</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="ce799e40a5e7b523d011b80868fe4ca4">
         <source>Database Server is not found. Please verify the login, password and server fields</source>
         <target>Database Server is not found. Please verify the login, password and server fields</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:93</note>
+        <note>Line: 93</note>
       </trans-unit>
       <trans-unit id="9a0b7b3a849553ab760177a12f4ebc7f">
         <source>Connection to MySQL server succeeded, but database "%database%" not found</source>
         <target>Connection to MySQL server succeeded, but database "%database%" not found</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:97</note>
+        <note>Line: 97</note>
       </trans-unit>
       <trans-unit id="0462e75865c8794c7785f7c6952ae7a3">
         <source>Attempt to create the database automatically</source>
         <target>Attempt to create the database automatically</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Database.php:99</note>
+        <note>Line: 99</note>
       </trans-unit>
     </body>
   </file>
@@ -1221,150 +1031,92 @@ File: src/PrestaShopBundle/Install/Database.php:99</note>
       <trans-unit id="13cd0b09fa253a2b524ca2345638aacf">
         <source>%file% file is not writable (check permissions)</source>
         <target>%file% file is not writable (check permissions)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:140</note>
+        <note>Line: 140</note>
       </trans-unit>
       <trans-unit id="5b0aceda64c33fa187bdd138c42de909">
         <source>%folder% folder is not writable (check permissions)</source>
         <target>%folder% folder is not writable (check permissions)</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:148</note>
+        <note>Line: 148</note>
       </trans-unit>
       <trans-unit id="b63440f4a2f5faa849b821e433c85e53">
         <source>Cannot write settings file</source>
         <target>Cannot write settings file</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:201</note>
+        <note>Line: 201</note>
       </trans-unit>
       <trans-unit id="39fcc4a2539d44e1bc88df1af88df1e8">
         <source>Cannot write app/config/parameters.php file</source>
         <target>Cannot write app/config/parameters.php file</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:224</note>
+        <note>Line: 224</note>
       </trans-unit>
       <trans-unit id="da766b8e6f70454b5fdde126ba5c761c">
         <source>Cannot write app/config/parameters.yml file</source>
         <target>Cannot write app/config/parameters.yml file</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:238</note>
+        <note>Line: 238</note>
       </trans-unit>
       <trans-unit id="453faec2c85b2b9c0b9c2b474b30bd21">
         <source>Database structure file not found</source>
         <target>Database structure file not found</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:289</note>
+        <note>Line: 289</note>
       </trans-unit>
       <trans-unit id="f726c29f41d9b6ab3d61f6f4e41959a3">
         <source>Cannot create group shop</source>
         <target>Cannot create group shop</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:544</note>
+        <note>Line: 544</note>
       </trans-unit>
       <trans-unit id="19de782cabcc5cc12fa9730264cd5325">
         <source>Cannot create shop</source>
         <target>Cannot create shop</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:557</note>
+        <note>Line: 557</note>
       </trans-unit>
       <trans-unit id="90ae323fee3fa743290c6ebdbd7fea65">
         <source>Cannot create shop URL</source>
         <target>Cannot create shop URL</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:573</note>
+        <note>Line: 573</note>
       </trans-unit>
       <trans-unit id="53d7a51998faa87f513eb974a2a596f2">
         <source>File "language.xml" not found for language iso "%iso%"</source>
         <target>File "language.xml" not found for language iso "%iso%"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:604</note>
+        <note>Line: 604</note>
       </trans-unit>
       <trans-unit id="9972ad1ade2906747dbb39490a96b191">
         <source>File "language.xml" not valid for language iso "%iso%"</source>
         <target>File "language.xml" not valid for language iso "%iso%"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:608</note>
+        <note>Line: 608</note>
       </trans-unit>
       <trans-unit id="54c23cef7fbebba7ee1267cc0cf97b2a">
         <source>Cannot download language pack "%iso%"</source>
         <target>Cannot download language pack "%iso%"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:626</note>
+        <note>Line: 626</note>
       </trans-unit>
       <trans-unit id="9d321a378efc308c33c5f345f623dd90">
         <source>Cannot install language "%iso%"</source>
         <target>Cannot install language "%iso%"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:639</note>
+        <note>Line: 639</note>
       </trans-unit>
       <trans-unit id="258057c839ab36aa9e3bb60550348c5e">
         <source>Cannot copy flag language "%flag%"</source>
         <target>Cannot copy flag language "%flag%"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:647</note>
+        <note>Line: 647</note>
       </trans-unit>
       <trans-unit id="27654955bc85150712aa0bc53bcc6224">
         <source>Cannot create admin account</source>
         <target>Cannot create admin account</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:844</note>
+        <note>Line: 844</note>
       </trans-unit>
       <trans-unit id="26b901ba3ecdcb91823f05ce15a70ce4">
         <source>Cannot install module "%module%"</source>
         <target>Cannot install module "%module%"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:1055</note>
+        <note>Line: 1055</note>
       </trans-unit>
       <trans-unit id="4a85cd1d84d691a2e0b73a5f08cd3483">
         <source>Fixtures class "%class%" not found</source>
         <target>Fixtures class "%class%" not found</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:1089</note>
+        <note>Line: 1089</note>
       </trans-unit>
       <trans-unit id="e1120cceb6bcfd9596161e3912b2ad9d">
         <source>"%class%" must be an instance of "InstallXmlLoader"</source>
         <target>"%class%" must be an instance of "InstallXmlLoader"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Install.php:1096</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Install/XmlLoader.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6c16e88afa7f92cfe15e74a1fbe9c250">
-        <source><![CDATA[SQL error on query <i>%query%</i>]]></source>
-        <target><![CDATA[SQL error on query <i>%query%</i>]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/XmlLoader.php:1206</note>
-      </trans-unit>
-      <trans-unit id="5b56439cb79f3a01ae56d92e52be2218">
-        <source><![CDATA[An SQL error occurred for entity <i>%entity%</i>: <i>%message%</i>]]></source>
-        <target><![CDATA[An SQL error occurred for entity <i>%entity%</i>: <i>%message%</i>]]></target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/XmlLoader.php:468</note>
-      </trans-unit>
-      <trans-unit id="11b53a5381cd2ca843a6089493de6716">
-        <source>Cannot create image "%identifier%" for entity "%entity%"</source>
-        <target>Cannot create image "%identifier%" for entity "%entity%"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/XmlLoader.php:804</note>
-      </trans-unit>
-      <trans-unit id="a6bc945aa3c279156298ed70872cd20b">
-        <source>Cannot create image "%identifier%" (bad permissions on folder "%folder%")</source>
-        <target>Cannot create image "%identifier%" (bad permissions on folder "%folder%")</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/XmlLoader.php:782</note>
-      </trans-unit>
-      <trans-unit id="25b42d449f5ebcdb85fb6cae0663c40f">
-        <source>Cannot create image "%identifier%"</source>
-        <target>Cannot create image "%identifier%"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/XmlLoader.php:709</note>
-      </trans-unit>
-      <trans-unit id="44a700a0c9496b4436c16c5e46351707">
-        <source>Cannot create image "%1$s" for entity "%2$s"</source>
-        <target>Cannot create image "%1$s" for entity "%2$s"</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/XmlLoader.php:793</note>
+        <note>Line: 1096</note>
       </trans-unit>
     </body>
   </file>
@@ -1373,80 +1125,101 @@ File: src/PrestaShopBundle/Install/XmlLoader.php:793</note>
       <trans-unit id="de08f967b14ff56ab63e1b6a6e0c9f4e">
         <source>Database upgrade completed.</source>
         <target>Database upgrade completed.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:821</note>
+        <note>Line: 821</note>
       </trans-unit>
       <trans-unit id="c281522a27a8e9ce71483d97f93f9681">
         <source>Disabling modules now...</source>
         <target>Disabling modules now...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:822</note>
+        <note>Line: 822</note>
       </trans-unit>
       <trans-unit id="1946a60a931f7c67013eae819b42751b">
         <source>Modules successfully disabled.</source>
         <target>Modules successfully disabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:838</note>
+        <note>Line: 838</note>
       </trans-unit>
       <trans-unit id="4598df2738b72a48a5d92debdf6b2648">
         <source>Enabling modules now...</source>
         <target>Enabling modules now...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:839</note>
+        <note>Line: 839</note>
       </trans-unit>
       <trans-unit id="41cf6d7c774a6f0e0e131c556272bd23">
         <source>Modules successfully enabled.</source>
         <target>Modules successfully enabled.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:851</note>
+        <note>Line: 851</note>
       </trans-unit>
       <trans-unit id="adc432de81c16df1d52bcdb0ae27888b">
         <source>Upgrading images now...</source>
         <target>Upgrading images now...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:852</note>
+        <note>Line: 852</note>
       </trans-unit>
       <trans-unit id="5050f74dbf781812e2de8d9c89bcefb9">
         <source>Images successfully upgraded.</source>
         <target>Images successfully upgraded.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:870</note>
+        <note>Line: 870</note>
       </trans-unit>
       <trans-unit id="66beff6fe8199b7e380b9b86a1cfd62c">
         <source>Upgrading languages now...</source>
         <target>Upgrading languages now...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:871</note>
+        <note>Line: 871</note>
       </trans-unit>
       <trans-unit id="95427ea0db7f28827968539ce09bc8ad">
         <source>Languages successfully upgraded.</source>
         <target>Languages successfully upgraded.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:884</note>
+        <note>Line: 884</note>
       </trans-unit>
       <trans-unit id="92cbcfa88b4123c79ff4ecc503d1f4d6">
         <source>Upgrading theme now...</source>
         <target>Upgrading theme now...</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:885</note>
+        <note>Line: 885</note>
       </trans-unit>
       <trans-unit id="6fef8a125435e82e3b1f4d6c0de64e18">
         <source>Theme successfully upgraded.</source>
         <target>Theme successfully upgraded.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:899</note>
+        <note>Line: 899</note>
       </trans-unit>
       <trans-unit id="9c7e0ba2c6ecb11af7f39843bbc18ff8">
         <source>Warning detected during upgrade.</source>
         <target>Warning detected during upgrade.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:944</note>
+        <note>Line: 944</note>
       </trans-unit>
       <trans-unit id="bd077be8e2cdf937e5b77300a0131f9a">
         <source>Error detected during upgrade.</source>
         <target>Error detected during upgrade.</target>
-        <note>Context:
-File: src/PrestaShopBundle/Install/Upgrade.php:972</note>
+        <note>Line: 972</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Install/XmlLoader.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6c16e88afa7f92cfe15e74a1fbe9c250">
+        <source><![CDATA[SQL error on query <i>%query%</i>]]></source>
+        <target><![CDATA[SQL error on query <i>%query%</i>]]></target>
+        <note>Line: 1206</note>
+      </trans-unit>
+      <trans-unit id="5b56439cb79f3a01ae56d92e52be2218">
+        <source><![CDATA[An SQL error occurred for entity <i>%entity%</i>: <i>%message%</i>]]></source>
+        <target><![CDATA[An SQL error occurred for entity <i>%entity%</i>: <i>%message%</i>]]></target>
+        <note>Line: 468</note>
+      </trans-unit>
+      <trans-unit id="11b53a5381cd2ca843a6089493de6716">
+        <source>Cannot create image "%identifier%" for entity "%entity%"</source>
+        <target>Cannot create image "%identifier%" for entity "%entity%"</target>
+        <note>Line: 804</note>
+      </trans-unit>
+      <trans-unit id="a6bc945aa3c279156298ed70872cd20b">
+        <source>Cannot create image "%identifier%" (bad permissions on folder "%folder%")</source>
+        <target>Cannot create image "%identifier%" (bad permissions on folder "%folder%")</target>
+        <note>Line: 782</note>
+      </trans-unit>
+      <trans-unit id="25b42d449f5ebcdb85fb6cae0663c40f">
+        <source>Cannot create image "%identifier%"</source>
+        <target>Cannot create image "%identifier%"</target>
+        <note>Line: 709</note>
+      </trans-unit>
+      <trans-unit id="44a700a0c9496b4436c16c5e46351707">
+        <source>Cannot create image "%1$s" for entity "%2$s"</source>
+        <target>Cannot create image "%1$s" for entity "%2$s"</target>
+        <note>Line: 793</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesBannerAdmin.xlf
+++ b/app/Resources/translations/default/ModulesBannerAdmin.xlf
@@ -5,50 +5,42 @@
       <trans-unit id="6ff29916f99fff9d2494d28e721ae77e">
         <source>Banner</source>
         <target>Banner</target>
-        <note>Context:
-File: modules/ps_banner/ps_banner.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="3e1d9fcbd3d3493d53cf9594c983d754">
         <source>Displays a banner on your shop.</source>
         <target>Displays a banner on your shop.</target>
-        <note>Context:
-File: modules/ps_banner/ps_banner.php:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="137d2d6f01b4762e90938fbe1c053a74">
         <source>Banner image</source>
         <target>Banner image</target>
-        <note>Context:
-File: modules/ps_banner/ps_banner.php:167</note>
+        <note>Line: 167</note>
       </trans-unit>
       <trans-unit id="154050410754c33dadde1a9c558ed349">
         <source>Upload an image for your top banner. The recommended dimensions are 1110 x 214px if you are using the default theme.</source>
         <target>Upload an image for your top banner. The recommended dimensions are 1110 x 214px if you are using the default theme.</target>
-        <note>Context:
-File: modules/ps_banner/ps_banner.php:169</note>
+        <note>Line: 169</note>
       </trans-unit>
       <trans-unit id="46fae48f998058600248a16100acfb7e">
         <source>Banner Link</source>
         <target>Banner Link</target>
-        <note>Context:
-File: modules/ps_banner/ps_banner.php:175</note>
+        <note>Line: 175</note>
       </trans-unit>
       <trans-unit id="084fa1da897dfe3717efa184616ff91c">
         <source>Enter the link associated to your banner. When clicking on the banner, the link opens in the same window. If no link is entered, it redirects to the homepage.</source>
         <target>Enter the link associated to your banner. When clicking on the banner, the link opens in the same window. If no link is entered, it redirects to the homepage.</target>
-        <note>Context:
-File: modules/ps_banner/ps_banner.php:177</note>
+        <note>Line: 177</note>
       </trans-unit>
       <trans-unit id="ff09729bee8a82c374f6b61e14a4af76">
         <source>Banner description</source>
         <target>Banner description</target>
-        <note>Context:
-File: modules/ps_banner/ps_banner.php:182</note>
+        <note>Line: 182</note>
       </trans-unit>
       <trans-unit id="112f6f9a1026d85f440e5ca68d8e2ec5">
         <source>Please enter a short but meaningful description for the banner.</source>
         <target>Please enter a short but meaningful description for the banner.</target>
-        <note>Context:
-File: modules/ps_banner/ps_banner.php:184</note>
+        <note>Line: 184</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesBannerShop.xlf
+++ b/app/Resources/translations/default/ModulesBannerShop.xlf
@@ -5,8 +5,7 @@
       <trans-unit id="92fbf0e5d97b8afd7e73126b52bdc4bb">
         <source>Choose a file</source>
         <target>Choose a file</target>
-        <note>Context:
-File: modules/ps_banner/views/templates/admin/_configure/helpers/form/form.tpl:42</note>
+        <note>Line: 42</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesBlockreassuranceAdmin.xlf
+++ b/app/Resources/translations/default/ModulesBlockreassuranceAdmin.xlf
@@ -5,32 +5,27 @@
       <trans-unit id="659e8e7501bea2ab8c35659fc321525d">
         <source>Customer reassurance</source>
         <target>Customer reassurance</target>
-        <note>Context:
-File: modules/blockreassurance/blockreassurance.php:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="7e7f70db3c75e428db8e2d0a1765c4e9">
         <source>Adds an information block aimed at offering helpful information to reassure customers that your store is trustworthy.</source>
         <target>Adds an information block aimed at offering helpful information to reassure customers that your store is trustworthy.</target>
-        <note>Context:
-File: modules/blockreassurance/blockreassurance.php:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="0366c7b2ea1bb228cd44aec7e3e26a3e">
         <source>The block configuration has been updated.</source>
         <target>The block configuration has been updated.</target>
-        <note>Context:
-File: modules/blockreassurance/blockreassurance.php:224</note>
+        <note>Line: 224</note>
       </trans-unit>
       <trans-unit id="8363eee01f4da190a4cef9d26a36750c">
         <source>New reassurance block</source>
         <target>New reassurance block</target>
-        <note>Context:
-File: modules/blockreassurance/blockreassurance.php:246</note>
+        <note>Line: 246</note>
       </trans-unit>
       <trans-unit id="23498d91b6017e5d7f4ddde70daba286">
         <source>ID Shop</source>
         <target>ID Shop</target>
-        <note>Context:
-File: modules/blockreassurance/blockreassurance.php:326</note>
+        <note>Line: 326</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesBlockreassuranceShop.xlf
+++ b/app/Resources/translations/default/ModulesBlockreassuranceShop.xlf
@@ -5,20 +5,17 @@
       <trans-unit id="c71c3bd188354139cfc0f710d8f01710">
         <source>Security policy (edit with Customer reassurance module)</source>
         <target>Security policy (edit with Customer reassurance module)</target>
-        <note>Context:
-File: modules/blockreassurance/lang/ReassuranceLang.php:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="88d14965d6085734430a5215a1a1f18c">
         <source>Delivery policy (edit with Customer reassurance module)</source>
         <target>Delivery policy (edit with Customer reassurance module)</target>
-        <note>Context:
-File: modules/blockreassurance/lang/ReassuranceLang.php:44</note>
+        <note>Line: 44</note>
       </trans-unit>
       <trans-unit id="da5cbc8f71f0b5e024c3b252572f014d">
         <source>Return policy (edit with Customer reassurance module)</source>
         <target>Return policy (edit with Customer reassurance module)</target>
-        <note>Context:
-File: modules/blockreassurance/lang/ReassuranceLang.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesBuybuttonliteAdmin.xlf
+++ b/app/Resources/translations/default/ModulesBuybuttonliteAdmin.xlf
@@ -8,7 +8,7 @@
         <note>Context:
 File: modules/ps_buybuttonlite/ps_buybuttonlite.php:49</note>
       </trans-unit>
-      <trans-unit id="0bb2845aebaa9f02016153983fb35dd8">
+      <trans-unit id="b6fc6adf920ff6307628b7fa4a9f1132">
         <source>Increase your conversion rate and boost your sales, generate links and add them to your content so that visitors can easily proceed to checkout</source>
         <target>Increase your conversion rate and boost your sales, generate links and add them to your content so that visitors can easily proceed to checkout</target>
         <note>Context:
@@ -50,7 +50,7 @@ File: modules/ps_buybuttonlite/ps_buybuttonlite.php:157</note>
         <note>Context:
 File: modules/ps_buybuttonlite/ps_buybuttonlite.php:158</note>
       </trans-unit>
-      <trans-unit id="d93566e8812ea9469fa4cabaa10a21a6">
+      <trans-unit id="31edfec531c02c0cfe522ed5ca726e2f">
         <source>Want to go further?</source>
         <target>Want to go further?</target>
         <note>Context:

--- a/app/Resources/translations/default/ModulesCashondeliveryShop.xlf
+++ b/app/Resources/translations/default/ModulesCashondeliveryShop.xlf
@@ -10,16 +10,6 @@ File: modules/ps_cashondelivery/ps_cashondelivery.php:100</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_cashondelivery/views/templates/hook/ps_cashondelivery_intro.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="536dc7424180872c8c2488ae0286fb53">
-        <source>You pay for the merchandise upon delivery</source>
-        <target>You pay for the merchandise upon delivery</target>
-        <note>Context:
-File: modules/ps_cashondelivery/views/templates/hook/ps_cashondelivery_intro.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="modules/ps_cashondelivery/views/templates/hook/payment_return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="88526efe38fd18179a127024aba8c1d7">
@@ -51,6 +41,16 @@ File: modules/ps_cashondelivery/views/templates/hook/payment_return.tpl:31</note
         <target>customer support</target>
         <note>Context:
 File: modules/ps_cashondelivery/views/templates/hook/payment_return.tpl:31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_cashondelivery/views/templates/hook/ps_cashondelivery_intro.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="536dc7424180872c8c2488ae0286fb53">
+        <source>You pay for the merchandise upon delivery</source>
+        <target>You pay for the merchandise upon delivery</target>
+        <note>Context:
+File: modules/ps_cashondelivery/views/templates/hook/ps_cashondelivery_intro.tpl:28</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesCategorytreeAdmin.xlf
+++ b/app/Resources/translations/default/ModulesCategorytreeAdmin.xlf
@@ -5,62 +5,52 @@
       <trans-unit id="60cc52727703ddd6792698d958ef76aa">
         <source>Category tree links</source>
         <target>Category tree links</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="15a6f5841d9e4d7e62bec3319b4b7036">
         <source>Adds a block featuring product categories.</source>
         <target>Adds a block featuring product categories.</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="1379a6b19242372c1f23cc9adedfcdd6">
         <source>Category root</source>
         <target>Category root</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:168</note>
+        <note>Line: 168</note>
       </trans-unit>
       <trans-unit id="c6d333d07d30f7b4c31a94bbd510bf88">
         <source>Select which category is displayed in the block. The current category is the one the visitor is currently browsing.</source>
         <target>Select which category is displayed in the block. The current category is the one the visitor is currently browsing.</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:170</note>
+        <note>Line: 170</note>
       </trans-unit>
       <trans-unit id="89b278a71f2be5f620307502326587a0">
         <source>Home category</source>
         <target>Home category</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:175</note>
+        <note>Line: 175</note>
       </trans-unit>
       <trans-unit id="62381fc27e62649a16182a616de3f7ea">
         <source>Current category</source>
         <target>Current category</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:180</note>
+        <note>Line: 180</note>
       </trans-unit>
       <trans-unit id="52b68aaa602d202c340d9e4e9157f276">
         <source>Parent category</source>
         <target>Parent category</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:185</note>
+        <note>Line: 185</note>
       </trans-unit>
       <trans-unit id="f225631c1a6f71e99cc779f6bbf06dd4">
         <source>Current category, unless it has no subcategories, in which case the parent category of the current category is used</source>
         <target>Current category, unless it has no subcategories, in which case the parent category of the current category is used</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:190</note>
+        <note>Line: 190</note>
       </trans-unit>
       <trans-unit id="19561e33450d1d3dfe6af08df5710dd0">
         <source>Maximum depth</source>
         <target>Maximum depth</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:196</note>
+        <note>Line: 196</note>
       </trans-unit>
       <trans-unit id="584d4e251b6f778eda9cfc2fc756b0b0">
         <source>Set the maximum depth of category sublevels displayed in this block (0 = infinite).</source>
         <target>Set the maximum depth of category sublevels displayed in this block (0 = infinite).</target>
-        <note>Context:
-File: modules/ps_categorytree/ps_categorytree.php:198</note>
+        <note>Line: 198</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesCheckpaymentAdmin.xlf
+++ b/app/Resources/translations/default/ModulesCheckpaymentAdmin.xlf
@@ -5,74 +5,62 @@
       <trans-unit id="7b4cc4f79be9aae43efd53b4ae5cba4d">
         <source>Payments by check</source>
         <target>Payments by check</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:64</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="e09484ba6c16bc20236b63cc0d87ee95">
         <source>Are you sure you want to delete these details?</source>
         <target>Are you sure you want to delete these details?</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:66</note>
+        <note>Line: 66</note>
       </trans-unit>
       <trans-unit id="eb7ee09497f2bb2a5c766c4e5ef0cc4b">
         <source>The "Payee" and "Address" fields must be configured before using this module.</source>
         <target>The "Payee" and "Address" fields must be configured before using this module.</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:70</note>
+        <note>Line: 70</note>
       </trans-unit>
       <trans-unit id="a02758d758e8bec77a33d7f392eb3f8a">
         <source>No currency has been set for this module.</source>
         <target>No currency has been set for this module.</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:73</note>
+        <note>Line: 73</note>
       </trans-unit>
       <trans-unit id="a6911ad28a15bf35c506e46c3a613c68">
         <source>The "Payee" field is required.</source>
         <target>The "Payee" field is required.</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:103</note>
+        <note>Line: 103</note>
       </trans-unit>
       <trans-unit id="00a369029140cfd18857425d49b472f8">
         <source>The "Address" field is required.</source>
         <target>The "Address" field is required.</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:105</note>
+        <note>Line: 105</note>
       </trans-unit>
       <trans-unit id="a60468657881aa431a0a5fccc76258e2">
         <source>Pay by Check</source>
         <target>Pay by Check</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:160</note>
+        <note>Line: 160</note>
       </trans-unit>
       <trans-unit id="5dd532f0a63d89c5af0243b74732f63c">
         <source>Contact details</source>
         <target>Contact details</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:216</note>
+        <note>Line: 216</note>
       </trans-unit>
       <trans-unit id="84649906133e37fefda33a301de8cd4f">
         <source>Payee (name)</source>
         <target>Payee (name)</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:222</note>
+        <note>Line: 222</note>
       </trans-unit>
       <trans-unit id="dd7bf230fde8d4836917806aff6a6b27">
         <source>Address</source>
         <target>Address</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:228</note>
+        <note>Line: 228</note>
       </trans-unit>
       <trans-unit id="0fe62049ad5246bc188ec1bae347269e">
         <source>Address where the check should be sent to.</source>
         <target>Address where the check should be sent to.</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:229</note>
+        <note>Line: 229</note>
       </trans-unit>
       <trans-unit id="bb56f3a51352fe2ddce129260770c440">
         <source>%amount% (tax incl.)</source>
         <target>%amount% (tax incl.)</target>
-        <note>Context:
-File: modules/ps_checkpayment/ps_checkpayment.php:268</note>
+        <note>Line: 268</note>
       </trans-unit>
     </body>
   </file>
@@ -81,20 +69,17 @@ File: modules/ps_checkpayment/ps_checkpayment.php:268</note>
       <trans-unit id="14e41f4cfd99b10766cc15676d8cda66">
         <source>This module allows you to accept payments by check.</source>
         <target>This module allows you to accept payments by check.</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/infos.tpl:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="22df5428ca8a4d0f5ec081d4815c86f6">
         <source>If the client chooses this payment method, the order status will change to 'Waiting for payment'.</source>
         <target>If the client chooses this payment method, the order status will change to 'Waiting for payment'.</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/infos.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
       <trans-unit id="8c88bbf5712292b26e2a6bbeb0a7b5c4">
         <source>You will need to manually confirm the order as soon as you receive a check.</source>
         <target>You will need to manually confirm the order as soon as you receive a check.</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/infos.tpl:30</note>
+        <note>Line: 30</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesCheckpaymentShop.xlf
+++ b/app/Resources/translations/default/ModulesCheckpaymentShop.xlf
@@ -5,8 +5,7 @@
       <trans-unit id="e2b7dec8fa4b498156dfee6e4c84b156">
         <source>This payment method is not available.</source>
         <target>This payment method is not available.</target>
-        <note>Context:
-File: modules/ps_checkpayment/controllers/front/validation.php:50</note>
+        <note>Line: 50</note>
       </trans-unit>
     </body>
   </file>
@@ -15,102 +14,22 @@ File: modules/ps_checkpayment/controllers/front/validation.php:50</note>
       <trans-unit id="84a25ff3edb86f9b9fd4f6238cd54e51">
         <source>Please send us your check following these rules:</source>
         <target>Please send us your check following these rules:</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/front/payment_infos.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="b2f40690858b404ed10e62bdf422c704">
         <source>Amount</source>
         <target>Amount</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/front/payment_infos.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
       <trans-unit id="961c4d5afb146e7ad1dba22951450e3c">
         <source>Payee</source>
         <target>Payee</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/front/payment_infos.tpl:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="a0335a127854df8e1138f1a42151f484">
         <source>Send your check to this address</source>
         <target>Send your check to this address</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/front/payment_infos.tpl:33</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_checkpayment/views/templates/hook/payment_return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="88526efe38fd18179a127024aba8c1d7">
-        <source>Your order on %s is complete.</source>
-        <target>Your order on %s is complete.</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:27</note>
-      </trans-unit>
-      <trans-unit id="61da27a5dd1f8ced46c77b0feaa9e159">
-        <source>Your check must include:</source>
-        <target>Your check must include:</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="621455d95c5de701e05900a98aaa9c66">
-        <source>Payment amount.</source>
-        <target>Payment amount.</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="9b8f932b1412d130ece5045ecafd1b42">
-        <source>Payable to the order of</source>
-        <target>Payable to the order of</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="9a94f1d749a3de5d299674d6c685e416">
-        <source>Mail to</source>
-        <target>Mail to</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="e1c54fdba2544646684f41ace03b5fda">
-        <source>Do not forget to insert your order number #%d.</source>
-        <target>Do not forget to insert your order number #%d.</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:34</note>
-      </trans-unit>
-      <trans-unit id="4761b03b53bc2b3bd948bb7443a26f31">
-        <source>Do not forget to insert your order reference %s.</source>
-        <target>Do not forget to insert your order reference %s.</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:36</note>
-      </trans-unit>
-      <trans-unit id="610abe74e72f00210e3dcb91a0a3f717">
-        <source>An email has been sent to you with this information.</source>
-        <target>An email has been sent to you with this information.</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="ffd2478830ca2f519f7fe7ee259d4b96">
-        <source>Your order will be sent as soon as we receive your payment.</source>
-        <target>Your order will be sent as soon as we receive your payment.</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="0db71da7150c27142eef9d22b843b4a9">
-        <source>For any questions or for further information, please contact our</source>
-        <target>For any questions or for further information, please contact our</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="decce112a9e64363c997b04aa71b7cb8">
-        <source>customer service department.</source>
-        <target>customer service department.</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="9bdf695c5a30784327137011da6ef568">
-        <source>We have noticed that there is a problem with your order. If you think this is an error, you can contact our</source>
-        <target>We have noticed that there is a problem with your order. If you think this is an error, you can contact our</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:44</note>
+        <note>Line: 33</note>
       </trans-unit>
     </body>
   </file>
@@ -119,14 +38,76 @@ File: modules/ps_checkpayment/views/templates/hook/payment_return.tpl:44</note>
       <trans-unit id="4b80fae2153218ed763bdadc418e8589">
         <source>Pay by check</source>
         <target>Pay by check</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
       <trans-unit id="4e1fb9f4b46556d64db55d50629ee301">
         <source>(order processing will be longer)</source>
         <target>(order processing will be longer)</target>
-        <note>Context:
-File: modules/ps_checkpayment/views/templates/hook/payment.tpl:29</note>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_checkpayment/views/templates/hook/payment_return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="88526efe38fd18179a127024aba8c1d7">
+        <source>Your order on %s is complete.</source>
+        <target>Your order on %s is complete.</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="61da27a5dd1f8ced46c77b0feaa9e159">
+        <source>Your check must include:</source>
+        <target>Your check must include:</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="621455d95c5de701e05900a98aaa9c66">
+        <source>Payment amount.</source>
+        <target>Payment amount.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="9b8f932b1412d130ece5045ecafd1b42">
+        <source>Payable to the order of</source>
+        <target>Payable to the order of</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="9a94f1d749a3de5d299674d6c685e416">
+        <source>Mail to</source>
+        <target>Mail to</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="e1c54fdba2544646684f41ace03b5fda">
+        <source>Do not forget to insert your order number #%d.</source>
+        <target>Do not forget to insert your order number #%d.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="4761b03b53bc2b3bd948bb7443a26f31">
+        <source>Do not forget to insert your order reference %s.</source>
+        <target>Do not forget to insert your order reference %s.</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="610abe74e72f00210e3dcb91a0a3f717">
+        <source>An email has been sent to you with this information.</source>
+        <target>An email has been sent to you with this information.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="ffd2478830ca2f519f7fe7ee259d4b96">
+        <source>Your order will be sent as soon as we receive your payment.</source>
+        <target>Your order will be sent as soon as we receive your payment.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="0db71da7150c27142eef9d22b843b4a9">
+        <source>For any questions or for further information, please contact our</source>
+        <target>For any questions or for further information, please contact our</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="decce112a9e64363c997b04aa71b7cb8">
+        <source>customer service department.</source>
+        <target>customer service department.</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="9bdf695c5a30784327137011da6ef568">
+        <source>We have noticed that there is a problem with your order. If you think this is an error, you can contact our</source>
+        <target>We have noticed that there is a problem with your order. If you think this is an error, you can contact our</target>
+        <note>Line: 44</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesContactformAdmin.xlf
+++ b/app/Resources/translations/default/ModulesContactformAdmin.xlf
@@ -5,50 +5,42 @@
       <trans-unit id="c661cf76442d8d2cb318d560285a2a57">
         <source>Contact form</source>
         <target>Contact form</target>
-        <note>Context:
-File: modules/contactform/contactform.php:63</note>
+        <note>Line: 63</note>
       </trans-unit>
       <trans-unit id="3d720dee87296628c1479b39b2cb6f5a">
         <source>Adds a contact form to the "Contact us" page.</source>
         <target>Adds a contact form to the "Contact us" page.</target>
-        <note>Context:
-File: modules/contactform/contactform.php:65</note>
+        <note>Line: 65</note>
       </trans-unit>
       <trans-unit id="212b06350965b6aa7339b5bee457dda9">
         <source><![CDATA[For even more security on your website forms, consult our Security & Access modules category on the %link%]]></source>
         <target><![CDATA[For even more security on your website forms, consult our Security & Access modules category on the %link%]]></target>
-        <note>Context:
-File: modules/contactform/contactform.php:86</note>
+        <note>Line: 86</note>
       </trans-unit>
       <trans-unit id="3225a10b07f1580f10dee4abc3779e6c">
         <source>Parameters</source>
         <target>Parameters</target>
-        <note>Context:
-File: modules/contactform/contactform.php:160</note>
+        <note>Line: 160</note>
       </trans-unit>
       <trans-unit id="d2c0b054e117c70cefb10a911da903ea">
         <source>Send confirmation email to your customers</source>
         <target>Send confirmation email to your customers</target>
-        <note>Context:
-File: modules/contactform/contactform.php:167</note>
+        <note>Line: 167</note>
       </trans-unit>
       <trans-unit id="80780f42b7844f0860b04ea392e45993">
         <source>Choose Yes and your customers will receive a generic confirmation email including a tracking number after their message is sent. Note: to discourage spam, the content of their message won't be included in the email.</source>
         <target>Choose Yes and your customers will receive a generic confirmation email including a tracking number after their message is sent. Note: to discourage spam, the content of their message won't be included in the email.</target>
-        <note>Context:
-File: modules/contactform/contactform.php:172</note>
+        <note>Line: 172</note>
       </trans-unit>
       <trans-unit id="30944f0a539cd549bb24c4e92966b875">
         <source>Receive customers' messages by email</source>
         <target>Receive customers' messages by email</target>
-        <note>Context:
-File: modules/contactform/contactform.php:195</note>
+        <note>Line: 195</note>
       </trans-unit>
       <trans-unit id="8ab6e7e84d344c8cb79798fee5605638">
         <source>By default, you will only receive contact messages through your Customer service tab.</source>
         <target>By default, you will only receive contact messages through your Customer service tab.</target>
-        <note>Context:
-File: modules/contactform/contactform.php:200</note>
+        <note>Line: 200</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesContactformShop.xlf
+++ b/app/Resources/translations/default/ModulesContactformShop.xlf
@@ -5,38 +5,32 @@
       <trans-unit id="79cedb1d1acf680c3dba79dc679aa249">
         <source>Please select a subject from the list provided. </source>
         <target>Please select a subject from the list provided.</target>
-        <note>Context:
-File: modules/contactform/contactform.php:460</note>
+        <note>Line: 460</note>
       </trans-unit>
       <trans-unit id="ee9f24e2aebc1da18ffd88823144437b">
         <source>An error occurred during the file-upload process.</source>
         <target>An error occurred during the file-upload process.</target>
-        <note>Context:
-File: modules/contactform/contactform.php:466</note>
+        <note>Line: 466</note>
       </trans-unit>
       <trans-unit id="d1a9295d276a65933e0a7334a12e6f41">
         <source>Bad file extension</source>
         <target>Bad file extension</target>
-        <note>Context:
-File: modules/contactform/contactform.php:475</note>
+        <note>Line: 475</note>
       </trans-unit>
       <trans-unit id="56682052b2576fd6944f23dcad609107">
         <source>An error occurred while sending the message, please try again.</source>
         <target>An error occurred while sending the message, please try again.</target>
-        <note>Context:
-File: modules/contactform/contactform.php:485</note>
+        <note>Line: 485</note>
       </trans-unit>
       <trans-unit id="881ae7c0ea0a71b12b4548d4268464f7">
         <source>An error occurred while sending the message.</source>
         <target>An error occurred while sending the message.</target>
-        <note>Context:
-File: modules/contactform/contactform.php:664</note>
+        <note>Line: 664</note>
       </trans-unit>
       <trans-unit id="4ec1c39345fe8820d68463eea8803b0f">
         <source>Your message has been successfully sent to our team.</source>
         <target>Your message has been successfully sent to our team.</target>
-        <note>Context:
-File: modules/contactform/contactform.php:674</note>
+        <note>Line: 674</note>
       </trans-unit>
     </body>
   </file>
@@ -45,62 +39,52 @@ File: modules/contactform/contactform.php:674</note>
       <trans-unit id="d85236bf435afbc0060dec82b9ef80b3">
         <source>Customer service - Contact us</source>
         <target>Customer service - Contact us</target>
-        <note>Context:
-File: modules/contactform/views/templates/widget/contactform.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="cc5fd9b9f1cad59fcff97a1f21f34304">
         <source>Send a message</source>
         <target>Send a message</target>
-        <note>Context:
-File: modules/contactform/views/templates/widget/contactform.tpl:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="d93651d012e77dac5581b08db33195b2">
         <source>If you would like to add a comment about your order, please write it in the field below.</source>
         <target>If you would like to add a comment about your order, please write it in the field below.</target>
-        <note>Context:
-File: modules/contactform/views/templates/widget/contactform.tpl:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="6c27c08f40e1b0d9901deb9ff5f722f7">
         <source>Subject Heading</source>
         <target>Subject Heading</target>
-        <note>Context:
-File: modules/contactform/views/templates/widget/contactform.tpl:52</note>
+        <note>Line: 52</note>
       </trans-unit>
       <trans-unit id="b357b524e740bc85b9790a0712d84a30">
         <source>Email address</source>
         <target>Email address</target>
-        <note>Context:
-File: modules/contactform/views/templates/widget/contactform.tpl:61</note>
+        <note>Line: 61</note>
       </trans-unit>
       <trans-unit id="5d4710f9a8250b13164a82c94d5b00d1">
         <source>Order reference</source>
         <target>Order reference</target>
-        <note>Context:
-File: modules/contactform/views/templates/widget/contactform.tpl:67</note>
+        <note>Line: 67</note>
       </trans-unit>
       <trans-unit id="863cf84b34def228394c03c156bff42c">
         <source>Select reference</source>
         <target>Select reference</target>
-        <note>Context:
-File: modules/contactform/views/templates/widget/contactform.tpl:69</note>
+        <note>Line: 69</note>
       </trans-unit>
       <trans-unit id="13d6078da2e6592822ede083931d6826">
         <source>Attach File</source>
         <target>Attach File</target>
-        <note>Context:
-File: modules/contactform/views/templates/widget/contactform.tpl:79</note>
+        <note>Line: 79</note>
       </trans-unit>
       <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4">
         <source>Message</source>
         <target>Message</target>
-        <note>Context:
-File: modules/contactform/views/templates/widget/contactform.tpl:85</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="94966d90747b97d1f0f206c98a8b1ac3">
         <source>Send</source>
         <target>Send</target>
-        <note>Context:
-File: modules/contactform/views/templates/widget/contactform.tpl:102</note>
+        <note>Line: 102</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesContactinfoAdmin.xlf
+++ b/app/Resources/translations/default/ModulesContactinfoAdmin.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="5e3d6d040d8a81befd75127d526646bc">
         <source>Contact information</source>
         <target>Contact information</target>
-        <note>Context:
-File: modules/ps_contactinfo/ps_contactinfo.php:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="3bef52cd2426ac538e6230c70d7b5929">
         <source>Allows you to display additional information about your store's customer service.</source>
         <target>Allows you to display additional information about your store's customer service.</target>
-        <note>Context:
-File: modules/ps_contactinfo/ps_contactinfo.php:51</note>
+        <note>Line: 51</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesContactinfoShop.xlf
+++ b/app/Resources/translations/default/ModulesContactinfoShop.xlf
@@ -1,40 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="modules/ps_contactinfo/nav.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="02d4482d332e1aef3437cd61c9bcc624">
+        <source>Contact us</source>
+        <target>Contact us</target>
+        <note>Line: 26</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="modules/ps_contactinfo/ps_contactinfo-rich.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="3aea774cdcd8f2c45549f10758a71323">
         <source>Store information</source>
         <target>Store information</target>
-        <note>Context:
-File: modules/ps_contactinfo/ps_contactinfo-rich.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="da6eb684bd77243a780629a180c9d19b">
         <source>Fax: [1]%fax%[/1]</source>
         <target>Fax: [1]%fax%[/1]</target>
-        <note>Context:
-File: modules/ps_contactinfo/ps_contactinfo-rich.tpl:44</note>
+        <note>Line: 44</note>
       </trans-unit>
       <trans-unit id="077d21d48dae9586405c0d264f6d32e7">
         <source>Email us: [1]%email%[/1]</source>
         <target>Email us: [1]%email%[/1]</target>
-        <note>Context:
-File: modules/ps_contactinfo/ps_contactinfo-rich.tpl:57</note>
+        <note>Line: 57</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_contactinfo/nav.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
       <trans-unit id="c6359db4a43cb7267a84b389229fd073">
         <source>Call us: [1]%phone%[/1]</source>
         <target>Call us: [1]%phone%[/1]</target>
-        <note>Context:
-File: modules/ps_contactinfo/nav.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="02d4482d332e1aef3437cd61c9bcc624">
-        <source>Contact us</source>
-        <target>Contact us</target>
-        <note>Context:
-File: modules/ps_contactinfo/nav.tpl:26</note>
+        <note>Line: 32</note>
       </trans-unit>
     </body>
   </file>
@@ -43,20 +38,17 @@ File: modules/ps_contactinfo/nav.tpl:26</note>
       <trans-unit id="0bda3a05a6be2f106eb4f1da481bc7ce">
         <source>Tel: %phone%</source>
         <target>Tel: %phone%</target>
-        <note>Context:
-File: modules/ps_contactinfo/ps_contactinfo.tpl:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="1b1c1c8cc58a5c2d05bd4cb61a9c9e0d">
         <source>Fax: %fax%</source>
         <target>Fax: %fax%</target>
-        <note>Context:
-File: modules/ps_contactinfo/ps_contactinfo.tpl:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="a41346e4da379842644de7448cd7424e">
         <source>Email: [1]%email%[/1]</source>
         <target>Email: [1]%email%[/1]</target>
-        <note>Context:
-File: modules/ps_contactinfo/ps_contactinfo.tpl:54</note>
+        <note>Line: 54</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesCurrencyselectorAdmin.xlf
+++ b/app/Resources/translations/default/ModulesCurrencyselectorAdmin.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="f7a31ae8f776597d4282bd3b1013f08b">
         <source>Currency block</source>
         <target>Currency block</target>
-        <note>Context:
-File: modules/ps_currencyselector/ps_currencyselector.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="80ed40ee905b534ee85ce49a54380107">
         <source>Adds a block allowing customers to choose their preferred shopping currency.</source>
         <target>Adds a block allowing customers to choose their preferred shopping currency.</target>
-        <note>Context:
-File: modules/ps_currencyselector/ps_currencyselector.php:48</note>
+        <note>Line: 48</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesCustomeraccountlinksAdmin.xlf
+++ b/app/Resources/translations/default/ModulesCustomeraccountlinksAdmin.xlf
@@ -5,32 +5,27 @@
       <trans-unit id="ecf3e4f8f34a293099620cc25d5b4d93">
         <source>My Account block</source>
         <target>My Account block</target>
-        <note>Context:
-File: modules/ps_customeraccountlinks/ps_customeraccountlinks.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="03ffbea7542d050afa18fdc857e86462">
         <source>Displays a block with links relative to a user's account.</source>
         <target>Displays a block with links relative to a user's account.</target>
-        <note>Context:
-File: modules/ps_customeraccountlinks/ps_customeraccountlinks.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="d1a365ea7809ae5831c6d9f86886630c">
         <source>Credit slips</source>
         <target>Credit slips</target>
-        <note>Context:
-File: modules/ps_customeraccountlinks/ps_customeraccountlinks.php:107</note>
+        <note>Line: 107</note>
       </trans-unit>
       <trans-unit id="0fd8dc8abb2404ad11af4182f10643c1">
         <source>Personal info</source>
         <target>Personal info</target>
-        <note>Context:
-File: modules/ps_customeraccountlinks/ps_customeraccountlinks.php:115</note>
+        <note>Line: 115</note>
       </trans-unit>
       <trans-unit id="e06d7593c1cd6dabef450be6c3da7091">
         <source>Merchandise returns</source>
         <target>Merchandise returns</target>
-        <note>Context:
-File: modules/ps_customeraccountlinks/ps_customeraccountlinks.php:122</note>
+        <note>Line: 122</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesCustomersigninAdmin.xlf
+++ b/app/Resources/translations/default/ModulesCustomersigninAdmin.xlf
@@ -5,20 +5,17 @@
       <trans-unit id="5f3209b28ac0403f72c912ce1392c870">
         <source>Customer "Sign in" link</source>
         <target>Customer "Sign in" link</target>
-        <note>Context:
-File: modules/ps_customersignin/ps_customersignin.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="970a31aa19d205f92ccfd1913ca04dc0">
         <source>Adds a block that displays information about the customer.</source>
         <target>Adds a block that displays information about the customer.</target>
-        <note>Context:
-File: modules/ps_customersignin/ps_customersignin.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="c131c3e08e3f4780e204fcbd8d0eb6e6">
         <source>%firstname% %lastname%</source>
         <target>%firstname% %lastname%</target>
-        <note>Context:
-File: modules/ps_customersignin/ps_customersignin.php:59</note>
+        <note>Line: 59</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesCustomtextAdmin.xlf
+++ b/app/Resources/translations/default/ModulesCustomtextAdmin.xlf
@@ -5,26 +5,22 @@
       <trans-unit id="da8afa303fe717440d352e7dd7081680">
         <source>Custom text blocks</source>
         <target>Custom text blocks</target>
-        <note>Context:
-File: modules/ps_customtext/ps_customtext.php:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="9b5d9c91c9e2cc8d6d3fe78113824ac1">
         <source>Integrates custom text blocks anywhere in your store front</source>
         <target>Integrates custom text blocks anywhere in your store front</target>
-        <note>Context:
-File: modules/ps_customtext/ps_customtext.php:56</note>
+        <note>Line: 56</note>
       </trans-unit>
       <trans-unit id="ca3e06233b736d289df9f4580a4ab19a">
         <source>CMS block</source>
         <target>CMS block</target>
-        <note>Context:
-File: modules/ps_customtext/ps_customtext.php:196</note>
+        <note>Line: 196</note>
       </trans-unit>
       <trans-unit id="7ef25f7b93adc8bf024ed532d722f697">
         <source>Text block</source>
         <target>Text block</target>
-        <note>Context:
-File: modules/ps_customtext/ps_customtext.php:205</note>
+        <note>Line: 205</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesDashactivityAdmin.xlf
+++ b/app/Resources/translations/default/ModulesDashactivityAdmin.xlf
@@ -5,68 +5,57 @@
       <trans-unit id="0369e7f54bf8a30b2766e6a9a708de0b">
         <source>Dashboard Activity</source>
         <target>Dashboard Activity</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="02b5205ddff3073efc5c8b5b9cc165ba">
         <source>(from %s to %s)</source>
         <target>(from %s to %s)</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:100</note>
+        <note>Line: 100</note>
       </trans-unit>
       <trans-unit id="914030b0a079e4eec3b3f5090c0fc35a">
         <source>Active cart</source>
         <target>Active cart</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:422</note>
+        <note>Line: 422</note>
       </trans-unit>
       <trans-unit id="78fa968db0e87c6fc302614b26f93b5d">
         <source>How long (in minutes) a cart is to be considered as active after the last recorded change (default: 30 min).</source>
         <target>How long (in minutes) a cart is to be considered as active after the last recorded change (default: 30 min).</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:423</note>
+        <note>Line: 423</note>
       </trans-unit>
       <trans-unit id="47b8a33a5335cce8d4e353c4d1743f31">
         <source>Online visitor</source>
         <target>Online visitor</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:440</note>
+        <note>Line: 440</note>
       </trans-unit>
       <trans-unit id="b13a895857368f29e5e127767388b0ab">
         <source>How long (in minutes) a visitor is to be considered as online after their last action (default: 30 min).</source>
         <target>How long (in minutes) a visitor is to be considered as online after their last action (default: 30 min).</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:441</note>
+        <note>Line: 441</note>
       </trans-unit>
       <trans-unit id="6ad366c171531a83ffbc5625e159f340">
         <source>Abandoned cart (min)</source>
         <target>Abandoned cart (min)</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:458</note>
+        <note>Line: 458</note>
       </trans-unit>
       <trans-unit id="8f1f252cfd3cbbcba7a2325f12e3dbc4">
         <source>How long (in hours) after the last action a cart is to be considered as abandoned (default: 24 hrs).</source>
         <target>How long (in hours) after the last action a cart is to be considered as abandoned (default: 24 hrs).</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:459</note>
+        <note>Line: 459</note>
       </trans-unit>
       <trans-unit id="c760237f74bcc7e3f90ad956086edb66">
         <source>hrs</source>
         <target>hrs</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:469</note>
+        <note>Line: 469</note>
       </trans-unit>
       <trans-unit id="a5493eb7cba36f452249d093e7757adc">
         <source>Abandoned cart (max)</source>
         <target>Abandoned cart (max)</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:465</note>
+        <note>Line: 465</note>
       </trans-unit>
       <trans-unit id="45e9c82415a3bee4413485c6bcb4347f">
         <source>How long (in hours) after the last action a cart is no longer to be considered as abandoned (default: 24 hrs).</source>
         <target>How long (in hours) after the last action a cart is no longer to be considered as abandoned (default: 24 hrs).</target>
-        <note>Context:
-File: modules/dashactivity/dashactivity.php:466</note>
+        <note>Line: 466</note>
       </trans-unit>
     </body>
   </file>
@@ -75,110 +64,92 @@ File: modules/dashactivity/dashactivity.php:466</note>
       <trans-unit id="91b1b529580f2bb429493a51a1af932b">
         <source>Activity overview</source>
         <target>Activity overview</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="edfc5fccc0439856b5bd432522ef47aa">
         <source>Online Visitors</source>
         <target>Online Visitors</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="962b7da7912bc637b03626e23b5832b5">
         <source>in the last %d minutes</source>
         <target>in the last %d minutes</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:58</note>
+        <note>Line: 58</note>
       </trans-unit>
       <trans-unit id="7aaacf26dbf7d8929916618bb57d81f8">
         <source>Active Shopping Carts</source>
         <target>Active Shopping Carts</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:56</note>
+        <note>Line: 56</note>
       </trans-unit>
       <trans-unit id="24042b0e4b783724dac4178df4db5d68">
         <source>Currently Pending</source>
         <target>Currently Pending</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:68</note>
+        <note>Line: 68</note>
       </trans-unit>
       <trans-unit id="247d96cbab5bfc79dff10eb2ce6d8897">
         <source>Return/Exchanges</source>
         <target>Return/Exchanges</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:77</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="1c4407dd95b9ef941d30c2838208977e">
         <source>Out of Stock Products</source>
         <target>Out of Stock Products</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:90</note>
+        <note>Line: 90</note>
       </trans-unit>
       <trans-unit id="a644e8cd597f2b92aa52861632c0363d">
         <source>New Messages</source>
         <target>New Messages</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:102</note>
+        <note>Line: 102</note>
       </trans-unit>
       <trans-unit id="56d4e9a4c8e9f47549e8129393b3740f">
         <source>Product Reviews</source>
         <target>Product Reviews</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:109</note>
+        <note>Line: 109</note>
       </trans-unit>
       <trans-unit id="e539ae01694149c9e12295fe564a376b">
         <source><![CDATA[Customers & Newsletters]]></source>
         <target><![CDATA[Customers & Newsletters]]></target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:118</note>
+        <note>Line: 118</note>
       </trans-unit>
       <trans-unit id="8471314b4a53476fbf2379d9a0f7ac28">
         <source>New Customers</source>
         <target>New Customers</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:121</note>
+        <note>Line: 121</note>
       </trans-unit>
       <trans-unit id="d833d1b3c98b980090f79ad42badcf9f">
         <source>New Subscriptions</source>
         <target>New Subscriptions</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:127</note>
+        <note>Line: 127</note>
       </trans-unit>
       <trans-unit id="e42bc03dcf18091455cb8a06ce1d56e9">
         <source>Total Subscribers</source>
         <target>Total Subscribers</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:133</note>
+        <note>Line: 133</note>
       </trans-unit>
       <trans-unit id="e7935ae6c516d89405ec532359d2d75a">
         <source>Traffic</source>
         <target>Traffic</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:142</note>
+        <note>Line: 142</note>
       </trans-unit>
       <trans-unit id="1a4aeb4ca6cd736a4a7b25d8657d9972">
         <source>Link to your Google Analytics account</source>
         <target>Link to your Google Analytics account</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:148</note>
+        <note>Line: 148</note>
       </trans-unit>
       <trans-unit id="d7e637a6e9ff116de2fa89551240a94d">
         <source>Visits</source>
         <target>Visits</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:153</note>
+        <note>Line: 153</note>
       </trans-unit>
       <trans-unit id="945f170a18e4894c90381a3d01bdef8b">
         <source>Unique Visitors</source>
         <target>Unique Visitors</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:159</note>
+        <note>Line: 159</note>
       </trans-unit>
       <trans-unit id="0fcff541ec15c6ed895d5dec49436488">
         <source>Traffic Sources</source>
         <target>Traffic Sources</target>
-        <note>Context:
-File: modules/dashactivity/views/templates/hook/dashboard_zone_one.tpl:165</note>
+        <note>Line: 165</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesDashgoalsAdmin.xlf
+++ b/app/Resources/translations/default/ModulesDashgoalsAdmin.xlf
@@ -5,138 +5,92 @@
       <trans-unit id="50698c5b8ffaf2b7dd089898a244a668">
         <source>Dashboard Goals</source>
         <target>Dashboard Goals</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="ac73c1d4a6befbca8cecf2171cd45d4f">
         <source>Adds a block with your store's forecast.</source>
         <target>Adds a block with your store's forecast.</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="86f5978d9b80124f509bdb71786e929e">
         <source>January</source>
         <target>January</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:54</note>
+        <note>Line: 54</note>
       </trans-unit>
       <trans-unit id="659e59f062c75f81259d22786d6c44aa">
         <source>February</source>
         <target>February</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="fa3e5edac607a88d8fd7ecb9d6d67424">
         <source>March</source>
         <target>March</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:56</note>
+        <note>Line: 56</note>
       </trans-unit>
       <trans-unit id="3fcf026bbfffb63fb24b8de9d0446949">
         <source>April</source>
         <target>April</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:57</note>
+        <note>Line: 57</note>
       </trans-unit>
       <trans-unit id="195fbb57ffe7449796d23466085ce6d8">
         <source>May</source>
         <target>May</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:58</note>
+        <note>Line: 58</note>
       </trans-unit>
       <trans-unit id="688937ccaf2a2b0c45a1c9bbba09698d">
         <source>June</source>
         <target>June</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:59</note>
+        <note>Line: 59</note>
       </trans-unit>
       <trans-unit id="1b539f6f34e8503c97f6d3421346b63c">
         <source>July</source>
         <target>July</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:60</note>
+        <note>Line: 60</note>
       </trans-unit>
       <trans-unit id="41ba70891fb6f39327d8ccb9b1dafb84">
         <source>August</source>
         <target>August</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:61</note>
+        <note>Line: 61</note>
       </trans-unit>
       <trans-unit id="cc5d90569e1c8313c2b1c2aab1401174">
         <source>September</source>
         <target>September</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:62</note>
+        <note>Line: 62</note>
       </trans-unit>
       <trans-unit id="eca60ae8611369fe28a02e2ab8c5d12e">
         <source>October</source>
         <target>October</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:63</note>
+        <note>Line: 63</note>
       </trans-unit>
       <trans-unit id="7e823b37564da492ca1629b4732289a8">
         <source>November</source>
         <target>November</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:64</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="82331503174acbae012b2004f6431fa5">
         <source>December</source>
         <target>December</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:65</note>
+        <note>Line: 65</note>
       </trans-unit>
       <trans-unit id="71241798130f714cbd2786df3da2cf0b">
         <source>Average cart value</source>
         <target>Average cart value</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:193</note>
+        <note>Line: 193</note>
       </trans-unit>
       <trans-unit id="9ac642c5ef334ea05256563f921bb304">
         <source>Goal exceeded</source>
         <target>Goal exceeded</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:198</note>
+        <note>Line: 198</note>
       </trans-unit>
       <trans-unit id="7c103c9bbbaecee07ca898ed65667cbf">
         <source>Goal not reached</source>
         <target>Goal not reached</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:199</note>
+        <note>Line: 199</note>
       </trans-unit>
       <trans-unit id="eb233580dc419f03df5905f175606e4d">
         <source>Goal set:</source>
         <target>Goal set:</target>
-        <note>Context:
-File: modules/dashgoals/dashgoals.php:489</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e7935ae6c516d89405ec532359d2d75a">
-        <source>Traffic</source>
-        <target>Traffic</target>
-        <note>Context:
-File: modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl:58</note>
-      </trans-unit>
-      <trans-unit id="3bb1503332637805beddb73a2dd1fe1b">
-        <source>Conversion</source>
-        <target>Conversion</target>
-        <note>Context:
-File: modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="8c804960da61b637c548c951652b0cac">
-        <source>Average Cart Value</source>
-        <target>Average Cart Value</target>
-        <note>Context:
-File: modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl:64</note>
-      </trans-unit>
-      <trans-unit id="89c1265be62d3ba835a3d963db5956b0">
-        <source>Forecast</source>
-        <target>Forecast</target>
-        <note>Context:
-File: modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl:38</note>
+        <note>Line: 489</note>
       </trans-unit>
     </body>
   </file>
@@ -145,8 +99,31 @@ File: modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl:38</note>
       <trans-unit id="e4c3da18c66c0147144767efeb59198f">
         <source>Conversion Rate</source>
         <target>Conversion Rate</target>
-        <note>Context:
-File: modules/dashgoals/views/templates/hook/config.tpl:33</note>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/dashgoals/views/templates/hook/dashboard_zone_two.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e7935ae6c516d89405ec532359d2d75a">
+        <source>Traffic</source>
+        <target>Traffic</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="3bb1503332637805beddb73a2dd1fe1b">
+        <source>Conversion</source>
+        <target>Conversion</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="8c804960da61b637c548c951652b0cac">
+        <source>Average Cart Value</source>
+        <target>Average Cart Value</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="89c1265be62d3ba835a3d963db5956b0">
+        <source>Forecast</source>
+        <target>Forecast</target>
+        <note>Line: 38</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesDashproductsAdmin.xlf
+++ b/app/Resources/translations/default/ModulesDashproductsAdmin.xlf
@@ -5,98 +5,82 @@
       <trans-unit id="6655df4af87b2038afd507a33545a56d">
         <source>Dashboard Products</source>
         <target>Dashboard Products</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:44</note>
+        <note>Line: 44</note>
       </trans-unit>
       <trans-unit id="4a528e24be5aca96e8a15b256efe1f31">
         <source>Adds a block with a table of your latest orders and a ranking of your products</source>
         <target>Adds a block with a table of your latest orders and a ranking of your products</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="2ea989f83006e233627987293f4bde0a">
         <source>Customer Name</source>
         <target>Customer Name</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:104</note>
+        <note>Line: 104</note>
       </trans-unit>
       <trans-unit id="3ec365dd533ddb7ef3d1c111186ce872">
         <source>Details</source>
         <target>Details</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:150</note>
+        <note>Line: 150</note>
       </trans-unit>
       <trans-unit id="2aed3d711270a6ed67d21ec2d7cd4af8">
         <source>Total sold</source>
         <target>Total sold</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:180</note>
+        <note>Line: 180</note>
       </trans-unit>
       <trans-unit id="9e79098315622e58529d664b9a8b3cf8">
         <source>Net profit</source>
         <target>Net profit</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:190</note>
+        <note>Line: 190</note>
       </trans-unit>
       <trans-unit id="ed4832a84ee072b00a6740f657183598">
         <source>Views</source>
         <target>Views</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:289</note>
+        <note>Line: 289</note>
       </trans-unit>
       <trans-unit id="2c04f1ad7694378897b98624780327ff">
         <source>Added to cart</source>
         <target>Added to cart</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:294</note>
+        <note>Line: 294</note>
       </trans-unit>
       <trans-unit id="ce4ee01637f4279d02d0f232459dc9a4">
         <source>Purchased</source>
         <target>Purchased</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:299</note>
+        <note>Line: 299</note>
       </trans-unit>
       <trans-unit id="1eb18ea1d018abef5759cef60ddc289b">
         <source>You must enable the "Save global page views" option from the "Data mining for statistics" module in order to display the most viewed products, or use the Google Analytics module.</source>
         <target>You must enable the "Save global page views" option from the "Data mining for statistics" module in order to display the most viewed products, or use the Google Analytics module.</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:368</note>
+        <note>Line: 368</note>
       </trans-unit>
       <trans-unit id="cf5f3091e30dee6597885d8c0e0c357f">
         <source>Term</source>
         <target>Term</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:378</note>
+        <note>Line: 378</note>
       </trans-unit>
       <trans-unit id="fd69c5cf902969e6fb71d043085ddee6">
         <source>Results</source>
         <target>Results</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:388</note>
+        <note>Line: 388</note>
       </trans-unit>
       <trans-unit id="85bf7474324d7d02725e4dca586afcd9">
         <source>Number of "Recent Orders" to display</source>
         <target>Number of "Recent Orders" to display</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:546</note>
+        <note>Line: 546</note>
       </trans-unit>
       <trans-unit id="735b8c7f6d50b4c6f818deeab3cdea4a">
         <source>Number of "Best Sellers" to display</source>
         <target>Number of "Best Sellers" to display</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:550</note>
+        <note>Line: 550</note>
       </trans-unit>
       <trans-unit id="14d24dddc4c67abf8364b980b2ccd5a2">
         <source>Number of "Most Viewed" to display</source>
         <target>Number of "Most Viewed" to display</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:554</note>
+        <note>Line: 554</note>
       </trans-unit>
       <trans-unit id="f1ee1eaab342241138d45f35f4d8466a">
         <source>Number of "Top Searches" to display</source>
         <target>Number of "Top Searches" to display</target>
-        <note>Context:
-File: modules/dashproducts/dashproducts.php:558</note>
+        <note>Line: 558</note>
       </trans-unit>
     </body>
   </file>
@@ -105,62 +89,52 @@ File: modules/dashproducts/dashproducts.php:558</note>
       <trans-unit id="3e361ce73ecabd6524af286d55809ed7">
         <source>Products and Sales</source>
         <target>Products and Sales</target>
-        <note>Context:
-File: modules/dashproducts/views/templates/hook/dashboard_zone_two.tpl:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="fd3458547ef9c3a8bd0e1e1b4ef2b4dd">
         <source>Recent Orders</source>
         <target>Recent Orders</target>
-        <note>Context:
-File: modules/dashproducts/views/templates/hook/dashboard_zone_two.tpl:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="d7b2933ba512ada478c97fa43dd7ebe6">
         <source>Best Sellers</source>
         <target>Best Sellers</target>
-        <note>Context:
-File: modules/dashproducts/views/templates/hook/dashboard_zone_two.tpl:56</note>
+        <note>Line: 56</note>
       </trans-unit>
       <trans-unit id="be5006eb5af9ab6dbca803f8d3065bbc">
         <source>Most Viewed</source>
         <target>Most Viewed</target>
-        <note>Context:
-File: modules/dashproducts/views/templates/hook/dashboard_zone_two.tpl:98</note>
+        <note>Line: 98</note>
       </trans-unit>
       <trans-unit id="1eb5e5713d7363e921dd7f5500b6d212">
         <source>Top Searches</source>
         <target>Top Searches</target>
-        <note>Context:
-File: modules/dashproducts/views/templates/hook/dashboard_zone_two.tpl:68</note>
+        <note>Line: 68</note>
       </trans-unit>
       <trans-unit id="3d23ac9ab254a9f1014c3a859b01bcfc">
         <source>Last %d orders</source>
         <target>Last %d orders</target>
-        <note>Context:
-File: modules/dashproducts/views/templates/hook/dashboard_zone_two.tpl:76</note>
+        <note>Line: 76</note>
       </trans-unit>
       <trans-unit id="82f0f8d535196ce2a6ea16652d981f94">
         <source>Top %d products</source>
         <target>Top %d products</target>
-        <note>Context:
-File: modules/dashproducts/views/templates/hook/dashboard_zone_two.tpl:86</note>
+        <note>Line: 86</note>
       </trans-unit>
       <trans-unit id="5da618e8e4b89c66fe86e32cdafde142">
         <source>From</source>
         <target>From</target>
-        <note>Context:
-File: modules/dashproducts/views/templates/hook/dashboard_zone_two.tpl:111</note>
+        <note>Line: 111</note>
       </trans-unit>
       <trans-unit id="01b6e20344b68835c5ed1ddedf20d531">
         <source>to</source>
         <target>to</target>
-        <note>Context:
-File: modules/dashproducts/views/templates/hook/dashboard_zone_two.tpl:111</note>
+        <note>Line: 111</note>
       </trans-unit>
       <trans-unit id="1daaca459ce1e6610e0b97a9ad723f27">
         <source>Top %d most search terms</source>
         <target>Top %d most search terms</target>
-        <note>Context:
-File: modules/dashproducts/views/templates/hook/dashboard_zone_two.tpl:110</note>
+        <note>Line: 110</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesDashtrendsAdmin.xlf
+++ b/app/Resources/translations/default/ModulesDashtrendsAdmin.xlf
@@ -5,38 +5,32 @@
       <trans-unit id="ee653ade5f520037ef95e9dc2a42364c">
         <source>Dashboard Trends</source>
         <target>Dashboard Trends</target>
-        <note>Context:
-File: modules/dashtrends/dashtrends.php:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="f2d0efa68eb71bfd5209abeb9f4b0943">
         <source>Adds a block with a graphical representation of the development of your store(s) based on selected key data.</source>
         <target>Adds a block with a graphical representation of the development of your store(s) based on selected key data.</target>
-        <note>Context:
-File: modules/dashtrends/dashtrends.php:51</note>
+        <note>Line: 51</note>
       </trans-unit>
       <trans-unit id="2d125dc25b158f28a1960bd96a9fa8d1">
         <source>%s points</source>
         <target>%s points</target>
-        <note>Context:
-File: modules/dashtrends/dashtrends.php:198</note>
+        <note>Line: 198</note>
       </trans-unit>
       <trans-unit id="8c804960da61b637c548c951652b0cac">
         <source>Average Cart Value</source>
         <target>Average Cart Value</target>
-        <note>Context:
-File: modules/dashtrends/dashtrends.php:315</note>
+        <note>Line: 315</note>
       </trans-unit>
       <trans-unit id="e4c3da18c66c0147144767efeb59198f">
         <source>Conversion Rate</source>
         <target>Conversion Rate</target>
-        <note>Context:
-File: modules/dashtrends/dashtrends.php:317</note>
+        <note>Line: 317</note>
       </trans-unit>
       <trans-unit id="46418a037045b91e6715c4da91a2a269">
         <source>%s (previous period)</source>
         <target>%s (previous period)</target>
-        <note>Context:
-File: modules/dashtrends/dashtrends.php:338</note>
+        <note>Line: 338</note>
       </trans-unit>
     </body>
   </file>
@@ -45,56 +39,47 @@ File: modules/dashtrends/dashtrends.php:338</note>
       <trans-unit id="43d729c7b81bfa5fc10e756660d877d1">
         <source>Net Profit</source>
         <target>Net Profit</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:71</note>
+        <note>Line: 71</note>
       </trans-unit>
       <trans-unit id="2938c7f7e560ed972f8a4f68e80ff834">
         <source>Dashboard</source>
         <target>Dashboard</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="e537825dd409a90ef70d8c2eb56122a1">
         <source>Sum of revenue (excl. tax) generated within the date range by orders considered validated.</source>
         <target>Sum of revenue (excl. tax) generated within the date range by orders considered validated.</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="8bc1c5ca521b99b87908db0bcd33ec76">
         <source>Total number of orders received within the date range that are considered validated.</source>
         <target>Total number of orders received within the date range that are considered validated.</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="f15f2a2bf99d3dcad2cba1a2c615b9dc">
         <source>Average Cart Value is a metric representing the value of an average order within the date range. It is calculated by dividing Sales by Orders.</source>
         <target>Average Cart Value is a metric representing the value of an average order within the date range. It is calculated by dividing Sales by Orders.</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="791d6355d34dfaf60d68ef04d1ee5767">
         <source>Cart Value</source>
         <target>Cart Value</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:56</note>
+        <note>Line: 56</note>
       </trans-unit>
       <trans-unit id="4f631447981c5fa240006a5ae2c4b267">
         <source>Total number of visits within the date range. A visit is the period of time a user is actively engaged with your website.</source>
         <target>Total number of visits within the date range. A visit is the period of time a user is actively engaged with your website.</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:60</note>
+        <note>Line: 60</note>
       </trans-unit>
       <trans-unit id="7a6e858f8c7c0b78fb4d43cefcb8c017">
         <source>Ecommerce Conversion Rate is the percentage of visits that resulted in an validated order.</source>
         <target>Ecommerce Conversion Rate is the percentage of visits that resulted in an validated order.</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:65</note>
+        <note>Line: 65</note>
       </trans-unit>
       <trans-unit id="8dedc1b3ee3a92212fb5b5acad7f207f">
         <source>Net profit is a measure of the profitability of a venture after accounting for all Ecommerce costs. You can provide these costs by clicking on the configuration icon right above here.</source>
         <target>Net profit is a measure of the profitability of a venture after accounting for all Ecommerce costs. You can provide these costs by clicking on the configuration icon right above here.</target>
-        <note>Context:
-File: modules/dashtrends/views/templates/hook/dashboard_zone_two.tpl:70</note>
+        <note>Line: 70</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesDateofdeliveryShop.xlf
+++ b/app/Resources/translations/default/ModulesDateofdeliveryShop.xlf
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/dateofdelivery/orderDetail.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="32dfb655a7b12a2c5662516e82f5d79b">
-        <source>Approximate date of delivery is between %1$s and %2$s</source>
-        <target>Approximate date of delivery is between %1$s and %2$s</target>
-        <note>Context:
-File: modules/dateofdelivery/orderDetail.tpl:26</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="modules/dateofdelivery/beforeCarrier.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="c9ed8c0b07828727ca6653924b0498d3">
@@ -35,6 +25,16 @@ File: modules/dateofdelivery/beforeCarrier.tpl:85</note>
         <target>and</target>
         <note>Context:
 File: modules/dateofdelivery/beforeCarrier.tpl:87</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/dateofdelivery/orderDetail.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="32dfb655a7b12a2c5662516e82f5d79b">
+        <source>Approximate date of delivery is between %1$s and %2$s</source>
+        <target>Approximate date of delivery is between %1$s and %2$s</target>
+        <note>Context:
+File: modules/dateofdelivery/orderDetail.tpl:26</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesEmailsubscriptionAdmin.xlf
+++ b/app/Resources/translations/default/ModulesEmailsubscriptionAdmin.xlf
@@ -5,242 +5,202 @@
       <trans-unit id="7bf7f18afabb5122fa68fbab617e509b">
         <source>Newsletter subscription</source>
         <target>Newsletter subscription</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="10ae246e682f91bb896dd1d8405514ed">
         <source>Adds a form for newsletter subscription.</source>
         <target>Adds a form for newsletter subscription.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:54</note>
+        <note>Line: 54</note>
       </trans-unit>
       <trans-unit id="396c88991101b5ca362932952293d291">
         <source>Are you sure that you want to delete all of your contacts?</source>
         <target>Are you sure that you want to delete all of your contacts?</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="808c7457c768423c5651cbf676d9f6d7">
         <source>Subscribed</source>
         <target>Subscribed</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:220</note>
+        <note>Line: 220</note>
       </trans-unit>
       <trans-unit id="ec59738d441f28011a81e62bdcea6200">
         <source>Subscribed on</source>
         <target>Subscribed on</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:226</note>
+        <note>Line: 226</note>
       </trans-unit>
       <trans-unit id="3a1205098d0a13a9c41a8d538fd6a34a">
         <source>Newsletter registrations</source>
         <target>Newsletter registrations</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:238</note>
+        <note>Line: 238</note>
       </trans-unit>
       <trans-unit id="4182c8f19d40c7ca236a5f4f83faeb6b">
         <source>Unsubscribe</source>
         <target>Unsubscribe</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:290</note>
+        <note>Line: 290</note>
       </trans-unit>
       <trans-unit id="54d2f1bab16b550e32395a7e6edb8de5">
         <source>Would you like to send a verification email after subscription?</source>
         <target>Would you like to send a verification email after subscription?</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:842</note>
+        <note>Line: 842</note>
       </trans-unit>
       <trans-unit id="b37f32d509cf5aabe806b16791588aa3">
         <source>Would you like to send a confirmation email after subscription?</source>
         <target>Would you like to send a confirmation email after subscription?</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:859</note>
+        <note>Line: 859</note>
       </trans-unit>
       <trans-unit id="506e58042922bff5bd753dc612e84f5b">
         <source>Welcome voucher code</source>
         <target>Welcome voucher code</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:876</note>
+        <note>Line: 876</note>
       </trans-unit>
       <trans-unit id="1d612b943b8f4792bff603384a46e5f1">
         <source>Leave blank to disable by default.</source>
         <target>Leave blank to disable by default.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:893</note>
+        <note>Line: 893</note>
       </trans-unit>
       <trans-unit id="7328d85830cd590d040882106846e28d">
         <source>Newsletter conditions</source>
         <target>Newsletter conditions</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:883</note>
+        <note>Line: 883</note>
       </trans-unit>
       <trans-unit id="23467d023d8767effca98a537a6a0622">
         <source>This text will be displayed beneath the newsletter subscribe button.</source>
         <target>This text will be displayed beneath the newsletter subscribe button.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:889</note>
+        <note>Line: 889</note>
       </trans-unit>
       <trans-unit id="f1c0e2889f04c8333beb7f4d7f87ad23">
         <source>Export customers' addresses</source>
         <target>Export customers' addresses</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:935</note>
+        <note>Line: 935</note>
       </trans-unit>
       <trans-unit id="5353d769bec6eb3977ef36a3d8021682">
         <source>Customers' country</source>
         <target>Customers' country</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:941</note>
+        <note>Line: 941</note>
       </trans-unit>
       <trans-unit id="521f7e76a7d4f9e50c50bb945559b942">
         <source>Filter customers by country.</source>
         <target>Filter customers by country.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:942</note>
+        <note>Line: 942</note>
       </trans-unit>
       <trans-unit id="2198f293f5e1e95dddeff819fbca0975">
         <source>Newsletter subscribers</source>
         <target>Newsletter subscribers</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:954</note>
+        <note>Line: 954</note>
       </trans-unit>
       <trans-unit id="1b09c341aa487e26dac94d2467b7f7e3">
         <source>Filter customers who have subscribed to the newsletter or not, and who have an account or not.</source>
         <target>Filter customers who have subscribed to the newsletter or not, and who have an account or not.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:955</note>
+        <note>Line: 955</note>
       </trans-unit>
       <trans-unit id="e4369fb2bfc3fea17ea362d1eb9e53c4">
         <source>Customers can subscribe to your newsletter when registering, or by entering their email in the newsletter form.</source>
         <target>Customers can subscribe to your newsletter when registering, or by entering their email in the newsletter form.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:956</note>
+        <note>Line: 956</note>
       </trans-unit>
       <trans-unit id="847b0223c73ac0fec0d9df6539c7cad6">
         <source>All subscribers</source>
         <target>All subscribers</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:962</note>
+        <note>Line: 962</note>
       </trans-unit>
       <trans-unit id="a307579714b75082f3f8734971b125cd">
         <source>Subscribers with account</source>
         <target>Subscribers with account</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:963</note>
+        <note>Line: 963</note>
       </trans-unit>
       <trans-unit id="d0da5609e4aebc5d532de97511a5a34a">
         <source>Subscribers without account</source>
         <target>Subscribers without account</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:964</note>
+        <note>Line: 964</note>
       </trans-unit>
       <trans-unit id="011d8c5d94f729f013963d856cd78745">
         <source>Non-subscribers</source>
         <target>Non-subscribers</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:965</note>
+        <note>Line: 965</note>
       </trans-unit>
       <trans-unit id="3c094542e33d2d21a27a0f0f1be1acaf">
         <source>Partner offers subscribers</source>
         <target>Partner offers subscribers</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:982</note>
+        <note>Line: 982</note>
       </trans-unit>
       <trans-unit id="3c450a9c3b3d890e8e7ab06ed3de2c27">
         <source>Filter customers who have agreed to receive your partners' offers or not.</source>
         <target>Filter customers who have agreed to receive your partners' offers or not.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:974</note>
+        <note>Line: 974</note>
       </trans-unit>
       <trans-unit id="511e5032ffddf444de90c630fac63567">
         <source>Partner offers subscribers have agreed to receive your partners' offers.</source>
         <target>Partner offers subscribers have agreed to receive your partners' offers.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:975</note>
+        <note>Line: 975</note>
       </trans-unit>
       <trans-unit id="7e3a51a56ddd2846e21c33f05e0aea6f">
         <source>All customers</source>
         <target>All customers</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:981</note>
+        <note>Line: 981</note>
       </trans-unit>
       <trans-unit id="2760982525dd5028d13b0d4f6abcfa59">
         <source>Partner offers non-subscribers</source>
         <target>Partner offers non-subscribers</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:983</note>
+        <note>Line: 983</note>
       </trans-unit>
       <trans-unit id="f6df4ad6dc4798f26d1f2460eef4f2e9">
         <source>Search for addresses</source>
         <target>Search for addresses</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1027</note>
+        <note>Line: 1027</note>
       </trans-unit>
       <trans-unit id="375afa60efcc1d48300bd339cb8154b0">
         <source>Email address to search</source>
         <target>Email address to search</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1033</note>
+        <note>Line: 1033</note>
       </trans-unit>
       <trans-unit id="e347582d22a4ba3c822de504b23d4704">
         <source>Example: contact@prestashop.com or @prestashop.com</source>
         <target>Example: contact@prestashop.com or @prestashop.com</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1036</note>
+        <note>Line: 1036</note>
       </trans-unit>
       <trans-unit id="82e5e0bc0f9c776c98253d569c111c0f">
         <source>No customers found with these filters!</source>
         <target>No customers found with these filters!</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1095</note>
+        <note>Line: 1095</note>
       </trans-unit>
       <trans-unit id="644ecc2486a059ca16b001a77909bf40">
         <source>The .CSV file has been successfully exported: %d customers found.</source>
         <target>The .CSV file has been successfully exported: %d customers found.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1104</note>
+        <note>Line: 1104</note>
       </trans-unit>
       <trans-unit id="48e3d5f66961b621c78f709afcd7d437">
         <source>Download the file</source>
         <target>Download the file</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1106</note>
+        <note>Line: 1106</note>
       </trans-unit>
       <trans-unit id="dca37b874cf34bd5ebcf1c2fdc59a8b4">
         <source>WARNING: When opening this .csv file with Excel, choose UTF-8 encoding to avoid strange characters.</source>
         <target>WARNING: When opening this .csv file with Excel, choose UTF-8 encoding to avoid strange characters.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1111</note>
+        <note>Line: 1111</note>
       </trans-unit>
       <trans-unit id="b40866b115d74009183e06fc86b5c014">
         <source>Error: Write access limited</source>
         <target>Error: Write access limited</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1210</note>
+        <note>Line: 1210</note>
       </trans-unit>
       <trans-unit id="87b0ca57db642f4e7780174a6abdc37d">
         <source>No result found!</source>
         <target>No result found!</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1118</note>
+        <note>Line: 1118</note>
       </trans-unit>
       <trans-unit id="9896806b3fb40a73bdda4781f61052bf">
         <source>-- Select associated page --</source>
         <target>-- Select associated page --</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1131</note>
+        <note>Line: 1131</note>
       </trans-unit>
-      <trans-unit id="2df860f82be52de57fc5e3f7ecac9431">
+      <trans-unit id="d2bea8f0552d424dcb7180b873eb7b3a">
         <source>Newsletter subscription: no email to delete, this customer has not registered.</source>
         <target>Newsletter subscription: no email to delete, this customer has not registered.</target>
-        <note>Context:
-          File: modules/ps_emailsubscription/ps_emailsubscription.php:1267</note>
+        <note>Line: 1267</note>
       </trans-unit>
-      <trans-unit id="0b6664aa3bb3e3130368b120a8adfa91">
+      <trans-unit id="6915ab8f41e7f6f7805fd3f94117804a">
         <source>Newsletter subscription: no email to export, this customer has not registered.</source>
         <target>Newsletter subscription: no email to export, this customer has not registered.</target>
-        <note>Context:
-          File: modules/ps_emailsubscription/ps_emailsubscription.php:1277</note>
+        <note>Line: 1277</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesEmailsubscriptionShop.xlf
+++ b/app/Resources/translations/default/ModulesEmailsubscriptionShop.xlf
@@ -1,82 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/ps_emailsubscription/views/templates/front/subscription_execution.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7bf7f18afabb5122fa68fbab617e509b">
-        <source>Newsletter subscription</source>
-        <target>Newsletter subscription</target>
-        <note>Context:
-          File: modules/ps_emailsubscription/views/templates/front/subscription_execution.tpl:29</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="1c623b291d95f4f1b1d0c03d0dc0ffa1">
         <source>This email address is not registered.</source>
         <target>This email address is not registered.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:344</note>
+        <note>Line: 344</note>
       </trans-unit>
       <trans-unit id="3b1f17a6fd92e35bc744e986b8e7a61c">
         <source>An error occurred while attempting to unsubscribe.</source>
         <target>An error occurred while attempting to unsubscribe.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:348</note>
+        <note>Line: 348</note>
       </trans-unit>
       <trans-unit id="d4197f3e8e8b4b5d06b599bc45d683bb">
         <source>Unsubscription successful.</source>
         <target>Unsubscription successful.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:351</note>
+        <note>Line: 351</note>
       </trans-unit>
       <trans-unit id="f6618fce0acbfca15e1f2b0991ddbcd0">
         <source>This email address is already registered.</source>
         <target>This email address is already registered.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:355</note>
+        <note>Line: 355</note>
       </trans-unit>
       <trans-unit id="e172cb581e84f43a3bd8ee4e3b512197">
         <source>An error occurred during the subscription process.</source>
         <target>An error occurred during the subscription process.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:377</note>
+        <note>Line: 377</note>
       </trans-unit>
       <trans-unit id="ebc069b1b9a2c48edfa39e344103be1e">
         <source>A verification email has been sent. Please check your inbox.</source>
         <target>A verification email has been sent. Please check your inbox.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:372</note>
+        <note>Line: 372</note>
       </trans-unit>
       <trans-unit id="77c576a354d5d6f5e2c1ba50167addf8">
         <source>You have successfully subscribed to this newsletter.</source>
         <target>You have successfully subscribed to this newsletter.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:375</note>
+        <note>Line: 375</note>
       </trans-unit>
       <trans-unit id="99c8b8e5e51bf8f00f1d66820684be9a">
         <source>This email is already registered and/or invalid.</source>
         <target>This email is already registered and/or invalid.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:612</note>
+        <note>Line: 612</note>
       </trans-unit>
       <trans-unit id="4e1c51e233f1ed368c58db9ef09010ba">
         <source>Thank you for subscribing to our newsletter.</source>
         <target>Thank you for subscribing to our newsletter.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:623</note>
+        <note>Line: 623</note>
       </trans-unit>
       <trans-unit id="b65736001bfe3cc53a665b2e077e5653">
         <source>Sign up for our newsletter[1][2]%conditions%[/2]</source>
         <target>Sign up for our newsletter[1][2]%conditions%[/2]</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:814</note>
+        <note>Line: 814</note>
       </trans-unit>
       <trans-unit id="c3d67cba349c7ecb5465ae92bdb38970">
         <source>You may unsubscribe at any moment. For that purpose, please find our contact info in the legal notice.</source>
         <target>You may unsubscribe at any moment. For that purpose, please find our contact info in the legal notice.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:1219</note>
+        <note>Line: 1219</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailsubscription/views/templates/front/subscription_execution.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7bf7f18afabb5122fa68fbab617e509b">
+        <source>Newsletter subscription</source>
+        <target>Newsletter subscription</target>
+        <note>Line: 29</note>
       </trans-unit>
     </body>
   </file>
@@ -85,14 +73,12 @@ File: modules/ps_emailsubscription/ps_emailsubscription.php:1219</note>
       <trans-unit id="ffb7e666a70151215b4c55c6268d7d72">
         <source>Newsletter</source>
         <target>Newsletter</target>
-        <note>Context:
-File: modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="625f93a63da35ee7150341160460f31e">
         <source>Your e-mail</source>
         <target>Your e-mail</target>
-        <note>Context:
-File: modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl:32</note>
+        <note>Line: 32</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesFacetedsearchAdmin.xlf
+++ b/app/Resources/translations/default/ModulesFacetedsearchAdmin.xlf
@@ -5,158 +5,216 @@
       <trans-unit id="d67b7992a94709663ce72ce9c1606597">
         <source>Faceted search</source>
         <target>Faceted search</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:57</note>
+        <note>Line: 57</note>
       </trans-unit>
       <trans-unit id="0b3be13d3fe8cfc942ae7e8a64f3718b">
         <source>Displays a block allowing multiple filters.</source>
         <target>Displays a block allowing multiple filters.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:58</note>
+        <note>Line: 58</note>
       </trans-unit>
       <trans-unit id="b3786b970611c1a3809dd51b630812a7">
         <source>"%s" is not a valid url</source>
         <target>"%s" is not a valid url</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:618</note>
+        <note>Line: 618</note>
       </trans-unit>
       <trans-unit id="ccc12c5568381293a27db0232877937b">
         <source>Filter template name required (cannot be empty)</source>
         <target>Filter template name required (cannot be empty)</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1043</note>
+        <note>Line: 1043</note>
       </trans-unit>
       <trans-unit id="8c97e587c1b4e519bec26f3903561da3">
         <source>You must select at least one category.</source>
         <target>You must select at least one category.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1045</note>
+        <note>Line: 1045</note>
       </trans-unit>
       <trans-unit id="817c37b9c1f5cd4a450dad384e63e6c7">
         <source>Your filter</source>
         <target>Your filter</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1153</note>
+        <note>Line: 1153</note>
       </trans-unit>
       <trans-unit id="3185cefd67b575e582063148e4f15860">
         <source>was updated successfully.</source>
         <target>was updated successfully.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1154</note>
+        <note>Line: 1154</note>
       </trans-unit>
       <trans-unit id="7ccab4d8de5d6b9bb61e99c7bba343ab">
         <source>was added successfully.</source>
         <target>was added successfully.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1154</note>
+        <note>Line: 1154</note>
       </trans-unit>
       <trans-unit id="fe016d3b990c2a9dd72ab6b45892f2ae">
         <source>Settings saved successfully</source>
         <target>Settings saved successfully</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1169</note>
+        <note>Line: 1169</note>
       </trans-unit>
       <trans-unit id="0d07af70081a2421e2b2972609d699db">
         <source>Filter template deleted, categories updated (reverted to default Filter template).</source>
         <target>Filter template deleted, categories updated (reverted to default Filter template).</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1184</note>
+        <note>Line: 1184</note>
       </trans-unit>
       <trans-unit id="491f46aa6101560e9f1e0d55a063231b">
         <source>Filter template not found</source>
         <target>Filter template not found</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1186</note>
+        <note>Line: 1186</note>
       </trans-unit>
       <trans-unit id="fa03eb688ad8aa1db593d33dabd89bad">
         <source>Root</source>
         <target>Root</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1225</note>
+        <note>Line: 1225</note>
       </trans-unit>
       <trans-unit id="a3868119dc6858db57127fd26e6f9656">
         <source>My template - %s</source>
         <target>My template - %s</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1252</note>
+        <note>Line: 1252</note>
       </trans-unit>
       <trans-unit id="32d2e6cd4bb1719c572ef470a3a525b6">
         <source>My template %s</source>
         <target>My template %s</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2675</note>
+        <note>Line: 2677</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_facetedsearch/views/templates/hook/attribute_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_facetedsearch/views/templates/admin/add.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="28034a200e932f22b324a4dda1bb9f64">
-        <source><![CDATA[Invalid characters: <>;=#{}_]]></source>
-        <target><![CDATA[Invalid characters: <>;=#{}_]]></target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/attribute_form.tpl:27</note>
+      <trans-unit id="51e17eed0057675de4bde1b34206bb12">
+        <source>New filters template</source>
+        <target>New filters template</target>
+        <note>Line: 3</note>
       </trans-unit>
-      <trans-unit id="e919c0dcca631198a18993158182c96b">
-        <source>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this attribute. By default, PrestaShop uses the attribute's name, but you can change that setting using this field.</source>
-        <target>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this attribute. By default, PrestaShop uses the attribute's name, but you can change that setting using this field.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/attribute_form.tpl:50</note>
+      <trans-unit id="f8263d99054a4cdb3428196f078fa212">
+        <source>Template name:</source>
+        <target>Template name:</target>
+        <note>Line: 7</note>
       </trans-unit>
-      <trans-unit id="988d04f25d03c7753f5e4752a9397e79">
-        <source>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this attribute. By default, PrestaShop uses the attribute's name, but you can change that setting using this field.</source>
-        <target>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this attribute. By default, PrestaShop uses the attribute's name, but you can change that setting using this field.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/attribute_form.tpl:78</note>
+      <trans-unit id="4284fda63513b7da70b5d8f032900580">
+        <source>Only as a reminder</source>
+        <target>Only as a reminder</target>
+        <note>Line: 10</note>
       </trans-unit>
-      <trans-unit id="e6b391a8d2c4d45902a23a8b6585703d">
-        <source>URL</source>
-        <target>URL</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/attribute_form.tpl:27</note>
+      <trans-unit id="5d9632c49fb1586eed7123afe2bd806f">
+        <source>Categories used for this template:</source>
+        <target>Categories used for this template:</target>
+        <note>Line: 14</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_facetedsearch/views/templates/hook/feature_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0bcff42b5aed2b0e4501ed178e4f2510">
-        <source>Indexable</source>
-        <target>Indexable</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/feature_form.tpl:84</note>
+      <trans-unit id="78587049e12fb4f6b12e2bb045f2880a">
+        <source>Categories selection is disabled because you have no categories or you are in a "all shops" context.</source>
+        <target>Categories selection is disabled because you have no categories or you are in a "all shops" context.</target>
+        <note>Line: 20</note>
       </trans-unit>
-      <trans-unit id="4e495bf87859dbd3914919cccea139e2">
-        <source>Use this attribute in URL generated by the Faceted Search module.</source>
-        <target>Use this attribute in URL generated by the Faceted Search module.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/feature_form.tpl:99</note>
+      <trans-unit id="c2d0bf5ad42279c519cdcb4a94eb46b6">
+        <source>Choose shop association:</source>
+        <target>Choose shop association:</target>
+        <note>Line: 27</note>
       </trans-unit>
-      <trans-unit id="81e6451dad5734120899da86f7da4e4e">
-        <source>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this feature. By default, PrestaShop uses the feature's name, but you can change that setting using this field.</source>
-        <target>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this feature. By default, PrestaShop uses the feature's name, but you can change that setting using this field.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/feature_form.tpl:50</note>
+      <trans-unit id="88ec58dbbe7a8b727200696cfca4df3d">
+        <source>You can drag and drop filters to adjust position</source>
+        <target>You can drag and drop filters to adjust position</target>
+        <note>Line: 34</note>
       </trans-unit>
-      <trans-unit id="78b4c0278638dd0fd4b29a05895d7891">
-        <source>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this feature. By default, PrestaShop uses the feature's name, but you can change that setting using this field.</source>
-        <target>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this feature. By default, PrestaShop uses the feature's name, but you can change that setting using this field.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/feature_form.tpl:78</note>
+      <trans-unit id="60266302eeda2ac9775c3a2036ae25ca">
+        <source>Filters:</source>
+        <target>Filters:</target>
+        <note>Line: 34</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_facetedsearch/views/templates/hook/feature_value_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b0aefa9a5ca20f89372b37c2c35c1d4b">
-        <source>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this feature's value. By default, PrestaShop uses the value's name, but you can change that setting using this field.</source>
-        <target>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this feature's value. By default, PrestaShop uses the value's name, but you can change that setting using this field.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/feature_value_form.tpl:50</note>
+      <trans-unit id="29da3cb8b65298a3e88f5041e9fb9761">
+        <source>Total filters: %s</source>
+        <target>Total filters: %s</target>
+        <note>Line: 40</note>
       </trans-unit>
-      <trans-unit id="0e6de50c32b9b10fd375ee52090b7f3e">
-        <source>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this feature's value. By default, PrestaShop uses the value's name, but you can change that setting using this field.</source>
-        <target>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this feature's value. By default, PrestaShop uses the value's name, but you can change that setting using this field.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/hook/feature_value_form.tpl:78</note>
+      <trans-unit id="cfbc982f8fb7a0cc3abb3c85c795ab41">
+        <source>Sub-categories filter</source>
+        <target>Sub-categories filter</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="379d3973e10dfd90c475060f31b9ae74">
+        <source>Filter result limit:</source>
+        <target>Filter result limit:</target>
+        <note>Line: 367</note>
+      </trans-unit>
+      <trans-unit id="af605ea55ee39e54c444f217e346048f">
+        <source>No limit</source>
+        <target>No limit</target>
+        <note>Line: 370</note>
+      </trans-unit>
+      <trans-unit id="284fd1ee8a33e84e08699ba0bbc44943">
+        <source>Filter style:</source>
+        <target>Filter style:</target>
+        <note>Line: 379</note>
+      </trans-unit>
+      <trans-unit id="4f8222964f9a317cef99dddc23a121bd">
+        <source>Checkbox</source>
+        <target>Checkbox</target>
+        <note>Line: 382</note>
+      </trans-unit>
+      <trans-unit id="07a9ca8c8228dd3399141e228034fedf">
+        <source>Radio button</source>
+        <target>Radio button</target>
+        <note>Line: 383</note>
+      </trans-unit>
+      <trans-unit id="5204077231fc7164e2269e96b584dd95">
+        <source>Drop-down list</source>
+        <target>Drop-down list</target>
+        <note>Line: 384</note>
+      </trans-unit>
+      <trans-unit id="cd50ff1c5332f9920acf8173c4aab425">
+        <source>Product stock filter</source>
+        <target>Product stock filter</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="048c1728a0a6cf36f56c9dcdd23d8a14">
+        <source>Product condition filter</source>
+        <target>Product condition filter</target>
+        <note>Line: 135</note>
+      </trans-unit>
+      <trans-unit id="e581c019fe5c1b2aa8dfa18d93f88d13">
+        <source>Product brand filter</source>
+        <target>Product brand filter</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="cc72ed9534a489b5d2e5882735bf1364">
+        <source>Product weight filter (slider)</source>
+        <target>Product weight filter (slider)</target>
+        <note>Line: 209</note>
+      </trans-unit>
+      <trans-unit id="ce9bd6e7a7bfa2fa2d9e43bc4fcfeb8a">
+        <source>List of ranges</source>
+        <target>List of ranges</target>
+        <note>Line: 261</note>
+      </trans-unit>
+      <trans-unit id="0649bb392812f99ff6b0e2ba160675fa">
+        <source>Product price filter (slider)</source>
+        <target>Product price filter (slider)</target>
+        <note>Line: 243</note>
+      </trans-unit>
+      <trans-unit id="db6b86d05039c4f657a28647f8eb5140">
+        <source>Attribute group: %name% (%count% attributes)</source>
+        <target>Attribute group: %name% (%count% attributes)</target>
+        <note>Line: 281</note>
+      </trans-unit>
+      <trans-unit id="788a474b0e55d612b3d500743c6251a0">
+        <source>Attribute group: %name% (%count% attribute)</source>
+        <target>Attribute group: %name% (%count% attribute)</target>
+        <note>Line: 290</note>
+      </trans-unit>
+      <trans-unit id="ee59f74265cd7f85d0ad30206a1a89b0">
+        <source>This group will allow user to select a color</source>
+        <target>This group will allow user to select a color</target>
+        <note>Line: 300</note>
+      </trans-unit>
+      <trans-unit id="4127fb33c1db9597f3c881ae057f1370">
+        <source>Feature: %name% (%count% values)</source>
+        <target>Feature: %name% (%count% values)</target>
+        <note>Line: 346</note>
+      </trans-unit>
+      <trans-unit id="cadad7b648bb2b1d3f22421b00a14fd2">
+        <source>Feature: %name% (%count% value)</source>
+        <target>Feature: %name% (%count% value)</target>
+        <note>Line: 355</note>
+      </trans-unit>
+      <trans-unit id="dc3f85827350641490287c65c0c4ddf8">
+        <source>You must select at least one filter</source>
+        <target>You must select at least one filter</target>
+        <note>Line: 409</note>
       </trans-unit>
     </body>
   </file>
@@ -165,402 +223,254 @@ File: modules/ps_facetedsearch/views/templates/hook/feature_value_form.tpl:78</n
       <trans-unit id="1f0f8b59397f34d499b181297714713a">
         <source>Warning! Your hosting provider is using the Suhosin patch for PHP, which limits the maximum number of fields allowed in a form:</source>
         <target>Warning! Your hosting provider is using the Suhosin patch for PHP, which limits the maximum number of fields allowed in a form:</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:11</note>
+        <note>Line: 11</note>
       </trans-unit>
       <trans-unit id="9df9f71b2fc62b0ce48cbb8cb5671ee6">
         <source>for suhosin.post.max_vars.</source>
         <target>for suhosin.post.max_vars.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:13</note>
+        <note>Line: 13</note>
       </trans-unit>
       <trans-unit id="961e2bc7e3f570a3209546330de84a00">
         <source>for suhosin.request.max_vars.</source>
         <target>for suhosin.request.max_vars.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:14</note>
+        <note>Line: 14</note>
       </trans-unit>
       <trans-unit id="308c1cf98be9973142833c9a9dbbc2ef">
         <source>Please ask your hosting provider to increase the Suhosin limit to</source>
         <target>Please ask your hosting provider to increase the Suhosin limit to</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:15</note>
+        <note>Line: 15</note>
       </trans-unit>
       <trans-unit id="5ad040870ae5ccaeb2d57e4d052163a4">
         <source>Warning! Your PHP configuration limits the maximum number of fields allowed in a form:</source>
         <target>Warning! Your PHP configuration limits the maximum number of fields allowed in a form:</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:17</note>
+        <note>Line: 17</note>
       </trans-unit>
       <trans-unit id="5607dc45ebdfc0baaab64d944aa88f47">
         <source>for max_input_vars.</source>
         <target>for max_input_vars.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:18</note>
+        <note>Line: 18</note>
       </trans-unit>
       <trans-unit id="6e709babf4b5a0ed4194ad5240e1be2c">
         <source>Please ask your hosting provider to increase this limit to</source>
         <target>Please ask your hosting provider to increase this limit to</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:19</note>
+        <note>Line: 19</note>
       </trans-unit>
       <trans-unit id="5d27fef01a54790de11db21f1ed47892">
         <source>%s at least, or you will have to edit the translation files manually.</source>
         <target>%s at least, or you will have to edit the translation files manually.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:21</note>
+        <note>Line: 21</note>
       </trans-unit>
       <trans-unit id="df2bbc994d10995dcffdf96dbb7acbb1">
         <source>Indexes and caches</source>
         <target>Indexes and caches</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:25</note>
+        <note>Line: 25</note>
       </trans-unit>
       <trans-unit id="ad3e7eb269d8ba0ac388267627f45b5a">
         <source>Indexing is in progress. Please do not leave this page</source>
         <target>Indexing is in progress. Please do not leave this page</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="5e2420d2318025812dc3e231ddb66b0b">
         <source>Index all missing prices</source>
         <target>Index all missing prices</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="9612e005e96ad32b8830be4d0377e7e6">
         <source>Rebuild entire price index</source>
         <target>Rebuild entire price index</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="d47f700b6db025d98cae0b340ed847e9">
         <source>Build attribute index</source>
         <target>Build attribute index</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="53795c3624ae2361363780589aa2aa42">
         <source>You can set a cron job that will rebuild price index using the following URL:</source>
         <target>You can set a cron job that will rebuild price index using the following URL:</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:38</note>
+        <note>Line: 38</note>
       </trans-unit>
       <trans-unit id="e43b32b88c77e49f06144cd1ffaeba96">
         <source>You can set a cron job that will rebuild attribute index using the following URL:</source>
         <target>You can set a cron job that will rebuild attribute index using the following URL:</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="16349835364cf839e6670b0de7da6362">
         <source>A nightly rebuild is recommended.</source>
         <target>A nightly rebuild is recommended.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="dc83eb2d8601743d8111c5150b93fc71">
         <source>Filters templates</source>
         <target>Filters templates</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="f7f19392da30e81c3abf433ce7b8ca38">
         <source>Created on</source>
         <target>Created on</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:62</note>
+        <note>Line: 62</note>
       </trans-unit>
       <trans-unit id="06df33001c1d7187fdd81ea1f5b277aa">
         <source>Actions</source>
         <target>Actions</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:63</note>
+        <note>Line: 63</note>
       </trans-unit>
       <trans-unit id="eb0728df77683ac0f7210ed0d4a18d62">
         <source>Do you really want to delete this filter template?</source>
         <target>Do you really want to delete this filter template?</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:86</note>
+        <note>Line: 86</note>
       </trans-unit>
       <trans-unit id="058eeeba77f547f8a9a295a0efd4f6cd">
         <source>No filter template found.</source>
         <target>No filter template found.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:102</note>
+        <note>Line: 102</note>
       </trans-unit>
       <trans-unit id="ae2b83a081959fff7ab2e96f4ce972d1">
         <source>Add new template</source>
         <target>Add new template</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:106</note>
+        <note>Line: 106</note>
       </trans-unit>
       <trans-unit id="8531c73de81b9ed94322dda7cf947daa">
         <source>Show the number of matching products</source>
         <target>Show the number of matching products</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:114</note>
+        <note>Line: 114</note>
       </trans-unit>
       <trans-unit id="ee61c015043c79c1370fc14980dd27b9">
         <source>Show products from subcategories</source>
         <target>Show products from subcategories</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:130</note>
+        <note>Line: 130</note>
       </trans-unit>
       <trans-unit id="a19399fa42f1ab059401a14b9f13eba1">
         <source>Category filter depth (0 for no limits, 1 by default)</source>
         <target>Category filter depth (0 for no limits, 1 by default)</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:146</note>
+        <note>Line: 146</note>
       </trans-unit>
       <trans-unit id="3e652bd299bb3ee3d458c0dcc7fd706e">
         <source>Use tax to filter price</source>
         <target>Use tax to filter price</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:152</note>
+        <note>Line: 152</note>
       </trans-unit>
       <trans-unit id="30b1f6f4369e3d0f7a0d50b5cb96aabd">
         <source>Use rounding to filter price</source>
         <target>Use rounding to filter price</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:168</note>
+        <note>Line: 168</note>
       </trans-unit>
       <trans-unit id="56fc8142961f1f3e9f9ec0c178881b69">
         <source>(in progress)</source>
         <target>(in progress)</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:196</note>
+        <note>Line: 196</note>
       </trans-unit>
       <trans-unit id="8c83a87ac8ee57d9bcd79d1aa9243bc0">
         <source>URL indexing finished</source>
         <target>URL indexing finished</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:197</note>
+        <note>Line: 197</note>
       </trans-unit>
       <trans-unit id="49afa0d9ad5c1f8bf5413b9dc8a252c9">
         <source>Attribute indexing finished</source>
         <target>Attribute indexing finished</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:198</note>
+        <note>Line: 198</note>
       </trans-unit>
       <trans-unit id="9ea5bab5df9a3f3abaa64951daf07e9b">
         <source>URL indexing failed</source>
         <target>URL indexing failed</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:199</note>
+        <note>Line: 199</note>
       </trans-unit>
       <trans-unit id="414301b329318b3e916c5b91b0ca9126">
         <source>Attribute indexing failed</source>
         <target>Attribute indexing failed</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:200</note>
+        <note>Line: 200</note>
       </trans-unit>
       <trans-unit id="fa059e7a64ab37fe21b01a220b6c073f">
         <source>Price indexing finished</source>
         <target>Price indexing finished</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:201</note>
+        <note>Line: 201</note>
       </trans-unit>
       <trans-unit id="b55143bb1f46af4207ea4b5eb8e844ed">
         <source>Price indexing failed</source>
         <target>Price indexing failed</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:202</note>
+        <note>Line: 202</note>
       </trans-unit>
       <trans-unit id="7cf7d150dd287df0a8e17eeb4cf2161d">
         <source>(in progress, %s products price to index)</source>
         <target>(in progress, %s products price to index)</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:203</note>
+        <note>Line: 203</note>
       </trans-unit>
       <trans-unit id="8524de963f07201e5c086830d370797f">
         <source>Loading...</source>
         <target>Loading...</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:204</note>
+        <note>Line: 204</note>
       </trans-unit>
       <trans-unit id="eb9c805f7590679f0742ba0ea0a3e77f">
         <source>You selected -All categories-: all existing filter templates will be deleted. Is it OK?</source>
         <target>You selected -All categories-: all existing filter templates will be deleted. Is it OK?</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/view.tpl:205</note>
+        <note>Line: 205</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_facetedsearch/views/templates/admin/add.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
       <trans-unit id="18c6120643596bd2626f3b0720b1df3a">
         <source>You must select at least one category</source>
         <target>You must select at least one category</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:408</note>
+        <note>Line: 206</note>
       </trans-unit>
-      <trans-unit id="51e17eed0057675de4bde1b34206bb12">
-        <source>New filters template</source>
-        <target>New filters template</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:3</note>
+    </body>
+  </file>
+  <file original="modules/ps_facetedsearch/views/templates/hook/attribute_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e919c0dcca631198a18993158182c96b">
+        <source>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this attribute. By default, PrestaShop uses the attribute's name, but you can change that setting using this field.</source>
+        <target>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this attribute. By default, PrestaShop uses the attribute's name, but you can change that setting using this field.</target>
+        <note>Line: 50</note>
       </trans-unit>
-      <trans-unit id="f8263d99054a4cdb3428196f078fa212">
-        <source>Template name:</source>
-        <target>Template name:</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:7</note>
+      <trans-unit id="988d04f25d03c7753f5e4752a9397e79">
+        <source>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this attribute. By default, PrestaShop uses the attribute's name, but you can change that setting using this field.</source>
+        <target>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this attribute. By default, PrestaShop uses the attribute's name, but you can change that setting using this field.</target>
+        <note>Line: 78</note>
       </trans-unit>
-      <trans-unit id="4284fda63513b7da70b5d8f032900580">
-        <source>Only as a reminder</source>
-        <target>Only as a reminder</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:10</note>
+      <trans-unit id="e6b391a8d2c4d45902a23a8b6585703d">
+        <source>URL</source>
+        <target>URL</target>
+        <note>Line: 27</note>
       </trans-unit>
-      <trans-unit id="5d9632c49fb1586eed7123afe2bd806f">
-        <source>Categories used for this template:</source>
-        <target>Categories used for this template:</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:14</note>
+    </body>
+  </file>
+  <file original="modules/ps_facetedsearch/views/templates/hook/feature_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="28034a200e932f22b324a4dda1bb9f64">
+        <source><![CDATA[Invalid characters: <>;=#{}_]]></source>
+        <target><![CDATA[Invalid characters: <>;=#{}_]]></target>
+        <note>Line: 27</note>
       </trans-unit>
-      <trans-unit id="78587049e12fb4f6b12e2bb045f2880a">
-        <source>Categories selection is disabled because you have no categories or you are in a "all shops" context.</source>
-        <target>Categories selection is disabled because you have no categories or you are in a "all shops" context.</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:20</note>
+      <trans-unit id="0bcff42b5aed2b0e4501ed178e4f2510">
+        <source>Indexable</source>
+        <target>Indexable</target>
+        <note>Line: 84</note>
       </trans-unit>
-      <trans-unit id="c2d0bf5ad42279c519cdcb4a94eb46b6">
-        <source>Choose shop association:</source>
-        <target>Choose shop association:</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:27</note>
+      <trans-unit id="4e495bf87859dbd3914919cccea139e2">
+        <source>Use this attribute in URL generated by the Faceted Search module.</source>
+        <target>Use this attribute in URL generated by the Faceted Search module.</target>
+        <note>Line: 99</note>
       </trans-unit>
-      <trans-unit id="88ec58dbbe7a8b727200696cfca4df3d">
-        <source>You can drag and drop filters to adjust position</source>
-        <target>You can drag and drop filters to adjust position</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:34</note>
+      <trans-unit id="81e6451dad5734120899da86f7da4e4e">
+        <source>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this feature. By default, PrestaShop uses the feature's name, but you can change that setting using this field.</source>
+        <target>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this feature. By default, PrestaShop uses the feature's name, but you can change that setting using this field.</target>
+        <note>Line: 50</note>
       </trans-unit>
-      <trans-unit id="60266302eeda2ac9775c3a2036ae25ca">
-        <source>Filters:</source>
-        <target>Filters:</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:34</note>
+      <trans-unit id="78b4c0278638dd0fd4b29a05895d7891">
+        <source>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this feature. By default, PrestaShop uses the feature's name, but you can change that setting using this field.</source>
+        <target>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this feature. By default, PrestaShop uses the feature's name, but you can change that setting using this field.</target>
+        <note>Line: 78</note>
       </trans-unit>
-      <trans-unit id="29da3cb8b65298a3e88f5041e9fb9761">
-        <source>Total filters: %s</source>
-        <target>Total filters: %s</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:40</note>
+    </body>
+  </file>
+  <file original="modules/ps_facetedsearch/views/templates/hook/feature_value_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b0aefa9a5ca20f89372b37c2c35c1d4b">
+        <source>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this feature's value. By default, PrestaShop uses the value's name, but you can change that setting using this field.</source>
+        <target>When the Faceted Search module is enabled, you can get more detailed URLs by choosing the word that best represent this feature's value. By default, PrestaShop uses the value's name, but you can change that setting using this field.</target>
+        <note>Line: 50</note>
       </trans-unit>
-      <trans-unit id="cfbc982f8fb7a0cc3abb3c85c795ab41">
-        <source>Sub-categories filter</source>
-        <target>Sub-categories filter</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="379d3973e10dfd90c475060f31b9ae74">
-        <source>Filter result limit:</source>
-        <target>Filter result limit:</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:367</note>
-      </trans-unit>
-      <trans-unit id="af605ea55ee39e54c444f217e346048f">
-        <source>No limit</source>
-        <target>No limit</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:370</note>
-      </trans-unit>
-      <trans-unit id="284fd1ee8a33e84e08699ba0bbc44943">
-        <source>Filter style:</source>
-        <target>Filter style:</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:379</note>
-      </trans-unit>
-      <trans-unit id="4f8222964f9a317cef99dddc23a121bd">
-        <source>Checkbox</source>
-        <target>Checkbox</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:382</note>
-      </trans-unit>
-      <trans-unit id="07a9ca8c8228dd3399141e228034fedf">
-        <source>Radio button</source>
-        <target>Radio button</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:383</note>
-      </trans-unit>
-      <trans-unit id="5204077231fc7164e2269e96b584dd95">
-        <source>Drop-down list</source>
-        <target>Drop-down list</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:384</note>
-      </trans-unit>
-      <trans-unit id="cd50ff1c5332f9920acf8173c4aab425">
-        <source>Product stock filter</source>
-        <target>Product stock filter</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:98</note>
-      </trans-unit>
-      <trans-unit id="048c1728a0a6cf36f56c9dcdd23d8a14">
-        <source>Product condition filter</source>
-        <target>Product condition filter</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:135</note>
-      </trans-unit>
-      <trans-unit id="e581c019fe5c1b2aa8dfa18d93f88d13">
-        <source>Product brand filter</source>
-        <target>Product brand filter</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:172</note>
-      </trans-unit>
-      <trans-unit id="cc72ed9534a489b5d2e5882735bf1364">
-        <source>Product weight filter (slider)</source>
-        <target>Product weight filter (slider)</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:209</note>
-      </trans-unit>
-      <trans-unit id="ce9bd6e7a7bfa2fa2d9e43bc4fcfeb8a">
-        <source>List of ranges</source>
-        <target>List of ranges</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:261</note>
-      </trans-unit>
-      <trans-unit id="0649bb392812f99ff6b0e2ba160675fa">
-        <source>Product price filter (slider)</source>
-        <target>Product price filter (slider)</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:243</note>
-      </trans-unit>
-      <trans-unit id="db6b86d05039c4f657a28647f8eb5140">
-        <source>Attribute group: %name% (%count% attributes)</source>
-        <target>Attribute group: %name% (%count% attributes)</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:281</note>
-      </trans-unit>
-      <trans-unit id="788a474b0e55d612b3d500743c6251a0">
-        <source>Attribute group: %name% (%count% attribute)</source>
-        <target>Attribute group: %name% (%count% attribute)</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:290</note>
-      </trans-unit>
-      <trans-unit id="ee59f74265cd7f85d0ad30206a1a89b0">
-        <source>This group will allow user to select a color</source>
-        <target>This group will allow user to select a color</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:300</note>
-      </trans-unit>
-      <trans-unit id="4127fb33c1db9597f3c881ae057f1370">
-        <source>Feature: %name% (%count% values)</source>
-        <target>Feature: %name% (%count% values)</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:346</note>
-      </trans-unit>
-      <trans-unit id="cadad7b648bb2b1d3f22421b00a14fd2">
-        <source>Feature: %name% (%count% value)</source>
-        <target>Feature: %name% (%count% value)</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:355</note>
-      </trans-unit>
-      <trans-unit id="dc3f85827350641490287c65c0c4ddf8">
-        <source>You must select at least one filter</source>
-        <target>You must select at least one filter</target>
-        <note>Context:
-File: modules/ps_facetedsearch/views/templates/admin/add.tpl:409</note>
+      <trans-unit id="0e6de50c32b9b10fd375ee52090b7f3e">
+        <source>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this feature's value. By default, PrestaShop uses the value's name, but you can change that setting using this field.</source>
+        <target>When the Faceted Search module is enabled, you can get more detailed page titles by choosing the word that best represent this feature's value. By default, PrestaShop uses the value's name, but you can change that setting using this field.</target>
+        <note>Line: 78</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesFacetedsearchShop.xlf
+++ b/app/Resources/translations/default/ModulesFacetedsearchShop.xlf
@@ -1,82 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/ps_facetedsearch/src/Ps_FacetedsearchProductSearchProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ad24ffca4f9e9c0c7e80fe1512df6db9">
-        <source>Relevance</source>
-        <target>Relevance</target>
-        <note>Context:
-File: modules/ps_facetedsearch/src/Ps_FacetedsearchProductSearchProvider.php:121</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="modules/ps_facetedsearch/ps_facetedsearch.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="3601146c4e948c32b6424d2c0a7f0118">
         <source>Price</source>
         <target>Price</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:1994</note>
+        <note>Line: 1996</note>
       </trans-unit>
       <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
         <source>Weight</source>
         <target>Weight</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2038</note>
+        <note>Line: 2040</note>
       </trans-unit>
       <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e">
         <source>New</source>
         <target>New</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2091</note>
+        <note>Line: 2093</note>
       </trans-unit>
       <trans-unit id="019d1ca7d50cc54b995f60d456435e87">
         <source>Used</source>
         <target>Used</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2092</note>
+        <note>Line: 2094</note>
       </trans-unit>
       <trans-unit id="6da03a74721a0554b7143254225cc08a">
         <source>Refurbished</source>
         <target>Refurbished</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2093</note>
+        <note>Line: 2095</note>
       </trans-unit>
       <trans-unit id="9e2941b3c81256fac10392aaca4ccfde">
         <source>Condition</source>
         <target>Condition</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2119</note>
+        <note>Line: 2121</note>
       </trans-unit>
       <trans-unit id="2d25c72c1b18e562f6654fff8e11711e">
         <source>Not available</source>
         <target>Not available</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2128</note>
+        <note>Line: 2130</note>
       </trans-unit>
       <trans-unit id="fcebe56087b9373f15514831184fa572">
         <source>In stock</source>
         <target>In stock</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2129</note>
+        <note>Line: 2131</note>
       </trans-unit>
       <trans-unit id="faeaec9eda6bc4c8cb6e1a9156a858be">
         <source>Availability</source>
         <target>Availability</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2151</note>
+        <note>Line: 2153</note>
       </trans-unit>
       <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
         <source>Brand</source>
         <target>Brand</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2174</note>
+        <note>Line: 2176</note>
       </trans-unit>
       <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
         <source>Categories</source>
         <target>Categories</target>
-        <note>Context:
-File: modules/ps_facetedsearch/ps_facetedsearch.php:2294</note>
+        <note>Line: 2296</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_facetedsearch/src/Ps_FacetedsearchProductSearchProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ad24ffca4f9e9c0c7e80fe1512df6db9">
+        <source>Relevance</source>
+        <target>Relevance</target>
+        <note>Line: 121</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesFaviconnotificationboAdmin.xlf
+++ b/app/Resources/translations/default/ModulesFaviconnotificationboAdmin.xlf
@@ -1,43 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/ps_faviconnotificationbo/views/templates/admin/tabs/faviconConfiguration.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="df47b138ef38d036367dd40804eaf281">
-        <source>Display notifications in the browser tab for:</source>
-        <target>Display notifications in the browser tab for:</target>
-        <note>Context:
-File: modules/ps_faviconnotificationbo/views/templates/admin/tabs/faviconConfiguration.tpl:22</note>
-      </trans-unit>
-      <trans-unit id="39f955a983e02682aeecdf0c94854c9b">
-        <source>New orders</source>
-        <target>New orders</target>
-        <note>Context:
-File: modules/ps_faviconnotificationbo/views/templates/admin/tabs/faviconConfiguration.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="d836b5e952dee5c17b2168ee86ebe8e6">
-        <source>Notification background color</source>
-        <target>Notification background color</target>
-        <note>Context:
-File: modules/ps_faviconnotificationbo/views/templates/admin/tabs/faviconConfiguration.tpl:80</note>
-      </trans-unit>
-      <trans-unit id="edfc54b8273bf6358f53c1bbcfdd8fd0">
-        <source>Notification text color</source>
-        <target>Notification text color</target>
-        <note>Context:
-File: modules/ps_faviconnotificationbo/views/templates/admin/tabs/faviconConfiguration.tpl:90</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_faviconnotificationbo/views/templates/admin/menu.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="be11c74c1dd7f307bb80183a90dc2067">
-        <source>Get started</source>
-        <target>Get started</target>
-        <note>Context:
-File: modules/ps_faviconnotificationbo/views/templates/admin/menu.tpl:30</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="modules/ps_faviconnotificationbo/ps_faviconnotificationbo.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="87cc29282288a147a6c6a8fca50ba414">
@@ -46,11 +8,44 @@ File: modules/ps_faviconnotificationbo/views/templates/admin/menu.tpl:30</note>
         <note>Context:
           File: modules/ps_faviconnotificationbo/ps_faviconnotificationbo.php:58</note>
       </trans-unit>
-      <trans-unit id="421c53421b5ea9820af60bb4dba58584">
+      <trans-unit id="30dbe7ee3d7be2e58b5e0fe6075360fa">
         <source>Be notified of each new order, client or message directly in the browser tab of your back office, even when working on another page</source>
         <target>Be notified of each new order, client or message directly in the browser tab of your back office, even when working on another page</target>
         <note>Context:
           File: modules/ps_faviconnotificationbo/ps_faviconnotificationbo.php:59</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_faviconnotificationbo/views/templates/admin/menu.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="be11c74c1dd7f307bb80183a90dc2067">
+        <source>Get started</source>
+        <target>Get started</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_faviconnotificationbo/views/templates/admin/tabs/faviconConfiguration.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df47b138ef38d036367dd40804eaf281">
+        <source>Display notifications in the browser tab for:</source>
+        <target>Display notifications in the browser tab for:</target>
+        <note>Line: 22</note>
+      </trans-unit>
+      <trans-unit id="39f955a983e02682aeecdf0c94854c9b">
+        <source>New orders</source>
+        <target>New orders</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="d836b5e952dee5c17b2168ee86ebe8e6">
+        <source>Notification background color</source>
+        <target>Notification background color</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="edfc54b8273bf6358f53c1bbcfdd8fd0">
+        <source>Notification text color</source>
+        <target>Notification text color</target>
+        <note>Line: 90</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesFeaturedproductsAdmin.xlf
+++ b/app/Resources/translations/default/ModulesFeaturedproductsAdmin.xlf
@@ -5,74 +5,62 @@
       <trans-unit id="ca7d973c26c57b69e0857e7a0332d545">
         <source>Featured products</source>
         <target>Featured products</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:60</note>
+        <note>Line: 60</note>
       </trans-unit>
       <trans-unit id="6d37ec35b5b6820f90394e5ee49e8cec">
         <source>Displays featured products in the central column of your homepage.</source>
         <target>Displays featured products in the central column of your homepage.</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:61</note>
+        <note>Line: 61</note>
       </trans-unit>
       <trans-unit id="fddb8a1881e39ad11bfe0d0aca5becc3">
         <source>The number of products is invalid. Please enter a positive number.</source>
         <target>The number of products is invalid. Please enter a positive number.</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:131</note>
+        <note>Line: 131</note>
       </trans-unit>
       <trans-unit id="c284a59996a4e984b30319999a7feb1d">
         <source>The category ID is invalid. Please choose an existing category ID.</source>
         <target>The category ID is invalid. Please choose an existing category ID.</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:136</note>
+        <note>Line: 136</note>
       </trans-unit>
       <trans-unit id="fd2608d329d90e9a49731393427d0a5a">
         <source>Invalid value for the "randomize" flag.</source>
         <target>Invalid value for the "randomize" flag.</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:141</note>
+        <note>Line: 141</note>
       </trans-unit>
       <trans-unit id="abc877135a96e04fc076becb9ce6fdfa">
         <source>To add products to your homepage, simply add them to the corresponding product category (default: "Home").</source>
         <target>To add products to your homepage, simply add them to the corresponding product category (default: "Home").</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:168</note>
+        <note>Line: 168</note>
       </trans-unit>
       <trans-unit id="d44168e17d91bac89aab3f38d8a4da8e">
         <source>Number of products to be displayed</source>
         <target>Number of products to be displayed</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:172</note>
+        <note>Line: 172</note>
       </trans-unit>
       <trans-unit id="1b73f6b70a0fcd38bbc6a6e4b67e3010">
         <source>Set the number of products that you would like to display on homepage (default: 8).</source>
         <target>Set the number of products that you would like to display on homepage (default: 8).</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:175</note>
+        <note>Line: 175</note>
       </trans-unit>
       <trans-unit id="b773a38d8c456f7b24506c0e3cd67889">
         <source>Category from which to pick products to be displayed</source>
         <target>Category from which to pick products to be displayed</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:179</note>
+        <note>Line: 179</note>
       </trans-unit>
       <trans-unit id="0db2d53545e2ee088cfb3f45e618ba68">
         <source>Choose the category ID of the products that you would like to display on homepage (default: 2 for "Home").</source>
         <target>Choose the category ID of the products that you would like to display on homepage (default: 2 for "Home").</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:182</note>
+        <note>Line: 182</note>
       </trans-unit>
       <trans-unit id="49417670345173e7b95018b7bf976fc7">
         <source>Randomly display featured products</source>
         <target>Randomly display featured products</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:186</note>
+        <note>Line: 186</note>
       </trans-unit>
       <trans-unit id="3c12c1068fb0e02fe65a6c4fc40bc29a">
         <source>Enable if you wish the products to be displayed randomly (default: no).</source>
         <target>Enable if you wish the products to be displayed randomly (default: no).</target>
-        <note>Context:
-File: modules/ps_featuredproducts/ps_featuredproducts.php:189</note>
+        <note>Line: 189</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesFeaturedproductsShop.xlf
+++ b/app/Resources/translations/default/ModulesFeaturedproductsShop.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="dd8c84ae3dc95566dc071d0effc40dd2">
         <source>Our Products</source>
         <target>Our Products</target>
-        <note>Context:
-File: modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="40dec546414c1ebdfde8d9858f0938c3">
         <source>All products</source>
         <target>All products</target>
-        <note>Context:
-File: modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesGraphnvd3Admin.xlf
+++ b/app/Resources/translations/default/ModulesGraphnvd3Admin.xlf
@@ -5,8 +5,7 @@
       <trans-unit id="a9f70dff230e6fc8e878043486e6cddf">
         <source>NVD3 Charts</source>
         <target>NVD3 Charts</target>
-        <note>Context:
-File: modules/graphnvd3/graphnvd3.php:51</note>
+        <note>Line: 51</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesGridhtmlAdmin.xlf
+++ b/app/Resources/translations/default/ModulesGridhtmlAdmin.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="cf6b972204ee563b4e5691b293e931b6">
         <source>Simple HTML table display</source>
         <target>Simple HTML table display</target>
-        <note>Context:
-File: modules/gridhtml/gridhtml.php:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="05ce5a49b49dd6245f71e384c4b43564">
         <source>Allows the statistics system to display data in a grid.</source>
         <target>Allows the statistics system to display data in a grid.</target>
-        <note>Context:
-File: modules/gridhtml/gridhtml.php:50</note>
+        <note>Line: 50</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesGsitemapAdmin.xlf
+++ b/app/Resources/translations/default/ModulesGsitemapAdmin.xlf
@@ -1,30 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="modules/gsitemap/gsitemap.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3aaaafde6f9b2701f9e6eb9292e95521">
+        <source>Google sitemap</source>
+        <target>Google sitemap</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="935a6bc13704a117d22333c3155b5dae">
+        <source>Generate your Google sitemap file</source>
+        <target>Generate your Google sitemap file</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="b52bf50c73995780892b9945ddc98708">
+        <source>An error occured while trying to check your file permissions. Please adjust your permissions to allow PrestaShop to write a file in your root directory.</source>
+        <target>An error occured while trying to check your file permissions. Please adjust your permissions to allow PrestaShop to write a file in your root directory.</target>
+        <note>Line: 580</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="modules/gsitemap/views/templates/admin/configuration.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="67ddb0d12fa1963b202d4ac310547709">
+      <trans-unit id="6d63b2a47b35719206cdb45b2f3fff22">
         <source>Your sitemaps were successfully created. Please do not forget to setup the URL</source>
         <target>Your sitemaps were successfully created. Please do not forget to setup the URL</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="9d934413d2737c2a15f58de573657ce3">
         <source>in your Google Webmaster account.</source>
         <target>in your Google Webmaster account.</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 31</note>
       </trans-unit>
-      <trans-unit id="1c95b77d135b55c84429588c11697ea4">
+      <trans-unit id="837075a7571640837495c90cb68e39b9">
         <source>Your sitemaps</source>
         <target>Your sitemaps</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="aa17b80751f4ae53ab8e3ed2fe99e94d">
         <source>Sitemaps were already created.</source>
         <target>Sitemaps were already created.</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="a0bfb8e59e6c13fc8d990781f77694fe">
         <source>Continue</source>
@@ -32,13 +47,12 @@
         <note>Context:
           File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
       </trans-unit>
-      <trans-unit id="9ab08b9ceeef857df07ad10e1de9301e">
+      <trans-unit id="bdf0482e95f48fd33fae3765df4dcf06">
         <source>Please set up the following sitemap URL in your Google Webmaster account:</source>
         <target>Please set up the following sitemap URL in your Google Webmaster account:</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 52</note>
       </trans-unit>
-      <trans-unit id="aef717e48ecd01989c92849d44bff9b6">
+      <trans-unit id="8d260d2aae84bcc75ba695a141c1fa11">
         <source>This URL is the master sitemaps file. It refers to the following sub-sitemap files:</source>
         <target>This URL is the master sitemaps file. It refers to the following sub-sitemap files:</target>
         <note>Context:
@@ -47,116 +61,97 @@
       <trans-unit id="0dbf904a2b27f036cf06741aad221ecc">
         <source>Your last update was made on this date:</source>
         <target>Your last update was made on this date:</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 62</note>
       </trans-unit>
       <trans-unit id="6d37779958434303f8397436a1484ed8">
         <source>For a better use of the module, please make sure that you have</source>
         <target>For a better use of the module, please make sure that you have</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 74</note>
       </trans-unit>
-      <trans-unit id="6a3282611e5ffb8539ce434133073f15">
+      <trans-unit id="6ed33d11f15a01c582cdd808a35af421">
         <source>A minimum memory_limit value of 128 MB.</source>
         <target>A minimum memory_limit value of 128 MB.</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 77</note>
       </trans-unit>
-      <trans-unit id="f891951357d4892887f0e416c54f972d">
+      <trans-unit id="e527d339f62509213a9fffbdb37dce99">
         <source>A minimum max_execution_time value of 30 seconds.</source>
         <target>A minimum max_execution_time value of 30 seconds.</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 80</note>
       </trans-unit>
       <trans-unit id="8156303464de0fba7cb8306cc768e998">
         <source>You can edit these limits in your php.ini file. For more details, please contact your hosting provider.</source>
         <target>You can edit these limits in your php.ini file. For more details, please contact your hosting provider.</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 83</note>
       </trans-unit>
-      <trans-unit id="0b9b4b91e0a8f59e264202a23d9c57a6">
+      <trans-unit id="5a61d69bfc495937fc43ae6004ebfbfd">
         <source>Configure your sitemap</source>
         <target>Configure your sitemap</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 90</note>
       </trans-unit>
-      <trans-unit id="fe242b3dd3f455778072dc7042637a5e">
+      <trans-unit id="94880e11ec8ba05c8b71353e9281851f">
         <source>Several sitemap files will be generated depending on how your server is configured and on the number of activated products in your catalog.</source>
         <target>Several sitemap files will be generated depending on how your server is configured and on the number of activated products in your catalog.</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 91</note>
       </trans-unit>
       <trans-unit id="7f751d19f85d49a411d5691f5bb0b5f2">
         <source>How often do you update your store?</source>
         <target>How often do you update your store?</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 93</note>
       </trans-unit>
       <trans-unit id="f9f90eeaf400d228facde6bc48da5cfb">
         <source>always</source>
         <target>always</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 95</note>
       </trans-unit>
       <trans-unit id="745fd0ea7f576f350a0eed4b8c48a8e2">
         <source>hourly</source>
         <target>hourly</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 96</note>
       </trans-unit>
       <trans-unit id="bea79186fd7af2da67e59b4b15df5a26">
         <source>daily</source>
         <target>daily</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 97</note>
       </trans-unit>
       <trans-unit id="4a11fc05ed694c195f0703605b64da90">
         <source>weekly</source>
         <target>weekly</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 98</note>
       </trans-unit>
       <trans-unit id="708638881f3bac9d9c8c742c79502811">
         <source>monthly</source>
         <target>monthly</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 99</note>
       </trans-unit>
       <trans-unit id="1bf712896e6077fa0b708e911d8ee0b3">
         <source>yearly</source>
         <target>yearly</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 100</note>
       </trans-unit>
       <trans-unit id="c7561db7a418dd39b2201dfe110ab4a4">
         <source>never</source>
         <target>never</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 101</note>
       </trans-unit>
       <trans-unit id="e51d91c7bfa9fc658b11afca4d84653c">
         <source>Check this box if you wish to check the presence of the image files on the server</source>
         <target>Check this box if you wish to check the presence of the image files on the server</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 104</note>
       </trans-unit>
-      <trans-unit id="05ff8159ccaef6f0f8391c61a6d0e631">
+      <trans-unit id="b7d7436a18bf546dd6438d92218868c1">
         <source>Check all</source>
         <target>Check all</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 150</note>
       </trans-unit>
-      <trans-unit id="0dfcf5f2f5b9ab7c909f9bdca2b53b56">
+      <trans-unit id="0cbc12a507b5e6c5e2cd4fe3f7a62d1f">
         <source>Indicate the pages that you do not want to include in your sitemap files:</source>
         <target>Indicate the pages that you do not want to include in your sitemap files:</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 106</note>
       </trans-unit>
-      <trans-unit id="2ec111ec9826a83509c02bf5e6b797f1">
+      <trans-unit id="8123c8ac806194dca71afdba4dad85a3">
         <source>Generate sitemap</source>
         <target>Generate sitemap</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 120</note>
       </trans-unit>
       <trans-unit id="ca99f8a0d484faef3a057fe7a5da3141">
         <source>This can take several minutes</source>
@@ -164,35 +159,30 @@
         <note>Context:
           File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
       </trans-unit>
-      <trans-unit id="162b34489ed8df561be1720f04fe6d42">
+      <trans-unit id="221dffef949377570bdc389d3f983c66">
         <source>You have two ways to generate sitemaps.</source>
         <target>You have two ways to generate sitemaps.</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 133</note>
       </trans-unit>
       <trans-unit id="6caa369fd774beef106abbc5cc1e3368">
         <source>Manually:</source>
         <target>Manually:</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 134</note>
       </trans-unit>
-      <trans-unit id="4ed0b6a0097c3d38c43d756fe2653962">
+      <trans-unit id="a331b19ce5be82a91e1e60a091e81212">
         <source>Using the form above (as often as needed)</source>
         <target>Using the form above (as often as needed)</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 134</note>
       </trans-unit>
       <trans-unit id="3d263eb0233f14872193733387840c80">
         <source>-or-</source>
         <target>-or-</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 135</note>
       </trans-unit>
       <trans-unit id="957d27165d1dc5947fb00e57967ffcce">
         <source>Automatically:</source>
         <target>Automatically:</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 136</note>
       </trans-unit>
       <trans-unit id="024d2d2f6d7fd575701fd1b30cc5c0c2">
         <source>Ask your hosting provider to setup a "Cron task" to load the following URL at the time you would like:</source>
@@ -200,57 +190,40 @@
         <note>Context:
           File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
       </trans-unit>
-      <trans-unit id="8076be06e575e50c7f9585271c8842ad">
+      <trans-unit id="ad71f6d43a4db5fe6bf961882adfa113">
         <source>It will automatically generate your XML sitemaps.</source>
         <target>It will automatically generate your XML sitemaps.</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 138</note>
       </trans-unit>
-      <trans-unit id="98a9d595be84a0687c4b26887977e0c3">
+      <trans-unit id="13a3549902fb75af1df329df5f3b265a">
         <source>Uncheck all</source>
         <target>Uncheck all</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 153</note>
       </trans-unit>
-      <trans-unit id="d951cc0b515817adc578b427d5ddb0b7">
+      <trans-unit id="b79b56dbede0077a92563175fda9b54f">
         <source>This shop has no sitemap yet.</source>
         <target>This shop has no sitemap yet.</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 65</note>
       </trans-unit>
-      <trans-unit id="8e7838224d6ce9ecc533ee9e3a5c73d5">
+      <trans-unit id="53fdf9abbbe9a13fccaf2a6dd5b6220f">
         <source>Generating a sitemap can take several minutes</source>
         <target>Generating a sitemap can take several minutes</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 123</note>
       </trans-unit>
-      <trans-unit id="031b845f225dc2d5f21757dc66d14f4b">
+      <trans-unit id="a82be0f551b8708bc08eb33cd9ded0cf">
         <source>Information</source>
         <target>Information</target>
-        <note>Context:
-          File: modules/gsitemap/views/templates/admin/configuration.tpl</note>
+        <note>Line: 131</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="modules/gsitemap/gsitemap.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3aaaafde6f9b2701f9e6eb9292e95521">
-        <source>Google sitemap</source>
-        <target>Google sitemap</target>
-        <note>Context:
-          File: modules/gsitemap/gsitemap.php</note>
+      <trans-unit id="8ef76e3a7b01e9b08a23ddf87cbc242e">
+        <source>The above URL is the master sitemap file. It refers to the following sub-sitemap files:</source>
+        <target>The above URL is the master sitemap file. It refers to the following sub-sitemap files:</target>
+        <note>Line: 54</note>
       </trans-unit>
-      <trans-unit id="935a6bc13704a117d22333c3155b5dae">
-        <source>Generate your Google sitemap file</source>
-        <target>Generate your Google sitemap file</target>
-        <note>Context:
-          File: modules/gsitemap/gsitemap.php</note>
-      </trans-unit>
-      <trans-unit id="b52bf50c73995780892b9945ddc98708">
-        <source>An error occured while trying to check your file permissions. Please adjust your permissions to allow PrestaShop to write a file in your root directory.</source>
-        <target>An error occured while trying to check your file permissions. Please adjust your permissions to allow PrestaShop to write a file in your root directory.</target>
-        <note>Context:
-          File: modules/gsitemap/gsitemap.php</note>
+      <trans-unit id="03f772c9541dddad66266c0cf698bba6">
+        <source>Ask your hosting provider to setup a "Cron job" to load the following URL at the time you would like:</source>
+        <target>Ask your hosting provider to setup a "Cron job" to load the following URL at the time you would like:</target>
+        <note>Line: 136</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesImagesliderAdmin.xlf
+++ b/app/Resources/translations/default/ModulesImagesliderAdmin.xlf
@@ -5,218 +5,182 @@
       <trans-unit id="5ec0de0c7404b2405a4d1a338be84b62">
         <source>Image slider</source>
         <target>Image slider</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:60</note>
+        <note>Line: 60</note>
       </trans-unit>
       <trans-unit id="b6b0bc2f758de605f7589a85d105c1ec">
         <source>Adds an image slider to your site.</source>
         <target>Adds an image slider to your site.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:61</note>
+        <note>Line: 61</note>
       </trans-unit>
       <trans-unit id="3f80dc2cdd06939d4f5514362067cd86">
         <source>Invalid values</source>
         <target>Invalid values</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:297</note>
+        <note>Line: 297</note>
       </trans-unit>
       <trans-unit id="a6abafe564d3940cc36ee43e2f09400b">
         <source>Invalid slide</source>
         <target>Invalid slide</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:301</note>
+        <note>Line: 301</note>
       </trans-unit>
       <trans-unit id="e0ce30bfbf90d2306ecf72f06a83133f">
         <source>Invalid slide state.</source>
         <target>Invalid slide state.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:306</note>
+        <note>Line: 306</note>
       </trans-unit>
       <trans-unit id="9f79795e050649dc6b8bd0cdc874cbdc">
         <source>Invalid slide position.</source>
         <target>Invalid slide position.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:310</note>
+        <note>Line: 310</note>
       </trans-unit>
       <trans-unit id="5c8bedc4c0c9f42d9b0f14340bbe53da">
         <source>Invalid slide ID</source>
         <target>Invalid slide ID</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:440</note>
+        <note>Line: 440</note>
       </trans-unit>
       <trans-unit id="14f09fd0804a8f1cd0eb757125fc9c28">
         <source>The title is too long.</source>
         <target>The title is too long.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:322</note>
+        <note>Line: 322</note>
       </trans-unit>
       <trans-unit id="dc89634d1d28cd4e055531e62047156b">
         <source>The caption is too long.</source>
         <target>The caption is too long.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:325</note>
+        <note>Line: 325</note>
       </trans-unit>
       <trans-unit id="4477f672766f6f255f760649af8bd92a">
         <source>The URL is too long.</source>
         <target>The URL is too long.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:328</note>
+        <note>Line: 328</note>
       </trans-unit>
       <trans-unit id="62239300ba982b06ab0f1aa7100ad297">
         <source>The description is too long.</source>
         <target>The description is too long.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:331</note>
+        <note>Line: 331</note>
       </trans-unit>
       <trans-unit id="980f56796b8bf9d607283de9815fe217">
         <source>The URL format is not correct.</source>
         <target>The URL format is not correct.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:334</note>
+        <note>Line: 334</note>
       </trans-unit>
       <trans-unit id="73133ce32267e8c7a854d15258eb17e0">
         <source>Invalid filename.</source>
         <target>Invalid filename.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:340</note>
+        <note>Line: 340</note>
       </trans-unit>
       <trans-unit id="0f059227d0a750ce652337d911879671">
         <source>The URL is not set.</source>
         <target>The URL is not set.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:347</note>
+        <note>Line: 347</note>
       </trans-unit>
       <trans-unit id="8cf45ba354f4725ec8a0d31164910895">
         <source>The image is not set.</source>
         <target>The image is not set.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:353</note>
+        <note>Line: 353</note>
       </trans-unit>
       <trans-unit id="7f82c65d548588c8d5412463c182e450">
         <source>The configuration could not be updated.</source>
         <target>The configuration could not be updated.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:434</note>
+        <note>Line: 434</note>
       </trans-unit>
       <trans-unit id="cdf841e01e10cae6355f72e6838808eb">
         <source>The slide could not be added.</source>
         <target>The slide could not be added.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:500</note>
+        <note>Line: 500</note>
       </trans-unit>
       <trans-unit id="eb28485b92fbf9201918698245ec6430">
         <source>The slide could not be updated.</source>
         <target>The slide could not be updated.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:503</note>
+        <note>Line: 503</note>
       </trans-unit>
       <trans-unit id="ced7338587c502f76917b5a693f848c5">
         <source>Slide information</source>
         <target>Slide information</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:736</note>
+        <note>Line: 736</note>
       </trans-unit>
       <trans-unit id="e64df1d7c22b9638f084ce8a4aff3ff3">
         <source>Target URL</source>
         <target>Target URL</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:756</note>
+        <note>Line: 756</note>
       </trans-unit>
       <trans-unit id="272ba7d164aa836995be6319a698be84">
         <source>Caption</source>
         <target>Caption</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:763</note>
+        <note>Line: 763</note>
       </trans-unit>
       <trans-unit id="44877c6aa8e93fa5a91c9361211464fb">
         <source>Speed</source>
         <target>Speed</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:864</note>
+        <note>Line: 864</note>
       </trans-unit>
       <trans-unit id="11cd394e1bd88abe611fd331887f0c74">
         <source>The duration of the transition between two slides.</source>
         <target>The duration of the transition between two slides.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:868</note>
+        <note>Line: 868</note>
       </trans-unit>
       <trans-unit id="8836d88aaad538c39647aab768d91932">
         <source>Pause on hover</source>
         <target>Pause on hover</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:872</note>
+        <note>Line: 872</note>
       </trans-unit>
       <trans-unit id="448e0fa7b305331385aef516333e1c65">
         <source>Stop sliding when the mouse cursor is over the slideshow.</source>
         <target>Stop sliding when the mouse cursor is over the slideshow.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:874</note>
+        <note>Line: 874</note>
       </trans-unit>
       <trans-unit id="70ab55fc8ac90620143b01c453be77a3">
         <source>Loop forever</source>
         <target>Loop forever</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:890</note>
+        <note>Line: 890</note>
       </trans-unit>
       <trans-unit id="1072f2a780ebfc87b511a3d0263b5d61">
         <source>Loop or stop after the last slide.</source>
         <target>Loop or stop after the last slide.</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:892</note>
+        <note>Line: 892</note>
       </trans-unit>
       <trans-unit id="5a3489cc067f89b268b6958bffb98ebf">
         <source>Since multiple languages are activated on your shop, please mind to upload your image for each one of them</source>
         <target>Since multiple languages are activated on your shop, please mind to upload your image for each one of them</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:976</note>
+        <note>Line: 976</note>
       </trans-unit>
       <trans-unit id="c8a1ed10db4201b3ae06ea0aa912028d">
         <source>You cannot manage slides items from a "All Shops" or a "Group Shop" context, select directly the shop you want to edit</source>
         <target>You cannot manage slides items from a "All Shops" or a "Group Shop" context, select directly the shop you want to edit</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:984</note>
+        <note>Line: 984</note>
       </trans-unit>
       <trans-unit id="432ed99c2e808d79c96f892807d33325">
         <source>You can only edit this slide from the shop(s) context: %s</source>
         <target>You can only edit this slide from the shop(s) context: %s</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:999</note>
+        <note>Line: 999</note>
       </trans-unit>
       <trans-unit id="6a1ae4ad1018e00dddb16a2ce30a24f6">
         <source>You cannot add slides from a "All Shops" or a "Group Shop" context</source>
         <target>You cannot add slides from a "All Shops" or a "Group Shop" context</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:1003</note>
+        <note>Line: 1003</note>
       </trans-unit>
       <trans-unit id="7a5c11dddbb2118d08611a1f0678bb91">
         <source>Unable to get slide shop association information (id_slide: %d)</source>
         <target>Unable to get slide shop association information (id_slide: %d)</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:1011</note>
+        <note>Line: 1011</note>
       </trans-unit>
       <trans-unit id="298b615220606d42b6ac60269df0d321">
         <source>The modifications will be applied to shop: %s</source>
         <target>The modifications will be applied to shop: %s</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:1022</note>
+        <note>Line: 1022</note>
       </trans-unit>
       <trans-unit id="aef3662e6419ddaaa0a31df70e3b6557">
         <source>The modifications will be applied to this group: %s</source>
         <target>The modifications will be applied to this group: %s</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:1024</note>
+        <note>Line: 1024</note>
       </trans-unit>
       <trans-unit id="71063fd397d237e563089c22dd8b69e8">
         <source>The modifications will be applied to all shops and shop groups</source>
         <target>The modifications will be applied to all shops and shop groups</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:1026</note>
+        <note>Line: 1026</note>
       </trans-unit>
       <trans-unit id="6a5aa2542c21debccd82b2e0038c3d1a">
         <source>This slide is shared with other shops! All shops associated to this slide will apply modifications made here</source>
         <target>This slide is shared with other shops! All shops associated to this slide will apply modifications made here</target>
-        <note>Context:
-File: modules/ps_imageslider/ps_imageslider.php:1040</note>
+        <note>Line: 1040</note>
       </trans-unit>
     </body>
   </file>
@@ -225,14 +189,12 @@ File: modules/ps_imageslider/ps_imageslider.php:1040</note>
       <trans-unit id="c82324ebbcea34f55627a897b37190e3">
         <source>Slides list</source>
         <target>Slides list</target>
-        <note>Context:
-File: modules/ps_imageslider/views/templates/hook/list.tpl:25</note>
+        <note>Line: 25</note>
       </trans-unit>
       <trans-unit id="379a88861412d686cfaf475c84a24920">
         <source>Shared slide</source>
         <target>Shared slide</target>
-        <note>Context:
-File: modules/ps_imageslider/views/templates/hook/list.tpl:51</note>
+        <note>Line: 51</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesLanguageselectorAdmin.xlf
+++ b/app/Resources/translations/default/ModulesLanguageselectorAdmin.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="d33f69bfa67e20063a8905c923d9cf59">
         <source>Language selector block</source>
         <target>Language selector block</target>
-        <note>Context:
-File: modules/ps_languageselector/ps_languageselector.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="26519a08e607733fa050b88303bea070">
         <source>Adds a block allowing customers to select a language for your store's content.</source>
         <target>Adds a block allowing customers to select a language for your store's content.</target>
-        <note>Context:
-File: modules/ps_languageselector/ps_languageselector.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesLegalcomplianceAdmin.xlf
+++ b/app/Resources/translations/default/ModulesLegalcomplianceAdmin.xlf
@@ -1,335 +1,280 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/ps_legalcompliance/ps_legalcompliance.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_legalcompliance/controllers/AdminAEUCController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="de2cd9f1dfad85516edd95679af377fd">
         <source>Legal Compliance</source>
         <target>Legal Compliance</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:79</note>
+        <note>Line: 33</note>
       </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_legalcompliance/ps_legalcompliance.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
       <trans-unit id="3abc778d1eb09576ba6b26848520bbdd">
         <source>This module helps merchants comply with applicable e-commerce laws.</source>
         <target>This module helps merchants comply with applicable e-commerce laws.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:80</note>
+        <note>Line: 80</note>
       </trans-unit>
       <trans-unit id="3b528a3fe35bcd29ad2ab0e77fe01d4d">
         <source>Could not install new hook</source>
         <target>Could not install new hook</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:212</note>
+        <note>Line: 212</note>
       </trans-unit>
       <trans-unit id="23e162ba6bf36c7560ebbc868d9e2552">
         <source>Legal notice</source>
         <target>Legal notice</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1283</note>
+        <note>Line: 1283</note>
       </trans-unit>
       <trans-unit id="626682a1bbf1426b7bbd9834e9201e0c">
         <source>Please add your legal information to this site.</source>
         <target>Please add your legal information to this site.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:258</note>
+        <note>Line: 258</note>
       </trans-unit>
       <trans-unit id="98664ee75f74254b622a52d86a798ae3">
         <source>Terms of Service (ToS)</source>
         <target>Terms of Service (ToS)</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1284</note>
+        <note>Line: 1284</note>
       </trans-unit>
       <trans-unit id="4090d0a6d74c4be967a71d0d6f115bbe">
         <source>Please add your Terms of Service (ToS) to this site.</source>
         <target>Please add your Terms of Service (ToS) to this site.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:261</note>
+        <note>Line: 261</note>
       </trans-unit>
       <trans-unit id="93fb7e4d4616f108db46461360b7a6ae">
         <source>Revocation terms</source>
         <target>Revocation terms</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1285</note>
+        <note>Line: 1285</note>
       </trans-unit>
       <trans-unit id="179c72212692decde8373a216e3452f4">
         <source>Please add your Revocation terms to this site.</source>
         <target>Please add your Revocation terms to this site.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:264</note>
+        <note>Line: 264</note>
       </trans-unit>
       <trans-unit id="c5f29bb36f9158d2e00f5d4dc213a0ff">
         <source>Privacy</source>
         <target>Privacy</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1287</note>
+        <note>Line: 1287</note>
       </trans-unit>
       <trans-unit id="0629e092ce60c75222213895157a3799">
         <source>Please insert here your content about privacy. If you have activated Social Media modules, please provide a notice about third-party access to data.</source>
         <target>Please insert here your content about privacy. If you have activated Social Media modules, please provide a notice about third-party access to data.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:267</note>
+        <note>Line: 267</note>
       </trans-unit>
       <trans-unit id="5fb4f05f62f9967052977077d783fc2d">
         <source>Shipping and payment</source>
         <target>Shipping and payment</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1289</note>
+        <note>Line: 1289</note>
       </trans-unit>
       <trans-unit id="27f540f8da86e60ba0375cdfbd123edf">
         <source>Please add your Shipping and payment information to this site.</source>
         <target>Please add your Shipping and payment information to this site.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:270</note>
+        <note>Line: 270</note>
       </trans-unit>
       <trans-unit id="b305968eb47e25015e2cebf313f70842">
         <source>Environmental notice</source>
         <target>Environmental notice</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1288</note>
+        <note>Line: 1288</note>
       </trans-unit>
       <trans-unit id="d5b976245a30b64d97c68cb7a8f439f4">
         <source>Please add your Environmental information to this site.</source>
         <target>Please add your Environmental information to this site.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:273</note>
+        <note>Line: 273</note>
       </trans-unit>
       <trans-unit id="f9227a2ab59639e217bd44ec47f35fcc">
         <source>This module helps European merchants to comply with legal requirements. Learn how to configure the module and other shop parameters so that you're in compliance with the law.[1][2]PrestaShop 1.7 legal compliance documentation[/2]</source>
         <target>This module helps European merchants to comply with legal requirements. Learn how to configure the module and other shop parameters so that you're in compliance with the law.[1][2]PrestaShop 1.7 legal compliance documentation[/2]</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1027</note>
+        <note>Line: 1027</note>
       </trans-unit>
       <trans-unit id="2ad348b570305efbdb00791eab07ccea">
         <source>Failed to associate legal content with an email template.</source>
         <target>Failed to associate legal content with an email template.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1169</note>
+        <note>Line: 1169</note>
       </trans-unit>
       <trans-unit id="348ecf8192ea7ec5ec0620e8e4c93176">
         <source>'Revocation Terms within ToS' label cannot be activated unless you associate "%s" role with a Page.</source>
         <target>'Revocation Terms within ToS' label cannot be activated unless you associate "%s" role with a Page.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1185</note>
+        <note>Line: 1185</note>
       </trans-unit>
       <trans-unit id="59d41c30eac4f63d7f2adceb05a6687e">
         <source>Shipping fees label cannot be activated unless you associate "%s" role with a Page.</source>
         <target>Shipping fees label cannot be activated unless you associate "%s" role with a Page.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1220</note>
+        <note>Line: 1220</note>
       </trans-unit>
       <trans-unit id="01ed64f3ede93b663b4d78d2a0693f0a">
         <source>Revocation form</source>
         <target>Revocation form</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1286</note>
+        <note>Line: 1286</note>
       </trans-unit>
       <trans-unit id="3ad6cb6100190c8f81e99fd52debf7ef">
         <source>Labels</source>
         <target>Labels</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1328</note>
+        <note>Line: 1328</note>
       </trans-unit>
       <trans-unit id="bdd4f0a0fbdc23d1d20e027c2f3050ee">
         <source>Additional information about delivery time</source>
         <target>Additional information about delivery time</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1333</note>
+        <note>Line: 1333</note>
       </trans-unit>
       <trans-unit id="b0c2a88bea1ad0728e3901bce50f1d69">
         <source><![CDATA[If you specified a delivery time, this additional information is displayed in the footer of product pages with a link to the "Shipping & Payment" Page. Leave the field empty to disable.]]></source>
         <target><![CDATA[If you specified a delivery time, this additional information is displayed in the footer of product pages with a link to the "Shipping & Payment" Page. Leave the field empty to disable.]]></target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1335</note>
+        <note>Line: 1335</note>
       </trans-unit>
       <trans-unit id="d01f8eb7dc644036a1ead2b82aaed055">
         <source>Indicate for which countries your delivery time applies.</source>
         <target>Indicate for which countries your delivery time applies.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1336</note>
+        <note>Line: 1336</note>
       </trans-unit>
       <trans-unit id="472b0d002b98940cdd7a36062ef1d457">
         <source> 'Our previous price' label</source>
         <target>'Our previous price' label</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1339</note>
+        <note>Line: 1339</note>
       </trans-unit>
       <trans-unit id="cf4e7929f6a8cafcba348d0889f7a452">
         <source>When a product is on sale, displays a 'Our previous price' label before the original price crossed out, next to the price on the product page.</source>
         <target>When a product is on sale, displays a 'Our previous price' label before the original price crossed out, next to the price on the product page.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1342</note>
+        <note>Line: 1342</note>
       </trans-unit>
       <trans-unit id="91f7c813a787f39521bcf07a2421935d">
         <source>Tax 'inc./excl.' label</source>
         <target>Tax 'inc./excl.' label</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1354</note>
+        <note>Line: 1354</note>
       </trans-unit>
       <trans-unit id="3acf85f0ce1d57facc75620d5b536c68">
         <source>Displays whether the tax is included on the product page ('Tax incl./excl.' label) and adds a short mention in the footer of other pages.</source>
         <target>Displays whether the tax is included on the product page ('Tax incl./excl.' label) and adds a short mention in the footer of other pages.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1357</note>
+        <note>Line: 1357</note>
       </trans-unit>
       <trans-unit id="2baeb2d4d90e1cdb9182f4e229508b3b">
         <source>Price per unit label</source>
         <target>Price per unit label</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1369</note>
+        <note>Line: 1369</note>
       </trans-unit>
       <trans-unit id="3f9e6407d82977ad20a7815fcaa65e47">
         <source>If available, displays the price per unit everywhere the product price is listed.</source>
         <target>If available, displays the price per unit everywhere the product price is listed.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1372</note>
+        <note>Line: 1372</note>
       </trans-unit>
       <trans-unit id="68efcb6dada7227cc184a87a6405532e">
         <source>'Shipping fees excl.' label</source>
         <target>'Shipping fees excl.' label</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1384</note>
+        <note>Line: 1384</note>
       </trans-unit>
       <trans-unit id="979516139081495e903a48ed1489415c">
         <source>Displays a label next to the product price ('Shipping excluded') and adds a short mention in the footer of other pages.</source>
         <target>Displays a label next to the product price ('Shipping excluded') and adds a short mention in the footer of other pages.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1387</note>
+        <note>Line: 1387</note>
       </trans-unit>
       <trans-unit id="f3b604ff05c70406fc2f1b68c1a9c658">
         <source>If enabled, make sure the Shipping terms are associated with a page below (Legal Content Management). The label will link to this content.</source>
         <target>If enabled, make sure the Shipping terms are associated with a page below (Legal Content Management). The label will link to this content.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1388</note>
+        <note>Line: 1388</note>
       </trans-unit>
       <trans-unit id="36351ad1d80323e91bdc6f69caee6775">
         <source>Revocation Terms within ToS</source>
         <target>Revocation Terms within ToS</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1404</note>
+        <note>Line: 1404</note>
       </trans-unit>
       <trans-unit id="bdf4cbf3cdbf8a0e03aad7f4910c1b57">
         <source>Includes content from the Revocation Terms page within the Terms of Services (ToS).</source>
         <target>Includes content from the Revocation Terms page within the Terms of Services (ToS).</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1407</note>
+        <note>Line: 1407</note>
       </trans-unit>
       <trans-unit id="e3630cb2cd5786b78824ebc3fd818597">
         <source>If enabled, make sure the Revocation Terms are associated with a page below (Legal Content Management).</source>
         <target>If enabled, make sure the Revocation Terms are associated with a page below (Legal Content Management).</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1408</note>
+        <note>Line: 1408</note>
       </trans-unit>
       <trans-unit id="f4ced086e850fc06ff4267366382f5d6">
         <source>Revocation for virtual products</source>
         <target>Revocation for virtual products</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1425</note>
+        <note>Line: 1425</note>
       </trans-unit>
       <trans-unit id="4a45c80a18900618e6c2f690f08b58ec">
         <source>Adds a mandatory checkbox when the cart contains a virtual product. Use it to ensure customers are aware that a virtual product cannot be returned.</source>
         <target>Adds a mandatory checkbox when the cart contains a virtual product. Use it to ensure customers are aware that a virtual product cannot be returned.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1428</note>
+        <note>Line: 1428</note>
       </trans-unit>
       <trans-unit id="776f2e85270c935a226d11cd45c4487a">
         <source>Require customers to renounce their revocation right when purchasing virtual products (digital goods or services).</source>
         <target>Require customers to renounce their revocation right when purchasing virtual products (digital goods or services).</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1429</note>
+        <note>Line: 1429</note>
       </trans-unit>
       <trans-unit id="1c37d3c4d123c1b8332711a1c14ac232">
         <source>'From' price label (when combinations)</source>
         <target>'From' price label (when combinations)</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1446</note>
+        <note>Line: 1446</note>
       </trans-unit>
       <trans-unit id="f6f7eb6f0c585ab51533c31dd4b1f488">
         <source>Displays a 'From' label before the price on products with combinations.</source>
         <target>Displays a 'From' label before the price on products with combinations.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1449</note>
+        <note>Line: 1449</note>
       </trans-unit>
       <trans-unit id="2c5d047df77f799f0140d5e1881edd04">
         <source>As prices can vary from a combination to another, this label indicates that the final price may be higher.</source>
         <target>As prices can vary from a combination to another, this label indicates that the final price may be higher.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1450</note>
+        <note>Line: 1450</note>
       </trans-unit>
       <trans-unit id="ccefb967cfedec2f7395fd015acd3727">
         <source>Custom text in shopping cart page</source>
         <target>Custom text in shopping cart page</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1467</note>
+        <note>Line: 1467</note>
       </trans-unit>
       <trans-unit id="bee423c6b151e76995ed05befc861409">
         <source>This text will be displayed on the shopping cart page. Leave empty to disable.</source>
         <target>This text will be displayed on the shopping cart page. Leave empty to disable.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1469</note>
+        <note>Line: 1469</note>
       </trans-unit>
       <trans-unit id="428bb092722a6c1c41d308ec4e9f15aa">
         <source>Please inform your customers about how the order is legally confirmed.</source>
         <target>Please inform your customers about how the order is legally confirmed.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1470</note>
+        <note>Line: 1470</note>
       </trans-unit>
       <trans-unit id="98f770b0af18ca763421bac22b4b6805">
         <source>Features</source>
         <target>Features</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1545</note>
+        <note>Line: 1545</note>
       </trans-unit>
       <trans-unit id="b08100205abea27ec0fdb7cd9369f028">
         <source>Enable 'Reordering' feature</source>
         <target>Enable 'Reordering' feature</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1551</note>
+        <note>Line: 1551</note>
       </trans-unit>
       <trans-unit id="05c86a70075dc39057403169ef0007cc">
         <source>If enabled, the 'Reorder' option allows customers to reorder in one click from their Order History page.</source>
         <target>If enabled, the 'Reorder' option allows customers to reorder in one click from their Order History page.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1552</note>
+        <note>Line: 1552</note>
       </trans-unit>
       <trans-unit id="1fa508d743a9f464f8b4510257ca492a">
         <source>Make sure you comply with your local legislation before enabling: it can be considered as unsolicited goods.</source>
         <target>Make sure you comply with your local legislation before enabling: it can be considered as unsolicited goods.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1555</note>
+        <note>Line: 1555</note>
       </trans-unit>
       <trans-unit id="cadebe42ec37a2654161a876bc11d52c">
         <source>Proportionate tax for shipping and wrapping</source>
         <target>Proportionate tax for shipping and wrapping</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1571</note>
+        <note>Line: 1571</note>
       </trans-unit>
       <trans-unit id="a2bfc699a0a4b724be41740c97c6b27b">
         <source>When enabled, tax for shipping and wrapping costs will be calculated proportionate to taxes applying to the products in the cart.</source>
         <target>When enabled, tax for shipping and wrapping costs will be calculated proportionate to taxes applying to the products in the cart.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1574</note>
+        <note>Line: 1574</note>
       </trans-unit>
       <trans-unit id="6d9e1b60acc3cc4397af901c111bb9a1">
         <source>If active, your carriers' shipping fees must be tax included! Make sure it is the case in the Shipping section.</source>
         <target>If active, your carriers' shipping fees must be tax included! Make sure it is the case in the Shipping section.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1575</note>
+        <note>Line: 1575</note>
       </trans-unit>
       <trans-unit id="9896806b3fb40a73bdda4781f61052bf">
         <source>-- Select associated page --</source>
         <target>-- Select associated page --</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:1638</note>
+        <note>Line: 1638</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_buybuttonlite/ps_buybuttonlite.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
       <trans-unit id="bb8956c67b82c7444a80c6b2433dd8b4">
         <source>Are you sure you want to uninstall this module?</source>
         <target>Are you sure you want to uninstall this module?</target>
-        <note>Context:
-File: modules/ps_buybuttonlite/ps_buybuttonlite.php:57
- Comment: Confirm uninstall</note>
+        <note>Line: 81</note>
       </trans-unit>
     </body>
   </file>
@@ -338,26 +283,22 @@ File: modules/ps_buybuttonlite/ps_buybuttonlite.php:57
       <trans-unit id="c49b8914d58716ebb70e35e5a08db6dd">
         <source>Email content inclusion</source>
         <target>Email content inclusion</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/admin/email_attachments_form.tpl:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="124c44c55082e763c52819653560e925">
         <source>This section allows you to include information from the "Legal Content Management" section above at the bottom of your shop's emails.</source>
         <target>This section allows you to include information from the "Legal Content Management" section above at the bottom of your shop's emails.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/admin/email_attachments_form.tpl:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="96103eb82bd7f00ef55fac85c2f0a410">
         <source>For each type of email, you can define which content you would like to include.</source>
         <target>For each type of email, you can define which content you would like to include.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/admin/email_attachments_form.tpl:37</note>
+        <note>Line: 37</note>
       </trans-unit>
       <trans-unit id="e29252902fd4eaee6279ea5b60bc9092">
         <source>Email templates</source>
         <target>Email templates</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/admin/email_attachments_form.tpl:47</note>
+        <note>Line: 47</note>
       </trans-unit>
     </body>
   </file>
@@ -366,32 +307,27 @@ File: modules/ps_legalcompliance/views/templates/admin/email_attachments_form.tp
       <trans-unit id="c47ab33401eaded8f1cb361a05f20e14">
         <source>Legal content management</source>
         <target>Legal content management</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/admin/legal_cms_manager_form.tpl:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="d7045651974bcdbcec6b44c6d7e7ffd4">
         <source>Your country's legislation may require you to communicate some specific legal information to your customers.</source>
         <target>Your country's legislation may require you to communicate some specific legal information to your customers.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/admin/legal_cms_manager_form.tpl:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="56a98e3806ba49b60a534872eb19d01a">
         <source>The Legal Compliance module provides the means to indicate legally required informations to your customer, using static pages (some created on purpose by the module). It is your responsibility to fill in the corresponding pages with the required content.</source>
         <target>The Legal Compliance module provides the means to indicate legally required informations to your customer, using static pages (some created on purpose by the module). It is your responsibility to fill in the corresponding pages with the required content.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/admin/legal_cms_manager_form.tpl:37</note>
+        <note>Line: 37</note>
       </trans-unit>
       <trans-unit id="e087a70de5566015c0b9d3f54318a606">
         <source>For each of the topics below, first indicate which of your Pages contains the required information:</source>
         <target>For each of the topics below, first indicate which of your Pages contains the required information:</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/admin/legal_cms_manager_form.tpl:40</note>
+        <note>Line: 40</note>
       </trans-unit>
       <trans-unit id="dc4cd8f87379d05d6a67eb1fe4ae162d">
         <source>Add new Page</source>
         <target>Add new Page</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/admin/legal_cms_manager_form.tpl:68</note>
+        <note>Line: 68</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesLegalcomplianceShop.xlf
+++ b/app/Resources/translations/default/ModulesLegalcomplianceShop.xlf
@@ -5,136 +5,52 @@
       <trans-unit id="7c5b051f9cd69598866d9abe424ace5b">
         <source>The order will only be confirmed when you click on the button 'Order with an obligation to pay' at the end of the checkout!</source>
         <target>The order will only be confirmed when you click on the button 'Order with an obligation to pay' at the end of the checkout!</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:227</note>
+        <note>Line: 227</note>
       </trans-unit>
       <trans-unit id="272c87c1b60ba25f293fab358ba94a39">
         <source>You must agree to our Terms of Service before going any further!</source>
         <target>You must agree to our Terms of Service before going any further!</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:631</note>
+        <note>Line: 631</note>
       </trans-unit>
       <trans-unit id="2223d375913a9a3b4619a1ada82f8de7">
         <source>Something went wrong. If the problem persists, please contact us.</source>
         <target>Something went wrong. If the problem persists, please contact us.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:632</note>
+        <note>Line: 632</note>
       </trans-unit>
       <trans-unit id="7219074549f88adb580bf5a6fe57c459">
         <source>Select a payment option first.</source>
         <target>Select a payment option first.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:633</note>
+        <note>Line: 633</note>
       </trans-unit>
       <trans-unit id="8b70c72bfa7600032a1cbd6a554d8828">
         <source>Please check the "Revocation of virtual products" box first!</source>
         <target>Please check the "Revocation of virtual products" box first!</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:634</note>
+        <note>Line: 634</note>
       </trans-unit>
       <trans-unit id="60657eaf863277872e2c9a2d31423842">
         <source>I agree to the [terms of service] and [revocation terms] and will adhere to them unconditionally.</source>
         <target>I agree to the [terms of service] and [revocation terms] and will adhere to them unconditionally.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:794</note>
+        <note>Line: 794</note>
       </trans-unit>
       <trans-unit id="6f06a13b9608ee5f2da343a3ca049f31">
         <source>[1]For digital goods:[/1] I want immediate access to the digital content and I acknowledge that thereby I lose my right to cancel once the service has begun.[2][1]For services:[/1] I agree to the starting of the service and I acknowledge that I lose my right to cancel once the service has been fully performed.</source>
         <target>[1]For digital goods:[/1] I want immediate access to the digital content and I acknowledge that thereby I lose my right to cancel once the service has begun.[2][1]For services:[/1] I agree to the starting of the service and I acknowledge that I lose my right to cancel once the service has been fully performed.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:809</note>
+        <note>Line: 809</note>
       </trans-unit>
       <trans-unit id="5da618e8e4b89c66fe86e32cdafde142">
         <source>From</source>
         <target>From</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:890</note>
+        <note>Line: 890</note>
       </trans-unit>
       <trans-unit id="16b24a264ab76a36917095bf6e41ef62">
         <source>Our previous price</source>
         <target>Our previous price</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:903</note>
+        <note>Line: 903</note>
       </trans-unit>
       <trans-unit id="89bea8045e50a337d8ce9849a4e1633c">
         <source>Shipping excluded</source>
         <target>Shipping excluded</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:928</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_legalcompliance/views/templates/hook/hookDisplayCMSPrintButton.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="427e29628d9f5d9bfde0e58b32569619">
-        <source>Print this page</source>
-        <target>Print this page</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/hook/hookDisplayCMSPrintButton.tpl:29</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_legalcompliance/views/templates/hook/hookDisplayCheckoutSummaryTop.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="59a297091dace235b4bce5af7b86ead6">
-        <source>My shopping cart</source>
-        <target>My shopping cart</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/hook/hookDisplayCheckoutSummaryTop.tpl:26</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_legalcompliance/views/templates/hook/hookDisplayCartPriceBlock_shipping_details.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6af90b162bd8ab1c547c76492d8a2380">
-        <source>(Under conditions)</source>
-        <target>(Under conditions)</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/hook/hookDisplayCartPriceBlock_shipping_details.tpl:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_legalcompliance/views/templates/hook/hookDisplayFooter.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a82be0f551b8708bc08eb33cd9ded0cf">
-        <source>Information</source>
-        <target>Information</target>
-        <note>Context:
-File: themes/classic/modules/ps_legalcompliance/views/templates/hook/hookDisplayFooter.tpl:29</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_legalcompliance/views/templates/hook/hookDisplayFooterAfter.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5fb4f05f62f9967052977077d783fc2d">
-        <source>Shipping and payment</source>
-        <target>Shipping and payment</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/hook/hookDisplayFooterAfter.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="361e7fe59f227267dd4a926de69fc658">
-        <source>All prices are mentioned tax included</source>
-        <target>All prices are mentioned tax included</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/hook/hookDisplayFooterAfter.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="ceae7caad3d61341d1ddc4c78b21546c">
-        <source>All prices are mentioned tax excluded</source>
-        <target>All prices are mentioned tax excluded</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/hook/hookDisplayFooterAfter.tpl:34</note>
-      </trans-unit>
-      <trans-unit id="be5d5d37542d75f93a87094459f76678">
-        <source>and</source>
-        <target>and</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/hook/hookDisplayFooterAfter.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="53ae8b43aace8a1d1349d659c150d99f">
-        <source>shipping excluded</source>
-        <target>shipping excluded</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/hook/hookDisplayFooterAfter.tpl:41</note>
+        <note>Line: 928</note>
       </trans-unit>
     </body>
   </file>
@@ -143,14 +59,77 @@ File: modules/ps_legalcompliance/views/templates/hook/hookDisplayFooterAfter.tpl
       <trans-unit id="ded564687a6602917eb07c460577f456">
         <source>Information regarding online dispute resolution pursuant to Art. 14 Para. 1 of the ODR (Online Dispute Resolution Regulation):</source>
         <target>Information regarding online dispute resolution pursuant to Art. 14 Para. 1 of the ODR (Online Dispute Resolution Regulation):</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/hook/hookDisplayCMSDisputeInformation.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="29bd9770285cd28ad9e55714db33e8bd">
         <source>The European Commission gives consumers the opportunity to resolve online disputes pursuant to Art. 14 Para. 1 of the ODR on one of their platforms. The platform ([1]http://ec.europa.eu/consumers/odr[/1]) serves as a site where consumers can try to reach out-of-court settlements of disputes arising from online purchases and contracts for services.</source>
         <target>The European Commission gives consumers the opportunity to resolve online disputes pursuant to Art. 14 Para. 1 of the ODR on one of their platforms. The platform ([1]http://ec.europa.eu/consumers/odr[/1]) serves as a site where consumers can try to reach out-of-court settlements of disputes arising from online purchases and contracts for services.</target>
-        <note>Context:
-File: modules/ps_legalcompliance/views/templates/hook/hookDisplayCMSDisputeInformation.tpl:31</note>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_legalcompliance/views/templates/hook/hookDisplayCMSPrintButton.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="427e29628d9f5d9bfde0e58b32569619">
+        <source>Print this page</source>
+        <target>Print this page</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_legalcompliance/views/templates/hook/hookDisplayCartPriceBlock_shipping_details.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6af90b162bd8ab1c547c76492d8a2380">
+        <source>(Under conditions)</source>
+        <target>(Under conditions)</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_legalcompliance/views/templates/hook/hookDisplayCheckoutSummaryTop.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="59a297091dace235b4bce5af7b86ead6">
+        <source>My shopping cart</source>
+        <target>My shopping cart</target>
+        <note>Line: 26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_legalcompliance/views/templates/hook/hookDisplayFooterAfter.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5fb4f05f62f9967052977077d783fc2d">
+        <source>Shipping and payment</source>
+        <target>Shipping and payment</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="361e7fe59f227267dd4a926de69fc658">
+        <source>All prices are mentioned tax included</source>
+        <target>All prices are mentioned tax included</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="ceae7caad3d61341d1ddc4c78b21546c">
+        <source>All prices are mentioned tax excluded</source>
+        <target>All prices are mentioned tax excluded</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="be5d5d37542d75f93a87094459f76678">
+        <source>and</source>
+        <target>and</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="53ae8b43aace8a1d1349d659c150d99f">
+        <source>shipping excluded</source>
+        <target>shipping excluded</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_legalcompliance/views/templates/hook/hookDisplayFooter.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a82be0f551b8708bc08eb33cd9ded0cf">
+        <source>Information</source>
+        <target>Information</target>
+        <note>Line: 29</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesLinklistAdmin.xlf
+++ b/app/Resources/translations/default/ModulesLinklistAdmin.xlf
@@ -1,106 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/ps_linklist/ps_linklist.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b5750478c3c490d2c1df5dfdfdd6b7a4">
-        <source>Link List</source>
-        <target>Link List</target>
-        <note>Context:
-File: modules/ps_linklist/ps_linklist.php:57</note>
-      </trans-unit>
-      <trans-unit id="34a65b805d7e94c02bad18890a97f134">
-        <source>Adds a block with several links.</source>
-        <target>Adds a block with several links.</target>
-        <note>Context:
-File: modules/ps_linklist/ps_linklist.php:58</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="e2a999acc8db5fd702e2f91b25b45222">
         <source>Link Widget</source>
         <target>Link Widget</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:232</note>
+        <note>Line: 232</note>
       </trans-unit>
       <trans-unit id="85ec26fb32110f2fa7ffc9b12015959a">
         <source>Link block configuration</source>
         <target>Link block configuration</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:77</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="5436b31a608ba3794ba11014cf59c26c">
         <source>Link Blocks</source>
         <target>Link Blocks</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:87</note>
+        <note>Line: 87</note>
       </trans-unit>
       <trans-unit id="0a41f7ebbcf8a28362f8635ca8341d28">
         <source>New block</source>
         <target>New block</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:94</note>
+        <note>Line: 94</note>
       </trans-unit>
       <trans-unit id="daf3043cd80ce98935908b37e2a7c97b">
         <source>Edit the link block.</source>
         <target>Edit the link block.</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:121</note>
+        <note>Line: 121</note>
       </trans-unit>
       <trans-unit id="ef7c1780c75500dc68d71a6824d10c6b">
         <source>New link block</source>
         <target>New link block</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:121</note>
+        <note>Line: 121</note>
       </trans-unit>
       <trans-unit id="e3352eb748a4c1cbcd1b41e98582bcac">
         <source>Name of the link block</source>
         <target>Name of the link block</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:131</note>
+        <note>Line: 131</note>
       </trans-unit>
       <trans-unit id="8b12d77641baf3ee673f6508bde7b707">
         <source>Content pages</source>
         <target>Content pages</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:149</note>
+        <note>Line: 149</note>
       </trans-unit>
       <trans-unit id="04313a11bf4a501b7cf2273ea7b32862">
         <source>Please mark every page that you want to display in this block.</source>
         <target>Please mark every page that you want to display in this block.</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:166</note>
+        <note>Line: 166</note>
       </trans-unit>
       <trans-unit id="f4e01b4c717593dd98723eaa3c68b423">
         <source>Product pages</source>
         <target>Product pages</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:156</note>
+        <note>Line: 156</note>
       </trans-unit>
       <trans-unit id="1accac49de3b88324dc4cd52712d9f53">
         <source>Static content</source>
         <target>Static content</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:163</note>
+        <note>Line: 163</note>
       </trans-unit>
       <trans-unit id="943336f1b4259f6599f4715e6799fac1">
         <source>Custom content</source>
         <target>Custom content</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:170</note>
+        <note>Line: 170</note>
       </trans-unit>
       <trans-unit id="15d95ad5102ba429be8ddcb646b7d42b">
         <source>Please add every page that you want to display in this block.</source>
         <target>Please add every page that you want to display in this block.</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:173</note>
+        <note>Line: 173</note>
       </trans-unit>
       <trans-unit id="83915d1254927f41241e8630890bec6e">
         <source>Themes</source>
         <target>Themes</target>
-        <note>Context:
-File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:231</note>
+        <note>Line: 231</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_linklist/ps_linklist.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b5750478c3c490d2c1df5dfdfdd6b7a4">
+        <source>Link List</source>
+        <target>Link List</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="34a65b805d7e94c02bad18890a97f134">
+        <source>Adds a block with several links.</source>
+        <target>Adds a block with several links.</target>
+        <note>Line: 58</note>
       </trans-unit>
     </body>
   </file>
@@ -109,44 +93,37 @@ File: modules/ps_linklist/controllers/admin/AdminLinkWidgetController.php:231</n
       <trans-unit id="b718adec73e04ce3ec720dd11a06a308">
         <source>ID</source>
         <target>ID</target>
-        <note>Context:
-File: modules/ps_linklist/views/templates/admin/linkwidget/helpers/form/form.tpl:135</note>
+        <note>Line: 135</note>
       </trans-unit>
       <trans-unit id="52f5e0bc3859bc5f5e25130b6c7e8881">
         <source>Position</source>
         <target>Position</target>
-        <note>Context:
-File: modules/ps_linklist/views/templates/admin/linkwidget/helpers/form/form.tpl:74</note>
+        <note>Line: 74</note>
       </trans-unit>
       <trans-unit id="83ef1503b3bd9858cc923a74e5f9e917">
         <source>Name of the block</source>
         <target>Name of the block</target>
-        <note>Context:
-File: modules/ps_linklist/views/templates/admin/linkwidget/helpers/form/form.tpl:75</note>
+        <note>Line: 75</note>
       </trans-unit>
       <trans-unit id="7dce122004969d56ae2e0245cb754d35">
         <source>Edit</source>
         <target>Edit</target>
-        <note>Context:
-File: modules/ps_linklist/views/templates/admin/linkwidget/helpers/form/form.tpl:95</note>
+        <note>Line: 95</note>
       </trans-unit>
       <trans-unit id="f2a6c498fb90ee345d997f888fce3b18">
         <source>Delete</source>
         <target>Delete</target>
-        <note>Context:
-File: modules/ps_linklist/views/templates/admin/linkwidget/helpers/form/form.tpl:103</note>
+        <note>Line: 103</note>
       </trans-unit>
       <trans-unit id="49ee3087348e8d44e1feda1917443987">
         <source>Name</source>
         <target>Name</target>
-        <note>Context:
-File: modules/ps_linklist/views/templates/admin/linkwidget/helpers/form/form.tpl:217</note>
+        <note>Line: 217</note>
       </trans-unit>
       <trans-unit id="e6b391a8d2c4d45902a23a8b6585703d">
         <source>URL</source>
         <target>URL</target>
-        <note>Context:
-File: modules/ps_linklist/views/templates/admin/linkwidget/helpers/form/form.tpl:218</note>
+        <note>Line: 218</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesLinklistShop.xlf
+++ b/app/Resources/translations/default/ModulesLinklistShop.xlf
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/ps_linklist/lang/LinkBlockLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="modules/ps_linklist/src/LinkBlockRepository.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="068f80c7519d0528fb08e82137a72131">
         <source>Products</source>
         <target>Products</target>
-        <note>Context:
-File: modules/ps_linklist/lang/LinkBlockLang.php:40</note>
+        <note>Line: 275</note>
       </trans-unit>
       <trans-unit id="ebdaa50b843565605176eb40816e77fe">
         <source>Our company</source>
         <target>Our company</target>
-        <note>Context:
-File: modules/ps_linklist/lang/LinkBlockLang.php:41</note>
+        <note>Line: 276</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesMainmenuAdmin.xlf
+++ b/app/Resources/translations/default/ModulesMainmenuAdmin.xlf
@@ -5,167 +5,140 @@
       <trans-unit id="4d7a3b1c46041dc73dec5764f3a6b63a">
         <source>Main menu</source>
         <target>Main menu</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:65</note>
+        <note>Line: 65</note>
       </trans-unit>
       <trans-unit id="e2456ba8b78357d7aefa983b1b14ac27">
         <source>Adds a new menu to the top of your e-commerce website.</source>
         <target>Adds a new menu to the top of your e-commerce website.</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:66</note>
+        <note>Line: 66</note>
       </trans-unit>
       <trans-unit id="d9a776c185f73d018b2915f4d5e7cc05">
         <source>Unable to update settings for the following shop(s): %s</source>
         <target>Unable to update settings for the following shop(s): %s</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:199</note>
+        <note>Line: 199</note>
       </trans-unit>
       <trans-unit id="f32880ae5183a02c0a743bfd37a42cbc">
         <source>Please complete the "Link" field.</source>
         <target>Please complete the "Link" field.</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:217</note>
+        <note>Line: 217</note>
       </trans-unit>
       <trans-unit id="cf8d684bd5f89d30da67c95363a48ab9">
         <source>Please add a label.</source>
         <target>Please add a label.</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:219</note>
+        <note>Line: 219</note>
       </trans-unit>
       <trans-unit id="e8d6809226ab177013e0a26bd2d8b60d">
         <source>Please add a label for your default language.</source>
         <target>Please add a label for your default language.</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:221</note>
+        <note>Line: 221</note>
       </trans-unit>
       <trans-unit id="3da9d5745155a430aac6d7de3b6de0c8">
         <source>The link has been added.</source>
         <target>The link has been added.</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:235</note>
+        <note>Line: 235</note>
       </trans-unit>
       <trans-unit id="022bb0995e3256abeeac1788a5e2c5b3">
         <source>Unable to add link for the following shop(s): %s</source>
         <target>Unable to add link for the following shop(s): %s</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:237</note>
+        <note>Line: 237</note>
       </trans-unit>
       <trans-unit id="e24e88b590807c2816be15abd7c7dbbc">
         <source>The link has been removed.</source>
         <target>The link has been removed.</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:258</note>
+        <note>Line: 258</note>
       </trans-unit>
       <trans-unit id="e418ee8626f7941239c5b7a0880691ae">
         <source>Unable to remove link for the following shop(s): %s</source>
         <target>Unable to remove link for the following shop(s): %s</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:260</note>
+        <note>Line: 260</note>
       </trans-unit>
       <trans-unit id="beb4f951c292ec9218473ffe5f59849d">
         <source>The link has been edited.</source>
         <target>The link has been edited.</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:279</note>
+        <note>Line: 279</note>
       </trans-unit>
       <trans-unit id="b1a23c1a76918c10acc27bfa60798c42">
         <source>You cannot manage top menu items from a "All Shops" or a "Group Shop" context, select directly the shop you want to edit</source>
         <target>You cannot manage top menu items from a "All Shops" or a "Group Shop" context, select directly the shop you want to edit</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:318</note>
+        <note>Line: 318</note>
       </trans-unit>
       <trans-unit id="298b615220606d42b6ac60269df0d321">
         <source>The modifications will be applied to shop: %s</source>
         <target>The modifications will be applied to shop: %s</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:327</note>
+        <note>Line: 327</note>
       </trans-unit>
       <trans-unit id="aef3662e6419ddaaa0a31df70e3b6557">
         <source>The modifications will be applied to this group: %s</source>
         <target>The modifications will be applied to this group: %s</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:330</note>
+        <note>Line: 330</note>
       </trans-unit>
       <trans-unit id="dd25f68471362f6f5f183d6158d67854">
         <source>The modifications will be applied to all shops</source>
         <target>The modifications will be applied to all shops</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:332</note>
+        <note>Line: 332</note>
       </trans-unit>
       <trans-unit id="e18a22d145b38e4fff582663b5b4ec1e">
         <source>All brands</source>
         <target>All brands</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1162
- Comment: Option to show all Manufacturers</note>
+        <note>Line: 1162
+Comment: Option to show all Manufacturers</note>
       </trans-unit>
       <trans-unit id="ecf253735ac0cba84a9d2eeff1f1b87c">
         <source>All suppliers</source>
         <target>All suppliers</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1150
- Comment: Option to show all Suppliers</note>
+        <note>Line: 1150
+Comment: Option to show all Suppliers</note>
       </trans-unit>
       <trans-unit id="944d19a34e5fa333a6a0de27e8c971da">
         <source>Menu Top Link</source>
         <target>Menu Top Link</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1022</note>
+        <note>Line: 1022</note>
       </trans-unit>
       <trans-unit id="0a112e5da975d8eaf28df9219c397764">
         <source>All active products combinations quantities will be changed</source>
         <target>All active products combinations quantities will be changed</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1026</note>
+        <note>Line: 1026</note>
       </trans-unit>
       <trans-unit id="1a6191a2dc928ff8fb8c02c050975ea7">
         <source>Update link</source>
         <target>Update link</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1062</note>
+        <note>Line: 1062</note>
       </trans-unit>
       <trans-unit id="58e9b25bb2e2699986a3abe2c92fc82e">
         <source>Add a new link</source>
         <target>Add a new link</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1062</note>
+        <note>Line: 1062</note>
       </trans-unit>
       <trans-unit id="c7da501f54544eba6787960200d9efdb">
         <source>CMS</source>
         <target>CMS</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1143</note>
+        <note>Line: 1143</note>
       </trans-unit>
       <trans-unit id="12a521af593422cd508f7707662c9eb2">
         <source>Shops</source>
         <target>Shops</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1184</note>
+        <note>Line: 1184</note>
       </trans-unit>
       <trans-unit id="778118c7dd993db08f704e15efa4a7fa">
         <source>Choose product ID</source>
         <target>Choose product ID</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1200</note>
+        <note>Line: 1200</note>
       </trans-unit>
       <trans-unit id="56e8bf6c54f1638e7bce5a2fcd5b20fe">
         <source>Menu Top Links</source>
         <target>Menu Top Links</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1204
- Comment: BEGIN Menu Top Links</note>
+        <note>Line: 1204
+Comment: BEGIN Menu Top Links</note>
       </trans-unit>
       <trans-unit id="449f6d82cde894eafd3c85b6fa918f89">
         <source>Link ID</source>
         <target>Link ID</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1326</note>
+        <note>Line: 1326</note>
       </trans-unit>
       <trans-unit id="387a8014f530f080bf2f3be723f8c164">
         <source>Link list</source>
         <target>Link list</target>
-        <note>Context:
-File: modules/ps_mainmenu/ps_mainmenu.php:1357</note>
+        <note>Line: 1357</note>
       </trans-unit>
     </body>
   </file>
@@ -174,44 +147,37 @@ File: modules/ps_mainmenu/ps_mainmenu.php:1357</note>
       <trans-unit id="17a1352d3f69a733fd472fce0238a07d">
         <source>Indicate the ID number for the product</source>
         <target>Indicate the ID number for the product</target>
-        <note>Context:
-File: modules/ps_mainmenu/views/templates/admin/_configure/helpers/form/form.tpl:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="6bb999afde6fca60d70edce79d20b370">
         <source>Product ID #</source>
         <target>Product ID #</target>
-        <note>Context:
-File: modules/ps_mainmenu/views/templates/admin/_configure/helpers/form/form.tpl:56</note>
+        <note>Line: 56</note>
       </trans-unit>
       <trans-unit id="3ee3549ff0c93372a730749f784e9438">
         <source>Please select just one item</source>
         <target>Please select just one item</target>
-        <note>Context:
-File: modules/ps_mainmenu/views/templates/admin/_configure/helpers/form/form.tpl:85</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="e1b11c03820641dd1d1441bf68898d08">
         <source>Change position</source>
         <target>Change position</target>
-        <note>Context:
-File: modules/ps_mainmenu/views/templates/admin/_configure/helpers/form/form.tpl:102</note>
+        <note>Line: 102</note>
       </trans-unit>
       <trans-unit id="3713a99a6284e39061bd48069807aa52">
         <source>Selected items</source>
         <target>Selected items</target>
-        <note>Context:
-File: modules/ps_mainmenu/views/templates/admin/_configure/helpers/form/form.tpl:107</note>
+        <note>Line: 107</note>
       </trans-unit>
       <trans-unit id="8fb31b552d63ffef9df733646a195bc0">
         <source>Available items</source>
         <target>Available items</target>
-        <note>Context:
-File: modules/ps_mainmenu/views/templates/admin/_configure/helpers/form/form.tpl:111</note>
+        <note>Line: 111</note>
       </trans-unit>
       <trans-unit id="1063e38cb53d94d386f21227fcd84717">
         <source>Remove</source>
         <target>Remove</target>
-        <note>Context:
-File: modules/ps_mainmenu/views/templates/admin/_configure/helpers/form/form.tpl:119</note>
+        <note>Line: 119</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesNewsletterAdmin.xlf
+++ b/app/Resources/translations/default/ModulesNewsletterAdmin.xlf
@@ -5,141 +5,118 @@
       <trans-unit id="ffb7e666a70151215b4c55c6268d7d72">
         <source>Newsletter</source>
         <target>Newsletter</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="804a924e464fd21ed92f820224c4091d">
         <source>Generates a .CSV file for mass mailings</source>
         <target>Generates a .CSV file for mass mailings</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="c3987e4cac14a8456515f0d200da04ee">
         <source>All countries</source>
         <target>All countries</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:235
- Comment: ...formatting array</note>
+        <note>Line: 235
+Comment: ...formatting array</note>
       </trans-unit>
       <trans-unit id="5353d769bec6eb3977ef36a3d8021682">
         <source>Customers' country</source>
         <target>Customers' country</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:282</note>
+        <note>Line: 282</note>
       </trans-unit>
       <trans-unit id="516cdf157ed8ef01602e6f23b7667c69">
         <source>Filter customers' country.</source>
         <target>Filter customers' country.</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:283</note>
+        <note>Line: 283</note>
       </trans-unit>
       <trans-unit id="2198f293f5e1e95dddeff819fbca0975">
         <source>Newsletter subscribers</source>
         <target>Newsletter subscribers</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:295</note>
+        <note>Line: 295</note>
       </trans-unit>
       <trans-unit id="99006a61d48499231e1be92241cf772a">
         <source>Filter newsletter subscribers.</source>
         <target>Filter newsletter subscribers.</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:296</note>
+        <note>Line: 296</note>
       </trans-unit>
       <trans-unit id="7e3a51a56ddd2846e21c33f05e0aea6f">
         <source>All customers</source>
         <target>All customers</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:320</note>
+        <note>Line: 320</note>
       </trans-unit>
       <trans-unit id="39f7a3e2b56e9bfd753ba6325533a127">
         <source>Subscribers</source>
         <target>Subscribers</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:321</note>
+        <note>Line: 321</note>
       </trans-unit>
       <trans-unit id="011d8c5d94f729f013963d856cd78745">
         <source>Non-subscribers</source>
         <target>Non-subscribers</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:322</note>
+        <note>Line: 322</note>
       </trans-unit>
       <trans-unit id="6395c19dc5a1cef9ca125b9736358dc7">
         <source>Opt-in subscribers</source>
         <target>Opt-in subscribers</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:313</note>
+        <note>Line: 313</note>
       </trans-unit>
       <trans-unit id="3136b84457870341f29f741f7a07d325">
         <source>Filter opt-in subscribers.</source>
         <target>Filter opt-in subscribers.</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:314</note>
+        <note>Line: 314</note>
       </trans-unit>
       <trans-unit id="82e5e0bc0f9c776c98253d569c111c0f">
         <source>No customers found with these filters!</source>
         <target>No customers found with these filters!</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:114</note>
+        <note>Line: 114</note>
       </trans-unit>
       <trans-unit id="644ecc2486a059ca16b001a77909bf40">
         <source>The .CSV file has been successfully exported: %d customers found.</source>
         <target>The .CSV file has been successfully exported: %d customers found.</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:123</note>
+        <note>Line: 123</note>
       </trans-unit>
       <trans-unit id="48e3d5f66961b621c78f709afcd7d437">
         <source>Download the file</source>
         <target>Download the file</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:125</note>
+        <note>Line: 125</note>
       </trans-unit>
       <trans-unit id="dca37b874cf34bd5ebcf1c2fdc59a8b4">
         <source>WARNING: When opening this .csv file with Excel, choose UTF-8 encoding to avoid strange characters.</source>
         <target>WARNING: When opening this .csv file with Excel, choose UTF-8 encoding to avoid strange characters.</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:130</note>
+        <note>Line: 130</note>
       </trans-unit>
       <trans-unit id="b40866b115d74009183e06fc86b5c014">
         <source>Error: Write access limited</source>
         <target>Error: Write access limited</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:135</note>
+        <note>Line: 135</note>
       </trans-unit>
       <trans-unit id="81573e0ea79138f02fd2cee94786d7e9">
         <source>Error: cannot write</source>
         <target>Error: cannot write</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:215</note>
+        <note>Line: 215</note>
       </trans-unit>
       <trans-unit id="73059f9530a1a37563150df4dea4bb70">
         <source>All Subscribers</source>
         <target>All Subscribers</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:302</note>
+        <note>Line: 302</note>
       </trans-unit>
       <trans-unit id="a307579714b75082f3f8734971b125cd">
         <source>Subscribers with account</source>
         <target>Subscribers with account</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:303</note>
+        <note>Line: 303</note>
       </trans-unit>
       <trans-unit id="d0da5609e4aebc5d532de97511a5a34a">
         <source>Subscribers without account</source>
         <target>Subscribers without account</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:304</note>
+        <note>Line: 304</note>
       </trans-unit>
       <trans-unit id="4713ef5f2d6fc1e8f088c850e696a04b">
         <source>Export customers</source>
         <target>Export customers</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:276</note>
+        <note>Line: 276</note>
       </trans-unit>
       <trans-unit id="dbb392a2dc9b38722e69f6032faea73e">
         <source>Export .CSV file</source>
         <target>Export .CSV file</target>
-        <note>Context:
-File: modules/newsletter/newsletter.php:334</note>
+        <note>Line: 334</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesPagesnotfoundAdmin.xlf
+++ b/app/Resources/translations/default/ModulesPagesnotfoundAdmin.xlf
@@ -5,110 +5,92 @@
       <trans-unit id="251295238bdf7693252f2804c8d3707e">
         <source>Pages not found</source>
         <target>Pages not found</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:44</note>
+        <note>Line: 44</note>
       </trans-unit>
       <trans-unit id="607cc8b8993662a37cac86032fb071d2">
         <source>Adds a tab to the Stats dashboard, showing the pages requested by your visitors that have not been found.</source>
         <target>Adds a tab to the Stats dashboard, showing the pages requested by your visitors that have not been found.</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="dc3a3db6b98723bf91f924537a630600">
         <source>The "pages not found" cache has been emptied.</source>
         <target>The "pages not found" cache has been emptied.</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:108</note>
+        <note>Line: 108</note>
       </trans-unit>
       <trans-unit id="b323790d8ee3c43d317d19aea5012626">
         <source>The "pages not found" cache has been deleted.</source>
         <target>The "pages not found" cache has been deleted.</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:115</note>
+        <note>Line: 115</note>
       </trans-unit>
       <trans-unit id="6602bbeb2956c035fb4cb5e844a4861b">
         <source>Guide</source>
         <target>Guide</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:122</note>
+        <note>Line: 122</note>
       </trans-unit>
       <trans-unit id="3604249130acf7fda296e16edc996e5b">
         <source>404 errors</source>
         <target>404 errors</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:124</note>
+        <note>Line: 124</note>
       </trans-unit>
       <trans-unit id="e43435dc55f752b2849609863362daeb">
         <source>A 404 error is an HTTP error code which means that the file requested by the user cannot be found. In your case it means that one of your visitors entered a wrong URL in the address bar, or that you or another website has a dead link. When possible, the referrer is shown so you can find the page/site which contains the dead link. If not, it generally means that it is a direct access, so someone may have bookmarked a link which doesn't exist anymore.</source>
         <target>A 404 error is an HTTP error code which means that the file requested by the user cannot be found. In your case it means that one of your visitors entered a wrong URL in the address bar, or that you or another website has a dead link. When possible, the referrer is shown so you can find the page/site which contains the dead link. If not, it generally means that it is a direct access, so someone may have bookmarked a link which doesn't exist anymore.</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:126</note>
+        <note>Line: 126</note>
       </trans-unit>
       <trans-unit id="a90083861c168ef985bf70763980aa60">
         <source>How to catch these errors?</source>
         <target>How to catch these errors?</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:129</note>
+        <note>Line: 129</note>
       </trans-unit>
       <trans-unit id="4f803d59ee120b11662027e049cba1f3">
         <source>If your webhost supports .htaccess files, you can create one in the root directory of PrestaShop and insert the following line inside: "%s".</source>
         <target>If your webhost supports .htaccess files, you can create one in the root directory of PrestaShop and insert the following line inside: "%s".</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:131</note>
+        <note>Line: 131</note>
       </trans-unit>
       <trans-unit id="a2f5d9a8196ef554479d72d2425f3f73">
         <source>A user requesting a page which doesn't exist will be redirected to the following page: %s. This module logs access to this page.</source>
         <target>A user requesting a page which doesn't exist will be redirected to the following page: %s. This module logs access to this page.</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:132</note>
+        <note>Line: 132</note>
       </trans-unit>
       <trans-unit id="01bd0bf7c5a68ad6ee4423118be3f7b6">
         <source>You must use a .htaccess file to redirect 404 errors to the "404.php" page.</source>
         <target>You must use a .htaccess file to redirect 404 errors to the "404.php" page.</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:136</note>
+        <note>Line: 136</note>
       </trans-unit>
       <trans-unit id="193cfc9be3b995831c6af2fea6650e60">
         <source>Page</source>
         <target>Page</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:145</note>
+        <note>Line: 145</note>
       </trans-unit>
       <trans-unit id="b6f05e5ddde1ec63d992d61144452dfa">
         <source>Referrer</source>
         <target>Referrer</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:146</note>
+        <note>Line: 146</note>
       </trans-unit>
       <trans-unit id="64d129224a5377b63e9727479ec987d9">
         <source>Counter</source>
         <target>Counter</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:147</note>
+        <note>Line: 147</note>
       </trans-unit>
       <trans-unit id="4a7a7e7cda40454cee7ec247660f8017">
         <source>No "page not found" issue registered for now.</source>
         <target>No "page not found" issue registered for now.</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:164</note>
+        <note>Line: 164</note>
       </trans-unit>
       <trans-unit id="d8847bc418fc4f5a3e37c2e8390bb9ed">
         <source>Empty database</source>
         <target>Empty database</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:168</note>
+        <note>Line: 168</note>
       </trans-unit>
       <trans-unit id="b9ae3636d6e672413a163f7cb34beb84">
         <source>Empty ALL "pages not found" notices for this period</source>
         <target>Empty ALL "pages not found" notices for this period</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:171</note>
+        <note>Line: 171</note>
       </trans-unit>
       <trans-unit id="0cf5c3a279c0e8c57b232d8c6bc3f06a">
         <source>Empty ALL "pages not found" notices</source>
         <target>Empty ALL "pages not found" notices</target>
-        <note>Context:
-File: modules/pagesnotfound/pagesnotfound.php:174</note>
+        <note>Line: 174</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesSearchbarAdmin.xlf
+++ b/app/Resources/translations/default/ModulesSearchbarAdmin.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="eacd852cc1f621763dccbda3f3c15081">
         <source>Search bar</source>
         <target>Search bar</target>
-        <note>Context:
-File: modules/ps_searchbar/ps_searchbar.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="be305c865235f417d9b4d22fcdf9f1c5">
         <source>Adds a quick search field to your website.</source>
         <target>Adds a quick search field to your website.</target>
-        <note>Context:
-File: modules/ps_searchbar/ps_searchbar.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesSearchbarShop.xlf
+++ b/app/Resources/translations/default/ModulesSearchbarShop.xlf
@@ -5,8 +5,7 @@
       <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
         <source>Search</source>
         <target>Search</target>
-        <note>Context:
-File: modules/ps_searchbar/ps_searchbar.tpl:31</note>
+        <note>Line: 31</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesSekeywordsAdmin.xlf
+++ b/app/Resources/translations/default/ModulesSekeywordsAdmin.xlf
@@ -5,110 +5,92 @@
       <trans-unit id="65b0b42febc8ea16db4652eab6f420a4">
         <source>Search engine keywords</source>
         <target>Search engine keywords</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:57</note>
+        <note>Line: 57</note>
       </trans-unit>
       <trans-unit id="8effa630c1740a748801b881acb90fa6">
         <source>Displays which keywords have led visitors to your website.</source>
         <target>Displays which keywords have led visitors to your website.</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:58</note>
+        <note>Line: 58</note>
       </trans-unit>
       <trans-unit id="9ed50bd6876a9273f2192c224b87657b">
         <source>Identify external search engine keywords</source>
         <target>Identify external search engine keywords</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:121</note>
+        <note>Line: 121</note>
       </trans-unit>
       <trans-unit id="7acbda50735929f05f6f463e05bc7ead">
         <source>This is one of the most common ways of finding a website through a search engine.</source>
         <target>This is one of the most common ways of finding a website through a search engine.</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:123</note>
+        <note>Line: 123</note>
       </trans-unit>
       <trans-unit id="4ad084c0b816ff9278765a00720caf32">
         <source>Identifying the most popular keywords entered by your new visitors allows you to see the products you should put in front if you want to achieve better visibility in search engines.</source>
         <target>Identifying the most popular keywords entered by your new visitors allows you to see the products you should put in front if you want to achieve better visibility in search engines.</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:124</note>
+        <note>Line: 124</note>
       </trans-unit>
       <trans-unit id="359f9e79e746fa9f684e5cda9e60ca2e">
         <source>How does it work?</source>
         <target>How does it work?</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:127</note>
+        <note>Line: 127</note>
       </trans-unit>
       <trans-unit id="ec2184245585ba979912af9e34d738c6">
         <source>When a visitor comes to your website, the web server notes the URL of the site he/she comes from. This module then parses the URL, and if it finds a reference to a known search engine, it finds the keywords in it.</source>
         <target>When a visitor comes to your website, the web server notes the URL of the site he/she comes from. This module then parses the URL, and if it finds a reference to a known search engine, it finds the keywords in it.</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:129</note>
+        <note>Line: 129</note>
       </trans-unit>
       <trans-unit id="b4b0dfed66b57ab3b20eb8c0ee429501">
         <source>This module can recognize all the search engines listed in PrestaShop's Stats/Search Engine page -- and you can add more!</source>
         <target>This module can recognize all the search engines listed in PrestaShop's Stats/Search Engine page -- and you can add more!</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:130</note>
+        <note>Line: 130</note>
       </trans-unit>
       <trans-unit id="dcbcf5d190af87351a16edd5f132c657">
         <source>IMPORTANT NOTE: in September 2013, Google chose to encrypt its searches queries using SSL. This means all the referer-based tools in the World (including this one) cannot identify Google keywords anymore.</source>
         <target>IMPORTANT NOTE: in September 2013, Google chose to encrypt its searches queries using SSL. This means all the referer-based tools in the World (including this one) cannot identify Google keywords anymore.</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:131</note>
+        <note>Line: 131</note>
       </trans-unit>
       <trans-unit id="16d5f8dc3bc4411c85848ae9cf6a947a">
         <source>%d keyword matches your query.</source>
         <target>%d keyword matches your query.</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:134</note>
+        <note>Line: 134</note>
       </trans-unit>
       <trans-unit id="5029f8eef402bb8ddd6191dffb5e7c19">
         <source>%d keywords match your query.</source>
         <target>%d keywords match your query.</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:134</note>
+        <note>Line: 134</note>
       </trans-unit>
       <trans-unit id="0849140171616600e8f2c35f0a225212">
         <source>Filter by keyword</source>
         <target>Filter by keyword</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:139</note>
+        <note>Line: 139</note>
       </trans-unit>
       <trans-unit id="6e632566b6e16dbd2273e83d7c53182b">
         <source>And min occurrences</source>
         <target>And min occurrences</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:145</note>
+        <note>Line: 145</note>
       </trans-unit>
       <trans-unit id="867343577fa1f33caa632a19543bd252">
         <source>Keywords</source>
         <target>Keywords</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:164</note>
+        <note>Line: 164</note>
       </trans-unit>
       <trans-unit id="e52e6aa1a43a0187e44f048f658db5f9">
         <source>Occurrences</source>
         <target>Occurrences</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:165</note>
+        <note>Line: 165</note>
       </trans-unit>
       <trans-unit id="7b48f6cc4a1dde7fca9597e717c2465f">
         <source>No keywords</source>
         <target>No keywords</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:179</note>
+        <note>Line: 179</note>
       </trans-unit>
       <trans-unit id="e15832aa200f342e8f4ab580b43a72a8">
         <source>Top 10 keywords</source>
         <target>Top 10 keywords</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:229</note>
+        <note>Line: 229</note>
       </trans-unit>
       <trans-unit id="52ef9633d88a7480b3a938ff9eaa2a25">
         <source>Others</source>
         <target>Others</target>
-        <note>Context:
-File: modules/sekeywords/sekeywords.php:243</note>
+        <note>Line: 243</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesSharebuttonsAdmin.xlf
+++ b/app/Resources/translations/default/ModulesSharebuttonsAdmin.xlf
@@ -5,14 +5,12 @@
       <trans-unit id="d3c92a24ab45afe985ee34e758787dd3">
         <source>Social media share buttons</source>
         <target>Social media share buttons</target>
-        <note>Context:
-File: modules/ps_sharebuttons/ps_sharebuttons.php:52</note>
+        <note>Line: 52</note>
       </trans-unit>
       <trans-unit id="221c46a34f553f08f4c5e7685a9dcc89">
         <source>Displays social media sharing buttons (Twitter, Facebook, Google+ and Pinterest) on every product page.</source>
         <target>Displays social media sharing buttons (Twitter, Facebook, Google+ and Pinterest) on every product page.</target>
-        <note>Context:
-File: modules/ps_sharebuttons/ps_sharebuttons.php:53</note>
+        <note>Line: 53</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesSharebuttonsShop.xlf
+++ b/app/Resources/translations/default/ModulesSharebuttonsShop.xlf
@@ -5,26 +5,22 @@
       <trans-unit id="5a95a425f74314a96f13a2f136992178">
         <source>Share</source>
         <target>Share</target>
-        <note>Context:
-File: modules/ps_sharebuttons/ps_sharebuttons.php:179</note>
+        <note>Line: 179</note>
       </trans-unit>
       <trans-unit id="3746d4aa96f19672260a424d76729dd1">
         <source>Tweet</source>
         <target>Tweet</target>
-        <note>Context:
-File: modules/ps_sharebuttons/ps_sharebuttons.php:187</note>
+        <note>Line: 187</note>
       </trans-unit>
       <trans-unit id="5b2c8bfd1bc974966209b7be1cb51a72">
         <source>Google+</source>
         <target>Google+</target>
-        <note>Context:
-File: modules/ps_sharebuttons/ps_sharebuttons.php:195</note>
+        <note>Line: 195</note>
       </trans-unit>
       <trans-unit id="86709a608bd914b28221164e6680ebf7">
         <source>Pinterest</source>
         <target>Pinterest</target>
-        <note>Context:
-File: modules/ps_sharebuttons/ps_sharebuttons.php:203</note>
+        <note>Line: 203</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesShoppingcartAdmin.xlf
+++ b/app/Resources/translations/default/ModulesShoppingcartAdmin.xlf
@@ -5,32 +5,27 @@
       <trans-unit id="f373b403975d367491574fb2c739fef7">
         <source>Shopping cart</source>
         <target>Shopping cart</target>
-        <note>Context:
-File: modules/ps_shoppingcart/ps_shoppingcart.php:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="32114c6d4529db62a4703c4b04a3f214">
         <source>Adds a block containing the customer's shopping cart.</source>
         <target>Adds a block containing the customer's shopping cart.</target>
-        <note>Context:
-File: modules/ps_shoppingcart/ps_shoppingcart.php:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="a21e5718d2a196280b729438933501c7">
         <source>Ajax: Invalid choice.</source>
         <target>Ajax: Invalid choice.</target>
-        <note>Context:
-File: modules/ps_shoppingcart/ps_shoppingcart.php:127</note>
+        <note>Line: 127</note>
       </trans-unit>
       <trans-unit id="614a8820aa4ac08ce2ee398a41b10778">
         <source>Ajax cart</source>
         <target>Ajax cart</target>
-        <note>Context:
-File: modules/ps_shoppingcart/ps_shoppingcart.php:156</note>
+        <note>Line: 156</note>
       </trans-unit>
       <trans-unit id="eefd19ecf1f6d94a308dcfc95981bbf9">
         <source>Activate Ajax mode for the cart (compatible with the default theme).</source>
         <target>Activate Ajax mode for the cart (compatible with the default theme).</target>
-        <note>Context:
-File: modules/ps_shoppingcart/ps_shoppingcart.php:159</note>
+        <note>Line: 159</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesSocialfollowAdmin.xlf
+++ b/app/Resources/translations/default/ModulesSocialfollowAdmin.xlf
@@ -5,110 +5,92 @@
       <trans-unit id="57066e29e9b1ef80851b42afc0745db7">
         <source>Social media follow links</source>
         <target>Social media follow links</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="d02883d61d6ccabe562b5c330ebe174a">
         <source>Allows you to add information about your brand's social networking accounts.</source>
         <target>Allows you to add information about your brand's social networking accounts.</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="76f8961bb8f4bb2b95c07650f30a7e7b">
         <source>Facebook URL</source>
         <target>Facebook URL</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:117</note>
+        <note>Line: 117</note>
       </trans-unit>
       <trans-unit id="c162369096f0fe5784f05052ceee6b47">
         <source>Your Facebook fan page.</source>
         <target>Your Facebook fan page.</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:119</note>
+        <note>Line: 119</note>
       </trans-unit>
       <trans-unit id="bcca29e10968edaf6e0154d2339ad556">
         <source>Twitter URL</source>
         <target>Twitter URL</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:123</note>
+        <note>Line: 123</note>
       </trans-unit>
       <trans-unit id="6aadf667dfc3538abc2708ba76861bba">
         <source>Your official Twitter account.</source>
         <target>Your official Twitter account.</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:125</note>
+        <note>Line: 125</note>
       </trans-unit>
       <trans-unit id="1a530e4877d8d41f810d9d05f065722d">
         <source>RSS URL</source>
         <target>RSS URL</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:129</note>
+        <note>Line: 129</note>
       </trans-unit>
       <trans-unit id="672f301ddc5372b2477ed3c1d9322949">
         <source>The RSS feed of your choice (your blog, your store, etc.).</source>
         <target>The RSS feed of your choice (your blog, your store, etc.).</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:131</note>
+        <note>Line: 131</note>
       </trans-unit>
       <trans-unit id="ad7198d676478ac70c3243c1d3446331">
         <source>YouTube URL</source>
         <target>YouTube URL</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:135</note>
+        <note>Line: 135</note>
       </trans-unit>
       <trans-unit id="5817a34292f074f9f596de6cb3607540">
         <source>Your official YouTube account.</source>
         <target>Your official YouTube account.</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:137</note>
+        <note>Line: 137</note>
       </trans-unit>
       <trans-unit id="1dd99e363d1bebee81578708c1e8a5e0">
         <source>Google+ URL:</source>
         <target>Google+ URL:</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:141</note>
+        <note>Line: 141</note>
       </trans-unit>
       <trans-unit id="1dd0a74974711190139fa51579765a04">
         <source>Your official Google+ page.</source>
         <target>Your official Google+ page.</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:143</note>
+        <note>Line: 143</note>
       </trans-unit>
       <trans-unit id="76abe3a162f22f63fae44d60fbe8f11b">
         <source>Pinterest URL:</source>
         <target>Pinterest URL:</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:147</note>
+        <note>Line: 147</note>
       </trans-unit>
       <trans-unit id="e158a81859319b5e442bc490b0e81af3">
         <source>Your official Pinterest account.</source>
         <target>Your official Pinterest account.</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:149</note>
+        <note>Line: 149</note>
       </trans-unit>
       <trans-unit id="815f12ace0a25af8c12e036810002683">
         <source>Vimeo URL:</source>
         <target>Vimeo URL:</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:153</note>
+        <note>Line: 153</note>
       </trans-unit>
       <trans-unit id="cba991994fe165dfcf4f5bd256bbe119">
         <source>Your official Vimeo account.</source>
         <target>Your official Vimeo account.</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:155</note>
+        <note>Line: 155</note>
       </trans-unit>
       <trans-unit id="130bab903955b2f6047a0db82f460386">
         <source>Instagram URL:</source>
         <target>Instagram URL:</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:159</note>
+        <note>Line: 159</note>
       </trans-unit>
       <trans-unit id="d55a27c3408d38f3137182c89b69a7a7">
         <source>Your official Instagram account.</source>
         <target>Your official Instagram account.</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:161</note>
+        <note>Line: 161</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesSocialfollowShop.xlf
+++ b/app/Resources/translations/default/ModulesSocialfollowShop.xlf
@@ -5,50 +5,42 @@
       <trans-unit id="d85544fce402c7a2a96a48078edaf203">
         <source>Facebook</source>
         <target>Facebook</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:210</note>
+        <note>Line: 210</note>
       </trans-unit>
       <trans-unit id="2491bc9c7d8731e1ae33124093bc7026">
         <source>Twitter</source>
         <target>Twitter</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:218</note>
+        <note>Line: 218</note>
       </trans-unit>
       <trans-unit id="48ee8ba81f747e2afa3344472d9f2f7c">
         <source>Rss</source>
         <target>Rss</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:226</note>
+        <note>Line: 226</note>
       </trans-unit>
       <trans-unit id="8dd1bae8da2e2408210d0656fbe6b7d1">
         <source>YouTube</source>
         <target>YouTube</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:234</note>
+        <note>Line: 234</note>
       </trans-unit>
       <trans-unit id="a1d7d2089dfd98072df7c45b07f9a89c">
         <source>Google +</source>
         <target>Google +</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:242</note>
+        <note>Line: 242</note>
       </trans-unit>
       <trans-unit id="86709a608bd914b28221164e6680ebf7">
         <source>Pinterest</source>
         <target>Pinterest</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:250</note>
+        <note>Line: 250</note>
       </trans-unit>
       <trans-unit id="15db599e0119be476d71bfc1fda72217">
         <source>Vimeo</source>
         <target>Vimeo</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:258</note>
+        <note>Line: 258</note>
       </trans-unit>
       <trans-unit id="55f015a0c5605702f913536afe70cfb0">
         <source>Instagram</source>
         <target>Instagram</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.php:266</note>
+        <note>Line: 266</note>
       </trans-unit>
     </body>
   </file>
@@ -57,8 +49,7 @@ File: modules/ps_socialfollow/ps_socialfollow.php:266</note>
       <trans-unit id="d918f99442796e88b6fe5ad32c217f76">
         <source>Follow us</source>
         <target>Follow us</target>
-        <note>Context:
-File: modules/ps_socialfollow/ps_socialfollow.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsbestcategoriesAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsbestcategoriesAdmin.xlf
@@ -5,50 +5,42 @@
       <trans-unit id="4f29d8c727dcf2022ac241cb96c31083">
         <source>Empty recordset returned</source>
         <target>Empty recordset returned</target>
-        <note>Context:
-File: modules/statsbestcategories/statsbestcategories.php:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="eebfd2d9a7ea25b9e61e8260bcd4849c">
         <source>Total Quantity Sold</source>
         <target>Total Quantity Sold</target>
-        <note>Context:
-File: modules/statsbestcategories/statsbestcategories.php:65</note>
+        <note>Line: 65</note>
       </trans-unit>
       <trans-unit id="f3547ae5e06426d87312eff7dda775aa">
         <source>Total Price</source>
         <target>Total Price</target>
-        <note>Context:
-File: modules/statsbestcategories/statsbestcategories.php:71</note>
+        <note>Line: 71</note>
       </trans-unit>
       <trans-unit id="89a4e26859399438513f41c4971795b5">
         <source>Total Margin</source>
         <target>Total Margin</target>
-        <note>Context:
-File: modules/statsbestcategories/statsbestcategories.php:77</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="c13329e42ec01a10f84c0f950274b404">
         <source>Total Viewed</source>
         <target>Total Viewed</target>
-        <note>Context:
-File: modules/statsbestcategories/statsbestcategories.php:83</note>
+        <note>Line: 83</note>
       </trans-unit>
       <trans-unit id="6e3b3150807da868ebd33ad2c991b8d7">
         <source>Best categories</source>
         <target>Best categories</target>
-        <note>Context:
-File: modules/statsbestcategories/statsbestcategories.php:89</note>
+        <note>Line: 89</note>
       </trans-unit>
       <trans-unit id="e5510869e31bbf721ca15dff21cf1169">
         <source>Adds a list of the best categories to the Stats dashboard.</source>
         <target>Adds a list of the best categories to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsbestcategories/statsbestcategories.php:90</note>
+        <note>Line: 90</note>
       </trans-unit>
       <trans-unit id="26f1502c886f4daa37c43d27bb58d40d">
         <source>Display final level categories only (that have no child categories)</source>
         <target>Display final level categories only (that have no child categories)</target>
-        <note>Context:
-File: modules/statsbestcategories/statsbestcategories.php:135</note>
+        <note>Line: 135</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsbestcustomersAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsbestcustomersAdmin.xlf
@@ -5,74 +5,62 @@
       <trans-unit id="4f29d8c727dcf2022ac241cb96c31083">
         <source>Empty recordset returned</source>
         <target>Empty recordset returned</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="ec1ee973b8947391f8f014c76ac7379f">
         <source>Valid orders</source>
         <target>Valid orders</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:85</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="1ff1b62d08d1195f073c6adac00f1894">
         <source>Money spent</source>
         <target>Money spent</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:91</note>
+        <note>Line: 91</note>
       </trans-unit>
       <trans-unit id="8b83489bd116cb60e2f348e9c63cd7f6">
         <source>Best customers</source>
         <target>Best customers</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:97</note>
+        <note>Line: 97</note>
       </trans-unit>
       <trans-unit id="9a1643c70b51526dd35d546ef8e17b87">
         <source>Adds a list of the best customers to the Stats dashboard.</source>
         <target>Adds a list of the best customers to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:98</note>
+        <note>Line: 98</note>
       </trans-unit>
       <trans-unit id="a32a87bb2fc40ac5e3701941fb715cb4">
         <source>Develop clients' loyalty</source>
         <target>Develop clients' loyalty</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:129</note>
+        <note>Line: 129</note>
       </trans-unit>
       <trans-unit id="c01d21a09f02b8e661114db60a0f60d4">
         <source>Keeping a client can be more profitable than gaining a new one. That is one of the many reasons it is necessary to cultivate customer loyalty.</source>
         <target>Keeping a client can be more profitable than gaining a new one. That is one of the many reasons it is necessary to cultivate customer loyalty.</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:131</note>
+        <note>Line: 131</note>
       </trans-unit>
       <trans-unit id="197bad7ad08abfd1dc45ab92f96f155d">
         <source>Word of mouth is also a means for getting new, satisfied clients. A dissatisfied customer can hurt your e-reputation and obstruct future sales goals.</source>
         <target>Word of mouth is also a means for getting new, satisfied clients. A dissatisfied customer can hurt your e-reputation and obstruct future sales goals.</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:132</note>
+        <note>Line: 132</note>
       </trans-unit>
       <trans-unit id="bf0d87b5aa8d331563ee61f2ac82069d">
         <source>In order to achieve this goal, you can organize:</source>
         <target>In order to achieve this goal, you can organize:</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:133</note>
+        <note>Line: 133</note>
       </trans-unit>
       <trans-unit id="397a5e109a5897ee7d699050cbc93347">
         <source>Punctual operations: commercial rewards (personalized special offers, product or service offered), non commercial rewards (priority handling of an order or a product), pecuniary rewards (bonds, discount coupons, payback).</source>
         <target>Punctual operations: commercial rewards (personalized special offers, product or service offered), non commercial rewards (priority handling of an order or a product), pecuniary rewards (bonds, discount coupons, payback).</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:135</note>
+        <note>Line: 135</note>
       </trans-unit>
       <trans-unit id="4bc24eed56e0ba89fc3ab4e094d18d8a">
         <source>Sustainable operations: loyalty points or cards, which not only justify communication between merchant and client, but also offer advantages to clients (private offers, discounts).</source>
         <target>Sustainable operations: loyalty points or cards, which not only justify communication between merchant and client, but also offer advantages to clients (private offers, discounts).</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:136</note>
+        <note>Line: 136</note>
       </trans-unit>
       <trans-unit id="2f408c42912e3afe23a0e4adcbe34b96">
         <source>These operations encourage clients to buy products and visit your online store more regularly.</source>
         <target>These operations encourage clients to buy products and visit your online store more regularly.</target>
-        <note>Context:
-File: modules/statsbestcustomers/statsbestcustomers.php:138</note>
+        <note>Line: 138</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsbestmanufacturersAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsbestmanufacturersAdmin.xlf
@@ -5,20 +5,17 @@
       <trans-unit id="ea067eb37801c5aab1a1c685eb97d601">
         <source>Total paid</source>
         <target>Total paid</target>
-        <note>Context:
-File: modules/statsbestmanufacturers/statsbestmanufacturers.php:73</note>
+        <note>Line: 73</note>
       </trans-unit>
       <trans-unit id="db6a532890a0d1a32fd31b77ca71f3d4">
         <source>Best brands</source>
         <target>Best brands</target>
-        <note>Context:
-File: modules/statsbestmanufacturers/statsbestmanufacturers.php:80</note>
+        <note>Line: 80</note>
       </trans-unit>
       <trans-unit id="1303f6630f41d138b17b47b9c33a84ff">
         <source>Adds a list of the best brands to the Stats dashboard.</source>
         <target>Adds a list of the best brands to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsbestmanufacturers/statsbestmanufacturers.php:81</note>
+        <note>Line: 81</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsbestproductsAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsbestproductsAdmin.xlf
@@ -5,38 +5,32 @@
       <trans-unit id="8c4d7af5f578693f9a6cf391e912ee33">
         <source>An empty record-set was returned.</source>
         <target>An empty record-set was returned.</target>
-        <note>Context:
-File: modules/statsbestproducts/statsbestproducts.php:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="6771f2d557a34bd89ea7abc92a0a069c">
         <source>Price sold</source>
         <target>Price sold</target>
-        <note>Context:
-File: modules/statsbestproducts/statsbestproducts.php:77</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="25f4b31e8f3baec8b2f266e05af88943">
         <source>Quantity sold in a day</source>
         <target>Quantity sold in a day</target>
-        <note>Context:
-File: modules/statsbestproducts/statsbestproducts.php:89</note>
+        <note>Line: 89</note>
       </trans-unit>
       <trans-unit id="7664a37e0cc56aaf39aebf2edbd3f98e">
         <source>Page views</source>
         <target>Page views</target>
-        <note>Context:
-File: modules/statsbestproducts/statsbestproducts.php:95</note>
+        <note>Line: 95</note>
       </trans-unit>
       <trans-unit id="950cf49f8ca529be64c924f16fcb5404">
         <source>Best-selling products</source>
         <target>Best-selling products</target>
-        <note>Context:
-File: modules/statsbestproducts/statsbestproducts.php:113</note>
+        <note>Line: 113</note>
       </trans-unit>
       <trans-unit id="15429f69e40860368f6e113e4cba5601">
         <source>Adds a list of the best-selling products to the Stats dashboard.</source>
         <target>Adds a list of the best-selling products to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsbestproducts/statsbestproducts.php:114</note>
+        <note>Line: 114</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsbestsuppliersAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsbestsuppliersAdmin.xlf
@@ -5,20 +5,17 @@
       <trans-unit id="ea067eb37801c5aab1a1c685eb97d601">
         <source>Total paid</source>
         <target>Total paid</target>
-        <note>Context:
-File: modules/statsbestsuppliers/statsbestsuppliers.php:71</note>
+        <note>Line: 71</note>
       </trans-unit>
       <trans-unit id="cc3eb9ba7d0e236f33023a4744d0693a">
         <source>Best suppliers</source>
         <target>Best suppliers</target>
-        <note>Context:
-File: modules/statsbestsuppliers/statsbestsuppliers.php:77</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="37607fc64452028f4d484aa014071934">
         <source>Adds a list of the best suppliers to the Stats dashboard.</source>
         <target>Adds a list of the best suppliers to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsbestsuppliers/statsbestsuppliers.php:78</note>
+        <note>Line: 78</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsbestvouchersAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsbestvouchersAdmin.xlf
@@ -5,26 +5,22 @@
       <trans-unit id="58ef962a87e6fbbea6027c17a954a18d">
         <source>Empty recordset returned.</source>
         <target>Empty recordset returned.</target>
-        <note>Context:
-File: modules/statsbestvouchers/statsbestvouchers.php:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="df25596dc94d556af2f1823725118572">
         <source>Total used</source>
         <target>Total used</target>
-        <note>Context:
-File: modules/statsbestvouchers/statsbestvouchers.php:77</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="b769cee333527b8dc6f3f67882e35a0b">
         <source>Best vouchers</source>
         <target>Best vouchers</target>
-        <note>Context:
-File: modules/statsbestvouchers/statsbestvouchers.php:83</note>
+        <note>Line: 83</note>
       </trans-unit>
       <trans-unit id="d32edaf4608c91c5795eceaa1948aea7">
         <source>Adds a list of the best vouchers to the Stats dashboard.</source>
         <target>Adds a list of the best vouchers to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsbestvouchers/statsbestvouchers.php:84</note>
+        <note>Line: 84</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatscarrierAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatscarrierAdmin.xlf
@@ -5,32 +5,27 @@
       <trans-unit id="2e6774abc54cb13cef2c5bfd5a2cb463">
         <source>Carrier distribution</source>
         <target>Carrier distribution</target>
-        <note>Context:
-File: modules/statscarrier/statscarrier.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="2e30734499b8dca052626a5145679eff">
         <source>Adds a graph displaying each carriers' distribution to the Stats dashboard.</source>
         <target>Adds a graph displaying each carriers' distribution to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statscarrier/statscarrier.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="ff61af405aa570a9000e6ba2da39857a">
         <source>This graph represents the carrier distribution for your orders. You can also narrow the focus of the graph to display distribution for a particular order status.</source>
         <target>This graph represents the carrier distribution for your orders. You can also narrow the focus of the graph to display distribution for a particular order status.</target>
-        <note>Context:
-File: modules/statscarrier/statscarrier.php:90</note>
+        <note>Line: 90</note>
       </trans-unit>
       <trans-unit id="ae916988f1944283efa2968808a71287">
         <source>No valid orders have been received for this period.</source>
         <target>No valid orders have been received for this period.</target>
-        <note>Context:
-File: modules/statscarrier/statscarrier.php:103</note>
+        <note>Line: 103</note>
       </trans-unit>
       <trans-unit id="d5b9d0daaf017332f1f8188ab2a3f802">
         <source>Percentage of orders listed by carrier.</source>
         <target>Percentage of orders listed by carrier.</target>
-        <note>Context:
-File: modules/statscarrier/statscarrier.php:126</note>
+        <note>Line: 126</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatscatalogAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatscatalogAdmin.xlf
@@ -5,104 +5,87 @@
       <trans-unit id="cf3aa21c6a2147ddbd86f34091daeccd">
         <source>Catalog statistics</source>
         <target>Catalog statistics</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="08a7c3cf820979d2c8d4de4f47abb5e6">
         <source>Adds a tab containing general statistics about your catalog to the Stats dashboard.</source>
         <target>Adds a tab containing general statistics about your catalog to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="74cda5a02df704cc5c3e8fee7fc0f7bc">
         <source>(1 purchase / %d visits)</source>
         <target>(1 purchase / %d visits)</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:171</note>
+        <note>Line: 171</note>
       </trans-unit>
       <trans-unit id="0173374ac20f5843d58b553d5b226ef6">
         <source>Choose a category</source>
         <target>Choose a category</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:184</note>
+        <note>Line: 184</note>
       </trans-unit>
       <trans-unit id="a7b623414d4b6a3225b4e935babec6d2">
         <source>Products available:</source>
         <target>Products available:</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:200</note>
+        <note>Line: 200</note>
       </trans-unit>
       <trans-unit id="1099377f1598a0856e2457a5145d89c2">
         <source>Average price (base price):</source>
         <target>Average price (base price):</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:201</note>
+        <note>Line: 201</note>
       </trans-unit>
       <trans-unit id="48a93dc02c74f3065af1ba47fca070d0">
         <source>Product pages viewed:</source>
         <target>Product pages viewed:</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:202</note>
+        <note>Line: 202</note>
       </trans-unit>
       <trans-unit id="85f179d4142ca061d49605a7fffdc09d">
         <source>Average number of page visits:</source>
         <target>Average number of page visits:</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:204</note>
+        <note>Line: 204</note>
       </trans-unit>
       <trans-unit id="05ff4bfc3baf0acd31a72f1ac754de04">
         <source>Average number of purchases:</source>
         <target>Average number of purchases:</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:205</note>
+        <note>Line: 205</note>
       </trans-unit>
       <trans-unit id="c09d09e371989d89847049c9574b6b8e">
         <source>Images available:</source>
         <target>Images available:</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:206</note>
+        <note>Line: 206</note>
       </trans-unit>
       <trans-unit id="65275d1b04037d8c8e42425002110363">
         <source>Average number of images:</source>
         <target>Average number of images:</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:207</note>
+        <note>Line: 207</note>
       </trans-unit>
       <trans-unit id="51b8891d531ad91128ba58c8928322ab">
         <source>Products never viewed:</source>
         <target>Products never viewed:</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:208</note>
+        <note>Line: 208</note>
       </trans-unit>
       <trans-unit id="8725647ef741e5d48c1e6f652ce80b50">
         <source>Products never purchased:</source>
         <target>Products never purchased:</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:209</note>
+        <note>Line: 209</note>
       </trans-unit>
       <trans-unit id="b86770bc713186bcf43dbb1164c5fd28">
         <source>Conversion rate*:</source>
         <target>Conversion rate*:</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:210</note>
+        <note>Line: 210</note>
       </trans-unit>
       <trans-unit id="082d537edb8c61539b9f266eb331c88e">
         <source>Defines the average conversion rate for the product page. It is possible to purchase a product without viewing the product page, so this rate can be greater than 1.</source>
         <target>Defines the average conversion rate for the product page. It is possible to purchase a product without viewing the product page, so this rate can be greater than 1.</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:214</note>
+        <note>Line: 214</note>
       </trans-unit>
       <trans-unit id="58a714d3e9bb2902a5b688c99bd4d8e6">
         <source>Products never purchased</source>
         <target>Products never purchased</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:220</note>
+        <note>Line: 220</note>
       </trans-unit>
       <trans-unit id="8e7c9a35104a5a68199678bd6bc5d187">
         <source>Edit / View</source>
         <target>Edit / View</target>
-        <note>Context:
-File: modules/statscatalog/statscatalog.php:226</note>
+        <note>Line: 226</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatscheckupAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatscheckupAdmin.xlf
@@ -5,98 +5,82 @@
       <trans-unit id="e7a908d79d3758c911692ba791da9c70">
         <source>Catalog evaluation</source>
         <target>Catalog evaluation</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="11c7290f636a816cbcffb9059958b5c0">
         <source>Adds a quick evaluation of your catalog quality to the Stats dashboard.</source>
         <target>Adds a quick evaluation of your catalog quality to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="7ff3e75ce6aca348bc513ed3d5882946">
         <source>Bad</source>
         <target>Bad</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:109</note>
+        <note>Line: 109</note>
       </trans-unit>
       <trans-unit id="b1897515d548a960afe49ecf66a29021">
         <source>Average</source>
         <target>Average</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:110</note>
+        <note>Line: 110</note>
       </trans-unit>
       <trans-unit id="0c6ad70beb3a7e76c3fc7adab7c46acc">
         <source>Good</source>
         <target>Good</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:111</note>
+        <note>Line: 111</note>
       </trans-unit>
       <trans-unit id="619a1efbedc7855aa27c0a50579c104e">
         <source>No product was found.</source>
         <target>No product was found.</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:152</note>
+        <note>Line: 152</note>
       </trans-unit>
       <trans-unit id="8bc84316c4078bf66723fd019616d920">
         <source>Descriptions</source>
         <target>Descriptions</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:156</note>
+        <note>Line: 156</note>
       </trans-unit>
       <trans-unit id="5cd1930570823694abdd596f29c8943d">
         <source>chars (without HTML)</source>
         <target>chars (without HTML)</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:156</note>
+        <note>Line: 156</note>
       </trans-unit>
       <trans-unit id="c3917e1f7138a24c6dc954fe81b86679">
         <source>orders / month</source>
         <target>orders / month</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:158</note>
+        <note>Line: 158</note>
       </trans-unit>
       <trans-unit id="dc270bcf468689b19074a5eef7581b52">
         <source>Not enough</source>
         <target>Not enough</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:171</note>
+        <note>Line: 171</note>
       </trans-unit>
       <trans-unit id="f4abc77d498c89880f67331609406774">
         <source>Alright</source>
         <target>Alright</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:172</note>
+        <note>Line: 172</note>
       </trans-unit>
       <trans-unit id="ad647e4ae904c7ed54ee93040d8298c7">
         <source>Less than</source>
         <target>Less than</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:185</note>
+        <note>Line: 185</note>
       </trans-unit>
       <trans-unit id="05824b7be006782aaefd1fdb97c71e06">
         <source>Greater than</source>
         <target>Greater than</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:194</note>
+        <note>Line: 194</note>
       </trans-unit>
       <trans-unit id="01fda57aa6c7e9f07f5aa36b108e95cb">
         <source>Order by</source>
         <target>Order by</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:211</note>
+        <note>Line: 211</note>
       </trans-unit>
       <trans-unit id="3f74e68055b1123e5d7deb32cd8b0b1b">
         <source>Desc.</source>
         <target>Desc.</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:313</note>
+        <note>Line: 313</note>
       </trans-unit>
       <trans-unit id="4cc6684df7b4a92b1dec6fce3264fac8">
         <source>Global</source>
         <target>Global</target>
-        <note>Context:
-File: modules/statscheckup/statscheckup.php:319</note>
+        <note>Line: 319</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsdataAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsdataAdmin.xlf
@@ -5,50 +5,42 @@
       <trans-unit id="a51950bf91ba55cd93a33ce3f8d448c2">
         <source>Data mining for statistics</source>
         <target>Data mining for statistics</target>
-        <note>Context:
-File: modules/statsdata/statsdata.php:44</note>
+        <note>Line: 44</note>
       </trans-unit>
       <trans-unit id="c77dfd683d0d76940e5e04cb24e8bce1">
         <source>This module must be enabled if you want to use statistics.</source>
         <target>This module must be enabled if you want to use statistics.</target>
-        <note>Context:
-File: modules/statsdata/statsdata.php:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="1a5b75c4be3c0100c99764b21e844cc8">
         <source>Save page views for each customer</source>
         <target>Save page views for each customer</target>
-        <note>Context:
-File: modules/statsdata/statsdata.php:189</note>
+        <note>Line: 189</note>
       </trans-unit>
       <trans-unit id="73d55f0a158656cbfabab45a3e151d73">
         <source>Storing customer page views uses a lot of CPU resources and database space. Only enable if your server can handle it.</source>
         <target>Storing customer page views uses a lot of CPU resources and database space. Only enable if your server can handle it.</target>
-        <note>Context:
-File: modules/statsdata/statsdata.php:191</note>
+        <note>Line: 191</note>
       </trans-unit>
       <trans-unit id="dd8289e220ec0de9a8b99adc7f9014b1">
         <source>Save global page views</source>
         <target>Save global page views</target>
-        <note>Context:
-File: modules/statsdata/statsdata.php:207</note>
+        <note>Line: 207</note>
       </trans-unit>
       <trans-unit id="b5a401cc0eff79d4c60871f245f7e8ef">
         <source>Global page views uses fewer resources than customer's, but it uses resources nonetheless.</source>
         <target>Global page views uses fewer resources than customer's, but it uses resources nonetheless.</target>
-        <note>Context:
-File: modules/statsdata/statsdata.php:209</note>
+        <note>Line: 209</note>
       </trans-unit>
       <trans-unit id="c0e4406117ba4c29c4d66e3069ebf3d3">
         <source>Plugins detection</source>
         <target>Plugins detection</target>
-        <note>Context:
-File: modules/statsdata/statsdata.php:225</note>
+        <note>Line: 225</note>
       </trans-unit>
       <trans-unit id="e4af29282b3a403c2b23c2a516bba889">
         <source>Plugins detection loads an extra 20 kb JavaScript file once for new visitors.</source>
         <target>Plugins detection loads an extra 20 kb JavaScript file once for new visitors.</target>
-        <note>Context:
-File: modules/statsdata/statsdata.php:227</note>
+        <note>Line: 227</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsequipmentAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsequipmentAdmin.xlf
@@ -5,62 +5,52 @@
       <trans-unit id="247270d410e2b9de01814b82111becda">
         <source>Browsers and operating systems</source>
         <target>Browsers and operating systems</target>
-        <note>Context:
-File: modules/statsequipment/statsequipment.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="2876718a648dea03aaafd4b5a63b1efe">
         <source>Adds a tab containing graphs about web browser and operating system usage to the Stats dashboard.</source>
         <target>Adds a tab containing graphs about web browser and operating system usage to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsequipment/statsequipment.php:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="854c8e126f839cc861cde822b641230e">
         <source>Making sure that your website is accessible to as many people as possible</source>
         <target>Making sure that your website is accessible to as many people as possible</target>
-        <note>Context:
-File: modules/statsequipment/statsequipment.php:133</note>
+        <note>Line: 133</note>
       </trans-unit>
       <trans-unit id="0d5f13106dec10bb8a9301541052278c">
         <source>When managing a website, it is important to keep track of the software used by visitors so as to be sure that the site displays the same way for everyone. PrestaShop was built to be compatible with the most recent Web browsers and computer operating systems (OS). However, because you may end up adding advanced features to your website or even modifying the core PrestaShop code, these additions may not be accessible to everyone. That is why it is a good idea to keep track of the percentage of users for each type of software before adding or changing something that only a limited number of users will be able to access.</source>
         <target>When managing a website, it is important to keep track of the software used by visitors so as to be sure that the site displays the same way for everyone. PrestaShop was built to be compatible with the most recent Web browsers and computer operating systems (OS). However, because you may end up adding advanced features to your website or even modifying the core PrestaShop code, these additions may not be accessible to everyone. That is why it is a good idea to keep track of the percentage of users for each type of software before adding or changing something that only a limited number of users will be able to access.</target>
-        <note>Context:
-File: modules/statsequipment/statsequipment.php:135</note>
+        <note>Line: 135</note>
       </trans-unit>
       <trans-unit id="11db1362a88c5e3e74c8f699c14d6798">
         <source>Indicates the percentage of each web browser used by customers.</source>
         <target>Indicates the percentage of each web browser used by customers.</target>
-        <note>Context:
-File: modules/statsequipment/statsequipment.php:144</note>
+        <note>Line: 144</note>
       </trans-unit>
       <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
         <source>CSV Export</source>
         <target>CSV Export</target>
-        <note>Context:
-File: modules/statsequipment/statsequipment.php:161</note>
+        <note>Line: 161</note>
       </trans-unit>
       <trans-unit id="90c58bfe4872fc9ca7bf6a181c3e5edd">
         <source>Indicates the percentage of each operating system used by customers.</source>
         <target>Indicates the percentage of each operating system used by customers.</target>
-        <note>Context:
-File: modules/statsequipment/statsequipment.php:158</note>
+        <note>Line: 158</note>
       </trans-unit>
       <trans-unit id="bb38096ab39160dc20d44f3ea6b44507">
         <source>Plugins</source>
         <target>Plugins</target>
-        <note>Context:
-File: modules/statsequipment/statsequipment.php:168</note>
+        <note>Line: 168</note>
       </trans-unit>
       <trans-unit id="9ffafc9e090c8e1c06f928ef2817efd6">
         <source>Web browser used</source>
         <target>Web browser used</target>
-        <note>Context:
-File: modules/statsequipment/statsequipment.php:182</note>
+        <note>Line: 182</note>
       </trans-unit>
       <trans-unit id="0241b7aaaa5f76afd585bb6cdae314d1">
         <source>Operating system used</source>
         <target>Operating system used</target>
-        <note>Context:
-File: modules/statsequipment/statsequipment.php:194</note>
+        <note>Line: 194</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsforecastAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsforecastAdmin.xlf
@@ -5,230 +5,192 @@
       <trans-unit id="240c994d8b61c7bd68ac1c5182bbdb2e">
         <source>Stats Dashboard</source>
         <target>Stats Dashboard</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:53</note>
+        <note>Line: 53</note>
       </trans-unit>
       <trans-unit id="b17fbc0dacaf9964df883d8065118b98">
         <source>This is the main module for the Stats dashboard. It displays a summary of all your current statistics.</source>
         <target>This is the main module for the Stats dashboard. It displays a summary of all your current statistics.</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:54</note>
+        <note>Line: 54</note>
       </trans-unit>
       <trans-unit id="7a27f506c0104592dcb95c31e650cfed">
         <source>The listed amounts do not include tax.</source>
         <target>The listed amounts do not include tax.</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:144</note>
+        <note>Line: 144</note>
       </trans-unit>
       <trans-unit id="0f65535c189c29b4a5326a319baa4a8d">
         <source>Time frame</source>
         <target>Time frame</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:148</note>
+        <note>Line: 148</note>
       </trans-unit>
       <trans-unit id="c512b685438f41daa7386329a3b8f8d3">
         <source>Daily</source>
         <target>Daily</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:153</note>
+        <note>Line: 153</note>
       </trans-unit>
       <trans-unit id="6c25e6a6da95b3d583c6ec4c3f82ed4d">
         <source>Weekly</source>
         <target>Weekly</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:154</note>
+        <note>Line: 154</note>
       </trans-unit>
       <trans-unit id="9030e39f00132d583da4122532e509e9">
         <source>Monthly</source>
         <target>Monthly</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:155</note>
+        <note>Line: 155</note>
       </trans-unit>
       <trans-unit id="cf5ea7953dc47105e0eb179dbefaaf46">
         <source>Yearly</source>
         <target>Yearly</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:156</note>
+        <note>Line: 156</note>
       </trans-unit>
       <trans-unit id="fc6e0920b914b164802d44220e6163f3">
         <source>Placed orders</source>
         <target>Placed orders</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:223</note>
+        <note>Line: 223</note>
       </trans-unit>
       <trans-unit id="95deefb44d887f65b77407b87684b593">
         <source>Bought items</source>
         <target>Bought items</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:224</note>
+        <note>Line: 224</note>
       </trans-unit>
       <trans-unit id="51f2b17f5537de83c8b52dc52867fb1c">
         <source>Percentage of registrations</source>
         <target>Percentage of registrations</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:225</note>
+        <note>Line: 225</note>
       </trans-unit>
       <trans-unit id="688cb5b32405309351ee01da0ff3c3ac">
         <source>Percentage of orders</source>
         <target>Percentage of orders</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:565</note>
+        <note>Line: 565</note>
       </trans-unit>
       <trans-unit id="54358a914f51e1af19df8520159fe607">
         <source>Revenue</source>
         <target>Revenue</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:227</note>
+        <note>Line: 227</note>
       </trans-unit>
       <trans-unit id="b1897515d548a960afe49ecf66a29021">
         <source>Average</source>
         <target>Average</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:240</note>
+        <note>Line: 240</note>
       </trans-unit>
       <trans-unit id="89c1265be62d3ba835a3d963db5956b0">
         <source>Forecast</source>
         <target>Forecast</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:250</note>
+        <note>Line: 250</note>
       </trans-unit>
       <trans-unit id="3bb1503332637805beddb73a2dd1fe1b">
         <source>Conversion</source>
         <target>Conversion</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:302</note>
+        <note>Line: 302</note>
       </trans-unit>
       <trans-unit id="9b945efebb006547a94415eadaa12921">
         <source>Accounts</source>
         <target>Accounts</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:317</note>
+        <note>Line: 317</note>
       </trans-unit>
       <trans-unit id="87cac5a0b60008003ccf46dc1d49e0c3">
         <source>Full carts</source>
         <target>Full carts</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:325</note>
+        <note>Line: 325</note>
       </trans-unit>
       <trans-unit id="5a9e532b24379dca2ab0e973172a78e1">
         <source>Registered visitors</source>
         <target>Registered visitors</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:337</note>
+        <note>Line: 337</note>
       </trans-unit>
       <trans-unit id="a34f9feb654595d53807df17b041d804">
         <source>A simple statistical calculation lets you know the monetary value of your visitors:</source>
         <target>A simple statistical calculation lets you know the monetary value of your visitors:</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:385</note>
+        <note>Line: 385</note>
       </trans-unit>
       <trans-unit id="42de3b7ec2450ded7d6c600b359def52">
         <source>On average, each visitor places an order for this amount:</source>
         <target>On average, each visitor places an order for this amount:</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:386</note>
+        <note>Line: 386</note>
       </trans-unit>
       <trans-unit id="c06cbe5e69067225dbcab04fb85200fa">
         <source>On average, each registered visitor places an order for this amount:</source>
         <target>On average, each registered visitor places an order for this amount:</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:387</note>
+        <note>Line: 387</note>
       </trans-unit>
       <trans-unit id="3fa6443ce3f838b6901b70cd812abf0d">
         <source>Payment distribution</source>
         <target>Payment distribution</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:396</note>
+        <note>Line: 396</note>
       </trans-unit>
       <trans-unit id="cbb3a9a8d0b10c0618904ce4ecb08716">
         <source>The amounts include taxes, so you can get an estimation of the commission due to the payment method.</source>
         <target>The amounts include taxes, so you can get an estimation of the commission due to the payment method.</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:398</note>
+        <note>Line: 398</note>
       </trans-unit>
       <trans-unit id="5ed26836c96d7dcae8a40307e8e250c3">
         <source>-- No filter --</source>
         <target>-- No filter --</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:550</note>
+        <note>Line: 550</note>
       </trans-unit>
       <trans-unit id="e55f75a29310d7b60f7ac1d390c8ae42">
         <source>Module</source>
         <target>Module</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:420</note>
+        <note>Line: 420</note>
       </trans-unit>
       <trans-unit id="71241798130f714cbd2786df3da2cf0b">
         <source>Average cart value</source>
         <target>Average cart value</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:423</note>
+        <note>Line: 423</note>
       </trans-unit>
       <trans-unit id="f13877f6ad53ce91fcb20fb8b7969698">
         <source>Category distribution</source>
         <target>Category distribution</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:441</note>
+        <note>Line: 441</note>
       </trans-unit>
       <trans-unit id="d1873a71f318c4e4733240f0b5911af3">
         <source>Products sold</source>
         <target>Products sold</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:463</note>
+        <note>Line: 463</note>
       </trans-unit>
       <trans-unit id="954b04c203e651728d12622da369cd80">
         <source>Percentage of products sold</source>
         <target>Percentage of products sold</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:465</note>
+        <note>Line: 465</note>
       </trans-unit>
       <trans-unit id="a613e7309e4cb7fdaf416fa4f8bfd360">
         <source>Percentage of sales</source>
         <target>Percentage of sales</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:566</note>
+        <note>Line: 566</note>
       </trans-unit>
       <trans-unit id="f1dd68fb6a00d3e4d7f751deacde995d">
         <source>Language distribution</source>
         <target>Language distribution</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:487</note>
+        <note>Line: 487</note>
       </trans-unit>
       <trans-unit id="699aed86dada6ca01ef74013a4464066">
         <source>Growth</source>
         <target>Growth</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:494</note>
+        <note>Line: 494</note>
       </trans-unit>
       <trans-unit id="07aa83862ec591697b4325b66d36a78b">
         <source>Zone distribution</source>
         <target>Zone distribution</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:514</note>
+        <note>Line: 514</note>
       </trans-unit>
       <trans-unit id="28e81c8343702f6c813cc31a7f90616a">
         <source>Currency distribution</source>
         <target>Currency distribution</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:541</note>
+        <note>Line: 541</note>
       </trans-unit>
       <trans-unit id="61569923d8075889a162c4e603258e6e">
         <source>Sales (converted)</source>
         <target>Sales (converted)</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:564</note>
+        <note>Line: 564</note>
       </trans-unit>
       <trans-unit id="8471eed257db7258f935588a664ba4f3">
         <source>Attribute distribution</source>
         <target>Attribute distribution</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:585</note>
+        <note>Line: 585</note>
       </trans-unit>
       <trans-unit id="9b95278ceb25bd5ddfcd7b22be6e4000">
         <source>Quantity of products sold</source>
         <target>Quantity of products sold</target>
-        <note>Context:
-File: modules/statsforecast/statsforecast.php:591</note>
+        <note>Line: 591</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsliveAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsliveAdmin.xlf
@@ -5,92 +5,77 @@
       <trans-unit id="fa55230e9791f2b71322869318a5f00f">
         <source>Visitors online</source>
         <target>Visitors online</target>
-        <note>Context:
-File: modules/statslive/statslive.php:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="abf306fd198ab007d480ed610a6690fb">
         <source>Adds a list of customers and visitors who are currently online to the Stats dashboard.</source>
         <target>Adds a list of customers and visitors who are currently online to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statslive/statslive.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="85f955e33756b8f40ce35e5b277de5bc">
         <source>You must activate the "Save page views for each customer" option in the "Data mining for statistics" (StatsData) module in order to see the pages that your visitors are currently viewing.</source>
         <target>You must activate the "Save page views for each customer" option in the "Data mining for statistics" (StatsData) module in order to see the pages that your visitors are currently viewing.</target>
-        <note>Context:
-File: modules/statslive/statslive.php:149</note>
+        <note>Line: 149</note>
       </trans-unit>
       <trans-unit id="f5ee3b50dba1fb98f1342a584e46cd30">
         <source>Current online customers</source>
         <target>Current online customers</target>
-        <note>Context:
-File: modules/statslive/statslive.php:153</note>
+        <note>Line: 153</note>
       </trans-unit>
       <trans-unit id="66c4c5112f455a19afde47829df363fa">
         <source>Total:</source>
         <target>Total:</target>
-        <note>Context:
-File: modules/statslive/statslive.php:189</note>
+        <note>Line: 189</note>
       </trans-unit>
       <trans-unit id="13aa8652e950bb7c4b9b213e6d8d0dc5">
         <source>Current page</source>
         <target>Current page</target>
-        <note>Context:
-File: modules/statslive/statslive.php:197</note>
+        <note>Line: 197</note>
       </trans-unit>
       <trans-unit id="9dd3bc54879dc9425d44de81f3d7dfdc">
         <source>View customer profile</source>
         <target>View customer profile</target>
-        <note>Context:
-File: modules/statslive/statslive.php:162</note>
+        <note>Line: 162</note>
       </trans-unit>
       <trans-unit id="08448d43d8e4b39ad5126d4b06e2f3cc">
         <source>There are no active customers online right now.</source>
         <target>There are no active customers online right now.</target>
-        <note>Context:
-File: modules/statslive/statslive.php:184</note>
+        <note>Line: 184</note>
       </trans-unit>
       <trans-unit id="cf6377279146be659952cea754c558b1">
         <source>Current online visitors</source>
         <target>Current online visitors</target>
-        <note>Context:
-File: modules/statslive/statslive.php:187</note>
+        <note>Line: 187</note>
       </trans-unit>
       <trans-unit id="f8cf0a1a6b03d2b01602992ea273134c">
         <source>Guest ID</source>
         <target>Guest ID</target>
-        <note>Context:
-File: modules/statslive/statslive.php:194</note>
+        <note>Line: 194</note>
       </trans-unit>
       <trans-unit id="a12a3079e14ced46e69ba52b8a90b21a">
         <source>IP</source>
         <target>IP</target>
-        <note>Context:
-File: modules/statslive/statslive.php:195</note>
+        <note>Line: 195</note>
       </trans-unit>
       <trans-unit id="bc5188ca43d423ba3730e4c030609d6e">
         <source>Last activity</source>
         <target>Last activity</target>
-        <note>Context:
-File: modules/statslive/statslive.php:196</note>
+        <note>Line: 196</note>
       </trans-unit>
       <trans-unit id="24efa7ee4511563b16144f39706d594f">
         <source>Notice</source>
         <target>Notice</target>
-        <note>Context:
-File: modules/statslive/statslive.php:219</note>
+        <note>Line: 219</note>
       </trans-unit>
       <trans-unit id="e5900cd9ae26ca607f7cd497f114b9f9">
         <source>Maintenance IPs are excluded from the online visitors.</source>
         <target>Maintenance IPs are excluded from the online visitors.</target>
-        <note>Context:
-File: modules/statslive/statslive.php:220</note>
+        <note>Line: 220</note>
       </trans-unit>
       <trans-unit id="05b564d49dbd9049f0df80a45cfe7d1c">
         <source>Add or remove an IP address.</source>
         <target>Add or remove an IP address.</target>
-        <note>Context:
-File: modules/statslive/statslive.php:222</note>
+        <note>Line: 222</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsnewsletterAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsnewsletterAdmin.xlf
@@ -5,44 +5,37 @@
       <trans-unit id="5106250927c6e24c99601968284066de">
         <source>Adds a tab with a graph showing newsletter registrations to the Stats dashboard.</source>
         <target>Adds a tab with a graph showing newsletter registrations to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsnewsletter/statsnewsletter.php:57</note>
+        <note>Line: 57</note>
       </trans-unit>
       <trans-unit id="61a898af87607e3f4d41c3613d8761c7">
         <source>Customer registrations:</source>
         <target>Customer registrations:</target>
-        <note>Context:
-File: modules/statsnewsletter/statsnewsletter.php:84</note>
+        <note>Line: 84</note>
       </trans-unit>
       <trans-unit id="7fe462207f98012d9ff00cf0e6633c94">
         <source>Visitor registrations: </source>
         <target>Visitor registrations:</target>
-        <note>Context:
-File: modules/statsnewsletter/statsnewsletter.php:85</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="64342cd480b27dfeefb08bace6e82fdc">
         <source>Both:</source>
         <target>Both:</target>
-        <note>Context:
-File: modules/statsnewsletter/statsnewsletter.php:86</note>
+        <note>Line: 86</note>
       </trans-unit>
       <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
         <source>CSV Export</source>
         <target>CSV Export</target>
-        <note>Context:
-File: modules/statsnewsletter/statsnewsletter.php:90</note>
+        <note>Line: 90</note>
       </trans-unit>
       <trans-unit id="b1e8ef173f53bc64af2600fdb6247ffd">
         <source>The %s module must be installed.</source>
         <target>The %s module must be installed.</target>
-        <note>Context:
-File: modules/statsnewsletter/statsnewsletter.php:96</note>
+        <note>Line: 96</note>
       </trans-unit>
       <trans-unit id="cf74c2815ab62be1efa55a4a5d3f46a4">
         <source>Newsletter statistics</source>
         <target>Newsletter statistics</target>
-        <note>Context:
-File: modules/statsnewsletter/statsnewsletter.php:122</note>
+        <note>Line: 122</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsoriginAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsoriginAdmin.xlf
@@ -5,86 +5,72 @@
       <trans-unit id="f0b1507c6bdcdefb60a0e6f9b89d4ae8">
         <source>Visitors origin</source>
         <target>Visitors origin</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="a69c2a3091fe48c7f4f391595aa3ac19">
         <source>Adds a graph displaying the websites your visitors came from to the Stats dashboard.</source>
         <target>Adds a graph displaying the websites your visitors came from to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="3edf8ca26a1ec14dd6e91dd277ae1de6">
         <source>Origin</source>
         <target>Origin</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:123</note>
+        <note>Line: 123</note>
       </trans-unit>
       <trans-unit id="4b69c1f7f555aa19fd90ee01e4aa63cd">
         <source>In the tab, we break down the 10 most popular referral websites that bring customers to your online store.</source>
         <target>In the tab, we break down the 10 most popular referral websites that bring customers to your online store.</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:93</note>
+        <note>Line: 93</note>
       </trans-unit>
       <trans-unit id="cec998cc46cd200fa97490137de2cc7f">
         <source>What is a referral website?</source>
         <target>What is a referral website?</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:97</note>
+        <note>Line: 97</note>
       </trans-unit>
       <trans-unit id="54f00c2c9a36e2b300b5bacc1bb7912c">
         <source>The referrer is the URL of the previous webpage from which a link was followed by the visitor.</source>
         <target>The referrer is the URL of the previous webpage from which a link was followed by the visitor.</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:99</note>
+        <note>Line: 99</note>
       </trans-unit>
       <trans-unit id="7231fe46fc79eb2b3a269f790b79e01f">
         <source>A referrer also enables you to know which keywords visitors use in search engines when browsing for your online store.</source>
         <target>A referrer also enables you to know which keywords visitors use in search engines when browsing for your online store.</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:100</note>
+        <note>Line: 100</note>
       </trans-unit>
       <trans-unit id="af19c8da1c414055c960a73d86471119">
         <source>A referrer can be:</source>
         <target>A referrer can be:</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:101</note>
+        <note>Line: 101</note>
       </trans-unit>
       <trans-unit id="c227be237c874ba6b2f8771d7b66b90e">
         <source>Someone who posts a link to your shop.</source>
         <target>Someone who posts a link to your shop.</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:104</note>
+        <note>Line: 104</note>
       </trans-unit>
       <trans-unit id="ea87a2280d5cdb638a2727147a3dd85c">
         <source>A partner who has agreed to a link exchange in order to attract new customers.</source>
         <target>A partner who has agreed to a link exchange in order to attract new customers.</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:105</note>
+        <note>Line: 105</note>
       </trans-unit>
       <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
         <source>CSV Export</source>
         <target>CSV Export</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:115</note>
+        <note>Line: 115</note>
       </trans-unit>
       <trans-unit id="0bebf95ee829c33f34fde535ed4ed100">
         <source>Direct links only</source>
         <target>Direct links only</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:138</note>
+        <note>Line: 138</note>
       </trans-unit>
       <trans-unit id="450a7e38e636dd49f5dfb356f96d3996">
         <source>Top ten referral websites</source>
         <target>Top ten referral websites</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:145</note>
+        <note>Line: 145</note>
       </trans-unit>
       <trans-unit id="52ef9633d88a7480b3a938ff9eaa2a25">
         <source>Others</source>
         <target>Others</target>
-        <note>Context:
-File: modules/statsorigin/statsorigin.php:162</note>
+        <note>Line: 162</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatspersonalinfosAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatspersonalinfosAdmin.xlf
@@ -5,170 +5,142 @@
       <trans-unit id="1b94af23fd8ea879910a6307460ebba4">
         <source>Registered customer information</source>
         <target>Registered customer information</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="b0cb4ea4e89c2107cb100be8417fd94e">
         <source>Adds information about your registered customers (such as gender and age) to the Stats dashboard.</source>
         <target>Adds information about your registered customers (such as gender and age) to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="3ca26e413e485538a7f3e610c0324636">
         <source>Target your audience</source>
         <target>Target your audience</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:64</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="74036f0101d2f3f9b082b8de981c18dc">
         <source>In order for each message to have an impact, you need to know who it is being addressed to. </source>
         <target>In order for each message to have an impact, you need to know who it is being addressed to.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:66</note>
+        <note>Line: 66</note>
       </trans-unit>
       <trans-unit id="daa0ad6a8b07a64f18b26e0f5e1255bd">
         <source>Defining your target audience is essential when choosing the right tools to win them over.</source>
         <target>Defining your target audience is essential when choosing the right tools to win them over.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:68</note>
+        <note>Line: 68</note>
       </trans-unit>
       <trans-unit id="8044a3d0d61282c4c425cd0da5432f11">
         <source>It is best to limit an action to a group -- or to groups -- of clients.</source>
         <target>It is best to limit an action to a group -- or to groups -- of clients.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:70</note>
+        <note>Line: 70</note>
       </trans-unit>
       <trans-unit id="05f074d112460c990203ff2f17a7d46d">
         <source>Storing registered customer information allows you to accurately define customer profiles so you can adapt your special deals and promotions.</source>
         <target>Storing registered customer information allows you to accurately define customer profiles so you can adapt your special deals and promotions.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:72</note>
+        <note>Line: 72</note>
       </trans-unit>
       <trans-unit id="9dc739320e2523183e8b31f395e1e489">
         <source>You can increase your sales by:</source>
         <target>You can increase your sales by:</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:75</note>
+        <note>Line: 75</note>
       </trans-unit>
       <trans-unit id="2f619981f1abd95da0907766cc409be9">
         <source>Launching targeted advertisement campaigns.</source>
         <target>Launching targeted advertisement campaigns.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:77</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="428dc481e13dad2818d8088da7362dd2">
         <source>Contacting a group of clients by email or newsletter.</source>
         <target>Contacting a group of clients by email or newsletter.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:78</note>
+        <note>Line: 78</note>
       </trans-unit>
       <trans-unit id="12344d957b4aee1e2c322549ddc9741f">
         <source>Gender distribution allows you to determine the percentage of men and women shoppers on your store.</source>
         <target>Gender distribution allows you to determine the percentage of men and women shoppers on your store.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:123</note>
+        <note>Line: 123</note>
       </trans-unit>
       <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
         <source>CSV Export</source>
         <target>CSV Export</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:194</note>
+        <note>Line: 194</note>
       </trans-unit>
       <trans-unit id="08a12630390dc8ddd4c9fdcd9060dce6">
         <source>Age ranges allow you to better understand target demographics.</source>
         <target>Age ranges allow you to better understand target demographics.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:140</note>
+        <note>Line: 140</note>
       </trans-unit>
       <trans-unit id="db9750afee08c6e88c91fbe1b3404ba6">
         <source>Country distribution allows you to analyze which part of the World your customers are shopping from.</source>
         <target>Country distribution allows you to analyze which part of the World your customers are shopping from.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:157</note>
+        <note>Line: 157</note>
       </trans-unit>
       <trans-unit id="e0fcbbd416a4872ec8f91fefa823debe">
         <source>Currency range allows you to determine which currency your customers are using.</source>
         <target>Currency range allows you to determine which currency your customers are using.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:174</note>
+        <note>Line: 174</note>
       </trans-unit>
       <trans-unit id="94d50571d0f2e98276cfbe2f3de41b20">
         <source>Language distribution allows you to analyze the browsing language used by your customers.</source>
         <target>Language distribution allows you to analyze the browsing language used by your customers.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:191</note>
+        <note>Line: 191</note>
       </trans-unit>
       <trans-unit id="9fde3510abe63111086fd4288a19e1be">
         <source>No customers have registered yet.</source>
         <target>No customers have registered yet.</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:200</note>
+        <note>Line: 200</note>
       </trans-unit>
       <trans-unit id="8dc514f6da8c696c4a522efc145ad28a">
         <source>Gender distribution</source>
         <target>Gender distribution</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:215</note>
+        <note>Line: 215</note>
       </trans-unit>
       <trans-unit id="4d79e3d0b4d09b2f42d0831193cea200">
         <source>Age range</source>
         <target>Age range</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:246</note>
+        <note>Line: 246</note>
       </trans-unit>
       <trans-unit id="6e69fbf88d84db874f365542b0284a95">
         <source>0-18</source>
         <target>0-18</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:257</note>
+        <note>Line: 257</note>
       </trans-unit>
       <trans-unit id="b20e0ed6158978a3a23d092060b5dbab">
         <source>18-24</source>
         <target>18-24</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:270</note>
+        <note>Line: 270</note>
       </trans-unit>
       <trans-unit id="e5884ca49180d38295ee426c624d936c">
         <source>25-34</source>
         <target>25-34</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:283</note>
+        <note>Line: 283</note>
       </trans-unit>
       <trans-unit id="62ce9f61153b331eabe9efc2fc7eb5c2">
         <source>35-49</source>
         <target>35-49</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:296</note>
+        <note>Line: 296</note>
       </trans-unit>
       <trans-unit id="a7724f78dcdf2179c5ca651d15ed5b2c">
         <source>50-59</source>
         <target>50-59</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:309</note>
+        <note>Line: 309</note>
       </trans-unit>
       <trans-unit id="6a239f88f1aeb0561e7786b6120d1d5e">
         <source>60+</source>
         <target>60+</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:321</note>
+        <note>Line: 321</note>
       </trans-unit>
       <trans-unit id="73b0130037e21b76351aebfd29d0b9aa">
         <source>Country distribution</source>
         <target>Country distribution</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:337</note>
+        <note>Line: 337</note>
       </trans-unit>
       <trans-unit id="28e81c8343702f6c813cc31a7f90616a">
         <source>Currency distribution</source>
         <target>Currency distribution</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:354</note>
+        <note>Line: 354</note>
       </trans-unit>
       <trans-unit id="f1dd68fb6a00d3e4d7f751deacde995d">
         <source>Language distribution</source>
         <target>Language distribution</target>
-        <note>Context:
-File: modules/statspersonalinfos/statspersonalinfos.php:369</note>
+        <note>Line: 369</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsproductAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsproductAdmin.xlf
@@ -5,122 +5,102 @@
       <trans-unit id="78e454064a7d3a7755a011a3b79f31a7">
         <source>Product details</source>
         <target>Product details</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="15944ce3356cfd0513cbc76e7df9d233">
         <source>Adds detailed statistics for each product to the Stats dashboard.</source>
         <target>Adds detailed statistics for each product to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="f083d0403991f2b0ae72ea8782518f36">
         <source>Number of purchases compared to number of views</source>
         <target>Number of purchases compared to number of views</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:180</note>
+        <note>Line: 180</note>
       </trans-unit>
       <trans-unit id="6e13e61b8535a66feb27d285f5c42855">
         <source>After choosing a category and selecting a product, informational graphs will appear.</source>
         <target>After choosing a category and selecting a product, informational graphs will appear.</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:181</note>
+        <note>Line: 181</note>
       </trans-unit>
       <trans-unit id="6734b1d16e064d64d9ea4affaed74cc7">
         <source>If you notice that a product is often purchased but viewed infrequently, you should display it more prominently in your Front Office.</source>
         <target>If you notice that a product is often purchased but viewed infrequently, you should display it more prominently in your Front Office.</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:183</note>
+        <note>Line: 183</note>
       </trans-unit>
       <trans-unit id="fd3dd734ca8b2bb1afcd70466d553498">
         <source>On the other hand, if a product has many views but is not often purchased, we advise you to check or modify this product's information, description and photography again, see if you can find something better.</source>
         <target>On the other hand, if a product has many views but is not often purchased, we advise you to check or modify this product's information, description and photography again, see if you can find something better.</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:184</note>
+        <note>Line: 184</note>
       </trans-unit>
       <trans-unit id="3ec365dd533ddb7ef3d1c111186ce872">
         <source>Details</source>
         <target>Details</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:207</note>
+        <note>Line: 207</note>
       </trans-unit>
       <trans-unit id="290b169159edc205e3a46902d4554d52">
         <source>Total bought</source>
         <target>Total bought</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:219</note>
+        <note>Line: 219</note>
       </trans-unit>
       <trans-unit id="155d5c362e6887660600763fc0d55f02">
         <source>Sales (tax excluded)</source>
         <target>Sales (tax excluded)</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:220</note>
+        <note>Line: 220</note>
       </trans-unit>
       <trans-unit id="c13329e42ec01a10f84c0f950274b404">
         <source>Total Viewed</source>
         <target>Total Viewed</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:221</note>
+        <note>Line: 221</note>
       </trans-unit>
       <trans-unit id="d311128c6b9f34f85e6b0e29bcbcd165">
         <source>Conversion rate</source>
         <target>Conversion rate</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:222</note>
+        <note>Line: 222</note>
       </trans-unit>
       <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
         <source>CSV Export</source>
         <target>CSV Export</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:369</note>
+        <note>Line: 369</note>
       </trans-unit>
       <trans-unit id="c90b9dca2d3f5bb6e0d0bdceac8a631d">
         <source>Attribute sales distribution</source>
         <target>Attribute sales distribution</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:232</note>
+        <note>Line: 232</note>
       </trans-unit>
       <trans-unit id="87017c9259838bb0918a2ab4f96016c0">
         <source>Cross selling</source>
         <target>Cross selling</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:284</note>
+        <note>Line: 284</note>
       </trans-unit>
       <trans-unit id="818f7defe18dbc97da82d054831df2ad">
         <source>Click on a product to access its statistics!</source>
         <target>Click on a product to access its statistics!</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:322</note>
+        <note>Line: 322</note>
       </trans-unit>
       <trans-unit id="0173374ac20f5843d58b553d5b226ef6">
         <source>Choose a category</source>
         <target>Choose a category</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:323</note>
+        <note>Line: 323</note>
       </trans-unit>
       <trans-unit id="6ccf03bc05e4b749b74b5d577c7e7d3a">
         <source>Products available</source>
         <target>Products available</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:337</note>
+        <note>Line: 337</note>
       </trans-unit>
       <trans-unit id="e22269bb51f9f2394e148716babbafbb">
         <source>Popularity</source>
         <target>Popularity</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:387</note>
+        <note>Line: 387</note>
       </trans-unit>
       <trans-unit id="5e9613e58f3bdbc89b1fef07274c0877">
         <source>Visits (x100)</source>
         <target>Visits (x100)</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:389</note>
+        <note>Line: 389</note>
       </trans-unit>
       <trans-unit id="27ce7f8b5623b2e2df568d64cf051607">
         <source>Stock</source>
         <target>Stock</target>
-        <note>Context:
-File: modules/statsproduct/statsproduct.php:427</note>
+        <note>Line: 427</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsregistrationsAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsregistrationsAdmin.xlf
@@ -5,92 +5,77 @@
       <trans-unit id="8b15fc6468c919d299f9a601b61b95fc">
         <source>Customer accounts</source>
         <target>Customer accounts</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="f14056d6fef225c8aafd5a99d4c70fa8">
         <source>Adds a registration progress tab to the Stats dashboard.</source>
         <target>Adds a registration progress tab to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="247b3bdef50a59d5a83f23c4f1c8fa47">
         <source>Number of visitors who stopped at the registering step:</source>
         <target>Number of visitors who stopped at the registering step:</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:126</note>
+        <note>Line: 126</note>
       </trans-unit>
       <trans-unit id="479c1246d97709e234574e1d2921994d">
         <source>Number of visitors who placed an order directly after registration:</source>
         <target>Number of visitors who placed an order directly after registration:</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:127</note>
+        <note>Line: 127</note>
       </trans-unit>
       <trans-unit id="a751e9cc4ed4c7585ecc0d97781cb48a">
         <source>Total customer accounts:</source>
         <target>Total customer accounts:</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:129</note>
+        <note>Line: 129</note>
       </trans-unit>
       <trans-unit id="fba0e64541196123bbf8e3737bf9287b">
         <source>Number of customer accounts created</source>
         <target>Number of customer accounts created</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:173</note>
+        <note>Line: 173</note>
       </trans-unit>
       <trans-unit id="76dcf557776c2b40d47b72ebcd9ac6b7">
         <source>The total number of accounts created is not in itself important information. However, it is beneficial to analyze the number created over time. This will indicate whether or not things are on the right track. You feel me?</source>
         <target>The total number of accounts created is not in itself important information. However, it is beneficial to analyze the number created over time. This will indicate whether or not things are on the right track. You feel me?</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:135</note>
+        <note>Line: 135</note>
       </trans-unit>
       <trans-unit id="f66b3e4b23c60dd713bee1aa7d90ff85">
         <source>How to act on the registrations' evolution?</source>
         <target>How to act on the registrations' evolution?</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:137</note>
+        <note>Line: 137</note>
       </trans-unit>
       <trans-unit id="271ef73d55b8e3cc30963ca9413d4a52">
         <source>If you let your shop run without changing anything, the number of customer registrations should stay stable or show a slight decline.</source>
         <target>If you let your shop run without changing anything, the number of customer registrations should stay stable or show a slight decline.</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:139</note>
+        <note>Line: 139</note>
       </trans-unit>
       <trans-unit id="bcabec23c8f36cecde037bd35ca4c709">
         <source>A significant increase or decrease in customer registration shows that there has probably been a change to your shop. With that in mind, we suggest that you identify the cause, correct the issue and get back in the business of making money!</source>
         <target>A significant increase or decrease in customer registration shows that there has probably been a change to your shop. With that in mind, we suggest that you identify the cause, correct the issue and get back in the business of making money!</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:140</note>
+        <note>Line: 140</note>
       </trans-unit>
       <trans-unit id="ded9c8756dc14fd26e3150c4718cd9d0">
         <source>Here is a summary of what may affect the creation of customer accounts:</source>
         <target>Here is a summary of what may affect the creation of customer accounts:</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:141</note>
+        <note>Line: 141</note>
       </trans-unit>
       <trans-unit id="318a7bb6dacd248bd7252286edeafc96">
         <source>An advertising campaign can attract an increased number of visitors to your online store. This will likely be followed by an increase in customer accounts and profit margins, which will depend on customer "quality." Well-targeted advertising is typically more effective than large-scale advertising... and it's cheaper too!</source>
         <target>An advertising campaign can attract an increased number of visitors to your online store. This will likely be followed by an increase in customer accounts and profit margins, which will depend on customer "quality." Well-targeted advertising is typically more effective than large-scale advertising... and it's cheaper too!</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:143</note>
+        <note>Line: 143</note>
       </trans-unit>
       <trans-unit id="4a3ca0c74bdbe87ba210ed1bf598c314">
         <source>Specials, sales, promotions and/or contests typically demand a shoppers' attentions. Offering such things will not only keep your business lively, it will also increase traffic, build customer loyalty and genuinely change your current e-commerce philosophy.</source>
         <target>Specials, sales, promotions and/or contests typically demand a shoppers' attentions. Offering such things will not only keep your business lively, it will also increase traffic, build customer loyalty and genuinely change your current e-commerce philosophy.</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:144</note>
+        <note>Line: 144</note>
       </trans-unit>
       <trans-unit id="8cb5605d77d1d2f9eab6191c0e027747">
         <source>Design and user-friendliness are more important than ever in the world of online sales. An ill-chosen or hard-to-follow graphical theme can keep shoppers at bay. This means that you should aspire to find the right balance between beauty and functionality for your online store.</source>
         <target>Design and user-friendliness are more important than ever in the world of online sales. An ill-chosen or hard-to-follow graphical theme can keep shoppers at bay. This means that you should aspire to find the right balance between beauty and functionality for your online store.</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:145</note>
+        <note>Line: 145</note>
       </trans-unit>
       <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
         <source>CSV Export</source>
         <target>CSV Export</target>
-        <note>Context:
-File: modules/statsregistrations/statsregistrations.php:156</note>
+        <note>Line: 156</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatssalesAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatssalesAdmin.xlf
@@ -5,110 +5,92 @@
       <trans-unit id="45c4b3e103155326596d6ccd2fea0f25">
         <source>Sales and orders</source>
         <target>Sales and orders</target>
-        <note>Context:
-File: modules/statssales/statssales.php:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="d2fb07753354576172a2b144c373a610">
         <source>Adds graphics presenting the evolution of sales and orders to the Stats dashboard.</source>
         <target>Adds graphics presenting the evolution of sales and orders to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statssales/statssales.php:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="bdaa0cab56c2880f8f60e6a2cef40e63">
         <source>About order statuses</source>
         <target>About order statuses</target>
-        <note>Context:
-File: modules/statssales/statssales.php:88</note>
+        <note>Line: 88</note>
       </trans-unit>
       <trans-unit id="fdfa8599f3887bef99e9572f3611260f">
         <source>In your Back Office, you can modify the following order statuses: Awaiting Check Payment, Payment Accepted, Preparation in Progress, Shipping, Delivered, Canceled, Refund, Payment Error, Out of Stock, and Awaiting Bank Wire Payment.</source>
         <target>In your Back Office, you can modify the following order statuses: Awaiting Check Payment, Payment Accepted, Preparation in Progress, Shipping, Delivered, Canceled, Refund, Payment Error, Out of Stock, and Awaiting Bank Wire Payment.</target>
-        <note>Context:
-File: modules/statssales/statssales.php:90</note>
+        <note>Line: 90</note>
       </trans-unit>
       <trans-unit id="4b75384caa4e6830c22f15e06e0bfac0">
         <source>These order statuses cannot be removed from the Back Office; however you have the option to add more.</source>
         <target>These order statuses cannot be removed from the Back Office; however you have the option to add more.</target>
-        <note>Context:
-File: modules/statssales/statssales.php:91</note>
+        <note>Line: 91</note>
       </trans-unit>
       <trans-unit id="85fa6dbe688e6187550abf46fb592e5b">
         <source>The following graphs represent the evolution of your shop's orders and sales turnover for a selected period.</source>
         <target>The following graphs represent the evolution of your shop's orders and sales turnover for a selected period.</target>
-        <note>Context:
-File: modules/statssales/statssales.php:96</note>
+        <note>Line: 96</note>
       </trans-unit>
       <trans-unit id="631b6ed00d320b89b25e017586b918b8">
         <source>You should often consult this screen, as it allows you to quickly monitor your shop's sustainability. It also allows you to monitor multiple time periods.</source>
         <target>You should often consult this screen, as it allows you to quickly monitor your shop's sustainability. It also allows you to monitor multiple time periods.</target>
-        <note>Context:
-File: modules/statssales/statssales.php:97</note>
+        <note>Line: 97</note>
       </trans-unit>
       <trans-unit id="5cc6f5194e3ef633bcab4869d79eeefa">
         <source>Only valid orders are graphically represented.</source>
         <target>Only valid orders are graphically represented.</target>
-        <note>Context:
-File: modules/statssales/statssales.php:98</note>
+        <note>Line: 98</note>
       </trans-unit>
       <trans-unit id="9ccb8353e945f1389a9585e7f21b5a0d">
         <source>Orders placed:</source>
         <target>Orders placed:</target>
-        <note>Context:
-File: modules/statssales/statssales.php:127</note>
+        <note>Line: 127</note>
       </trans-unit>
       <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
         <source>CSV Export</source>
         <target>CSV Export</target>
-        <note>Context:
-File: modules/statssales/statssales.php:169</note>
+        <note>Line: 169</note>
       </trans-unit>
       <trans-unit id="ec3e48bb9aa902ba2ad608547fdcbfdc">
         <source>Sales:</source>
         <target>Sales:</target>
-        <note>Context:
-File: modules/statssales/statssales.php:147</note>
+        <note>Line: 147</note>
       </trans-unit>
       <trans-unit id="f6825178a5fef0a97dacf963409829f0">
         <source>You can view the distribution of order statuses below.</source>
         <target>You can view the distribution of order statuses below.</target>
-        <note>Context:
-File: modules/statssales/statssales.php:157</note>
+        <note>Line: 157</note>
       </trans-unit>
       <trans-unit id="da80af4de99df74dd59e665adf1fac8f">
         <source>No orders for this period.</source>
         <target>No orders for this period.</target>
-        <note>Context:
-File: modules/statssales/statssales.php:165</note>
+        <note>Line: 165</note>
       </trans-unit>
       <trans-unit id="c58114720bcd52bfe96fd801cee77e93">
         <source>Orders placed</source>
         <target>Orders placed</target>
-        <note>Context:
-File: modules/statssales/statssales.php:207</note>
+        <note>Line: 207</note>
       </trans-unit>
       <trans-unit id="c8be451a5698956a0e78b5c2caab4821">
         <source>Products bought</source>
         <target>Products bought</target>
-        <note>Context:
-File: modules/statssales/statssales.php:208</note>
+        <note>Line: 208</note>
       </trans-unit>
       <trans-unit id="b52b44c9d23e141b067d7e83b44bb556">
         <source>Products:</source>
         <target>Products:</target>
-        <note>Context:
-File: modules/statssales/statssales.php:209</note>
+        <note>Line: 209</note>
       </trans-unit>
       <trans-unit id="497a2a4cf0a780ff5b60a7a6e43ea533">
         <source>Sales currency: %s</source>
         <target>Sales currency: %s</target>
-        <note>Context:
-File: modules/statssales/statssales.php:213</note>
+        <note>Line: 213</note>
       </trans-unit>
       <trans-unit id="17833fb3783b26e0a9bc8b21ee85302a">
         <source>Percentage of orders per status.</source>
         <target>Percentage of orders per status.</target>
-        <note>Context:
-File: modules/statssales/statssales.php:216</note>
+        <note>Line: 216</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatssearchAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatssearchAdmin.xlf
@@ -5,56 +5,47 @@
       <trans-unit id="8c3c245232744602822902b97e65d6f9">
         <source>Shop search</source>
         <target>Shop search</target>
-        <note>Context:
-File: modules/statssearch/statssearch.php:57</note>
+        <note>Line: 57</note>
       </trans-unit>
       <trans-unit id="61e73a44bd33933e4d4f85ad339de086">
         <source>Adds a tab to the Stats dashboard, showing which keywords have been searched by your store's visitors.</source>
         <target>Adds a tab to the Stats dashboard, showing which keywords have been searched by your store's visitors.</target>
-        <note>Context:
-File: modules/statssearch/statssearch.php:58</note>
+        <note>Line: 58</note>
       </trans-unit>
       <trans-unit id="867343577fa1f33caa632a19543bd252">
         <source>Keywords</source>
         <target>Keywords</target>
-        <note>Context:
-File: modules/statssearch/statssearch.php:114</note>
+        <note>Line: 114</note>
       </trans-unit>
       <trans-unit id="e52e6aa1a43a0187e44f048f658db5f9">
         <source>Occurrences</source>
         <target>Occurrences</target>
-        <note>Context:
-File: modules/statssearch/statssearch.php:115</note>
+        <note>Line: 115</note>
       </trans-unit>
       <trans-unit id="fd69c5cf902969e6fb71d043085ddee6">
         <source>Results</source>
         <target>Results</target>
-        <note>Context:
-File: modules/statssearch/statssearch.php:116</note>
+        <note>Line: 116</note>
       </trans-unit>
       <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
         <source>CSV Export</source>
         <target>CSV Export</target>
-        <note>Context:
-File: modules/statssearch/statssearch.php:137</note>
+        <note>Line: 137</note>
       </trans-unit>
       <trans-unit id="710af2afb2786d5f79b2c9bd8a746b8b">
         <source>Cannot find any keywords that have been searched for more than once.</source>
         <target>Cannot find any keywords that have been searched for more than once.</target>
-        <note>Context:
-File: modules/statssearch/statssearch.php:140</note>
+        <note>Line: 140</note>
       </trans-unit>
       <trans-unit id="e15832aa200f342e8f4ab580b43a72a8">
         <source>Top 10 keywords</source>
         <target>Top 10 keywords</target>
-        <note>Context:
-File: modules/statssearch/statssearch.php:148</note>
+        <note>Line: 148</note>
       </trans-unit>
       <trans-unit id="52ef9633d88a7480b3a938ff9eaa2a25">
         <source>Others</source>
         <target>Others</target>
-        <note>Context:
-File: modules/statssearch/statssearch.php:165</note>
+        <note>Line: 165</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsstockAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsstockAdmin.xlf
@@ -5,56 +5,47 @@
       <trans-unit id="96ca47f429c269b85e31be9fb17df6d4">
         <source>Available quantities</source>
         <target>Available quantities</target>
-        <note>Context:
-File: modules/statsstock/statsstock.php:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="7782fb19c81ec8a47e39f9c073b7da59">
         <source>Adds a tab showing the quantity of available products for sale to the Stats dashboard.</source>
         <target>Adds a tab showing the quantity of available products for sale to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsstock/statsstock.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="c49b42f642c62f20a3640f20ca132840">
         <source>Evaluation of available quantities for sale</source>
         <target>Evaluation of available quantities for sale</target>
-        <note>Context:
-File: modules/statsstock/statsstock.php:91</note>
+        <note>Line: 91</note>
       </trans-unit>
       <trans-unit id="1b2379801de373b6b563c347014fb34b">
         <source>Your catalog is empty.</source>
         <target>Your catalog is empty.</target>
-        <note>Context:
-File: modules/statsstock/statsstock.php:113</note>
+        <note>Line: 113</note>
       </trans-unit>
       <trans-unit id="12d3c7a4296542c62474856ec452c045">
         <source>Ref.</source>
         <target>Ref.</target>
-        <note>Context:
-File: modules/statsstock/statsstock.php:121</note>
+        <note>Line: 121</note>
       </trans-unit>
       <trans-unit id="88940d60e75cf4ff38ce27db4efc83b2">
         <source>Price*</source>
         <target>Price*</target>
-        <note>Context:
-File: modules/statsstock/statsstock.php:124</note>
+        <note>Line: 124</note>
       </trans-unit>
       <trans-unit id="347cbf03d737b02a70a96ff204c22fbc">
         <source>Total quantities</source>
         <target>Total quantities</target>
-        <note>Context:
-File: modules/statsstock/statsstock.php:147</note>
+        <note>Line: 147</note>
       </trans-unit>
       <trans-unit id="62668f75fc6977f3d09df632d1585d07">
         <source>Total value</source>
         <target>Total value</target>
-        <note>Context:
-File: modules/statsstock/statsstock.php:149</note>
+        <note>Line: 149</note>
       </trans-unit>
       <trans-unit id="a9873f90f06f9e2cfa3d048298ecca8c">
         <source>This section corresponds to the default wholesale price according to the default supplier for the product. An average price is used when the product has attributes.</source>
         <target>This section corresponds to the default wholesale price according to the default supplier for the product. An average price is used when the product has attributes.</target>
-        <note>Context:
-File: modules/statsstock/statsstock.php:159</note>
+        <note>Line: 159</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesStatsvisitsAdmin.xlf
+++ b/app/Resources/translations/default/ModulesStatsvisitsAdmin.xlf
@@ -5,80 +5,67 @@
       <trans-unit id="504c16c26a96283f91fb46a69b7c8153">
         <source>Visits and Visitors</source>
         <target>Visits and Visitors</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="432c3ab90b3af30ad318201ba09aa824">
         <source>Adds statistics about your visits and visitors to the Stats dashboard.</source>
         <target>Adds statistics about your visits and visitors to the Stats dashboard.</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="ffbee337f031c2282b311bac40bc8bb9">
         <source>Determine the interest of a visit</source>
         <target>Determine the interest of a visit</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:99</note>
+        <note>Line: 99</note>
       </trans-unit>
       <trans-unit id="5a688ee0660f9a42ddcf1e0844281461">
         <source>The visitors' evolution graph strongly resembles the visits' graph, but provides additional information:</source>
         <target>The visitors' evolution graph strongly resembles the visits' graph, but provides additional information:</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:101</note>
+        <note>Line: 101</note>
       </trans-unit>
       <trans-unit id="76c7ed2c75936e77b913d805195dc408">
         <source>If this is the case, congratulations, your website is well planned and pleasing. Glad to see that you've been paying attention.</source>
         <target>If this is the case, congratulations, your website is well planned and pleasing. Glad to see that you've been paying attention.</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:104</note>
+        <note>Line: 104</note>
       </trans-unit>
       <trans-unit id="c745121a98cf1d5b26bc5299d9880d5c">
         <source>Otherwise, the conclusion is not so simple. The problem can be aesthetic or ergonomic. It is also possible that many visitors have mistakenly visited your URL without possessing a particular interest in your shop. This strange and ever-confusing phenomenon is most likely cause by search engines. If this is the case, you should consider revising your SEO structure.</source>
         <target>Otherwise, the conclusion is not so simple. The problem can be aesthetic or ergonomic. It is also possible that many visitors have mistakenly visited your URL without possessing a particular interest in your shop. This strange and ever-confusing phenomenon is most likely cause by search engines. If this is the case, you should consider revising your SEO structure.</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:105</note>
+        <note>Line: 105</note>
       </trans-unit>
       <trans-unit id="9bf5a493522a65d550f096505874873b">
         <source>This information is mostly qualitative. It is up to you to determine the interest of a disjointed visit.</source>
         <target>This information is mostly qualitative. It is up to you to determine the interest of a disjointed visit.</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:108</note>
+        <note>Line: 108</note>
       </trans-unit>
       <trans-unit id="b8901fb7bbfaf9b0c4724343c7cd1f90">
         <source>A visit corresponds to an internet user coming to your shop, and until the end of their session, only one visit is counted.</source>
         <target>A visit corresponds to an internet user coming to your shop, and until the end of their session, only one visit is counted.</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:112</note>
+        <note>Line: 112</note>
       </trans-unit>
       <trans-unit id="f43a4cf6dcc4ec617d2296d03d26c90f">
         <source>A visitor is an unknown person who has not registered or logged into your store. A visitor can also be considered a person who has visited your shop multiple times.</source>
         <target>A visitor is an unknown person who has not registered or logged into your store. A visitor can also be considered a person who has visited your shop multiple times.</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:113</note>
+        <note>Line: 113</note>
       </trans-unit>
       <trans-unit id="54067074d24489ddb5654bf46642cb85">
         <source>Total visits:</source>
         <target>Total visits:</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:122</note>
+        <note>Line: 122</note>
       </trans-unit>
       <trans-unit id="23e640d55e56db79971918936e95bf9d">
         <source>Total visitors:</source>
         <target>Total visitors:</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:123</note>
+        <note>Line: 123</note>
       </trans-unit>
       <trans-unit id="998e4c5c80f27dec552e99dfed34889a">
         <source>CSV Export</source>
         <target>CSV Export</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:127</note>
+        <note>Line: 127</note>
       </trans-unit>
       <trans-unit id="39b960b0a5e2ebaaa638d946f1892050">
         <source>Number of visits and unique visitors</source>
         <target>Number of visits and unique visitors</target>
-        <note>Context:
-File: modules/statsvisits/statsvisits.php:140</note>
+        <note>Line: 140</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesWelcomeAdmin.xlf
+++ b/app/Resources/translations/default/ModulesWelcomeAdmin.xlf
@@ -1,312 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/welcome/welcome.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="83218ac34c1834c26781fe4bde918ee4">
-        <source>Welcome</source>
-        <target>Welcome</target>
-        <note>Context:
-File: modules/welcome/welcome.php:57</note>
-      </trans-unit>
-      <trans-unit id="bf2e8e9545a7aa0e8279986eea30e2db">
-        <source>Help the user to create his first product.</source>
-        <target>Help the user to create his first product.</target>
-        <note>Context:
-File: modules/welcome/welcome.php:58</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="modules/welcome/OnBoarding/Configuration.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="cec23b2350e76e6d8c06b3d44ae04ce3">
         <source>Let's create your first product</source>
         <target>Let's create your first product</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:84</note>
+        <note>Line: 84</note>
       </trans-unit>
       <trans-unit id="543a5aed6af3b1a0caf2bfe48b6c59f2">
         <source>What do you want to tell about it? Think about what your customers want to know.</source>
         <target>What do you want to tell about it? Think about what your customers want to know.</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:86</note>
+        <note>Line: 86</note>
       </trans-unit>
       <trans-unit id="3aeb6c214db86e113e07bdefd6f0bbbe">
         <source>Add clear and attractive information. Don't worry, you can edit it later :)</source>
         <target>Add clear and attractive information. Don't worry, you can edit it later :)</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:87</note>
+        <note>Line: 87</note>
       </trans-unit>
       <trans-unit id="96fd3aef4886801f89835232451ed4ee">
         <source>Give your product a catchy name.</source>
         <target>Give your product a catchy name.</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:92</note>
+        <note>Line: 92</note>
       </trans-unit>
       <trans-unit id="ae94c31490652b720e0f269281ec587a">
         <source>Fill out the essential details in this tab. The other tabs are for more advanced information.</source>
         <target>Fill out the essential details in this tab. The other tabs are for more advanced information.</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:105</note>
+        <note>Line: 105</note>
       </trans-unit>
       <trans-unit id="d9be3eb406443bd8858204256bf83513">
         <source>Add one or more pictures so your product looks tempting!</source>
         <target>Add one or more pictures so your product looks tempting!</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:112</note>
+        <note>Line: 112</note>
       </trans-unit>
       <trans-unit id="69168bfbea070ea2d4d311cef7c4c39a">
         <source>How much do you want to sell it for?</source>
         <target>How much do you want to sell it for?</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:119</note>
+        <note>Line: 119</note>
       </trans-unit>
       <trans-unit id="331ca7db26429b18d4fc27a4c0682aa2">
         <source>Yay! You just created your first product. Looks good, right?</source>
         <target>Yay! You just created your first product. Looks good, right?</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:130</note>
+        <note>Line: 130</note>
       </trans-unit>
       <trans-unit id="0edb272a8cfaf08e1253f7b453df3480">
         <source>Give your shop its own identity</source>
         <target>Give your shop its own identity</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:138</note>
+        <note>Line: 138</note>
       </trans-unit>
       <trans-unit id="f22c2cafb35dcc4a2a0d140a3d651d73">
         <source>How do you want your shop to look? What makes it so special?</source>
         <target>How do you want your shop to look? What makes it so special?</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:140</note>
+        <note>Line: 140</note>
       </trans-unit>
       <trans-unit id="888a400770d1964e24b28779d48a3ece">
         <source>Customize your theme or choose the best design from our theme catalog.</source>
         <target>Customize your theme or choose the best design from our theme catalog.</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:141</note>
+        <note>Line: 141</note>
       </trans-unit>
       <trans-unit id="cf297199c39d0871b40dacdbceb98832">
         <source>A good way to start is to add your own logo here!</source>
         <target>A good way to start is to add your own logo here!</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:146</note>
+        <note>Line: 146</note>
       </trans-unit>
       <trans-unit id="f2495fb7f9d820abb99c7b920f74361c">
         <source>If you want something really special, have a look at the theme catalog!</source>
         <target>If you want something really special, have a look at the theme catalog!</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:156</note>
+        <note>Line: 156</note>
       </trans-unit>
       <trans-unit id="9067f937e50eccdb6e7aeaf92cd054e1">
         <source>Get your shop ready for payments</source>
         <target>Get your shop ready for payments</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:168</note>
+        <note>Line: 168</note>
       </trans-unit>
       <trans-unit id="69b49a643f6ca4b943c6bc99e263b5b4">
         <source>How do you want your customers to pay you?</source>
         <target>How do you want your customers to pay you?</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:170</note>
+        <note>Line: 170</note>
       </trans-unit>
       <trans-unit id="af7c66bbf83c48324a2787cc5f5b90cc">
         <source>These payment methods are already available to your customers.</source>
         <target>These payment methods are already available to your customers.</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:175</note>
+        <note>Line: 175</note>
       </trans-unit>
       <trans-unit id="2f612032b9e1b60bd7b569e99c1e9ee4">
         <source>Adapt your offer to your market: add the most popular payment methods for your customers!</source>
         <target>Adapt your offer to your market: add the most popular payment methods for your customers!</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:188</note>
+        <note>Line: 188</note>
       </trans-unit>
       <trans-unit id="5bb5e61f625be5604d26e93ce35bf820">
         <source>And you can choose to add other payment methods from here!</source>
         <target>And you can choose to add other payment methods from here!</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:194</note>
+        <note>Line: 194</note>
       </trans-unit>
       <trans-unit id="2eda6b6f1c298d51960ba299fbb9b2c3">
         <source>Choose your shipping solutions</source>
         <target>Choose your shipping solutions</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:203</note>
+        <note>Line: 203</note>
       </trans-unit>
       <trans-unit id="7461f1e6cc12ebf12c1b757fda70cd04">
         <source>How do you want to deliver your products?</source>
         <target>How do you want to deliver your products?</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:205</note>
+        <note>Line: 205</note>
       </trans-unit>
       <trans-unit id="57667bc65ba18f633595319dc6e2ff0f">
         <source>Here are the shipping methods available on your shop today.</source>
         <target>Here are the shipping methods available on your shop today.</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:210</note>
+        <note>Line: 210</note>
       </trans-unit>
       <trans-unit id="d769ab532918e6ff5f39d12c0f21ba42">
         <source>Select the shipping solutions the most likely to suit your customers! Create your own carrier or add a ready-made module.</source>
         <target>Select the shipping solutions the most likely to suit your customers! Create your own carrier or add a ready-made module.</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:223</note>
+        <note>Line: 223</note>
       </trans-unit>
       <trans-unit id="369cb52120a70dd8568cb6529ed6c765">
         <source>You can offer more delivery options by setting up additional carriers</source>
         <target>You can offer more delivery options by setting up additional carriers</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:230</note>
+        <note>Line: 230</note>
       </trans-unit>
       <trans-unit id="8e0dbde341d9f7ee07f245d2434b3285">
         <source>Improve your shop with modules</source>
         <target>Improve your shop with modules</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:240</note>
+        <note>Line: 240</note>
       </trans-unit>
       <trans-unit id="ee566ba0c5af0554cf89c9fc12699986">
         <source>Add new features and manage existing ones thanks to modules.</source>
         <target>Add new features and manage existing ones thanks to modules.</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:242</note>
+        <note>Line: 242</note>
       </trans-unit>
       <trans-unit id="8f2dd8cbf2ed7e2edf0a56c63fe7f8c9">
         <source>Some modules are already pre-installed, others may be free or paid modules - browse our selection and find out what is available!</source>
         <target>Some modules are already pre-installed, others may be free or paid modules - browse our selection and find out what is available!</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:243</note>
+        <note>Line: 243</note>
       </trans-unit>
       <trans-unit id="9ef9b18a610d823a8a3555acb879c686">
         <source>Discover our module selection in the first tab. Manage your modules on the second one and be aware of notifications in the third tab.</source>
         <target>Discover our module selection in the first tab. Manage your modules on the second one and be aware of notifications in the third tab.</target>
-        <note>Context:
-File: modules/welcome/OnBoarding/Configuration.php:248</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/welcome/views/templates/tooltip.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="48c7c41b72e1d678923ce3571aa65b2d">
-        <source>Step</source>
-        <target>Step</target>
-        <note>Context:
-File: modules/welcome/views/templates/tooltip.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55">
-        <source>Next</source>
-        <target>Next</target>
-        <note>Context:
-File: modules/welcome/views/templates/tooltip.tpl:33</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/welcome/views/templates/lost.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c1971ccebcf29ddc64c66218a75ea67d">
-        <source>Hey! Are you lost?</source>
-        <target>Hey! Are you lost?</target>
-        <note>Context:
-File: modules/welcome/views/templates/lost.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="bfc5a2ef18761320c6f699d790a204c4">
-        <source>To continue, click here:</source>
-        <target>To continue, click here:</target>
-        <note>Context:
-File: modules/welcome/views/templates/lost.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="bf7b3e2996598c588ca98a6715c5cde9">
-        <source>If you want to stop the tutorial for good, click here:</source>
-        <target>If you want to stop the tutorial for good, click here:</target>
-        <note>Context:
-File: modules/welcome/views/templates/lost.tpl:33</note>
-      </trans-unit>
-      <trans-unit id="44ae30cf103b6835c27cd42bd0352038">
-        <source>Quit the Welcome tutorial</source>
-        <target>Quit the Welcome tutorial</target>
-        <note>Context:
-File: modules/welcome/views/templates/lost.tpl:35</note>
+        <note>Line: 248</note>
       </trans-unit>
     </body>
   </file>
   <file original="modules/welcome/views/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="a0bfb8e59e6c13fc8d990781f77694fe">
-        <source>Continue</source>
-        <target>Continue</target>
-        <note>Context:
-File: modules/welcome/views/content.tpl:40</note>
-      </trans-unit>
       <trans-unit id="3342209ae0c129fabccab65b82a503a6">
         <source>Skip this tutorial</source>
         <target>Skip this tutorial</target>
-        <note>Context:
-File: modules/welcome/views/content.tpl:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/welcome/views/navbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5288ff6ac61192d7aaa0cde233172439">
-        <source>Launch your shop!</source>
-        <target>Launch your shop!</target>
-        <note>Context:
-File: modules/welcome/views/navbar.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="f1cefec9e2196c672a622347f1fbc325">
-        <source>Resume</source>
-        <target>Resume</target>
-        <note>Context:
-File: modules/welcome/views/navbar.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="47f8b2f0734e26f53a3f4ca2aa5bdf52">
-        <source>Stop the OnBoarding</source>
-        <target>Stop the OnBoarding</target>
-        <note>Context:
-File: modules/welcome/views/navbar.tpl:40</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/welcome/views/contents/welcome.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9ad776f10bab1af366c5a778f6843c6d">
-        <source>Welcome to your shop!</source>
-        <target>Welcome to your shop!</target>
-        <note>Context:
-File: modules/welcome/views/contents/welcome.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="2cbf0061207494c9dce122b293baa628">
-        <source>Hi! My name is Preston and I'm here to show you around.</source>
-        <target>Hi! My name is Preston and I'm here to show you around.</target>
-        <note>Context:
-File: modules/welcome/views/contents/welcome.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="f666c0a66c5d0ad6e3ffff76fbe1ba7a">
-        <source>You will discover a few essential steps before you can launch your shop:</source>
-        <target>You will discover a few essential steps before you can launch your shop:</target>
-        <note>Context:
-File: modules/welcome/views/contents/welcome.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="effa93903da7512b8c1cfa3e588ef265">
-        <source>Create your first product, customize your shop, configure shipping and payments...</source>
-        <target>Create your first product, customize your shop, configure shipping and payments...</target>
-        <note>Context:
-File: modules/welcome/views/contents/welcome.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="c07acd58fccb46536772b5461fbd6b82">
-        <source>Let's get started!</source>
-        <target>Let's get started!</target>
-        <note>Context:
-File: modules/welcome/views/contents/welcome.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="61057a0c84605444201929bdd72014f0">
-        <source>Later</source>
-        <target>Later</target>
-        <note>Context:
-File: modules/welcome/views/contents/welcome.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="a6122a65eaa676f700ae68d393054a37">
-        <source>Start</source>
-        <target>Start</target>
-        <note>Context:
-File: modules/welcome/views/contents/welcome.tpl:39</note>
+        <note>Line: 41</note>
       </trans-unit>
     </body>
   </file>
@@ -315,50 +153,157 @@ File: modules/welcome/views/contents/welcome.tpl:39</note>
       <trans-unit id="c03cc59a15ca0026a7ab3d27c559fc94">
         <source>Over to you!</source>
         <target>Over to you!</target>
-        <note>Context:
-File: modules/welcome/views/contents/end.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
       <trans-unit id="bd7f2b6fca549764564962b931388799">
         <source>You've seen the essential, but there's a lot more to explore.</source>
         <target>You've seen the essential, but there's a lot more to explore.</target>
-        <note>Context:
-File: modules/welcome/views/contents/end.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="2963152f4af9a5c721b657c191e65287">
         <source>Some ressources can help you go further:</source>
         <target>Some ressources can help you go further:</target>
-        <note>Context:
-File: modules/welcome/views/contents/end.tpl:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="0bd72b8c7a3131410b7d9173937aee42">
         <source>Starter Guide</source>
         <target>Starter Guide</target>
-        <note>Context:
-File: modules/welcome/views/contents/end.tpl:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="e6a7f8a2f42cc35979973da8dfb10720">
         <source>Forum</source>
         <target>Forum</target>
-        <note>Context:
-File: modules/welcome/views/contents/end.tpl:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="cf270e40d273f9e7fd7c3061729060c3">
         <source>Training</source>
         <target>Training</target>
-        <note>Context:
-File: modules/welcome/views/contents/end.tpl:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="a1b4f53bc793c237fbfa1370cc7119e5">
         <source>Video tutorial</source>
         <target>Video tutorial</target>
-        <note>Context:
-File: modules/welcome/views/contents/end.tpl:61</note>
+        <note>Line: 61</note>
       </trans-unit>
       <trans-unit id="51cdccf36c2b30017317d5fb74e0f766">
         <source>I'm ready</source>
         <target>I'm ready</target>
-        <note>Context:
-File: modules/welcome/views/contents/end.tpl:70</note>
+        <note>Line: 70</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/welcome/views/contents/welcome.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9ad776f10bab1af366c5a778f6843c6d">
+        <source>Welcome to your shop!</source>
+        <target>Welcome to your shop!</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="2cbf0061207494c9dce122b293baa628">
+        <source>Hi! My name is Preston and I'm here to show you around.</source>
+        <target>Hi! My name is Preston and I'm here to show you around.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="f666c0a66c5d0ad6e3ffff76fbe1ba7a">
+        <source>You will discover a few essential steps before you can launch your shop:</source>
+        <target>You will discover a few essential steps before you can launch your shop:</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="effa93903da7512b8c1cfa3e588ef265">
+        <source>Create your first product, customize your shop, configure shipping and payments...</source>
+        <target>Create your first product, customize your shop, configure shipping and payments...</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="c07acd58fccb46536772b5461fbd6b82">
+        <source>Let's get started!</source>
+        <target>Let's get started!</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="61057a0c84605444201929bdd72014f0">
+        <source>Later</source>
+        <target>Later</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="a6122a65eaa676f700ae68d393054a37">
+        <source>Start</source>
+        <target>Start</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/welcome/views/navbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5288ff6ac61192d7aaa0cde233172439">
+        <source>Launch your shop!</source>
+        <target>Launch your shop!</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="f1cefec9e2196c672a622347f1fbc325">
+        <source>Resume</source>
+        <target>Resume</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="47f8b2f0734e26f53a3f4ca2aa5bdf52">
+        <source>Stop the OnBoarding</source>
+        <target>Stop the OnBoarding</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/welcome/views/templates/lost.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c1971ccebcf29ddc64c66218a75ea67d">
+        <source>Hey! Are you lost?</source>
+        <target>Hey! Are you lost?</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="bfc5a2ef18761320c6f699d790a204c4">
+        <source>To continue, click here:</source>
+        <target>To continue, click here:</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="bf7b3e2996598c588ca98a6715c5cde9">
+        <source>If you want to stop the tutorial for good, click here:</source>
+        <target>If you want to stop the tutorial for good, click here:</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="44ae30cf103b6835c27cd42bd0352038">
+        <source>Quit the Welcome tutorial</source>
+        <target>Quit the Welcome tutorial</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="a0bfb8e59e6c13fc8d990781f77694fe">
+        <source>Continue</source>
+        <target>Continue</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/welcome/views/templates/tooltip.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="48c7c41b72e1d678923ce3571aa65b2d">
+        <source>Step</source>
+        <target>Step</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55">
+        <source>Next</source>
+        <target>Next</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/welcome/welcome.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="83218ac34c1834c26781fe4bde918ee4">
+        <source>Welcome</source>
+        <target>Welcome</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="bf2e8e9545a7aa0e8279986eea30e2db">
+        <source>Help the user to create his first product.</source>
+        <target>Help the user to create his first product.</target>
+        <note>Line: 58</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesWirepaymentAdmin.xlf
+++ b/app/Resources/translations/default/ModulesWirepaymentAdmin.xlf
@@ -5,110 +5,92 @@
       <trans-unit id="48c6aa380e9fc3a3a605273d7af50016">
         <source>Wire payment</source>
         <target>Wire payment</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:75</note>
+        <note>Line: 75</note>
       </trans-unit>
       <trans-unit id="cedc96489132776ce19ebc2751f17454">
         <source>Accept payments by bank transfer.</source>
         <target>Accept payments by bank transfer.</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:76</note>
+        <note>Line: 76</note>
       </trans-unit>
       <trans-unit id="cbe0a99684b145e77f3e14174ac212e3">
         <source>Are you sure about removing these details?</source>
         <target>Are you sure about removing these details?</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:77</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="0ea0227283d959415eda0cfa31d9f718">
         <source>Account owner and account details must be configured before using this module.</source>
         <target>Account owner and account details must be configured before using this module.</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:79</note>
+        <note>Line: 79</note>
       </trans-unit>
       <trans-unit id="a02758d758e8bec77a33d7f392eb3f8a">
         <source>No currency has been set for this module.</source>
         <target>No currency has been set for this module.</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:82</note>
+        <note>Line: 82</note>
       </trans-unit>
       <trans-unit id="bfa43217dfe8261ee7cb040339085677">
         <source>Account details are required.</source>
         <target>Account details are required.</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:128</note>
+        <note>Line: 128</note>
       </trans-unit>
       <trans-unit id="ccab155f173ac76f79eb192703f86b18">
         <source>Account owner is required.</source>
         <target>Account owner is required.</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:130</note>
+        <note>Line: 130</note>
       </trans-unit>
       <trans-unit id="8bc212f48680748479bbd322d4d73d3f">
         <source>Account details</source>
         <target>Account details</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:296</note>
+        <note>Line: 296</note>
       </trans-unit>
       <trans-unit id="857216dd1b374de9bf54068fcd78a8f3">
         <source>Account owner</source>
         <target>Account owner</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:290</note>
+        <note>Line: 290</note>
       </trans-unit>
       <trans-unit id="6b154cafbab54ba3a1e76a78c290c02a">
         <source>Such as bank branch, IBAN number, BIC, etc.</source>
         <target>Such as bank branch, IBAN number, BIC, etc.</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:298</note>
+        <note>Line: 298</note>
       </trans-unit>
       <trans-unit id="f9a1a1bb716cbae0503d351ea2af4b34">
         <source>Bank address</source>
         <target>Bank address</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:303</note>
+        <note>Line: 303</note>
       </trans-unit>
       <trans-unit id="da22c93ccb398c72070f4000cc7b59a1">
         <source>Customization</source>
         <target>Customization</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:316</note>
+        <note>Line: 316</note>
       </trans-unit>
       <trans-unit id="873a2778bdb25b9dcca6de640216c4a9">
         <source>Reservation period</source>
         <target>Reservation period</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:322</note>
+        <note>Line: 322</note>
       </trans-unit>
       <trans-unit id="120cf2b5eab7f28e5fb03b8fb7bbd07b">
         <source>Number of days the items remain reserved</source>
         <target>Number of days the items remain reserved</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:323</note>
+        <note>Line: 323</note>
       </trans-unit>
       <trans-unit id="6b8d5618e646b2ad407158c1da89ca0c">
         <source>Information to the customer</source>
         <target>Information to the customer</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:328</note>
+        <note>Line: 328</note>
       </trans-unit>
       <trans-unit id="65ed2ab0c7edcccc96fcedaa594f94c6">
         <source>Information on the bank transfer (processing time, starting of the shipping...)</source>
         <target>Information on the bank transfer (processing time, starting of the shipping...)</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:330</note>
+        <note>Line: 330</note>
       </trans-unit>
       <trans-unit id="9b07982b472390295e7da7d430c8ec1d">
         <source>Display the invitation to pay in the order confirmation page</source>
         <target>Display the invitation to pay in the order confirmation page</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:335</note>
+        <note>Line: 335</note>
       </trans-unit>
       <trans-unit id="b8a891b1e28c2049da81774493d8779c">
         <source>Your country's legislation may require you to send the invitation to pay by email only. Disabling the option will hide the invitation on the confirmation page.</source>
         <target>Your country's legislation may require you to send the invitation to pay by email only. Disabling the option will hide the invitation on the confirmation page.</target>
-        <note>Context:
-File: modules/ps_wirepayment/ps_wirepayment.php:338</note>
+        <note>Line: 338</note>
       </trans-unit>
     </body>
   </file>
@@ -117,20 +99,17 @@ File: modules/ps_wirepayment/ps_wirepayment.php:338</note>
       <trans-unit id="c1be305030739396775edaca9813f77d">
         <source>This module allows you to accept secure payments by bank wire.</source>
         <target>This module allows you to accept secure payments by bank wire.</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/infos.tpl:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="cfc0561623b37471f267aa911092b3ac">
         <source>If the client chooses to pay by bank wire, the order status will change to 'Waiting for Payment'.</source>
         <target>If the client chooses to pay by bank wire, the order status will change to 'Waiting for Payment'.</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/infos.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
       <trans-unit id="5fb4bbf993c23848433caf58e6b2816d">
         <source>That said, you must manually confirm the order upon receiving the bank wire.</source>
         <target>That said, you must manually confirm the order upon receiving the bank wire.</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/infos.tpl:30</note>
+        <note>Line: 30</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ModulesWirepaymentShop.xlf
+++ b/app/Resources/translations/default/ModulesWirepaymentShop.xlf
@@ -1,28 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="modules/ps_wirepayment/views/templates/hook/payment.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5e1695822fc5af98f6b749ea3cbc9b4c">
-        <source>Pay by bank wire</source>
-        <target>Pay by bank wire</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/payment.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="4e1fb9f4b46556d64db55d50629ee301">
-        <source>(order processing will be longer)</source>
-        <target>(order processing will be longer)</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/payment.tpl:29</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="modules/ps_wirepayment/controllers/front/payment.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="763538d192c0e4a3a341c1c7d0db9240">
         <source>%1$s (tax incl.)</source>
         <target>%1$s (tax incl.)</target>
-        <note>Context:
-File: modules/ps_wirepayment/controllers/front/payment.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
     </body>
   </file>
@@ -31,8 +14,7 @@ File: modules/ps_wirepayment/controllers/front/payment.php:46</note>
       <trans-unit id="e2b7dec8fa4b498156dfee6e4c84b156">
         <source>This payment method is not available.</source>
         <target>This payment method is not available.</target>
-        <note>Context:
-File: modules/ps_wirepayment/controllers/front/validation.php:50</note>
+        <note>Line: 50</note>
       </trans-unit>
     </body>
   </file>
@@ -41,26 +23,36 @@ File: modules/ps_wirepayment/controllers/front/validation.php:50</note>
       <trans-unit id="b2f40690858b404ed10e62bdf422c704">
         <source>Amount</source>
         <target>Amount</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="5ca0b1b910f393ed1f9f6fa99e414255">
         <source>Name of account owner</source>
         <target>Name of account owner</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl:30</note>
+        <note>Line: 30</note>
       </trans-unit>
       <trans-unit id="51f4741f4c53f0fe3ba1be9ac3a34f2f">
         <source>Please include these details</source>
         <target>Please include these details</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="984482eb9ff11e6310fef641d2268a2a">
         <source>Bank name</source>
         <target>Bank name</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl:34</note>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_wirepayment/views/templates/hook/payment.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5e1695822fc5af98f6b749ea3cbc9b4c">
+        <source>Pay by bank wire</source>
+        <target>Pay by bank wire</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="4e1fb9f4b46556d64db55d50629ee301">
+        <source>(order processing will be longer)</source>
+        <target>(order processing will be longer)</target>
+        <note>Line: 29</note>
       </trans-unit>
     </body>
   </file>
@@ -69,14 +61,37 @@ File: modules/ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl:34
       <trans-unit id="88526efe38fd18179a127024aba8c1d7">
         <source>Your order on %s is complete.</source>
         <target>Your order on %s is complete.</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/payment_return.tpl:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="1552c5916ccfe019f35d91fd8955755e">
         <source>Please send us a bank wire with:</source>
         <target>Please send us a bank wire with:</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/payment_return.tpl:29</note>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="e82b76a36b23218201ac431c5c2da4c6">
+        <source>Please specify your order reference %s in the bankwire description.</source>
+        <target>Please specify your order reference %s in the bankwire description.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="09e6ed8a978471819332e14dcc5cbe39">
+        <source>We've also sent you this information by e-mail.</source>
+        <target>We've also sent you this information by e-mail.</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="b9a1cae09e5754424e33764777cfcaa0">
+        <source>Your order will be sent as soon as we receive payment.</source>
+        <target>Your order will be sent as soon as we receive payment.</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="1b22721c0967c351b34d82496917654f">
+        <source>If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].</source>
+        <target>If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="c00373052588907ffdd28d1866a75aee">
+        <source>We noticed a problem with your order. If you think this is an error, feel free to contact our [1]expert customer support team[/1].</source>
+        <target>We noticed a problem with your order. If you think this is an error, feel free to contact our [1]expert customer support team[/1].</target>
+        <note>Line: 43</note>
       </trans-unit>
     </body>
   </file>
@@ -85,32 +100,27 @@ File: modules/ps_wirepayment/views/templates/hook/payment_return.tpl:29</note>
       <trans-unit id="c8ad6f14cf0f4c6de65b92737b096c37">
         <source>Please transfer the invoice amount to our bank account. You will receive our order confirmation by email containing bank details and order number.</source>
         <target>Please transfer the invoice amount to our bank account. You will receive our order confirmation by email containing bank details and order number.</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/ps_wirepayment_intro.tpl:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="1a81e90b854883236a07009057635bcd">
         <source>Goods will be reserved %s days for you and we'll process the order immediately after receiving the payment.</source>
         <target>Goods will be reserved %s days for you and we'll process the order immediately after receiving the payment.</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/ps_wirepayment_intro.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
       <trans-unit id="ab066b3292d8ab61ef3b5c77169cdd19">
         <source>More information</source>
         <target>More information</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/ps_wirepayment_intro.tpl:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="35b4b09d5d0686ec5c2e2cc9f3d9039c">
         <source>Bankwire</source>
         <target>Bankwire</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/ps_wirepayment_intro.tpl:42</note>
+        <note>Line: 42</note>
       </trans-unit>
       <trans-unit id="ebcdf354e92daa6f6dee8a83a14e5c7a">
         <source>Payment is made by transfer of the invoice amount to the following account:</source>
         <target>Payment is made by transfer of the invoice amount to the following account:</target>
-        <note>Context:
-File: modules/ps_wirepayment/views/templates/hook/ps_wirepayment_intro.tpl:45</note>
+        <note>Line: 45</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopDemoCatalog.xlf
+++ b/app/Resources/translations/default/ShopDemoCatalog.xlf
@@ -5,268 +5,17 @@
       <trans-unit id="6f6cb72d544962fa333e2e34ce64f719">
         <source>Size</source>
         <target>Size</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeGroupLang.php:26</note>
+        <note>Line: 26</note>
       </trans-unit>
       <trans-unit id="e696b64a5c32e901115dea05abd75afc">
         <source>Shoe size</source>
         <target>Shoe size</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeGroupLang.php:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="cb5feb1b7314637725a2e73bdc9f7295">
         <source>Color</source>
         <target>Color</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeGroupLang.php:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/FeatureLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="eec6c4bdbd339edf8cbea68becb85244">
-        <source>Height</source>
-        <target>Height</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="32954654ac8fe66a1d09be19001de2d4">
-        <source>Width</source>
-        <target>Width</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureLang.php:27</note>
-      </trans-unit>
-      <trans-unit id="675056ad1441b6375b2c5abd48c27ef1">
-        <source>Depth</source>
-        <target>Depth</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureLang.php:28</note>
-      </trans-unit>
-      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
-        <source>Weight</source>
-        <target>Weight</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureLang.php:29</note>
-      </trans-unit>
-      <trans-unit id="8153d35af624d7f0355fc6b54c9a3e32">
-        <source>Compositions</source>
-        <target>Compositions</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureLang.php:30</note>
-      </trans-unit>
-      <trans-unit id="4c1c7d945fcd04d68bd3b3f1d99a55a1">
-        <source>Styles</source>
-        <target>Styles</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureLang.php:31</note>
-      </trans-unit>
-      <trans-unit id="9fc2d28c05ed9eb1d75ba4465abf15a9">
-        <source>Properties</source>
-        <target>Properties</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureLang.php:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/lang/KeysReference/FeatureValueLang.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f6937723663d9c11f1ee4edf9f935fa8">
-        <source>Polyester</source>
-        <target>Polyester</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:26</note>
-      </trans-unit>
-      <trans-unit id="11c69b2a8ff1502a44e350ace6f172e4">
-        <source>Wool</source>
-        <target>Wool</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:28</note>
-      </trans-unit>
-      <trans-unit id="5344e5ae58a454f75268240cff5ae1be">
-        <source>Viscose</source>
-        <target>Viscose</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:30</note>
-      </trans-unit>
-      <trans-unit id="b3de5045d4f335597ac9a23fd225e3e7">
-        <source>Elastane</source>
-        <target>Elastane</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:32</note>
-      </trans-unit>
-      <trans-unit id="db547a9a5b84991c24ec850ac0749c0b">
-        <source>Cotton</source>
-        <target>Cotton</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:34</note>
-      </trans-unit>
-      <trans-unit id="a2a3a0347f0f001a4473dd54dca2462e">
-        <source>Silk</source>
-        <target>Silk</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:36</note>
-      </trans-unit>
-      <trans-unit id="e8a3cb6a854cbfffd958d5bc73303806">
-        <source>Suede</source>
-        <target>Suede</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:38</note>
-      </trans-unit>
-      <trans-unit id="be181575a12020428018676dedd91f9d">
-        <source>Straw</source>
-        <target>Straw</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:40</note>
-      </trans-unit>
-      <trans-unit id="bdf7ad23e89b55f904bca0304819309e">
-        <source>Leather</source>
-        <target>Leather</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:42</note>
-      </trans-unit>
-      <trans-unit id="d35b51b639528d580362ca7042de6a0e">
-        <source>Classic</source>
-        <target>Classic</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:44</note>
-      </trans-unit>
-      <trans-unit id="28d5d53226be8aa8da42d9cbdd312e62">
-        <source>Casual</source>
-        <target>Casual</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:46</note>
-      </trans-unit>
-      <trans-unit id="7d2957dfd3b888fc4087f60c3c650953">
-        <source>Military</source>
-        <target>Military</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:48</note>
-      </trans-unit>
-      <trans-unit id="3e80e32cdcfb5cf850b1340241c30412">
-        <source>Girly</source>
-        <target>Girly</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:50</note>
-      </trans-unit>
-      <trans-unit id="4cfbb125e9878528bab91d12421134d8">
-        <source>Rock</source>
-        <target>Rock</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:52</note>
-      </trans-unit>
-      <trans-unit id="972e73b7a882d0802a4e3a16946a2f94">
-        <source>Basic</source>
-        <target>Basic</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:54</note>
-      </trans-unit>
-      <trans-unit id="8a19a741babf557d260bd74b2474a940">
-        <source>Dressy</source>
-        <target>Dressy</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:56</note>
-      </trans-unit>
-      <trans-unit id="818c50db4c174e9a0c972f343c21cdd5">
-        <source>Short Sleeve</source>
-        <target>Short Sleeve</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:58</note>
-      </trans-unit>
-      <trans-unit id="50085b52dafa67ba14e1d07a65bf3698">
-        <source>Colorful Dress</source>
-        <target>Colorful Dress</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:60</note>
-      </trans-unit>
-      <trans-unit id="6447ac704069175c7bee940fbefdc6c6">
-        <source>Short Dress</source>
-        <target>Short Dress</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:62</note>
-      </trans-unit>
-      <trans-unit id="a12f6cb35c8c69fd5c18d6c54e0c0dae">
-        <source>Midi Dress</source>
-        <target>Midi Dress</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:64</note>
-      </trans-unit>
-      <trans-unit id="c2558f658f49ff9beb46ee7f8e293736">
-        <source>Maxi Dress</source>
-        <target>Maxi Dress</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:66</note>
-      </trans-unit>
-      <trans-unit id="e9be07c8edbe075469d06124d1c59763">
-        <source>2.75 in</source>
-        <target>2.75 in</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:68</note>
-      </trans-unit>
-      <trans-unit id="a7ec73b7953e85fcb250232e25d63114">
-        <source>2.06 in</source>
-        <target>2.06 in</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:70</note>
-      </trans-unit>
-      <trans-unit id="8b8d3719bda5725283d96edf1eb81e8a">
-        <source>49.2 g</source>
-        <target>49.2 g</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:72</note>
-      </trans-unit>
-      <trans-unit id="9ac8a61ab67a9d5c70f7f89aec726837">
-        <source>0.26 in</source>
-        <target>0.26 in</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:74</note>
-      </trans-unit>
-      <trans-unit id="7bb46ed88a0439d1dc46432d047367c4">
-        <source>1.07 in</source>
-        <target>1.07 in</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:76</note>
-      </trans-unit>
-      <trans-unit id="20d5fb144977705f933bdfbbc832ea6a">
-        <source>1.62 in</source>
-        <target>1.62 in</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:78</note>
-      </trans-unit>
-      <trans-unit id="e606cdfdbf6f1ab12a689d95dc8567c8">
-        <source>15.5 g</source>
-        <target>15.5 g</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:80</note>
-      </trans-unit>
-      <trans-unit id="da8eb48d87659a6068406e900f812df8">
-        <source>0.41 in (clip included)</source>
-        <target>0.41 in (clip included)</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:82</note>
-      </trans-unit>
-      <trans-unit id="2f7853c84bd333ea5eb933cb0e0c2b1c">
-        <source>4.33 in</source>
-        <target>4.33 in</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:84</note>
-      </trans-unit>
-      <trans-unit id="ae33ac014a46da7bd584dc7d85cdb67e">
-        <source>2.76 in</source>
-        <target>2.76 in</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:86</note>
-      </trans-unit>
-      <trans-unit id="6b35230c6696a94f05785003d8c6ce85">
-        <source>120g</source>
-        <target>120g</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:88</note>
-      </trans-unit>
-      <trans-unit id="ed931dce45aac99e09664dff538648d3">
-        <source>0.31 in</source>
-        <target>0.31 in</target>
-        <note>Context:
-File: classes/lang/KeysReference/FeatureValueLang.php:90</note>
+        <note>Line: 28</note>
       </trans-unit>
     </body>
   </file>
@@ -275,146 +24,330 @@ File: classes/lang/KeysReference/FeatureValueLang.php:90</note>
       <trans-unit id="5dbc98dcc983a70728bd082d1a47546e">
         <source>S</source>
         <target>S</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:26</note>
+        <note>Line: 26</note>
       </trans-unit>
       <trans-unit id="69691c7bdcc3ce6d5d8a1361f22d04ac">
         <source>M</source>
         <target>M</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="d20caec3b48a1eef164cb4ca81ba2587">
         <source>L</source>
         <target>L</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="f4320e291600fe9ba803755db65adfb3">
         <source>One size</source>
         <target>One size</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:29</note>
+        <note>Line: 29</note>
       </trans-unit>
       <trans-unit id="caf3a042a037c064b7513ed640c22f77">
         <source>Grey</source>
         <target>Grey</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:30</note>
+        <note>Line: 30</note>
       </trans-unit>
       <trans-unit id="dc0743b5858f9665cf21f549d860965f">
         <source>Taupe</source>
         <target>Taupe</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="2bd8c63b2fe3e8e3b4f933b6130f49e6">
         <source>Beige</source>
         <target>Beige</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="25a81701fbfa4a1efdf660a950c1d006">
         <source>White</source>
         <target>White</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="dc0560539854a760a8e545a52e51d506">
         <source>Off White</source>
         <target>Off White</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="ee38e4d5dd68c4e440825018d549cb47">
         <source>Red</source>
         <target>Red</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="e90dfb84e30edf611e326eeb04d680de">
         <source>Black</source>
         <target>Black</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:36</note>
+        <note>Line: 36</note>
       </trans-unit>
       <trans-unit id="1690f30fd60771c4db1aec13248b39b2">
         <source>Camel</source>
         <target>Camel</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:37</note>
+        <note>Line: 37</note>
       </trans-unit>
       <trans-unit id="909cea0c97058cfe2e3ea8d675cb08e1">
         <source>Orange</source>
         <target>Orange</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:38</note>
+        <note>Line: 38</note>
       </trans-unit>
       <trans-unit id="9594eec95be70e7b1710f730fdda33d9">
         <source>Blue</source>
         <target>Blue</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:39</note>
+        <note>Line: 39</note>
       </trans-unit>
       <trans-unit id="d382816a3cbeed082c9e216e7392eed1">
         <source>Green</source>
         <target>Green</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:40</note>
+        <note>Line: 40</note>
       </trans-unit>
       <trans-unit id="51e6cd92b6c45f9affdc158ecca2b8b8">
         <source>Yellow</source>
         <target>Yellow</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="ed63fc91500594c3086714f86b3001e4">
         <source>Brown</source>
         <target>Brown</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:42</note>
+        <note>Line: 42</note>
       </trans-unit>
       <trans-unit id="1c383cd30b7c298ab50293adfecb7b18">
         <source>35</source>
         <target>35</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="19ca14e7ea6328a42e0eb13d585e4c22">
         <source>36</source>
         <target>36</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:44</note>
+        <note>Line: 44</note>
       </trans-unit>
       <trans-unit id="a5bfc9e07964f8dddeb95fc584cd965d">
         <source>37</source>
         <target>37</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="a5771bce93e200c36f7cd9dfd0e5deaa">
         <source>38</source>
         <target>38</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="d67d8ab4f4c10bf22aa353e27879133c">
         <source>39</source>
         <target>39</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="d645920e395fedad7bbbed0eca3fe2e0">
         <source>40</source>
         <target>40</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="8dc5344bc0746e1cc5abf896ca03bbdf">
         <source>Pink</source>
         <target>Pink</target>
-        <note>Context:
-File: classes/lang/KeysReference/AttributeLang.php:49</note>
+        <note>Line: 49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/FeatureLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="eec6c4bdbd339edf8cbea68becb85244">
+        <source>Height</source>
+        <target>Height</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="32954654ac8fe66a1d09be19001de2d4">
+        <source>Width</source>
+        <target>Width</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="675056ad1441b6375b2c5abd48c27ef1">
+        <source>Depth</source>
+        <target>Depth</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
+        <source>Weight</source>
+        <target>Weight</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="8153d35af624d7f0355fc6b54c9a3e32">
+        <source>Compositions</source>
+        <target>Compositions</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="4c1c7d945fcd04d68bd3b3f1d99a55a1">
+        <source>Styles</source>
+        <target>Styles</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="9fc2d28c05ed9eb1d75ba4465abf15a9">
+        <source>Properties</source>
+        <target>Properties</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/lang/KeysReference/FeatureValueLang.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f6937723663d9c11f1ee4edf9f935fa8">
+        <source>Polyester</source>
+        <target>Polyester</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="11c69b2a8ff1502a44e350ace6f172e4">
+        <source>Wool</source>
+        <target>Wool</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="5344e5ae58a454f75268240cff5ae1be">
+        <source>Viscose</source>
+        <target>Viscose</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="b3de5045d4f335597ac9a23fd225e3e7">
+        <source>Elastane</source>
+        <target>Elastane</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="db547a9a5b84991c24ec850ac0749c0b">
+        <source>Cotton</source>
+        <target>Cotton</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="a2a3a0347f0f001a4473dd54dca2462e">
+        <source>Silk</source>
+        <target>Silk</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="e8a3cb6a854cbfffd958d5bc73303806">
+        <source>Suede</source>
+        <target>Suede</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="be181575a12020428018676dedd91f9d">
+        <source>Straw</source>
+        <target>Straw</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="bdf7ad23e89b55f904bca0304819309e">
+        <source>Leather</source>
+        <target>Leather</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="d35b51b639528d580362ca7042de6a0e">
+        <source>Classic</source>
+        <target>Classic</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="28d5d53226be8aa8da42d9cbdd312e62">
+        <source>Casual</source>
+        <target>Casual</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="7d2957dfd3b888fc4087f60c3c650953">
+        <source>Military</source>
+        <target>Military</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="3e80e32cdcfb5cf850b1340241c30412">
+        <source>Girly</source>
+        <target>Girly</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="4cfbb125e9878528bab91d12421134d8">
+        <source>Rock</source>
+        <target>Rock</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="972e73b7a882d0802a4e3a16946a2f94">
+        <source>Basic</source>
+        <target>Basic</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="8a19a741babf557d260bd74b2474a940">
+        <source>Dressy</source>
+        <target>Dressy</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="818c50db4c174e9a0c972f343c21cdd5">
+        <source>Short Sleeve</source>
+        <target>Short Sleeve</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="50085b52dafa67ba14e1d07a65bf3698">
+        <source>Colorful Dress</source>
+        <target>Colorful Dress</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="6447ac704069175c7bee940fbefdc6c6">
+        <source>Short Dress</source>
+        <target>Short Dress</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="a12f6cb35c8c69fd5c18d6c54e0c0dae">
+        <source>Midi Dress</source>
+        <target>Midi Dress</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="c2558f658f49ff9beb46ee7f8e293736">
+        <source>Maxi Dress</source>
+        <target>Maxi Dress</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="e9be07c8edbe075469d06124d1c59763">
+        <source>2.75 in</source>
+        <target>2.75 in</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="a7ec73b7953e85fcb250232e25d63114">
+        <source>2.06 in</source>
+        <target>2.06 in</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="8b8d3719bda5725283d96edf1eb81e8a">
+        <source>49.2 g</source>
+        <target>49.2 g</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="9ac8a61ab67a9d5c70f7f89aec726837">
+        <source>0.26 in</source>
+        <target>0.26 in</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="7bb46ed88a0439d1dc46432d047367c4">
+        <source>1.07 in</source>
+        <target>1.07 in</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="20d5fb144977705f933bdfbbc832ea6a">
+        <source>1.62 in</source>
+        <target>1.62 in</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="e606cdfdbf6f1ab12a689d95dc8567c8">
+        <source>15.5 g</source>
+        <target>15.5 g</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="da8eb48d87659a6068406e900f812df8">
+        <source>0.41 in (clip included)</source>
+        <target>0.41 in (clip included)</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="2f7853c84bd333ea5eb933cb0e0c2b1c">
+        <source>4.33 in</source>
+        <target>4.33 in</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="ae33ac014a46da7bd584dc7d85cdb67e">
+        <source>2.76 in</source>
+        <target>2.76 in</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="6b35230c6696a94f05785003d8c6ce85">
+        <source>120g</source>
+        <target>120g</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="ed931dce45aac99e09664dff538648d3">
+        <source>0.31 in</source>
+        <target>0.31 in</target>
+        <note>Line: 90</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopFormsErrors.xlf
+++ b/app/Resources/translations/default/ShopFormsErrors.xlf
@@ -5,26 +5,22 @@
       <trans-unit id="f55c2aa6ad7a9d9d52eaca01b6a8f121">
         <source>Invalid name</source>
         <target>Invalid name</target>
-        <note>Context:
-File: classes/ValidateConstraintTranslator.php:54</note>
+        <note>Line: 54</note>
       </trans-unit>
       <trans-unit id="694db8ddd75de82e148834e0f55e4761">
         <source>Format should be %s.</source>
         <target>Format should be %s.</target>
-        <note>Context:
-File: classes/ValidateConstraintTranslator.php:58</note>
+        <note>Line: 58</note>
       </trans-unit>
       <trans-unit id="19f823c6453c2b1ffd09cb715214813d">
         <source>Required field</source>
         <target>Required field</target>
-        <note>Context:
-File: classes/ValidateConstraintTranslator.php:62</note>
+        <note>Line: 62</note>
       </trans-unit>
       <trans-unit id="23cac50dabcf7afd3eb4218454e5e911">
         <source>Invalid format.</source>
         <target>Invalid format.</target>
-        <note>Context:
-File: classes/ValidateConstraintTranslator.php:67</note>
+        <note>Line: 67</note>
       </trans-unit>
     </body>
   </file>
@@ -33,8 +29,7 @@ File: classes/ValidateConstraintTranslator.php:67</note>
       <trans-unit id="2845ecdc5099c86c8375b45aae5178b6">
         <source>Invalid postcode - should look like "%zipcode%"</source>
         <target>Invalid postcode - should look like "%zipcode%"</target>
-        <note>Context:
-File: classes/form/CustomerAddressForm.php:113</note>
+        <note>Line: 113</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopFormsHelp.xlf
+++ b/app/Resources/translations/default/ShopFormsHelp.xlf
@@ -1,56 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/front/GuestTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bd9737bd1a3057cd059167a4a19fe6ca">
-        <source>Your password must be at least %min% characters long.</source>
-        <target>Your password must be at least %min% characters long.</target>
-        <note>Context:
-File: controllers/front/GuestTrackingController.php:96</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="classes/form/CustomerFormatter.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="b8760dae14ad4963c909f83424de3e7f">
         <source>(E.g.: %date_format%)</source>
         <target>(E.g.: %date_format%)</target>
-        <note>Context:
-File: classes/form/CustomerFormatter.php:200</note>
+        <note>Line: 200</note>
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/catalog/_partials/product-customization.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/front/GuestTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="7e8cfff1e4f6fbdc4d6f4149c84e17ed">
-        <source>250 char. max</source>
-        <target>250 char. max</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-customization.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="20f4168399201bd498e52bafeb59b478">
-        <source>Don't forget to save your customization to be able to add to cart</source>
-        <target>Don't forget to save your customization to be able to add to cart</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-customization.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="6ba73729cf3b0503435d54870d993e8d">
-        <source>Your message here</source>
-        <target>Your message here</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-customization.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="9378eeabb3f4f2c5122659d50560a448">
-        <source>No selected file</source>
-        <target>No selected file</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-customization.tpl:52</note>
-      </trans-unit>
-      <trans-unit id="0da3c8b31e3e2d9d769a86cd3f31949c">
-        <source>.png .jpg .gif</source>
-        <target>.png .jpg .gif</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-customization.tpl:56</note>
+      <trans-unit id="bd9737bd1a3057cd059167a4a19fe6ca">
+        <source>Your password must be at least %min% characters long.</source>
+        <target>Your password must be at least %min% characters long.</target>
+        <note>Line: 96</note>
       </trans-unit>
     </body>
   </file>
@@ -59,26 +23,51 @@ File: themes/classic/templates/catalog/_partials/product-customization.tpl:56</n
       <trans-unit id="67135a14d3ac4f1369633dd006d6efec">
         <source>your@email.com</source>
         <target>your@email.com</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:66</note>
+        <note>Line: 66</note>
       </trans-unit>
       <trans-unit id="863cf84b34def228394c03c156bff42c">
         <source>Select reference</source>
         <target>Select reference</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:76</note>
+        <note>Line: 76</note>
       </trans-unit>
       <trans-unit id="d57c24f3fe52d16e7169b912dd647f0d">
         <source>optional</source>
         <target>optional</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:95</note>
+        <note>Line: 95</note>
       </trans-unit>
       <trans-unit id="8307fac59310d028334df0306c7b29ad">
         <source>How can we help?</source>
         <target>How can we help?</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:106</note>
+        <note>Line: 106</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-customization.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7e8cfff1e4f6fbdc4d6f4149c84e17ed">
+        <source>250 char. max</source>
+        <target>250 char. max</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="20f4168399201bd498e52bafeb59b478">
+        <source>Don't forget to save your customization to be able to add to cart</source>
+        <target>Don't forget to save your customization to be able to add to cart</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="6ba73729cf3b0503435d54870d993e8d">
+        <source>Your message here</source>
+        <target>Your message here</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="9378eeabb3f4f2c5122659d50560a448">
+        <source>No selected file</source>
+        <target>No selected file</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="0da3c8b31e3e2d9d769a86cd3f31949c">
+        <source>.png .jpg .gif</source>
+        <target>.png .jpg .gif</target>
+        <note>Line: 56</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopFormsLabels.xlf
+++ b/app/Resources/translations/default/ShopFormsLabels.xlf
@@ -1,180 +1,110 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/form/CustomerAddressFormatter.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="effdb9ce6c5d44df31b89d7069c8e0fb">
+        <source>Alias</source>
+        <target>Alias</target>
+        <note>Line: 192</note>
+      </trans-unit>
+      <trans-unit id="dd7bf230fde8d4836917806aff6a6b27">
+        <source>Address</source>
+        <target>Address</target>
+        <note>Line: 198</note>
+      </trans-unit>
+      <trans-unit id="86376e3b5c80d090dbc625b4d241431b">
+        <source>Address Complement</source>
+        <target>Address Complement</target>
+        <note>Line: 200</note>
+      </trans-unit>
+      <trans-unit id="e4eb5dadb6ee84c5c55a8edf53f6e554">
+        <source>Zip/Postal Code</source>
+        <target>Zip/Postal Code</target>
+        <note>Line: 202</note>
+      </trans-unit>
+      <trans-unit id="57d056ed0984166336b7879c2af3657f">
+        <source>City</source>
+        <target>City</target>
+        <note>Line: 204</note>
+      </trans-unit>
+      <trans-unit id="59716c97497eb9694541f7c3d37b1a4d">
+        <source>Country</source>
+        <target>Country</target>
+        <note>Line: 206</note>
+      </trans-unit>
+      <trans-unit id="46a2a41cc6e552044816a2d04634545d">
+        <source>State</source>
+        <target>State</target>
+        <note>Line: 208</note>
+      </trans-unit>
+      <trans-unit id="bcc254b55c4a1babdf1dcb82c207506b">
+        <source>Phone</source>
+        <target>Phone</target>
+        <note>Line: 210</note>
+      </trans-unit>
+      <trans-unit id="41c2fff4867cc204120f001e7af20f7a">
+        <source>Mobile phone</source>
+        <target>Mobile phone</target>
+        <note>Line: 212</note>
+      </trans-unit>
+      <trans-unit id="7cb32e708d6b961d476baced73d362bb">
+        <source>VAT number</source>
+        <target>VAT number</target>
+        <note>Line: 216</note>
+      </trans-unit>
+      <trans-unit id="6311ae17c1ee52b36e68aaf4ad066387">
+        <source>Other</source>
+        <target>Other</target>
+        <note>Line: 220</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="classes/form/CustomerFormatter.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="5e74f2daf4ae8030571ceee5b4837579">
         <source>Social title</source>
         <target>Social title</target>
-        <note>Context:
-File: classes/form/CustomerFormatter.php:106</note>
+        <note>Line: 106</note>
       </trans-unit>
       <trans-unit id="ccd41dac2cc2284362975a05bd9ce363">
         <source>Birthdate</source>
         <target>Birthdate</target>
-        <note>Context:
-File: classes/form/CustomerFormatter.php:194</note>
+        <note>Line: 194</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="classes/form/CustomerAddressFormatter.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
       <trans-unit id="20db0bfeecd8fe60533206a2b5e9891a">
         <source>First name</source>
         <target>First name</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:194</note>
+        <note>Line: 120</note>
       </trans-unit>
       <trans-unit id="8d3f5eff9c40ee315d452392bed5309b">
         <source>Last name</source>
         <target>Last name</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:196</note>
+        <note>Line: 130</note>
       </trans-unit>
       <trans-unit id="1c76cbfe21c6f44c1d1e59d54f3e4420">
         <source>Company</source>
         <target>Company</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:214</note>
+        <note>Line: 141</note>
       </trans-unit>
       <trans-unit id="b60bb13a87fe3ae5463aeb0980a5a8a1">
         <source>Identification number</source>
         <target>Identification number</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:218</note>
-      </trans-unit>
-      <trans-unit id="effdb9ce6c5d44df31b89d7069c8e0fb">
-        <source>Alias</source>
-        <target>Alias</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:192</note>
-      </trans-unit>
-      <trans-unit id="dd7bf230fde8d4836917806aff6a6b27">
-        <source>Address</source>
-        <target>Address</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:198</note>
-      </trans-unit>
-      <trans-unit id="86376e3b5c80d090dbc625b4d241431b">
-        <source>Address Complement</source>
-        <target>Address Complement</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:200</note>
-      </trans-unit>
-      <trans-unit id="e4eb5dadb6ee84c5c55a8edf53f6e554">
-        <source>Zip/Postal Code</source>
-        <target>Zip/Postal Code</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:202</note>
-      </trans-unit>
-      <trans-unit id="57d056ed0984166336b7879c2af3657f">
-        <source>City</source>
-        <target>City</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:204</note>
-      </trans-unit>
-      <trans-unit id="59716c97497eb9694541f7c3d37b1a4d">
-        <source>Country</source>
-        <target>Country</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:206</note>
-      </trans-unit>
-      <trans-unit id="46a2a41cc6e552044816a2d04634545d">
-        <source>State</source>
-        <target>State</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:208</note>
-      </trans-unit>
-      <trans-unit id="bcc254b55c4a1babdf1dcb82c207506b">
-        <source>Phone</source>
-        <target>Phone</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:210</note>
-      </trans-unit>
-      <trans-unit id="41c2fff4867cc204120f001e7af20f7a">
-        <source>Mobile phone</source>
-        <target>Mobile phone</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:212</note>
-      </trans-unit>
-      <trans-unit id="7cb32e708d6b961d476baced73d362bb">
-        <source>VAT number</source>
-        <target>VAT number</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:216</note>
-      </trans-unit>
-      <trans-unit id="6311ae17c1ee52b36e68aaf4ad066387">
-        <source>Other</source>
-        <target>Other</target>
-        <note>Context:
-File: classes/form/CustomerAddressFormatter.php:220</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/StarterTheme/templates/customer/password-email.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ce8ae9da5b7cd6c3df2929543a9af92d">
-        <source>Email</source>
-        <target>Email</target>
-        <note>Context:
-File: themes/StarterTheme/templates/customer/password-email.tpl:46</note>
+        <note>Line: 148
+Comment: Please localize this string with the applicable registration number type in your country. For example : "SIRET" in France and "Código fiscal" in Spain.</note>
       </trans-unit>
     </body>
   </file>
   <file original="classes/form/CustomerLoginFormatter.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="ce8ae9da5b7cd6c3df2929543a9af92d">
+        <source>Email</source>
+        <target>Email</target>
+        <note>Line: 48</note>
+      </trans-unit>
       <trans-unit id="dc647eb65e6711e155375218212b3964">
         <source>Password</source>
         <target>Password</target>
-        <note>Context:
-File: classes/form/CustomerLoginFormatter.php:56</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/password-new.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3544848f820b9d94a3f3871a382cf138">
-        <source>New password</source>
-        <target>New password</target>
-        <note>Context:
-File: themes/classic/templates/customer/password-new.tpl:56</note>
-      </trans-unit>
-      <trans-unit id="f4d1ea475eaa85102e2b4e6d95da84bd">
-        <source>Confirmation</source>
-        <target>Confirmation</target>
-        <note>Context:
-File: themes/classic/templates/customer/password-new.tpl:63</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/_partials/order-messages.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1625e29c02062efe5dbc42c3efeeebc4">
-        <source>-- please choose --</source>
-        <target>-- please choose --</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-messages.tpl:59</note>
-      </trans-unit>
-      <trans-unit id="deb10517653c255364175796ace3553f">
-        <source>Product</source>
-        <target>Product</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-messages.tpl:56</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/guest-login.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="63c193f613dd3d9d6c16da7678efda2a">
-        <source>Order Reference:</source>
-        <target>Order Reference:</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-login.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="6a1e265f92087bb6dd18194833fe946b">
-        <source>Email:</source>
-        <target>Email:</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-login.tpl:59</note>
+        <note>Line: 56</note>
       </trans-unit>
     </body>
   </file>
@@ -199,70 +129,27 @@ File: themes/StarterTheme/templates/customer/_partials/order-messages.tpl:64</no
       <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4">
         <source>Message</source>
         <target>Message</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:101</note>
+        <note>Line: 101</note>
       </trans-unit>
       <trans-unit id="b357b524e740bc85b9790a0712d84a30">
         <source>Email address</source>
         <target>Email address</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:59</note>
+        <note>Line: 59</note>
       </trans-unit>
       <trans-unit id="c7892ebbb139886662c6f2fc8c450710">
         <source>Subject</source>
         <target>Subject</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="5d4710f9a8250b13164a82c94d5b00d1">
         <source>Order reference</source>
         <target>Order reference</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:73</note>
+        <note>Line: 73</note>
       </trans-unit>
       <trans-unit id="e9cb217697088a98b1937d111d936281">
         <source>Attachment</source>
         <target>Attachment</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:90</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/guest-tracking.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3b6bf3c0c07b89dc86f415117a1f0b80">
-        <source>Set your password:</source>
-        <target>Set your password:</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-tracking.tpl:53</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/_partials/form-fields.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="93332134fd11cffbe680dd8afaa521fc">
-        <source>-- day --</source>
-        <target>-- day --</target>
-        <note>Context:
-File: themes/classic/templates/_partials/form-fields.tpl:124</note>
-      </trans-unit>
-      <trans-unit id="9180b4d5ab8103f244c2d4fd661934e2">
-        <source>-- month --</source>
-        <target>-- month --</target>
-        <note>Context:
-File: themes/classic/templates/_partials/form-fields.tpl:125</note>
-      </trans-unit>
-      <trans-unit id="ae1cc541ba45ce670ea7e0e3a30e3205">
-        <source>-- year --</source>
-        <target>-- year --</target>
-        <note>Context:
-File: themes/classic/templates/_partials/form-fields.tpl:126</note>
-      </trans-unit>
-      <trans-unit id="ebb061953c0454b2c8ee7b0ac615ebcd">
-        <source>Optional</source>
-        <target>Optional</target>
-        <note>Context:
-File: themes/classic/templates/_partials/form-fields.tpl:188</note>
+        <note>Line: 90</note>
       </trans-unit>
     </body>
   </file>
@@ -271,8 +158,82 @@ File: themes/classic/templates/_partials/form-fields.tpl:188</note>
       <trans-unit id="198584454b0ce1101ff5b50323325aa8">
         <source>Your email address</source>
         <target>Your email address</target>
-        <note>Context:
-File: themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl:50</note>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/_partials/form-fields.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="93332134fd11cffbe680dd8afaa521fc">
+        <source>-- day --</source>
+        <target>-- day --</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="9180b4d5ab8103f244c2d4fd661934e2">
+        <source>-- month --</source>
+        <target>-- month --</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="ae1cc541ba45ce670ea7e0e3a30e3205">
+        <source>-- year --</source>
+        <target>-- year --</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="ebb061953c0454b2c8ee7b0ac615ebcd">
+        <source>Optional</source>
+        <target>Optional</target>
+        <note>Line: 188</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/order-messages.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1625e29c02062efe5dbc42c3efeeebc4">
+        <source>-- please choose --</source>
+        <target>-- please choose --</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="deb10517653c255364175796ace3553f">
+        <source>Product</source>
+        <target>Product</target>
+        <note>Line: 56</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/guest-login.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="63c193f613dd3d9d6c16da7678efda2a">
+        <source>Order Reference:</source>
+        <target>Order Reference:</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="6a1e265f92087bb6dd18194833fe946b">
+        <source>Email:</source>
+        <target>Email:</target>
+        <note>Line: 59</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/guest-tracking.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3b6bf3c0c07b89dc86f415117a1f0b80">
+        <source>Set your password:</source>
+        <target>Set your password:</target>
+        <note>Line: 53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/password-new.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3544848f820b9d94a3f3871a382cf138">
+        <source>New password</source>
+        <target>New password</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="f4d1ea475eaa85102e2b4e6d95da84bd">
+        <source>Confirmation</source>
+        <target>Confirmation</target>
+        <note>Line: 63</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopNavigation.xlf
+++ b/app/Resources/translations/default/ShopNavigation.xlf
@@ -5,350 +5,292 @@
       <trans-unit id="c62420fe56ba1bd9be3bad2d6203a28e">
         <source>404 error</source>
         <target>404 error</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:26</note>
+        <note>Line: 26</note>
       </trans-unit>
       <trans-unit id="bd7929bc6bed5d8ec99db715a980ba04">
         <source>Best sales</source>
         <target>Best sales</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="02d4482d332e1aef3437cd61c9bcc624">
         <source>Contact us</source>
         <target>Contact us</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="2377be3c2ad9b435ba277a73f0f1ca76">
         <source>Manufacturers</source>
         <target>Manufacturers</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:29</note>
+        <note>Line: 29</note>
       </trans-unit>
       <trans-unit id="9ff0635f5737513b1a6f559ac2bff745">
         <source>New products</source>
         <target>New products</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:30</note>
+        <note>Line: 30</note>
       </trans-unit>
       <trans-unit id="0fb655f37529ad006eb0d503e23e10f1">
         <source>Forgot your password</source>
         <target>Forgot your password</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:31</note>
+        <note>Line: 31</note>
       </trans-unit>
       <trans-unit id="6de5d0b17afc50642850ff9486934f87">
         <source>Prices drop</source>
         <target>Prices drop</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="5813ce0ec7196c492c97596718f71969">
         <source>Sitemap</source>
         <target>Sitemap</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="1814d65a76028fdfbadab64a5a8076df">
         <source>Suppliers</source>
         <target>Suppliers</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="dd7bf230fde8d4836917806aff6a6b27">
         <source>Address</source>
         <target>Address</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
         <source>Addresses</source>
         <target>Addresses</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:36</note>
+        <note>Line: 36</note>
       </trans-unit>
       <trans-unit id="99dea78007133396a7b8ed70578ac6ae">
         <source>Login</source>
         <target>Login</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:37</note>
+        <note>Line: 37</note>
       </trans-unit>
       <trans-unit id="a85eba4c6c699122b2bb1387ea4813ad">
         <source>Cart</source>
         <target>Cart</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:38</note>
+        <note>Line: 38</note>
       </trans-unit>
       <trans-unit id="104d9898c04874d0fbac36e125fa1369">
         <source>Discount</source>
         <target>Discount</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:39</note>
+        <note>Line: 39</note>
       </trans-unit>
       <trans-unit id="782c8b38bce4f2f6975ca7f33ac8189b">
         <source>Order history</source>
         <target>Order history</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:40</note>
+        <note>Line: 40</note>
       </trans-unit>
       <trans-unit id="c9c5c65fb4af9cf90eb99b3b84424189">
         <source>Identity</source>
         <target>Identity</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="d95cf4ab2cbf1dfb63f066b50558b07d">
         <source>My account</source>
         <target>My account</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:42</note>
+        <note>Line: 42</note>
       </trans-unit>
       <trans-unit id="16c7f223c517b6d24958c2b82312945f">
         <source>Order follow</source>
         <target>Order follow</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="cf3bae95c5f6023d5a10fe415b205a45">
         <source>Credit slip</source>
         <target>Credit slip</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:44</note>
+        <note>Line: 44</note>
       </trans-unit>
       <trans-unit id="a240fa27925a635b08dc28c9e4f9216d">
         <source>Order</source>
         <target>Order</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
         <source>Search</source>
         <target>Search</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:46</note>
+        <note>Line: 46</note>
       </trans-unit>
       <trans-unit id="821b8ee6937cec96c30fdafbfe836d68">
         <source>Stores</source>
         <target>Stores</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="4fb8550e52b59f7f93d60c1d1b56e93e">
         <source>Guest tracking</source>
         <target>Guest tracking</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="fb077ecba55e5552916bde26d8b9e794">
         <source>Order confirmation</source>
         <target>Order confirmation</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:49</note>
+        <note>Line: 49</note>
       </trans-unit>
       <trans-unit id="da3768d3291e2d42512cde89f2b66a11">
         <source>This page cannot be found</source>
         <target>This page cannot be found</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:50</note>
+        <note>Line: 50</note>
       </trans-unit>
       <trans-unit id="d7f59475fb24e5e654d4c8e409a2de7b">
         <source>Our best sales</source>
         <target>Our best sales</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:52</note>
+        <note>Line: 52</note>
       </trans-unit>
       <trans-unit id="77d117320b02d137e4d3aa7b4300d2f5">
         <source>Use our form to contact us</source>
         <target>Use our form to contact us</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:54</note>
+        <note>Line: 54</note>
       </trans-unit>
       <trans-unit id="94aafa0c1ac39af1afaa0e798b2bad73">
         <source>Shop powered by PrestaShop</source>
         <target>Shop powered by PrestaShop</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:56</note>
+        <note>Line: 56</note>
       </trans-unit>
       <trans-unit id="67c2b2e2172f6d03a44c4a93adbb4845">
         <source>Brand list</source>
         <target>Brand list</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:58</note>
+        <note>Line: 58</note>
       </trans-unit>
       <trans-unit id="f048e5676a4e7e45acea76628b628cf8">
         <source>Our new products</source>
         <target>Our new products</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:60</note>
+        <note>Line: 60</note>
       </trans-unit>
       <trans-unit id="a068c4959ec37c3f511011e10808b4ce">
         <source>Enter the e-mail address you use to sign in to receive an e-mail with a new password</source>
         <target>Enter the e-mail address you use to sign in to receive an e-mail with a new password</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:62</note>
+        <note>Line: 62</note>
       </trans-unit>
       <trans-unit id="feb65ab262a484a24e2d6229ff42b136">
         <source>On-sale products</source>
         <target>On-sale products</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:64</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="86791147a83e82f4bf90927c84fa3f6f">
         <source>Lost ? Find what your are looking for</source>
         <target>Lost ? Find what your are looking for</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:66</note>
+        <note>Line: 66</note>
       </trans-unit>
       <trans-unit id="95e22c32ee49f6549a9cabb539d82090">
         <source>Suppliers list</source>
         <target>Suppliers list</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:68</note>
+        <note>Line: 68</note>
       </trans-unit>
       <trans-unit id="346802d009904a107e153c8a16068002">
         <source>page-not-found</source>
         <target>page-not-found</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:69</note>
+        <note>Line: 69</note>
       </trans-unit>
       <trans-unit id="2c9ff64fb8c71aa15080de697586fe68">
         <source>best-sales</source>
         <target>best-sales</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:70</note>
+        <note>Line: 70</note>
       </trans-unit>
       <trans-unit id="03f2197d47a602c679c5f667e3482855">
         <source>contact-us</source>
         <target>contact-us</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:71</note>
+        <note>Line: 71</note>
       </trans-unit>
       <trans-unit id="077326568c4bb9ed153c12c171827a54">
         <source>manufacturers</source>
         <target>manufacturers</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:72</note>
+        <note>Line: 72</note>
       </trans-unit>
       <trans-unit id="169c4f8c3dcee7feff031dd2a73a44fb">
         <source>new-products</source>
         <target>new-products</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:73</note>
+        <note>Line: 73</note>
       </trans-unit>
       <trans-unit id="bfaf38cf11aa56ab195a4a229b19715a">
         <source>password-recovery</source>
         <target>password-recovery</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:74</note>
+        <note>Line: 74</note>
       </trans-unit>
       <trans-unit id="98add0e701132ba329cfc17db2c3024e">
         <source>prices-drop</source>
         <target>prices-drop</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:75</note>
+        <note>Line: 75</note>
       </trans-unit>
       <trans-unit id="e1da49db34b0bdfdddaba2ad6552f848">
         <source>sitemap</source>
         <target>sitemap</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:76</note>
+        <note>Line: 76</note>
       </trans-unit>
       <trans-unit id="99b0e8da24e29e4ccb5d7d76e677c2ac">
         <source>supplier</source>
         <target>supplier</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:77</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="884d9804999fc47a3c2694e49ad2536a">
         <source>address</source>
         <target>address</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:78</note>
+        <note>Line: 78</note>
       </trans-unit>
       <trans-unit id="963e3a2fe559e393bad631f3dc686f69">
         <source>addresses</source>
         <target>addresses</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:79</note>
+        <note>Line: 79</note>
       </trans-unit>
       <trans-unit id="d56b699830e77ba53855679cb1d252da">
         <source>login</source>
         <target>login</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:80</note>
+        <note>Line: 80</note>
       </trans-unit>
       <trans-unit id="54013ba69c196820e56801f1ef5aad54">
         <source>cart</source>
         <target>cart</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:81</note>
+        <note>Line: 81</note>
       </trans-unit>
       <trans-unit id="e2dc6c48c56de466f6d13781796abf3d">
         <source>discount</source>
         <target>discount</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:82</note>
+        <note>Line: 82</note>
       </trans-unit>
       <trans-unit id="0ed9f3fa4d887426b8040c82fdc2fe62">
         <source>order-history</source>
         <target>order-history</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:83</note>
+        <note>Line: 83</note>
       </trans-unit>
       <trans-unit id="ff483d1ff591898a9942916050d2ca3f">
         <source>identity</source>
         <target>identity</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:84</note>
+        <note>Line: 84</note>
       </trans-unit>
       <trans-unit id="38e865b05a4079b487a78b4b857de77b">
         <source>my-account</source>
         <target>my-account</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:85</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="00ca581609c5c22965f915a4680e097a">
         <source>order-follow</source>
         <target>order-follow</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:86</note>
+        <note>Line: 86</note>
       </trans-unit>
       <trans-unit id="8f77f9a08cd6c9a27dd9142cecee5b6e">
         <source>credit-slip</source>
         <target>credit-slip</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:87</note>
+        <note>Line: 87</note>
       </trans-unit>
       <trans-unit id="70a17ffa722a3985b86d30b034ad06d7">
         <source>order</source>
         <target>order</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:88</note>
+        <note>Line: 88</note>
       </trans-unit>
       <trans-unit id="06a943c59f33a34bb5924aaf72cd2995">
         <source>search</source>
         <target>search</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:89</note>
+        <note>Line: 89</note>
       </trans-unit>
       <trans-unit id="61af09f34bc001f3b6d9139687a723fd">
         <source>stores</source>
         <target>stores</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:90</note>
+        <note>Line: 90</note>
       </trans-unit>
       <trans-unit id="a18a3ca75ab720242ec38d2e77373a92">
         <source>guest-tracking</source>
         <target>guest-tracking</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:91</note>
+        <note>Line: 91</note>
       </trans-unit>
       <trans-unit id="215d444395453d02d844b99143f00ad4">
         <source>order-confirmation</source>
         <target>order-confirmation</target>
-        <note>Context:
-File: classes/lang/KeysReference/MetaLang.php:92</note>
+        <note>Line: 92</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopNotificationsError.xlf
+++ b/app/Resources/translations/default/ShopNotificationsError.xlf
@@ -1,320 +1,176 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/CartRule.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5a6448a8d8e77fa43df91db2eea79fb1">
+        <source>This voucher is disabled</source>
+        <target>This voucher is disabled</target>
+        <note>Line: 633</note>
+      </trans-unit>
+      <trans-unit id="8232b04735bff65500e6fcc378ba1f4a">
+        <source>This voucher has already been used</source>
+        <target>This voucher has already been used</target>
+        <note>Line: 636</note>
+      </trans-unit>
+      <trans-unit id="b38f15cfb6f5640c4ff55cd72c7575f6">
+        <source>This voucher is not valid yet</source>
+        <target>This voucher is not valid yet</target>
+        <note>Line: 639</note>
+      </trans-unit>
+      <trans-unit id="098eb45965b4097a844451b00737e89b">
+        <source>This voucher has expired</source>
+        <target>This voucher has expired</target>
+        <note>Line: 642</note>
+      </trans-unit>
+      <trans-unit id="6da9714ab9db11108de5b4a82bf7f59e">
+        <source>You cannot use this voucher anymore (usage limit reached)</source>
+        <target>You cannot use this voucher anymore (usage limit reached)</target>
+        <note>Line: 655</note>
+      </trans-unit>
+      <trans-unit id="097d067ff8635d1496467ce7dd236c07">
+        <source>You cannot use this voucher</source>
+        <target>You cannot use this voucher</target>
+        <note>Line: 744</note>
+      </trans-unit>
+      <trans-unit id="02b1546a6a121a54540f3755758a976b">
+        <source>You must choose a delivery address before applying this voucher to your order</source>
+        <target>You must choose a delivery address before applying this voucher to your order</target>
+        <note>Line: 674</note>
+      </trans-unit>
+      <trans-unit id="fd6034a1544218709264bfa5c70ffb69">
+        <source>You cannot use this voucher in your country of delivery</source>
+        <target>You cannot use this voucher in your country of delivery</target>
+        <note>Line: 682</note>
+      </trans-unit>
+      <trans-unit id="eb4a4722b2130dad0a240b2d49742be8">
+        <source>You must choose a carrier before applying this voucher to your order</source>
+        <target>You must choose a carrier before applying this voucher to your order</target>
+        <note>Line: 689</note>
+      </trans-unit>
+      <trans-unit id="1a7bdc2c01aaa7757d475e204f2bc6f9">
+        <source>You cannot use this voucher with this carrier</source>
+        <target>You cannot use this voucher with this carrier</target>
+        <note>Line: 698</note>
+      </trans-unit>
+      <trans-unit id="40869c38d826da9c21cc0359f905e5b3">
+        <source>You cannot use this voucher on products on sale</source>
+        <target>You cannot use this voucher on products on sale</target>
+        <note>Line: 712</note>
+      </trans-unit>
+      <trans-unit id="3fb396b59440efc171f576e02ecfa88a">
+        <source>Please log in first</source>
+        <target>Please log in first</target>
+        <note>Line: 741</note>
+      </trans-unit>
+      <trans-unit id="dc0c81278849e0f6a297e93c935e465d">
+        <source>You have not reached the minimum amount required to use this voucher</source>
+        <target>You have not reached the minimum amount required to use this voucher</target>
+        <note>Line: 772</note>
+      </trans-unit>
+      <trans-unit id="d0f1560c5d1b13b1e64fa87a301dd83b">
+        <source>This voucher is already in your cart</source>
+        <target>This voucher is already in your cart</target>
+        <note>Line: 790</note>
+      </trans-unit>
+      <trans-unit id="4837d38bc896f38c39d6f7024e466967">
+        <source>This voucher is not combinable with an other voucher already in your cart: %s</source>
+        <target>This voucher is not combinable with an other voucher already in your cart: %s</target>
+        <note>Line: 808</note>
+      </trans-unit>
+      <trans-unit id="e199546c0a1d80f1bf116b131ee02e22">
+        <source>Cart is empty</source>
+        <target>Cart is empty</target>
+        <note>Line: 819</note>
+      </trans-unit>
+      <trans-unit id="f6b43936fe8476614100c342b9c4750d">
+        <source>You cannot use this voucher in an empty cart</source>
+        <target>You cannot use this voucher in an empty cart</target>
+        <note>Line: 878</note>
+      </trans-unit>
+      <trans-unit id="f9330b1b2afa3c4dbc8e31e14a0b150a">
+        <source>You cannot use this voucher with these products</source>
+        <target>You cannot use this voucher with these products</target>
+        <note>Line: 1037</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/form/CustomerForm.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="eefb581d7c421334e62a68223c7a242a">
+        <source>The email is already used, please choose another one or sign in</source>
+        <target>The email is already used, please choose another one or sign in</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/form/CustomerLoginForm.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="90162cff1b4a1a5a765c542ddc499998">
+        <source>Your account isn't available at this time, please contact us</source>
+        <target>Your account isn't available at this time, please contact us</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="802b207b05fe5cea22e11b9db804b33d">
+        <source>Authentication failed.</source>
+        <target>Authentication failed.</target>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/form/CustomerPersister.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="47be05698f8dd87bb445ceefce6abd0d">
+        <source>Password is required</source>
+        <target>Password is required</target>
+        <note>Line: 155</note>
+      </trans-unit>
+      <trans-unit id="d2f614cac7a0f970168f6d129860a1c0">
+        <source>Invalid email/password combination</source>
+        <target>Invalid email/password combination</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="5f377de6cd38d0577c9628eeaecb3d0f">
+        <source>There seems to be an issue with your account, please contact support</source>
+        <target>There seems to be an issue with your account, please contact support</target>
+        <note>Line: 101</note>
+      </trans-unit>
+      <trans-unit id="e3cf2c117615da59fb8930d299eb16f3">
+        <source>An account was already registered with this email address</source>
+        <target>An account was already registered with this email address</target>
+        <note>Line: 183</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/stock/SupplyOrderDetail.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1f597c6798d6a39dd2bde999d547331a">
+        <source>%s is required.</source>
+        <target>%s is required.</target>
+        <note>Line: 294</note>
+      </trans-unit>
+      <trans-unit id="8ae0cb74f9724518e1ce68c503377002">
+        <source>is invalid.</source>
+        <target>is invalid.</target>
+        <note>Line: 339</note>
+      </trans-unit>
+      <trans-unit id="0e2338b37ab3dfeed544e8233b53d4e0">
+        <source>The %1$s field is too long (%2$d chars max).</source>
+        <target>The %1$s field is too long (%2$d chars max).</target>
+        <note>Line: 308</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="controllers/front/AddressController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="0adae640fffe5e6c0208e25f13aaa414">
         <source>Please fix the error below.</source>
         <target>Please fix the error below.</target>
-        <note>Context:
-File: controllers/front/AddressController.php:60</note>
+        <note>Line: 60</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="classes/checkout/CheckoutAddressesStep.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
       <trans-unit id="2af64b8ece83492468fbc41f9b692556">
         <source>Could not delete address.</source>
         <target>Could not delete address.</target>
-        <note>Context:
-File: classes/checkout/CheckoutAddressesStep.php:174</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/GetFileController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="456e77e04e2e26231ee352304627b26d">
-        <source>Invalid key.</source>
-        <target>Invalid key.</target>
-        <note>Context:
-File: controllers/front/GetFileController.php:318</note>
-      </trans-unit>
-      <trans-unit id="1347119d36ae31564a89763f21476c1a">
-        <source>This product does not exist in our store.</source>
-        <target>This product does not exist in our store.</target>
-        <note>Context:
-File: controllers/front/GetFileController.php:319</note>
-      </trans-unit>
-      <trans-unit id="38d5595927b80b331239ef904341b07c">
-        <source>This product has been deleted.</source>
-        <target>This product has been deleted.</target>
-        <note>Context:
-File: controllers/front/GetFileController.php:320</note>
-      </trans-unit>
-      <trans-unit id="c9615dc36879116ef8c5f1ab08543191">
-        <source>This file no longer exists.</source>
-        <target>This file no longer exists.</target>
-        <note>Context:
-File: controllers/front/GetFileController.php:321</note>
-      </trans-unit>
-      <trans-unit id="b1046eaca37cbbd3b53d17c33299bfab">
-        <source>This product has been refunded.</source>
-        <target>This product has been refunded.</target>
-        <note>Context:
-File: controllers/front/GetFileController.php:322</note>
-      </trans-unit>
-      <trans-unit id="2d30f823fe8f59bbcbec1fec853e4549">
-        <source>The product deadline is in the past.</source>
-        <target>The product deadline is in the past.</target>
-        <note>Context:
-File: controllers/front/GetFileController.php:323</note>
-      </trans-unit>
-      <trans-unit id="d5304279c07642327b2909efd15ff539">
-        <source>The product expiration date has passed, preventing you from download this product.</source>
-        <target>The product expiration date has passed, preventing you from download this product.</target>
-        <note>Context:
-File: controllers/front/GetFileController.php:324</note>
-      </trans-unit>
-      <trans-unit id="cb3bf6b78b0297d94c00187dcafd77a3">
-        <source>Expiration date has passed, you cannot download this product.</source>
-        <target>Expiration date has passed, you cannot download this product.</target>
-        <note>Context:
-File: controllers/front/GetFileController.php:325</note>
-      </trans-unit>
-      <trans-unit id="98bc3b9df6852d17661209b9c969128b">
-        <source>You have reached the maximum number of downloads allowed.</source>
-        <target>You have reached the maximum number of downloads allowed.</target>
-        <note>Context:
-File: controllers/front/GetFileController.php:326</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/OrderDetailController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ffabab221ec5c24fbdb4a70ad48bc985">
-        <source>The order is no longer valid.</source>
-        <target>The order is no longer valid.</target>
-        <note>Context:
-File: controllers/front/OrderDetailController.php:49</note>
-      </trans-unit>
-      <trans-unit id="15efe0f18ecffd8e75556c5c60cb1cb6">
-        <source>This message is invalid (HTML is not allowed).</source>
-        <target>This message is invalid (HTML is not allowed).</target>
-        <note>Context:
-File: controllers/front/OrderDetailController.php:53</note>
-      </trans-unit>
-      <trans-unit id="8a6034d3379499b66d730aa17e007683">
-        <source>You do not have enough products to request an additional merchandise return.</source>
-        <target>You do not have enough products to request an additional merchandise return.</target>
-        <note>Context:
-File: controllers/front/OrderDetailController.php:170</note>
-      </trans-unit>
-      <trans-unit id="229ca46a5d762e19a428f59449c916ad">
-        <source>Please provide an explanation for your RMA.</source>
-        <target>Please provide an explanation for your RMA.</target>
-        <note>Context:
-File: controllers/front/OrderDetailController.php:172</note>
-      </trans-unit>
-      <trans-unit id="e6f6a5e58ee6d010f22e4b3dbd756213">
-        <source>Please check at least one product you would like to return.</source>
-        <target>Please check at least one product you would like to return.</target>
-        <note>Context:
-File: controllers/front/OrderDetailController.php:174</note>
-      </trans-unit>
-      <trans-unit id="1819b587867a9c604a4d21c753756b4a">
-        <source>For each product you wish to add, please specify the desired quantity.</source>
-        <target>For each product you wish to add, please specify the desired quantity.</target>
-        <note>Context:
-File: controllers/front/OrderDetailController.php:176</note>
-      </trans-unit>
-      <trans-unit id="a3c5d3c6953c588760d90657e4f0b790">
-        <source>This order cannot be returned</source>
-        <target>This order cannot be returned</target>
-        <note>Context:
-File: controllers/front/OrderDetailController.php:178</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/contactform/contactform.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3dc245110e1f3601860c20299d97c01d">
-        <source>The message cannot be blank.</source>
-        <target>The message cannot be blank.</target>
-        <note>Context:
-File: modules/contactform/contactform.php:446</note>
-      </trans-unit>
-      <trans-unit id="dd6b089a49908d671c3e9cc8dc5899ae">
-        <source>Invalid message</source>
-        <target>Invalid message</target>
-        <note>Context:
-File: modules/contactform/contactform.php:452</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/PdfOrderReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b430bfb9e8ec89ded934087889c2e845">
-        <source>Order return not found.</source>
-        <target>Order return not found.</target>
-        <note>Context:
-File: controllers/front/PdfOrderReturnController.php:47</note>
-      </trans-unit>
-      <trans-unit id="b55e152dc0683c3d315b6baabb98495d">
-        <source>Order return not confirmed.</source>
-        <target>Order return not confirmed.</target>
-        <note>Context:
-File: controllers/front/PdfOrderReturnController.php:49</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/OrderFollowController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="15ef0f1f63c1e8a9fb8abad024939262">
-        <source>You have no merchandise return authorizations.</source>
-        <target>You have no merchandise return authorizations.</target>
-        <note>Context:
-File: controllers/front/OrderFollowController.php:103</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/listing/CategoryController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ba2bfa3216ea97ec1e454239610d089a">
-        <source>You do not have access to this category.</source>
-        <target>You do not have access to this category.</target>
-        <note>Context:
-File: controllers/front/listing/CategoryController.php:97</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/PdfInvoiceController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6b9cc232bf4044274ec42062b60736fb">
-        <source>Invoices are disabled in this shop.</source>
-        <target>Invoices are disabled in this shop.</target>
-        <note>Context:
-File: controllers/front/PdfInvoiceController.php:44</note>
-      </trans-unit>
-      <trans-unit id="2ef90fa1b9369f1ad3ca66852ca464a2">
-        <source>The invoice was not found.</source>
-        <target>The invoice was not found.</target>
-        <note>Context:
-File: controllers/front/PdfInvoiceController.php:57</note>
-      </trans-unit>
-      <trans-unit id="8200c4097227159b14dd0669b8dfe22c">
-        <source>No invoice is available.</source>
-        <target>No invoice is available.</target>
-        <note>Context:
-File: controllers/front/PdfInvoiceController.php:61</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/CartController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="897bbb78781eb767eee3a4ac3e820185">
-        <source>You must enter a voucher code.</source>
-        <target>You must enter a voucher code.</target>
-        <note>Context:
-File: controllers/front/CartController.php:247</note>
-      </trans-unit>
-      <trans-unit id="417d63b1effb110e438d4b4b9f0fbd95">
-        <source>The voucher code is invalid.</source>
-        <target>The voucher code is invalid.</target>
-        <note>Context:
-File: controllers/front/CartController.php:253</note>
-      </trans-unit>
-      <trans-unit id="d21c3bf7d25db04b73e7e269aef555fe">
-        <source>This voucher does not exist.</source>
-        <target>This voucher does not exist.</target>
-        <note>Context:
-File: controllers/front/CartController.php:268</note>
-      </trans-unit>
-      <trans-unit id="8b84452c494aa9106d26b20c9df0e431">
-        <source>You must add %quantity% minimum quantity</source>
-        <target>You must add %quantity% minimum quantity</target>
-        <note>Context:
-File: controllers/front/CartController.php:513</note>
-      </trans-unit>
-      <trans-unit id="9730e222894d4568ed4cd2de30cb233a">
-        <source>Null quantity.</source>
-        <target>Null quantity.</target>
-        <note>Context:
-File: controllers/front/CartController.php:374</note>
-      </trans-unit>
-      <trans-unit id="dfbe69c6d9568ecb0e65e7b32ed92a3a">
-        <source>Product not found</source>
-        <target>Product not found</target>
-        <note>Context:
-File: controllers/front/CartController.php:380</note>
-      </trans-unit>
-      <trans-unit id="cb0b5b032f2426b3fe341460320b5a8e">
-        <source>This product (%product%) is no longer available.</source>
-        <target>This product (%product%) is no longer available.</target>
-        <note>Context:
-File: controllers/front/CartController.php:617</note>
-      </trans-unit>
-      <trans-unit id="9a7c79186c1ff1cd48b31ed6caf6ff48">
-        <source>The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.</source>
-        <target>The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.</target>
-        <note>Context:
-File: controllers/front/CartController.php:610</note>
-      </trans-unit>
-      <trans-unit id="feb34b89eb5bf8066025f508b9b86ab2">
-        <source>The minimum purchase order quantity for the product %product% is %quantity%.</source>
-        <target>The minimum purchase order quantity for the product %product% is %quantity%.</target>
-        <note>Context:
-File: controllers/front/CartController.php:451</note>
-      </trans-unit>
-      <trans-unit id="84a7c3aeebf09d169aca8555be640bbf">
-        <source>Please fill in all of the required fields, and then save your customizations.</source>
-        <target>Please fill in all of the required fields, and then save your customizations.</target>
-        <note>Context:
-File: controllers/front/CartController.php:478</note>
-      </trans-unit>
-      <trans-unit id="de10fc28511b894f704c1a67fcff7b4f">
-        <source>You already have the maximum quantity available for this product.</source>
-        <target>You already have the maximum quantity available for this product.</target>
-        <note>Context:
-File: controllers/front/CartController.php:519</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="91e6cde963af2000218553722fc7a093">
-        <source>This product is no longer available.</source>
-        <target>This product is no longer available.</target>
-        <note>Context:
-File: controllers/front/ProductController.php:159</note>
-      </trans-unit>
-      <trans-unit id="a5df8bfce318a15ea55f18082b9b56c0">
-        <source>You do not have access to this product.</source>
-        <target>You do not have access to this product.</target>
-        <note>Context:
-File: controllers/front/ProductController.php:167</note>
-      </trans-unit>
-      <trans-unit id="636ae3559a19937ca8e53781d804a34d">
-        <source>An error occurred while deleting the selected picture.</source>
-        <target>An error occurred while deleting the selected picture.</target>
-        <note>Context:
-File: controllers/front/ProductController.php:248</note>
-      </trans-unit>
-      <trans-unit id="7cc92687130ea12abb80556681538001">
-        <source>An error occurred during the image upload process.</source>
-        <target>An error occurred during the image upload process.</target>
-        <note>Context:
-File: controllers/front/ProductController.php:821</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/GuestTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ddb329ec6521925a245fbe1334d2ce18">
-        <source>Please provide the required information</source>
-        <target>Please provide the required information</target>
-        <note>Context:
-File: controllers/front/GuestTrackingController.php:63</note>
-      </trans-unit>
-      <trans-unit id="ac68011e87111c9833dab09935bd88f3">
-        <source>We couldn't find your order with the information provided, please try again</source>
-        <target>We couldn't find your order with the information provided, please try again</target>
-        <note>Context:
-File: controllers/front/GuestTrackingController.php:83</note>
-      </trans-unit>
-      <trans-unit id="97f79d53b078e529949d5c3c8b676d52">
-        <source>An unexpected error occurred while creating your account.</source>
-        <target>An unexpected error occurred while creating your account.</target>
-        <note>Context:
-File: controllers/front/GuestTrackingController.php:108</note>
+        <note>Line: 81</note>
       </trans-unit>
     </body>
   </file>
@@ -323,34 +179,134 @@ File: controllers/front/GuestTrackingController.php:108</note>
       <trans-unit id="a3abb251955ac102dfda84c06e7e2e13">
         <source>The customer could not be found.</source>
         <target>The customer could not be found.</target>
-        <note>Context:
-File: controllers/front/AddressesController.php:43</note>
+        <note>Line: 43</note>
       </trans-unit>
     </body>
   </file>
-  <file original="controllers/front/OrderController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/front/CartController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="56ca67fde405db4d75fb5fc3350db81b">
-        <source>Sorry. We cannot renew your order.</source>
-        <target>Sorry. We cannot renew your order.</target>
-        <note>Context:
-File: controllers/front/OrderController.php:65</note>
+      <trans-unit id="897bbb78781eb767eee3a4ac3e820185">
+        <source>You must enter a voucher code.</source>
+        <target>You must enter a voucher code.</target>
+        <note>Line: 247</note>
       </trans-unit>
-      <trans-unit id="b22604f6ddd3fb79ff38568a5a0141e0">
-        <source>Some items are no longer available, and we are unable to renew your order.</source>
-        <target>Some items are no longer available, and we are unable to renew your order.</target>
-        <note>Context:
-File: controllers/front/OrderController.php:68</note>
+      <trans-unit id="417d63b1effb110e438d4b4b9f0fbd95">
+        <source>The voucher code is invalid.</source>
+        <target>The voucher code is invalid.</target>
+        <note>Line: 253</note>
+      </trans-unit>
+      <trans-unit id="d21c3bf7d25db04b73e7e269aef555fe">
+        <source>This voucher does not exist.</source>
+        <target>This voucher does not exist.</target>
+        <note>Line: 268</note>
+      </trans-unit>
+      <trans-unit id="8b84452c494aa9106d26b20c9df0e431">
+        <source>You must add %quantity% minimum quantity</source>
+        <target>You must add %quantity% minimum quantity</target>
+        <note>Line: 513</note>
+      </trans-unit>
+      <trans-unit id="9730e222894d4568ed4cd2de30cb233a">
+        <source>Null quantity.</source>
+        <target>Null quantity.</target>
+        <note>Line: 374</note>
+      </trans-unit>
+      <trans-unit id="dfbe69c6d9568ecb0e65e7b32ed92a3a">
+        <source>Product not found</source>
+        <target>Product not found</target>
+        <note>Line: 380</note>
+      </trans-unit>
+      <trans-unit id="cb0b5b032f2426b3fe341460320b5a8e">
+        <source>This product (%product%) is no longer available.</source>
+        <target>This product (%product%) is no longer available.</target>
+        <note>Line: 617</note>
+      </trans-unit>
+      <trans-unit id="9a7c79186c1ff1cd48b31ed6caf6ff48">
+        <source>The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.</source>
+        <target>The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.</target>
+        <note>Line: 610</note>
+      </trans-unit>
+      <trans-unit id="feb34b89eb5bf8066025f508b9b86ab2">
+        <source>The minimum purchase order quantity for the product %product% is %quantity%.</source>
+        <target>The minimum purchase order quantity for the product %product% is %quantity%.</target>
+        <note>Line: 451</note>
+      </trans-unit>
+      <trans-unit id="84a7c3aeebf09d169aca8555be640bbf">
+        <source>Please fill in all of the required fields, and then save your customizations.</source>
+        <target>Please fill in all of the required fields, and then save your customizations.</target>
+        <note>Line: 478</note>
+      </trans-unit>
+      <trans-unit id="de10fc28511b894f704c1a67fcff7b4f">
+        <source>You already have the maximum quantity available for this product.</source>
+        <target>You already have the maximum quantity available for this product.</target>
+        <note>Line: 519</note>
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/checkout/_partials/steps/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/front/GetFileController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="ea34b5c6cf6511c7c9e23cf7bf5d6792">
-        <source>Your address is incomplete, please update it.</source>
-        <target>Your address is incomplete, please update it.</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/addresses.tpl:116</note>
+      <trans-unit id="456e77e04e2e26231ee352304627b26d">
+        <source>Invalid key.</source>
+        <target>Invalid key.</target>
+        <note>Line: 318</note>
+      </trans-unit>
+      <trans-unit id="1347119d36ae31564a89763f21476c1a">
+        <source>This product does not exist in our store.</source>
+        <target>This product does not exist in our store.</target>
+        <note>Line: 319</note>
+      </trans-unit>
+      <trans-unit id="38d5595927b80b331239ef904341b07c">
+        <source>This product has been deleted.</source>
+        <target>This product has been deleted.</target>
+        <note>Line: 320</note>
+      </trans-unit>
+      <trans-unit id="c9615dc36879116ef8c5f1ab08543191">
+        <source>This file no longer exists.</source>
+        <target>This file no longer exists.</target>
+        <note>Line: 321</note>
+      </trans-unit>
+      <trans-unit id="b1046eaca37cbbd3b53d17c33299bfab">
+        <source>This product has been refunded.</source>
+        <target>This product has been refunded.</target>
+        <note>Line: 322</note>
+      </trans-unit>
+      <trans-unit id="2d30f823fe8f59bbcbec1fec853e4549">
+        <source>The product deadline is in the past.</source>
+        <target>The product deadline is in the past.</target>
+        <note>Line: 323</note>
+      </trans-unit>
+      <trans-unit id="d5304279c07642327b2909efd15ff539">
+        <source>The product expiration date has passed, preventing you from download this product.</source>
+        <target>The product expiration date has passed, preventing you from download this product.</target>
+        <note>Line: 324</note>
+      </trans-unit>
+      <trans-unit id="cb3bf6b78b0297d94c00187dcafd77a3">
+        <source>Expiration date has passed, you cannot download this product.</source>
+        <target>Expiration date has passed, you cannot download this product.</target>
+        <note>Line: 325</note>
+      </trans-unit>
+      <trans-unit id="98bc3b9df6852d17661209b9c969128b">
+        <source>You have reached the maximum number of downloads allowed.</source>
+        <target>You have reached the maximum number of downloads allowed.</target>
+        <note>Line: 326</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/GuestTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ddb329ec6521925a245fbe1334d2ce18">
+        <source>Please provide the required information</source>
+        <target>Please provide the required information</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="ac68011e87111c9833dab09935bd88f3">
+        <source>We couldn't find your order with the information provided, please try again</source>
+        <target>We couldn't find your order with the information provided, please try again</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="97f79d53b078e529949d5c3c8b676d52">
+        <source>An unexpected error occurred while creating your account.</source>
+        <target>An unexpected error occurred while creating your account.</target>
+        <note>Line: 108</note>
       </trans-unit>
     </body>
   </file>
@@ -359,8 +315,74 @@ File: themes/classic/templates/checkout/_partials/steps/addresses.tpl:116</note>
       <trans-unit id="7cee9e5fd53cf1d3d1677ef3edc4a613">
         <source>Could not update your information, please check your data.</source>
         <target>Could not update your information, please check your data.</target>
-        <note>Context:
-File: controllers/front/IdentityController.php:60</note>
+        <note>Line: 60</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="56ca67fde405db4d75fb5fc3350db81b">
+        <source>Sorry. We cannot renew your order.</source>
+        <target>Sorry. We cannot renew your order.</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="b22604f6ddd3fb79ff38568a5a0141e0">
+        <source>Some items are no longer available, and we are unable to renew your order.</source>
+        <target>Some items are no longer available, and we are unable to renew your order.</target>
+        <note>Line: 68</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderDetailController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ffabab221ec5c24fbdb4a70ad48bc985">
+        <source>The order is no longer valid.</source>
+        <target>The order is no longer valid.</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="15efe0f18ecffd8e75556c5c60cb1cb6">
+        <source>This message is invalid (HTML is not allowed).</source>
+        <target>This message is invalid (HTML is not allowed).</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="8a6034d3379499b66d730aa17e007683">
+        <source>You do not have enough products to request an additional merchandise return.</source>
+        <target>You do not have enough products to request an additional merchandise return.</target>
+        <note>Line: 170</note>
+      </trans-unit>
+      <trans-unit id="229ca46a5d762e19a428f59449c916ad">
+        <source>Please provide an explanation for your RMA.</source>
+        <target>Please provide an explanation for your RMA.</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="e6f6a5e58ee6d010f22e4b3dbd756213">
+        <source>Please check at least one product you would like to return.</source>
+        <target>Please check at least one product you would like to return.</target>
+        <note>Line: 174</note>
+      </trans-unit>
+      <trans-unit id="1819b587867a9c604a4d21c753756b4a">
+        <source>For each product you wish to add, please specify the desired quantity.</source>
+        <target>For each product you wish to add, please specify the desired quantity.</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="a3c5d3c6953c588760d90657e4f0b790">
+        <source>This order cannot be returned</source>
+        <target>This order cannot be returned</target>
+        <note>Line: 178</note>
+      </trans-unit>
+      <trans-unit id="3dc245110e1f3601860c20299d97c01d">
+        <source>The message cannot be blank.</source>
+        <target>The message cannot be blank.</target>
+        <note>Line: 51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderFollowController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="15ef0f1f63c1e8a9fb8abad024939262">
+        <source>You have no merchandise return authorizations.</source>
+        <target>You have no merchandise return authorizations.</target>
+        <note>Line: 103</note>
       </trans-unit>
     </body>
   </file>
@@ -369,60 +391,109 @@ File: controllers/front/IdentityController.php:60</note>
       <trans-unit id="909179695703d6a048fab0bcc9af4758">
         <source>We cannot regenerate your password with the data you've submitted</source>
         <target>We cannot regenerate your password with the data you've submitted</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:193</note>
+        <note>Line: 193</note>
       </trans-unit>
       <trans-unit id="194496a52d41fba1c9e6140c4eb34f83">
         <source>You cannot regenerate the password for this account.</source>
         <target>You cannot regenerate the password for this account.</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:119</note>
+        <note>Line: 119</note>
       </trans-unit>
       <trans-unit id="922dc0515643fb69585b67281692644a">
         <source>You can regenerate your password only every %d minute(s)</source>
         <target>You can regenerate your password only every %d minute(s)</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:71</note>
+        <note>Line: 71</note>
       </trans-unit>
       <trans-unit id="6e2fc94479ac0c63543886a235e3370c">
         <source>An error occurred while sending the email.</source>
         <target>An error occurred while sending the email.</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:184</note>
+        <note>Line: 184</note>
       </trans-unit>
       <trans-unit id="f7ae511276e04d42e9cfe2f714b5128e">
         <source>Customer account not found</source>
         <target>Customer account not found</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:117</note>
+        <note>Line: 117</note>
       </trans-unit>
       <trans-unit id="da9aa00ef0107af3e55d9ae1e8a1f361">
         <source>The password and its confirmation do not match.</source>
         <target>The password and its confirmation do not match.</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:129</note>
+        <note>Line: 129</note>
       </trans-unit>
       <trans-unit id="cf84bfe60dba837405db6f0a3cb9c086">
         <source>The password change request expired. You should ask for a new one.</source>
         <target>The password change request expired. You should ask for a new one.</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:147</note>
+        <note>Line: 147</note>
       </trans-unit>
       <trans-unit id="619469491be87d328254b6f41cd73770">
         <source>An error occurred with your account, which prevents us from updating the new password. Please report this issue using the contact form.</source>
         <target>An error occurred with your account, which prevents us from updating the new password. Please report this issue using the contact form.</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:187</note>
+        <note>Line: 187</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
       <trans-unit id="e267e2be02cf3e29f4ba53b5d97cf78a">
         <source>Invalid email address.</source>
         <target>Invalid email address.</target>
-        <note>Context:
-File: modules/ps_emailsubscription/ps_emailsubscription.php:339</note>
+        <note>Line: 53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/PdfInvoiceController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6b9cc232bf4044274ec42062b60736fb">
+        <source>Invoices are disabled in this shop.</source>
+        <target>Invoices are disabled in this shop.</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="2ef90fa1b9369f1ad3ca66852ca464a2">
+        <source>The invoice was not found.</source>
+        <target>The invoice was not found.</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="8200c4097227159b14dd0669b8dfe22c">
+        <source>No invoice is available.</source>
+        <target>No invoice is available.</target>
+        <note>Line: 61</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/PdfOrderReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b430bfb9e8ec89ded934087889c2e845">
+        <source>Order return not found.</source>
+        <target>Order return not found.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="b55e152dc0683c3d315b6baabb98495d">
+        <source>Order return not confirmed.</source>
+        <target>Order return not confirmed.</target>
+        <note>Line: 49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dd6b089a49908d671c3e9cc8dc5899ae">
+        <source>Invalid message</source>
+        <target>Invalid message</target>
+        <note>Line: 851</note>
+      </trans-unit>
+      <trans-unit id="91e6cde963af2000218553722fc7a093">
+        <source>This product is no longer available.</source>
+        <target>This product is no longer available.</target>
+        <note>Line: 159</note>
+      </trans-unit>
+      <trans-unit id="a5df8bfce318a15ea55f18082b9b56c0">
+        <source>You do not have access to this product.</source>
+        <target>You do not have access to this product.</target>
+        <note>Line: 167</note>
+      </trans-unit>
+      <trans-unit id="636ae3559a19937ca8e53781d804a34d">
+        <source>An error occurred while deleting the selected picture.</source>
+        <target>An error occurred while deleting the selected picture.</target>
+        <note>Line: 248</note>
+      </trans-unit>
+      <trans-unit id="7cc92687130ea12abb80556681538001">
+        <source>An error occurred during the image upload process.</source>
+        <target>An error occurred during the image upload process.</target>
+        <note>Line: 823</note>
       </trans-unit>
     </body>
   </file>
@@ -431,8 +502,16 @@ File: modules/ps_emailsubscription/ps_emailsubscription.php:339</note>
       <trans-unit id="046f5d51d8d0da00cba63d33299c2d66">
         <source>PHP "Dom" extension has not been loaded.</source>
         <target>PHP "Dom" extension has not been loaded.</target>
-        <note>Context:
-File: controllers/front/StoresController.php:41</note>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/CategoryController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ba2bfa3216ea97ec1e454239610d089a">
+        <source>You do not have access to this category.</source>
+        <target>You do not have access to this category.</target>
+        <note>Line: 97</note>
       </trans-unit>
     </body>
   </file>
@@ -464,201 +543,21 @@ File: modules/trackingfront/trackingfront.php:99</note>
       </trans-unit>
     </body>
   </file>
-  <file original="classes/form/CustomerPersister.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="47be05698f8dd87bb445ceefce6abd0d">
-        <source>Password is required</source>
-        <target>Password is required</target>
-        <note>Context:
-File: classes/form/CustomerPersister.php:155</note>
-      </trans-unit>
-      <trans-unit id="d2f614cac7a0f970168f6d129860a1c0">
-        <source>Invalid email/password combination</source>
-        <target>Invalid email/password combination</target>
-        <note>Context:
-File: classes/form/CustomerPersister.php:71</note>
-      </trans-unit>
-      <trans-unit id="5f377de6cd38d0577c9628eeaecb3d0f">
-        <source>There seems to be an issue with your account, please contact support</source>
-        <target>There seems to be an issue with your account, please contact support</target>
-        <note>Context:
-File: classes/form/CustomerPersister.php:101</note>
-      </trans-unit>
-      <trans-unit id="e3cf2c117615da59fb8930d299eb16f3">
-        <source>An account was already registered with this email address</source>
-        <target>An account was already registered with this email address</target>
-        <note>Context:
-File: classes/form/CustomerPersister.php:183</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="src/Adapter/Presenter/Product/ProductLazyArray.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="a923575984949608ce04c4984806ec2a">
         <source>There are not enough products in stock</source>
         <target>There are not enough products in stock</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:768</note>
+        <note>Line: 768</note>
       </trans-unit>
     </body>
   </file>
-  <file original="classes/stock/SupplyOrderDetail.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="themes/classic/templates/checkout/_partials/steps/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="1f597c6798d6a39dd2bde999d547331a">
-        <source>%s is required.</source>
-        <target>%s is required.</target>
-        <note>Context:
-File: classes/stock/SupplyOrderDetail.php:294</note>
-      </trans-unit>
-      <trans-unit id="8ae0cb74f9724518e1ce68c503377002">
-        <source>is invalid.</source>
-        <target>is invalid.</target>
-        <note>Context:
-File: classes/stock/SupplyOrderDetail.php:339</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/form/CustomerForm.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0e2338b37ab3dfeed544e8233b53d4e0">
-        <source>The %1$s field is too long (%2$d chars max).</source>
-        <target>The %1$s field is too long (%2$d chars max).</target>
-        <note>Context:
-File: classes/form/CustomerForm.php:178</note>
-      </trans-unit>
-      <trans-unit id="b99c284c2a24cf024e5811c89706bf79">
-        <source>The email is already used, please choose another one or sign in</source>
-        <target>The email is already used, please choose another one or sign in</target>
-        <note>Context:
-File: classes/form/CustomerForm.php:112</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/CartRule.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5a6448a8d8e77fa43df91db2eea79fb1">
-        <source>This voucher is disabled</source>
-        <target>This voucher is disabled</target>
-        <note>Context:
-File: classes/CartRule.php:633</note>
-      </trans-unit>
-      <trans-unit id="8232b04735bff65500e6fcc378ba1f4a">
-        <source>This voucher has already been used</source>
-        <target>This voucher has already been used</target>
-        <note>Context:
-File: classes/CartRule.php:636</note>
-      </trans-unit>
-      <trans-unit id="b38f15cfb6f5640c4ff55cd72c7575f6">
-        <source>This voucher is not valid yet</source>
-        <target>This voucher is not valid yet</target>
-        <note>Context:
-File: classes/CartRule.php:639</note>
-      </trans-unit>
-      <trans-unit id="098eb45965b4097a844451b00737e89b">
-        <source>This voucher has expired</source>
-        <target>This voucher has expired</target>
-        <note>Context:
-File: classes/CartRule.php:642</note>
-      </trans-unit>
-      <trans-unit id="6da9714ab9db11108de5b4a82bf7f59e">
-        <source>You cannot use this voucher anymore (usage limit reached)</source>
-        <target>You cannot use this voucher anymore (usage limit reached)</target>
-        <note>Context:
-File: classes/CartRule.php:655</note>
-      </trans-unit>
-      <trans-unit id="097d067ff8635d1496467ce7dd236c07">
-        <source>You cannot use this voucher</source>
-        <target>You cannot use this voucher</target>
-        <note>Context:
-File: classes/CartRule.php:744</note>
-      </trans-unit>
-      <trans-unit id="02b1546a6a121a54540f3755758a976b">
-        <source>You must choose a delivery address before applying this voucher to your order</source>
-        <target>You must choose a delivery address before applying this voucher to your order</target>
-        <note>Context:
-File: classes/CartRule.php:674</note>
-      </trans-unit>
-      <trans-unit id="fd6034a1544218709264bfa5c70ffb69">
-        <source>You cannot use this voucher in your country of delivery</source>
-        <target>You cannot use this voucher in your country of delivery</target>
-        <note>Context:
-File: classes/CartRule.php:682</note>
-      </trans-unit>
-      <trans-unit id="eb4a4722b2130dad0a240b2d49742be8">
-        <source>You must choose a carrier before applying this voucher to your order</source>
-        <target>You must choose a carrier before applying this voucher to your order</target>
-        <note>Context:
-File: classes/CartRule.php:689</note>
-      </trans-unit>
-      <trans-unit id="1a7bdc2c01aaa7757d475e204f2bc6f9">
-        <source>You cannot use this voucher with this carrier</source>
-        <target>You cannot use this voucher with this carrier</target>
-        <note>Context:
-File: classes/CartRule.php:698</note>
-      </trans-unit>
-      <trans-unit id="40869c38d826da9c21cc0359f905e5b3">
-        <source>You cannot use this voucher on products on sale</source>
-        <target>You cannot use this voucher on products on sale</target>
-        <note>Context:
-File: classes/CartRule.php:712</note>
-      </trans-unit>
-      <trans-unit id="3fb396b59440efc171f576e02ecfa88a">
-        <source>Please log in first</source>
-        <target>Please log in first</target>
-        <note>Context:
-File: classes/CartRule.php:741</note>
-      </trans-unit>
-      <trans-unit id="dc0c81278849e0f6a297e93c935e465d">
-        <source>You have not reached the minimum amount required to use this voucher</source>
-        <target>You have not reached the minimum amount required to use this voucher</target>
-        <note>Context:
-File: classes/CartRule.php:772</note>
-      </trans-unit>
-      <trans-unit id="d0f1560c5d1b13b1e64fa87a301dd83b">
-        <source>This voucher is already in your cart</source>
-        <target>This voucher is already in your cart</target>
-        <note>Context:
-File: classes/CartRule.php:790</note>
-      </trans-unit>
-      <trans-unit id="4837d38bc896f38c39d6f7024e466967">
-        <source>This voucher is not combinable with an other voucher already in your cart: %s</source>
-        <target>This voucher is not combinable with an other voucher already in your cart: %s</target>
-        <note>Context:
-File: classes/CartRule.php:808</note>
-      </trans-unit>
-      <trans-unit id="e199546c0a1d80f1bf116b131ee02e22">
-        <source>Cart is empty</source>
-        <target>Cart is empty</target>
-        <note>Context:
-File: classes/CartRule.php:819</note>
-      </trans-unit>
-      <trans-unit id="f6b43936fe8476614100c342b9c4750d">
-        <source>You cannot use this voucher in an empty cart</source>
-        <target>You cannot use this voucher in an empty cart</target>
-        <note>Context:
-File: classes/CartRule.php:878</note>
-      </trans-unit>
-      <trans-unit id="f9330b1b2afa3c4dbc8e31e14a0b150a">
-        <source>You cannot use this voucher with these products</source>
-        <target>You cannot use this voucher with these products</target>
-        <note>Context:
-File: classes/CartRule.php:1037</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/form/CustomerLoginForm.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="90162cff1b4a1a5a765c542ddc499998">
-        <source>Your account isn't available at this time, please contact us</source>
-        <target>Your account isn't available at this time, please contact us</target>
-        <note>Context:
-File: classes/form/CustomerLoginForm.php:69</note>
-      </trans-unit>
-      <trans-unit id="802b207b05fe5cea22e11b9db804b33d">
-        <source>Authentication failed.</source>
-        <target>Authentication failed.</target>
-        <note>Context:
-File: classes/form/CustomerLoginForm.php:71</note>
+      <trans-unit id="ea34b5c6cf6511c7c9e23cf7bf5d6792">
+        <source>Your address is incomplete, please update it.</source>
+        <target>Your address is incomplete, please update it.</target>
+        <note>Line: 116</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopNotificationsInfo.xlf
+++ b/app/Resources/translations/default/ShopNotificationsInfo.xlf
@@ -5,8 +5,7 @@
       <trans-unit id="37c90b2d3eaec03973059cb01c3fea06">
         <source>Please log in to your customer account to view the order</source>
         <target>Please log in to your customer account to view the order</target>
-        <note>Context:
-File: controllers/front/GuestTrackingController.php:74</note>
+        <note>Line: 74</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopNotificationsSuccess.xlf
+++ b/app/Resources/translations/default/ShopNotificationsSuccess.xlf
@@ -5,44 +5,17 @@
       <trans-unit id="e8699fcc0a32d2a30f1506e3ab4e3c5f">
         <source>Address successfully updated!</source>
         <target>Address successfully updated!</target>
-        <note>Context:
-File: controllers/front/AddressController.php:63</note>
+        <note>Line: 63</note>
       </trans-unit>
       <trans-unit id="fac734224cd546613e8530c66d28f69c">
         <source>Address successfully added!</source>
         <target>Address successfully added!</target>
-        <note>Context:
-File: controllers/front/AddressController.php:65</note>
+        <note>Line: 65</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="classes/checkout/CheckoutAddressesStep.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
       <trans-unit id="2e3e7c5849ac5eefe1cc6c4c73f182af">
         <source>Address successfully deleted!</source>
         <target>Address successfully deleted!</target>
-        <note>Context:
-File: classes/checkout/CheckoutAddressesStep.php:164</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/OrderDetailController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0c478a7069ab13f446e9e765cffd1550">
-        <source>Message successfully sent</source>
-        <target>Message successfully sent</target>
-        <note>Context:
-File: controllers/front/OrderDetailController.php:180</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/GuestTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="228289d31b9bf52373066156f9b0190e">
-        <source>Your guest account has been successfully transformed into a customer account. You can now log in as a registered shopper.</source>
-        <target>Your guest account has been successfully transformed into a customer account. You can now log in as a registered shopper.</target>
-        <note>Context:
-File: controllers/front/GuestTrackingController.php:102</note>
+        <note>Line: 78</note>
       </trans-unit>
     </body>
   </file>
@@ -51,8 +24,16 @@ File: controllers/front/GuestTrackingController.php:102</note>
       <trans-unit id="0dc57d60348fa2a648d69e8d38ec43cc">
         <source>No addresses are available. %s</source>
         <target>No addresses are available. %s</target>
-        <note>Context:
-File: controllers/front/AddressesController.php:56</note>
+        <note>Line: 56</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/GuestTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="228289d31b9bf52373066156f9b0190e">
+        <source>Your guest account has been successfully transformed into a customer account. You can now log in as a registered shopper.</source>
+        <target>Your guest account has been successfully transformed into a customer account. You can now log in as a registered shopper.</target>
+        <note>Line: 102</note>
       </trans-unit>
     </body>
   </file>
@@ -61,8 +42,16 @@ File: controllers/front/AddressesController.php:56</note>
       <trans-unit id="7c8682d92dfb1522b4cc2975608e582d">
         <source>Information successfully updated.</source>
         <target>Information successfully updated.</target>
-        <note>Context:
-File: controllers/front/IdentityController.php:57</note>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderDetailController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0c478a7069ab13f446e9e765cffd1550">
+        <source>Message successfully sent</source>
+        <target>Message successfully sent</target>
+        <note>Line: 180</note>
       </trans-unit>
     </body>
   </file>
@@ -71,14 +60,12 @@ File: controllers/front/IdentityController.php:57</note>
       <trans-unit id="6e05d9291d7796566bb503890da070bf">
         <source>If this email address has been registered in our shop, you will receive a link to reset your password at %email%.</source>
         <target>If this email address has been registered in our shop, you will receive a link to reset your password at %email%.</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:99</note>
+        <note>Line: 99</note>
       </trans-unit>
       <trans-unit id="19b1f74d6e96f3db9805e8d5c9301b7a">
         <source>Your password has been successfully reset and a confirmation has been sent to your email address: %s</source>
         <target>Your password has been successfully reset and a confirmation has been sent to your email address: %s</target>
-        <note>Context:
-File: controllers/front/PasswordController.php:180</note>
+        <note>Line: 180</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopNotificationsWarning.xlf
+++ b/app/Resources/translations/default/ShopNotificationsWarning.xlf
@@ -1,38 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/front/HistoryController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/controller/FrontController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="116cb47fe026f7a3679486e086426a64">
-        <source>If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.</source>
-        <target>If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.</target>
-        <note>Context:
-File: controllers/front/HistoryController.php:52</note>
-      </trans-unit>
-      <trans-unit id="5acc2ceeb883ba07cef2d02ea382f242">
-        <source>You have not placed any orders.</source>
-        <target>You have not placed any orders.</target>
-        <note>Context:
-File: controllers/front/HistoryController.php:58</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f9ddd507fdf437437efdcb333a0f4ff0">
-        <source>This product is not visible to your customers.</source>
-        <target>This product is not visible to your customers.</target>
-        <note>Context:
-File: controllers/front/ProductController.php:173</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/GuestTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d22c170769e81d2229b17003553b6d57">
-        <source>You cannot return merchandise with a guest account.</source>
-        <target>You cannot return merchandise with a guest account.</target>
-        <note>Context:
-File: controllers/front/GuestTrackingController.php:131</note>
+      <trans-unit id="c8baafa963dab58836b08b5acdedc07a">
+        <source>You cannot place a new order from your country (%s).</source>
+        <target>You cannot place a new order from your country (%s).</target>
+        <note>Line: 886</note>
       </trans-unit>
     </body>
   </file>
@@ -41,8 +14,30 @@ File: controllers/front/GuestTrackingController.php:131</note>
       <trans-unit id="d3f5baf7537ec2a40ade00599a8da8c6">
         <source>You do not have any vouchers.</source>
         <target>You do not have any vouchers.</target>
-        <note>Context:
-File: controllers/front/DiscountController.php:47</note>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/GuestTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d22c170769e81d2229b17003553b6d57">
+        <source>You cannot return merchandise with a guest account.</source>
+        <target>You cannot return merchandise with a guest account.</target>
+        <note>Line: 131</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/HistoryController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="116cb47fe026f7a3679486e086426a64">
+        <source>If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.</source>
+        <target>If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="5acc2ceeb883ba07cef2d02ea382f242">
+        <source>You have not placed any orders.</source>
+        <target>You have not placed any orders.</target>
+        <note>Line: 58</note>
       </trans-unit>
     </body>
   </file>
@@ -51,8 +46,7 @@ File: controllers/front/DiscountController.php:47</note>
       <trans-unit id="44a9edeffb86277f007fa90d96689a6d">
         <source>You must wait for confirmation before returning any merchandise.</source>
         <target>You must wait for confirmation before returning any merchandise.</target>
-        <note>Context:
-File: controllers/front/OrderReturnController.php:56</note>
+        <note>Line: 56</note>
       </trans-unit>
     </body>
   </file>
@@ -61,18 +55,16 @@ File: controllers/front/OrderReturnController.php:56</note>
       <trans-unit id="0ba830b7ca1513a4882ce5aac84030b8">
         <source>You have not received any credit slips.</source>
         <target>You have not received any credit slips.</target>
-        <note>Context:
-File: controllers/front/OrderSlipController.php:47</note>
+        <note>Line: 47</note>
       </trans-unit>
     </body>
   </file>
-  <file original="classes/controller/FrontController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/front/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="c8baafa963dab58836b08b5acdedc07a">
-        <source>You cannot place a new order from your country (%s).</source>
-        <target>You cannot place a new order from your country (%s).</target>
-        <note>Context:
-File: classes/controller/FrontController.php:890</note>
+      <trans-unit id="f9ddd507fdf437437efdcb333a0f4ff0">
+        <source>This product is not visible to your customers.</source>
+        <target>This product is not visible to your customers.</target>
+        <note>Line: 173</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopPdf.xlf
+++ b/app/Resources/translations/default/ShopPdf.xlf
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="classes/pdf/HTMLTemplateOrderReturn.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/pdf/HTMLTemplateDeliverySlip.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="cc894fffb019b528d12951b74d6d2b6e">
-        <source>Order return</source>
-        <target>Order return</target>
-        <note>Context:
-File: classes/pdf/HTMLTemplateOrderReturn.php:120</note>
+      <trans-unit id="065ab3a28ca4f16f55f103adc7d0226f">
+        <source>Delivery</source>
+        <target>Delivery</target>
+        <note>Line: 73</note>
       </trans-unit>
     </body>
   </file>
@@ -15,36 +14,21 @@ File: classes/pdf/HTMLTemplateOrderReturn.php:120</note>
       <trans-unit id="466eadd40b3c10580e3ab4e8061161ce">
         <source>Invoice</source>
         <target>Invoice</target>
-        <note>Context:
-File: classes/pdf/HTMLTemplateInvoice.php:75</note>
+        <note>Line: 75</note>
       </trans-unit>
       <trans-unit id="a271cee71f5c411446db4f90676dbc96">
         <source>%taxrate%%space%%</source>
         <target>%taxrate%%space%%</target>
-        <note>Context:
-File: classes/pdf/HTMLTemplateInvoice.php:187</note>
+        <note>Line: 187</note>
       </trans-unit>
     </body>
   </file>
-  <file original="classes/pdf/HTMLTemplateSupplyOrderForm.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/pdf/HTMLTemplateOrderReturn.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="f771e4a4df40bf061607fdb8e3f140dc">
-        <source>Supply order form</source>
-        <target>Supply order form</target>
-        <note>Context:
-File: classes/pdf/HTMLTemplateSupplyOrderForm.php:56</note>
-      </trans-unit>
-      <trans-unit id="37bd15f0a465c1b6e96e516cdeee41fa">
-        <source>TE: Tax excluded</source>
-        <target>TE: Tax excluded</target>
-        <note>Context:
-File: classes/pdf/HTMLTemplateSupplyOrderForm.php:197</note>
-      </trans-unit>
-      <trans-unit id="8bcc82aa54d3755fffa1f1d4cbd8e95d">
-        <source>TI: Tax included</source>
-        <target>TI: Tax included</target>
-        <note>Context:
-File: classes/pdf/HTMLTemplateSupplyOrderForm.php:198</note>
+      <trans-unit id="cc894fffb019b528d12951b74d6d2b6e">
+        <source>Order return</source>
+        <target>Order return</target>
+        <note>Line: 120</note>
       </trans-unit>
     </body>
   </file>
@@ -53,264 +37,68 @@ File: classes/pdf/HTMLTemplateSupplyOrderForm.php:198</note>
       <trans-unit id="cf3bae95c5f6023d5a10fe415b205a45">
         <source>Credit slip</source>
         <target>Credit slip</target>
-        <note>Context:
-File: classes/pdf/HTMLTemplateOrderSlip.php:73</note>
+        <note>Line: 73</note>
       </trans-unit>
     </body>
   </file>
-  <file original="classes/pdf/HTMLTemplateDeliverySlip.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/pdf/HTMLTemplateSupplyOrderForm.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="065ab3a28ca4f16f55f103adc7d0226f">
-        <source>Delivery</source>
-        <target>Delivery</target>
-        <note>Context:
-File: classes/pdf/HTMLTemplateDeliverySlip.php:73</note>
+      <trans-unit id="f771e4a4df40bf061607fdb8e3f140dc">
+        <source>Supply order form</source>
+        <target>Supply order form</target>
+        <note>Line: 56</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="pdf/order-return.summary-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="88be9ea838e21273267409d76af3b284">
-        <source>We have logged your return request.</source>
-        <target>We have logged your return request.</target>
-        <note>Context:
-File: pdf/order-return.summary-tab.tpl:25</note>
+      <trans-unit id="37bd15f0a465c1b6e96e516cdeee41fa">
+        <source>TE: Tax excluded</source>
+        <target>TE: Tax excluded</target>
+        <note>Line: 197</note>
       </trans-unit>
-      <trans-unit id="dd0b8feb4eb6c389c284518f5683017c">
-        <source>Your package must be returned to us within</source>
-        <target>Your package must be returned to us within</target>
-        <note>Context:
-File: pdf/order-return.summary-tab.tpl:26</note>
-      </trans-unit>
-      <trans-unit id="ea62a2e28a800c367509773730120a67">
-        <source>days of receiving your order.</source>
-        <target>days of receiving your order.</target>
-        <note>Context:
-File: pdf/order-return.summary-tab.tpl:26</note>
-      </trans-unit>
-      <trans-unit id="f74ddd24db1322dfc89f1a9a61fd573f">
-        <source>Return Number</source>
-        <target>Return Number</target>
-        <note>Context:
-File: pdf/order-return.summary-tab.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="44749712dbec183e983dcd78a7736c41">
-        <source>Date</source>
-        <target>Date</target>
-        <note>Context:
-File: pdf/order-return.summary-tab.tpl:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="pdf/invoice.note-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3b0649c72650c313a357338dcdfb64ec">
-        <source>Note</source>
-        <target>Note</target>
-        <note>Context:
-File: pdf/invoice.note-tab.tpl:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="pdf/invoice.total-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b0f79042ac83c64f3ccc42268c8ade26">
-        <source>Total Products</source>
-        <target>Total Products</target>
-        <note>Context:
-File: pdf/invoice.total-tab.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="dd704458c6b79d0e86d171f1523918c3">
-        <source>Total Discounts</source>
-        <target>Total Discounts</target>
-        <note>Context:
-File: pdf/invoice.total-tab.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="f54bdce4ab4d26c259216da67b9d6431">
-        <source>Shipping Costs</source>
-        <target>Shipping Costs</target>
-        <note>Context:
-File: pdf/invoice.total-tab.tpl:51</note>
-      </trans-unit>
-      <trans-unit id="b00b85425e74ed2c85dc3119b78ff2c3">
-        <source>Free Shipping</source>
-        <target>Free Shipping</target>
-        <note>Context:
-File: pdf/invoice.total-tab.tpl:57</note>
-      </trans-unit>
-      <trans-unit id="0de13e783f21b3b923528cdf6bca43f5">
-        <source>Wrapping Costs</source>
-        <target>Wrapping Costs</target>
-        <note>Context:
-File: pdf/invoice.total-tab.tpl:66</note>
-      </trans-unit>
-      <trans-unit id="b94cb106eaa958b2ab473da305e57977">
-        <source>Total (Tax excl.)</source>
-        <target>Total (Tax excl.)</target>
-        <note>Context:
-File: pdf/invoice.total-tab.tpl:74</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="pdf/invoice.tax-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b602e0d0c6a72053d0a5be60cb2f8126">
-        <source>Total Tax</source>
-        <target>Total Tax</target>
-        <note>Context:
-File: pdf/invoice.tax-tab.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="ad0d28cdd9113d3ce911bc064b137cde">
-        <source>Base price</source>
-        <target>Base price</target>
-        <note>Context:
-File: pdf/invoice.tax-tab.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="8a2d7d9c237b2af40f2659aa76f0bd84">
-        <source>Exempt of VAT according to section 259B of the General Tax Code.</source>
-        <target>Exempt of VAT according to section 259B of the General Tax Code.</target>
-        <note>Context:
-File: pdf/invoice.tax-tab.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="023f66b09075fa1cc29e74bed9f5ac40">
-        <source>Tax Detail</source>
-        <target>Tax Detail</target>
-        <note>Context:
-File: pdf/invoice.tax-tab.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="068f80c7519d0528fb08e82137a72131">
-        <source>Products</source>
-        <target>Products</target>
-        <note>Context:
-File: pdf/invoice.tax-tab.tpl:58</note>
-      </trans-unit>
-      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
-        <source>Shipping</source>
-        <target>Shipping</target>
-        <note>Context:
-File: pdf/invoice.tax-tab.tpl:60</note>
-      </trans-unit>
-      <trans-unit id="e92cfa244b5eb9025d07522080468445">
-        <source>Ecotax</source>
-        <target>Ecotax</target>
-        <note>Context:
-File: pdf/invoice.tax-tab.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="ba794350deb07c0c96fe73bd12239059">
-        <source>Wrapping</source>
-        <target>Wrapping</target>
-        <note>Context:
-File: pdf/invoice.tax-tab.tpl:64</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="pdf/invoice.product-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="96b0141273eabab320119c467cdcaf17">
-        <source>Total</source>
-        <target>Total</target>
-        <note>Context:
-File: pdf/invoice.product-tab.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="deb10517653c255364175796ace3553f">
-        <source>Product</source>
-        <target>Product</target>
-        <note>Context:
-File: pdf/invoice.product-tab.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="1ac6ee29e9e68fb71bad91c1d34348cc">
-        <source>%s:</source>
-        <target>%s:</target>
-        <note>Context:
-File: pdf/invoice.product-tab.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="1be15dd275084ad2cae8f2aaa604c110">
-        <source>image(s):</source>
-        <target>image(s):</target>
-        <note>Context:
-File: pdf/invoice.product-tab.tpl:124</note>
-      </trans-unit>
-      <trans-unit id="9fec2102dd0b5b29d6cdf9d5614fabf7">
-        <source>(Tax excl.)</source>
-        <target>(Tax excl.)</target>
-        <note>Context:
-File: pdf/invoice.product-tab.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="197101c4a1b1fc503dcd6ebee127aa10">
-        <source>Unit Price</source>
-        <target>Unit Price</target>
-        <note>Context:
-File: pdf/invoice.product-tab.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="49005859f978fcb0dfddcf676e841245">
-        <source>ecotax: %s</source>
-        <target>ecotax: %s</target>
-        <note>Context:
-File: pdf/invoice.product-tab.tpl:91</note>
-      </trans-unit>
-      <trans-unit id="9d5bf15117441a1b52eb1f0808e4aad3">
-        <source>Discounts</source>
-        <target>Discounts</target>
-        <note>Context:
-File: pdf/invoice.product-tab.tpl:156</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="pdf/invoice.payment-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="707436a5aa13b82a4d777f64c717a625">
-        <source>Payment Method</source>
-        <target>Payment Method</target>
-        <note>Context:
-File: pdf/invoice.payment-tab.tpl:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="pdf/delivery-slip.payment-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e40007b408ac5f66d2c2e6c54f787c99">
-        <source>No payment</source>
-        <target>No payment</target>
-        <note>Context:
-File: pdf/delivery-slip.payment-tab.tpl:37</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="pdf/delivery-slip.summary-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
-        <source>Carrier</source>
-        <target>Carrier</target>
-        <note>Context:
-File: pdf/delivery-slip.summary-tab.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="6fbc355a02359656f1e4540d58b784e1">
-        <source>Order Date</source>
-        <target>Order Date</target>
-        <note>Context:
-File: pdf/delivery-slip.summary-tab.tpl:28</note>
+      <trans-unit id="8bcc82aa54d3755fffa1f1d4cbd8e95d">
+        <source>TI: Tax included</source>
+        <target>TI: Tax included</target>
+        <note>Line: 198</note>
       </trans-unit>
     </body>
   </file>
   <file original="pdf/delivery-slip.addresses-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="2f2f0f119a907c6c67a3c6fcde0193ab">
-        <source>Delivery Address</source>
-        <target>Delivery Address</target>
-        <note>Context:
-File: pdf/delivery-slip.addresses-tab.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="28a59051cd90053f87bacd5f1ffbc0b8">
-        <source>Billing Address</source>
-        <target>Billing Address</target>
-        <note>Context:
-File: pdf/delivery-slip.addresses-tab.tpl:35</note>
-      </trans-unit>
       <trans-unit id="e2f324b87eac820c81e4d4a1105dcddf">
         <source><![CDATA[Billing & Delivery Address]]></source>
         <target><![CDATA[Billing & Delivery Address]]></target>
-        <note>Context:
-File: pdf/delivery-slip.addresses-tab.tpl:39</note>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/delivery-slip.payment-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="707436a5aa13b82a4d777f64c717a625">
+        <source>Payment Method</source>
+        <target>Payment Method</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="e40007b408ac5f66d2c2e6c54f787c99">
+        <source>No payment</source>
+        <target>No payment</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/delivery-slip.product-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="deb10517653c255364175796ace3553f">
+        <source>Product</source>
+        <target>Product</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="1ac6ee29e9e68fb71bad91c1d34348cc">
+        <source>%s:</source>
+        <target>%s:</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="1be15dd275084ad2cae8f2aaa604c110">
+        <source>image(s):</source>
+        <target>image(s):</target>
+        <note>Line: 95</note>
       </trans-unit>
     </body>
   </file>
@@ -319,86 +107,175 @@ File: pdf/delivery-slip.addresses-tab.tpl:39</note>
       <trans-unit id="ff5db4935fb0fbf583796b50f05e25bc">
         <source>An electronic version of this invoice is available in your account. To access it, log in to our website using your e-mail address and password (which you created when placing your first order).</source>
         <target>An electronic version of this invoice is available in your account. To access it, log in to our website using your e-mail address and password (which you created when placing your first order).</target>
-        <note>Context:
-File: pdf/footer.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
     </body>
   </file>
-  <file original="pdf/supply-order-footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="pdf/invoice.addresses-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="59aac4eb50a8249cbc9c12240c6a0a14">
-        <source>For more assistance, contact Support:</source>
-        <target>For more assistance, contact Support:</target>
-        <note>Context:
-File: pdf/supply-order-footer.tpl:31</note>
+      <trans-unit id="2f2f0f119a907c6c67a3c6fcde0193ab">
+        <source>Delivery Address</source>
+        <target>Delivery Address</target>
+        <note>Line: 27</note>
       </trans-unit>
-      <trans-unit id="baf85890915b2793aac2b3282f0ea175">
-        <source>Tel: %s</source>
-        <target>Tel: %s</target>
-        <note>Context:
-File: pdf/supply-order-footer.tpl:33</note>
-      </trans-unit>
-      <trans-unit id="38b35526b23761f26b29a19af18df6e5">
-        <source>Fax: %s</source>
-        <target>Fax: %s</target>
-        <note>Context:
-File: pdf/supply-order-footer.tpl:37</note>
+      <trans-unit id="28a59051cd90053f87bacd5f1ffbc0b8">
+        <source>Billing Address</source>
+        <target>Billing Address</target>
+        <note>Line: 31</note>
       </trans-unit>
     </body>
   </file>
-  <file original="pdf/order-return.product-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="pdf/invoice.note-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca">
-        <source>Reference</source>
-        <target>Reference</target>
-        <note>Context:
-File: pdf/order-return.product-tab.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="03ab340b3f99e03cff9e84314ead38c0">
-        <source>Qty</source>
-        <target>Qty</target>
-        <note>Context:
-File: pdf/order-return.product-tab.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="adcf8d924285bef43f517d8f6c040e97">
-        <source>Items to be returned</source>
-        <target>Items to be returned</target>
-        <note>Context:
-File: pdf/order-return.product-tab.tpl:29</note>
+      <trans-unit id="3b0649c72650c313a357338dcdfb64ec">
+        <source>Note</source>
+        <target>Note</target>
+        <note>Line: 34</note>
       </trans-unit>
     </body>
   </file>
-  <file original="pdf/supply-order.tax-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="pdf/invoice.product-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="9fec2102dd0b5b29d6cdf9d5614fabf7">
+        <source>(Tax excl.)</source>
+        <target>(Tax excl.)</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="197101c4a1b1fc503dcd6ebee127aa10">
+        <source>Unit Price</source>
+        <target>Unit Price</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="49005859f978fcb0dfddcf676e841245">
+        <source>ecotax: %s</source>
+        <target>ecotax: %s</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="9d5bf15117441a1b52eb1f0808e4aad3">
+        <source>Discounts</source>
+        <target>Discounts</target>
+        <note>Line: 156</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/invoice.shipping-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
+        <source>Carrier</source>
+        <target>Carrier</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/invoice.summary-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4e065ba1bec1d62b2d5450256612fa96">
+        <source>Invoice Number</source>
+        <target>Invoice Number</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="440ac606343b8a66acad0d2978786d2a">
+        <source>Invoice Date</source>
+        <target>Invoice Date</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="559e7ca805230fc80e3644f87bb3994d">
+        <source>Order date</source>
+        <target>Order date</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/invoice.tax-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b602e0d0c6a72053d0a5be60cb2f8126">
+        <source>Total Tax</source>
+        <target>Total Tax</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="ad0d28cdd9113d3ce911bc064b137cde">
+        <source>Base price</source>
+        <target>Base price</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="8a2d7d9c237b2af40f2659aa76f0bd84">
+        <source>Exempt of VAT according to section 259B of the General Tax Code.</source>
+        <target>Exempt of VAT according to section 259B of the General Tax Code.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="023f66b09075fa1cc29e74bed9f5ac40">
+        <source>Tax Detail</source>
+        <target>Tax Detail</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="068f80c7519d0528fb08e82137a72131">
+        <source>Products</source>
+        <target>Products</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
+        <source>Shipping</source>
+        <target>Shipping</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="e92cfa244b5eb9025d07522080468445">
+        <source>Ecotax</source>
+        <target>Ecotax</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="ba794350deb07c0c96fe73bd12239059">
+        <source>Wrapping</source>
+        <target>Wrapping</target>
+        <note>Line: 64</note>
+      </trans-unit>
       <trans-unit id="8fe77c2601e54f1aaef28cfde997bbad">
         <source>Tax Rate</source>
         <target>Tax Rate</target>
-        <note>Context:
-File: pdf/supply-order.tax-tab.tpl:31</note>
+        <note>Line: 36</note>
       </trans-unit>
       <trans-unit id="baf5d10866a7a240830dcf34f29d2d11">
         <source>No taxes</source>
         <target>No taxes</target>
-        <note>Context:
-File: pdf/supply-order.tax-tab.tpl:50</note>
+        <note>Line: 92</note>
       </trans-unit>
-      <trans-unit id="716be2c7de31f063369ca297a9928403">
-        <source>Taxes:</source>
-        <target>Taxes:</target>
-        <note>Context:
-File: pdf/supply-order.tax-tab.tpl:25</note>
+    </body>
+  </file>
+  <file original="pdf/invoice.total-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b0f79042ac83c64f3ccc42268c8ade26">
+        <source>Total Products</source>
+        <target>Total Products</target>
+        <note>Line: 29</note>
       </trans-unit>
-      <trans-unit id="f4a232c48df10124ee867767a4e7280e">
-        <source>Base TE</source>
-        <target>Base TE</target>
-        <note>Context:
-File: pdf/supply-order.tax-tab.tpl:30</note>
+      <trans-unit id="dd704458c6b79d0e86d171f1523918c3">
+        <source>Total Discounts</source>
+        <target>Total Discounts</target>
+        <note>Line: 40</note>
       </trans-unit>
-      <trans-unit id="01a2436b8e3782c1f99e6b26adf901b2">
-        <source>Tax Value</source>
-        <target>Tax Value</target>
-        <note>Context:
-File: pdf/supply-order.tax-tab.tpl:32</note>
+      <trans-unit id="f54bdce4ab4d26c259216da67b9d6431">
+        <source>Shipping Costs</source>
+        <target>Shipping Costs</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="b00b85425e74ed2c85dc3119b78ff2c3">
+        <source>Free Shipping</source>
+        <target>Free Shipping</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="0de13e783f21b3b923528cdf6bca43f5">
+        <source>Wrapping Costs</source>
+        <target>Wrapping Costs</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="b94cb106eaa958b2ab473da305e57977">
+        <source>Total (Tax excl.)</source>
+        <target>Total (Tax excl.)</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="96b0141273eabab320119c467cdcaf17">
+        <source>Total</source>
+        <target>Total</target>
+        <note>Line: 92</note>
       </trans-unit>
     </body>
   </file>
@@ -407,38 +284,80 @@ File: pdf/supply-order.tax-tab.tpl:32</note>
       <trans-unit id="583aef07f75a57bda4f3ea63f9666ad1">
         <source>If the following conditions are not met, we reserve the right to refuse your package and/or refund:</source>
         <target>If the following conditions are not met, we reserve the right to refuse your package and/or refund:</target>
-        <note>Context:
-File: pdf/order-return.conditions-tab.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="20f3d1a3e717b7de53d14f0d3848a1c8">
         <source>Please include this return reference on your return package:</source>
         <target>Please include this return reference on your return package:</target>
-        <note>Context:
-File: pdf/order-return.conditions-tab.tpl:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="38134e53d40c6e4288f27868aa79d63f">
         <source>All products must be returned in their original package and condition, unused and without damage.</source>
         <target>All products must be returned in their original package and condition, unused and without damage.</target>
-        <note>Context:
-File: pdf/order-return.conditions-tab.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="34bfda153cbe51eef5d4a88cdd7b616d">
         <source>Please print out this document and slip it into your package.</source>
         <target>Please print out this document and slip it into your package.</target>
-        <note>Context:
-File: pdf/order-return.conditions-tab.tpl:34</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="c7711fbc0d8f010e06a306cc63ef5393">
         <source>The package should be sent to the following address:</source>
         <target>The package should be sent to the following address:</target>
-        <note>Context:
-File: pdf/order-return.conditions-tab.tpl:35</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="141fe419586cdebe331fd7317e88954c">
         <source>Upon receiving your package, we will notify you by e-mail. We will then begin processing the refund, if applicable. Let us know if you have any questions</source>
         <target>Upon receiving your package, we will notify you by e-mail. We will then begin processing the refund, if applicable. Let us know if you have any questions</target>
-        <note>Context:
-File: pdf/order-return.conditions-tab.tpl:42</note>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/order-return.product-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca">
+        <source>Reference</source>
+        <target>Reference</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="03ab340b3f99e03cff9e84314ead38c0">
+        <source>Qty</source>
+        <target>Qty</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="adcf8d924285bef43f517d8f6c040e97">
+        <source>Items to be returned</source>
+        <target>Items to be returned</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/order-return.summary-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="88be9ea838e21273267409d76af3b284">
+        <source>We have logged your return request.</source>
+        <target>We have logged your return request.</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="dd0b8feb4eb6c389c284518f5683017c">
+        <source>Your package must be returned to us within</source>
+        <target>Your package must be returned to us within</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="ea62a2e28a800c367509773730120a67">
+        <source>days of receiving your order.</source>
+        <target>days of receiving your order.</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="f74ddd24db1322dfc89f1a9a61fd573f">
+        <source>Return Number</source>
+        <target>Return Number</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="44749712dbec183e983dcd78a7736c41">
+        <source>Date</source>
+        <target>Date</target>
+        <note>Line: 31</note>
       </trans-unit>
     </body>
   </file>
@@ -447,176 +366,56 @@ File: pdf/order-return.conditions-tab.tpl:42</note>
       <trans-unit id="1a22913fb1b16ada25c2637af9d44013">
         <source>Product / Reference</source>
         <target>Product / Reference</target>
-        <note>Context:
-File: pdf/order-slip.product-tab.tpl:30</note>
+        <note>Line: 30</note>
       </trans-unit>
       <trans-unit id="6c957f72dc8cdacc75762f2cbdcdfaf2">
         <source>Unit price</source>
         <target>Unit price</target>
-        <note>Context:
-File: pdf/order-slip.product-tab.tpl:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="078ac079d154d21533c57bced9fcb10f">
         <source>(Tax Excl.)</source>
         <target>(Tax Excl.)</target>
-        <note>Context:
-File: pdf/order-slip.product-tab.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="29103375229a5c363403ec4afb5c3e8f">
         <source>(Tax Incl.)</source>
         <target>(Tax Incl.)</target>
-        <note>Context:
-File: pdf/order-slip.product-tab.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="3601146c4e948c32b6424d2c0a7f0118">
         <source>Price</source>
         <target>Price</target>
-        <note>Context:
-File: pdf/order-slip.product-tab.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="720a61482c95ee6def09718b963f8fa0">
         <source>No details</source>
         <target>No details</target>
-        <note>Context:
-File: pdf/order-slip.product-tab.tpl:41</note>
+        <note>Line: 41</note>
       </trans-unit>
       <trans-unit id="1d744a9ad1dac20645cfc4a36b77323b">
         <source>image(s)</source>
         <target>image(s)</target>
-        <note>Context:
-File: pdf/order-slip.product-tab.tpl:84</note>
+        <note>Line: 84</note>
       </trans-unit>
     </body>
   </file>
-  <file original="pdf/invoice.summary-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="pdf/order-slip.summary-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="6fbc355a02359656f1e4540d58b784e1">
+        <source>Order Date</source>
+        <target>Order Date</target>
+        <note>Line: 28</note>
+      </trans-unit>
       <trans-unit id="1e860e56970a81a1ba3e1fcb7fccc846">
         <source>Order Reference</source>
         <target>Order Reference</target>
-        <note>Context:
-File: pdf/invoice.summary-tab.tpl:29</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="c462960a6bd53db34f778d0562703ad3">
         <source>VAT Number</source>
         <target>VAT Number</target>
-        <note>Context:
-File: pdf/invoice.summary-tab.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="4e065ba1bec1d62b2d5450256612fa96">
-        <source>Invoice Number</source>
-        <target>Invoice Number</target>
-        <note>Context:
-File: pdf/invoice.summary-tab.tpl:27</note>
-      </trans-unit>
-      <trans-unit id="440ac606343b8a66acad0d2978786d2a">
-        <source>Invoice Date</source>
-        <target>Invoice Date</target>
-        <note>Context:
-File: pdf/invoice.summary-tab.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="559e7ca805230fc80e3644f87bb3994d">
-        <source>Order date</source>
-        <target>Order date</target>
-        <note>Context:
-File: pdf/invoice.summary-tab.tpl:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="pdf/supply-order.total-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1300f86974cafc2d65eb1f082a26bdf1">
-        <source>Summary:</source>
-        <target>Summary:</target>
-        <note>Context:
-File: pdf/supply-order.total-tab.tpl:25</note>
-      </trans-unit>
-      <trans-unit id="d1f223eb051fae871c3c29a0777e95aa">
-        <source>(Before discount)</source>
-        <target>(Before discount)</target>
-        <note>Context:
-File: pdf/supply-order.total-tab.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="6b9e9f2472786ed1e76005bfc37bc8af">
-        <source>Order Discount</source>
-        <target>Order Discount</target>
-        <note>Context:
-File: pdf/supply-order.total-tab.tpl:36</note>
-      </trans-unit>
-      <trans-unit id="99d48dba6b2b30a09c4a84a2912a5e5d">
-        <source>(After discount)</source>
-        <target>(After discount)</target>
-        <note>Context:
-File: pdf/supply-order.total-tab.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="699e6bd4690ed3bd5f658052e12aba04">
-        <source>Tax value</source>
-        <target>Tax value</target>
-        <note>Context:
-File: pdf/supply-order.total-tab.tpl:48</note>
-      </trans-unit>
-      <trans-unit id="8cc072b14a8fda0c4f9aa0c166471cc9">
-        <source>Total to pay</source>
-        <target>Total to pay</target>
-        <note>Context:
-File: pdf/supply-order.total-tab.tpl:60</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="pdf/supply-order.product-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3a6a6d37bea2c7567f8599ea88b47930">
-        <source>Total TE</source>
-        <target>Total TE</target>
-        <note>Context:
-File: pdf/supply-order.product-tab.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="fa2ce544158555e8f06c69dd9e681832">
-        <source>Total TI</source>
-        <target>Total TI</target>
-        <note>Context:
-File: pdf/supply-order.product-tab.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="66f6e4bbd0a0af1af6b54763871dd280">
-        <source>Products ordered:</source>
-        <target>Products ordered:</target>
-        <note>Context:
-File: pdf/supply-order.product-tab.tpl:25</note>
-      </trans-unit>
-      <trans-unit id="f107f5a9ee4ecea58d0f29ae7959baa8">
-        <source>Designation</source>
-        <target>Designation</target>
-        <note>Context:
-File: pdf/supply-order.product-tab.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="c8ba77264f6e923f5ee35abf3108ae7c">
-        <source>Unit Price TE</source>
-        <target>Unit Price TE</target>
-        <note>Context:
-File: pdf/supply-order.product-tab.tpl:34</note>
-      </trans-unit>
-      <trans-unit id="7521172dd37ba56442ea866ac18eb49d">
-        <source>Before discount</source>
-        <target>Before discount</target>
-        <note>Context:
-File: pdf/supply-order.product-tab.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="6703aa9936582b4381418f7d523370b4">
-        <source>Discount Rate</source>
-        <target>Discount Rate</target>
-        <note>Context:
-File: pdf/supply-order.product-tab.tpl:36</note>
-      </trans-unit>
-      <trans-unit id="a61109b693023aed557445989c517982">
-        <source>After discount</source>
-        <target>After discount</target>
-        <note>Context:
-File: pdf/supply-order.product-tab.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="20a34c4e30c5bbe1d3f870ac55f0d831">
-        <source>Tax rate</source>
-        <target>Tax rate</target>
-        <note>Context:
-File: pdf/supply-order.product-tab.tpl:38</note>
+        <note>Line: 30</note>
       </trans-unit>
     </body>
   </file>
@@ -625,44 +424,158 @@ File: pdf/supply-order.product-tab.tpl:38</note>
       <trans-unit id="f61e91b684fc1063894baa9e61fde630">
         <source>Shipping (Tax Excl.)</source>
         <target>Shipping (Tax Excl.)</target>
-        <note>Context:
-File: pdf/order-slip.total-tab.tpl:30</note>
+        <note>Line: 30</note>
       </trans-unit>
       <trans-unit id="4bcc004e904bd1b84d255a9953e242fd">
         <source>Shipping (Tax Incl.)</source>
         <target>Shipping (Tax Incl.)</target>
-        <note>Context:
-File: pdf/order-slip.total-tab.tpl:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="7926243ab60a08b15932021bf108c578">
         <source>Product Total (Tax Excl.)</source>
         <target>Product Total (Tax Excl.)</target>
-        <note>Context:
-File: pdf/order-slip.total-tab.tpl:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="984a93f9899bf0b0a250ba66f022c630">
         <source>Product Total (Tax Incl.)</source>
         <target>Product Total (Tax Incl.)</target>
-        <note>Context:
-File: pdf/order-slip.total-tab.tpl:54</note>
+        <note>Line: 54</note>
       </trans-unit>
       <trans-unit id="5082245495aa792b3d0874088d2b111b">
         <source>Product Total</source>
         <target>Product Total</target>
-        <note>Context:
-File: pdf/order-slip.total-tab.tpl:64</note>
+        <note>Line: 64</note>
       </trans-unit>
       <trans-unit id="4118e1a6606ae9bff5134ba3cf50db67">
         <source>Total (Tax Excl.)</source>
         <target>Total (Tax Excl.)</target>
-        <note>Context:
-File: pdf/order-slip.total-tab.tpl:87</note>
+        <note>Line: 87</note>
       </trans-unit>
       <trans-unit id="11ef70f0c7f9fed90c43dffb9a0e813e">
         <source>Total (Tax Incl.)</source>
         <target>Total (Tax Incl.)</target>
-        <note>Context:
-File: pdf/order-slip.total-tab.tpl:103</note>
+        <note>Line: 103</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/supply-order-footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="59aac4eb50a8249cbc9c12240c6a0a14">
+        <source>For more assistance, contact Support:</source>
+        <target>For more assistance, contact Support:</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="baf85890915b2793aac2b3282f0ea175">
+        <source>Tel: %s</source>
+        <target>Tel: %s</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="38b35526b23761f26b29a19af18df6e5">
+        <source>Fax: %s</source>
+        <target>Fax: %s</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/supply-order.product-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3a6a6d37bea2c7567f8599ea88b47930">
+        <source>Total TE</source>
+        <target>Total TE</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="fa2ce544158555e8f06c69dd9e681832">
+        <source>Total TI</source>
+        <target>Total TI</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="66f6e4bbd0a0af1af6b54763871dd280">
+        <source>Products ordered:</source>
+        <target>Products ordered:</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="f107f5a9ee4ecea58d0f29ae7959baa8">
+        <source>Designation</source>
+        <target>Designation</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="c8ba77264f6e923f5ee35abf3108ae7c">
+        <source>Unit Price TE</source>
+        <target>Unit Price TE</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="7521172dd37ba56442ea866ac18eb49d">
+        <source>Before discount</source>
+        <target>Before discount</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="6703aa9936582b4381418f7d523370b4">
+        <source>Discount Rate</source>
+        <target>Discount Rate</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="a61109b693023aed557445989c517982">
+        <source>After discount</source>
+        <target>After discount</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="20a34c4e30c5bbe1d3f870ac55f0d831">
+        <source>Tax rate</source>
+        <target>Tax rate</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/supply-order.tax-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="716be2c7de31f063369ca297a9928403">
+        <source>Taxes:</source>
+        <target>Taxes:</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="f4a232c48df10124ee867767a4e7280e">
+        <source>Base TE</source>
+        <target>Base TE</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="01a2436b8e3782c1f99e6b26adf901b2">
+        <source>Tax Value</source>
+        <target>Tax Value</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="pdf/supply-order.total-tab.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1300f86974cafc2d65eb1f082a26bdf1">
+        <source>Summary:</source>
+        <target>Summary:</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="d1f223eb051fae871c3c29a0777e95aa">
+        <source>(Before discount)</source>
+        <target>(Before discount)</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="6b9e9f2472786ed1e76005bfc37bc8af">
+        <source>Order Discount</source>
+        <target>Order Discount</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="99d48dba6b2b30a09c4a84a2912a5e5d">
+        <source>(After discount)</source>
+        <target>(After discount)</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="699e6bd4690ed3bd5f658052e12aba04">
+        <source>Tax value</source>
+        <target>Tax value</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="8cc072b14a8fda0c4f9aa0c166471cc9">
+        <source>Total to pay</source>
+        <target>Total to pay</target>
+        <note>Line: 60</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopThemeActions.xlf
+++ b/app/Resources/translations/default/ShopThemeActions.xlf
@@ -1,44 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="themes/StarterTheme/templates/checkout/_partials/steps/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/front/AddressesController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="b15e1100a6196acba01ef7aaa5b2a9e5">
         <source>Add a new address</source>
         <target>Add a new address</target>
-        <note>Context:
-File: themes/StarterTheme/templates/checkout/_partials/steps/addresses.tpl:105</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_customersignin/ps_customersignin.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c87aacf5673fada1108c9f809d354311">
-        <source>Sign out</source>
-        <target>Sign out</target>
-        <note>Context:
-File: themes/classic/modules/ps_customersignin/ps_customersignin.tpl:34</note>
-      </trans-unit>
-      <trans-unit id="b6d4223e60986fa4c9af77ee5f7149c5">
-        <source>Sign in</source>
-        <target>Sign in</target>
-        <note>Context:
-File: themes/classic/modules/ps_customersignin/ps_customersignin.tpl:52</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_shoppingcart/ps_shoppingcart-product-line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1063e38cb53d94d386f21227fcd84717">
-        <source>Remove</source>
-        <target>Remove</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/ps_shoppingcart-product-line.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="4de8cf7f71c90bd5276f3eeb67da1803">
-        <source>remove from cart</source>
-        <target>remove from cart</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/ps_shoppingcart-product-line.tpl:42</note>
+        <note>Line: 55</note>
       </trans-unit>
     </body>
   </file>
@@ -47,70 +14,7 @@ File: themes/classic/modules/ps_shoppingcart/ps_shoppingcart-product-line.tpl:42
       <trans-unit id="a85eba4c6c699122b2bb1387ea4813ad">
         <source>Cart</source>
         <target>Cart</target>
-        <note>Context:
-File: modules/ps_shoppingcart/ps_shoppingcart.tpl:5</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/_partials/pagination.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dd1f775e443ff3b9a89270713580a51b">
-        <source>Previous</source>
-        <target>Previous</target>
-        <note>Context:
-File: themes/classic/templates/_partials/pagination.tpl:49</note>
-      </trans-unit>
-      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55">
-        <source>Next</source>
-        <target>Next</target>
-        <note>Context:
-File: themes/classic/templates/_partials/pagination.tpl:51</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/products.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7c491b68fcdc8169f7aadfffbafaf47d">
-        <source>Back to top</source>
-        <target>Back to top</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/products.tpl:40</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/miniatures/brand.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c61ab4204f572e9b3aa84a040e0dab31">
-        <source>View products</source>
-        <target>View products</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/miniatures/brand.tpl:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/product-add-to-cart.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2d0f6b8300be19cf35e89e66f0677f95">
-        <source>Add to cart</source>
-        <target>Add to cart</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-add-to-cart.tpl:53</note>
-      </trans-unit>
-      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
-        <source>Quantity</source>
-        <target>Quantity</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-add-to-cart.tpl:39</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/products-top.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d7778d0c64b6ba21494c97f77a66885a">
-        <source>Filter</source>
-        <target>Filter</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/products-top.tpl:43</note>
+        <note>Line: 5</note>
       </trans-unit>
     </body>
   </file>
@@ -124,22 +28,6 @@ File: themes/StarterTheme/templates/catalog/_partials/active_filters.tpl:34</not
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/catalog/_partials/product-customization.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fc35ec973f5b3a16f0d4b009834f39a6">
-        <source>Remove Image</source>
-        <target>Remove Image</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-customization.tpl:49</note>
-      </trans-unit>
-      <trans-unit id="f346acd7aed7508df8fec4da8353c81e">
-        <source>Save Customization</source>
-        <target>Save Customization</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-customization.tpl:62</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="themes/StarterTheme/templates/catalog/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="63a6a88c066880c5ac42394a22803ca6">
@@ -147,176 +35,6 @@ File: themes/classic/templates/catalog/_partials/product-customization.tpl:62</n
         <target>Refresh</target>
         <note>Context:
 File: themes/StarterTheme/templates/catalog/product.tpl:165</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d">
-        <source>Download</source>
-        <target>Download</target>
-        <note>Context:
-File: themes/classic/templates/catalog/product.tpl:212</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/contactform/views/templates/widget/contactform.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="94966d90747b97d1f0f206c98a8b1ac3">
-        <source>Send</source>
-        <target>Send</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:130</note>
-      </trans-unit>
-      <trans-unit id="cbe55e77ffa67d13322eb1ce7d22f1ba">
-        <source>Choose file</source>
-        <target>Choose file</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:92</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/address-selector-block.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c9cc8cce247e49bae79f15173ce97354">
-        <source>Save</source>
-        <target>Save</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/address-selector-block.tpl:69</note>
-      </trans-unit>
-      <trans-unit id="f2a6c498fb90ee345d997f888fce3b18">
-        <source>Delete</source>
-        <target>Delete</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/address-selector-block.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="7dce122004969d56ae2e0245cb754d35">
-        <source>Edit</source>
-        <target>Edit</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/address-selector-block.tpl:54</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/_partials/block-address.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="06933067aafd48425d67bcb01bba5cb6">
-        <source>Update</source>
-        <target>Update</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/block-address.tpl:36</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/history.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="332c80b1838dc515f5031e09da3b7f3f">
-        <source>Reorder</source>
-        <target>Reorder</target>
-        <note>Context:
-File: themes/classic/templates/customer/history.tpl:107</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5144a9adfce5a7d475bb8194a4a310a5">
-        <source>Create new address</source>
-        <target>Create new address</target>
-        <note>Context:
-File: themes/classic/templates/customer/addresses.tpl:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/password-email.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="733ae3eecadd5777cea5ce9a32379d7a">
-        <source>Send reset link</source>
-        <target>Send reset link</target>
-        <note>Context:
-File: themes/classic/templates/customer/password-email.tpl:58</note>
-      </trans-unit>
-      <trans-unit id="463e58c1d35fb5a4a8d717c99a60d257">
-        <source>Back to login</source>
-        <target>Back to login</target>
-        <note>Context:
-File: themes/classic/templates/customer/password-email.tpl:72</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/password-infos.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="95e6faaba5e8b016e5f9bcf5ea6c8270">
-        <source>Back to Login</source>
-        <target>Back to Login</target>
-        <note>Context:
-File: themes/classic/templates/customer/password-infos.tpl:48</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/order-follow.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="daf51d7d9e10e6a469434ae548d9a173">
-        <source>Print out</source>
-        <target>Print out</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-follow.tpl:88</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/password-new.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8f1e77e0d2be21da93cd4d9a939148f7">
-        <source>Change Password</source>
-        <target>Change Password</target>
-        <note>Context:
-File: themes/classic/templates/customer/password-new.tpl:76</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/StarterTheme/templates/checkout/_partials/cart-voucher.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="444bcb3a3fcf8389296c49467f27e1d6">
-        <source>ok</source>
-        <target>ok</target>
-        <note>Context:
-File: themes/StarterTheme/templates/checkout/_partials/cart-voucher.tpl:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/cart-voucher.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="12a7a93d72ded50311b52c7d0a853e3c">
-        <source>Take advantage of our exclusive offers:</source>
-        <target>Take advantage of our exclusive offers:</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/cart-voucher.tpl:70</note>
-      </trans-unit>
-      <trans-unit id="ec211f7c20af43e742bf2570c3cb84f9">
-        <source>Add</source>
-        <target>Add</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/cart-voucher.tpl:57</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/steps/shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a0bfb8e59e6c13fc8d990781f77694fe">
-        <source>Continue</source>
-        <target>Continue</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/shipping.tpl:111</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/address-form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ea4788705e6873b424c65e91c2846b19">
-        <source>Cancel</source>
-        <target>Cancel</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/address-form.tpl:42</note>
       </trans-unit>
     </body>
   </file>
@@ -330,13 +48,13 @@ File: themes/StarterTheme/templates/checkout/_partials/address-form.tpl:37</note
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/checkout/_partials/steps/payment.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="themes/StarterTheme/templates/checkout/_partials/cart-voucher.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="961f2247a2070bedff9f9cd8d64e2650">
-        <source>Choose</source>
-        <target>Choose</target>
+      <trans-unit id="444bcb3a3fcf8389296c49467f27e1d6">
+        <source>ok</source>
+        <target>ok</target>
         <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/payment.tpl:34</note>
+File: themes/StarterTheme/templates/checkout/_partials/cart-voucher.tpl:44</note>
       </trans-unit>
     </body>
   </file>
@@ -350,121 +68,31 @@ File: themes/StarterTheme/templates/checkout/_partials/steps/payment.tpl:115</no
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/checkout/cart-empty.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="themes/classic/modules/contactform/views/templates/widget/contactform.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="6ff063fbc860a79759a7369ac32cee22">
-        <source>Checkout</source>
-        <target>Checkout</target>
-        <note>Context:
-File: themes/classic/templates/checkout/cart-empty.tpl:39</note>
+      <trans-unit id="94966d90747b97d1f0f206c98a8b1ac3">
+        <source>Send</source>
+        <target>Send</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="cbe55e77ffa67d13322eb1ce7d22f1ba">
+        <source>Choose file</source>
+        <target>Choose file</target>
+        <note>Line: 92</note>
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/modules/ps_shoppingcart/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="themes/classic/modules/ps_customersignin/ps_customersignin.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="300225ee958b6350abc51805dab83c24">
-        <source>Continue shopping</source>
-        <target>Continue shopping</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/modal.tpl:66</note>
+      <trans-unit id="c87aacf5673fada1108c9f809d354311">
+        <source>Sign out</source>
+        <target>Sign out</target>
+        <note>Line: 34</note>
       </trans-unit>
-      <trans-unit id="7e0bf6d67701868aac3116ade8fea957">
-        <source>Proceed to checkout</source>
-        <target>Proceed to checkout</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/modal.tpl:67</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/_partials/form-fields.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="498f79c4c5bbde77f1bceb6c86fd0f6d">
-        <source>Show</source>
-        <target>Show</target>
-        <note>Context:
-File: themes/classic/templates/_partials/form-fields.tpl:152</note>
-      </trans-unit>
-      <trans-unit id="62a5e490880a92eef74f167d9dc6dca0">
-        <source>Hide</source>
-        <target>Hide</target>
-        <note>Context:
-File: themes/classic/templates/_partials/form-fields.tpl:150</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/sort-orders.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e0626222614bdee31951d84c64e5e9ff">
-        <source>Select</source>
-        <target>Select</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/sort-orders.tpl:33</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/miniatures/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c91e4ee170226d66e90f99ba917e4c20">
-        <source>Quick view</source>
-        <target>Quick view</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/miniatures/product.tpl:98</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/facets.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5015f5f6af450ad9492bc74f1059244b">
-        <source>Filter By</source>
-        <target>Filter By</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/facets.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="81aa2078d1eceede831b2976dbf32e62">
-        <source>Clear all</source>
-        <target>Clear all</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/facets.tpl:35</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/order-final-summary-table.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="de95b43bceeb4b998aed4aed5cef1ae7">
-        <source>edit</source>
-        <target>edit</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/order-final-summary-table.tpl:35</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/steps/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e512598333dceaaaf22889038b89a4a4">
-        <source>add new address</source>
-        <target>add new address</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/addresses.tpl:120</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/cart-summary.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="acb0f29bb6d39aaabc7d2d62aaa4a57d">
-        <source>show details</source>
-        <target>show details</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/cart-summary.tpl:38</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_sharebuttons/views/templates/hook/ps_sharebuttons.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5a95a425f74314a96f13a2f136992178">
-        <source>Share</source>
-        <target>Share</target>
-        <note>Context:
-File: themes/classic/modules/ps_sharebuttons/views/templates/hook/ps_sharebuttons.tpl:29</note>
+      <trans-unit id="b6d4223e60986fa4c9af77ee5f7149c5">
+        <source>Sign in</source>
+        <target>Sign in</target>
+        <note>Line: 52</note>
       </trans-unit>
     </body>
   </file>
@@ -473,18 +101,341 @@ File: themes/classic/modules/ps_sharebuttons/views/templates/hook/ps_sharebutton
       <trans-unit id="b26917587d98330d93f87808fc9d7267">
         <source>Subscribe</source>
         <target>Subscribe</target>
-        <note>Context:
-File: themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl:37</note>
+        <note>Line: 37</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_facetedsearch/ps_facetedsearch.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
       <trans-unit id="e0aa021e21dddbd6d8cecec71e9cf564">
         <source>OK</source>
         <target>OK</target>
-        <note>Context:
-File: themes/classic/modules/ps_facetedsearch/ps_facetedsearch.tpl:31</note>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_sharebuttons/views/templates/hook/ps_sharebuttons.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5a95a425f74314a96f13a2f136992178">
+        <source>Share</source>
+        <target>Share</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_shoppingcart/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="300225ee958b6350abc51805dab83c24">
+        <source>Continue shopping</source>
+        <target>Continue shopping</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="7e0bf6d67701868aac3116ade8fea957">
+        <source>Proceed to checkout</source>
+        <target>Proceed to checkout</target>
+        <note>Line: 67</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_shoppingcart/ps_shoppingcart-product-line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1063e38cb53d94d386f21227fcd84717">
+        <source>Remove</source>
+        <target>Remove</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="4de8cf7f71c90bd5276f3eeb67da1803">
+        <source>remove from cart</source>
+        <target>remove from cart</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/_partials/form-fields.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="498f79c4c5bbde77f1bceb6c86fd0f6d">
+        <source>Show</source>
+        <target>Show</target>
+        <note>Line: 152</note>
+      </trans-unit>
+      <trans-unit id="62a5e490880a92eef74f167d9dc6dca0">
+        <source>Hide</source>
+        <target>Hide</target>
+        <note>Line: 150</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/_partials/pagination.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dd1f775e443ff3b9a89270713580a51b">
+        <source>Previous</source>
+        <target>Previous</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55">
+        <source>Next</source>
+        <target>Next</target>
+        <note>Line: 51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/facets.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5015f5f6af450ad9492bc74f1059244b">
+        <source>Filter By</source>
+        <target>Filter By</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="81aa2078d1eceede831b2976dbf32e62">
+        <source>Clear all</source>
+        <target>Clear all</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/miniatures/brand.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c61ab4204f572e9b3aa84a040e0dab31">
+        <source>View products</source>
+        <target>View products</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/miniatures/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c91e4ee170226d66e90f99ba917e4c20">
+        <source>Quick view</source>
+        <target>Quick view</target>
+        <note>Line: 98</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-add-to-cart.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2d0f6b8300be19cf35e89e66f0677f95">
+        <source>Add to cart</source>
+        <target>Add to cart</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
+        <source>Quantity</source>
+        <target>Quantity</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-customization.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fc35ec973f5b3a16f0d4b009834f39a6">
+        <source>Remove Image</source>
+        <target>Remove Image</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="f346acd7aed7508df8fec4da8353c81e">
+        <source>Save Customization</source>
+        <target>Save Customization</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/products-top.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d7778d0c64b6ba21494c97f77a66885a">
+        <source>Filter</source>
+        <target>Filter</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/products.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7c491b68fcdc8169f7aadfffbafaf47d">
+        <source>Back to top</source>
+        <target>Back to top</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/sort-orders.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e0626222614bdee31951d84c64e5e9ff">
+        <source>Select</source>
+        <target>Select</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d">
+        <source>Download</source>
+        <target>Download</target>
+        <note>Line: 212</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/address-form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ea4788705e6873b424c65e91c2846b19">
+        <source>Cancel</source>
+        <target>Cancel</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/cart-summary.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="acb0f29bb6d39aaabc7d2d62aaa4a57d">
+        <source>show details</source>
+        <target>show details</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/cart-voucher.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="12a7a93d72ded50311b52c7d0a853e3c">
+        <source>Take advantage of our exclusive offers:</source>
+        <target>Take advantage of our exclusive offers:</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="ec211f7c20af43e742bf2570c3cb84f9">
+        <source>Add</source>
+        <target>Add</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/login-form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a0bfb8e59e6c13fc8d990781f77694fe">
+        <source>Continue</source>
+        <target>Continue</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/order-final-summary.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="de95b43bceeb4b998aed4aed5cef1ae7">
+        <source>edit</source>
+        <target>edit</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/steps/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e512598333dceaaaf22889038b89a4a4">
+        <source>add new address</source>
+        <target>add new address</target>
+        <note>Line: 120</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/steps/checkout-step.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7dce122004969d56ae2e0245cb754d35">
+        <source>Edit</source>
+        <target>Edit</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/steps/payment.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="961f2247a2070bedff9f9cd8d64e2650">
+        <source>Choose</source>
+        <target>Choose</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/cart-empty.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6ff063fbc860a79759a7369ac32cee22">
+        <source>Checkout</source>
+        <target>Checkout</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/block-address.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f2a6c498fb90ee345d997f888fce3b18">
+        <source>Delete</source>
+        <target>Delete</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="06933067aafd48425d67bcb01bba5cb6">
+        <source>Update</source>
+        <target>Update</target>
+        <note>Line: 36</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/customer-form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c9cc8cce247e49bae79f15173ce97354">
+        <source>Save</source>
+        <target>Save</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5144a9adfce5a7d475bb8194a4a310a5">
+        <source>Create new address</source>
+        <target>Create new address</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-detail.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="332c80b1838dc515f5031e09da3b7f3f">
+        <source>Reorder</source>
+        <target>Reorder</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-follow.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="daf51d7d9e10e6a469434ae548d9a173">
+        <source>Print out</source>
+        <target>Print out</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/password-email.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="733ae3eecadd5777cea5ce9a32379d7a">
+        <source>Send reset link</source>
+        <target>Send reset link</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="463e58c1d35fb5a4a8d717c99a60d257">
+        <source>Back to login</source>
+        <target>Back to login</target>
+        <note>Line: 72</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/password-infos.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="95e6faaba5e8b016e5f9bcf5ea6c8270">
+        <source>Back to Login</source>
+        <target>Back to Login</target>
+        <note>Line: 48</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/password-new.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8f1e77e0d2be21da93cd4d9a939148f7">
+        <source>Change Password</source>
+        <target>Change Password</target>
+        <note>Line: 76</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopThemeCatalog.xlf
+++ b/app/Resources/translations/default/ShopThemeCatalog.xlf
@@ -1,134 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="themes/classic/templates/catalog/listing/manufacturer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/controller/FrontController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="d0679d37c204278465192d34b1917c01">
-        <source>List of products by brand %brand_name%</source>
-        <target>List of products by brand %brand_name%</target>
-        <note>Context:
-File: themes/classic/templates/catalog/listing/manufacturer.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/listing/ManufacturerController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bd51980476ab3cd93603c9548fb78775">
-        <source>List of all brands</source>
-        <target>List of all brands</target>
-        <note>Context:
-File: controllers/front/listing/ManufacturerController.php:92</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/listing/SupplierController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="108b413416adf90e7c6f21a68bb02dd2">
-        <source>%number% products</source>
-        <target>%number% products</target>
-        <note>Context:
-File: controllers/front/listing/SupplierController.php:190</note>
-      </trans-unit>
-      <trans-unit id="8e7fb1213c4692b195ed6b7cf580d7f3">
-        <source>%number% product</source>
-        <target>%number% product</target>
-        <note>Context:
-File: controllers/front/listing/SupplierController.php:191</note>
-      </trans-unit>
-      <trans-unit id="d9e0619813f9247f8a506b9b1e61599f">
-        <source>List of all suppliers</source>
-        <target>List of all suppliers</target>
-        <note>Context:
-File: controllers/front/listing/SupplierController.php:94</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/listing/CategoryController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="aa89fd8bf65df5c1a1c11474bf2c16b5">
-        <source>Category: %category_name%</source>
-        <target>Category: %category_name%</target>
-        <note>Context:
-File: controllers/front/listing/CategoryController.php:269</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/SitemapController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="01f7ac959c1e6ebbb2e0ee706a7a5255">
-        <source>Best sellers</source>
-        <target>Best sellers</target>
-        <note>Context:
-File: controllers/front/SitemapController.php:157</note>
-      </trans-unit>
-      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
-        <source>Categories</source>
-        <target>Categories</target>
-        <note>Context:
-File: controllers/front/SitemapController.php:40</note>
-      </trans-unit>
-      <trans-unit id="453aceb005ceaf54a47da15fee8b2a26">
-        <source>Pages</source>
-        <target>Pages</target>
-        <note>Context:
-File: controllers/front/SitemapController.php:42</note>
-      </trans-unit>
-      <trans-unit id="c8f312df214e2295809027c6ca79d232">
-        <source>Price drop</source>
-        <target>Price drop</target>
-        <note>Context:
-File: controllers/front/SitemapController.php:162</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_specials/views/templates/hook/ps_specials.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="588907ab2d492aca0b07b5bf9c931eea">
-        <source>On sale</source>
-        <target>On sale</target>
-        <note>Context:
-File: themes/classic/modules/ps_specials/views/templates/hook/ps_specials.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="f95ceb82c51c99dc9b9e5678b291c44b">
-        <source>All sale products</source>
-        <target>All sale products</target>
-        <note>Context:
-File: themes/classic/modules/ps_specials/views/templates/hook/ps_specials.tpl:36</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9ff0635f5737513b1a6f559ac2bff745">
-        <source>New products</source>
-        <target>New products</target>
-        <note>Context:
-File: themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="60efcc704ef1456678f77eb9ee20847b">
-        <source>All new products</source>
-        <target>All new products</target>
-        <note>Context:
-File: themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl:36</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/listing/SearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="eb6b06cab0dd72e04c4da68d511facf2">
-        <source>Search results</source>
-        <target>Search results</target>
-        <note>Context:
-File: controllers/front/listing/SearchController.php:93</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/StarterTheme/templates/catalog/listing/supplier.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bcdf044a723993079e77ec66e4d6cbf2">
-        <source>List of products by supplier %supplier_name%</source>
-        <target>List of products by supplier %supplier_name%</target>
-        <note>Context:
-File: themes/StarterTheme/templates/catalog/listing/supplier.tpl:9</note>
+      <trans-unit id="104d9898c04874d0fbac36e125fa1369">
+        <source>Discount</source>
+        <target>Discount</target>
+        <note>Line: 1541</note>
       </trans-unit>
     </body>
   </file>
@@ -137,158 +14,120 @@ File: themes/StarterTheme/templates/catalog/listing/supplier.tpl:9</note>
       <trans-unit id="9dea4016dbcc290b773ab2fae678aaa8">
         <source>Items</source>
         <target>Items</target>
-        <note>Context:
-File: controllers/front/ProductController.php:1066</note>
+        <note>Line: 1068</note>
       </trans-unit>
       <trans-unit id="7d74f3b92b19da5e606d737d339a9679">
         <source>Item</source>
         <target>Item</target>
-        <note>Context:
-File: controllers/front/ProductController.php:1066</note>
+        <note>Line: 1068</note>
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/front/SitemapController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="84be54bb4bd1b755a27d86388700d097">
-        <source>Brands</source>
-        <target>Brands</target>
-        <note>Context:
-File: themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl:30</note>
+      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
+        <source>Categories</source>
+        <target>Categories</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="453aceb005ceaf54a47da15fee8b2a26">
+        <source>Pages</source>
+        <target>Pages</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="c8f312df214e2295809027c6ca79d232">
+        <source>Price drop</source>
+        <target>Price drop</target>
+        <note>Line: 162</note>
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/modules/ps_supplierlist/views/templates/hook/ps_supplierlist.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/front/listing/BestSalesController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="1814d65a76028fdfbadab64a5a8076df">
-        <source>Suppliers</source>
-        <target>Suppliers</target>
-        <note>Context:
-File: themes/classic/modules/ps_supplierlist/views/templates/hook/ps_supplierlist.tpl:30</note>
+      <trans-unit id="01f7ac959c1e6ebbb2e0ee706a7a5255">
+        <source>Best sellers</source>
+        <target>Best sellers</target>
+        <note>Line: 80</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/Adapter/PricesDrop/PricesDropProductSearchProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/front/listing/CategoryController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="aa89fd8bf65df5c1a1c11474bf2c16b5">
+        <source>Category: %category_name%</source>
+        <target>Category: %category_name%</target>
+        <note>Line: 269</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/ManufacturerController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bd51980476ab3cd93603c9548fb78775">
+        <source>List of all brands</source>
+        <target>List of all brands</target>
+        <note>Line: 92</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/SearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="eb6b06cab0dd72e04c4da68d511facf2">
+        <source>Search results</source>
+        <target>Search results</target>
+        <note>Line: 93</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/SupplierController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="108b413416adf90e7c6f21a68bb02dd2">
+        <source>%number% products</source>
+        <target>%number% products</target>
+        <note>Line: 190</note>
+      </trans-unit>
+      <trans-unit id="8e7fb1213c4692b195ed6b7cf580d7f3">
+        <source>%number% product</source>
+        <target>%number% product</target>
+        <note>Line: 191</note>
+      </trans-unit>
+      <trans-unit id="d9e0619813f9247f8a506b9b1e61599f">
+        <source>List of all suppliers</source>
+        <target>List of all suppliers</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="bcdf044a723993079e77ec66e4d6cbf2">
+        <source>List of products by supplier %supplier_name%</source>
+        <target>List of products by supplier %supplier_name%</target>
+        <note>Line: 81</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/BestSales/BestSalesProductSearchProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="05d61847840bcddb5d37374de3be0ccc">
         <source>Name, A to Z</source>
         <target>Name, A to Z</target>
-        <note>Context:
-File: src/Adapter/PricesDrop/PricesDropProductSearchProvider.php:104</note>
+        <note>Line: 99</note>
       </trans-unit>
       <trans-unit id="e21f2ef58ff858167655c18a874f9706">
         <source>Name, Z to A</source>
         <target>Name, Z to A</target>
-        <note>Context:
-File: src/Adapter/PricesDrop/PricesDropProductSearchProvider.php:107</note>
+        <note>Line: 102</note>
       </trans-unit>
       <trans-unit id="e2174d7435696694b8f4d984d99eef03">
         <source>Price, low to high</source>
         <target>Price, low to high</target>
-        <note>Context:
-File: src/Adapter/PricesDrop/PricesDropProductSearchProvider.php:110</note>
+        <note>Line: 105</note>
       </trans-unit>
       <trans-unit id="0ee81913615b71aba7dc8bbf1f144672">
         <source>Price, high to low</source>
         <target>Price, high to low</target>
-        <note>Context:
-File: src/Adapter/PricesDrop/PricesDropProductSearchProvider.php:113</note>
+        <note>Line: 108</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="src/Core/Product/Search/SortOrderFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ad24ffca4f9e9c0c7e80fe1512df6db9">
-        <source>Relevance</source>
-        <target>Relevance</target>
-        <note>Context:
-File: src/Core/Product/Search/SortOrderFactory.php:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Presenter/Product/ProductLazyArray.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="656c3be690ee43df4b845bd2a2ebe587">
-        <source>New product</source>
-        <target>New product</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:225</note>
-      </trans-unit>
-      <trans-unit id="03de921a8ea82897e13d33d66c28b4db">
-        <source>Online only</source>
-        <target>Online only</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:434</note>
-      </trans-unit>
-      <trans-unit id="800e90e940e7f1fb938b0fda5137f38c">
-        <source>On sale!</source>
-        <target>On sale!</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:441</note>
-      </trans-unit>
-      <trans-unit id="63b539babcf7978229d66ba4052ca71f">
-        <source>Reduced price</source>
-        <target>Reduced price</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:451</note>
-      </trans-unit>
-      <trans-unit id="4492081ca02b059f9e8af4ddaf0f7292">
-        <source>Pack</source>
-        <target>Pack</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:465</note>
-      </trans-unit>
-      <trans-unit id="cb3c718c905f00adbb6735f55bfb38ef">
-        <source>Product available with different options</source>
-        <target>Product available with different options</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:776</note>
-      </trans-unit>
-      <trans-unit id="348325afced7f3da215310efbe21f1c1">
-        <source>Last items in stock</source>
-        <target>Last items in stock</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:801</note>
-      </trans-unit>
-      <trans-unit id="a3b6a4d0897451813950029a3066f219">
-        <source>ean13</source>
-        <target>ean13</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:817</note>
-      </trans-unit>
-      <trans-unit id="6496117322fd76fa12ac1b87d8a4db6c">
-        <source>isbn</source>
-        <target>isbn</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:819</note>
-      </trans-unit>
-      <trans-unit id="2f9e567efb6a38663162f65eaac2d73b">
-        <source>upc</source>
-        <target>upc</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:821</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="019d1ca7d50cc54b995f60d456435e87">
-        <source>Used</source>
-        <target>Used</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:200</note>
-      </trans-unit>
-      <trans-unit id="6da03a74721a0554b7143254225cc08a">
-        <source>Refurbished</source>
-        <target>Refurbished</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:201</note>
-      </trans-unit>
-      <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e">
-        <source>New</source>
-        <target>New</target>
-        <note>Context:
-File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:199</note>
+      <trans-unit id="b56ffaa1656269759857ba14573dc144">
+        <source>Sales, highest to lowest</source>
+        <target>Sales, highest to lowest</target>
+        <note>Line: 69</note>
       </trans-unit>
     </body>
   </file>
@@ -297,156 +136,90 @@ File: src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php:199</note>
       <trans-unit id="900a70008b0ed52ee5f6907f7b61f0e8">
         <source>Date added, newest to oldest</source>
         <target>Date added, newest to oldest</target>
-        <note>Context:
-File: src/Adapter/NewProducts/NewProductsProductSearchProvider.php:104</note>
+        <note>Line: 104</note>
       </trans-unit>
       <trans-unit id="c2718c816e7ebf8495e3c9ce20061317">
         <source>Date added, oldest to newest</source>
         <target>Date added, oldest to newest</target>
-        <note>Context:
-File: src/Adapter/NewProducts/NewProductsProductSearchProvider.php:107</note>
+        <note>Line: 107</note>
       </trans-unit>
     </body>
   </file>
-  <file original="src/Adapter/BestSales/BestSalesProductSearchProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/Adapter/Presenter/Product/ProductLazyArray.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="b56ffaa1656269759857ba14573dc144">
-        <source>Sales, highest to lowest</source>
-        <target>Sales, highest to lowest</target>
-        <note>Context:
-File: src/Adapter/BestSales/BestSalesProductSearchProvider.php:69</note>
+      <trans-unit id="656c3be690ee43df4b845bd2a2ebe587">
+        <source>New product</source>
+        <target>New product</target>
+        <note>Line: 225</note>
+      </trans-unit>
+      <trans-unit id="03de921a8ea82897e13d33d66c28b4db">
+        <source>Online only</source>
+        <target>Online only</target>
+        <note>Line: 434</note>
+      </trans-unit>
+      <trans-unit id="800e90e940e7f1fb938b0fda5137f38c">
+        <source>On sale!</source>
+        <target>On sale!</target>
+        <note>Line: 441</note>
+      </trans-unit>
+      <trans-unit id="63b539babcf7978229d66ba4052ca71f">
+        <source>Reduced price</source>
+        <target>Reduced price</target>
+        <note>Line: 451</note>
+      </trans-unit>
+      <trans-unit id="4492081ca02b059f9e8af4ddaf0f7292">
+        <source>Pack</source>
+        <target>Pack</target>
+        <note>Line: 465</note>
+      </trans-unit>
+      <trans-unit id="cb3c718c905f00adbb6735f55bfb38ef">
+        <source>Product available with different options</source>
+        <target>Product available with different options</target>
+        <note>Line: 776</note>
+      </trans-unit>
+      <trans-unit id="348325afced7f3da215310efbe21f1c1">
+        <source>Last items in stock</source>
+        <target>Last items in stock</target>
+        <note>Line: 801</note>
+      </trans-unit>
+      <trans-unit id="a3b6a4d0897451813950029a3066f219">
+        <source>ean13</source>
+        <target>ean13</target>
+        <note>Line: 817</note>
+      </trans-unit>
+      <trans-unit id="6496117322fd76fa12ac1b87d8a4db6c">
+        <source>isbn</source>
+        <target>isbn</target>
+        <note>Line: 819</note>
+      </trans-unit>
+      <trans-unit id="2f9e567efb6a38663162f65eaac2d73b">
+        <source>upc</source>
+        <target>upc</target>
+        <note>Line: 821</note>
+      </trans-unit>
+      <trans-unit id="019d1ca7d50cc54b995f60d456435e87">
+        <source>Used</source>
+        <target>Used</target>
+        <note>Line: 231</note>
+      </trans-unit>
+      <trans-unit id="6da03a74721a0554b7143254225cc08a">
+        <source>Refurbished</source>
+        <target>Refurbished</target>
+        <note>Line: 238</note>
+      </trans-unit>
+      <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e">
+        <source>New</source>
+        <target>New</target>
+        <note>Line: 458</note>
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/catalog/_partials/miniatures/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/Core/Product/Search/SortOrderFactory.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="3601146c4e948c32b6424d2c0a7f0118">
-        <source>Price</source>
-        <target>Price</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/miniatures/product.tpl:72</note>
-      </trans-unit>
-      <trans-unit id="4d8adffdc001189e0202c01ac529a3a9">
-        <source>Regular price</source>
-        <target>Regular price</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/miniatures/product.tpl:61</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/controller/FrontController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="104d9898c04874d0fbac36e125fa1369">
-        <source>Discount</source>
-        <target>Discount</target>
-        <note>Context:
-File: classes/controller/FrontController.php:1545</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_productinfo/views/templates/hook/ps_productinfo.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="035749e4c50392a661c0f1b220ae0516">
-        <source>1 person is currently watching this product.</source>
-        <target>1 person is currently watching this product.</target>
-        <note>Context:
-File: themes/classic/modules/ps_productinfo/views/templates/hook/ps_productinfo.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="c24cf2abae9286b8f69a8ccdf7ed8d5e">
-        <source>%nb_people% people are currently watching this product.</source>
-        <target>%nb_people% people are currently watching this product.</target>
-        <note>Context:
-File: themes/classic/modules/ps_productinfo/views/templates/hook/ps_productinfo.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="247f15e3dc0e7906ab9573685423899f">
-        <source>Last time this product was bought: %date_last_order%</source>
-        <target>Last time this product was bought: %date_last_order%</target>
-        <note>Context:
-File: themes/classic/modules/ps_productinfo/views/templates/hook/ps_productinfo.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="160b4798999cb85c815beeb40ac268cc">
-        <source>Last time this product was added to a cart: %date_last_cart%</source>
-        <target>Last time this product was added to a cart: %date_last_cart%</target>
-        <note>Context:
-File: themes/classic/modules/ps_productinfo/views/templates/hook/ps_productinfo.tpl:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/products-top.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fb526aaa0add86e4e124263db50438c8">
-        <source>Showing %from%-%to% of %total% item(s)</source>
-        <target>Showing %from%-%to% of %total% item(s)</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/products-top.tpl:50</note>
-      </trans-unit>
-      <trans-unit id="498007f495e00b14f415d5f6ae6a1362">
-        <source>There are %product_count% products.</source>
-        <target>There are %product_count% products.</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/products-top.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="79ac892bd1769d83ef1c16dae9f4eddd">
-        <source>There is 1 product.</source>
-        <target>There is 1 product.</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/products-top.tpl:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/product-details.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
-        <source>Brand</source>
-        <target>Brand</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-details.tpl:14</note>
-      </trans-unit>
-      <trans-unit id="fcebe56087b9373f15514831184fa572">
-        <source>In stock</source>
-        <target>In stock</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-details.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="ea254ced8be4adb6c4a2750e84087da6">
-        <source>Availability date:</source>
-        <target>Availability date:</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-details.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="7dcd185f890fd28f69d1ed210292d77f">
-        <source>Data sheet</source>
-        <target>Data sheet</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-details.tpl:56</note>
-      </trans-unit>
-      <trans-unit id="4594f39c6dac58760daeb19d79389576">
-        <source>Specific References</source>
-        <target>Specific References</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-details.tpl:71</note>
-      </trans-unit>
-      <trans-unit id="9e2941b3c81256fac10392aaca4ccfde">
-        <source>Condition</source>
-        <target>Condition</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-details.tpl:85</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/order-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca">
-        <source>Reference</source>
-        <target>Reference</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:50</note>
-      </trans-unit>
-      <trans-unit id="deb10517653c255364175796ace3553f">
-        <source>Product</source>
-        <target>Product</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:39</note>
+      <trans-unit id="ad24ffca4f9e9c0c7e80fe1512df6db9">
+        <source>Relevance</source>
+        <target>Relevance</target>
+        <note>Line: 44</note>
       </trans-unit>
     </body>
   </file>
@@ -457,116 +230,6 @@ File: themes/classic/templates/customer/order-return.tpl:39</note>
         <target>%facet_label%: %facet_value%</target>
         <note>Context:
 File: themes/StarterTheme/templates/catalog/_partials/active_filters.tpl:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/_partials/order-detail-no-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
-        <source>Quantity</source>
-        <target>Quantity</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-detail-no-return.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="6c957f72dc8cdacc75762f2cbdcdfaf2">
-        <source>Unit price</source>
-        <target>Unit price</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-detail-no-return.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="0eede552438475bdfe820c13f24c9399">
-        <source>Total price</source>
-        <target>Total price</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-detail-no-return.tpl:33</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/product-prices.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d502fa4950894baeaeaf3c5195bb8206">
-        <source>Save %percentage%</source>
-        <target>Save %percentage%</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-prices.tpl:51</note>
-      </trans-unit>
-      <trans-unit id="5e9ce3b8961433dfa8cd441709c78176">
-        <source>Save %amount%</source>
-        <target>Save %amount%</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-prices.tpl:54</note>
-      </trans-unit>
-      <trans-unit id="e532954941a2469e3b3ae35ce44885d6">
-        <source>%price% tax excl.</source>
-        <target>%price% tax excl.</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-prices.tpl:70</note>
-      </trans-unit>
-      <trans-unit id="a72a454b308052ed277f7b69ab307caa">
-        <source>Instead of %price%</source>
-        <target>Instead of %price%</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-prices.tpl:76</note>
-      </trans-unit>
-      <trans-unit id="98508b5a9b590896cc627beb46d86b96">
-        <source>Including %amount% for ecotax</source>
-        <target>Including %amount% for ecotax</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-prices.tpl:82</note>
-      </trans-unit>
-      <trans-unit id="a134618182b99ff9151d7e0b6b92410a">
-        <source>(not impacted by the discount)</source>
-        <target>(not impacted by the discount)</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-prices.tpl:84</note>
-      </trans-unit>
-      <trans-unit id="48fa315ec57b5fea80176d1c5f9f6bbf">
-        <source>(%unit_price%)</source>
-        <target>(%unit_price%)</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-prices.tpl:62</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/product-discounts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="fc21aa6a8b0bceb8570c8c81b6b38307">
-        <source>Volume discounts</source>
-        <target>Volume discounts</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-discounts.tpl:27</note>
-      </trans-unit>
-      <trans-unit id="861c0c6ef832cd96c5fe152f9d610973">
-        <source>You Save</source>
-        <target>You Save</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-discounts.tpl:34</note>
-      </trans-unit>
-      <trans-unit id="64c22a1426c5b8fce46c6314d73dc99e">
-        <source>Up to %discount%</source>
-        <target>Up to %discount%</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-discounts.tpl:42</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/order-confirmation-table.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="54c02ba7929b1fda4847991a45b58a48">
-        <source>Product customization</source>
-        <target>Product customization</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/order-confirmation-table.tpl:57</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/product-customization.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5d1190edfb16f1dcaaecc56570c864be">
-        <source>Your customization:</source>
-        <target>Your customization:</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-customization.tpl:41</note>
       </trans-unit>
     </body>
   </file>
@@ -596,145 +259,17 @@ File: themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl:3
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/catalog/_partials/active_filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cfff8593a3adedd98a18631f85152d23">
-        <source>%1$s: </source>
-        <target>%1$s: </target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/active_filters.tpl:35</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/listing/supplier.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4c5c40c99a89125e22218cb62335c60a">
-        <source>List of products by supplier %s</source>
-        <target>List of products by supplier %s</target>
-        <note>Context:
-File: themes/classic/templates/catalog/listing/supplier.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="56e11b516943cb38a57c9a53219a8370">
-        <source>This pack contains</source>
-        <target>This pack contains</target>
-        <note>Context:
-File: themes/classic/templates/catalog/product.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
-        <source>Description</source>
-        <target>Description</target>
-        <note>Context:
-File: themes/classic/templates/catalog/product.tpl:157</note>
-      </trans-unit>
-      <trans-unit id="b8900d8adf598b6653bb8c071bc49a1d">
-        <source>Product Details</source>
-        <target>Product Details</target>
-        <note>Context:
-File: themes/classic/templates/catalog/product.tpl:167</note>
-      </trans-unit>
-      <trans-unit id="7e2708aeb65763c54052f57ed1a1ec1d">
-        <source>Attachments</source>
-        <target>Attachments</target>
-        <note>Context:
-File: themes/classic/templates/catalog/product.tpl:176</note>
-      </trans-unit>
-      <trans-unit id="3767d4f3efe17bd95a1bc7cf4194bb93">
-        <source>You might also like</source>
-        <target>You might also like</target>
-        <note>Context:
-File: themes/classic/templates/catalog/product.tpl:236</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="themes/classic/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="d7b2933ba512ada478c97fa43dd7ebe6">
         <source>Best Sellers</source>
         <target>Best Sellers</target>
-        <note>Context:
-File: themes/classic/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
       <trans-unit id="eae99cd6a931f3553123420b16383812">
         <source>All best sellers</source>
         <target>All best sellers</target>
-        <note>Context:
-File: themes/classic/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl:35</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_rssfeed/views/templates/hook/ps_rssfeed.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="10fd25dcd3353c0ba3731d4a23657f2e">
-        <source>No RSS feed added</source>
-        <target>No RSS feed added</target>
-        <note>Context:
-File: themes/classic/modules/ps_rssfeed/views/templates/hook/ps_rssfeed.tpl:36</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_emailalerts/views/templates/hook/my-account-footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4edfd10d0bb5f51e0fd2327df608b5a8">
-        <source>My alerts</source>
-        <target>My alerts</target>
-        <note>Context:
-File: themes/classic/modules/ps_emailalerts/views/templates/hook/my-account-footer.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f55e0a28b86c2ab66ac632ab9ddf1833">
-        <source>%s other product in the same category:</source>
-        <target>%s other product in the same category:</target>
-        <note>Context:
-File: themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="bebb44f38b03407098d48198c1d0aaa5">
-        <source>%s other products in the same category:</source>
-        <target>%s other products in the same category:</target>
-        <note>Context:
-File: themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f473acb18ebcd825235ca5624203f31a">
-        <source>Popular Products</source>
-        <target>Popular Products</target>
-        <note>Context:
-File: themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl:27</note>
-      </trans-unit>
-      <trans-unit id="40dec546414c1ebdfde8d9858f0938c3">
-        <source>All products</source>
-        <target>All products</target>
-        <note>Context:
-File: themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl:35</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ef2b66b0b65479e08ff0cce29e19d006">
-        <source>Customers who bought this product also bought:</source>
-        <target>Customers who bought this product also bought:</target>
-        <note>Context:
-File: themes/classic/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_viewedproduct/views/template/hook/ps_viewedproduct.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="43560641f91e63dc83682bc598892fa1">
-        <source>Viewed products</source>
-        <target>Viewed products</target>
-        <note>Context:
-File: themes/classic/modules/ps_viewedproduct/views/template/hook/ps_viewedproduct.tpl:26</note>
+        <note>Line: 35</note>
       </trans-unit>
     </body>
   </file>
@@ -743,8 +278,114 @@ File: themes/classic/modules/ps_viewedproduct/views/template/hook/ps_viewedprodu
       <trans-unit id="e18a22d145b38e4fff582663b5b4ec1e">
         <source>All brands</source>
         <target>All brands</target>
-        <note>Context:
-File: themes/classic/modules/ps_brandlist/views/templates/_partials/brand_form.tpl:28</note>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="84be54bb4bd1b755a27d86388700d097">
+        <source>Brands</source>
+        <target>Brands</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="8e41eae149ff3fa38cc9c4fde945f2c3">
+        <source>No brand</source>
+        <target>No brand</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f55e0a28b86c2ab66ac632ab9ddf1833">
+        <source>%s other product in the same category:</source>
+        <target>%s other product in the same category:</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="bebb44f38b03407098d48198c1d0aaa5">
+        <source>%s other products in the same category:</source>
+        <target>%s other products in the same category:</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ef2b66b0b65479e08ff0cce29e19d006">
+        <source>Customers who bought this product also bought:</source>
+        <target>Customers who bought this product also bought:</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_emailalerts/views/templates/hook/my-account-footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4edfd10d0bb5f51e0fd2327df608b5a8">
+        <source>My alerts</source>
+        <target>My alerts</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f473acb18ebcd825235ca5624203f31a">
+        <source>Popular Products</source>
+        <target>Popular Products</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="40dec546414c1ebdfde8d9858f0938c3">
+        <source>All products</source>
+        <target>All products</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9ff0635f5737513b1a6f559ac2bff745">
+        <source>New products</source>
+        <target>New products</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="60efcc704ef1456678f77eb9ee20847b">
+        <source>All new products</source>
+        <target>All new products</target>
+        <note>Line: 36</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_productinfo/views/templates/hook/ps_productinfo.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="035749e4c50392a661c0f1b220ae0516">
+        <source>1 person is currently watching this product.</source>
+        <target>1 person is currently watching this product.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="c24cf2abae9286b8f69a8ccdf7ed8d5e">
+        <source>%nb_people% people are currently watching this product.</source>
+        <target>%nb_people% people are currently watching this product.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="247f15e3dc0e7906ab9573685423899f">
+        <source>Last time this product was bought: %date_last_order%</source>
+        <target>Last time this product was bought: %date_last_order%</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="160b4798999cb85c815beeb40ac268cc">
+        <source>Last time this product was added to a cart: %date_last_cart%</source>
+        <target>Last time this product was added to a cart: %date_last_cart%</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_rssfeed/views/templates/hook/ps_rssfeed.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="10fd25dcd3353c0ba3731d4a23657f2e">
+        <source>No RSS feed added</source>
+        <target>No RSS feed added</target>
+        <note>Line: 36</note>
       </trans-unit>
     </body>
   </file>
@@ -753,14 +394,26 @@ File: themes/classic/modules/ps_brandlist/views/templates/_partials/brand_form.t
       <trans-unit id="5bdba1fc0fba1010d61ce253c2e57da8">
         <source>Search our catalog</source>
         <target>Search our catalog</target>
-        <note>Context:
-File: themes/classic/modules/ps_searchbar/ps_searchbar.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
       <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
         <source>Search</source>
         <target>Search</target>
-        <note>Context:
-File: themes/classic/modules/ps_searchbar/ps_searchbar.tpl:32</note>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_specials/views/templates/hook/ps_specials.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="588907ab2d492aca0b07b5bf9c931eea">
+        <source>On sale</source>
+        <target>On sale</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="f95ceb82c51c99dc9b9e5678b291c44b">
+        <source>All sale products</source>
+        <target>All sale products</target>
+        <note>Line: 36</note>
       </trans-unit>
     </body>
   </file>
@@ -769,8 +422,258 @@ File: themes/classic/modules/ps_searchbar/ps_searchbar.tpl:32</note>
       <trans-unit id="ecf253735ac0cba84a9d2eeff1f1b87c">
         <source>All suppliers</source>
         <target>All suppliers</target>
-        <note>Context:
-File: themes/classic/modules/ps_supplierlist/views/templates/_partials/supplier_form.tpl:28</note>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_supplierlist/views/templates/hook/ps_supplierlist.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1814d65a76028fdfbadab64a5a8076df">
+        <source>Suppliers</source>
+        <target>Suppliers</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="496689fbd342f80d30f1f266d060415a">
+        <source>No supplier</source>
+        <target>No supplier</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_viewedproduct/views/template/hook/ps_viewedproduct.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="43560641f91e63dc83682bc598892fa1">
+        <source>Viewed products</source>
+        <target>Viewed products</target>
+        <note>Line: 26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/_partials/pagination.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fb526aaa0add86e4e124263db50438c8">
+        <source>Showing %from%-%to% of %total% item(s)</source>
+        <target>Showing %from%-%to% of %total% item(s)</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/active_filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cfff8593a3adedd98a18631f85152d23">
+        <source>%1$s: </source>
+        <target>%1$s: </target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/miniatures/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3601146c4e948c32b6424d2c0a7f0118">
+        <source>Price</source>
+        <target>Price</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="4d8adffdc001189e0202c01ac529a3a9">
+        <source>Regular price</source>
+        <target>Regular price</target>
+        <note>Line: 61</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-customization.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5d1190edfb16f1dcaaecc56570c864be">
+        <source>Your customization:</source>
+        <target>Your customization:</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-details.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
+        <source>Brand</source>
+        <target>Brand</target>
+        <note>Line: 14</note>
+      </trans-unit>
+      <trans-unit id="fcebe56087b9373f15514831184fa572">
+        <source>In stock</source>
+        <target>In stock</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="ea254ced8be4adb6c4a2750e84087da6">
+        <source>Availability date:</source>
+        <target>Availability date:</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="7dcd185f890fd28f69d1ed210292d77f">
+        <source>Data sheet</source>
+        <target>Data sheet</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="4594f39c6dac58760daeb19d79389576">
+        <source>Specific References</source>
+        <target>Specific References</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="9e2941b3c81256fac10392aaca4ccfde">
+        <source>Condition</source>
+        <target>Condition</target>
+        <note>Line: 85</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-discounts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fc21aa6a8b0bceb8570c8c81b6b38307">
+        <source>Volume discounts</source>
+        <target>Volume discounts</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="861c0c6ef832cd96c5fe152f9d610973">
+        <source>You Save</source>
+        <target>You Save</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="64c22a1426c5b8fce46c6314d73dc99e">
+        <source>Up to %discount%</source>
+        <target>Up to %discount%</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-prices.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d502fa4950894baeaeaf3c5195bb8206">
+        <source>Save %percentage%</source>
+        <target>Save %percentage%</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="5e9ce3b8961433dfa8cd441709c78176">
+        <source>Save %amount%</source>
+        <target>Save %amount%</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="e532954941a2469e3b3ae35ce44885d6">
+        <source>%price% tax excl.</source>
+        <target>%price% tax excl.</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="a72a454b308052ed277f7b69ab307caa">
+        <source>Instead of %price%</source>
+        <target>Instead of %price%</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="98508b5a9b590896cc627beb46d86b96">
+        <source>Including %amount% for ecotax</source>
+        <target>Including %amount% for ecotax</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="a134618182b99ff9151d7e0b6b92410a">
+        <source>(not impacted by the discount)</source>
+        <target>(not impacted by the discount)</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="48fa315ec57b5fea80176d1c5f9f6bbf">
+        <source>(%unit_price%)</source>
+        <target>(%unit_price%)</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/products-top.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="498007f495e00b14f415d5f6ae6a1362">
+        <source>There are %product_count% products.</source>
+        <target>There are %product_count% products.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="79ac892bd1769d83ef1c16dae9f4eddd">
+        <source>There is 1 product.</source>
+        <target>There is 1 product.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/listing/manufacturer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d0679d37c204278465192d34b1917c01">
+        <source>List of products by brand %brand_name%</source>
+        <target>List of products by brand %brand_name%</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/listing/supplier.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4c5c40c99a89125e22218cb62335c60a">
+        <source>List of products by supplier %s</source>
+        <target>List of products by supplier %s</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="56e11b516943cb38a57c9a53219a8370">
+        <source>This pack contains</source>
+        <target>This pack contains</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
+        <source>Description</source>
+        <target>Description</target>
+        <note>Line: 157</note>
+      </trans-unit>
+      <trans-unit id="b8900d8adf598b6653bb8c071bc49a1d">
+        <source>Product Details</source>
+        <target>Product Details</target>
+        <note>Line: 167</note>
+      </trans-unit>
+      <trans-unit id="7e2708aeb65763c54052f57ed1a1ec1d">
+        <source>Attachments</source>
+        <target>Attachments</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="3767d4f3efe17bd95a1bc7cf4194bb93">
+        <source>You might also like</source>
+        <target>You might also like</target>
+        <note>Line: 236</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/order-detail-no-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca">
+        <source>Reference</source>
+        <target>Reference</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="deb10517653c255364175796ace3553f">
+        <source>Product</source>
+        <target>Product</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
+        <source>Quantity</source>
+        <target>Quantity</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="6c957f72dc8cdacc75762f2cbdcdfaf2">
+        <source>Unit price</source>
+        <target>Unit price</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="0eede552438475bdfe820c13f24c9399">
+        <source>Total price</source>
+        <target>Total price</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="54c02ba7929b1fda4847991a45b58a48">
+        <source>Product customization</source>
+        <target>Product customization</target>
+        <note>Line: 131</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopThemeCheckout.xlf
+++ b/app/Resources/translations/default/ShopThemeCheckout.xlf
@@ -1,256 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="controllers/front/GuestTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8bbbace7ffb26d61b400c72ffe493f4d">
-        <source>Guest order tracking</source>
-        <target>Guest order tracking</target>
-        <note>Context:
-File: controllers/front/GuestTrackingController.php:151</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="modules/ps_legalcompliance/ps_legalcompliance.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f4a0d7cb0cd45214c8ca5912c970de13">
-        <source>Tax included</source>
-        <target>Tax included</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:958</note>
-      </trans-unit>
-      <trans-unit id="befcac0f9644a7abee43e69f49252ac4">
-        <source>Tax excluded</source>
-        <target>Tax excluded</target>
-        <note>Context:
-File: modules/ps_legalcompliance/ps_legalcompliance.php:960</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/DiscountController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="29aa46cc3d2677c7e0f216910df600ff">
-        <source>Free shipping</source>
-        <target>Free shipping</target>
-        <note>Context:
-File: controllers/front/DiscountController.php:165</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/checkout/DeliveryOptionsFinder.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b24ce0cd392a5b0b8dedc66c25213594">
-        <source>Free</source>
-        <target>Free</target>
-        <note>Context:
-File: classes/checkout/DeliveryOptionsFinder.php:91</note>
-      </trans-unit>
-      <trans-unit id="464f47d6975750e4cbd91c90ccf1791e">
-        <source>%price% tax incl.</source>
-        <target>%price% tax incl.</target>
-        <note>Context:
-File: classes/checkout/DeliveryOptionsFinder.php:98</note>
-      </trans-unit>
-      <trans-unit id="e532954941a2469e3b3ae35ce44885d6">
-        <source>%price% tax excl.</source>
-        <target>%price% tax excl.</target>
-        <note>Context:
-File: classes/checkout/DeliveryOptionsFinder.php:107</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Presenter/Cart/CartPresenter.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="96b0141273eabab320119c467cdcaf17">
-        <source>Total</source>
-        <target>Total</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:391</note>
-      </trans-unit>
-      <trans-unit id="2194aaec8cc7086ab0e93f74547e5f53">
-        <source>Subtotal</source>
-        <target>Subtotal</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:330</note>
-      </trans-unit>
-      <trans-unit id="104d9898c04874d0fbac36e125fa1369">
-        <source>Discount</source>
-        <target>Discount</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:338</note>
-      </trans-unit>
-      <trans-unit id="484f5a79672cebe198ebdde45a1d672f">
-        <source>Gift wrapping</source>
-        <target>Gift wrapping</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:353</note>
-      </trans-unit>
-      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
-        <source>Shipping</source>
-        <target>Shipping</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:368</note>
-      </trans-unit>
-      <trans-unit id="3b5a05f2c4a0373c7a6e8d1cfec7020f">
-        <source>Included taxes</source>
-        <target>Included taxes</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:381</note>
-      </trans-unit>
-      <trans-unit id="719fec04166d6fa75f89cd29ad61fa8c">
-        <source>Taxes</source>
-        <target>Taxes</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:382</note>
-      </trans-unit>
-      <trans-unit id="adc852563bca51fb6b10c7905010406d">
-        <source>Total (tax incl.)</source>
-        <target>Total (tax incl.)</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:399</note>
-      </trans-unit>
-      <trans-unit id="8faf99e02e4d0ccb4dd933404f87a4ea">
-        <source>Total (tax excl.)</source>
-        <target>Total (tax excl.)</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:405</note>
-      </trans-unit>
-      <trans-unit id="7e0eb131cbb6280fe2b38edf92a3bcc5">
-        <source>1 item</source>
-        <target>1 item</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:416</note>
-      </trans-unit>
-      <trans-unit id="ca96f27e7d3e3b67b5d1f43a54296466">
-        <source>%count% items</source>
-        <target>%count% items</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:417</note>
-      </trans-unit>
-      <trans-unit id="2bd544f123f671c597c4b330ef05b5da">
-        <source>A minimum shopping cart total of %amount% (tax excl.) is required to validate your order. Current cart total is %total% (tax excl.).</source>
-        <target>A minimum shopping cart total of %amount% (tax excl.) is required to validate your order. Current cart total is %total% (tax excl.).</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:465</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Presenter/Order/OrderLazyArray.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ea067eb37801c5aab1a1c685eb97d601">
-        <source>Total paid</source>
-        <target>Total paid</target>
-        <note>Context:
-File: src/Adapter/Presenter/Order/OrderLazyArray.php:243</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7589dfa9a5a899e9701335164c9ab520">
-        <source>Shipping and handling</source>
-        <target>Shipping and handling</target>
-        <note>Context:
-File: src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php:139</note>
-      </trans-unit>
-      <trans-unit id="4b78ac8eb158840e9638a3aeb26c4a9d">
-        <source>Tax</source>
-        <target>Tax</target>
-        <note>Context:
-File: src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php:168</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="classes/checkout/CheckoutDeliveryStep.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="d62106dfcdba5cacd1a5f5efe9cefc79">
         <source> (additional cost of %giftcost% %taxlabel%)</source>
         <target>(additional cost of %giftcost% %taxlabel%)</target>
-        <note>Context:
-File: classes/checkout/CheckoutDeliveryStep.php:111</note>
+        <note>Line: 111</note>
       </trans-unit>
       <trans-unit id="882ed1e831a6175e4a3dd2c09faa225c">
         <source>I would like my order to be gift wrapped %cost%</source>
         <target>I would like my order to be gift wrapped %cost%</target>
-        <note>Context:
-File: classes/checkout/CheckoutDeliveryStep.php:178</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/order-final-summary.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="49ffd9480effff979143d2e8d38931c4">
-        <source>Shipping Method</source>
-        <target>Shipping Method</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/order-final-summary.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
-        <source>Addresses</source>
-        <target>Addresses</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/order-final-summary.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="7ce3a11073ffba68bd1e83e243aaabf7">
-        <source>Please check your order before payment</source>
-        <target>Please check your order before payment</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/order-final-summary.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="f2a5a4ccf14820292a27cca1c8cab12e">
-        <source>Your Delivery Address</source>
-        <target>Your Delivery Address</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/order-final-summary.tpl:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/history.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c453a4b8e8d98e82f35b67f433e3b4da">
-        <source>Payment</source>
-        <target>Payment</target>
-        <note>Context:
-File: themes/classic/templates/customer/history.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="5d4710f9a8250b13164a82c94d5b00d1">
-        <source>Order reference</source>
-        <target>Order reference</target>
-        <note>Context:
-File: themes/classic/templates/customer/history.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="44749712dbec183e983dcd78a7736c41">
-        <source>Date</source>
-        <target>Date</target>
-        <note>Context:
-File: themes/classic/templates/customer/history.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="0eede552438475bdfe820c13f24c9399">
-        <source>Total price</source>
-        <target>Total price</target>
-        <note>Context:
-File: themes/classic/templates/customer/history.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="ec53a8c4f07baed5d8825072c89799be">
-        <source>Status</source>
-        <target>Status</target>
-        <note>Context:
-File: themes/classic/templates/customer/history.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="466eadd40b3c10580e3ab4e8061161ce">
-        <source>Invoice</source>
-        <target>Invoice</target>
-        <note>Context:
-File: themes/classic/templates/customer/history.tpl:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/checkout/ConditionsToApproveFinder.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="823e713a0e72b5dc3d75a71a7bbc6274">
-        <source>I agree to the [terms of service] and will adhere to them unconditionally.</source>
-        <target>I agree to the [terms of service] and will adhere to them unconditionally.</target>
-        <note>Context:
-File: classes/checkout/ConditionsToApproveFinder.php:50</note>
+        <note>Line: 178</note>
       </trans-unit>
     </body>
   </file>
@@ -259,8 +19,30 @@ File: classes/checkout/ConditionsToApproveFinder.php:50</note>
       <trans-unit id="61f1667518c8516a8a4fe18686a4e6fc">
         <source>Personal Information</source>
         <target>Personal Information</target>
-        <note>Context:
-File: classes/checkout/CheckoutPersonalInformationStep.php:95</note>
+        <note>Line: 95</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/checkout/ConditionsToApproveFinder.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="823e713a0e72b5dc3d75a71a7bbc6274">
+        <source>I agree to the [terms of service] and will adhere to them unconditionally.</source>
+        <target>I agree to the [terms of service] and will adhere to them unconditionally.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/checkout/DeliveryOptionsFinder.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="464f47d6975750e4cbd91c90ccf1791e">
+        <source>%price% tax incl.</source>
+        <target>%price% tax incl.</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="e532954941a2469e3b3ae35ce44885d6">
+        <source>%price% tax excl.</source>
+        <target>%price% tax excl.</target>
+        <note>Line: 107</note>
       </trans-unit>
     </body>
   </file>
@@ -269,8 +51,35 @@ File: classes/checkout/CheckoutPersonalInformationStep.php:95</note>
       <trans-unit id="0bf3928d84fde940f6feafac75062280">
         <source>My Address</source>
         <target>My Address</target>
-        <note>Context:
-File: classes/form/CustomerAddressForm.php:148</note>
+        <note>Line: 148</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/DiscountController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f4a0d7cb0cd45214c8ca5912c970de13">
+        <source>Tax included</source>
+        <target>Tax included</target>
+        <note>Line: 122</note>
+      </trans-unit>
+      <trans-unit id="befcac0f9644a7abee43e69f49252ac4">
+        <source>Tax excluded</source>
+        <target>Tax excluded</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="29aa46cc3d2677c7e0f216910df600ff">
+        <source>Free shipping</source>
+        <target>Free shipping</target>
+        <note>Line: 165</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/GuestTrackingController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8bbbace7ffb26d61b400c72ffe493f4d">
+        <source>Guest order tracking</source>
+        <target>Guest order tracking</target>
+        <note>Line: 151</note>
       </trans-unit>
     </body>
   </file>
@@ -279,28 +88,99 @@ File: classes/form/CustomerAddressForm.php:148</note>
       <trans-unit id="e2121483e5e6c879ecef260a7f72e959">
         <source>Product Successfully Added to Your Shopping Cart</source>
         <target>Product Successfully Added to Your Shopping Cart</target>
-        <note>Context:
-File: modules/ps_shoppingcart/modal.tpl:4</note>
+        <note>Line: 4</note>
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/catalog/_partials/product-add-to-cart.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/Adapter/Presenter/Cart/CartPresenter.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="21cf667b2d56747effd90b0333c6813c">
-        <source>The minimum purchase order quantity for the product is %quantity%.</source>
-        <target>The minimum purchase order quantity for the product is %quantity%.</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/product-add-to-cart.tpl:77</note>
+      <trans-unit id="b24ce0cd392a5b0b8dedc66c25213594">
+        <source>Free</source>
+        <target>Free</target>
+        <note>Line: 372</note>
+      </trans-unit>
+      <trans-unit id="96b0141273eabab320119c467cdcaf17">
+        <source>Total</source>
+        <target>Total</target>
+        <note>Line: 391</note>
+      </trans-unit>
+      <trans-unit id="2194aaec8cc7086ab0e93f74547e5f53">
+        <source>Subtotal</source>
+        <target>Subtotal</target>
+        <note>Line: 330</note>
+      </trans-unit>
+      <trans-unit id="104d9898c04874d0fbac36e125fa1369">
+        <source>Discount</source>
+        <target>Discount</target>
+        <note>Line: 338</note>
+      </trans-unit>
+      <trans-unit id="484f5a79672cebe198ebdde45a1d672f">
+        <source>Gift wrapping</source>
+        <target>Gift wrapping</target>
+        <note>Line: 353</note>
+      </trans-unit>
+      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
+        <source>Shipping</source>
+        <target>Shipping</target>
+        <note>Line: 368</note>
+      </trans-unit>
+      <trans-unit id="3b5a05f2c4a0373c7a6e8d1cfec7020f">
+        <source>Included taxes</source>
+        <target>Included taxes</target>
+        <note>Line: 381</note>
+      </trans-unit>
+      <trans-unit id="719fec04166d6fa75f89cd29ad61fa8c">
+        <source>Taxes</source>
+        <target>Taxes</target>
+        <note>Line: 382</note>
+      </trans-unit>
+      <trans-unit id="adc852563bca51fb6b10c7905010406d">
+        <source>Total (tax incl.)</source>
+        <target>Total (tax incl.)</target>
+        <note>Line: 399</note>
+      </trans-unit>
+      <trans-unit id="8faf99e02e4d0ccb4dd933404f87a4ea">
+        <source>Total (tax excl.)</source>
+        <target>Total (tax excl.)</target>
+        <note>Line: 405</note>
+      </trans-unit>
+      <trans-unit id="7e0eb131cbb6280fe2b38edf92a3bcc5">
+        <source>1 item</source>
+        <target>1 item</target>
+        <note>Line: 416</note>
+      </trans-unit>
+      <trans-unit id="ca96f27e7d3e3b67b5d1f43a54296466">
+        <source>%count% items</source>
+        <target>%count% items</target>
+        <note>Line: 417</note>
+      </trans-unit>
+      <trans-unit id="2bd544f123f671c597c4b330ef05b5da">
+        <source>A minimum shopping cart total of %amount% (tax excl.) is required to validate your order. Current cart total is %total% (tax excl.).</source>
+        <target>A minimum shopping cart total of %amount% (tax excl.) is required to validate your order. Current cart total is %total% (tax excl.).</target>
+        <note>Line: 465</note>
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/customer/order-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/Adapter/Presenter/Order/OrderLazyArray.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
-        <source>Quantity</source>
-        <target>Quantity</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:40</note>
+      <trans-unit id="ea067eb37801c5aab1a1c685eb97d601">
+        <source>Total paid</source>
+        <target>Total paid</target>
+        <note>Line: 243</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7589dfa9a5a899e9701335164c9ab520">
+        <source>Shipping and handling</source>
+        <target>Shipping and handling</target>
+        <note>Line: 139</note>
+      </trans-unit>
+      <trans-unit id="4b78ac8eb158840e9638a3aeb26c4a9d">
+        <source>Tax</source>
+        <target>Tax</target>
+        <note>Line: 168</note>
       </trans-unit>
     </body>
   </file>
@@ -320,128 +200,6 @@ File: themes/StarterTheme/templates/catalog/_partials/product-discounts.tpl:48</
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/customer/order-detail.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
-        <source>Carrier</source>
-        <target>Carrier</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:191</note>
-      </trans-unit>
-      <trans-unit id="f0aaaae189e9c7711931a65ffcd22543">
-        <source>Payment method</source>
-        <target>Payment method</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:57</note>
-      </trans-unit>
-      <trans-unit id="d350478ea9dc7f1f8ae3c78a41630f1d">
-        <source>Delivery address %alias%</source>
-        <target>Delivery address %alias%</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:132</note>
-      </trans-unit>
-      <trans-unit id="7d0244dc42acadee967bf9d8e612bffb">
-        <source>Invoice address %alias%</source>
-        <target>Invoice address %alias%</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:140</note>
-      </trans-unit>
-      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
-        <source>Weight</source>
-        <target>Weight</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:194</note>
-      </trans-unit>
-      <trans-unit id="552a0d8c17d95d5dbdc0c28217024f5a">
-        <source>Shipping cost</source>
-        <target>Shipping cost</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:197</note>
-      </trans-unit>
-      <trans-unit id="5068c162a60b5859f973f701333f45c5">
-        <source>Tracking number</source>
-        <target>Tracking number</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:200</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/discount.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ca0dbad92a874b2f69b549293387925e">
-        <source>Code</source>
-        <target>Code</target>
-        <note>Context:
-File: themes/classic/templates/customer/discount.tpl:64</note>
-      </trans-unit>
-      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
-        <source>Description</source>
-        <target>Description</target>
-        <note>Context:
-File: themes/classic/templates/customer/discount.tpl:68</note>
-      </trans-unit>
-      <trans-unit id="689202409e48743b914713f96d93947c">
-        <source>Value</source>
-        <target>Value</target>
-        <note>Context:
-File: themes/classic/templates/customer/discount.tpl:76</note>
-      </trans-unit>
-      <trans-unit id="a1d0ec6d56f8833a078b5a7ac4caf2d4">
-        <source>Minimum</source>
-        <target>Minimum</target>
-        <note>Context:
-File: themes/classic/templates/customer/discount.tpl:80</note>
-      </trans-unit>
-      <trans-unit id="eb2527806a7e1ef48009eaaa785368fe">
-        <source>Cumulative</source>
-        <target>Cumulative</target>
-        <note>Context:
-File: themes/classic/templates/customer/discount.tpl:84</note>
-      </trans-unit>
-      <trans-unit id="8c1279db4db86553e4b9682f78cf500e">
-        <source>Expiration date</source>
-        <target>Expiration date</target>
-        <note>Context:
-File: themes/classic/templates/customer/discount.tpl:88</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/cart-voucher.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0ab608f7e0d1501be457f7646c1e57c0">
-        <source>Promo code</source>
-        <target>Promo code</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/cart-voucher.tpl:56</note>
-      </trans-unit>
-      <trans-unit id="3111382b0f345f39639de6e580a94933">
-        <source>Have a promo code?</source>
-        <target>Have a promo code?</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/cart-voucher.tpl:47</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0d9175fe89fb80d815e7d03698b6e83a">
-        <source>Gift</source>
-        <target>Gift</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl:140</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/address-form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5c74d926c4b89517ad64133990d04413">
-        <source>Use this address for invoice too</source>
-        <target>Use this address for invoice too</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/address-form.tpl:26</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="themes/StarterTheme/templates/checkout/_partials/customer-form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="4d26a4e106aa8a35f25d97fd14055981">
@@ -452,56 +210,6 @@ File: themes/StarterTheme/templates/checkout/_partials/customer-form.tpl:30</not
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/checkout/_partials/steps/personal-information.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3e0b39c8cd14dd15fff36eecf9c19861">
-        <source>If you sign out now, your cart will be emptied.</source>
-        <target>If you sign out now, your cart will be emptied.</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/personal-information.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="c1fc8e1c54652420d0822e0614089df6">
-        <source>Order as a guest</source>
-        <target>Order as a guest</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/personal-information.tpl:46</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/steps/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="48974cc3df177e6b565c39aa155458cd">
-        <source>Shipping Address</source>
-        <target>Shipping Address</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/addresses.tpl:36</note>
-      </trans-unit>
-      <trans-unit id="dc024b376ebf01abd90cf4d5e4dca1c7">
-        <source>The selected address will be used as your personal address (for invoice).</source>
-        <target>The selected address will be used as your personal address (for invoice).</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/addresses.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="313d7cbfa2b3c25f09d69ad7e40974a7">
-        <source>Billing address differs from shipping address</source>
-        <target>Billing address differs from shipping address</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/addresses.tpl:82</note>
-      </trans-unit>
-      <trans-unit id="baa63a898921164abe2d1d532ab27e79">
-        <source>Your Invoice Address</source>
-        <target>Your Invoice Address</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/addresses.tpl:91</note>
-      </trans-unit>
-      <trans-unit id="56d0ed7cd789dd772be59aa6b1e437de">
-        <source>The selected address will be used both as your personal address (for invoice) and as your delivery address.</source>
-        <target>The selected address will be used both as your personal address (for invoice) and as your delivery address.</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/addresses.tpl:41</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="themes/StarterTheme/templates/checkout/_partials/steps/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="59123a64986f5a831723020061400054">
@@ -509,100 +217,6 @@ File: themes/classic/templates/checkout/_partials/steps/addresses.tpl:41</note>
         <target>The selected address will be used both as your personal address (for invoice) and as your shipping address.</target>
         <note>Context:
 File: themes/StarterTheme/templates/checkout/_partials/steps/addresses.tpl:41</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/steps/payment.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="238150e8bd467ab9cb6c7e5618db54e9">
-        <source>Transaction amount has been correctly updated</source>
-        <target>Transaction amount has been correctly updated</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/payment.tpl:12</note>
-      </trans-unit>
-      <trans-unit id="9ea465e939c30ceba6e0d46810913142">
-        <source>By confirming the order, you certify that you have read and agree with all of the conditions below:</source>
-        <target>By confirming the order, you certify that you have read and agree with all of the conditions below:</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/payment.tpl:85</note>
-      </trans-unit>
-      <trans-unit id="91b442d385b54e1418d81adc34871053">
-        <source>Selected</source>
-        <target>Selected</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/payment.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="97b72d419a22e2d1144b2fb05ee26901">
-        <source>Unfortunately, there are no payment method available.</source>
-        <target>Unfortunately, there are no payment method available.</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/payment.tpl:75</note>
-      </trans-unit>
-      <trans-unit id="3a31d70f8c2eb35a29f6c58e9664cd7f">
-        <source>Please make sure you've chosen a [1]payment method[/1] and accepted the [2]terms and conditions[/2].</source>
-        <target>Please make sure you've chosen a [1]payment method[/1] and accepted the [2]terms and conditions[/2].</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/payment.tpl:126</note>
-      </trans-unit>
-      <trans-unit id="dde6c860ae1ac6573875352abf1822ef">
-        <source>No payment needed for this order</source>
-        <target>No payment needed for this order</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/payment.tpl:8</note>
-      </trans-unit>
-      <trans-unit id="5486191906ec27c1c4bb5bd3e46b3442">
-        <source>Order with an obligation to pay</source>
-        <target>Order with an obligation to pay</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/payment.tpl:141</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/steps/shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="9193b58520051d8b59ca64a5cc5353ff">
-        <source>I would like to receive my order in recycled packaging.</source>
-        <target>I would like to receive my order in recycled packaging.</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/shipping.tpl:91</note>
-      </trans-unit>
-      <trans-unit id="5153f37f9159735ef4ae472c19b732e3">
-        <source>If you'd like, you can add a note to the gift:</source>
-        <target>If you'd like, you can add a note to the gift:</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/shipping.tpl:103</note>
-      </trans-unit>
-      <trans-unit id="9a605fc0e1667ebdbd0ac37cf9f90789">
-        <source>Unfortunately, there are no carriers available for your delivery address.</source>
-        <target>Unfortunately, there are no carriers available for your delivery address.</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/shipping.tpl:115</note>
-      </trans-unit>
-      <trans-unit id="d93651d012e77dac5581b08db33195b2">
-        <source>If you would like to add a comment about your order, please write it in the field below.</source>
-        <target>If you would like to add a comment about your order, please write it in the field below.</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/shipping.tpl:83</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/order-confirmation-table.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2cee9edacddde0856a46d7db6aff9110">
-        <source>Order items</source>
-        <target>Order items</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/order-confirmation-table.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/cart.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b75443a19207ed3a3552edda86536857">
-        <source>Shopping Cart</source>
-        <target>Shopping Cart</target>
-        <note>Context:
-File: themes/classic/templates/checkout/cart.tpl:38</note>
       </trans-unit>
     </body>
   </file>
@@ -634,149 +248,42 @@ File: themes/StarterTheme/templates/checkout/order-confirmation.tpl:62</note>
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/templates/checkout/order-confirmation.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7f21696f11929f5ed55ca5bcb15d2fc1">
-        <source>Your order is confirmed</source>
-        <target>Your order is confirmed</target>
-        <note>Context:
-File: themes/classic/templates/checkout/order-confirmation.tpl:11</note>
-      </trans-unit>
-      <trans-unit id="b8627ccd34529880156129d02a9ca37d">
-        <source>An email has been sent to your mail address %email%.</source>
-        <target>An email has been sent to your mail address %email%.</target>
-        <note>Context:
-File: themes/classic/templates/checkout/order-confirmation.tpl:16</note>
-      </trans-unit>
-      <trans-unit id="186f9a937f0afc4cce2bbc4087dfd3fa">
-        <source>You can also [1]download your invoice[/1]</source>
-        <target>You can also [1]download your invoice[/1]</target>
-        <note>Context:
-File: themes/classic/templates/checkout/order-confirmation.tpl:23</note>
-      </trans-unit>
-      <trans-unit id="f5d74ea75357b5e139854c14f8e24fe3">
-        <source>Order details</source>
-        <target>Order details</target>
-        <note>Context:
-File: themes/classic/templates/checkout/order-confirmation.tpl:58</note>
-      </trans-unit>
-      <trans-unit id="cc6f3e2192d71f54d7b181d91f04d165">
-        <source>Save time on your next order, sign up now</source>
-        <target>Save time on your next order, sign up now</target>
-        <note>Context:
-File: themes/classic/templates/checkout/order-confirmation.tpl:94</note>
-      </trans-unit>
-      <trans-unit id="00cd7d0890cd975da95799c32764c9ce">
-        <source>Order reference: %reference%</source>
-        <target>Order reference: %reference%</target>
-        <note>Context:
-File: themes/classic/templates/checkout/order-confirmation.tpl:60</note>
-      </trans-unit>
-      <trans-unit id="e120387480bc284c5347ae1baa480670">
-        <source>Payment method: %method%</source>
-        <target>Payment method: %method%</target>
-        <note>Context:
-File: themes/classic/templates/checkout/order-confirmation.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="080753487a8bc0bb9a5275bcb9951516">
-        <source>Shipping method: %method%</source>
-        <target>Shipping method: %method%</target>
-        <note>Context:
-File: themes/classic/templates/checkout/order-confirmation.tpl:64</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/customer-form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2fdfd506efea08144c0794c32ca8250a">
-        <source>Create an account</source>
-        <target>Create an account</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/customer-form.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="f53d1cd25e03173ba9eaa4e493636769">
-        <source>(optional)</source>
-        <target>(optional)</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/customer-form.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="c8334d474f091b12e87cf4f8632269f3">
-        <source>And save time on your next order!</source>
-        <target>And save time on your next order!</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/customer-form.tpl:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/order-final-summary-table.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e3e83a01990288b492a11a955723343d">
-        <source>%product_count% item in your cart</source>
-        <target>%product_count% item in your cart</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/order-final-summary-table.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="3f5cb84c95c577127e3f9e96d405d21b">
-        <source>%products_count% items in your cart</source>
-        <target>%products_count% items in your cart</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/order-final-summary-table.tpl:33</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/cart-detailed.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2f0dca8966242e58b83e0afc012b178b">
-        <source>There are no more items in your cart</source>
-        <target>There are no more items in your cart</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/cart-detailed.tpl:39</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="themes/classic/modules/ps_shoppingcart/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="544c3bd0eac526113a9c66542be1e5bc">
         <source>Product successfully added to your shopping cart</source>
         <target>Product successfully added to your shopping cart</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/modal.tpl:32</note>
+        <note>Line: 32</note>
       </trans-unit>
       <trans-unit id="3d0d1f906e27800531e054a3b6787b7c">
         <source>Quantity:</source>
         <target>Quantity:</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/modal.tpl:48</note>
+        <note>Line: 48</note>
       </trans-unit>
       <trans-unit id="5a0d620c4938bda6d4be4a2869cc3ee7">
         <source>There are %products_count% items in your cart.</source>
         <target>There are %products_count% items in your cart.</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/modal.tpl:55</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="e8a8612fb6fa9f657318f158780f0eeb">
         <source>There is %product_count% item in your cart.</source>
         <target>There is %product_count% item in your cart.</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/modal.tpl:57</note>
+        <note>Line: 57</note>
       </trans-unit>
       <trans-unit id="543ae6adeb524f98cc7d3c816a1ec1e3">
         <source>Total products:</source>
         <target>Total products:</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/modal.tpl:59</note>
+        <note>Line: 59</note>
       </trans-unit>
       <trans-unit id="691b338fa68b3c177c6ebbc745624c6a">
         <source>Total shipping:</source>
         <target>Total shipping:</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/modal.tpl:60</note>
+        <note>Line: 60</note>
       </trans-unit>
       <trans-unit id="66c4c5112f455a19afde47829df363fa">
         <source>Total:</source>
         <target>Total:</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/modal.tpl:64</note>
+        <note>Line: 64</note>
       </trans-unit>
     </body>
   </file>
@@ -785,8 +292,398 @@ File: themes/classic/modules/ps_shoppingcart/modal.tpl:64</note>
       <trans-unit id="a85eba4c6c699122b2bb1387ea4813ad">
         <source>Cart</source>
         <target>Cart</target>
-        <note>Context:
-File: themes/classic/modules/ps_shoppingcart/ps_shoppingcart.tpl:32</note>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-add-to-cart.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="21cf667b2d56747effd90b0333c6813c">
+        <source>The minimum purchase order quantity for the product is %quantity%.</source>
+        <target>The minimum purchase order quantity for the product is %quantity%.</target>
+        <note>Line: 77</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/address-form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5c74d926c4b89517ad64133990d04413">
+        <source>Use this address for invoice too</source>
+        <target>Use this address for invoice too</target>
+        <note>Line: 26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0d9175fe89fb80d815e7d03698b6e83a">
+        <source>Gift</source>
+        <target>Gift</target>
+        <note>Line: 140</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/cart-detailed.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2f0dca8966242e58b83e0afc012b178b">
+        <source>There are no more items in your cart</source>
+        <target>There are no more items in your cart</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/cart-voucher.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0ab608f7e0d1501be457f7646c1e57c0">
+        <source>Promo code</source>
+        <target>Promo code</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="3111382b0f345f39639de6e580a94933">
+        <source>Have a promo code?</source>
+        <target>Have a promo code?</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/customer-form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2fdfd506efea08144c0794c32ca8250a">
+        <source>Create an account</source>
+        <target>Create an account</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="f53d1cd25e03173ba9eaa4e493636769">
+        <source>(optional)</source>
+        <target>(optional)</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="c8334d474f091b12e87cf4f8632269f3">
+        <source>And save time on your next order!</source>
+        <target>And save time on your next order!</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/order-confirmation-table.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2cee9edacddde0856a46d7db6aff9110">
+        <source>Order items</source>
+        <target>Order items</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/order-final-summary-table.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e3e83a01990288b492a11a955723343d">
+        <source>%product_count% item in your cart</source>
+        <target>%product_count% item in your cart</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="3f5cb84c95c577127e3f9e96d405d21b">
+        <source>%products_count% items in your cart</source>
+        <target>%products_count% items in your cart</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/order-final-summary.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="49ffd9480effff979143d2e8d38931c4">
+        <source>Shipping Method</source>
+        <target>Shipping Method</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
+        <source>Addresses</source>
+        <target>Addresses</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="7ce3a11073ffba68bd1e83e243aaabf7">
+        <source>Please check your order before payment</source>
+        <target>Please check your order before payment</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="f2a5a4ccf14820292a27cca1c8cab12e">
+        <source>Your Delivery Address</source>
+        <target>Your Delivery Address</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/steps/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="48974cc3df177e6b565c39aa155458cd">
+        <source>Shipping Address</source>
+        <target>Shipping Address</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="dc024b376ebf01abd90cf4d5e4dca1c7">
+        <source>The selected address will be used as your personal address (for invoice).</source>
+        <target>The selected address will be used as your personal address (for invoice).</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="313d7cbfa2b3c25f09d69ad7e40974a7">
+        <source>Billing address differs from shipping address</source>
+        <target>Billing address differs from shipping address</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="baa63a898921164abe2d1d532ab27e79">
+        <source>Your Invoice Address</source>
+        <target>Your Invoice Address</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="56d0ed7cd789dd772be59aa6b1e437de">
+        <source>The selected address will be used both as your personal address (for invoice) and as your delivery address.</source>
+        <target>The selected address will be used both as your personal address (for invoice) and as your delivery address.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/steps/payment.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9fb4d9fd68ac3a078e956d034bce0474">
+        <source>Transaction amount has been correctly updated</source>
+        <target>Transaction amount has been correctly updated</target>
+        <note>Line: 12</note>
+      </trans-unit>
+      <trans-unit id="9ea465e939c30ceba6e0d46810913142">
+        <source>By confirming the order, you certify that you have read and agree with all of the conditions below:</source>
+        <target>By confirming the order, you certify that you have read and agree with all of the conditions below:</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="91b442d385b54e1418d81adc34871053">
+        <source>Selected</source>
+        <target>Selected</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="97b72d419a22e2d1144b2fb05ee26901">
+        <source>Unfortunately, there are no payment method available.</source>
+        <target>Unfortunately, there are no payment method available.</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="3a31d70f8c2eb35a29f6c58e9664cd7f">
+        <source>Please make sure you've chosen a [1]payment method[/1] and accepted the [2]terms and conditions[/2].</source>
+        <target>Please make sure you've chosen a [1]payment method[/1] and accepted the [2]terms and conditions[/2].</target>
+        <note>Line: 135</note>
+      </trans-unit>
+      <trans-unit id="dde6c860ae1ac6573875352abf1822ef">
+        <source>No payment needed for this order</source>
+        <target>No payment needed for this order</target>
+        <note>Line: 17</note>
+      </trans-unit>
+      <trans-unit id="5486191906ec27c1c4bb5bd3e46b3442">
+        <source>Order with an obligation to pay</source>
+        <target>Order with an obligation to pay</target>
+        <note>Line: 150</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/steps/personal-information.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3e0b39c8cd14dd15fff36eecf9c19861">
+        <source>If you sign out now, your cart will be emptied.</source>
+        <target>If you sign out now, your cart will be emptied.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="c1fc8e1c54652420d0822e0614089df6">
+        <source>Order as a guest</source>
+        <target>Order as a guest</target>
+        <note>Line: 46</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/steps/shipping.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9193b58520051d8b59ca64a5cc5353ff">
+        <source>I would like to receive my order in recycled packaging.</source>
+        <target>I would like to receive my order in recycled packaging.</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="5153f37f9159735ef4ae472c19b732e3">
+        <source>If you'd like, you can add a note to the gift:</source>
+        <target>If you'd like, you can add a note to the gift:</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="9a605fc0e1667ebdbd0ac37cf9f90789">
+        <source>Unfortunately, there are no carriers available for your delivery address.</source>
+        <target>Unfortunately, there are no carriers available for your delivery address.</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="d93651d012e77dac5581b08db33195b2">
+        <source>If you would like to add a comment about your order, please write it in the field below.</source>
+        <target>If you would like to add a comment about your order, please write it in the field below.</target>
+        <note>Line: 83</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/cart.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b75443a19207ed3a3552edda86536857">
+        <source>Shopping Cart</source>
+        <target>Shopping Cart</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/order-confirmation.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7f21696f11929f5ed55ca5bcb15d2fc1">
+        <source>Your order is confirmed</source>
+        <target>Your order is confirmed</target>
+        <note>Line: 11</note>
+      </trans-unit>
+      <trans-unit id="b8627ccd34529880156129d02a9ca37d">
+        <source>An email has been sent to your mail address %email%.</source>
+        <target>An email has been sent to your mail address %email%.</target>
+        <note>Line: 16</note>
+      </trans-unit>
+      <trans-unit id="186f9a937f0afc4cce2bbc4087dfd3fa">
+        <source>You can also [1]download your invoice[/1]</source>
+        <target>You can also [1]download your invoice[/1]</target>
+        <note>Line: 23</note>
+      </trans-unit>
+      <trans-unit id="f5d74ea75357b5e139854c14f8e24fe3">
+        <source>Order details</source>
+        <target>Order details</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="cc6f3e2192d71f54d7b181d91f04d165">
+        <source>Save time on your next order, sign up now</source>
+        <target>Save time on your next order, sign up now</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="00cd7d0890cd975da95799c32764c9ce">
+        <source>Order reference: %reference%</source>
+        <target>Order reference: %reference%</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="e120387480bc284c5347ae1baa480670">
+        <source>Payment method: %method%</source>
+        <target>Payment method: %method%</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="080753487a8bc0bb9a5275bcb9951516">
+        <source>Shipping method: %method%</source>
+        <target>Shipping method: %method%</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/discount.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ca0dbad92a874b2f69b549293387925e">
+        <source>Code</source>
+        <target>Code</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
+        <source>Description</source>
+        <target>Description</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="689202409e48743b914713f96d93947c">
+        <source>Value</source>
+        <target>Value</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="a1d0ec6d56f8833a078b5a7ac4caf2d4">
+        <source>Minimum</source>
+        <target>Minimum</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="eb2527806a7e1ef48009eaaa785368fe">
+        <source>Cumulative</source>
+        <target>Cumulative</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="8c1279db4db86553e4b9682f78cf500e">
+        <source>Expiration date</source>
+        <target>Expiration date</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/history.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c453a4b8e8d98e82f35b67f433e3b4da">
+        <source>Payment</source>
+        <target>Payment</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="5d4710f9a8250b13164a82c94d5b00d1">
+        <source>Order reference</source>
+        <target>Order reference</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="44749712dbec183e983dcd78a7736c41">
+        <source>Date</source>
+        <target>Date</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="0eede552438475bdfe820c13f24c9399">
+        <source>Total price</source>
+        <target>Total price</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="ec53a8c4f07baed5d8825072c89799be">
+        <source>Status</source>
+        <target>Status</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="466eadd40b3c10580e3ab4e8061161ce">
+        <source>Invoice</source>
+        <target>Invoice</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-detail.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
+        <source>Carrier</source>
+        <target>Carrier</target>
+        <note>Line: 191</note>
+      </trans-unit>
+      <trans-unit id="f0aaaae189e9c7711931a65ffcd22543">
+        <source>Payment method</source>
+        <target>Payment method</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="d350478ea9dc7f1f8ae3c78a41630f1d">
+        <source>Delivery address %alias%</source>
+        <target>Delivery address %alias%</target>
+        <note>Line: 132</note>
+      </trans-unit>
+      <trans-unit id="7d0244dc42acadee967bf9d8e612bffb">
+        <source>Invoice address %alias%</source>
+        <target>Invoice address %alias%</target>
+        <note>Line: 140</note>
+      </trans-unit>
+      <trans-unit id="8c489d0946f66d17d73f26366a4bf620">
+        <source>Weight</source>
+        <target>Weight</target>
+        <note>Line: 194</note>
+      </trans-unit>
+      <trans-unit id="552a0d8c17d95d5dbdc0c28217024f5a">
+        <source>Shipping cost</source>
+        <target>Shipping cost</target>
+        <note>Line: 197</note>
+      </trans-unit>
+      <trans-unit id="5068c162a60b5859f973f701333f45c5">
+        <source>Tracking number</source>
+        <target>Tracking number</target>
+        <note>Line: 200</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
+        <source>Quantity</source>
+        <target>Quantity</target>
+        <note>Line: 40</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopThemeCustomeraccount.xlf
+++ b/app/Resources/translations/default/ShopThemeCustomeraccount.xlf
@@ -1,34 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="themes/classic/templates/customer/history.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/form/CustomerFormatter.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="782c8b38bce4f2f6975ca7f33ac8189b">
-        <source>Order history</source>
-        <target>Order history</target>
-        <note>Context:
-File: themes/classic/templates/customer/history.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="28d5817f910ec3a8856126f5860fa490">
-        <source>Here are the orders you've placed since your account was created.</source>
-        <target>Here are the orders you've placed since your account was created.</target>
-        <note>Context:
-File: themes/classic/templates/customer/history.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="3ec365dd533ddb7ef3d1c111186ce872">
-        <source>Details</source>
-        <target>Details</target>
-        <note>Context:
-File: themes/classic/templates/customer/history.tpl:101</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f2fc7490cbdb0db5cd6f1a4e7edb0da1">
-        <source>Your account</source>
-        <target>Your account</target>
-        <note>Context:
-File: themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl:33</note>
+      <trans-unit id="a9e3d6296e9b194ee466230d8438935a">
+        <source>Receive offers from our partners</source>
+        <target>Receive offers from our partners</target>
+        <note>Line: 211</note>
       </trans-unit>
     </body>
   </file>
@@ -37,58 +14,7 @@ File: themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
       <trans-unit id="6f6347e99d6511fc895179a42301c001">
         <source>#%id%</source>
         <target>#%id%</target>
-        <note>Context:
-File: controllers/front/OrderSlipController.php:67</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/my-account.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a82868319826fb092b73968e661b5b38">
-        <source>Vouchers</source>
-        <target>Vouchers</target>
-        <note>Context:
-File: themes/classic/templates/customer/my-account.tpl:80</note>
-      </trans-unit>
-      <trans-unit id="d1a365ea7809ae5831c6d9f86886630c">
-        <source>Credit slips</source>
-        <target>Credit slips</target>
-        <note>Context:
-File: themes/classic/templates/customer/my-account.tpl:71</note>
-      </trans-unit>
-      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
-        <source>Addresses</source>
-        <target>Addresses</target>
-        <note>Context:
-File: themes/classic/templates/customer/my-account.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="da4791bc9700aca963b560fcb7db0605">
-        <source>Add first address</source>
-        <target>Add first address</target>
-        <note>Context:
-File: themes/classic/templates/customer/my-account.tpl:53</note>
-      </trans-unit>
-      <trans-unit id="a82be0f551b8708bc08eb33cd9ded0cf">
-        <source>Information</source>
-        <target>Information</target>
-        <note>Context:
-File: themes/classic/templates/customer/my-account.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="cea4dedd9147586b361b90e900944690">
-        <source>Order history and details</source>
-        <target>Order history and details</target>
-        <note>Context:
-File: themes/classic/templates/customer/my-account.tpl:62</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/form/CustomerFormatter.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a9e3d6296e9b194ee466230d8438935a">
-        <source>Receive offers from our partners</source>
-        <target>Receive offers from our partners</target>
-        <note>Context:
-File: classes/form/CustomerFormatter.php:211</note>
+        <note>Line: 67</note>
       </trans-unit>
     </body>
   </file>
@@ -97,498 +23,17 @@ File: classes/form/CustomerFormatter.php:211</note>
       <trans-unit id="4b877ba8588b19f1b278510bf2b57ebb">
         <source>Log me out</source>
         <target>Log me out</target>
-        <note>Context:
-File: modules/ps_customersignin/ps_customersignin.tpl:3</note>
+        <note>Line: 3</note>
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/modules/ps_customersignin/ps_customersignin.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="themes/StarterTheme/templates/checkout/_partials/cart-summary.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="2cbfb6731610056e1d0aaacde07096c1">
-        <source>View my customer account</source>
-        <target>View my customer account</target>
-        <note>Context:
-File: themes/classic/modules/ps_customersignin/ps_customersignin.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="d4151a9a3959bdd43690735737034f27">
-        <source>Log in to your customer account</source>
-        <target>Log in to your customer account</target>
-        <note>Context:
-File: themes/classic/modules/ps_customersignin/ps_customersignin.tpl:48</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/guest-login.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6b10b52dc4d44e780e6e38073668be56">
-        <source>Guest Order Tracking</source>
-        <target>Guest Order Tracking</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-login.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="d2948a89e47a4ad7eb8412c1c260ea88">
-        <source>To track your order, please enter the following information:</source>
-        <target>To track your order, please enter the following information:</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-login.tpl:34</note>
-      </trans-unit>
-      <trans-unit id="92dbb751eb9457441af82a53f3cfae54">
-        <source>For example: QIIXJXNUI or QIIXJXNUI#1</source>
-        <target>For example: QIIXJXNUI or QIIXJXNUI#1</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-login.tpl:52</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/order-slip.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5996bd24bf8b740b8205e0d9fe1a0709">
-        <source>Credit slips you have received after canceled orders.</source>
-        <target>Credit slips you have received after canceled orders.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-slip.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="cf3bae95c5f6023d5a10fe415b205a45">
-        <source>Credit slip</source>
-        <target>Credit slip</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-slip.tpl:65</note>
-      </trans-unit>
-      <trans-unit id="3cb6ea48a427bf3a1687302e3b764c27">
-        <source>View credit slip</source>
-        <target>View credit slip</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-slip.tpl:73</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/order-follow.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a240fa27925a635b08dc28c9e4f9216d">
-        <source>Order</source>
-        <target>Order</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-follow.tpl:70</note>
-      </trans-unit>
-      <trans-unit id="446faa7da2d42ba4ffeda73cb119dd91">
-        <source>Date issued</source>
-        <target>Date issued</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-follow.tpl:82</note>
-      </trans-unit>
-      <trans-unit id="e06d7593c1cd6dabef450be6c3da7091">
-        <source>Merchandise returns</source>
-        <target>Merchandise returns</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-follow.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="9cf9ab35a1b24314913bb739d25a0b36">
-        <source>Here is a list of pending merchandise returns</source>
-        <target>Here is a list of pending merchandise returns</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-follow.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="988fd738de9c6d177440c5dcf69e73ce">
-        <source>Return</source>
-        <target>Return</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-follow.tpl:74</note>
-      </trans-unit>
-      <trans-unit id="d442cb92c3b031eceacbfe87605b9356">
-        <source>Package status</source>
-        <target>Package status</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-follow.tpl:78</note>
-      </trans-unit>
-      <trans-unit id="6d72e074fdface4ae892543d39434175">
-        <source>Returns form</source>
-        <target>Returns form</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-follow.tpl:87</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/StarterTheme/templates/customer/history.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bcd1b68617759b1dfcff0403a6b5a8d1">
-        <source>PDF</source>
-        <target>PDF</target>
-        <note>Context:
-File: themes/StarterTheme/templates/customer/history.tpl:64</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/_partials/order-detail-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3956298bcfc047e15b0e0d218492ce09">
-        <source>Merchandise return</source>
-        <target>Merchandise return</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-detail-return.tpl:236</note>
-      </trans-unit>
-      <trans-unit id="bef8403608dc4cb3ade799f63dd4bf59">
-        <source>If you wish to return one or more products, please mark the corresponding boxes and provide an explanation for the return. When complete, click the button below.</source>
-        <target>If you wish to return one or more products, please mark the corresponding boxes and provide an explanation for the return. When complete, click the button below.</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-detail-return.tpl:237</note>
-      </trans-unit>
-      <trans-unit id="1af342a10e8238b722ba844facf5768b">
-        <source>Request a return</source>
-        <target>Request a return</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-detail-return.tpl:247</note>
-      </trans-unit>
-      <trans-unit id="fdfac28b5ad628f25649d9c2eb4fc62e">
-        <source>Returned</source>
-        <target>Returned</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-detail-return.tpl:205</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/password-infos.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="01a569ddc6cf67ddec2a683f0a5f5956">
-        <source>Forgot your password?</source>
-        <target>Forgot your password?</target>
-        <note>Context:
-File: themes/classic/templates/customer/password-infos.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/_partials/my-account-links.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a958dbb46713e59856c35f89e5092a5e">
-        <source>Back to your account</source>
-        <target>Back to your account</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/my-account-links.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/_partials/order-messages.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="41de6d6cfb8953c021bbe4ba0701c8a1">
-        <source>Messages</source>
-        <target>Messages</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-messages.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="58b3d8603dffe8484e90c0ca371921ac">
-        <source>Add a message</source>
-        <target>Add a message</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-messages.tpl:49</note>
-      </trans-unit>
-      <trans-unit id="d93651d012e77dac5581b08db33195b2">
-        <source>If you would like to add a comment about your order, please write it in the field below.</source>
-        <target>If you would like to add a comment about your order, please write it in the field below.</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/order-messages.tpl:50</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/identity.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6335a00a08fde0fbb8f6d6630cdadd92">
-        <source>Your personal information</source>
-        <target>Your personal information</target>
-        <note>Context:
-File: themes/classic/templates/customer/identity.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/authentication.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="11f4b4ba23dc72ee5e86ff5a90bdde60">
-        <source>Log in to your account</source>
-        <target>Log in to your account</target>
-        <note>Context:
-File: themes/classic/templates/customer/authentication.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="952998528c20798fbd22b49d505a29d5">
-        <source>No account? Create one here</source>
-        <target>No account? Create one here</target>
-        <note>Context:
-File: themes/classic/templates/customer/authentication.tpl:42</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/order-detail.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f5d74ea75357b5e139854c14f8e24fe3">
-        <source>Order details</source>
-        <target>Order details</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="674592d247a228106f4f0d9f81c0d92c">
-        <source>Order Reference %reference% - placed on %date%</source>
-        <target>Order Reference %reference% - placed on %date%</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="e682495785e844d491378817aa34aa3f">
-        <source>Download your invoice as a PDF file.</source>
-        <target>Download your invoice as a PDF file.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="755bb0834a77079fd1330b555b69e6bf">
-        <source>You have given permission to receive your order in recycled packaging.</source>
-        <target>You have given permission to receive your order in recycled packaging.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:69</note>
-      </trans-unit>
-      <trans-unit id="e14bc5cef02df7369b604ea3885adb96">
-        <source>You have requested gift wrapping for this order.</source>
-        <target>You have requested gift wrapping for this order.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:74</note>
-      </trans-unit>
-      <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4">
-        <source>Message</source>
-        <target>Message</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:75</note>
-      </trans-unit>
-      <trans-unit id="46774573a61204e0aac6c4ab10247d3e">
-        <source>Follow your order's status step-by-step</source>
-        <target>Follow your order's status step-by-step</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:84</note>
-      </trans-unit>
-      <trans-unit id="ced55d097872ab13bf177e8d31db396f">
-        <source>Click the following link to track the delivery of your order</source>
-        <target>Click the following link to track the delivery of your order</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:122</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/StarterTheme/templates/customer/my-account.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="999fe77c512638fd1b2ff18646d24781">
-        <source>Welcome to your account. Here you can manage all of your personal information and orders.</source>
-        <target>Welcome to your account. Here you can manage all of your personal information and orders.</target>
-        <note>Context:
-File: themes/StarterTheme/templates/customer/my-account.tpl:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3908e1afa0ff22fbf112aff3c5ba55c1">
-        <source>Your addresses</source>
-        <target>Your addresses</target>
-        <note>Context:
-File: themes/classic/templates/customer/addresses.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/address.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f469203cd9de85e9583bae25f1cb0557">
-        <source>Update your address</source>
-        <target>Update your address</target>
-        <note>Context:
-File: themes/classic/templates/customer/address.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="393d8c6bc7a04264bd9523dc8c92b818">
-        <source>New address</source>
-        <target>New address</target>
-        <note>Context:
-File: themes/classic/templates/customer/address.tpl:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/password-email.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f28d8a87d03470521d5a992312bfaed8">
-        <source>Please enter the email address you used to register. You will receive a temporary link to reset your password.</source>
-        <target>Please enter the email address you used to register. You will receive a temporary link to reset your password.</target>
-        <note>Context:
-File: themes/classic/templates/customer/password-email.tpl:48</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/steps/personal-information.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2fdfd506efea08144c0794c32ca8250a">
-        <source>Create an account</source>
-        <target>Create an account</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/personal-information.tpl:48</note>
-      </trans-unit>
-      <trans-unit id="8e3ecabff428ab5465ab8feb928436e0">
-        <source>Not you? [1]Log out[/1]</source>
-        <target>Not you? [1]Log out[/1]</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/personal-information.tpl:24</note>
-      </trans-unit>
-      <trans-unit id="6280ed214163d6e214763ff970910cdc">
-        <source>Connected as [1]%firstname% %lastname%[/1].</source>
-        <target>Connected as [1]%firstname% %lastname%[/1].</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/personal-information.tpl:11</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/registration.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="21bdc5689c12595ae14298354d5550d5">
-        <source>Already have an account?</source>
-        <target>Already have an account?</target>
-        <note>Context:
-File: themes/classic/templates/customer/registration.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="54fc27e749c6998fb54cebc1a0879692">
-        <source>Log in instead!</source>
-        <target>Log in instead!</target>
-        <note>Context:
-File: themes/classic/templates/customer/registration.tpl:35</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/password-new.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="32fe59513f5bbdd353b4527cc6af55ce">
-        <source>Reset your password</source>
-        <target>Reset your password</target>
-        <note>Context:
-File: themes/classic/templates/customer/password-new.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="24e372d72a306d924e8f1e53900dd7b6">
-        <source>Email address: %email%</source>
-        <target>Email address: %email%</target>
-        <note>Context:
-File: themes/classic/templates/customer/password-new.tpl:48</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/discount.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="70b77fea994d1bda0a46cb5f9c9275f3">
-        <source>Your vouchers</source>
-        <target>Your vouchers</target>
-        <note>Context:
-File: themes/classic/templates/customer/discount.tpl:28</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/guest-tracking.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3aedb5d3a3e36f7bb6baf1fbb9497894">
-        <source>Guest Tracking</source>
-        <target>Guest Tracking</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-tracking.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="109636f722b8fccc95d072b2760a6282">
-        <source>Transform your guest account into a customer account and enjoy:</source>
-        <target>Transform your guest account into a customer account and enjoy:</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-tracking.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="7a8fe8aaa64e691d82f429d39e0df3a5">
-        <source>Personalized and secure access</source>
-        <target>Personalized and secure access</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-tracking.tpl:44</note>
-      </trans-unit>
-      <trans-unit id="93aef17b1541efc1c3f8bd6679972096">
-        <source>Fast and easy checkout</source>
-        <target>Fast and easy checkout</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-tracking.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="1f1015bbef5f42d858e8486397ad8f3e">
-        <source>Easier merchandise return</source>
-        <target>Easier merchandise return</target>
-        <note>Context:
-File: themes/classic/templates/customer/guest-tracking.tpl:46</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/order-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="cd8ee64ef80cd6bb4e320a7d0563b56f">
-        <source>Return details</source>
-        <target>Return details</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:4</note>
-      </trans-unit>
-      <trans-unit id="4aa65c7cc01324ce850c2975f548d637">
-        <source>%number% on %date%</source>
-        <target>%number% on %date%</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:12</note>
-      </trans-unit>
-      <trans-unit id="88be9ea838e21273267409d76af3b284">
-        <source>We have logged your return request.</source>
-        <target>We have logged your return request.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:18</note>
-      </trans-unit>
-      <trans-unit id="d45c14e2fb387664ad2a66a2b8f7c0a4">
-        <source>Your package must be returned to us within %number% days of receiving your order.</source>
-        <target>Your package must be returned to us within %number% days of receiving your order.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:19</note>
-      </trans-unit>
-      <trans-unit id="77264630b0f035a114135e26f0e56a5c">
-        <source>The current status of your merchandise return is: [1] %status% [/1]</source>
-        <target>The current status of your merchandise return is: [1] %status% [/1]</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:25</note>
-      </trans-unit>
-      <trans-unit id="b24be74c768f02b296d4e8f41be486fb">
-        <source>List of items to be returned:</source>
-        <target>List of items to be returned:</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="92a9774c2a5df29ac4bffb46219ea9cd">
-        <source>Reminder</source>
-        <target>Reminder</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:106</note>
-      </trans-unit>
-      <trans-unit id="2b79d007c64009edf92d06f7cb280b25">
-        <source>All merchandise must be returned in its original packaging and in its original state.</source>
-        <target>All merchandise must be returned in its original packaging and in its original state.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:108</note>
-      </trans-unit>
-      <trans-unit id="3407538083069a115822986f5b34b21f">
-        <source>Please print out the [1]returns form[/1] and include it with your package.</source>
-        <target>Please print out the [1]returns form[/1] and include it with your package.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="2e2d29136e330ac7ba96f9004901be3a">
-        <source>Please check the [1]returns form[/1] for the correct address.</source>
-        <target>Please check the [1]returns form[/1] for the correct address.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:123</note>
-      </trans-unit>
-      <trans-unit id="16dafae9102750489087d1d087b72aba">
-        <source>When we receive your package, we will notify you by email. We will then begin processing order reimbursement.</source>
-        <target>When we receive your package, we will notify you by email. We will then begin processing order reimbursement.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:133</note>
-      </trans-unit>
-      <trans-unit id="f393a2fe17dc0cacff53a136479b845d">
-        <source>Please let us know if you have any questions.</source>
-        <target>Please let us know if you have any questions.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:138</note>
-      </trans-unit>
-      <trans-unit id="f637120d9f24c366b382ede6c21cddf0">
-        <source>If the conditions of return listed above are not respected, we reserve the right to refuse your package and/or reimbursement.</source>
-        <target>If the conditions of return listed above are not respected, we reserve the right to refuse your package and/or reimbursement.</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-return.tpl:143</note>
+      <trans-unit id="5238bd0d26ee4c221badd6e6c6475412">
+        <source>Your order</source>
+        <target>Your order</target>
+        <note>Context:
+File: themes/StarterTheme/templates/checkout/_partials/cart-summary.tpl:32</note>
       </trans-unit>
     </body>
   </file>
@@ -608,13 +53,490 @@ File: themes/StarterTheme/templates/checkout/_partials/steps/personal-informatio
       </trans-unit>
     </body>
   </file>
-  <file original="themes/StarterTheme/templates/checkout/_partials/cart-summary.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="themes/StarterTheme/templates/customer/history.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="5238bd0d26ee4c221badd6e6c6475412">
-        <source>Your order</source>
-        <target>Your order</target>
+      <trans-unit id="bcd1b68617759b1dfcff0403a6b5a8d1">
+        <source>PDF</source>
+        <target>PDF</target>
         <note>Context:
-File: themes/StarterTheme/templates/checkout/_partials/cart-summary.tpl:32</note>
+File: themes/StarterTheme/templates/customer/history.tpl:64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/StarterTheme/templates/customer/my-account.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="999fe77c512638fd1b2ff18646d24781">
+        <source>Welcome to your account. Here you can manage all of your personal information and orders.</source>
+        <target>Welcome to your account. Here you can manage all of your personal information and orders.</target>
+        <note>Context:
+File: themes/StarterTheme/templates/customer/my-account.tpl:34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f2fc7490cbdb0db5cd6f1a4e7edb0da1">
+        <source>Your account</source>
+        <target>Your account</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_customersignin/ps_customersignin.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2cbfb6731610056e1d0aaacde07096c1">
+        <source>View my customer account</source>
+        <target>View my customer account</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="d4151a9a3959bdd43690735737034f27">
+        <source>Log in to your customer account</source>
+        <target>Log in to your customer account</target>
+        <note>Line: 48</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/steps/personal-information.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8e3ecabff428ab5465ab8feb928436e0">
+        <source>Not you? [1]Log out[/1]</source>
+        <target>Not you? [1]Log out[/1]</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="6280ed214163d6e214763ff970910cdc">
+        <source>Connected as [1]%firstname% %lastname%[/1].</source>
+        <target>Connected as [1]%firstname% %lastname%[/1].</target>
+        <note>Line: 11</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/my-account-links.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a958dbb46713e59856c35f89e5092a5e">
+        <source>Back to your account</source>
+        <target>Back to your account</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/order-detail-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3956298bcfc047e15b0e0d218492ce09">
+        <source>Merchandise return</source>
+        <target>Merchandise return</target>
+        <note>Line: 236</note>
+      </trans-unit>
+      <trans-unit id="bef8403608dc4cb3ade799f63dd4bf59">
+        <source>If you wish to return one or more products, please mark the corresponding boxes and provide an explanation for the return. When complete, click the button below.</source>
+        <target>If you wish to return one or more products, please mark the corresponding boxes and provide an explanation for the return. When complete, click the button below.</target>
+        <note>Line: 237</note>
+      </trans-unit>
+      <trans-unit id="1af342a10e8238b722ba844facf5768b">
+        <source>Request a return</source>
+        <target>Request a return</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="fdfac28b5ad628f25649d9c2eb4fc62e">
+        <source>Returned</source>
+        <target>Returned</target>
+        <note>Line: 205</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/order-messages.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="41de6d6cfb8953c021bbe4ba0701c8a1">
+        <source>Messages</source>
+        <target>Messages</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="58b3d8603dffe8484e90c0ca371921ac">
+        <source>Add a message</source>
+        <target>Add a message</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="d93651d012e77dac5581b08db33195b2">
+        <source>If you would like to add a comment about your order, please write it in the field below.</source>
+        <target>If you would like to add a comment about your order, please write it in the field below.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/address.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f469203cd9de85e9583bae25f1cb0557">
+        <source>Update your address</source>
+        <target>Update your address</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="393d8c6bc7a04264bd9523dc8c92b818">
+        <source>New address</source>
+        <target>New address</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/addresses.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3908e1afa0ff22fbf112aff3c5ba55c1">
+        <source>Your addresses</source>
+        <target>Your addresses</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/authentication.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="11f4b4ba23dc72ee5e86ff5a90bdde60">
+        <source>Log in to your account</source>
+        <target>Log in to your account</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="952998528c20798fbd22b49d505a29d5">
+        <source>No account? Create one here</source>
+        <target>No account? Create one here</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/discount.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="70b77fea994d1bda0a46cb5f9c9275f3">
+        <source>Your vouchers</source>
+        <target>Your vouchers</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/guest-login.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6b10b52dc4d44e780e6e38073668be56">
+        <source>Guest Order Tracking</source>
+        <target>Guest Order Tracking</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="d2948a89e47a4ad7eb8412c1c260ea88">
+        <source>To track your order, please enter the following information:</source>
+        <target>To track your order, please enter the following information:</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="92dbb751eb9457441af82a53f3cfae54">
+        <source>For example: QIIXJXNUI or QIIXJXNUI#1</source>
+        <target>For example: QIIXJXNUI or QIIXJXNUI#1</target>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/guest-tracking.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3aedb5d3a3e36f7bb6baf1fbb9497894">
+        <source>Guest Tracking</source>
+        <target>Guest Tracking</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="109636f722b8fccc95d072b2760a6282">
+        <source>Transform your guest account into a customer account and enjoy:</source>
+        <target>Transform your guest account into a customer account and enjoy:</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="7a8fe8aaa64e691d82f429d39e0df3a5">
+        <source>Personalized and secure access</source>
+        <target>Personalized and secure access</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="93aef17b1541efc1c3f8bd6679972096">
+        <source>Fast and easy checkout</source>
+        <target>Fast and easy checkout</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="1f1015bbef5f42d858e8486397ad8f3e">
+        <source>Easier merchandise return</source>
+        <target>Easier merchandise return</target>
+        <note>Line: 46</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/history.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="782c8b38bce4f2f6975ca7f33ac8189b">
+        <source>Order history</source>
+        <target>Order history</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="28d5817f910ec3a8856126f5860fa490">
+        <source>Here are the orders you've placed since your account was created.</source>
+        <target>Here are the orders you've placed since your account was created.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="3ec365dd533ddb7ef3d1c111186ce872">
+        <source>Details</source>
+        <target>Details</target>
+        <note>Line: 101</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/identity.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6335a00a08fde0fbb8f6d6630cdadd92">
+        <source>Your personal information</source>
+        <target>Your personal information</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/my-account.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a82868319826fb092b73968e661b5b38">
+        <source>Vouchers</source>
+        <target>Vouchers</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="d1a365ea7809ae5831c6d9f86886630c">
+        <source>Credit slips</source>
+        <target>Credit slips</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
+        <source>Addresses</source>
+        <target>Addresses</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="da4791bc9700aca963b560fcb7db0605">
+        <source>Add first address</source>
+        <target>Add first address</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="a82be0f551b8708bc08eb33cd9ded0cf">
+        <source>Information</source>
+        <target>Information</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="cea4dedd9147586b361b90e900944690">
+        <source>Order history and details</source>
+        <target>Order history and details</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="e06d7593c1cd6dabef450be6c3da7091">
+        <source>Merchandise returns</source>
+        <target>Merchandise returns</target>
+        <note>Line: 89</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-detail.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f5d74ea75357b5e139854c14f8e24fe3">
+        <source>Order details</source>
+        <target>Order details</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="674592d247a228106f4f0d9f81c0d92c">
+        <source>Order Reference %reference% - placed on %date%</source>
+        <target>Order Reference %reference% - placed on %date%</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="e682495785e844d491378817aa34aa3f">
+        <source>Download your invoice as a PDF file.</source>
+        <target>Download your invoice as a PDF file.</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="755bb0834a77079fd1330b555b69e6bf">
+        <source>You have given permission to receive your order in recycled packaging.</source>
+        <target>You have given permission to receive your order in recycled packaging.</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="e14bc5cef02df7369b604ea3885adb96">
+        <source>You have requested gift wrapping for this order.</source>
+        <target>You have requested gift wrapping for this order.</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4">
+        <source>Message</source>
+        <target>Message</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="46774573a61204e0aac6c4ab10247d3e">
+        <source>Follow your order's status step-by-step</source>
+        <target>Follow your order's status step-by-step</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="ced55d097872ab13bf177e8d31db396f">
+        <source>Click the following link to track the delivery of your order</source>
+        <target>Click the following link to track the delivery of your order</target>
+        <note>Line: 122</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-follow.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a240fa27925a635b08dc28c9e4f9216d">
+        <source>Order</source>
+        <target>Order</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="446faa7da2d42ba4ffeda73cb119dd91">
+        <source>Date issued</source>
+        <target>Date issued</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="9cf9ab35a1b24314913bb739d25a0b36">
+        <source>Here is a list of pending merchandise returns</source>
+        <target>Here is a list of pending merchandise returns</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="988fd738de9c6d177440c5dcf69e73ce">
+        <source>Return</source>
+        <target>Return</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="d442cb92c3b031eceacbfe87605b9356">
+        <source>Package status</source>
+        <target>Package status</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="6d72e074fdface4ae892543d39434175">
+        <source>Returns form</source>
+        <target>Returns form</target>
+        <note>Line: 87</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cd8ee64ef80cd6bb4e320a7d0563b56f">
+        <source>Return details</source>
+        <target>Return details</target>
+        <note>Line: 4</note>
+      </trans-unit>
+      <trans-unit id="4aa65c7cc01324ce850c2975f548d637">
+        <source>%number% on %date%</source>
+        <target>%number% on %date%</target>
+        <note>Line: 12</note>
+      </trans-unit>
+      <trans-unit id="88be9ea838e21273267409d76af3b284">
+        <source>We have logged your return request.</source>
+        <target>We have logged your return request.</target>
+        <note>Line: 18</note>
+      </trans-unit>
+      <trans-unit id="d45c14e2fb387664ad2a66a2b8f7c0a4">
+        <source>Your package must be returned to us within %number% days of receiving your order.</source>
+        <target>Your package must be returned to us within %number% days of receiving your order.</target>
+        <note>Line: 19</note>
+      </trans-unit>
+      <trans-unit id="77264630b0f035a114135e26f0e56a5c">
+        <source>The current status of your merchandise return is: [1] %status% [/1]</source>
+        <target>The current status of your merchandise return is: [1] %status% [/1]</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="b24be74c768f02b296d4e8f41be486fb">
+        <source>List of items to be returned:</source>
+        <target>List of items to be returned:</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="92a9774c2a5df29ac4bffb46219ea9cd">
+        <source>Reminder</source>
+        <target>Reminder</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="2b79d007c64009edf92d06f7cb280b25">
+        <source>All merchandise must be returned in its original packaging and in its original state.</source>
+        <target>All merchandise must be returned in its original packaging and in its original state.</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="3407538083069a115822986f5b34b21f">
+        <source>Please print out the [1]returns form[/1] and include it with your package.</source>
+        <target>Please print out the [1]returns form[/1] and include it with your package.</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="2e2d29136e330ac7ba96f9004901be3a">
+        <source>Please check the [1]returns form[/1] for the correct address.</source>
+        <target>Please check the [1]returns form[/1] for the correct address.</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="16dafae9102750489087d1d087b72aba">
+        <source>When we receive your package, we will notify you by email. We will then begin processing order reimbursement.</source>
+        <target>When we receive your package, we will notify you by email. We will then begin processing order reimbursement.</target>
+        <note>Line: 133</note>
+      </trans-unit>
+      <trans-unit id="f393a2fe17dc0cacff53a136479b845d">
+        <source>Please let us know if you have any questions.</source>
+        <target>Please let us know if you have any questions.</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="f637120d9f24c366b382ede6c21cddf0">
+        <source>If the conditions of return listed above are not respected, we reserve the right to refuse your package and/or reimbursement.</source>
+        <target>If the conditions of return listed above are not respected, we reserve the right to refuse your package and/or reimbursement.</target>
+        <note>Line: 143</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-slip.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5996bd24bf8b740b8205e0d9fe1a0709">
+        <source>Credit slips you have received after canceled orders.</source>
+        <target>Credit slips you have received after canceled orders.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="cf3bae95c5f6023d5a10fe415b205a45">
+        <source>Credit slip</source>
+        <target>Credit slip</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="3cb6ea48a427bf3a1687302e3b764c27">
+        <source>View credit slip</source>
+        <target>View credit slip</target>
+        <note>Line: 73</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/password-email.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f28d8a87d03470521d5a992312bfaed8">
+        <source>Please enter the email address you used to register. You will receive a temporary link to reset your password.</source>
+        <target>Please enter the email address you used to register. You will receive a temporary link to reset your password.</target>
+        <note>Line: 48</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/password-infos.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="01a569ddc6cf67ddec2a683f0a5f5956">
+        <source>Forgot your password?</source>
+        <target>Forgot your password?</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/password-new.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="32fe59513f5bbdd353b4527cc6af55ce">
+        <source>Reset your password</source>
+        <target>Reset your password</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="24e372d72a306d924e8f1e53900dd7b6">
+        <source>Email address: %email%</source>
+        <target>Email address: %email%</target>
+        <note>Line: 48</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/registration.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2fdfd506efea08144c0794c32ca8250a">
+        <source>Create an account</source>
+        <target>Create an account</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="21bdc5689c12595ae14298354d5550d5">
+        <source>Already have an account?</source>
+        <target>Already have an account?</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="54fc27e749c6998fb54cebc1a0879692">
+        <source>Log in instead!</source>
+        <target>Log in instead!</target>
+        <note>Line: 35</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopThemeGlobal.xlf
+++ b/app/Resources/translations/default/ShopThemeGlobal.xlf
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="themes/classic/modules/contactform/views/templates/widget/contactform.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="classes/controller/FrontController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="02d4482d332e1aef3437cd61c9bcc624">
-        <source>Contact us</source>
-        <target>Contact us</target>
-        <note>Context:
-File: themes/classic/modules/contactform/views/templates/widget/contactform.tpl:43</note>
+      <trans-unit id="ec0fc0100c4fc1ce4eea230c3dc10360">
+        <source>Undefined</source>
+        <target>Undefined</target>
+        <note>Line: 881</note>
       </trans-unit>
     </body>
   </file>
-  <file original="modules/ps_customeraccountlinks/ps_customeraccountlinks.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="controllers/front/AddressController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf">
         <source>Addresses</source>
         <target>Addresses</target>
-        <note>Context:
-File: modules/ps_customeraccountlinks/ps_customeraccountlinks.php:111</note>
+        <note>Line: 116</note>
       </trans-unit>
     </body>
   </file>
@@ -25,78 +23,17 @@ File: modules/ps_customeraccountlinks/ps_customeraccountlinks.php:111</note>
       <trans-unit id="6adf97f83acf6453d4a6a4b1070f3754">
         <source>None</source>
         <target>None</target>
-        <note>Context:
-File: controllers/front/DiscountController.php:72</note>
+        <note>Line: 72</note>
       </trans-unit>
       <trans-unit id="bafd7322c6e97d25b6299b5d6fe8920b">
         <source>No</source>
         <target>No</target>
-        <note>Context:
-File: controllers/front/DiscountController.php:104</note>
+        <note>Line: 104</note>
       </trans-unit>
       <trans-unit id="93cba07454f06a4a960172bbd6e2a435">
         <source>Yes</source>
         <target>Yes</target>
-        <note>Context:
-File: controllers/front/DiscountController.php:106</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/PageNotFoundController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f2fbecfb4e1f8fd471dcc0881d8518f1">
-        <source>The page you are looking for was not found.</source>
-        <target>The page you are looking for was not found.</target>
-        <note>Context:
-File: controllers/front/PageNotFoundController.php:59</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/front/SitemapController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c82004d1ded071651efc9f2138342c50">
-        <source>Our Offers</source>
-        <target>Our Offers</target>
-        <note>Context:
-File: controllers/front/SitemapController.php:39</note>
-      </trans-unit>
-      <trans-unit id="bffe9a3c9a7e00ba00a11749e022d911">
-        <source>Log in</source>
-        <target>Log in</target>
-        <note>Context:
-File: controllers/front/SitemapController.php:128</note>
-      </trans-unit>
-      <trans-unit id="1aa668d559a3a32a44796aeee6978a59">
-        <source>Create new account</source>
-        <target>Create new account</target>
-        <note>Context:
-File: controllers/front/SitemapController.php:134</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/cms/stores.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="34c869c542dee932ef8cd96d2f91cae6">
-        <source>Our stores</source>
-        <target>Our stores</target>
-        <note>Context:
-File: themes/classic/templates/cms/stores.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="adc4f9f9cccaa450c10977d50da58d8d">
-        <source>About and Contact</source>
-        <target>About and Contact</target>
-        <note>Context:
-File: themes/classic/templates/cms/stores.tpl:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/cms/sitemap.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5813ce0ec7196c492c97596718f71969">
-        <source>Sitemap</source>
-        <target>Sitemap</target>
-        <note>Context:
-File: themes/classic/templates/cms/sitemap.tpl:28</note>
+        <note>Line: 106</note>
       </trans-unit>
     </body>
   </file>
@@ -105,8 +42,35 @@ File: themes/classic/templates/cms/sitemap.tpl:28</note>
       <trans-unit id="e06d7593c1cd6dabef450be6c3da7091">
         <source>Merchandise returns</source>
         <target>Merchandise returns</target>
-        <note>Context:
-File: controllers/front/OrderReturnController.php:174</note>
+        <note>Line: 174</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/PageNotFoundController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f2fbecfb4e1f8fd471dcc0881d8518f1">
+        <source>The page you are looking for was not found.</source>
+        <target>The page you are looking for was not found.</target>
+        <note>Line: 59</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/SitemapController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c82004d1ded071651efc9f2138342c50">
+        <source>Our Offers</source>
+        <target>Our Offers</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="bffe9a3c9a7e00ba00a11749e022d911">
+        <source>Log in</source>
+        <target>Log in</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="1aa668d559a3a32a44796aeee6978a59">
+        <source>Create new account</source>
+        <target>Create new account</target>
+        <note>Line: 134</note>
       </trans-unit>
     </body>
   </file>
@@ -115,44 +79,37 @@ File: controllers/front/OrderReturnController.php:174</note>
       <trans-unit id="6f8522e0610541f1ef215a22ffa66ff6">
         <source>Monday</source>
         <target>Monday</target>
-        <note>Context:
-File: controllers/front/StoresController.php:208</note>
+        <note>Line: 208</note>
       </trans-unit>
       <trans-unit id="5792315f09a5d54fb7e3d066672b507f">
         <source>Tuesday</source>
         <target>Tuesday</target>
-        <note>Context:
-File: controllers/front/StoresController.php:211</note>
+        <note>Line: 211</note>
       </trans-unit>
       <trans-unit id="796c163589f295373e171842f37265d5">
         <source>Wednesday</source>
         <target>Wednesday</target>
-        <note>Context:
-File: controllers/front/StoresController.php:214</note>
+        <note>Line: 214</note>
       </trans-unit>
       <trans-unit id="78ae6f0cd191d25147e252dc54768238">
         <source>Thursday</source>
         <target>Thursday</target>
-        <note>Context:
-File: controllers/front/StoresController.php:217</note>
+        <note>Line: 217</note>
       </trans-unit>
       <trans-unit id="c33b138a163847cdb6caeeb7c9a126b4">
         <source>Friday</source>
         <target>Friday</target>
-        <note>Context:
-File: controllers/front/StoresController.php:220</note>
+        <note>Line: 220</note>
       </trans-unit>
       <trans-unit id="8b7051187b9191cdcdae6ed5a10e5adc">
         <source>Saturday</source>
         <target>Saturday</target>
-        <note>Context:
-File: controllers/front/StoresController.php:223</note>
+        <note>Line: 223</note>
       </trans-unit>
       <trans-unit id="9d1a0949c39e66a0cd65240bc0ac9177">
         <source>Sunday</source>
         <target>Sunday</target>
-        <note>Context:
-File: controllers/front/StoresController.php:226</note>
+        <note>Line: 226</note>
       </trans-unit>
     </body>
   </file>
@@ -161,26 +118,22 @@ File: controllers/front/StoresController.php:226</note>
       <trans-unit id="1f87346a16cf80c372065de3c54c86d9">
         <source>(tax incl.)</source>
         <target>(tax incl.)</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:429</note>
+        <note>Line: 429</note>
       </trans-unit>
       <trans-unit id="21034ae6d01a83e702839a72ba8a77b0">
         <source>(tax excl.)</source>
         <target>(tax excl.)</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:430</note>
+        <note>Line: 430</note>
       </trans-unit>
       <trans-unit id="e3ddbe6b144e01554bfa072db9bcca2f">
         <source>(tax included)</source>
         <target>(tax included)</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:432</note>
+        <note>Line: 432</note>
       </trans-unit>
       <trans-unit id="e9e7ca277da652bde67ef5faafb755dc">
         <source>(tax excluded)</source>
         <target>(tax excluded)</target>
-        <note>Context:
-File: src/Adapter/Presenter/Cart/CartPresenter.php:433</note>
+        <note>Line: 433</note>
       </trans-unit>
     </body>
   </file>
@@ -189,86 +142,22 @@ File: src/Adapter/Presenter/Cart/CartPresenter.php:433</note>
       <trans-unit id="f4a0d7cb0cd45214c8ca5912c970de13">
         <source>Tax included</source>
         <target>Tax included</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:395</note>
+        <note>Line: 395</note>
       </trans-unit>
       <trans-unit id="befcac0f9644a7abee43e69f49252ac4">
         <source>Tax excluded</source>
         <target>Tax excluded</target>
-        <note>Context:
-File: src/Adapter/Presenter/Product/ProductLazyArray.php:396</note>
+        <note>Line: 396</note>
       </trans-unit>
     </body>
   </file>
-  <file original="classes/controller/FrontController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="themes/StarterTheme/templates/cms/category.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="ec0fc0100c4fc1ce4eea230c3dc10360">
-        <source>Undefined</source>
-        <target>Undefined</target>
+      <trans-unit id="38629047675346c704697fb85268192f">
+        <source>List of subcategories in %category_name%:</source>
+        <target>List of subcategories in %category_name%:</target>
         <note>Context:
-File: classes/controller/FrontController.php:885</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/_partials/my-account-links.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="8cf04a9734132302f96da8e113e80ce5">
-        <source>Home</source>
-        <target>Home</target>
-        <note>Context:
-File: themes/classic/templates/customer/_partials/my-account-links.tpl:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/errors/restricted-country.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6351030f724f6f42fd11ec9aa6ee8c76">
-        <source>403 Forbidden</source>
-        <target>403 Forbidden</target>
-        <note>Context:
-File: themes/classic/templates/errors/restricted-country.tpl:43</note>
-      </trans-unit>
-      <trans-unit id="cf8092a0be7b972d6cee3db90bfaf923">
-        <source>You cannot access this store from your country. We apologize for the inconvenience.</source>
-        <target>You cannot access this store from your country. We apologize for the inconvenience.</target>
-        <note>Context:
-File: themes/classic/templates/errors/restricted-country.tpl:44</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/errors/not-found.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7e74146e0ff2e289abfc8bec1d2b2a18">
-        <source>Sorry for the inconvenience.</source>
-        <target>Sorry for the inconvenience.</target>
-        <note>Context:
-File: themes/classic/templates/errors/not-found.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="519ee4cd58a2b719f7113965cc949d24">
-        <source>Search again what you are looking for</source>
-        <target>Search again what you are looking for</target>
-        <note>Context:
-File: themes/classic/templates/errors/not-found.tpl:29</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/errors/maintenance.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="27b4383b976d6be981598d457cc7e62d">
-        <source>We'll be back soon.</source>
-        <target>We'll be back soon.</target>
-        <note>Context:
-File: themes/classic/templates/errors/maintenance.tpl:42</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7601c8e861088bd27255e18afaefab6b">
-        <source>%copyright% %year% - Ecommerce software by %prestashop%</source>
-        <target>%copyright% %year% - Ecommerce software by %prestashop%</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/footer.tpl:27</note>
+File: themes/StarterTheme/templates/cms/category.tpl:34</note>
       </trans-unit>
     </body>
   </file>
@@ -294,183 +183,55 @@ File: themes/StarterTheme/templates/cms/stores.tpl:56</note>
       </trans-unit>
     </body>
   </file>
+  <file original="themes/classic/modules/contactform/views/templates/widget/contactform.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="02d4482d332e1aef3437cd61c9bcc624">
+        <source>Contact us</source>
+        <target>Contact us</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="0e2fb5b02182fd28b9b96e86ed27838f">
         <source>Fax:</source>
         <target>Fax:</target>
-        <note>Context:
-File: themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="1300caaefd15b839f37952dc7cc75d82">
         <source>Call us:</source>
         <target>Call us:</target>
-        <note>Context:
-File: themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl:37</note>
+        <note>Line: 37</note>
       </trans-unit>
       <trans-unit id="a0bfe0853cf82bdf5dcb9b0bac76c357">
         <source>Email us:</source>
         <target>Email us:</target>
-        <note>Context:
-File: themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl:57</note>
+        <note>Line: 57</note>
       </trans-unit>
-    </body>
-  </file>
-  <file original="themes/StarterTheme/templates/cms/category.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="38629047675346c704697fb85268192f">
-        <source>List of subcategories in %category_name%:</source>
-        <target>List of subcategories in %category_name%:</target>
-        <note>Context:
-File: themes/StarterTheme/templates/cms/category.tpl:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/cms/category.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1d34e1ee316477a8f64a835307f5b84e">
-        <source>List of pages in %category_name%:</source>
-        <target>List of pages in %category_name%:</target>
-        <note>Context:
-File: themes/classic/templates/cms/category.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="6c5c05a5b907385c60c3baa4087ea1a1">
-        <source>List of sub categories in %name%:</source>
-        <target>List of sub categories in %name%:</target>
-        <note>Context:
-File: themes/classic/templates/cms/category.tpl:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/sort-orders.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6f9d01a14011f05fffe48559583fc609">
-        <source>Sort by:</source>
-        <target>Sort by:</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/sort-orders.tpl:25</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/facets.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7a1c5301da6b1ce9e4345bd501397045">
-        <source>(no filter)</source>
-        <target>(no filter)</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/facets.tpl:132</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/catalog/_partials/active_filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2143f8cb66482342b35208bdc3fd949c">
-        <source>Active filters</source>
-        <target>Active filters</target>
-        <note>Context:
-File: themes/classic/templates/catalog/_partials/active_filters.tpl:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/customer/order-detail.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="44749712dbec183e983dcd78a7736c41">
-        <source>Date</source>
-        <target>Date</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:188</note>
-      </trans-unit>
-      <trans-unit id="ec53a8c4f07baed5d8825072c89799be">
-        <source>Status</source>
-        <target>Status</target>
-        <note>Context:
-File: themes/classic/templates/customer/order-detail.tpl:89</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="96d6f2e7e1f705ab5e59c84a6dc009b2">
-        <source>logo</source>
-        <target>logo</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/header.tpl:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/templates/checkout/_partials/steps/payment.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d3d2e617335f08df83599665eef8a418">
-        <source>Close</source>
-        <target>Close</target>
-        <note>Context:
-File: themes/classic/templates/checkout/_partials/steps/payment.tpl:151</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_imageslider/views/templates/hook/slider.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6dbac206aa2d7e374277ae9ff8ec1987">
-        <source>Carousel buttons</source>
-        <target>Carousel buttons</target>
-        <note>Context:
-File: themes/classic/modules/ps_imageslider/views/templates/hook/slider.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="dd1f775e443ff3b9a89270713580a51b">
-        <source>Previous</source>
-        <target>Previous</target>
-        <note>Context:
-File: themes/classic/modules/ps_imageslider/views/templates/hook/slider.tpl:50</note>
-      </trans-unit>
-      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55">
-        <source>Next</source>
-        <target>Next</target>
-        <note>Context:
-File: themes/classic/modules/ps_imageslider/views/templates/hook/slider.tpl:56</note>
+      <trans-unit id="3aea774cdcd8f2c45549f10758a71323">
+        <source>Store information</source>
+        <target>Store information</target>
+        <note>Line: 27</note>
       </trans-unit>
     </body>
   </file>
   <file original="themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="3aea774cdcd8f2c45549f10758a71323">
-        <source>Store information</source>
-        <target>Store information</target>
-        <note>Context:
-File: themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl:71</note>
-      </trans-unit>
       <trans-unit id="c6359db4a43cb7267a84b389229fd073">
         <source>Call us: [1]%phone%[/1]</source>
         <target>Call us: [1]%phone%[/1]</target>
-        <note>Context:
-File: themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl:33</note>
+        <note>Line: 33</note>
       </trans-unit>
       <trans-unit id="da6eb684bd77243a780629a180c9d19b">
         <source>Fax: [1]%fax%[/1]</source>
         <target>Fax: [1]%fax%[/1]</target>
-        <note>Context:
-File: themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl:45</note>
+        <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="077d21d48dae9586405c0d264f6d32e7">
         <source>Email us: [1]%email%[/1]</source>
         <target>Email us: [1]%email%[/1]</target>
-        <note>Context:
-File: themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl:58</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="themes/classic/modules/ps_languageselector/ps_languageselector.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0885f0c211f74834f0109c5abaf4cdc4">
-        <source>Language:</source>
-        <target>Language:</target>
-        <note>Context:
-File: themes/classic/modules/ps_languageselector/ps_languageselector.tpl:27</note>
-      </trans-unit>
-      <trans-unit id="217148b9c333b63a3fb1883670f5bff2">
-        <source>Language dropdown</source>
-        <target>Language dropdown</target>
-        <note>Context:
-File: themes/classic/modules/ps_languageselector/ps_languageselector.tpl:29</note>
+        <note>Line: 58</note>
       </trans-unit>
     </body>
   </file>
@@ -479,14 +240,12 @@ File: themes/classic/modules/ps_languageselector/ps_languageselector.tpl:29</not
       <trans-unit id="77295c7d814e7397c55f64ec06313984">
         <source>Currency:</source>
         <target>Currency:</target>
-        <note>Context:
-File: themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl:28</note>
+        <note>Line: 28</note>
       </trans-unit>
       <trans-unit id="72d43a6525ac95e552ca4eaf1dc0ad1a">
         <source>Currency dropdown</source>
         <target>Currency dropdown</target>
-        <note>Context:
-File: themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl:29</note>
+        <note>Line: 29</note>
       </trans-unit>
     </body>
   </file>
@@ -495,8 +254,191 @@ File: themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl:29</not
       <trans-unit id="3805f49499fa5010c394e219aa1fe7a0">
         <source>Get our latest news and special sales</source>
         <target>Get our latest news and special sales</target>
-        <note>Context:
-File: themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl:28</note>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_imageslider/views/templates/hook/slider.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6dbac206aa2d7e374277ae9ff8ec1987">
+        <source>Carousel buttons</source>
+        <target>Carousel buttons</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="dd1f775e443ff3b9a89270713580a51b">
+        <source>Previous</source>
+        <target>Previous</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55">
+        <source>Next</source>
+        <target>Next</target>
+        <note>Line: 56</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_languageselector/ps_languageselector.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0885f0c211f74834f0109c5abaf4cdc4">
+        <source>Language:</source>
+        <target>Language:</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="217148b9c333b63a3fb1883670f5bff2">
+        <source>Language dropdown</source>
+        <target>Language dropdown</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/_partials/footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7601c8e861088bd27255e18afaefab6b">
+        <source>%copyright% %year% - Ecommerce software by %prestashop%</source>
+        <target>%copyright% %year% - Ecommerce software by %prestashop%</target>
+        <note>Line: 49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/active_filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2143f8cb66482342b35208bdc3fd949c">
+        <source>Active filters</source>
+        <target>Active filters</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/facets.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7a1c5301da6b1ce9e4345bd501397045">
+        <source>(no filter)</source>
+        <target>(no filter)</target>
+        <note>Line: 132</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/sort-orders.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6f9d01a14011f05fffe48559583fc609">
+        <source>Sort by:</source>
+        <target>Sort by:</target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="96d6f2e7e1f705ab5e59c84a6dc009b2">
+        <source>logo</source>
+        <target>logo</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/steps/payment.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3d2e617335f08df83599665eef8a418">
+        <source>Close</source>
+        <target>Close</target>
+        <note>Line: 160</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/cms/category.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1d34e1ee316477a8f64a835307f5b84e">
+        <source>List of pages in %category_name%:</source>
+        <target>List of pages in %category_name%:</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="6c5c05a5b907385c60c3baa4087ea1a1">
+        <source>List of sub categories in %name%:</source>
+        <target>List of sub categories in %name%:</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/cms/sitemap.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5813ce0ec7196c492c97596718f71969">
+        <source>Sitemap</source>
+        <target>Sitemap</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/cms/stores.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="34c869c542dee932ef8cd96d2f91cae6">
+        <source>Our stores</source>
+        <target>Our stores</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="adc4f9f9cccaa450c10977d50da58d8d">
+        <source>About and Contact</source>
+        <target>About and Contact</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/my-account-links.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8cf04a9734132302f96da8e113e80ce5">
+        <source>Home</source>
+        <target>Home</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-detail.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="44749712dbec183e983dcd78a7736c41">
+        <source>Date</source>
+        <target>Date</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="ec53a8c4f07baed5d8825072c89799be">
+        <source>Status</source>
+        <target>Status</target>
+        <note>Line: 89</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/errors/maintenance.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="27b4383b976d6be981598d457cc7e62d">
+        <source>We'll be back soon.</source>
+        <target>We'll be back soon.</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/errors/not-found.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7e74146e0ff2e289abfc8bec1d2b2a18">
+        <source>Sorry for the inconvenience.</source>
+        <target>Sorry for the inconvenience.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="519ee4cd58a2b719f7113965cc949d24">
+        <source>Search again what you are looking for</source>
+        <target>Search again what you are looking for</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/errors/restricted-country.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6351030f724f6f42fd11ec9aa6ee8c76">
+        <source>403 Forbidden</source>
+        <target>403 Forbidden</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="cf8092a0be7b972d6cee3db90bfaf923">
+        <source>You cannot access this store from your country. We apologize for the inconvenience.</source>
+        <target>You cannot access this store from your country. We apologize for the inconvenience.</target>
+        <note>Line: 44</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/messages.xlf
+++ b/app/Resources/translations/default/messages.xlf
@@ -1,2790 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="admin-dev/themes/default/template/controllers/themes/configurelayouts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="193cfc9be3b995831c6af2fea6650e60">
-        <source>Page</source>
-        <target>Page</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/configurelayouts.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="f0dbca7d922e4e759a1e3b512b9be852">
-        <source>Choose layouts</source>
-        <target>Choose layouts</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/configurelayouts.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="ebd9bec4d70abc789d439c1f136b0538">
-        <source>Layout</source>
-        <target>Layout</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/configurelayouts.tpl:42</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminModulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7258e7251413465e0a3eb58094430bde">
-        <source>Administration</source>
-        <target>Administration</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:85
- Comment: Set the modules categories</note>
-      </trans-unit>
-      <trans-unit id="3defbfac3fcbea45049cddcf80aa9f21">
-        <source>Advertising and Marketing</source>
-        <target>Advertising and Marketing</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:86</note>
-      </trans-unit>
-      <trans-unit id="a99118454f54727d280e3d2d9c7ea0e3">
-        <source>Analytics and Stats</source>
-        <target>Analytics and Stats</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:87</note>
-      </trans-unit>
-      <trans-unit id="e09d0a51d181ee0b28180946f2af0f95">
-        <source><![CDATA[Taxes & Invoicing]]></source>
-        <target><![CDATA[Taxes & Invoicing]]></target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:88</note>
-      </trans-unit>
-      <trans-unit id="6ff063fbc860a79759a7369ac32cee22">
-        <source>Checkout</source>
-        <target>Checkout</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:89</note>
-      </trans-unit>
-      <trans-unit id="5dc6d69e21ca0f5779b9cfeae1154f05">
-        <source>Content Management</source>
-        <target>Content Management</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:90</note>
-      </trans-unit>
-      <trans-unit id="d8b5985b4baa0bfe0ce6734f99b22e6e">
-        <source>Customer Reviews</source>
-        <target>Customer Reviews</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:91</note>
-      </trans-unit>
-      <trans-unit id="e00dfb7a37c4f39c748f459e69fadb96">
-        <source>Front office Features</source>
-        <target>Front office Features</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:93</note>
-      </trans-unit>
-      <trans-unit id="a8cf512208bee5db82f968d2dc247c5f">
-        <source>Internationalization and Localization</source>
-        <target>Internationalization and Localization</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:94</note>
-      </trans-unit>
-      <trans-unit id="825896e7e83eff50879ed00cba2f9414">
-        <source>Merchandising</source>
-        <target>Merchandising</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:95</note>
-      </trans-unit>
-      <trans-unit id="5b985caa89b2ca61bbeee91a896c610d">
-        <source>Migration Tools</source>
-        <target>Migration Tools</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:96</note>
-      </trans-unit>
-      <trans-unit id="286030724099ebb1518552eeb8b00bd7">
-        <source>Payments and Gateways</source>
-        <target>Payments and Gateways</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:97</note>
-      </trans-unit>
-      <trans-unit id="dd05711d44de1fa4bf31303915bd41bc">
-        <source><![CDATA[Site certification & Fraud prevention]]></source>
-        <target><![CDATA[Site certification & Fraud prevention]]></target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:98</note>
-      </trans-unit>
-      <trans-unit id="54f65da381d43abf769b7ac2cb3a8270">
-        <source>Pricing and Promotion</source>
-        <target>Pricing and Promotion</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:99</note>
-      </trans-unit>
-      <trans-unit id="a9964513dc046a2cd404413f77b4656e">
-        <source>Quick / Bulk update</source>
-        <target>Quick / Bulk update</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:100</note>
-      </trans-unit>
-      <trans-unit id="d88946b678e4c2f251d4e292e8142291">
-        <source>SEO</source>
-        <target>SEO</target>
-        <note><![CDATA[Context:
-File: controllers/admin/AdminModulesController.php:102
- Comment: $this->list_modules_categories['search_filter']['name'] = $this->l('Search and Filter');]]></note>
-      </trans-unit>
-      <trans-unit id="19e295f6e2c8774937dd5144ce6aed23">
-        <source>Shipping and Logistics</source>
-        <target>Shipping and Logistics</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:103</note>
-      </trans-unit>
-      <trans-unit id="5f17a788546ddb43236732f8b0bdfd7e">
-        <source>Slideshows</source>
-        <target>Slideshows</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:104</note>
-      </trans-unit>
-      <trans-unit id="b93d83bd882a9507436946da114a9c25">
-        <source><![CDATA[Comparison site & Feed management]]></source>
-        <target><![CDATA[Comparison site & Feed management]]></target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:105</note>
-      </trans-unit>
-      <trans-unit id="675e31b94580e2642405e2f8586d112e">
-        <source>Marketplace</source>
-        <target>Marketplace</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:106</note>
-      </trans-unit>
-      <trans-unit id="87d17f4624a514e81dc7c8e016a7405c">
-        <source>Mobile</source>
-        <target>Mobile</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:108</note>
-      </trans-unit>
-      <trans-unit id="2938c7f7e560ed972f8a4f68e80ff834">
-        <source>Dashboard</source>
-        <target>Dashboard</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:109</note>
-      </trans-unit>
-      <trans-unit id="44f9bbe73101a9c7842e9384e0db70c9">
-        <source><![CDATA[Internationalization & Localization]]></source>
-        <target><![CDATA[Internationalization & Localization]]></target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:110</note>
-      </trans-unit>
-      <trans-unit id="e7e5eafdb7b6b3bbb9e38e9ae8a35094">
-        <source><![CDATA[Emailing & SMS]]></source>
-        <target><![CDATA[Emailing & SMS]]></target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:111</note>
-      </trans-unit>
-      <trans-unit id="222e1825c6eb93a516fba01be7861ddd">
-        <source>Social Networks</source>
-        <target>Social Networks</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:112</note>
-      </trans-unit>
-      <trans-unit id="06c21841ec088f9c8cbfb82946cf203b">
-        <source><![CDATA[Social & Community]]></source>
-        <target><![CDATA[Social & Community]]></target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:113</note>
-      </trans-unit>
-      <trans-unit id="8290fb626ffacf21450997f25967efeb">
-        <source>Module not found</source>
-        <target>Module not found</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:858</note>
-      </trans-unit>
-      <trans-unit id="0c81f6a8e4b7b1d0a812d7285289f17d">
-        <source>Modules to update</source>
-        <target>Modules to update</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:1394</note>
-      </trans-unit>
-      <trans-unit id="0f0c014bcfe255c6749d8e665ff8bb4e">
-        <source>Translate this module</source>
-        <target>Translate this module</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:1448</note>
-      </trans-unit>
-      <trans-unit id="7602b3edb382cf12573e156623fe9468">
-        <source>This module cannot be installed</source>
-        <target>This module cannot be installed</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:1456</note>
-      </trans-unit>
-      <trans-unit id="ac8f751177ba1d91a0ab11d3650cdfaf">
-        <source>Important Notice</source>
-        <target>Important Notice</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:1456</note>
-      </trans-unit>
-      <trans-unit id="c472f22a7459a000f0177a23fdc4212b">
-        <source>This module is Untrusted for your country</source>
-        <target>This module is Untrusted for your country</target>
-        <note>Context:
-File: controllers/admin/AdminModulesController.php:1464</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3182ea023795eb83ed0ce3beea5beb73">
-        <source>Other Modules</source>
-        <target>Other Modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:60</note>
-      </trans-unit>
-      <trans-unit id="d9e87fc7a13ba398295447791c67b586">
-        <source>Installed Modules</source>
-        <target>Installed Modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:34</note>
-      </trans-unit>
-      <trans-unit id="a0f454ebaee933c7791ffcdda76944b3">
-        <source>Disabled Modules</source>
-        <target>Disabled Modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:43</note>
-      </trans-unit>
-      <trans-unit id="1f0e9c979b965d24aa3c2c4b832c3ba1">
-        <source>Filter by</source>
-        <target>Filter by</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="7b4d2812164df0dceca0b53bb650e52d">
-        <source><![CDATA[Installed & Not Installed]]></source>
-        <target><![CDATA[Installed & Not Installed]]></target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:33</note>
-      </trans-unit>
-      <trans-unit id="94c8dec8d2fcfa80c9b6f4669be43eb0">
-        <source>Modules Not Installed </source>
-        <target>Modules Not Installed </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="6b8f34307b46c249a91d84e52ae94caf">
-        <source><![CDATA[Enabled & Disabled]]></source>
-        <target><![CDATA[Enabled & Disabled]]></target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="dfe6e46e2d3e3ba76b5d9aee197c0747">
-        <source>Enabled Modules</source>
-        <target>Enabled Modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="02684cc6b6ea1811a064f475a5fd1d18">
-        <source>Authors</source>
-        <target>Authors</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:49</note>
-      </trans-unit>
-      <trans-unit id="00c3388449f7c4d73cc8c417d7d38554">
-        <source>All Modules</source>
-        <target>All Modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:51</note>
-      </trans-unit>
-      <trans-unit id="d546df356f9b15d6d20b1e5d8b310fed">
-        <source>Free Modules</source>
-        <target>Free Modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:52</note>
-      </trans-unit>
-      <trans-unit id="d071f451a57ab54fa6890d0f501a99d4">
-        <source>Partner Modules (Free)</source>
-        <target>Partner Modules (Free)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:53</note>
-      </trans-unit>
-      <trans-unit id="02ae741da806bbeafc0ae6a84ce752d3">
-        <source>Must Have</source>
-        <target>Must Have</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:54</note>
-      </trans-unit>
-      <trans-unit id="174704dbe8a3a7d144b0ce840e734077">
-        <source>Modules purchased on Addons</source>
-        <target>Modules purchased on Addons</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:55</note>
-      </trans-unit>
-      <trans-unit id="fbdc9a432c8e6a94bb54864ae4f5fb7f">
-        <source>All authors</source>
-        <target>All authors</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:56</note>
-      </trans-unit>
-      <trans-unit id="c3987e4cac14a8456515f0d200da04ee">
-        <source>All countries</source>
-        <target>All countries</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:67</note>
-      </trans-unit>
-      <trans-unit id="d188407e1d066cd41925efebe2dab3da">
-        <source>Current country:</source>
-        <target>Current country:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/filters.tpl:68</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="controllers/admin/AdminTabsController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d3b206d196cd6be3a2764c1fb90b200f">
-        <source>Delete selected</source>
-        <target>Delete selected</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:52</note>
-      </trans-unit>
-      <trans-unit id="e25f0ecd41211b01c83e5fec41df4fe7">
-        <source>Delete selected items?</source>
-        <target>Delete selected items?</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:53</note>
-      </trans-unit>
-      <trans-unit id="9bd81329febf6efe22788e03ddeaf0af">
-        <source>Class</source>
-        <target>Class</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:155</note>
-      </trans-unit>
-      <trans-unit id="52f5e0bc3859bc5f5e25130b6c7e8881">
-        <source>Position</source>
-        <target>Position</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:80</note>
-      </trans-unit>
-      <trans-unit id="06145a21dcec7395085b033e6e169b61">
-        <source>Menus</source>
-        <target>Menus</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:136</note>
-      </trans-unit>
-      <trans-unit id="0164b35f3cbc5cbf9bf58abeb4bc14df">
-        <source>Add new menu</source>
-        <target>Add new menu</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:102</note>
-      </trans-unit>
-      <trans-unit id="8cf04a9734132302f96da8e113e80ce5">
-        <source>Home</source>
-        <target>Home</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:130</note>
-      </trans-unit>
-      <trans-unit id="6252c0f2c2ed83b7b06dfca86d4650bb">
-        <source>Invalid characters:</source>
-        <target>Invalid characters:</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:151</note>
-      </trans-unit>
-      <trans-unit id="ec53a8c4f07baed5d8825072c89799be">
-        <source>Status</source>
-        <target>Status</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:166</note>
-      </trans-unit>
-      <trans-unit id="fe513725b21a16ced7d05b454e74a33e">
-        <source>Show or hide menu.</source>
-        <target>Show or hide menu.</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:182</note>
-      </trans-unit>
-      <trans-unit id="30269022e9d8f51beaabb52e5d0de2b7">
-        <source>Parent</source>
-        <target>Parent</target>
-        <note>Context:
-File: controllers/admin/AdminTabsController.php:198</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/favorites.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e55f75a29310d7b60f7ac1d390c8ae42">
-        <source>Module</source>
-        <target>Module</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/favorites.tpl:51</note>
-      </trans-unit>
-      <trans-unit id="6afd80bf62a1b8bdfe729af8a0159fee">
-        <source>Modules list</source>
-        <target>Modules list</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/favorites.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="7e4a9cd054588a95b0394d92a2030e72">
-        <source>Normal view</source>
-        <target>Normal view</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/favorites.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="d7af23f5f349f2c4eace4927943b2760">
-        <source>Favorites view</source>
-        <target>Favorites view</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/favorites.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="5c6ba25104401c9ee0650230fc6ba413">
-        <source>Tab</source>
-        <target>Tab</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/favorites.tpl:52</note>
-      </trans-unit>
-      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
-        <source>Categories</source>
-        <target>Categories</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/favorites.tpl:53</note>
-      </trans-unit>
-      <trans-unit id="920beb5dda21b04a332e0457cb0cfbec">
-        <source>Interest</source>
-        <target>Interest</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/favorites.tpl:54</note>
-      </trans-unit>
-      <trans-unit id="01165dcf77c191e6c69b31d98b0ec6ff">
-        <source>Favorite</source>
-        <target>Favorite</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/favorites.tpl:55</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="630f6dc397fe74e52d5189e2c80f282b">
-        <source>Back to list</source>
-        <target>Back to list</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1621</note>
-      </trans-unit>
-      <trans-unit id="ede4759c9afae620fd586628789fa304">
-        <source>Enable selection</source>
-        <target>Enable selection</target>
-        <note>Context:
-File: classes/controller/AdminController.php:3028</note>
-      </trans-unit>
-      <trans-unit id="ab7fd6e250b64a46027a996088fdff74">
-        <source>Disable selection</source>
-        <target>Disable selection</target>
-        <note>Context:
-File: classes/controller/AdminController.php:3032</note>
-      </trans-unit>
-      <trans-unit id="c9cc8cce247e49bae79f15173ce97354">
-        <source>Save</source>
-        <target>Save</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1628</note>
-      </trans-unit>
-      <trans-unit id="ec211f7c20af43e742bf2570c3cb84f9">
-        <source>Add</source>
-        <target>Add</target>
-        <note>Context:
-File: classes/controller/AdminController.php:599</note>
-      </trans-unit>
-      <trans-unit id="7dce122004969d56ae2e0245cb754d35">
-        <source>Edit</source>
-        <target>Edit</target>
-        <note>Context:
-File: classes/controller/AdminController.php:649</note>
-      </trans-unit>
-      <trans-unit id="4ee29ca12c7d126654bd0e5275de6135">
-        <source>List</source>
-        <target>List</target>
-        <note>Context:
-File: classes/controller/AdminController.php:608</note>
-      </trans-unit>
-      <trans-unit id="6e9783376d951cfd780e9fdb67a0f02c">
-        <source>View details</source>
-        <target>View details</target>
-        <note>Context:
-File: classes/controller/AdminController.php:613</note>
-      </trans-unit>
-      <trans-unit id="dae8ace18bdcbcc6ae5aece263e14fe8">
-        <source>Options</source>
-        <target>Options</target>
-        <note>Context:
-File: classes/controller/AdminController.php:617</note>
-      </trans-unit>
-      <trans-unit id="92a8f0b9d28a89b480bd1d29f46f0484">
-        <source>Generator</source>
-        <target>Generator</target>
-        <note>Context:
-File: classes/controller/AdminController.php:621</note>
-      </trans-unit>
-      <trans-unit id="ef61fb324d729c341ea8ab9901e23566">
-        <source>Add new</source>
-        <target>Add new</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1635</note>
-      </trans-unit>
-      <trans-unit id="4351cfebe4b61d8aa5efa1d020710005">
-        <source>View</source>
-        <target>View</target>
-        <note>Context:
-File: classes/controller/AdminController.php:659</note>
-      </trans-unit>
-      <trans-unit id="a6105c0a611b41b08f1209506350279e">
-        <source>yes</source>
-        <target>yes</target>
-        <note>Context:
-File: classes/controller/AdminController.php:685</note>
-      </trans-unit>
-      <trans-unit id="7fa3b767c460b54a2be4d49030b349c7">
-        <source>no</source>
-        <target>no</target>
-        <note>Context:
-File: classes/controller/AdminController.php:685</note>
-      </trans-unit>
-      <trans-unit id="7d341c08fd102f0b86285b5ff2e26ea7">
-        <source>%s: %s</source>
-        <target>%s: %s</target>
-        <note>Context:
-File: classes/controller/AdminController.php:709</note>
-      </trans-unit>
-      <trans-unit id="921d54865f8169b84c90d4335c256494">
-        <source>filter by %s</source>
-        <target>filter by %s</target>
-        <note>Context:
-File: classes/controller/AdminController.php:716</note>
-      </trans-unit>
-      <trans-unit id="a333339eb21abf3d5a04f5ede8f73ae9">
-        <source>%s deletion</source>
-        <target>%s deletion</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4032</note>
-      </trans-unit>
-      <trans-unit id="6ca3b11e4d89a7649d10c2d70d98612f">
-        <source>%s addition</source>
-        <target>%s addition</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1154</note>
-      </trans-unit>
-      <trans-unit id="0919680b340ae0ac8d1a804c4c69b0ba">
-        <source>%s modification</source>
-        <target>%s modification</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1254</note>
-      </trans-unit>
-      <trans-unit id="f7931413dee107ddf5289c8886baf7ec">
-        <source>Edit: %s</source>
-        <target>Edit: %s</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1559</note>
-      </trans-unit>
-      <trans-unit id="0095a9fa74d1713e43e370a7d7846224">
-        <source>Export</source>
-        <target>Export</target>
-        <note>Context:
-File: classes/controller/AdminController.php:1640</note>
-      </trans-unit>
-      <trans-unit id="4668a49dfb4ba4ff7fa8019e7e5c28af">
-        <source>Recommended Modules</source>
-        <target>Recommended Modules</target>
-        <note>Context:
-File: classes/controller/AdminController.php:2184</note>
-      </trans-unit>
-      <trans-unit id="ee77ea46b0c548ed60eadf31bdd68613">
-        <source>Bad SQL query</source>
-        <target>Bad SQL query</target>
-        <note>Context:
-File: classes/controller/AdminController.php:2404</note>
-      </trans-unit>
-      <trans-unit id="431accab7897f05b0424e002ca30391d">
-        <source>Operational</source>
-        <target>Operational</target>
-        <note>Context:
-File: classes/controller/AdminController.php:2674</note>
-      </trans-unit>
-      <trans-unit id="fb381d41e52b0dc68e684c01decfe2ec">
-        <source>Degraded Performance</source>
-        <target>Degraded Performance</target>
-        <note>Context:
-File: classes/controller/AdminController.php:2675</note>
-      </trans-unit>
-      <trans-unit id="7c30b2ec6e5e59c7c327f7098fe36f36">
-        <source>Partial Outage</source>
-        <target>Partial Outage</target>
-        <note>Context:
-File: classes/controller/AdminController.php:2676</note>
-      </trans-unit>
-      <trans-unit id="b101c07e257875658c454fe5caef1db0">
-        <source>Major Outage</source>
-        <target>Major Outage</target>
-        <note>Context:
-File: classes/controller/AdminController.php:2677</note>
-      </trans-unit>
-      <trans-unit id="b9804794cbfeea33c6d9b2ce85100b48">
-        <source>Do you really want to uninstall this module?</source>
-        <target>Do you really want to uninstall this module?</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4334</note>
-      </trans-unit>
-      <trans-unit id="b2f31ef3065bf40b2da9fa8525c6adb9">
-        <source>Disable this module</source>
-        <target>Disable this module</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4336</note>
-      </trans-unit>
-      <trans-unit id="668c99c1164d5348f99c0878770b53a8">
-        <source>Enable this module for all shops</source>
-        <target>Enable this module for all shops</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4337</note>
-      </trans-unit>
-      <trans-unit id="112b842b7d5dda8d3fed05c0e5aaf983">
-        <source>Disable on mobiles</source>
-        <target>Disable on mobiles</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4340</note>
-      </trans-unit>
-      <trans-unit id="2ef92962bd1ac0c81675f10568ad5cca">
-        <source>Disable on tablets</source>
-        <target>Disable on tablets</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4341</note>
-      </trans-unit>
-      <trans-unit id="5e3ffb3123b3f23a33804d41e38745a0">
-        <source>Disable on computers</source>
-        <target>Disable on computers</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4342</note>
-      </trans-unit>
-      <trans-unit id="862e2caedb77ba14d86f180ca7fa90a8">
-        <source>Display on mobiles</source>
-        <target>Display on mobiles</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4343</note>
-      </trans-unit>
-      <trans-unit id="732ebdb0f33a8153b51ac58cac8f3563">
-        <source>Display on tablets</source>
-        <target>Display on tablets</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4344</note>
-      </trans-unit>
-      <trans-unit id="7f0f7c79f1d7b01b1d8a89f392e93d36">
-        <source>Display on computers</source>
-        <target>Display on computers</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4345</note>
-      </trans-unit>
-      <trans-unit id="f2a6c498fb90ee345d997f888fce3b18">
-        <source>Delete</source>
-        <target>Delete</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4348</note>
-      </trans-unit>
-      <trans-unit id="85687c63fd82afbc21632f288e53a6e4">
-        <source>This action will permanently remove the module from the server. Are you sure you want to do this?</source>
-        <target>This action will permanently remove the module from the server. Are you sure you want to do this?</target>
-        <note>Context:
-File: classes/controller/AdminController.php:4352</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d">
-        <source>Download</source>
-        <target>Download</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:151</note>
-      </trans-unit>
-      <trans-unit id="3bb4a695db0c87a3d70a2deffddeb743">
-        <source>Read more about the CSV format at:</source>
-        <target>Read more about the CSV format at:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:44</note>
-      </trans-unit>
-      <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">
-        <source>or</source>
-        <target>or</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:81</note>
-      </trans-unit>
-      <trans-unit id="e4cdcd51e6cf787d4ecc7d813f0c23cb">
-        <source>The locale must be installed</source>
-        <target>The locale must be installed</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:188</note>
-      </trans-unit>
-      <trans-unit id="e08caeac3f80ffa7889cdf1c8f30111f">
-        <source>Multiple value separator</source>
-        <target>Multiple value separator</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl:208</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/js.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="45e06e5610d29d675a875a6f7731b73d">
-        <source>Would you like to delete the content related to this module ?</source>
-        <target>Would you like to delete the content related to this module ?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/js.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="c0d19e251d0ff55ecb860e7349f779a4">
-        <source>Confirm reset</source>
-        <target>Confirm reset</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/js.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="d65c99010166606287266e4af4f0b934">
-        <source>No - reset only the parameters</source>
-        <target>No - reset only the parameters</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/js.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="0426ba52f94430cf093652d1ea18fedf">
-        <source>Yes - reset everything</source>
-        <target>Yes - reset everything</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/js.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="25b22a00db3085743f478140b8281a26">
-        <source>Preferences saved</source>
-        <target>Preferences saved</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/js.tpl:38</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4f9b5fa08f2ef86fdc5d0ceefc271981">
-        <source>Remove from Favorites</source>
-        <target>Remove from Favorites</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/list.tpl:168</note>
-      </trans-unit>
-      <trans-unit id="7263f59f5d8aeaf7d2117fcd4b70930a">
-        <source>Mark as Favorite</source>
-        <target>Mark as Favorite</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/list.tpl:171</note>
-      </trans-unit>
-      <trans-unit id="2c422a499f038293ed0c5a1e085cd827">
-        <source>No modules available in this section.</source>
-        <target>No modules available in this section.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/list.tpl:212</note>
-      </trans-unit>
-      <trans-unit id="59fcbc24a474d290fa540a3a27e2ff05">
-        <source>Module %1s </source>
-        <target>Module %1s </target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/list.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="3846bafee4cc9ce49c24a0b499d3e08d">
-        <source>Official, PrestaShop certified module. Free, secure and includes updates!</source>
-        <target>Official, PrestaShop certified module. Free, secure and includes updates!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/list.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="52dd3893c24e9cf4be761dcaee6bea39">
-        <source>Update it!</source>
-        <target>Update it!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/list.tpl:90</note>
-      </trans-unit>
-      <trans-unit id="29c632cf1c7f140b6e86f3af04df48d4">
-        <source>Install the selection</source>
-        <target>Install the selection</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/list.tpl:196</note>
-      </trans-unit>
-      <trans-unit id="7245ac07bbd56e6d0f7489a7dddb836f">
-        <source>Uninstall the selection</source>
-        <target>Uninstall the selection</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/list.tpl:202</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/helper/HelperOptions.php" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c770d8e0d1d1943ce239c64dbd6acc20">
-        <source>Add my IP</source>
-        <target>Add my IP</target>
-        <note>Context:
-File: classes/helper/HelperOptions.php:212</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="21034ae6d01a83e702839a72ba8a77b0">
-        <source>(tax excl.)</source>
-        <target>(tax excl.)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/options/options.tpl:220</note>
-      </trans-unit>
-      <trans-unit id="c103bafd6451f1f08200bebff539606f">
-        <source>Multistore</source>
-        <target>Multistore</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/options/options.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="50de2399e96ac57bed17e95376046c3b">
-        <source>Check / Uncheck all</source>
-        <target>Check / Uncheck all</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/options/options.tpl:80</note>
-      </trans-unit>
-      <trans-unit id="ff8ff5e54a1832486773ec48b8f8175d">
-        <source>You are editing this page for a specific shop or group. Click "Yes" to check all fields, "No" to uncheck all.</source>
-        <target>You are editing this page for a specific shop or group. Click "Yes" to check all fields, "No" to uncheck all.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/options/options.tpl:81</note>
-      </trans-unit>
-      <trans-unit id="d97ccb3e617d930d52ffd95e5db2c101">
-        <source>If you check a field, change its value, and save, the multistore behavior will not apply to this shop (or group), for this particular parameter.</source>
-        <target>If you check a field, change its value, and save, the multistore behavior will not apply to this shop (or group), for this particular parameter.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/options/options.tpl:82</note>
-      </trans-unit>
-      <trans-unit id="a157a50f5a421a7dfbdf280f3ff9d56e">
-        <source>You can't change the value of this configuration field in the context of this shop.</source>
-        <target>You can't change the value of this configuration field in the context of this shop.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/options/options.tpl:331</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/list/list_content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="087fb8756d4add87f2d162304ccd486b">
-        <source>No records found</source>
-        <target>No records found</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_content.tpl:205</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/tab_modules_list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ddd8eef6f86868a07f62b0e3810711f0">
-        <source>Not Installed</source>
-        <target>Not Installed</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_modules_list.tpl:33</note>
-      </trans-unit>
-      <trans-unit id="98dd43dfae05b11befe1f140e0ec787a">
-        <source>Installed</source>
-        <target>Installed</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_modules_list.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="4d2fa24347806e2bcc9925a040f78382">
-        <source>More modules on addons.prestashop.com</source>
-        <target>More modules on addons.prestashop.com</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_modules_list.tpl:69</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/new-theme/template/components/layout/error_messages.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2169b4627df97333ed94d1e30a9b8148">
-        <source>%d errors</source>
-        <target>%d errors</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/error_messages.tpl:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/layout-ajax.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="23a61fdb216b255d81b0d49ca1abb8a4">
-        <source>There are %d warnings.</source>
-        <target>There are %d warnings.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/layout-ajax.tpl:82</note>
-      </trans-unit>
-      <trans-unit id="8a3cfd894d57e33c55400fc9d76aa08a">
-        <source>Click here to see more</source>
-        <target>Click here to see more</target>
-        <note>Context:
-File: admin-dev/themes/default/template/layout-ajax.tpl:84</note>
-      </trans-unit>
-      <trans-unit id="a92269f5f14ac147a821728c23204c0b">
-        <source>Hide warning</source>
-        <target>Hide warning</target>
-        <note>Context:
-File: admin-dev/themes/default/template/layout-ajax.tpl:85</note>
-      </trans-unit>
-      <trans-unit id="406cabb68a6d8f9f7ebbb3c10cd535ef">
-        <source>There is %d warning.</source>
-        <target>There is %d warning.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/layout-ajax.tpl:88</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/new-theme/template/components/layout/search_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="03de6422045e4ed3ac822c673ace32d1">
-        <source>123.45.67.89</source>
-        <target>123.45.67.89</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="e6d0e1c8fc6a4fcf47869df87e04cd88">
-        <source>Customers</source>
-        <target>Customers</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
-        <source>Orders</source>
-        <target>Orders</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:47</note>
-      </trans-unit>
-      <trans-unit id="f5945546981ef6e50e1fade1b386da04">
-        <source>Search (e.g.: product reference, customer name…)</source>
-        <target>Search (e.g.: product reference, customer name…)</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:36</note>
-      </trans-unit>
-      <trans-unit id="13787cfb1a15ae6690a29d3895c54de9">
-        <source>Everywhere</source>
-        <target>Everywhere</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="2e67c0a79d35c15af2436c8d80ca072d">
-        <source>What are you looking for?</source>
-        <target>What are you looking for?</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="c32516babc5b6c47eb8ce1bfc223253c">
-        <source>Catalog</source>
-        <target>Catalog</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:44</note>
-      </trans-unit>
-      <trans-unit id="7f704ff8964f7b5f3f9a6444d450b5f7">
-        <source>Product name, SKU, reference...</source>
-        <target>Product name, SKU, reference...</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:44</note>
-      </trans-unit>
-      <trans-unit id="855d2bf59043b81e76bc931e685a4f58">
-        <source>by name</source>
-        <target>by name</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="a3681587c5320489b6a3dd21282e254d">
-        <source>Email, name...</source>
-        <target>Email, name...</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="399574be0ed95657dfac0e8d38374c62">
-        <source>by ip address</source>
-        <target>by ip address</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="16b2494238f8f996b09417d1dc56c795">
-        <source>by IP address</source>
-        <target>by IP address</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="d79cf3f429596f77db95c65074663a54">
-        <source>Order ID</source>
-        <target>Order ID</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:47</note>
-      </trans-unit>
-      <trans-unit id="fce9a6a1bd2a2050eb86d33103f46fd3">
-        <source>Invoices</source>
-        <target>Invoices</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:48</note>
-      </trans-unit>
-      <trans-unit id="4e065ba1bec1d62b2d5450256612fa96">
-        <source>Invoice Number</source>
-        <target>Invoice Number</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:48</note>
-      </trans-unit>
-      <trans-unit id="fc26e55e0993a75e892175deb02aae15">
-        <source>Carts</source>
-        <target>Carts</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:49</note>
-      </trans-unit>
-      <trans-unit id="fc6dfe4f8b07fc04c99e27425f780754">
-        <source>Cart ID</source>
-        <target>Cart ID</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:49</note>
-      </trans-unit>
-      <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2">
-        <source>Modules</source>
-        <target>Modules</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:50</note>
-      </trans-unit>
-      <trans-unit id="07403a8bc81d7865c8e040e718ec7828">
-        <source>Module name</source>
-        <target>Module name</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:50</note>
-      </trans-unit>
-      <trans-unit id="0f544d682c3a664870f025f48c4b04b5">
-        <source>SEARCH</source>
-        <target>SEARCH</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/search_form.tpl:52</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/new-theme/template/helpers/shops_list/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="804ccd6219996d12eda865d1c0707423">
-        <source>All shops</source>
-        <target>All shops</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/helpers/shops_list/list.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="93f04304c09d561ed79442ea9ee722d4">
-        <source>%s group</source>
-        <target>%s group</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/helpers/shops_list/list.tpl:38</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/dataviz/graph.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1f08d08fd864b99cbeebd88b9a0784a7">
-        <source>Income</source>
-        <target>Income</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/dataviz/graph.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4">
-        <source>Message</source>
-        <target>Message</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/dataviz/graph.tpl:51</note>
-      </trans-unit>
-      <trans-unit id="e7935ae6c516d89405ec532359d2d75a">
-        <source>Traffic</source>
-        <target>Traffic</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/dataviz/graph.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="3bb1503332637805beddb73a2dd1fe1b">
-        <source>Conversion</source>
-        <target>Conversion</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/dataviz/graph.tpl:69</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/required_fields.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0470d45929f27e1161330164c423b415">
-        <source>Set required fields for this section</source>
-        <target>Set required fields for this section</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/required_fields.tpl:26</note>
-      </trans-unit>
-      <trans-unit id="e54b38290c8bdd95e8bc10412c9cc096">
-        <source>Required Fields</source>
-        <target>Required Fields</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/required_fields.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="81f32b96f6626b8968e6a0f4a9bce62e">
-        <source>Select the fields you would like to be required for this section.</source>
-        <target>Select the fields you would like to be required for this section.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/required_fields.tpl:33</note>
-      </trans-unit>
-      <trans-unit id="ee9b2f3cf31c23c944b15fb0b33d6a77">
-        <source>Field Name</source>
-        <target>Field Name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/required_fields.tpl:42</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6ccfec41b65de46efeb7ca242341e8ea">
-        <source>Please fill at least one field to perform a search in this list.</source>
-        <target>Please fill at least one field to perform a search in this list.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_header.tpl:108</note>
-      </trans-unit>
-      <trans-unit id="e129ae480280e47ef82fc7702f8321ba">
-        <source>Refresh list</source>
-        <target>Refresh list</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_header.tpl:141</note>
-      </trans-unit>
-      <trans-unit id="dbcd43f8ba2bafd1bccc57fe9c8b5d7b">
-        <source>Show SQL query</source>
-        <target>Show SQL query</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_header.tpl:150</note>
-      </trans-unit>
-      <trans-unit id="351b6d570b6ba15fe66e85c1eaf9ec64">
-        <source>Export to SQL Manager</source>
-        <target>Export to SQL Manager</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_header.tpl:155</note>
-      </trans-unit>
-      <trans-unit id="4493e821e06072415518bd7ae4077996">
-        <source>Shop group</source>
-        <target>Shop group</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_header.tpl:294</note>
-      </trans-unit>
-      <trans-unit id="e12167aa0a7698e6ebc92b4ce3909b53">
-        <source>To</source>
-        <target>To</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_header.tpl:334</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/toolbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e9c7e4df74077626f7e42797c65273c4">
-        <source>and stay</source>
-        <target>and stay</target>
-        <note>Context:
-File: admin-dev/themes/default/template/toolbar.tpl:79</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/calendar/calendar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5da618e8e4b89c66fe86e32cdafde142">
-        <source>From</source>
-        <target>From</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:87</note>
-      </trans-unit>
-      <trans-unit id="08ee10c9fa141c53ae44667dcc1adf1e">
-        <source>Date range</source>
-        <target>Date range</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:48</note>
-      </trans-unit>
-      <trans-unit id="90589c47f06eb971d548591f23c285af">
-        <source>Custom</source>
-        <target>Custom</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:83</note>
-      </trans-unit>
-      <trans-unit id="01b6e20344b68835c5ed1ddedf20d531">
-        <source>to</source>
-        <target>to</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:89</note>
-      </trans-unit>
-      <trans-unit id="0c031866121d4fc6d21d0f524d0091e4">
-        <source>Compare to</source>
-        <target>Compare to</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:77</note>
-      </trans-unit>
-      <trans-unit id="97bf2dbc7a13706eeb1eac149bd2d130">
-        <source>Previous period</source>
-        <target>Previous period</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:81</note>
-      </trans-unit>
-      <trans-unit id="635f2145a06da2d4ce2c355bf94da6ed">
-        <source>Previous Year</source>
-        <target>Previous Year</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:82</note>
-      </trans-unit>
-      <trans-unit id="3ca6ac2463aa0dc57452cf676723b79f">
-        <source>Previous year</source>
-        <target>Previous year</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:82</note>
-      </trans-unit>
-      <trans-unit id="9d1a0949c39e66a0cd65240bc0ac9177">
-        <source>Sunday</source>
-        <target>Sunday</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="6f8522e0610541f1ef215a22ffa66ff6">
-        <source>Monday</source>
-        <target>Monday</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="5792315f09a5d54fb7e3d066672b507f">
-        <source>Tuesday</source>
-        <target>Tuesday</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="796c163589f295373e171842f37265d5">
-        <source>Wednesday</source>
-        <target>Wednesday</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="78ae6f0cd191d25147e252dc54768238">
-        <source>Thursday</source>
-        <target>Thursday</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="c33b138a163847cdb6caeeb7c9a126b4">
-        <source>Friday</source>
-        <target>Friday</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="8b7051187b9191cdcdae6ed5a10e5adc">
-        <source>Saturday</source>
-        <target>Saturday</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:113</note>
-      </trans-unit>
-      <trans-unit id="ef6572e4cd58bb39a3f4e82fc64fe9f0">
-        <source>Sun</source>
-        <target>Sun</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:114</note>
-      </trans-unit>
-      <trans-unit id="fd29458ae58ac32a2d8734ed90ad51ec">
-        <source>Mon</source>
-        <target>Mon</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:114</note>
-      </trans-unit>
-      <trans-unit id="2ddecde85408faf230652444db78cb72">
-        <source>Tue</source>
-        <target>Tue</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:114</note>
-      </trans-unit>
-      <trans-unit id="510c292b1686eb070d9e90a575f74106">
-        <source>Wed</source>
-        <target>Wed</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:114</note>
-      </trans-unit>
-      <trans-unit id="ed5e8353dfc585f4c6b3a55d1a9fc01d">
-        <source>Thu</source>
-        <target>Thu</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:114</note>
-      </trans-unit>
-      <trans-unit id="ac616f844b9a5ea5a827bf7fb99b1ad5">
-        <source>Fri</source>
-        <target>Fri</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:114</note>
-      </trans-unit>
-      <trans-unit id="13c7d2d737f81f7bf89aed9fbcd0ad55">
-        <source>Sat</source>
-        <target>Sat</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:114</note>
-      </trans-unit>
-      <trans-unit id="f72c915d8f575a5c0999b5f37b6d99b7">
-        <source>Su</source>
-        <target>Su</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:115</note>
-      </trans-unit>
-      <trans-unit id="c08df9bb5fb44242a6291b1eee5d09ad">
-        <source>Mo</source>
-        <target>Mo</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:115</note>
-      </trans-unit>
-      <trans-unit id="080502c4fa636ac639bf42b6d2ba01d7">
-        <source>Tu</source>
-        <target>Tu</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:115</note>
-      </trans-unit>
-      <trans-unit id="485c47a81eb6e3998ec05aca48eda184">
-        <source>We</source>
-        <target>We</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:115</note>
-      </trans-unit>
-      <trans-unit id="eeeb9a8eb45dd351d9ec0eb4acce66ce">
-        <source>Th</source>
-        <target>Th</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:115</note>
-      </trans-unit>
-      <trans-unit id="fa717ba17306cd76900510df8ac8013e">
-        <source>Fr</source>
-        <target>Fr</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:115</note>
-      </trans-unit>
-      <trans-unit id="e55bb1ae59b6a64858a85a2f48c53036">
-        <source>Sa</source>
-        <target>Sa</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:115</note>
-      </trans-unit>
-      <trans-unit id="86f5978d9b80124f509bdb71786e929e">
-        <source>January</source>
-        <target>January</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="659e59f062c75f81259d22786d6c44aa">
-        <source>February</source>
-        <target>February</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="fa3e5edac607a88d8fd7ecb9d6d67424">
-        <source>March</source>
-        <target>March</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="3fcf026bbfffb63fb24b8de9d0446949">
-        <source>April</source>
-        <target>April</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="195fbb57ffe7449796d23466085ce6d8">
-        <source>May</source>
-        <target>May</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="688937ccaf2a2b0c45a1c9bbba09698d">
-        <source>June</source>
-        <target>June</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="1b539f6f34e8503c97f6d3421346b63c">
-        <source>July</source>
-        <target>July</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="41ba70891fb6f39327d8ccb9b1dafb84">
-        <source>August</source>
-        <target>August</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="cc5d90569e1c8313c2b1c2aab1401174">
-        <source>September</source>
-        <target>September</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="eca60ae8611369fe28a02e2ab8c5d12e">
-        <source>October</source>
-        <target>October</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="7e823b37564da492ca1629b4732289a8">
-        <source>November</source>
-        <target>November</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="82331503174acbae012b2004f6431fa5">
-        <source>December</source>
-        <target>December</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="e68564f23e0e939acea76dc3d2bc01bf">
-        <source>Jan</source>
-        <target>Jan</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="ea171d540ccd5f0669171ef06d3cd848">
-        <source>Feb</source>
-        <target>Feb</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="7ce6b2286a5396e614b8484105d277e0">
-        <source>Mar</source>
-        <target>Mar</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="6d7215c4b3bc4716d026ac46c6d9ae64">
-        <source>Apr</source>
-        <target>Apr</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="e7f8f5c51fe3a6d48a79c6ede9112b7a">
-        <source>May </source>
-        <target>May </target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="eb4b40c1221dad5b23fe7ef84d292be1">
-        <source>Jun</source>
-        <target>Jun</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="a2866cd6efaa65c92278d4771a9eaec7">
-        <source>Jul</source>
-        <target>Jul</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="22f1a4667604b8557c9b209c201b4bc6">
-        <source>Aug</source>
-        <target>Aug</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="f04aa7019c490474fa3ce16e93501b57">
-        <source>Sep</source>
-        <target>Sep</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="594be08882c8e9d5efb9eeb62f303744">
-        <source>Oct</source>
-        <target>Oct</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="343e6957be77c6247aa2b8d0deb68bd6">
-        <source>Nov</source>
-        <target>Nov</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-      <trans-unit id="d207b4e0bce42a8f1555ce3a05e287f6">
-        <source>Dec</source>
-        <target>Dec</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/calendar/calendar.tpl:117</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0bcef9c45bd8a48eda1b26eb0c61c869">
-        <source>%</source>
-        <target>%</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl:107</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/list/list_footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4c41e0bd957698b58100a5c687d757d9">
-        <source>Select all</source>
-        <target>Select all</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_footer.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="237c7b6874386141a095e321c9fdfd38">
-        <source>Unselect all</source>
-        <target>Unselect all</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_footer.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="b9987a246a537f4fe86f1f2e3d10dbdb">
-        <source>Display</source>
-        <target>Display</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_footer.tpl:63</note>
-      </trans-unit>
-      <trans-unit id="dd8921b41e0279a02c6a26a509241700">
-        <source>result(s)</source>
-        <target>result(s)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/list/list_footer.tpl:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/uploader/ajax.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1908624a0bca678cd26b99bfd405324e">
-        <source>File size</source>
-        <target>File size</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/ajax.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="3fcbe6bd34e9279ec2c7b13adf7e4095">
-        <source>You have reached the limit (%s) of files to upload, please remove files to continue uploading</source>
-        <target>You have reached the limit (%s) of files to upload, please remove files to continue uploading</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/ajax.tpl:48</note>
-      </trans-unit>
-      <trans-unit id="86d3852bba89bf82128c3e156624ad08">
-        <source>Add files...</source>
-        <target>Add files...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/ajax.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="9e74a55bb862a98723f9cf3f868d837e">
-        <source>Add file...</source>
-        <target>Add file...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/ajax.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="c7de86f69db264c3950d8ae46ed2e33f">
-        <source>Upload files</source>
-        <target>Upload files</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/ajax.tpl:70</note>
-      </trans-unit>
-      <trans-unit id="ffeed24e8e4fd763c1d0d02c6e5d6e15">
-        <source>Upload file</source>
-        <target>Upload file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/ajax.tpl:70</note>
-      </trans-unit>
-      <trans-unit id="6dc85b454944660cf96e7d0c2d171ee3">
-        <source>You cannot have more than %s images in total. Please remove some of the current images before adding new ones.</source>
-        <target>You cannot have more than %s images in total. Please remove some of the current images before adding new ones.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/ajax.tpl:170</note>
-      </trans-unit>
-      <trans-unit id="b21f085d08623fc7a5a9da204cc66c8c">
-        <source>Remove file</source>
-        <target>Remove file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/ajax.tpl:178</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/uploader/simple.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d39ec66f08507e26fe86aa5325d070df">
-        <source>Add files</source>
-        <target>Add files</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/simple.tpl:67</note>
-      </trans-unit>
-      <trans-unit id="58be4de806253a6ee411b6c0c99296c7">
-        <source>Add file</source>
-        <target>Add file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/simple.tpl:67</note>
-      </trans-unit>
-      <trans-unit id="09942cec33b5becdf3e2275913b818e2">
-        <source>Download current file (%skb)</source>
-        <target>Download current file (%skb)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/simple.tpl:72</note>
-      </trans-unit>
-      <trans-unit id="c2299e6abb73991105dfacfb6fdd6dd4">
-        <source>Download current file</source>
-        <target>Download current file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/simple.tpl:72</note>
-      </trans-unit>
-      <trans-unit id="009044df8c709bfdefa065ae7fa733e1">
-        <source>You can upload a maximum of %s files</source>
-        <target>You can upload a maximum of %s files</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/uploader/simple.tpl:134</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/modules_list/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4b33fbf5ea2c4ced9800228574cfcc50">
-        <source>Recommended Modules and Services</source>
-        <target>Recommended Modules and Services</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/modules_list/modal.tpl:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/modules_list/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c0ebffb294bb46f8800a899e04c73f17">
-        <source>View all available payments solutions</source>
-        <target>View all available payments solutions</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/modules_list/list.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="98a52c00a9fb228601f8b423436d36e0">
-        <source>It seems there are no recommended payment solutions for your country.</source>
-        <target>It seems there are no recommended payment solutions for your country.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/modules_list/list.tpl:56</note>
-      </trans-unit>
-      <trans-unit id="39efbaa2f3600dd82a031d7ab5138f73">
-        <source>Do you think there should be one? Let us know!</source>
-        <target>Do you think there should be one? Let us know!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/modules_list/list.tpl:57</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="24fc6fbf93a9d551ea7da4cd69f3da3e">
-        <source>(%s selected)</source>
-        <target>(%s selected)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox.tpl:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d77a48a51f8c62087570ab8f9d6ca55a">
-        <source>search...</source>
-        <target>search...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl:32</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox_shops.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bebe39eef720d7cbb479d8b3428e4c04">
-        <source>Group: %s</source>
-        <target>Group: %s</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox_shops.tpl:29</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/form/form_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="c6155aaecccf794cd2a00fcc35898022">
-        <source>Group name</source>
-        <target>Group name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form_group.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="69e62346c35bc63795db142cfbb0af66">
-        <source>No group created</source>
-        <target>No group created</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form_group.tpl:64</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="2efd89b3ccc76b0b03a34196fc6d1c8b">
-        <source>Add tag</source>
-        <target>Add tag</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:194</note>
-      </trans-unit>
-      <trans-unit id="1063e38cb53d94d386f21227fcd84717">
-        <source>Remove</source>
-        <target>Remove</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:329</note>
-      </trans-unit>
-      <trans-unit id="26ce1315d2bff025e8fb8a0c6259e58c">
-        <source>Change password...</source>
-        <target>Change password...</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:525</note>
-      </trans-unit>
-      <trans-unit id="d9c2d86a66aa5a45326c3757f3a272cc">
-        <source>Current password</source>
-        <target>Current password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:530</note>
-      </trans-unit>
-      <trans-unit id="98a6ee4b0f0e346c15ab21a289165a2d">
-        <source>Password should be at least 8 characters long.</source>
-        <target>Password should be at least 8 characters long.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:544</note>
-      </trans-unit>
-      <trans-unit id="3544848f820b9d94a3f3871a382cf138">
-        <source>New password</source>
-        <target>New password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:545</note>
-      </trans-unit>
-      <trans-unit id="4c231e0da3eaaa6a9752174f7f9cfb31">
-        <source>Confirm password</source>
-        <target>Confirm password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:560</note>
-      </trans-unit>
-      <trans-unit id="2871afea416378d2772937c4d67d6c2c">
-        <source>Generate password</source>
-        <target>Generate password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:576</note>
-      </trans-unit>
-      <trans-unit id="4bbb8f967da6d1a610596d7257179c2b">
-        <source>Invalid</source>
-        <target>Invalid</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:601</note>
-      </trans-unit>
-      <trans-unit id="26b63f278101527e06a5547719568bb5">
-        <source>Okay</source>
-        <target>Okay</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:602</note>
-      </trans-unit>
-      <trans-unit id="0c6ad70beb3a7e76c3fc7adab7c46acc">
-        <source>Good</source>
-        <target>Good</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:603</note>
-      </trans-unit>
-      <trans-unit id="b8dc7c80939667637db7ac31ece215b9">
-        <source>Fabulous</source>
-        <target>Fabulous</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:604</note>
-      </trans-unit>
-      <trans-unit id="01e8202cf69f19ea7cf3a80f7673066a">
-        <source>Invalid password confirmation</source>
-        <target>Invalid password confirmation</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/form.tpl:641</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1e1cc9bdeb2f29f5480106aec7e9bc48">
-        <source>Now</source>
-        <target>Now</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1378</note>
-      </trans-unit>
-      <trans-unit id="f92965e2c8a7afb3c1b9a5c09a263636">
-        <source>Done</source>
-        <target>Done</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1379</note>
-      </trans-unit>
-      <trans-unit id="3964fd83339fec5014c831822005653a">
-        <source>Choose Time</source>
-        <target>Choose Time</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1385</note>
-      </trans-unit>
-      <trans-unit id="a76d4ef5f3f6a672bbfab2865563e530">
-        <source>Time</source>
-        <target>Time</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1386</note>
-      </trans-unit>
-      <trans-unit id="b55e509c697e4cca0e1d160a7806698f">
-        <source>Hour</source>
-        <target>Hour</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1387</note>
-      </trans-unit>
-      <trans-unit id="62902641c38f3a4a8eb3212454360e24">
-        <source>Minute</source>
-        <target>Minute</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1388</note>
-      </trans-unit>
-      <trans-unit id="730224c4825ae2c174f4cdaff321520e">
-        <source>Transform a guest into a customer</source>
-        <target>Transform a guest into a customer</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:598</note>
-      </trans-unit>
-      <trans-unit id="e5bd639f4d74cf2c52afada77086f788">
-        <source>Process a standard refund</source>
-        <target>Process a standard refund</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:902</note>
-      </trans-unit>
-      <trans-unit id="c4b689eeebf8e942907a1cc1d086dba6">
-        <source>Process a partial refund</source>
-        <target>Process a partial refund</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:903</note>
-      </trans-unit>
-      <trans-unit id="cc61945cbbf46721a053467c395c666f">
-        <source>Refunded</source>
-        <target>Refunded</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:931</note>
-      </trans-unit>
-      <trans-unit id="6a5efd211a422296eab4adc476c98f0e">
-        <source>Return products</source>
-        <target>Return products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1196</note>
-      </trans-unit>
-      <trans-unit id="74c06eb18eeb118d7b3c623d0c717290">
-        <source>Refund products</source>
-        <target>Refund products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1196</note>
-      </trans-unit>
-      <trans-unit id="4b8def9be8f45a8d6baea36b26868965">
-        <source>Cancel products</source>
-        <target>Cancel products</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1196</note>
-      </trans-unit>
-      <trans-unit id="867343577fa1f33caa632a19543bd252">
-        <source>Keywords</source>
-        <target>Keywords</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl:1265</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/helpers/form/assoshop.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1aa4c641d6920ddb97a2562f8ec53853">
-        <source>Group:</source>
-        <target>Group:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/helpers/form/assoshop.tpl:99</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/new-theme/template/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d3d2e617335f08df83599665eef8a418">
-        <source>Close</source>
-        <target>Close</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/modal.tpl:39</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3bf63a999cda6c9d95c3827e7942f41d">
-        <source>Customer since: %s</source>
-        <target>Customer since: %s</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:79</note>
-      </trans-unit>
-      <trans-unit id="8df41ed5ebc778c45f74a201e822613a">
-        <source>Choose a template</source>
-        <target>Choose a template</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:116</note>
-      </trans-unit>
-      <trans-unit id="94966d90747b97d1f0f206c98a8b1ac3">
-        <source>Send</source>
-        <target>Send</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:119</note>
-      </trans-unit>
-      <trans-unit id="2605a817441c19cc88eb9e5d17845dc0">
-        <source>You can add a comment here.</source>
-        <target>You can add a comment here.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl:155</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1e65b02f3464a517e0946a46d496327c">
-        <source>Sync success</source>
-        <target>Sync success</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl:75</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/customer_threads/message.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d13d8380c3f4de07fef91a42fe6c60d7">
-        <source>Customer ID:</source>
-        <target>Customer ID:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:127</note>
-      </trans-unit>
-      <trans-unit id="d1228f5476d15142b1358ae4b5fa2454">
-        <source>Order #</source>
-        <target>Order #</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:134</note>
-      </trans-unit>
-      <trans-unit id="c851a34d4806acb02a55df148f9d7f25">
-        <source>Product #</source>
-        <target>Product #</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:141</note>
-      </trans-unit>
-      <trans-unit id="47a0be8d1015d526a1fbaa56c3102135">
-        <source>Subject:</source>
-        <target>Subject:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customer_threads/message.tpl:147</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="a6361d40d23154d7d8fc801ae8bf9554">
-        <source>%refund_date% - %refund_amount%</source>
-        <target>%refund_date% - %refund_amount%</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_product_line.tpl:105</note>
-      </trans-unit>
-      <trans-unit id="26b26b0e309da0b8abbf624a57601f4c">
-        <source>%return_date% - %return_quantity% - %return_state%</source>
-        <target>%return_date% - %return_quantity% - %return_state%</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_product_line.tpl:121</note>
-      </trans-unit>
-      <trans-unit id="3d0d1f906e27800531e054a3b6787b7c">
-        <source>Quantity:</source>
-        <target>Quantity:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_product_line.tpl:175</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6416e8cb5fc0a208d94fa7f5a300dbc4">
-        <source>Warehouse</source>
-        <target>Warehouse</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="aa52110dbfce51cc1ec8a163264151e2">
-        <source>Existing</source>
-        <target>Existing</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:80</note>
-      </trans-unit>
-      <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e">
-        <source>New</source>
-        <target>New</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_new_product.tpl:85</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/_documents.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="585bc67adbb73dcca638b897fb73a900">
-        <source>See the document</source>
-        <target>See the document</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:77</note>
-      </trans-unit>
-      <trans-unit id="8b3e7bc0ed634c2bc8ac54a4cc2e781f">
-        <source>Set payment form</source>
-        <target>Set payment form</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:115</note>
-      </trans-unit>
-      <trans-unit id="50cd1871f950375eef4e2efce35366c6">
-        <source>Add note</source>
-        <target>Add note</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:121</note>
-      </trans-unit>
-      <trans-unit id="71e2851d86b252a44c658b896c486921">
-        <source>Edit note</source>
-        <target>Edit note</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/_documents.tpl:121</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="7315d80cbbbb36fdcd92ba46a6384eff">
-        <source>Show carts and orders for this customer.</source>
-        <target>Show carts and orders for this customer.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="1e504df905c966d01e09188c5ebd451f">
-        <source>Hide carts and orders for this customer.</source>
-        <target>Hide carts and orders for this customer.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="f4ec5f57bd4d31b803312d873be40da9">
-        <source>Change</source>
-        <target>Change</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:256</note>
-      </trans-unit>
-      <trans-unit id="0d9175fe89fb80d815e7d03698b6e83a">
-        <source>Gift</source>
-        <target>Gift</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:769</note>
-      </trans-unit>
-      <trans-unit id="c78ba40a94a132dc170cba2f8c66f310">
-        <source>Search for an existing product by typing the first letters of its name.</source>
-        <target>Search for an existing product by typing the first letters of its name.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/orders/form.tpl:1198</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/not_found/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="efc54df619cd3792c98805fba1ee5ff7">
-        <source>The controller %s is missing or invalid.</source>
-        <target>The controller %s is missing or invalid.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/not_found/content.tpl:27</note>
-      </trans-unit>
-      <trans-unit id="9178de10abf6a1368e7a73ec0adb0e8e">
-        <source>Back to the previous page</source>
-        <target>Back to the previous page</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/not_found/content.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="585c732d00a27a32cd9585fe481964cf">
-        <source>Go to the dashboard</source>
-        <target>Go to the dashboard</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/not_found/content.tpl:35</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e9cb217697088a98b1937d111d936281">
-        <source>Attachment</source>
-        <target>Attachment</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl:83</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f14b582c1b0eab88ed5904fb781568c0">
-        <source>Discount name</source>
-        <target>Discount name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl:203</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="d6d9190e86f812c0490da9360e12cee1">
-        <source>Add a rule concerning</source>
-        <target>Add a rule concerning</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl:45</note>
-      </trans-unit>
-      <trans-unit id="c5536e008327e8873c8daf321a088873">
-        <source>The product(s) are matching one of these:</source>
-        <target>The product(s) are matching one of these:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl:65</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/cart_rules/actions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="bcca39c6f36c3085c46429511614b227">
-        <source>If enabled, the voucher will not apply to products already on sale.</source>
-        <target>If enabled, the voucher will not apply to products already on sale.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/cart_rules/actions.tpl:145</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0071aa279bd1583754a544277740f047">
-        <source>Delete item #</source>
-        <target>Delete item #</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl:108</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="f2bbdf9f72c085adc4d0404e370f0f4c">
-        <source>Attribute</source>
-        <target>Attribute</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl:79</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/modal_translation.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="1311e5ddedf25a4f6cd6059cbf04c21e">
-        <source>Manage translations</source>
-        <target>Manage translations</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_translation.tpl:29</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/page.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="b10a51e4d433fa3330b26d266502db00">
-        <source>Addons membership provides access to all our PrestaShop modules.</source>
-        <target>Addons membership provides access to all our PrestaShop modules.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="20afba9e56de0c1da3d5188111d72947">
-        <source>Once connected, your new modules will be automatically installed.</source>
-        <target>Once connected, your new modules will be automatically installed.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="d9776f0775997b2e698c6975420b5c5d">
-        <source>Sign up</source>
-        <target>Sign up</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="bce8bac0184c6cd6d977e8a42a99aa99">
-        <source>Connect to PrestaShop Marketplace account</source>
-        <target>Connect to PrestaShop Marketplace account</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="bffe9a3c9a7e00ba00a11749e022d911">
-        <source>Log in</source>
-        <target>Log in</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="6dc2462f2851bdac265c852f023b6d3f">
-        <source>The module must either be a Zip file (.zip) or a tarball file (.tar, .tar.gz, .tgz).</source>
-        <target>The module must either be a Zip file (.zip) or a tarball file (.tar, .tar.gz, .tgz).</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:43</note>
-      </trans-unit>
-      <trans-unit id="6779ef184c16fbd18a0bc13ebda839c5">
-        <source>Upload a module from your computer.</source>
-        <target>Upload a module from your computer.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="5b48d0f5735d2f9b73a8f3ec7c4858ba">
-        <source>Module file</source>
-        <target>Module file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:47</note>
-      </trans-unit>
-      <trans-unit id="92fbf0e5d97b8afd7e73126b52bdc4bb">
-        <source>Choose a file</source>
-        <target>Choose a file</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:59</note>
-      </trans-unit>
-      <trans-unit id="8634e049945e0e8562673698a1abb485">
-        <source>Upload this module</source>
-        <target>Upload this module</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:71</note>
-      </trans-unit>
-      <trans-unit id="f2063dc3ff5945f5bf0c430da46e1109">
-        <source>An upgrade is available for some of your modules!</source>
-        <target>An upgrade is available for some of your modules!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:81</note>
-      </trans-unit>
-      <trans-unit id="d78986947356ddd37b43d57df289dee9">
-        <source>Favorites</source>
-        <target>Favorites</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:107</note>
-      </trans-unit>
-      <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680">
-        <source>All</source>
-        <target>All</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page.tpl:110</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/content-legacy.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="96e36efe70e72835ae51946e2650f9e7">
-        <source>Add a new module</source>
-        <target>Add a new module</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/content-legacy.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="fe6b7985acf4b17efbfe1b38545299d9">
-        <source>See all modules</source>
-        <target>See all modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/content-legacy.tpl:53</note>
-      </trans-unit>
-      <trans-unit id="4181fcfe54e8fadc0644e1cadde3483f">
-        <source>To add a new module, simply connect to your PrestaShop Addons account and all your purchases will be automatically imported.</source>
-        <target>To add a new module, simply connect to your PrestaShop Addons account and all your purchases will be automatically imported.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/content-legacy.tpl:67</note>
-      </trans-unit>
-      <trans-unit id="82010160301993d2d752d8f185b31d0c">
-        <source>Can I add my own modules?</source>
-        <target>Can I add my own modules?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/content-legacy.tpl:84</note>
-      </trans-unit>
-      <trans-unit id="bb2ee5b5f12b6eae3c1716d26cddeab7">
-        <source>Please note that for security reasons, you can only add modules that are being distributed on PrestaShop Addons, the official marketplace.</source>
-        <target>Please note that for security reasons, you can only add modules that are being distributed on PrestaShop Addons, the official marketplace.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/content-legacy.tpl:85</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted_blocked.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="e88e176e72b122566ada523a7297e4e5">
-        <source>This module could not be verified by PrestaShop.</source>
-        <target>This module could not be verified by PrestaShop.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_blocked.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="d16d7b2c414d4750596290776d0bfbf7">
-        <source>Since you may not have installed this module from PrestaShop Addons, we cannot assert that the module is complying with our safety requirements (e.g. that it is not adding some undisclosed functionalities such as ads, hidden links, spam, etc...).</source>
-        <target>Since you may not have installed this module from PrestaShop Addons, we cannot assert that the module is complying with our safety requirements (e.g. that it is not adding some undisclosed functionalities such as ads, hidden links, spam, etc...).</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_blocked.tpl:58</note>
-      </trans-unit>
-      <trans-unit id="64b9168c0ef9c05d1568a15c6e273bf1">
-        <source>You can search for similar modules on the official marketplace.</source>
-        <target>You can search for similar modules on the official marketplace.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_blocked.tpl:60</note>
-      </trans-unit>
-      <trans-unit id="57acfffeede560e141ea67a4487fe065">
-        <source>[1]Click here to browse our catalog on PrestaShop Addons[/1].</source>
-        <target>[1]Click here to browse our catalog on PrestaShop Addons[/1].</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_blocked.tpl:62</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6754e4799f554bcdf4fef4782bf4d7de">
-        <source>This generally happens when the module isn't distributed through our official marketplace, PrestaShop Addons - or when your server failed to communicate with PrestaShop Addons.</source>
-        <target>This generally happens when the module isn't distributed through our official marketplace, PrestaShop Addons - or when your server failed to communicate with PrestaShop Addons.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="a517747c3d12f99244ae598910d979c5">
-        <source>Author</source>
-        <target>Author</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="249212ebba2907c6087887db076179e6">
-        <source>Back to modules list</source>
-        <target>Back to modules list</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:54</note>
-      </trans-unit>
-      <trans-unit id="5724be5bf0b6c384f8f0e4ec5c56960e">
-        <source>What Should I Do?</source>
-        <target>What Should I Do?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:79</note>
-      </trans-unit>
-      <trans-unit id="34afcb42ab73990082d328d9b34811b5">
-        <source>Proceed with the installation</source>
-        <target>Proceed with the installation</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:53</note>
-      </trans-unit>
-      <trans-unit id="9c4573ad0738d689dcb4dfb11ea6ce5a">
-        <source>Do you want to install this module that could not be verified by PrestaShop?</source>
-        <target>Do you want to install this module that could not be verified by PrestaShop?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="cff96407d828626ba1219454e9dde40c">
-        <source>Since you may not have downloaded this module from PrestaShop Addons, we cannot assert that the module is not adding some undisclosed functionalities. We advise you to install it only if you trust the source of the content.</source>
-        <target>Since you may not have downloaded this module from PrestaShop Addons, we cannot assert that the module is not adding some undisclosed functionalities. We advise you to install it only if you trust the source of the content.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="cb6c308b881809f8ab33d50efad0b665">
-        <source>What's the risk?</source>
-        <target>What's the risk?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:63</note>
-      </trans-unit>
-      <trans-unit id="b1c3bf188b7df9285d57df41f00c7041">
-        <source>Am I at Risk?</source>
-        <target>Am I at Risk?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:73</note>
-      </trans-unit>
-      <trans-unit id="144f70b53defb91dacdb0a4ac79b7e70">
-        <source>A module that hasn't been verified may be dangerous and could add hidden functionalities like backdoors, ads, hidden links, spam, etc. Don’t worry, this alert is simply a warning.</source>
-        <target>A module that hasn't been verified may be dangerous and could add hidden functionalities like backdoors, ads, hidden links, spam, etc. Don’t worry, this alert is simply a warning.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:75</note>
-      </trans-unit>
-      <trans-unit id="50d39ed39f0e1c95d185acc6b89de6f8">
-        <source>PrestaShop, being an open-source software, has an awesome community with a long history of developing and sharing high quality modules. Before installing this module, making sure its author is a known community member is always a good idea (by checking [1]our forum[/1] for instance).</source>
-        <target>PrestaShop, being an open-source software, has an awesome community with a long history of developing and sharing high quality modules. Before installing this module, making sure its author is a known community member is always a good idea (by checking [1]our forum[/1] for instance).</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:77</note>
-      </trans-unit>
-      <trans-unit id="9bbcbf7c1f7c1df3c3d9d3b7767fac09">
-        <source>If you trust or find the author of this module to be an active community member, you can proceed with the installation.</source>
-        <target>If you trust or find the author of this module to be an active community member, you can proceed with the installation.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:81</note>
-      </trans-unit>
-      <trans-unit id="67afee0d8b56356469f89525a1423331">
-        <source>Otherwise you can look for similar modules on the official marketplace. [1]Click here to browse PrestaShop Addons[/1].</source>
-        <target>Otherwise you can look for similar modules on the official marketplace. [1]Click here to browse PrestaShop Addons[/1].</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl:83</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="54752f2f929b686b98ddb16e40c4a1be">
-        <source>You are about to install "%s", a module which is not compatible with your country.</source>
-        <target>You are about to install "%s", a module which is not compatible with your country.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="1a56544ab8d473b3383731fbe3fc9d07">
-        <source>This module was not verified by PrestaShop hence we cannot certify that it works well in your country and that it complies with our quality requirements.</source>
-        <target>This module was not verified by PrestaShop hence we cannot certify that it works well in your country and that it complies with our quality requirements.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl:32</note>
-      </trans-unit>
-      <trans-unit id="d1ce387d44c3dc9cdc4e30ad64dbf47e">
-        <source>Use at your own risk.</source>
-        <target>Use at your own risk.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl:33</note>
-      </trans-unit>
-      <trans-unit id="080e6f65e34e2ffe7162beb258f4577d">
-        <source>If you are unsure about this, you should contact the Customer Service of %s to ask them to make the module compatible with your country.</source>
-        <target>If you are unsure about this, you should contact the Customer Service of %s to ask them to make the module compatible with your country.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="17e8aa9ff6f7c374738eb3a15270583c">
-        <source>Moreover, we recommend that you use an equivalent module: compatible modules for your country are listed in the "Modules" tab of your back office.</source>
-        <target>Moreover, we recommend that you use an equivalent module: compatible modules for your country are listed in the "Modules" tab of your back office.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="1de1cd538749db5ea85a79c300b092e3">
-        <source>If you are unsure about this module, you can look for similar modules on the official marketplace.</source>
-        <target>If you are unsure about this module, you can look for similar modules on the official marketplace.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="f7df37601ea653a7a5bf63e3556772d3">
-        <source>Click here to browse PrestaShop Addons.</source>
-        <target>Click here to browse PrestaShop Addons.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl:43</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/readmore-header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="df3f079de6961496f0460dcfdbf9bca3">
-        <source>by</source>
-        <target>by</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/readmore-header.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="9e3669d19b675bd57058fd4664205d2a">
-        <source>v</source>
-        <target>v</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/readmore-header.tpl:30</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/ad_bar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4df29b3cd68e3d8e40be0ad31188f17c">
-        <source>You might be interested in</source>
-        <target>You might be interested in</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/ad_bar.tpl:27</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ee0e3cf3fd1a733924756c6534826843">
-        <source>If you want to be able to fully use the AdminModules panel and have free modules available, you should enable the following configuration on your server:</source>
-        <target>If you want to be able to fully use the AdminModules panel and have free modules available, you should enable the following configuration on your server:</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="c84172ea13aaad319bfb3324c8fda5ed">
-        <source>Enable PHP's allow_url_fopen setting</source>
-        <target>Enable PHP's allow_url_fopen setting</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl:33</note>
-      </trans-unit>
-      <trans-unit id="27d8cabeab5ec86130d0e9048a085b57">
-        <source>Enable PHP's OpenSSL extension</source>
-        <target>Enable PHP's OpenSSL extension</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl:34</note>
-      </trans-unit>
-      <trans-unit id="40218c0320e986d6b29fde4259ac43c2">
-        <source>Connect your shop to PrestaShop's marketplace in order to automatically import all your Addons purchases.</source>
-        <target>Connect your shop to PrestaShop's marketplace in order to automatically import all your Addons purchases.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="a5f61298da21626d0f490ebd06ecd811">
-        <source>Don't have an account?</source>
-        <target>Don't have an account?</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl:46</note>
-      </trans-unit>
-      <trans-unit id="030547d47b4cb2e88a3c9a581a61487a">
-        <source>Discover the Power of PrestaShop Addons! Explore the PrestaShop Official Marketplace and find over 3 500 innovative modules and themes that optimize conversion rates, increase traffic, build customer loyalty and maximize your productivity</source>
-        <target>Discover the Power of PrestaShop Addons! Explore the PrestaShop Official Marketplace and find over 3 500 innovative modules and themes that optimize conversion rates, increase traffic, build customer loyalty and maximize your productivity</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl:47</note>
-      </trans-unit>
-      <trans-unit id="74ec9ffc8d108924d191065b416d8544">
-        <source>Connect to PrestaShop Addons</source>
-        <target>Connect to PrestaShop Addons</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl:50</note>
-      </trans-unit>
-      <trans-unit id="b05d72142020283dc6812fd3a9bc691c">
-        <source>I forgot my password</source>
-        <target>I forgot my password</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl:66</note>
-      </trans-unit>
-      <trans-unit id="2fe4fe0a0ebea41ce43eb3dc3fce4ea3">
-        <source>Create an Account</source>
-        <target>Create an Account</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl:76</note>
-      </trans-unit>
-      <trans-unit id="b6d4223e60986fa4c9af77ee5f7149c5">
-        <source>Sign in</source>
-        <target>Sign in</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/controllers/modules/login_addons.tpl:84</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/configure.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="deccbe4e9083c3b5f7cd2632722765bb">
-        <source>Translate</source>
-        <target>Translate</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:84</note>
-      </trans-unit>
-      <trans-unit id="06933067aafd48425d67bcb01bba5cb6">
-        <source>Update</source>
-        <target>Update</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:92</note>
-      </trans-unit>
-      <trans-unit id="c439b45b0a80369402e0d6158b55590f">
-        <source>Generate RTL Stylesheets</source>
-        <target>Generate RTL Stylesheets</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:100</note>
-      </trans-unit>
-      <trans-unit id="53103fcc4656f55c219b600ded3c7438">
-        <source>Manage hooks</source>
-        <target>Manage hooks</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/configure.tpl:107</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ba6b1bc4d8bfe5e6e835afa72f102a02">
-        <source>You bought this module on PrestaShop Addons. Thank You.</source>
-        <target>You bought this module on PrestaShop Addons. Thank You.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl:36</note>
-      </trans-unit>
-      <trans-unit id="fe5a7fc9d9c907efdf6a384a71cd53fc">
-        <source>Bought</source>
-        <target>Bought</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl:36</note>
-      </trans-unit>
-      <trans-unit id="0461779839539a8ee8fb2dca43cf5bec">
-        <source>This module is available on PrestaShop Addons</source>
-        <target>This module is available on PrestaShop Addons</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="2cc1943d4c0b46bfcf503a75c44f988b">
-        <source>Popular</source>
-        <target>Popular</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="0008feba81a131902ece95d59f1b8f21">
-        <source>Official</source>
-        <target>Official</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="28f60d4760851bab00345a3cb86871f7">
-        <source>Need update</source>
-        <target>Need update</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl:43</note>
-      </trans-unit>
-      <trans-unit id="b24ce0cd392a5b0b8dedc66c25213594">
-        <source>Free</source>
-        <target>Free</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl:64</note>
-      </trans-unit>
-      <trans-unit id="f248df0d4d7e4ae98485c5df8af58945">
-        <source>This module is available for free thanks to our partner.</source>
-        <target>This module is available for free thanks to our partner.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl:40</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="43340e6cc4e88197d57f8d6d5ea50a46">
-        <source>Read more</source>
-        <target>Read more</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="908f8d9f34f375a55dd5b6a86489d364">
-        <source>No result</source>
-        <target>No result</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="37a502907cd750af8c65517a75d00030">
-        <source>Real Time</source>
-        <target>Real Time</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl:62</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/readmore-body.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="3424c86a3f3fdfcff4d8f310912ee82b">
-        <source>(%s votes)</source>
-        <target>(%s votes)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/readmore-body.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="268cb3857932e260b03bf1334220f3bc">
-        <source>(%s vote)</source>
-        <target>(%s vote)</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/readmore-body.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
-        <source>Description</source>
-        <target>Description</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/readmore-body.tpl:52</note>
-      </trans-unit>
-      <trans-unit id="7a66d21cf5a4354933980f6d79ec78a4">
-        <source>Merchant benefits</source>
-        <target>Merchant benefits</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/readmore-body.tpl:59</note>
-      </trans-unit>
-      <trans-unit id="8530d0ebaf22889c1b42061824f3769b">
-        <source>Install module</source>
-        <target>Install module</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/readmore-body.tpl:92</note>
-      </trans-unit>
-      <trans-unit id="a6642661dcfc0e354c61f4e8b8b9ec5a">
-        <source>View on PrestaShop Addons</source>
-        <target>View on PrestaShop Addons</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/readmore-body.tpl:94</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/modules/page_header_toolbar-legacy.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="28080c3603fb7e10f228381b181cae2c">
-        <source>List of modules</source>
-        <target>List of modules</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page_header_toolbar-legacy.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="71803586f945801418d03befeb4acd99">
-        <source>Update all</source>
-        <target>Update all</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page_header_toolbar-legacy.tpl:48</note>
-      </trans-unit>
-      <trans-unit id="a3105b7aa9edb1c07765bfdcdc2405b8">
-        <source>Check for update</source>
-        <target>Check for update</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules/page_header_toolbar-legacy.tpl:55</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/new-theme/template/page_header_toolbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="6a26f548831e6a8c26bfbbd9f6ec61e0">
-        <source>Help</source>
-        <target>Help</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/page_header_toolbar.tpl:78</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/new-theme/template/components/layout/non-responsive.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="0557fa923dcee4d0f86b1409f5c2167f">
-        <source>Back</source>
-        <target>Back</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/non-responsive.tpl:38</note>
-      </trans-unit>
-      <trans-unit id="ed95254a7068ffd8729fd94d07347d67">
-        <source>Oh no!</source>
-        <target>Oh no!</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/non-responsive.tpl:26</note>
-      </trans-unit>
-      <trans-unit id="93e2c2e3d9591e5d54b0e5e6f81d36e0">
-        <source>The mobile version of this page is not available yet.</source>
-        <target>The mobile version of this page is not available yet.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/non-responsive.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="56c42d822d794bc33d5e25bc53cd385b">
-        <source>Please use a desktop computer to access this page, until is adapted to mobile.</source>
-        <target>Please use a desktop computer to access this page, until is adapted to mobile.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/non-responsive.tpl:31</note>
-      </trans-unit>
-      <trans-unit id="2d439011ecebc222e1feb2e3e005c0ac">
-        <source>Thank you.</source>
-        <target>Thank you.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/non-responsive.tpl:34</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="95e3873b64426add2f3818e6a98dc9fb">
-        <source>Search on PrestaShop Marketplace:</source>
-        <target>Search on PrestaShop Marketplace:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="3a2d5fe857d8f9541136a124c2edec6c">
-        <source>Or</source>
-        <target>Or</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl:50</note>
-      </trans-unit>
-      <trans-unit id="1beaf22ea4850d25af342d91b0f25624">
-        <source>See all themes</source>
-        <target>See all themes</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl:50</note>
-      </trans-unit>
-      <trans-unit id="ae0e265c94eec2c38690ada171d60a4d">
-        <source>Add a new theme</source>
-        <target>Add a new theme</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl:59</note>
-      </trans-unit>
-      <trans-unit id="26a278c1e0598e21f7c1ed7ab113e6ac">
-        <source>To add a new theme, simply connect to your PrestaShop Addons account: your new theme will be automatically imported to your shop.</source>
-        <target>To add a new theme, simply connect to your PrestaShop Addons account: your new theme will be automatically imported to your shop.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl:64</note>
-      </trans-unit>
-      <trans-unit id="a5ed2b9ca9427746aced5b4037560434">
-        <source>You can choose among 1,500+ professional templates!</source>
-        <target>You can choose among 1,500+ professional templates!</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl:65</note>
-      </trans-unit>
-      <trans-unit id="dc9ac2e66cddf6e2c64e1c72b18ae130">
-        <source>Can I add my own theme?</source>
-        <target>Can I add my own theme?</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl:82</note>
-      </trans-unit>
-      <trans-unit id="7c854ab311760ecb245fb938378cd4e9">
-        <source>Please note that for security reasons, you can only add themes that are being distributed on PrestaShop Addons, the official marketplace.</source>
-        <target>Please note that for security reasons, you can only add themes that are being distributed on PrestaShop Addons, the official marketplace.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl:83</note>
-      </trans-unit>
-      <trans-unit id="80bf7b97a380d8d8aa29993fa61ab5e5">
-        <source>You can also create a new theme below.</source>
-        <target>You can also create a new theme below.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl:84</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="be8545ae7ab0276e15898aae7acfbd7a">
-        <source>Resource</source>
-        <target>Resource</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl:33</note>
+  <file original="admin-dev/themes/default/template/controllers/attribute_generator/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="32aa6a8b290538b9af3531ea1e1a9dbf">
+        <source>Tax Excluded</source>
+        <target>Tax Excluded</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="8794a5dad880ed1a30d82081872b050e">
+        <source>Tax Included</source>
+        <target>Tax Included</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="181ba1a9e1a38f1a83277046cdbbc2bc">
+        <source>%d product(s) successfully created.</source>
+        <target>%d product(s) successfully created.</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="81315cfd898aada1e99e0034b4b078c3">
+        <source>Attributes generator</source>
+        <target>Attributes generator</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="422f3f656e1a5f95e8b5cf7565d815b5">
+        <source>The Combinations Generator is a tool that allows you to easily create a series of combinations by selecting the related attributes. For example, if you're selling t-shirts in three different sizes and two different colors, the generator will create six combinations for you.</source>
+        <target>The Combinations Generator is a tool that allows you to easily create a series of combinations by selecting the related attributes. For example, if you're selling t-shirts in three different sizes and two different colors, the generator will create six combinations for you.</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="cfe938f78378cfd9739d4321cfa7ff78">
+        <source>You're currently generating combinations for the following product:</source>
+        <target>You're currently generating combinations for the following product:</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="31fd7663706f9829ba8e64b229df4e3f">
+        <source>Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")</source>
+        <target>Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="928929ae9eb360f552df9c62c5fef6e2">
+        <source>Impact on the product price</source>
+        <target>Impact on the product price</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="2cbb96b1bb8e0942f609bba818277f7c">
+        <source>Impact on the product weight</source>
+        <target>Impact on the product weight</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="4e927d0c87a6edc742e9c664f18a53c7">
+        <source>Select a default quantity, and reference, for each combination the generator will create for this product.</source>
+        <target>Select a default quantity, and reference, for each combination the generator will create for this product.</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="1b8bea6c0d2655c4e2c1070c9beee03a">
+        <source>Default Quantity:</source>
+        <target>Default Quantity:</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="49d079be0fc1fcccefdee6bdf67b02ff">
+        <source>Default Reference:</source>
+        <target>Default Reference:</target>
+        <note>Line: 133</note>
+      </trans-unit>
+      <trans-unit id="fb6d5b178b6f3ce02379006b7610ed6d">
+        <source>Please click on "Generate these combinations".</source>
+        <target>Please click on "Generate these combinations".</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="e3c57b7da599fa0a9410c456b59f6dd3">
+        <source>Generate these combinations</source>
+        <target>Generate these combinations</target>
+        <note>Line: 139</note>
       </trans-unit>
     </body>
   </file>
@@ -2793,380 +79,105 @@ File: admin-dev/themes/default/template/controllers/webservice/helpers/form/form
       <trans-unit id="62acf0bc057112bf91cd1ff9f1426c6c">
         <source>[undefined]</source>
         <target>[undefined]</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl:27</note>
+        <note>Line: 27</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/actions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="83057027f6b988dd2dbe422f6f3ddd21">
-        <source>No module was found for this hook.</source>
-        <target>No module was found for this hook.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl:157</note>
+      <trans-unit id="bcca39c6f36c3085c46429511614b227">
+        <source>If enabled, the voucher will not apply to products already on sale.</source>
+        <target>If enabled, the voucher will not apply to products already on sale.</target>
+        <note>Line: 145</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="3adbdb3ac060038aa0e6e6c138ef9873">
-        <source>Category</source>
-        <target>Category</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:241</note>
+      <trans-unit id="d6d9190e86f812c0490da9360e12cee1">
+        <source>Add a rule concerning</source>
+        <target>Add a rule concerning</target>
+        <note>Line: 45</note>
       </trans-unit>
-      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
-        <source>Brand</source>
-        <target>Brand</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:252</note>
-      </trans-unit>
-      <trans-unit id="ec136b444eede3bc85639fac0dd06229">
-        <source>Supplier</source>
-        <target>Supplier</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl:263</note>
+      <trans-unit id="c5536e008327e8873c8daf321a088873">
+        <source>The product(s) are matching one of these:</source>
+        <target>The product(s) are matching one of these:</target>
+        <note>Line: 65</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/attribute_generator/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="32aa6a8b290538b9af3531ea1e1a9dbf">
-        <source>Tax Excluded</source>
-        <target>Tax Excluded</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="8794a5dad880ed1a30d82081872b050e">
-        <source>Tax Included</source>
-        <target>Tax Included</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:42</note>
-      </trans-unit>
-      <trans-unit id="181ba1a9e1a38f1a83277046cdbbc2bc">
-        <source>%d product(s) successfully created.</source>
-        <target>%d product(s) successfully created.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:66</note>
-      </trans-unit>
-      <trans-unit id="81315cfd898aada1e99e0034b4b078c3">
-        <source>Attributes generator</source>
-        <target>Attributes generator</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:71</note>
-      </trans-unit>
-      <trans-unit id="422f3f656e1a5f95e8b5cf7565d815b5">
-        <source>The Combinations Generator is a tool that allows you to easily create a series of combinations by selecting the related attributes. For example, if you're selling t-shirts in three different sizes and two different colors, the generator will create six combinations for you.</source>
-        <target>The Combinations Generator is a tool that allows you to easily create a series of combinations by selecting the related attributes. For example, if you're selling t-shirts in three different sizes and two different colors, the generator will create six combinations for you.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:94</note>
-      </trans-unit>
-      <trans-unit id="cfe938f78378cfd9739d4321cfa7ff78">
-        <source>You're currently generating combinations for the following product:</source>
-        <target>You're currently generating combinations for the following product:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:96</note>
-      </trans-unit>
-      <trans-unit id="31fd7663706f9829ba8e64b229df4e3f">
-        <source>Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")</source>
-        <target>Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:98</note>
-      </trans-unit>
-      <trans-unit id="928929ae9eb360f552df9c62c5fef6e2">
-        <source>Impact on the product price</source>
-        <target>Impact on the product price</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:107</note>
-      </trans-unit>
-      <trans-unit id="2cbb96b1bb8e0942f609bba818277f7c">
-        <source>Impact on the product weight</source>
-        <target>Impact on the product weight</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:108</note>
-      </trans-unit>
-      <trans-unit id="4e927d0c87a6edc742e9c664f18a53c7">
-        <source>Select a default quantity, and reference, for each combination the generator will create for this product.</source>
-        <target>Select a default quantity, and reference, for each combination the generator will create for this product.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:125</note>
-      </trans-unit>
-      <trans-unit id="1b8bea6c0d2655c4e2c1070c9beee03a">
-        <source>Default Quantity:</source>
-        <target>Default Quantity:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:129</note>
-      </trans-unit>
-      <trans-unit id="49d079be0fc1fcccefdee6bdf67b02ff">
-        <source>Default Reference:</source>
-        <target>Default Reference:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:133</note>
-      </trans-unit>
-      <trans-unit id="fb6d5b178b6f3ce02379006b7610ed6d">
-        <source>Please click on "Generate these combinations".</source>
-        <target>Please click on "Generate these combinations".</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:138</note>
-      </trans-unit>
-      <trans-unit id="e3c57b7da599fa0a9410c456b59f6dd3">
-        <source>Generate these combinations</source>
-        <target>Generate these combinations</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/attribute_generator/content.tpl:139</note>
+      <trans-unit id="f14b582c1b0eab88ed5904fb781568c0">
+        <source>Discount name</source>
+        <target>Discount name</target>
+        <note>Line: 203</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="a7bd935a88c629dc11c52e0c16c2a8a0">
-        <source>%d</source>
-        <target>%d</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl:52</note>
-      </trans-unit>
-      <trans-unit id="bbfb7a636f839052067cc86c39fa595a">
-        <source>%limit% for suhosin.post.max_vars.</source>
-        <target>%limit% for suhosin.post.max_vars.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="e97da54b23c78752578cd7fa01e8866d">
-        <source>%limit% for suhosin.request.max_vars.</source>
-        <target>%limit% for suhosin.request.max_vars.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl:40</note>
+      <trans-unit id="1e65b02f3464a517e0946a46d496327c">
+        <source>Sync success</source>
+        <target>Sync success</target>
+        <note>Line: 75</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="f324bbd9de83d61ccb5f7d5593aec5b3">
-        <source>You MUST use this syntax in your translations. Here are several examples:</source>
-        <target>You MUST use this syntax in your translations. Here are several examples:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl:86</note>
+      <trans-unit id="d3d2e617335f08df83599665eef8a418">
+        <source>Close</source>
+        <target>Close</target>
+        <note>Line: 62</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="f1246f9ac6a7094789c17068713ebfe6">
-        <source>The "%1$s" theme has been successfully installed.</source>
-        <target>The "%1$s" theme has been successfully installed.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl:27</note>
+      <trans-unit id="3bf63a999cda6c9d95c3827e7942f41d">
+        <source>Customer since: %s</source>
+        <target>Customer since: %s</target>
+        <note>Line: 79</note>
       </trans-unit>
-      <trans-unit id="623a0df3a4b9fcca8e08c9ed1a07bba1">
-        <source>The following module(s) were not installed properly:</source>
-        <target>The following module(s) were not installed properly:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl:42</note>
+      <trans-unit id="8df41ed5ebc778c45f74a201e822613a">
+        <source>Choose a template</source>
+        <target>Choose a template</target>
+        <note>Line: 116</note>
       </trans-unit>
-      <trans-unit id="940d7a8d6502a022e8eb2d8a090b1a05">
-        <source>Warning: You may have to regenerate images to fit with this new theme.</source>
-        <target>Warning: You may have to regenerate images to fit with this new theme.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl:54</note>
+      <trans-unit id="94966d90747b97d1f0f206c98a8b1ac3">
+        <source>Send</source>
+        <target>Send</target>
+        <note>Line: 119</note>
       </trans-unit>
-      <trans-unit id="aedd6903868a8d6c7b01e0754fb56336">
-        <source>Go to the thumbnails regeneration page</source>
-        <target>Go to the thumbnails regeneration page</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl:56</note>
-      </trans-unit>
-      <trans-unit id="ce72a3420348d5b0bcd1382b1c88f553">
-        <source>Warning: This image type doesn’t exist. To manually set it, use the values below to create a new image type (in the "Images" page under the "Design" menu):</source>
-        <target>Warning: This image type doesn’t exist. To manually set it, use the values below to create a new image type (in the "Images" page under the "Design" menu):</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl:63</note>
-      </trans-unit>
-      <trans-unit id="3b90370ac32dead2af37eabe3bdbb97f">
-        <source>Name image type:</source>
-        <target>Name image type:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl:81</note>
-      </trans-unit>
-      <trans-unit id="c6ec097a1c02ee4db0dda78b98f4c08c">
-        <source>(width: %1$spx, height: %2$spx).</source>
-        <target>(width: %1$spx, height: %2$spx).</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl:81</note>
-      </trans-unit>
-      <trans-unit id="8f1cda3b6ae2df7c2c152cfeffaea57a">
-        <source>Images have been correctly updated in the database:</source>
-        <target>Images have been correctly updated in the database:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl:77</note>
-      </trans-unit>
-      <trans-unit id="a20ddccbb6f808ec42cd66323e6c6061">
-        <source>Finish</source>
-        <target>Finish</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl:90</note>
+      <trans-unit id="2605a817441c19cc88eb9e5d17845dc0">
+        <source>You can add a comment here.</source>
+        <target>You can add a comment here.</target>
+        <note>Line: 155</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/message.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="b6ba229b668e5a7b6700e4d275683084">
-        <source>Use this theme</source>
-        <target>Use this theme</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl:43</note>
+      <trans-unit id="d13d8380c3f4de07fef91a42fe6c60d7">
+        <source>Customer ID:</source>
+        <target>Customer ID:</target>
+        <note>Line: 127</note>
       </trans-unit>
-      <trans-unit id="e169a8fe61809e3679a424bf27166a78">
-        <source>Delete this theme</source>
-        <target>Delete this theme</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl:52</note>
+      <trans-unit id="d1228f5476d15142b1358ae4b5fa2454">
+        <source>Order #</source>
+        <target>Order #</target>
+        <note>Line: 134</note>
       </trans-unit>
-      <trans-unit id="837a54ae4874c4501c804173cd3c0fdf">
-        <source>Designed by %s</source>
-        <target>Designed by %s</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl:90</note>
+      <trans-unit id="c851a34d4806acb02a55df148f9d7f25">
+        <source>Product #</source>
+        <target>Product #</target>
+        <note>Line: 141</note>
       </trans-unit>
-      <trans-unit id="8ef656f84513928ea1b0c2f1735b62e9">
-        <source>Configure your page layouts</source>
-        <target>Configure your page layouts</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl:94</note>
-      </trans-unit>
-      <trans-unit id="4459ae4e873177642b30e9fc8b821d2f">
-        <source>Each page can use a different layout, choose it among the layouts bundled in your theme.</source>
-        <target>Each page can use a different layout, choose it among the layouts bundled in your theme.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl:97</note>
-      </trans-unit>
-      <trans-unit id="21e2bb42873eddcb9b476b8eafbe0c18">
-        <source>Reset to defaults</source>
-        <target>Reset to defaults</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl:106</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5f613cee6c941423b73e1f87ea3b99bc">
-        <source>Please name your data matching configuration in order to save it.</source>
-        <target>Please name your data matching configuration in order to save it.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl:28</note>
-      </trans-unit>
-      <trans-unit id="43a37c093f7655efe882a7ffd7ce2e8d">
-        <source>Match your data</source>
-        <target>Match your data</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="e275f3b49dc3286ef66d7c2774a1f79b">
-        <source>Please match each column of your source file to one of the destination columns.</source>
-        <target>Please match each column of your source file to one of the destination columns.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl:63</note>
-      </trans-unit>
-      <trans-unit id="4d83ebfaf28dd4436e1165a1764750db">
-        <source>Load a data matching configuration</source>
-        <target>Load a data matching configuration</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl:67</note>
-      </trans-unit>
-      <trans-unit id="f19dbf2edb3a0bd74b0524d960ff21eb">
-        <source>Load</source>
-        <target>Load</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl:76</note>
-      </trans-unit>
-      <trans-unit id="e195639ebd7491676218b40af7aeafe3">
-        <source>Save your data matching configuration</source>
-        <target>Save your data matching configuration</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl:81</note>
-      </trans-unit>
-      <trans-unit id="371ed088d2c0e456f5cae0bb97fe7c4b">
-        <source>Two columns cannot have the same type of values</source>
-        <target>Two columns cannot have the same type of values</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl:91</note>
-      </trans-unit>
-      <trans-unit id="6a00e03023004b3330275e8d9842b54c">
-        <source>This column must be set:</source>
-        <target>This column must be set:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl:94</note>
-      </trans-unit>
-      <trans-unit id="3b057f0f92ac8d274701c269ac00c5fa">
-        <source>Rows to skip</source>
-        <target>Rows to skip</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl:114</note>
-      </trans-unit>
-      <trans-unit id="225ba2bdb1c56af16651110411fc21b1">
-        <source>Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.</source>
-        <target>Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl:117</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="38f06ccd27281c8fc66e11581798ec06">
-        <source>Number of products:</source>
-        <target>Number of products:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl:30</note>
-      </trans-unit>
-      <trans-unit id="df644ae155e79abf54175bd15d75f363">
-        <source>Product name</source>
-        <target>Product name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl:34</note>
-      </trans-unit>
-      <trans-unit id="1caa6ff629641a4eb20f190f7a0539ca">
-        <source>Attribute name</source>
-        <target>Attribute name</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl:35</note>
-      </trans-unit>
-      <trans-unit id="bc67a1507258a758c3a31e66d7ceff8f">
-        <source>Supplier Reference</source>
-        <target>Supplier Reference</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl:36</note>
-      </trans-unit>
-      <trans-unit id="c804723ccdde3d7a46933b208c6f928d">
-        <source>Wholesale price</source>
-        <target>Wholesale price</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl:37</note>
-      </trans-unit>
-      <trans-unit id="52eb5928a34db3e3da7ba52b0644273b">
-        <source>EAN13</source>
-        <target>EAN13</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl:39</note>
-      </trans-unit>
-      <trans-unit id="fbd99ad01b92dbafc686772a39e3d065">
-        <source>UPC</source>
-        <target>UPC</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="c8c5918f1175c1296d19755b2f49d1c9">
-        <source>Available Quantity</source>
-        <target>Available Quantity</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl:41</note>
-      </trans-unit>
-      <trans-unit id="382b0f5185773fa0f67a8ed8056c7759">
-        <source>N/A</source>
-        <target>N/A</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl:66</note>
+      <trans-unit id="47a0be8d1015d526a1fbaa56c3102135">
+        <source>Subject:</source>
+        <target>Subject:</target>
+        <note>Line: 147</note>
       </trans-unit>
     </body>
   </file>
@@ -3175,14 +186,26 @@ File: admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.
       <trans-unit id="d1554912e46f8d36a800ad8b604225f1">
         <source>Valid orders:</source>
         <target>Valid orders:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:192</note>
+        <note>Line: 192</note>
       </trans-unit>
       <trans-unit id="0c71153e10e4cca705c7de8625f23344">
         <source>%firstname% %lastname% has not registered any addresses yet</source>
         <target>%firstname% %lastname% has not registered any addresses yet</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl:654</note>
+        <note>Line: 654</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="908f8d9f34f375a55dd5b6a86489d364">
+        <source>No result</source>
+        <target>No result</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="37a502907cd750af8c65517a75d00030">
+        <source>Real Time</source>
+        <target>Real Time</target>
+        <note>Line: 62</note>
       </trans-unit>
     </body>
   </file>
@@ -3191,8 +214,90 @@ File: admin-dev/themes/default/template/controllers/customers/helpers/view/view.
       <trans-unit id="a1e7379abfdbc3b8e03506e5489c6110">
         <source>Discount:</source>
         <target>Discount:</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl:36</note>
+        <note>Line: 36</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d">
+        <source>Download</source>
+        <target>Download</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="3bb4a695db0c87a3d70a2deffddeb743">
+        <source>Read more about the CSV format at:</source>
+        <target>Read more about the CSV format at:</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">
+        <source>or</source>
+        <target>or</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="e4cdcd51e6cf787d4ecc7d813f0c23cb">
+        <source>The locale must be installed</source>
+        <target>The locale must be installed</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="e08caeac3f80ffa7889cdf1c8f30111f">
+        <source>Multiple value separator</source>
+        <target>Multiple value separator</target>
+        <note>Line: 208</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5f613cee6c941423b73e1f87ea3b99bc">
+        <source>Please name your data matching configuration in order to save it.</source>
+        <target>Please name your data matching configuration in order to save it.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="43a37c093f7655efe882a7ffd7ce2e8d">
+        <source>Match your data</source>
+        <target>Match your data</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="e275f3b49dc3286ef66d7c2774a1f79b">
+        <source>Please match each column of your source file to one of the destination columns.</source>
+        <target>Please match each column of your source file to one of the destination columns.</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="4d83ebfaf28dd4436e1165a1764750db">
+        <source>Load a data matching configuration</source>
+        <target>Load a data matching configuration</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="f19dbf2edb3a0bd74b0524d960ff21eb">
+        <source>Load</source>
+        <target>Load</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="e195639ebd7491676218b40af7aeafe3">
+        <source>Save your data matching configuration</source>
+        <target>Save your data matching configuration</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="371ed088d2c0e456f5cae0bb97fe7c4b">
+        <source>Two columns cannot have the same type of values</source>
+        <target>Two columns cannot have the same type of values</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="6a00e03023004b3330275e8d9842b54c">
+        <source>This column must be set:</source>
+        <target>This column must be set:</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="3b057f0f92ac8d274701c269ac00c5fa">
+        <source>Rows to skip</source>
+        <target>Rows to skip</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="225ba2bdb1c56af16651110411fc21b1">
+        <source>Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.</source>
+        <target>Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.</target>
+        <note>Line: 117</note>
       </trans-unit>
     </body>
   </file>
@@ -3201,168 +306,1899 @@ File: admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl
       <trans-unit id="dc647eb65e6711e155375218212b3964">
         <source>Password</source>
         <target>Password</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:68</note>
+        <note>Line: 68</note>
       </trans-unit>
       <trans-unit id="685de99eb748aa2bba879a87af2ffed4">
         <source>Your password has been successfully changed.</source>
         <target>Your password has been successfully changed.</target>
-        <note>Context:
-File: admin-dev/themes/default/template/controllers/login/content.tpl:118</note>
+        <note>Line: 118</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/new-theme/template/components/layout/warning_messages.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="0071aa279bd1583754a544277740f047">
+        <source>Delete item #</source>
+        <target>Delete item #</target>
+        <note>Line: 108</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/ad_bar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4df29b3cd68e3d8e40be0ad31188f17c">
+        <source>You might be interested in</source>
+        <target>You might be interested in</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/configure.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="deccbe4e9083c3b5f7cd2632722765bb">
+        <source>Translate</source>
+        <target>Translate</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="06933067aafd48425d67bcb01bba5cb6">
+        <source>Update</source>
+        <target>Update</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="c439b45b0a80369402e0d6158b55590f">
+        <source>Generate RTL Stylesheets</source>
+        <target>Generate RTL Stylesheets</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="53103fcc4656f55c219b600ded3c7438">
+        <source>Manage hooks</source>
+        <target>Manage hooks</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="a27dfe771799a09fd55fea73286eb6ab">
+        <source>Uninstall</source>
+        <target>Uninstall</target>
+        <note>Line: 73</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/content-legacy.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fe6b7985acf4b17efbfe1b38545299d9">
+        <source>See all modules</source>
+        <target>See all modules</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="4181fcfe54e8fadc0644e1cadde3483f">
+        <source>To add a new module, simply connect to your PrestaShop Addons account and all your purchases will be automatically imported.</source>
+        <target>To add a new module, simply connect to your PrestaShop Addons account and all your purchases will be automatically imported.</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="82010160301993d2d752d8f185b31d0c">
+        <source>Can I add my own modules?</source>
+        <target>Can I add my own modules?</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="bb2ee5b5f12b6eae3c1716d26cddeab7">
+        <source>Please note that for security reasons, you can only add modules that are being distributed on PrestaShop Addons, the official marketplace.</source>
+        <target>Please note that for security reasons, you can only add modules that are being distributed on PrestaShop Addons, the official marketplace.</target>
+        <note>Line: 85</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/favorites.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e55f75a29310d7b60f7ac1d390c8ae42">
+        <source>Module</source>
+        <target>Module</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="7e4a9cd054588a95b0394d92a2030e72">
+        <source>Normal view</source>
+        <target>Normal view</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="d7af23f5f349f2c4eace4927943b2760">
+        <source>Favorites view</source>
+        <target>Favorites view</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="5c6ba25104401c9ee0650230fc6ba413">
+        <source>Tab</source>
+        <target>Tab</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
+        <source>Categories</source>
+        <target>Categories</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="920beb5dda21b04a332e0457cb0cfbec">
+        <source>Interest</source>
+        <target>Interest</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="01165dcf77c191e6c69b31d98b0ec6ff">
+        <source>Favorite</source>
+        <target>Favorite</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3182ea023795eb83ed0ce3beea5beb73">
+        <source>Other Modules</source>
+        <target>Other Modules</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="d9e87fc7a13ba398295447791c67b586">
+        <source>Installed Modules</source>
+        <target>Installed Modules</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="a0f454ebaee933c7791ffcdda76944b3">
+        <source>Disabled Modules</source>
+        <target>Disabled Modules</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="1f0e9c979b965d24aa3c2c4b832c3ba1">
+        <source>Filter by</source>
+        <target>Filter by</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="7b4d2812164df0dceca0b53bb650e52d">
+        <source><![CDATA[Installed & Not Installed]]></source>
+        <target><![CDATA[Installed & Not Installed]]></target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="94c8dec8d2fcfa80c9b6f4669be43eb0">
+        <source>Modules Not Installed </source>
+        <target>Modules Not Installed </target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="6b8f34307b46c249a91d84e52ae94caf">
+        <source><![CDATA[Enabled & Disabled]]></source>
+        <target><![CDATA[Enabled & Disabled]]></target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="dfe6e46e2d3e3ba76b5d9aee197c0747">
+        <source>Enabled Modules</source>
+        <target>Enabled Modules</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="02684cc6b6ea1811a064f475a5fd1d18">
+        <source>Authors</source>
+        <target>Authors</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="00c3388449f7c4d73cc8c417d7d38554">
+        <source>All Modules</source>
+        <target>All Modules</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="d546df356f9b15d6d20b1e5d8b310fed">
+        <source>Free Modules</source>
+        <target>Free Modules</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="d071f451a57ab54fa6890d0f501a99d4">
+        <source>Partner Modules (Free)</source>
+        <target>Partner Modules (Free)</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="02ae741da806bbeafc0ae6a84ce752d3">
+        <source>Must Have</source>
+        <target>Must Have</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="174704dbe8a3a7d144b0ce840e734077">
+        <source>Modules purchased on Addons</source>
+        <target>Modules purchased on Addons</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="fbdc9a432c8e6a94bb54864ae4f5fb7f">
+        <source>All authors</source>
+        <target>All authors</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="c3987e4cac14a8456515f0d200da04ee">
+        <source>All countries</source>
+        <target>All countries</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="d188407e1d066cd41925efebe2dab3da">
+        <source>Current country:</source>
+        <target>Current country:</target>
+        <note>Line: 68</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/js.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="45e06e5610d29d675a875a6f7731b73d">
+        <source>Would you like to delete the content related to this module ?</source>
+        <target>Would you like to delete the content related to this module ?</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="c0d19e251d0ff55ecb860e7349f779a4">
+        <source>Confirm reset</source>
+        <target>Confirm reset</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="d65c99010166606287266e4af4f0b934">
+        <source>No - reset only the parameters</source>
+        <target>No - reset only the parameters</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="0426ba52f94430cf093652d1ea18fedf">
+        <source>Yes - reset everything</source>
+        <target>Yes - reset everything</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="25b22a00db3085743f478140b8281a26">
+        <source>Preferences saved</source>
+        <target>Preferences saved</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4f9b5fa08f2ef86fdc5d0ceefc271981">
+        <source>Remove from Favorites</source>
+        <target>Remove from Favorites</target>
+        <note>Line: 168</note>
+      </trans-unit>
+      <trans-unit id="7263f59f5d8aeaf7d2117fcd4b70930a">
+        <source>Mark as Favorite</source>
+        <target>Mark as Favorite</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="59fcbc24a474d290fa540a3a27e2ff05">
+        <source>Module %1s </source>
+        <target>Module %1s </target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="3846bafee4cc9ce49c24a0b499d3e08d">
+        <source>Official, PrestaShop certified module. Free, secure and includes updates!</source>
+        <target>Official, PrestaShop certified module. Free, secure and includes updates!</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="52dd3893c24e9cf4be761dcaee6bea39">
+        <source>Update it!</source>
+        <target>Update it!</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="29c632cf1c7f140b6e86f3af04df48d4">
+        <source>Install the selection</source>
+        <target>Install the selection</target>
+        <note>Line: 196</note>
+      </trans-unit>
+      <trans-unit id="7245ac07bbd56e6d0f7489a7dddb836f">
+        <source>Uninstall the selection</source>
+        <target>Uninstall the selection</target>
+        <note>Line: 202</note>
+      </trans-unit>
+      <trans-unit id="df3f079de6961496f0460dcfdbf9bca3">
+        <source>by</source>
+        <target>by</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="ba6b1bc4d8bfe5e6e835afa72f102a02">
+        <source>You bought this module on PrestaShop Addons. Thank You.</source>
+        <target>You bought this module on PrestaShop Addons. Thank You.</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="fe5a7fc9d9c907efdf6a384a71cd53fc">
+        <source>Bought</source>
+        <target>Bought</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="0461779839539a8ee8fb2dca43cf5bec">
+        <source>This module is available on PrestaShop Addons</source>
+        <target>This module is available on PrestaShop Addons</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="2cc1943d4c0b46bfcf503a75c44f988b">
+        <source>Popular</source>
+        <target>Popular</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="0008feba81a131902ece95d59f1b8f21">
+        <source>Official</source>
+        <target>Official</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="28f60d4760851bab00345a3cb86871f7">
+        <source>Need update</source>
+        <target>Need update</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="b24ce0cd392a5b0b8dedc66c25213594">
+        <source>Free</source>
+        <target>Free</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="43340e6cc4e88197d57f8d6d5ea50a46">
+        <source>Read more</source>
+        <target>Read more</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="349838fb1d851d3e2014b9fe39203275">
+        <source>Install</source>
+        <target>Install</target>
+        <note>Line: 115</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/login_addons.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ee0e3cf3fd1a733924756c6534826843">
+        <source>If you want to be able to fully use the AdminModules panel and have free modules available, you should enable the following configuration on your server:</source>
+        <target>If you want to be able to fully use the AdminModules panel and have free modules available, you should enable the following configuration on your server:</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="c84172ea13aaad319bfb3324c8fda5ed">
+        <source>Enable PHP's allow_url_fopen setting</source>
+        <target>Enable PHP's allow_url_fopen setting</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="27d8cabeab5ec86130d0e9048a085b57">
+        <source>Enable PHP's OpenSSL extension</source>
+        <target>Enable PHP's OpenSSL extension</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="40218c0320e986d6b29fde4259ac43c2">
+        <source>Connect your shop to PrestaShop's marketplace in order to automatically import all your Addons purchases.</source>
+        <target>Connect your shop to PrestaShop's marketplace in order to automatically import all your Addons purchases.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="a5f61298da21626d0f490ebd06ecd811">
+        <source>Don't have an account?</source>
+        <target>Don't have an account?</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="030547d47b4cb2e88a3c9a581a61487a">
+        <source>Discover the Power of PrestaShop Addons! Explore the PrestaShop Official Marketplace and find over 3 500 innovative modules and themes that optimize conversion rates, increase traffic, build customer loyalty and maximize your productivity</source>
+        <target>Discover the Power of PrestaShop Addons! Explore the PrestaShop Official Marketplace and find over 3 500 innovative modules and themes that optimize conversion rates, increase traffic, build customer loyalty and maximize your productivity</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="74ec9ffc8d108924d191065b416d8544">
+        <source>Connect to PrestaShop Addons</source>
+        <target>Connect to PrestaShop Addons</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="b05d72142020283dc6812fd3a9bc691c">
+        <source>I forgot my password</source>
+        <target>I forgot my password</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="2fe4fe0a0ebea41ce43eb3dc3fce4ea3">
+        <source>Create an Account</source>
+        <target>Create an Account</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="b6d4223e60986fa4c9af77ee5f7149c5">
+        <source>Sign in</source>
+        <target>Sign in</target>
+        <note>Line: 80</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5724be5bf0b6c384f8f0e4ec5c56960e">
+        <source>What Should I Do?</source>
+        <target>What Should I Do?</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="34afcb42ab73990082d328d9b34811b5">
+        <source>Proceed with the installation</source>
+        <target>Proceed with the installation</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="9c4573ad0738d689dcb4dfb11ea6ce5a">
+        <source>Do you want to install this module that could not be verified by PrestaShop?</source>
+        <target>Do you want to install this module that could not be verified by PrestaShop?</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="cff96407d828626ba1219454e9dde40c">
+        <source>Since you may not have downloaded this module from PrestaShop Addons, we cannot assert that the module is not adding some undisclosed functionalities. We advise you to install it only if you trust the source of the content.</source>
+        <target>Since you may not have downloaded this module from PrestaShop Addons, we cannot assert that the module is not adding some undisclosed functionalities. We advise you to install it only if you trust the source of the content.</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="cb6c308b881809f8ab33d50efad0b665">
+        <source>What's the risk?</source>
+        <target>What's the risk?</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="b1c3bf188b7df9285d57df41f00c7041">
+        <source>Am I at Risk?</source>
+        <target>Am I at Risk?</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="144f70b53defb91dacdb0a4ac79b7e70">
+        <source>A module that hasn't been verified may be dangerous and could add hidden functionalities like backdoors, ads, hidden links, spam, etc. Don’t worry, this alert is simply a warning.</source>
+        <target>A module that hasn't been verified may be dangerous and could add hidden functionalities like backdoors, ads, hidden links, spam, etc. Don’t worry, this alert is simply a warning.</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="50d39ed39f0e1c95d185acc6b89de6f8">
+        <source>PrestaShop, being an open-source software, has an awesome community with a long history of developing and sharing high quality modules. Before installing this module, making sure its author is a known community member is always a good idea (by checking [1]our forum[/1] for instance).</source>
+        <target>PrestaShop, being an open-source software, has an awesome community with a long history of developing and sharing high quality modules. Before installing this module, making sure its author is a known community member is always a good idea (by checking [1]our forum[/1] for instance).</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="9bbcbf7c1f7c1df3c3d9d3b7767fac09">
+        <source>If you trust or find the author of this module to be an active community member, you can proceed with the installation.</source>
+        <target>If you trust or find the author of this module to be an active community member, you can proceed with the installation.</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="67afee0d8b56356469f89525a1423331">
+        <source>Otherwise you can look for similar modules on the official marketplace. [1]Click here to browse PrestaShop Addons[/1].</source>
+        <target>Otherwise you can look for similar modules on the official marketplace. [1]Click here to browse PrestaShop Addons[/1].</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="0557fa923dcee4d0f86b1409f5c2167f">
+        <source>Back</source>
+        <target>Back</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted_blocked.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e88e176e72b122566ada523a7297e4e5">
+        <source>This module could not be verified by PrestaShop.</source>
+        <target>This module could not be verified by PrestaShop.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="d16d7b2c414d4750596290776d0bfbf7">
+        <source>Since you may not have installed this module from PrestaShop Addons, we cannot assert that the module is complying with our safety requirements (e.g. that it is not adding some undisclosed functionalities such as ads, hidden links, spam, etc...).</source>
+        <target>Since you may not have installed this module from PrestaShop Addons, we cannot assert that the module is complying with our safety requirements (e.g. that it is not adding some undisclosed functionalities such as ads, hidden links, spam, etc...).</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="64b9168c0ef9c05d1568a15c6e273bf1">
+        <source>You can search for similar modules on the official marketplace.</source>
+        <target>You can search for similar modules on the official marketplace.</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="57acfffeede560e141ea67a4487fe065">
+        <source>[1]Click here to browse our catalog on PrestaShop Addons[/1].</source>
+        <target>[1]Click here to browse our catalog on PrestaShop Addons[/1].</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="6754e4799f554bcdf4fef4782bf4d7de">
+        <source>This generally happens when the module isn't distributed through our official marketplace, PrestaShop Addons - or when your server failed to communicate with PrestaShop Addons.</source>
+        <target>This generally happens when the module isn't distributed through our official marketplace, PrestaShop Addons - or when your server failed to communicate with PrestaShop Addons.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="a517747c3d12f99244ae598910d979c5">
+        <source>Author</source>
+        <target>Author</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="249212ebba2907c6087887db076179e6">
+        <source>Back to modules list</source>
+        <target>Back to modules list</target>
+        <note>Line: 51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="54752f2f929b686b98ddb16e40c4a1be">
+        <source>You are about to install "%s", a module which is not compatible with your country.</source>
+        <target>You are about to install "%s", a module which is not compatible with your country.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="1a56544ab8d473b3383731fbe3fc9d07">
+        <source>This module was not verified by PrestaShop hence we cannot certify that it works well in your country and that it complies with our quality requirements.</source>
+        <target>This module was not verified by PrestaShop hence we cannot certify that it works well in your country and that it complies with our quality requirements.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="d1ce387d44c3dc9cdc4e30ad64dbf47e">
+        <source>Use at your own risk.</source>
+        <target>Use at your own risk.</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="080e6f65e34e2ffe7162beb258f4577d">
+        <source>If you are unsure about this, you should contact the Customer Service of %s to ask them to make the module compatible with your country.</source>
+        <target>If you are unsure about this, you should contact the Customer Service of %s to ask them to make the module compatible with your country.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="17e8aa9ff6f7c374738eb3a15270583c">
+        <source>Moreover, we recommend that you use an equivalent module: compatible modules for your country are listed in the "Modules" tab of your back office.</source>
+        <target>Moreover, we recommend that you use an equivalent module: compatible modules for your country are listed in the "Modules" tab of your back office.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="1de1cd538749db5ea85a79c300b092e3">
+        <source>If you are unsure about this module, you can look for similar modules on the official marketplace.</source>
+        <target>If you are unsure about this module, you can look for similar modules on the official marketplace.</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="f7df37601ea653a7a5bf63e3556772d3">
+        <source>Click here to browse PrestaShop Addons.</source>
+        <target>Click here to browse PrestaShop Addons.</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_translation.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1311e5ddedf25a4f6cd6059cbf04c21e">
+        <source>Manage translations</source>
+        <target>Manage translations</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/page.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b10a51e4d433fa3330b26d266502db00">
+        <source>Addons membership provides access to all our PrestaShop modules.</source>
+        <target>Addons membership provides access to all our PrestaShop modules.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="20afba9e56de0c1da3d5188111d72947">
+        <source>Once connected, your new modules will be automatically installed.</source>
+        <target>Once connected, your new modules will be automatically installed.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="d9776f0775997b2e698c6975420b5c5d">
+        <source>Sign up</source>
+        <target>Sign up</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="bce8bac0184c6cd6d977e8a42a99aa99">
+        <source>Connect to PrestaShop Marketplace account</source>
+        <target>Connect to PrestaShop Marketplace account</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="bffe9a3c9a7e00ba00a11749e022d911">
+        <source>Log in</source>
+        <target>Log in</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="6dc2462f2851bdac265c852f023b6d3f">
+        <source>The module must either be a Zip file (.zip) or a tarball file (.tar, .tar.gz, .tgz).</source>
+        <target>The module must either be a Zip file (.zip) or a tarball file (.tar, .tar.gz, .tgz).</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="6779ef184c16fbd18a0bc13ebda839c5">
+        <source>Upload a module from your computer.</source>
+        <target>Upload a module from your computer.</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="5b48d0f5735d2f9b73a8f3ec7c4858ba">
+        <source>Module file</source>
+        <target>Module file</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="92fbf0e5d97b8afd7e73126b52bdc4bb">
+        <source>Choose a file</source>
+        <target>Choose a file</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="8634e049945e0e8562673698a1abb485">
+        <source>Upload this module</source>
+        <target>Upload this module</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="f2063dc3ff5945f5bf0c430da46e1109">
+        <source>An upgrade is available for some of your modules!</source>
+        <target>An upgrade is available for some of your modules!</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="d78986947356ddd37b43d57df289dee9">
+        <source>Favorites</source>
+        <target>Favorites</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680">
+        <source>All</source>
+        <target>All</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="96e36efe70e72835ae51946e2650f9e7">
+        <source>Add a new module</source>
+        <target>Add a new module</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/page_header_toolbar-legacy.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="28080c3603fb7e10f228381b181cae2c">
+        <source>List of modules</source>
+        <target>List of modules</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="71803586f945801418d03befeb4acd99">
+        <source>Update all</source>
+        <target>Update all</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="a3105b7aa9edb1c07765bfdcdc2405b8">
+        <source>Check for update</source>
+        <target>Check for update</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="6a26f548831e6a8c26bfbbd9f6ec61e0">
+        <source>Help</source>
+        <target>Help</target>
+        <note>Line: 78</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/readmore-body.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3424c86a3f3fdfcff4d8f310912ee82b">
+        <source>(%s votes)</source>
+        <target>(%s votes)</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="268cb3857932e260b03bf1334220f3bc">
+        <source>(%s vote)</source>
+        <target>(%s vote)</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
+        <source>Description</source>
+        <target>Description</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="7a66d21cf5a4354933980f6d79ec78a4">
+        <source>Merchant benefits</source>
+        <target>Merchant benefits</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="8530d0ebaf22889c1b42061824f3769b">
+        <source>Install module</source>
+        <target>Install module</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="a6642661dcfc0e354c61f4e8b8b9ec5a">
+        <source>View on PrestaShop Addons</source>
+        <target>View on PrestaShop Addons</target>
+        <note>Line: 94</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/readmore-header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9e3669d19b675bd57058fd4664205d2a">
+        <source>v</source>
+        <target>v</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f248df0d4d7e4ae98485c5df8af58945">
+        <source>This module is available for free thanks to our partner.</source>
+        <target>This module is available for free thanks to our partner.</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/tab_modules_list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ddd8eef6f86868a07f62b0e3810711f0">
+        <source>Not Installed</source>
+        <target>Not Installed</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="98dd43dfae05b11befe1f140e0ec787a">
+        <source>Installed</source>
+        <target>Installed</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="4d2fa24347806e2bcc9925a040f78382">
+        <source>More modules on addons.prestashop.com</source>
+        <target>More modules on addons.prestashop.com</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="83057027f6b988dd2dbe422f6f3ddd21">
+        <source>No module was found for this hook.</source>
+        <target>No module was found for this hook.</target>
+        <note>Line: 157</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/not_found/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="efc54df619cd3792c98805fba1ee5ff7">
+        <source>The controller %s is missing or invalid.</source>
+        <target>The controller %s is missing or invalid.</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="9178de10abf6a1368e7a73ec0adb0e8e">
+        <source>Back to the previous page</source>
+        <target>Back to the previous page</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="585c732d00a27a32cd9585fe481964cf">
+        <source>Go to the dashboard</source>
+        <target>Go to the dashboard</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_documents.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="585bc67adbb73dcca638b897fb73a900">
+        <source>See the document</source>
+        <target>See the document</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="8b3e7bc0ed634c2bc8ac54a4cc2e781f">
+        <source>Set payment form</source>
+        <target>Set payment form</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="50cd1871f950375eef4e2efce35366c6">
+        <source>Add note</source>
+        <target>Add note</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="71e2851d86b252a44c658b896c486921">
+        <source>Edit note</source>
+        <target>Edit note</target>
+        <note>Line: 121</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="aa52110dbfce51cc1ec8a163264151e2">
+        <source>Existing</source>
+        <target>Existing</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e">
+        <source>New</source>
+        <target>New</target>
+        <note>Line: 85</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a6361d40d23154d7d8fc801ae8bf9554">
+        <source>%refund_date% - %refund_amount%</source>
+        <target>%refund_date% - %refund_amount%</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="26b26b0e309da0b8abbf624a57601f4c">
+        <source>%return_date% - %return_quantity% - %return_state%</source>
+        <target>%return_date% - %return_quantity% - %return_state%</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="3d0d1f906e27800531e054a3b6787b7c">
+        <source>Quantity:</source>
+        <target>Quantity:</target>
+        <note>Line: 175</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7315d80cbbbb36fdcd92ba46a6384eff">
+        <source>Show carts and orders for this customer.</source>
+        <target>Show carts and orders for this customer.</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="1e504df905c966d01e09188c5ebd451f">
+        <source>Hide carts and orders for this customer.</source>
+        <target>Hide carts and orders for this customer.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="f4ec5f57bd4d31b803312d873be40da9">
+        <source>Change</source>
+        <target>Change</target>
+        <note>Line: 256</note>
+      </trans-unit>
+      <trans-unit id="0d9175fe89fb80d815e7d03698b6e83a">
+        <source>Gift</source>
+        <target>Gift</target>
+        <note>Line: 769</note>
+      </trans-unit>
+      <trans-unit id="c78ba40a94a132dc170cba2f8c66f310">
+        <source>Search for an existing product by typing the first letters of its name.</source>
+        <target>Search for an existing product by typing the first letters of its name.</target>
+        <note>Line: 1198</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="730224c4825ae2c174f4cdaff321520e">
+        <source>Transform a guest into a customer</source>
+        <target>Transform a guest into a customer</target>
+        <note>Line: 598</note>
+      </trans-unit>
+      <trans-unit id="e5bd639f4d74cf2c52afada77086f788">
+        <source>Process a standard refund</source>
+        <target>Process a standard refund</target>
+        <note>Line: 902</note>
+      </trans-unit>
+      <trans-unit id="c4b689eeebf8e942907a1cc1d086dba6">
+        <source>Process a partial refund</source>
+        <target>Process a partial refund</target>
+        <note>Line: 903</note>
+      </trans-unit>
+      <trans-unit id="cc61945cbbf46721a053467c395c666f">
+        <source>Refunded</source>
+        <target>Refunded</target>
+        <note>Line: 931</note>
+      </trans-unit>
+      <trans-unit id="6a5efd211a422296eab4adc476c98f0e">
+        <source>Return products</source>
+        <target>Return products</target>
+        <note>Line: 1196</note>
+      </trans-unit>
+      <trans-unit id="74c06eb18eeb118d7b3c623d0c717290">
+        <source>Refund products</source>
+        <target>Refund products</target>
+        <note>Line: 1196</note>
+      </trans-unit>
+      <trans-unit id="4b8def9be8f45a8d6baea36b26868965">
+        <source>Cancel products</source>
+        <target>Cancel products</target>
+        <note>Line: 1196</note>
+      </trans-unit>
+      <trans-unit id="867343577fa1f33caa632a19543bd252">
+        <source>Keywords</source>
+        <target>Keywords</target>
+        <note>Line: 1265</note>
+      </trans-unit>
+      <trans-unit id="6416e8cb5fc0a208d94fa7f5a300dbc4">
+        <source>Warehouse</source>
+        <target>Warehouse</target>
+        <note>Line: 930</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f2bbdf9f72c085adc4d0404e370f0f4c">
+        <source>Attribute</source>
+        <target>Attribute</target>
+        <note>Line: 79</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e9cb217697088a98b1937d111d936281">
+        <source>Attachment</source>
+        <target>Attachment</target>
+        <note>Line: 83</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3adbdb3ac060038aa0e6e6c138ef9873">
+        <source>Category</source>
+        <target>Category</target>
+        <note>Line: 241</note>
+      </trans-unit>
+      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
+        <source>Brand</source>
+        <target>Brand</target>
+        <note>Line: 252</note>
+      </trans-unit>
+      <trans-unit id="ec136b444eede3bc85639fac0dd06229">
+        <source>Supplier</source>
+        <target>Supplier</target>
+        <note>Line: 263</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="38f06ccd27281c8fc66e11581798ec06">
+        <source>Number of products:</source>
+        <target>Number of products:</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="df644ae155e79abf54175bd15d75f363">
+        <source>Product name</source>
+        <target>Product name</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="1caa6ff629641a4eb20f190f7a0539ca">
+        <source>Attribute name</source>
+        <target>Attribute name</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="bc67a1507258a758c3a31e66d7ceff8f">
+        <source>Supplier Reference</source>
+        <target>Supplier Reference</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="c804723ccdde3d7a46933b208c6f928d">
+        <source>Wholesale price</source>
+        <target>Wholesale price</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="52eb5928a34db3e3da7ba52b0644273b">
+        <source>EAN13</source>
+        <target>EAN13</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="fbd99ad01b92dbafc686772a39e3d065">
+        <source>UPC</source>
+        <target>UPC</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="c8c5918f1175c1296d19755b2f49d1c9">
+        <source>Available Quantity</source>
+        <target>Available Quantity</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="382b0f5185773fa0f67a8ed8056c7759">
+        <source>N/A</source>
+        <target>N/A</target>
+        <note>Line: 66</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/configurelayouts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="193cfc9be3b995831c6af2fea6650e60">
+        <source>Page</source>
+        <target>Page</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="ebd9bec4d70abc789d439c1f136b0538">
+        <source>Layout</source>
+        <target>Layout</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="95e3873b64426add2f3818e6a98dc9fb">
+        <source>Search on PrestaShop Marketplace:</source>
+        <target>Search on PrestaShop Marketplace:</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="3a2d5fe857d8f9541136a124c2edec6c">
+        <source>Or</source>
+        <target>Or</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="1beaf22ea4850d25af342d91b0f25624">
+        <source>See all themes</source>
+        <target>See all themes</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="ae0e265c94eec2c38690ada171d60a4d">
+        <source>Add a new theme</source>
+        <target>Add a new theme</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="26a278c1e0598e21f7c1ed7ab113e6ac">
+        <source>To add a new theme, simply connect to your PrestaShop Addons account: your new theme will be automatically imported to your shop.</source>
+        <target>To add a new theme, simply connect to your PrestaShop Addons account: your new theme will be automatically imported to your shop.</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="a5ed2b9ca9427746aced5b4037560434">
+        <source>You can choose among 1,500+ professional templates!</source>
+        <target>You can choose among 1,500+ professional templates!</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="dc9ac2e66cddf6e2c64e1c72b18ae130">
+        <source>Can I add my own theme?</source>
+        <target>Can I add my own theme?</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="7c854ab311760ecb245fb938378cd4e9">
+        <source>Please note that for security reasons, you can only add themes that are being distributed on PrestaShop Addons, the official marketplace.</source>
+        <target>Please note that for security reasons, you can only add themes that are being distributed on PrestaShop Addons, the official marketplace.</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="80bf7b97a380d8d8aa29993fa61ab5e5">
+        <source>You can also create a new theme below.</source>
+        <target>You can also create a new theme below.</target>
+        <note>Line: 84</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f0dbca7d922e4e759a1e3b512b9be852">
+        <source>Choose layouts</source>
+        <target>Choose layouts</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="b6ba229b668e5a7b6700e4d275683084">
+        <source>Use this theme</source>
+        <target>Use this theme</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="e169a8fe61809e3679a424bf27166a78">
+        <source>Delete this theme</source>
+        <target>Delete this theme</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="837a54ae4874c4501c804173cd3c0fdf">
+        <source>Designed by %s</source>
+        <target>Designed by %s</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="8ef656f84513928ea1b0c2f1735b62e9">
+        <source>Configure your page layouts</source>
+        <target>Configure your page layouts</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="4459ae4e873177642b30e9fc8b821d2f">
+        <source>Each page can use a different layout, choose it among the layouts bundled in your theme.</source>
+        <target>Each page can use a different layout, choose it among the layouts bundled in your theme.</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="21e2bb42873eddcb9b476b8eafbe0c18">
+        <source>Reset to defaults</source>
+        <target>Reset to defaults</target>
+        <note>Line: 108</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f1246f9ac6a7094789c17068713ebfe6">
+        <source>The "%1$s" theme has been successfully installed.</source>
+        <target>The "%1$s" theme has been successfully installed.</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="623a0df3a4b9fcca8e08c9ed1a07bba1">
+        <source>The following module(s) were not installed properly:</source>
+        <target>The following module(s) were not installed properly:</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="940d7a8d6502a022e8eb2d8a090b1a05">
+        <source>Warning: You may have to regenerate images to fit with this new theme.</source>
+        <target>Warning: You may have to regenerate images to fit with this new theme.</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="aedd6903868a8d6c7b01e0754fb56336">
+        <source>Go to the thumbnails regeneration page</source>
+        <target>Go to the thumbnails regeneration page</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="ce72a3420348d5b0bcd1382b1c88f553">
+        <source>Warning: This image type doesn’t exist. To manually set it, use the values below to create a new image type (in the "Images" page under the "Design" menu):</source>
+        <target>Warning: This image type doesn’t exist. To manually set it, use the values below to create a new image type (in the "Images" page under the "Design" menu):</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="3b90370ac32dead2af37eabe3bdbb97f">
+        <source>Name image type:</source>
+        <target>Name image type:</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="c6ec097a1c02ee4db0dda78b98f4c08c">
+        <source>(width: %1$spx, height: %2$spx).</source>
+        <target>(width: %1$spx, height: %2$spx).</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="8f1cda3b6ae2df7c2c152cfeffaea57a">
+        <source>Images have been correctly updated in the database:</source>
+        <target>Images have been correctly updated in the database:</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="a20ddccbb6f808ec42cd66323e6c6061">
+        <source>Finish</source>
+        <target>Finish</target>
+        <note>Line: 90</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bbfb7a636f839052067cc86c39fa595a">
+        <source>%limit% for suhosin.post.max_vars.</source>
+        <target>%limit% for suhosin.post.max_vars.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="e97da54b23c78752578cd7fa01e8866d">
+        <source>%limit% for suhosin.request.max_vars.</source>
+        <target>%limit% for suhosin.request.max_vars.</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="f324bbd9de83d61ccb5f7d5593aec5b3">
+        <source>You MUST use this syntax in your translations. Here are several examples:</source>
+        <target>You MUST use this syntax in your translations. Here are several examples:</target>
+        <note>Line: 86</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a7bd935a88c629dc11c52e0c16c2a8a0">
+        <source>%d</source>
+        <target>%d</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="be8545ae7ab0276e15898aae7acfbd7a">
+        <source>Resource</source>
+        <target>Resource</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/calendar/calendar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="08ee10c9fa141c53ae44667dcc1adf1e">
+        <source>Date range</source>
+        <target>Date range</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="90589c47f06eb971d548591f23c285af">
+        <source>Custom</source>
+        <target>Custom</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="01b6e20344b68835c5ed1ddedf20d531">
+        <source>to</source>
+        <target>to</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="0c031866121d4fc6d21d0f524d0091e4">
+        <source>Compare to</source>
+        <target>Compare to</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="97bf2dbc7a13706eeb1eac149bd2d130">
+        <source>Previous period</source>
+        <target>Previous period</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="635f2145a06da2d4ce2c355bf94da6ed">
+        <source>Previous Year</source>
+        <target>Previous Year</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="3ca6ac2463aa0dc57452cf676723b79f">
+        <source>Previous year</source>
+        <target>Previous year</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="9d1a0949c39e66a0cd65240bc0ac9177">
+        <source>Sunday</source>
+        <target>Sunday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="6f8522e0610541f1ef215a22ffa66ff6">
+        <source>Monday</source>
+        <target>Monday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="5792315f09a5d54fb7e3d066672b507f">
+        <source>Tuesday</source>
+        <target>Tuesday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="796c163589f295373e171842f37265d5">
+        <source>Wednesday</source>
+        <target>Wednesday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="78ae6f0cd191d25147e252dc54768238">
+        <source>Thursday</source>
+        <target>Thursday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="c33b138a163847cdb6caeeb7c9a126b4">
+        <source>Friday</source>
+        <target>Friday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="8b7051187b9191cdcdae6ed5a10e5adc">
+        <source>Saturday</source>
+        <target>Saturday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="ef6572e4cd58bb39a3f4e82fc64fe9f0">
+        <source>Sun</source>
+        <target>Sun</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="fd29458ae58ac32a2d8734ed90ad51ec">
+        <source>Mon</source>
+        <target>Mon</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="2ddecde85408faf230652444db78cb72">
+        <source>Tue</source>
+        <target>Tue</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="510c292b1686eb070d9e90a575f74106">
+        <source>Wed</source>
+        <target>Wed</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="ed5e8353dfc585f4c6b3a55d1a9fc01d">
+        <source>Thu</source>
+        <target>Thu</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="ac616f844b9a5ea5a827bf7fb99b1ad5">
+        <source>Fri</source>
+        <target>Fri</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="13c7d2d737f81f7bf89aed9fbcd0ad55">
+        <source>Sat</source>
+        <target>Sat</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="f72c915d8f575a5c0999b5f37b6d99b7">
+        <source>Su</source>
+        <target>Su</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="c08df9bb5fb44242a6291b1eee5d09ad">
+        <source>Mo</source>
+        <target>Mo</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="080502c4fa636ac639bf42b6d2ba01d7">
+        <source>Tu</source>
+        <target>Tu</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="485c47a81eb6e3998ec05aca48eda184">
+        <source>We</source>
+        <target>We</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="eeeb9a8eb45dd351d9ec0eb4acce66ce">
+        <source>Th</source>
+        <target>Th</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="fa717ba17306cd76900510df8ac8013e">
+        <source>Fr</source>
+        <target>Fr</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="e55bb1ae59b6a64858a85a2f48c53036">
+        <source>Sa</source>
+        <target>Sa</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="86f5978d9b80124f509bdb71786e929e">
+        <source>January</source>
+        <target>January</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="659e59f062c75f81259d22786d6c44aa">
+        <source>February</source>
+        <target>February</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="fa3e5edac607a88d8fd7ecb9d6d67424">
+        <source>March</source>
+        <target>March</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="3fcf026bbfffb63fb24b8de9d0446949">
+        <source>April</source>
+        <target>April</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="195fbb57ffe7449796d23466085ce6d8">
+        <source>May</source>
+        <target>May</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="688937ccaf2a2b0c45a1c9bbba09698d">
+        <source>June</source>
+        <target>June</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="1b539f6f34e8503c97f6d3421346b63c">
+        <source>July</source>
+        <target>July</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="41ba70891fb6f39327d8ccb9b1dafb84">
+        <source>August</source>
+        <target>August</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="cc5d90569e1c8313c2b1c2aab1401174">
+        <source>September</source>
+        <target>September</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="eca60ae8611369fe28a02e2ab8c5d12e">
+        <source>October</source>
+        <target>October</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="7e823b37564da492ca1629b4732289a8">
+        <source>November</source>
+        <target>November</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="82331503174acbae012b2004f6431fa5">
+        <source>December</source>
+        <target>December</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="e68564f23e0e939acea76dc3d2bc01bf">
+        <source>Jan</source>
+        <target>Jan</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="ea171d540ccd5f0669171ef06d3cd848">
+        <source>Feb</source>
+        <target>Feb</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="7ce6b2286a5396e614b8484105d277e0">
+        <source>Mar</source>
+        <target>Mar</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="6d7215c4b3bc4716d026ac46c6d9ae64">
+        <source>Apr</source>
+        <target>Apr</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="e7f8f5c51fe3a6d48a79c6ede9112b7a">
+        <source>May </source>
+        <target>May </target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="eb4b40c1221dad5b23fe7ef84d292be1">
+        <source>Jun</source>
+        <target>Jun</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="a2866cd6efaa65c92278d4771a9eaec7">
+        <source>Jul</source>
+        <target>Jul</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="22f1a4667604b8557c9b209c201b4bc6">
+        <source>Aug</source>
+        <target>Aug</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="f04aa7019c490474fa3ce16e93501b57">
+        <source>Sep</source>
+        <target>Sep</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="594be08882c8e9d5efb9eeb62f303744">
+        <source>Oct</source>
+        <target>Oct</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="343e6957be77c6247aa2b8d0deb68bd6">
+        <source>Nov</source>
+        <target>Nov</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="d207b4e0bce42a8f1555ce3a05e287f6">
+        <source>Dec</source>
+        <target>Dec</target>
+        <note>Line: 117</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/dataviz/graph.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e6d0e1c8fc6a4fcf47869df87e04cd88">
+        <source>Customers</source>
+        <target>Customers</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
+        <source>Orders</source>
+        <target>Orders</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="1f08d08fd864b99cbeebd88b9a0784a7">
+        <source>Income</source>
+        <target>Income</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4">
+        <source>Message</source>
+        <target>Message</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="e7935ae6c516d89405ec532359d2d75a">
+        <source>Traffic</source>
+        <target>Traffic</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="3bb1503332637805beddb73a2dd1fe1b">
+        <source>Conversion</source>
+        <target>Conversion</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/assoshop.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1aa4c641d6920ddb97a2562f8ec53853">
+        <source>Group:</source>
+        <target>Group:</target>
+        <note>Line: 99</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2efd89b3ccc76b0b03a34196fc6d1c8b">
+        <source>Add tag</source>
+        <target>Add tag</target>
+        <note>Line: 194</note>
+      </trans-unit>
+      <trans-unit id="1063e38cb53d94d386f21227fcd84717">
+        <source>Remove</source>
+        <target>Remove</target>
+        <note>Line: 329</note>
+      </trans-unit>
+      <trans-unit id="26ce1315d2bff025e8fb8a0c6259e58c">
+        <source>Change password...</source>
+        <target>Change password...</target>
+        <note>Line: 525</note>
+      </trans-unit>
+      <trans-unit id="d9c2d86a66aa5a45326c3757f3a272cc">
+        <source>Current password</source>
+        <target>Current password</target>
+        <note>Line: 530</note>
+      </trans-unit>
+      <trans-unit id="98a6ee4b0f0e346c15ab21a289165a2d">
+        <source>Password should be at least 8 characters long.</source>
+        <target>Password should be at least 8 characters long.</target>
+        <note>Line: 544</note>
+      </trans-unit>
+      <trans-unit id="3544848f820b9d94a3f3871a382cf138">
+        <source>New password</source>
+        <target>New password</target>
+        <note>Line: 545</note>
+      </trans-unit>
+      <trans-unit id="4c231e0da3eaaa6a9752174f7f9cfb31">
+        <source>Confirm password</source>
+        <target>Confirm password</target>
+        <note>Line: 560</note>
+      </trans-unit>
+      <trans-unit id="2871afea416378d2772937c4d67d6c2c">
+        <source>Generate password</source>
+        <target>Generate password</target>
+        <note>Line: 576</note>
+      </trans-unit>
+      <trans-unit id="4bbb8f967da6d1a610596d7257179c2b">
+        <source>Invalid</source>
+        <target>Invalid</target>
+        <note>Line: 601</note>
+      </trans-unit>
+      <trans-unit id="26b63f278101527e06a5547719568bb5">
+        <source>Okay</source>
+        <target>Okay</target>
+        <note>Line: 602</note>
+      </trans-unit>
+      <trans-unit id="0c6ad70beb3a7e76c3fc7adab7c46acc">
+        <source>Good</source>
+        <target>Good</target>
+        <note>Line: 603</note>
+      </trans-unit>
+      <trans-unit id="b8dc7c80939667637db7ac31ece215b9">
+        <source>Fabulous</source>
+        <target>Fabulous</target>
+        <note>Line: 604</note>
+      </trans-unit>
+      <trans-unit id="01e8202cf69f19ea7cf3a80f7673066a">
+        <source>Invalid password confirmation</source>
+        <target>Invalid password confirmation</target>
+        <note>Line: 641</note>
+      </trans-unit>
+      <trans-unit id="1e1cc9bdeb2f29f5480106aec7e9bc48">
+        <source>Now</source>
+        <target>Now</target>
+        <note>Line: 964</note>
+      </trans-unit>
+      <trans-unit id="f92965e2c8a7afb3c1b9a5c09a263636">
+        <source>Done</source>
+        <target>Done</target>
+        <note>Line: 965</note>
+      </trans-unit>
+      <trans-unit id="3964fd83339fec5014c831822005653a">
+        <source>Choose Time</source>
+        <target>Choose Time</target>
+        <note>Line: 971</note>
+      </trans-unit>
+      <trans-unit id="a76d4ef5f3f6a672bbfab2865563e530">
+        <source>Time</source>
+        <target>Time</target>
+        <note>Line: 972</note>
+      </trans-unit>
+      <trans-unit id="b55e509c697e4cca0e1d160a7806698f">
+        <source>Hour</source>
+        <target>Hour</target>
+        <note>Line: 973</note>
+      </trans-unit>
+      <trans-unit id="62902641c38f3a4a8eb3212454360e24">
+        <source>Minute</source>
+        <target>Minute</target>
+        <note>Line: 974</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/form_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c6155aaecccf794cd2a00fcc35898022">
+        <source>Group name</source>
+        <target>Group name</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="69e62346c35bc63795db142cfbb0af66">
+        <source>No group created</source>
+        <target>No group created</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="087fb8756d4add87f2d162304ccd486b">
+        <source>No records found</source>
+        <target>No records found</target>
+        <note>Line: 205</note>
+      </trans-unit>
+      <trans-unit id="0bcef9c45bd8a48eda1b26eb0c61c869">
+        <source>%</source>
+        <target>%</target>
+        <note>Line: 115</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4c41e0bd957698b58100a5c687d757d9">
+        <source>Select all</source>
+        <target>Select all</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="237c7b6874386141a095e321c9fdfd38">
+        <source>Unselect all</source>
+        <target>Unselect all</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="b9987a246a537f4fe86f1f2e3d10dbdb">
+        <source>Display</source>
+        <target>Display</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="dd8921b41e0279a02c6a26a509241700">
+        <source>result(s)</source>
+        <target>result(s)</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6ccfec41b65de46efeb7ca242341e8ea">
+        <source>Please fill at least one field to perform a search in this list.</source>
+        <target>Please fill at least one field to perform a search in this list.</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="e129ae480280e47ef82fc7702f8321ba">
+        <source>Refresh list</source>
+        <target>Refresh list</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="dbcd43f8ba2bafd1bccc57fe9c8b5d7b">
+        <source>Show SQL query</source>
+        <target>Show SQL query</target>
+        <note>Line: 150</note>
+      </trans-unit>
+      <trans-unit id="351b6d570b6ba15fe66e85c1eaf9ec64">
+        <source>Export to SQL Manager</source>
+        <target>Export to SQL Manager</target>
+        <note>Line: 155</note>
+      </trans-unit>
+      <trans-unit id="4493e821e06072415518bd7ae4077996">
+        <source>Shop group</source>
+        <target>Shop group</target>
+        <note>Line: 294</note>
+      </trans-unit>
+      <trans-unit id="e12167aa0a7698e6ebc92b4ce3909b53">
+        <source>To</source>
+        <target>To</target>
+        <note>Line: 334</note>
+      </trans-unit>
+      <trans-unit id="e9c7e4df74077626f7e42797c65273c4">
+        <source>and stay</source>
+        <target>and stay</target>
+        <note>Line: 187</note>
+      </trans-unit>
+      <trans-unit id="5da618e8e4b89c66fe86e32cdafde142">
+        <source>From</source>
+        <target>From</target>
+        <note>Line: 327</note>
+      </trans-unit>
+      <trans-unit id="526d688f37a86d3c3f27d0c5016eb71d">
+        <source>Reset</source>
+        <target>Reset</target>
+        <note>Line: 386</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/modules_list/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6afd80bf62a1b8bdfe729af8a0159fee">
+        <source>Modules list</source>
+        <target>Modules list</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="2c422a499f038293ed0c5a1e085cd827">
+        <source>No modules available in this section.</source>
+        <target>No modules available in this section.</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="c0ebffb294bb46f8800a899e04c73f17">
+        <source>View all available payments solutions</source>
+        <target>View all available payments solutions</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="98a52c00a9fb228601f8b423436d36e0">
+        <source>It seems there are no recommended payment solutions for your country.</source>
+        <target>It seems there are no recommended payment solutions for your country.</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="39efbaa2f3600dd82a031d7ab5138f73">
+        <source>Do you think there should be one? Let us know!</source>
+        <target>Do you think there should be one? Let us know!</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/modules_list/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4b33fbf5ea2c4ced9800228574cfcc50">
+        <source>Recommended Modules and Services</source>
+        <target>Recommended Modules and Services</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="21034ae6d01a83e702839a72ba8a77b0">
+        <source>(tax excl.)</source>
+        <target>(tax excl.)</target>
+        <note>Line: 220</note>
+      </trans-unit>
+      <trans-unit id="c103bafd6451f1f08200bebff539606f">
+        <source>Multistore</source>
+        <target>Multistore</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="50de2399e96ac57bed17e95376046c3b">
+        <source>Check / Uncheck all</source>
+        <target>Check / Uncheck all</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="ff8ff5e54a1832486773ec48b8f8175d">
+        <source>You are editing this page for a specific shop or group. Click "Yes" to check all fields, "No" to uncheck all.</source>
+        <target>You are editing this page for a specific shop or group. Click "Yes" to check all fields, "No" to uncheck all.</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="d97ccb3e617d930d52ffd95e5db2c101">
+        <source>If you check a field, change its value, and save, the multistore behavior will not apply to this shop (or group), for this particular parameter.</source>
+        <target>If you check a field, change its value, and save, the multistore behavior will not apply to this shop (or group), for this particular parameter.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="a157a50f5a421a7dfbdf280f3ff9d56e">
+        <source>You can't change the value of this configuration field in the context of this shop.</source>
+        <target>You can't change the value of this configuration field in the context of this shop.</target>
+        <note>Line: 331</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/required_fields.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0470d45929f27e1161330164c423b415">
+        <source>Set required fields for this section</source>
+        <target>Set required fields for this section</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="e54b38290c8bdd95e8bc10412c9cc096">
+        <source>Required Fields</source>
+        <target>Required Fields</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="81f32b96f6626b8968e6a0f4a9bce62e">
+        <source>Select the fields you would like to be required for this section.</source>
+        <target>Select the fields you would like to be required for this section.</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="ee9b2f3cf31c23c944b15fb0b33d6a77">
+        <source>Field Name</source>
+        <target>Field Name</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/shops_list/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="804ccd6219996d12eda865d1c0707423">
+        <source>All shops</source>
+        <target>All shops</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="93f04304c09d561ed79442ea9ee722d4">
+        <source>%s group</source>
+        <target>%s group</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="24fc6fbf93a9d551ea7da4cd69f3da3e">
+        <source>(%s selected)</source>
+        <target>(%s selected)</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox_shops.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bebe39eef720d7cbb479d8b3428e4c04">
+        <source>Group: %s</source>
+        <target>Group: %s</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d77a48a51f8c62087570ab8f9d6ca55a">
+        <source>search...</source>
+        <target>search...</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/uploader/ajax.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="86d3852bba89bf82128c3e156624ad08">
+        <source>Add files...</source>
+        <target>Add files...</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="9e74a55bb862a98723f9cf3f868d837e">
+        <source>Add file...</source>
+        <target>Add file...</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="c7de86f69db264c3950d8ae46ed2e33f">
+        <source>Upload files</source>
+        <target>Upload files</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="ffeed24e8e4fd763c1d0d02c6e5d6e15">
+        <source>Upload file</source>
+        <target>Upload file</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="6dc85b454944660cf96e7d0c2d171ee3">
+        <source>You cannot have more than %s images in total. Please remove some of the current images before adding new ones.</source>
+        <target>You cannot have more than %s images in total. Please remove some of the current images before adding new ones.</target>
+        <note>Line: 170</note>
+      </trans-unit>
+      <trans-unit id="b21f085d08623fc7a5a9da204cc66c8c">
+        <source>Remove file</source>
+        <target>Remove file</target>
+        <note>Line: 178</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/uploader/simple.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1908624a0bca678cd26b99bfd405324e">
+        <source>File size</source>
+        <target>File size</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="3fcbe6bd34e9279ec2c7b13adf7e4095">
+        <source>You have reached the limit (%s) of files to upload, please remove files to continue uploading</source>
+        <target>You have reached the limit (%s) of files to upload, please remove files to continue uploading</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="d39ec66f08507e26fe86aa5325d070df">
+        <source>Add files</source>
+        <target>Add files</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="58be4de806253a6ee411b6c0c99296c7">
+        <source>Add file</source>
+        <target>Add file</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="09942cec33b5becdf3e2275913b818e2">
+        <source>Download current file (%skb)</source>
+        <target>Download current file (%skb)</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="c2299e6abb73991105dfacfb6fdd6dd4">
+        <source>Download current file</source>
+        <target>Download current file</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="009044df8c709bfdefa065ae7fa733e1">
+        <source>You can upload a maximum of %s files</source>
+        <target>You can upload a maximum of %s files</target>
+        <note>Line: 134</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/layout-ajax.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="23a61fdb216b255d81b0d49ca1abb8a4">
+        <source>There are %d warnings.</source>
+        <target>There are %d warnings.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="8a3cfd894d57e33c55400fc9d76aa08a">
+        <source>Click here to see more</source>
+        <target>Click here to see more</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="a92269f5f14ac147a821728c23204c0b">
+        <source>Hide warning</source>
+        <target>Hide warning</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="406cabb68a6d8f9f7ebbb3c10cd535ef">
+        <source>There is %d warning.</source>
+        <target>There is %d warning.</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/layout.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2169b4627df97333ed94d1e30a9b8148">
+        <source>%d errors</source>
+        <target>%d errors</target>
+        <note>Line: 50</note>
+      </trans-unit>
       <trans-unit id="e112201196d8a38cfe15031655647cb6">
         <source>There are %d warnings:</source>
         <target>There are %d warnings:</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/warning_messages.tpl:30</note>
+        <note>Line: 87</note>
       </trans-unit>
     </body>
   </file>
-  <file original="admin-dev/themes/new-theme/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/search_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="2fc6204d2ca7e856d9e4844d2786f053">
-        <source>This field will be modified for all your shops.</source>
-        <target>This field will be modified for all your shops.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:48</note>
-      </trans-unit>
-      <trans-unit id="7ac170f2b47dbf7d4c5cd38449093c2b">
-        <source>This field will be modified for all shops in this shop group:</source>
-        <target>This field will be modified for all shops in this shop group:</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:50</note>
-      </trans-unit>
-      <trans-unit id="fe0ae15c8f93a5335f0991accadd13ca">
-        <source>This field will be modified for this shop:</source>
-        <target>This field will be modified for this shop:</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:52</note>
-      </trans-unit>
-      <trans-unit id="0a71c80de89d7b2d3e6b22974a4a7548">
-        <source>A new order has been placed on your shop.</source>
-        <target>A new order has been placed on your shop.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:55</note>
-      </trans-unit>
-      <trans-unit id="3df406952f3377a5e419d4d63abb1b1d">
-        <source>Order number:</source>
-        <target>Order number:</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:56</note>
-      </trans-unit>
-      <trans-unit id="66c4c5112f455a19afde47829df363fa">
-        <source>Total:</source>
-        <target>Total:</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:57</note>
-      </trans-unit>
-      <trans-unit id="1e6d57e813355689e9c77e947d73ad8f">
-        <source>From:</source>
-        <target>From:</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:58</note>
-      </trans-unit>
-      <trans-unit id="c112bd7d596888979be02bd780e6a94f">
-        <source>View this order</source>
-        <target>View this order</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:59</note>
-      </trans-unit>
-      <trans-unit id="d2d2000f7fa636acd871f43c085a75dc">
-        <source>A new customer registered on your shop.</source>
-        <target>A new customer registered on your shop.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:60</note>
-      </trans-unit>
-      <trans-unit id="7a2e40e90ddbc145f11afacb5eb83ae2">
-        <source>Customer name:</source>
-        <target>Customer name:</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:61</note>
-      </trans-unit>
-      <trans-unit id="d48549659ae6cc81e7d4729b068ba4b9">
-        <source>A new message was posted on your shop.</source>
-        <target>A new message was posted on your shop.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:62</note>
-      </trans-unit>
-      <trans-unit id="6fab17d3dc1147f9b170fb8e1aac2fa8">
-        <source>Read this message</source>
-        <target>Read this message</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:63</note>
-      </trans-unit>
-      <trans-unit id="a8d69cdfad4c19ed22bf693b8871064e">
-        <source>Choose language</source>
-        <target>Choose language</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:70</note>
-      </trans-unit>
-      <trans-unit id="151648106e4bf98297882ea2ea1c4b0e">
-        <source>Update successful</source>
-        <target>Update successful</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:74</note>
-      </trans-unit>
-      <trans-unit id="358cc9ee3a3d23d3390e5043122d9bea">
-        <source>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</source>
-        <target>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:75</note>
-      </trans-unit>
-      <trans-unit id="7bb36e0f484d91aeba5d83fe2af63d28">
-        <source>Search for a product</source>
-        <target>Search for a product</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/header.tpl:76</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/new-theme/template/error.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="ecdb1f330299c20ac9897cd73f92c8cd">
-        <source>%1$s on line %2$s in file %3$s</source>
-        <target>%1$s on line %2$s in file %3$s</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/error.tpl:31</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="admin-dev/themes/new-theme/template/components/layout/quick_access.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="4f32a32dea642737580dd71cdfd8d3c0">
-        <source>Quick Access</source>
-        <target>Quick Access</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/quick_access.tpl:4</note>
-      </trans-unit>
-      <trans-unit id="6f7579a25b7aba443386a5b86a7900b4">
-        <source>Please name this shortcut:</source>
-        <target>Please name this shortcut:</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/quick_access.tpl:40</note>
-      </trans-unit>
-      <trans-unit id="f5c26758149849ee0f84a2eceaf0acfd">
-        <source>Remove from QuickAccess</source>
-        <target>Remove from QuickAccess</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/quick_access.tpl:29</note>
-      </trans-unit>
-      <trans-unit id="383247a8cb198be4042d128986100cea">
-        <source>Add current page to QuickAccess</source>
-        <target>Add current page to QuickAccess</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/quick_access.tpl:44</note>
-      </trans-unit>
-      <trans-unit id="165122309e15dc09c30b78951e53cb5a">
-        <source>Manage quick accesses</source>
-        <target>Manage quick accesses</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/quick_access.tpl:49</note>
+      <trans-unit id="03de6422045e4ed3ac822c673ace32d1">
+        <source>123.45.67.89</source>
+        <target>123.45.67.89</target>
+        <note>Line: 50</note>
       </trans-unit>
     </body>
   </file>
@@ -3371,14 +2207,154 @@ File: admin-dev/themes/new-theme/template/components/layout/quick_access.tpl:49<
       <trans-unit id="3d8de6fcc09baf73f7175fe59f278ced">
         <source>Your profile</source>
         <target>Your profile</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl:37</note>
+        <note>Line: 37</note>
       </trans-unit>
       <trans-unit id="c87aacf5673fada1108c9f809d354311">
         <source>Sign out</source>
         <target>Sign out</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl:41</note>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/non-responsive.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ed95254a7068ffd8729fd94d07347d67">
+        <source>Oh no!</source>
+        <target>Oh no!</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="93e2c2e3d9591e5d54b0e5e6f81d36e0">
+        <source>The mobile version of this page is not available yet.</source>
+        <target>The mobile version of this page is not available yet.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="56c42d822d794bc33d5e25bc53cd385b">
+        <source>Please use a desktop computer to access this page, until is adapted to mobile.</source>
+        <target>Please use a desktop computer to access this page, until is adapted to mobile.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="2d439011ecebc222e1feb2e3e005c0ac">
+        <source>Thank you.</source>
+        <target>Thank you.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/quick_access.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4f32a32dea642737580dd71cdfd8d3c0">
+        <source>Quick Access</source>
+        <target>Quick Access</target>
+        <note>Line: 4</note>
+      </trans-unit>
+      <trans-unit id="6f7579a25b7aba443386a5b86a7900b4">
+        <source>Please name this shortcut:</source>
+        <target>Please name this shortcut:</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="f5c26758149849ee0f84a2eceaf0acfd">
+        <source>Remove from QuickAccess</source>
+        <target>Remove from QuickAccess</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="383247a8cb198be4042d128986100cea">
+        <source>Add current page to QuickAccess</source>
+        <target>Add current page to QuickAccess</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="165122309e15dc09c30b78951e53cb5a">
+        <source>Manage quick accesses</source>
+        <target>Manage quick accesses</target>
+        <note>Line: 49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/search_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f5945546981ef6e50e1fade1b386da04">
+        <source>Search (e.g.: product reference, customer name…)</source>
+        <target>Search (e.g.: product reference, customer name…)</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="13787cfb1a15ae6690a29d3895c54de9">
+        <source>Everywhere</source>
+        <target>Everywhere</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="2e67c0a79d35c15af2436c8d80ca072d">
+        <source>What are you looking for?</source>
+        <target>What are you looking for?</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="c32516babc5b6c47eb8ce1bfc223253c">
+        <source>Catalog</source>
+        <target>Catalog</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="7f704ff8964f7b5f3f9a6444d450b5f7">
+        <source>Product name, SKU, reference...</source>
+        <target>Product name, SKU, reference...</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="855d2bf59043b81e76bc931e685a4f58">
+        <source>by name</source>
+        <target>by name</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="a3681587c5320489b6a3dd21282e254d">
+        <source>Email, name...</source>
+        <target>Email, name...</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="399574be0ed95657dfac0e8d38374c62">
+        <source>by ip address</source>
+        <target>by ip address</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="16b2494238f8f996b09417d1dc56c795">
+        <source>by IP address</source>
+        <target>by IP address</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="d79cf3f429596f77db95c65074663a54">
+        <source>Order ID</source>
+        <target>Order ID</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="fce9a6a1bd2a2050eb86d33103f46fd3">
+        <source>Invoices</source>
+        <target>Invoices</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="4e065ba1bec1d62b2d5450256612fa96">
+        <source>Invoice Number</source>
+        <target>Invoice Number</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="fc26e55e0993a75e892175deb02aae15">
+        <source>Carts</source>
+        <target>Carts</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="fc6dfe4f8b07fc04c99e27425f780754">
+        <source>Cart ID</source>
+        <target>Cart ID</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2">
+        <source>Modules</source>
+        <target>Modules</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="07403a8bc81d7865c8e040e718ec7828">
+        <source>Module name</source>
+        <target>Module name</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="0f544d682c3a664870f025f48c4b04b5">
+        <source>SEARCH</source>
+        <target>SEARCH</target>
+        <note>Line: 52</note>
       </trans-unit>
     </body>
   </file>
@@ -3387,8 +2363,100 @@ File: admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tp
       <trans-unit id="d70861cbe7f8c9a1241c39b3e7ef5ef2">
         <source>View my shop</source>
         <target>View my shop</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/components/layout/shop_list.tpl:54</note>
+        <note>Line: 54</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/error.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ecdb1f330299c20ac9897cd73f92c8cd">
+        <source>%1$s on line %2$s in file %3$s</source>
+        <target>%1$s on line %2$s in file %3$s</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2fc6204d2ca7e856d9e4844d2786f053">
+        <source>This field will be modified for all your shops.</source>
+        <target>This field will be modified for all your shops.</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="7ac170f2b47dbf7d4c5cd38449093c2b">
+        <source>This field will be modified for all shops in this shop group:</source>
+        <target>This field will be modified for all shops in this shop group:</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="fe0ae15c8f93a5335f0991accadd13ca">
+        <source>This field will be modified for this shop:</source>
+        <target>This field will be modified for this shop:</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="0a71c80de89d7b2d3e6b22974a4a7548">
+        <source>A new order has been placed on your shop.</source>
+        <target>A new order has been placed on your shop.</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="3df406952f3377a5e419d4d63abb1b1d">
+        <source>Order number:</source>
+        <target>Order number:</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="66c4c5112f455a19afde47829df363fa">
+        <source>Total:</source>
+        <target>Total:</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="1e6d57e813355689e9c77e947d73ad8f">
+        <source>From:</source>
+        <target>From:</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="c112bd7d596888979be02bd780e6a94f">
+        <source>View this order</source>
+        <target>View this order</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="d2d2000f7fa636acd871f43c085a75dc">
+        <source>A new customer registered on your shop.</source>
+        <target>A new customer registered on your shop.</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="7a2e40e90ddbc145f11afacb5eb83ae2">
+        <source>Customer name:</source>
+        <target>Customer name:</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="d48549659ae6cc81e7d4729b068ba4b9">
+        <source>A new message was posted on your shop.</source>
+        <target>A new message was posted on your shop.</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="6fab17d3dc1147f9b170fb8e1aac2fa8">
+        <source>Read this message</source>
+        <target>Read this message</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="a8d69cdfad4c19ed22bf693b8871064e">
+        <source>Choose language</source>
+        <target>Choose language</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="151648106e4bf98297882ea2ea1c4b0e">
+        <source>Update successful</source>
+        <target>Update successful</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="358cc9ee3a3d23d3390e5043122d9bea">
+        <source>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</source>
+        <target>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="7bb36e0f484d91aeba5d83fe2af63d28">
+        <source>Search for a product</source>
+        <target>Search for a product</target>
+        <note>Line: 76</note>
       </trans-unit>
     </body>
   </file>
@@ -3397,46 +2465,1024 @@ File: admin-dev/themes/new-theme/template/components/layout/shop_list.tpl:54</no
       <trans-unit id="c821206b336b401bccf058f664f8255d">
         <source>Your shop is in debug mode.</source>
         <target>Your shop is in debug mode.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/layout.tpl:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="13886bc255a80b7c11e0585013feeb30">
         <source>All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.</source>
         <target>All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/layout.tpl:43</note>
+        <note>Line: 43</note>
       </trans-unit>
       <trans-unit id="ec3028a12402ab7f43962a6f3a667b6e">
         <source>Debug mode</source>
         <target>Debug mode</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/layout.tpl:47</note>
+        <note>Line: 47</note>
       </trans-unit>
       <trans-unit id="67a33d40bef41c3b79d6b973bfcbc89a">
         <source>Your shop is in maintenance.</source>
         <target>Your shop is in maintenance.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/layout.tpl:58</note>
+        <note>Line: 58</note>
       </trans-unit>
       <trans-unit id="929f5283d0fa1e9eecf20cc294f981e5">
         <source><![CDATA[Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.]]></source>
         <target><![CDATA[Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.]]></target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/layout.tpl:58</note>
+        <note>Line: 58</note>
       </trans-unit>
       <trans-unit id="38a27c0c7ef7a05e13efa2798ee21533">
         <source>Maintenance mode</source>
         <target>Maintenance mode</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/layout.tpl:61</note>
+        <note>Line: 61</note>
       </trans-unit>
       <trans-unit id="9ff082251dea737459c9f32e73ca7a62">
         <source>For security reasons, you must also delete the /install folder.</source>
         <target>For security reasons, you must also delete the /install folder.</target>
-        <note>Context:
-File: admin-dev/themes/new-theme/template/layout.tpl:93</note>
+        <note>Line: 93</note>
       </trans-unit>
     </body>
   </file>
-
+  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ec211f7c20af43e742bf2570c3cb84f9">
+        <source>Add</source>
+        <target>Add</target>
+        <note>Line: 599</note>
+      </trans-unit>
+      <trans-unit id="7dce122004969d56ae2e0245cb754d35">
+        <source>Edit</source>
+        <target>Edit</target>
+        <note>Line: 649</note>
+      </trans-unit>
+      <trans-unit id="4ee29ca12c7d126654bd0e5275de6135">
+        <source>List</source>
+        <target>List</target>
+        <note>Line: 608</note>
+      </trans-unit>
+      <trans-unit id="6e9783376d951cfd780e9fdb67a0f02c">
+        <source>View details</source>
+        <target>View details</target>
+        <note>Line: 613</note>
+      </trans-unit>
+      <trans-unit id="dae8ace18bdcbcc6ae5aece263e14fe8">
+        <source>Options</source>
+        <target>Options</target>
+        <note>Line: 617</note>
+      </trans-unit>
+      <trans-unit id="92a8f0b9d28a89b480bd1d29f46f0484">
+        <source>Generator</source>
+        <target>Generator</target>
+        <note>Line: 621</note>
+      </trans-unit>
+      <trans-unit id="ef61fb324d729c341ea8ab9901e23566">
+        <source>Add new</source>
+        <target>Add new</target>
+        <note>Line: 1635</note>
+      </trans-unit>
+      <trans-unit id="4351cfebe4b61d8aa5efa1d020710005">
+        <source>View</source>
+        <target>View</target>
+        <note>Line: 659</note>
+      </trans-unit>
+      <trans-unit id="a6105c0a611b41b08f1209506350279e">
+        <source>yes</source>
+        <target>yes</target>
+        <note>Line: 685</note>
+      </trans-unit>
+      <trans-unit id="7fa3b767c460b54a2be4d49030b349c7">
+        <source>no</source>
+        <target>no</target>
+        <note>Line: 685</note>
+      </trans-unit>
+      <trans-unit id="7d341c08fd102f0b86285b5ff2e26ea7">
+        <source>%s: %s</source>
+        <target>%s: %s</target>
+        <note>Line: 709</note>
+      </trans-unit>
+      <trans-unit id="921d54865f8169b84c90d4335c256494">
+        <source>filter by %s</source>
+        <target>filter by %s</target>
+        <note>Line: 716</note>
+      </trans-unit>
+      <trans-unit id="a333339eb21abf3d5a04f5ede8f73ae9">
+        <source>%s deletion</source>
+        <target>%s deletion</target>
+        <note>Line: 4032</note>
+      </trans-unit>
+      <trans-unit id="6ca3b11e4d89a7649d10c2d70d98612f">
+        <source>%s addition</source>
+        <target>%s addition</target>
+        <note>Line: 1154</note>
+      </trans-unit>
+      <trans-unit id="0919680b340ae0ac8d1a804c4c69b0ba">
+        <source>%s modification</source>
+        <target>%s modification</target>
+        <note>Line: 1254</note>
+      </trans-unit>
+      <trans-unit id="f7931413dee107ddf5289c8886baf7ec">
+        <source>Edit: %s</source>
+        <target>Edit: %s</target>
+        <note>Line: 1559</note>
+      </trans-unit>
+      <trans-unit id="0095a9fa74d1713e43e370a7d7846224">
+        <source>Export</source>
+        <target>Export</target>
+        <note>Line: 1640</note>
+      </trans-unit>
+      <trans-unit id="4668a49dfb4ba4ff7fa8019e7e5c28af">
+        <source>Recommended Modules</source>
+        <target>Recommended Modules</target>
+        <note>Line: 2184</note>
+      </trans-unit>
+      <trans-unit id="ee77ea46b0c548ed60eadf31bdd68613">
+        <source>Bad SQL query</source>
+        <target>Bad SQL query</target>
+        <note>Line: 2404</note>
+      </trans-unit>
+      <trans-unit id="431accab7897f05b0424e002ca30391d">
+        <source>Operational</source>
+        <target>Operational</target>
+        <note>Line: 2674</note>
+      </trans-unit>
+      <trans-unit id="fb381d41e52b0dc68e684c01decfe2ec">
+        <source>Degraded Performance</source>
+        <target>Degraded Performance</target>
+        <note>Line: 2675</note>
+      </trans-unit>
+      <trans-unit id="7c30b2ec6e5e59c7c327f7098fe36f36">
+        <source>Partial Outage</source>
+        <target>Partial Outage</target>
+        <note>Line: 2676</note>
+      </trans-unit>
+      <trans-unit id="b101c07e257875658c454fe5caef1db0">
+        <source>Major Outage</source>
+        <target>Major Outage</target>
+        <note>Line: 2677</note>
+      </trans-unit>
+      <trans-unit id="ea4788705e6873b424c65e91c2846b19">
+        <source>Cancel</source>
+        <target>Cancel</target>
+        <note>Line: 1605</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/helper/HelperOptions.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c770d8e0d1d1943ce239c64dbd6acc20">
+        <source>Add my IP</source>
+        <target>Add my IP</target>
+        <note>Line: 212</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="240f3031f25601fa128bd4e15f0a37de">
+        <source>Comment:</source>
+        <target>Comment:</target>
+        <note>Line: 410</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminModulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7258e7251413465e0a3eb58094430bde">
+        <source>Administration</source>
+        <target>Administration</target>
+        <note>Line: 85
+Comment: Set the modules categories</note>
+      </trans-unit>
+      <trans-unit id="3defbfac3fcbea45049cddcf80aa9f21">
+        <source>Advertising and Marketing</source>
+        <target>Advertising and Marketing</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="a99118454f54727d280e3d2d9c7ea0e3">
+        <source>Analytics and Stats</source>
+        <target>Analytics and Stats</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="e09d0a51d181ee0b28180946f2af0f95">
+        <source><![CDATA[Taxes & Invoicing]]></source>
+        <target><![CDATA[Taxes & Invoicing]]></target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="6ff063fbc860a79759a7369ac32cee22">
+        <source>Checkout</source>
+        <target>Checkout</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="5dc6d69e21ca0f5779b9cfeae1154f05">
+        <source>Content Management</source>
+        <target>Content Management</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="d8b5985b4baa0bfe0ce6734f99b22e6e">
+        <source>Customer Reviews</source>
+        <target>Customer Reviews</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="e00dfb7a37c4f39c748f459e69fadb96">
+        <source>Front office Features</source>
+        <target>Front office Features</target>
+        <note>Line: 93</note>
+      </trans-unit>
+      <trans-unit id="a8cf512208bee5db82f968d2dc247c5f">
+        <source>Internationalization and Localization</source>
+        <target>Internationalization and Localization</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="825896e7e83eff50879ed00cba2f9414">
+        <source>Merchandising</source>
+        <target>Merchandising</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="5b985caa89b2ca61bbeee91a896c610d">
+        <source>Migration Tools</source>
+        <target>Migration Tools</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="286030724099ebb1518552eeb8b00bd7">
+        <source>Payments and Gateways</source>
+        <target>Payments and Gateways</target>
+        <note>Line: 97</note>
+      </trans-unit>
+      <trans-unit id="dd05711d44de1fa4bf31303915bd41bc">
+        <source><![CDATA[Site certification & Fraud prevention]]></source>
+        <target><![CDATA[Site certification & Fraud prevention]]></target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="54f65da381d43abf769b7ac2cb3a8270">
+        <source>Pricing and Promotion</source>
+        <target>Pricing and Promotion</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="a9964513dc046a2cd404413f77b4656e">
+        <source>Quick / Bulk update</source>
+        <target>Quick / Bulk update</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="d88946b678e4c2f251d4e292e8142291">
+        <source>SEO</source>
+        <target>SEO</target>
+        <note><![CDATA[Line: 102
+Comment: $this->list_modules_categories['search_filter']['name'] = $this->l('Search and Filter');]]></note>
+      </trans-unit>
+      <trans-unit id="19e295f6e2c8774937dd5144ce6aed23">
+        <source>Shipping and Logistics</source>
+        <target>Shipping and Logistics</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="5f17a788546ddb43236732f8b0bdfd7e">
+        <source>Slideshows</source>
+        <target>Slideshows</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="b93d83bd882a9507436946da114a9c25">
+        <source><![CDATA[Comparison site & Feed management]]></source>
+        <target><![CDATA[Comparison site & Feed management]]></target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="675e31b94580e2642405e2f8586d112e">
+        <source>Marketplace</source>
+        <target>Marketplace</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="87d17f4624a514e81dc7c8e016a7405c">
+        <source>Mobile</source>
+        <target>Mobile</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="2938c7f7e560ed972f8a4f68e80ff834">
+        <source>Dashboard</source>
+        <target>Dashboard</target>
+        <note>Line: 109</note>
+      </trans-unit>
+      <trans-unit id="44f9bbe73101a9c7842e9384e0db70c9">
+        <source><![CDATA[Internationalization & Localization]]></source>
+        <target><![CDATA[Internationalization & Localization]]></target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="e7e5eafdb7b6b3bbb9e38e9ae8a35094">
+        <source><![CDATA[Emailing & SMS]]></source>
+        <target><![CDATA[Emailing & SMS]]></target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="222e1825c6eb93a516fba01be7861ddd">
+        <source>Social Networks</source>
+        <target>Social Networks</target>
+        <note>Line: 112</note>
+      </trans-unit>
+      <trans-unit id="06c21841ec088f9c8cbfb82946cf203b">
+        <source><![CDATA[Social & Community]]></source>
+        <target><![CDATA[Social & Community]]></target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="8290fb626ffacf21450997f25967efeb">
+        <source>Module not found</source>
+        <target>Module not found</target>
+        <note>Line: 858</note>
+      </trans-unit>
+      <trans-unit id="0c81f6a8e4b7b1d0a812d7285289f17d">
+        <source>Modules to update</source>
+        <target>Modules to update</target>
+        <note>Line: 1394</note>
+      </trans-unit>
+      <trans-unit id="0f0c014bcfe255c6749d8e665ff8bb4e">
+        <source>Translate this module</source>
+        <target>Translate this module</target>
+        <note>Line: 1448</note>
+      </trans-unit>
+      <trans-unit id="7602b3edb382cf12573e156623fe9468">
+        <source>This module cannot be installed</source>
+        <target>This module cannot be installed</target>
+        <note>Line: 1456</note>
+      </trans-unit>
+      <trans-unit id="ac8f751177ba1d91a0ab11d3650cdfaf">
+        <source>Important Notice</source>
+        <target>Important Notice</target>
+        <note>Line: 1456</note>
+      </trans-unit>
+      <trans-unit id="c472f22a7459a000f0177a23fdc4212b">
+        <source>This module is Untrusted for your country</source>
+        <target>This module is Untrusted for your country</target>
+        <note>Line: 1464</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTabsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3b206d196cd6be3a2764c1fb90b200f">
+        <source>Delete selected</source>
+        <target>Delete selected</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="e25f0ecd41211b01c83e5fec41df4fe7">
+        <source>Delete selected items?</source>
+        <target>Delete selected items?</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="9bd81329febf6efe22788e03ddeaf0af">
+        <source>Class</source>
+        <target>Class</target>
+        <note>Line: 155</note>
+      </trans-unit>
+      <trans-unit id="52f5e0bc3859bc5f5e25130b6c7e8881">
+        <source>Position</source>
+        <target>Position</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="06145a21dcec7395085b033e6e169b61">
+        <source>Menus</source>
+        <target>Menus</target>
+        <note>Line: 136</note>
+      </trans-unit>
+      <trans-unit id="0164b35f3cbc5cbf9bf58abeb4bc14df">
+        <source>Add new menu</source>
+        <target>Add new menu</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="8cf04a9734132302f96da8e113e80ce5">
+        <source>Home</source>
+        <target>Home</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="6252c0f2c2ed83b7b06dfca86d4650bb">
+        <source>Invalid characters:</source>
+        <target>Invalid characters:</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="ec53a8c4f07baed5d8825072c89799be">
+        <source>Status</source>
+        <target>Status</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="fe513725b21a16ced7d05b454e74a33e">
+        <source>Show or hide menu.</source>
+        <target>Show or hide menu.</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="30269022e9d8f51beaabb52e5d0de2b7">
+        <source>Parent</source>
+        <target>Parent</target>
+        <note>Line: 198</note>
+      </trans-unit>
+      <trans-unit id="630f6dc397fe74e52d5189e2c80f282b">
+        <source>Back to list</source>
+        <target>Back to list</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="ede4759c9afae620fd586628789fa304">
+        <source>Enable selection</source>
+        <target>Enable selection</target>
+        <note>Line: 303</note>
+      </trans-unit>
+      <trans-unit id="ab7fd6e250b64a46027a996088fdff74">
+        <source>Disable selection</source>
+        <target>Disable selection</target>
+        <note>Line: 307</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/cronjobs/classes/CronJobsForms.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c9cc8cce247e49bae79f15173ce97354">
+        <source>Save</source>
+        <target>Save</target>
+        <note>Line: 181</note>
+      </trans-unit>
+      <trans-unit id="d4169d52732e9ae8df56d2cbcad81a94">
+        <source>Task description</source>
+        <target>Task description</target>
+        <note>Line: 225</note>
+      </trans-unit>
+      <trans-unit id="70d4968bea9a6e76c0333904b9d385e4">
+        <source>Update my currencies</source>
+        <target>Update my currencies</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="0eff773cf33456a033e913f6ed18045c">
+        <source>Target link</source>
+        <target>Target link</target>
+        <note>Line: 226</note>
+      </trans-unit>
+      <trans-unit id="07045abc579615634804f42bc0b2b4bb">
+        <source>Enter a description for this task.</source>
+        <target>Enter a description for this task.</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="43773e69610c99be6c15daa4a2036443">
+        <source>Set the link of your cron task.</source>
+        <target>Set the link of your cron task.</target>
+        <note>Line: 97</note>
+      </trans-unit>
+      <trans-unit id="3a21e2309e8e6aa3759e466154508f2c">
+        <source>Do not forget to use an absolute URL to make it valid! The link also has to be on the same domain as the shop.</source>
+        <target>Do not forget to use an absolute URL to make it valid! The link also has to be on the same domain as the shop.</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="be938fb8c5582085599dfa95368fb489">
+        <source>Task frequency</source>
+        <target>Task frequency</target>
+        <note>Line: 122</note>
+      </trans-unit>
+      <trans-unit id="b3364fad867d47ca61265fd315e4071e">
+        <source>At what time should this task be executed?</source>
+        <target>At what time should this task be executed?</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="6c5d30049c4d8d644bd35650be4ac13a">
+        <source>On which day of the month should this task be executed?</source>
+        <target>On which day of the month should this task be executed?</target>
+        <note>Line: 132</note>
+      </trans-unit>
+      <trans-unit id="a1457ee25ec20fa032d37509b5a90a4e">
+        <source>On what month should this task be executed?</source>
+        <target>On what month should this task be executed?</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="65f768d204a3118f426c756056bef1e1">
+        <source>On which day of the week should this task be executed?</source>
+        <target>On which day of the week should this task be executed?</target>
+        <note>Line: 150</note>
+      </trans-unit>
+      <trans-unit id="f4f70727dc34561dfde1a3c529b6205c">
+        <source>Settings</source>
+        <target>Settings</target>
+        <note>Line: 165</note>
+      </trans-unit>
+      <trans-unit id="b3419e63398ccc41c062f36631bebd9a">
+        <source>Cron mode</source>
+        <target>Cron mode</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="972e73b7a882d0802a4e3a16946a2f94">
+        <source>Basic</source>
+        <target>Basic</target>
+        <note>Line: 174</note>
+      </trans-unit>
+      <trans-unit id="eaf1dc6d93a18adb2619233d8e99c197">
+        <source>Use the PrestaShop cron tasks webservice to execute your tasks.</source>
+        <target>Use the PrestaShop cron tasks webservice to execute your tasks.</target>
+        <note>Line: 175</note>
+      </trans-unit>
+      <trans-unit id="9b6545e4cea9b4ad4979d41bb9170e2b">
+        <source>Advanced</source>
+        <target>Advanced</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="b6610b26530c9ee3d7bc4a478cf35299">
+        <source>For advanced users only: use your own crontab manager instead of PrestaShop cron tasks service.</source>
+        <target>For advanced users only: use your own crontab manager instead of PrestaShop cron tasks service.</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="2257d36bcb68362b24cf74f626bac599">
+        <source>The Advanced mode enables you to use your own cron tasks manager instead of PrestaShop cron tasks webservice.</source>
+        <target>The Advanced mode enables you to use your own cron tasks manager instead of PrestaShop cron tasks webservice.</target>
+        <note>Line: 210</note>
+      </trans-unit>
+      <trans-unit id="43009010c8282eadc3f19f4b9c7c5ee4">
+        <source>First of all, make sure the 'curl' library is installed on your server.</source>
+        <target>First of all, make sure the 'curl' library is installed on your server.</target>
+        <note>Line: 211</note>
+      </trans-unit>
+      <trans-unit id="18028ef85b7ce8fbde749a2c49c6d18a">
+        <source>To execute your cron tasks, please insert the following line in your cron tasks manager:</source>
+        <target>To execute your cron tasks, please insert the following line in your cron tasks manager:</target>
+        <note>Line: 212</note>
+      </trans-unit>
+      <trans-unit id="03727ac48595a24daed975559c944a44">
+        <source>Day</source>
+        <target>Day</target>
+        <note>Line: 228</note>
+      </trans-unit>
+      <trans-unit id="7cbb885aa1164b390a0bc050a64e1812">
+        <source>Month</source>
+        <target>Month</target>
+        <note>Line: 229</note>
+      </trans-unit>
+      <trans-unit id="e59278675b8f1e052b22b7e5e7d65da7">
+        <source>Day of week</source>
+        <target>Day of week</target>
+        <note>Line: 230</note>
+      </trans-unit>
+      <trans-unit id="8cebfac3b4821cbc83041f5df54d7730">
+        <source>Last execution</source>
+        <target>Last execution</target>
+        <note>Line: 231</note>
+      </trans-unit>
+      <trans-unit id="1e3208e0b0d5de9281f88c34169cda6b">
+        <source>One shot</source>
+        <target>One shot</target>
+        <note>Line: 232</note>
+      </trans-unit>
+      <trans-unit id="4d3d769b812b6faa6b76e1a8abaece2d">
+        <source>Active</source>
+        <target>Active</target>
+        <note>Line: 233</note>
+      </trans-unit>
+      <trans-unit id="bdb6ae0d03e6793183349e00f67657f6">
+        <source>Module - Hook</source>
+        <target>Module - Hook</target>
+        <note>Line: 300</note>
+      </trans-unit>
+      <trans-unit id="02fd27d2951d00b83f111f63611ea863">
+        <source>Every hour</source>
+        <target>Every hour</target>
+        <note>Line: 319</note>
+      </trans-unit>
+      <trans-unit id="48bf14c419a1d441412510faf39c326d">
+        <source>Every day</source>
+        <target>Every day</target>
+        <note>Line: 306</note>
+      </trans-unit>
+      <trans-unit id="8ed91b71d01993965915f3b296c20336">
+        <source>Every month</source>
+        <target>Every month</target>
+        <note>Line: 341</note>
+      </trans-unit>
+      <trans-unit id="50875e72e1477618055d1508112199b4">
+        <source>Every day of the week</source>
+        <target>Every day of the week</target>
+        <note>Line: 352</note>
+      </trans-unit>
+      <trans-unit id="6e7b34fa59e1bd229b207892956dc41c">
+        <source>Never</source>
+        <target>Never</target>
+        <note>Line: 309</note>
+      </trans-unit>
+      <trans-unit id="16ed0a7b977ec3bbd23badfb5580d56f">
+        <source>Every day of the month</source>
+        <target>Every day of the month</target>
+        <note>Line: 330</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/cronjobs/cronjobs.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="682ee2e41e510efdbced967430173c66">
+        <source>Cron tasks manager</source>
+        <target>Cron tasks manager</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="c75e110ddb05aea61563c50d7baf0ae0">
+        <source>Manage all your automated web tasks from a single interface.</source>
+        <target>Manage all your automated web tasks from a single interface.</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="4093808c9781fb6ca2ed5ade71deff4d">
+        <source>To be able to use this module, please activate cURL (PHP extension).</source>
+        <target>To be able to use this module, please activate cURL (PHP extension).</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="035d5cdab2c65ad42b303f8125025160">
+        <source>Cron tasks</source>
+        <target>Cron tasks</target>
+        <note>Line: 412</note>
+      </trans-unit>
+      <trans-unit id="6588952424b58b4c9fc9df026b668991">
+        <source>Add new task</source>
+        <target>Add new task</target>
+        <note>Line: 427</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/gamification/controllers/admin/AdminGamificationController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3d4aafb2eedeba2fbf92e852f0af745a">
+        <source>Merchant Expertise</source>
+        <target>Merchant Expertise</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="ca96b4f8d13722aac99da25f94ea1711">
+        <source>Your Merchant Expertise</source>
+        <target>Your Merchant Expertise</target>
+        <note>Line: 12</note>
+      </trans-unit>
+      <trans-unit id="98f770b0af18ca763421bac22b4b6805">
+        <source>Features</source>
+        <target>Features</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="f5c7922da355fd289ec1d6469e0583a7">
+        <source>Achievements</source>
+        <target>Achievements</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="8189ecf686157db0c0274c1f49373318">
+        <source>International</source>
+        <target>International</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="851f12a0c936baace7f0e734d5c624e7">
+        <source>1. Beginner</source>
+        <target>1. Beginner</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="583981a16ea761fe852b64094d8a887e">
+        <source>2. Pro</source>
+        <target>2. Pro</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="38f7af7416ffcd1524d8a4acda756cbf">
+        <source>3. Expert</source>
+        <target>3. Expert</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="e7613fe56cdbeddfc9bb6276fd0f0d12">
+        <source>4. Wizard</source>
+        <target>4. Wizard</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="8d03eaad7ff7babdd33c2c74fe479ed0">
+        <source>5. Guru</source>
+        <target>5. Guru</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="e4be4f3e3ae4ee9dda6b60815bf774c1">
+        <source>6. Legend</source>
+        <target>6. Legend</target>
+        <note>Line: 90</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/gamification/gamification.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bacc1bf300527bad9c6ac2d3b875a8d8">
+        <source>Become an e-commerce expert within the blink of an eye!</source>
+        <target>Become an e-commerce expert within the blink of an eye!</target>
+        <note>Line: 58</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_faviconnotificationbo/ps_faviconnotificationbo.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="87cc29282288a147a6c6a8fca50ba414">
+        <source>Order Notifications on the Favicon</source>
+        <target>Order Notifications on the Favicon</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="421c53421b5ea9820af60bb4dba58584">
+        <source>Get notified when you get new order, new client or new message directly on your browser tab of your back office even if you are working on another page</source>
+        <target>Get notified when you get new order, new client or new message directly on your browser tab of your back office even if you are working on another page</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="bb8956c67b82c7444a80c6b2433dd8b4">
+        <source>Are you sure you want to uninstall this module?</source>
+        <target>Are you sure you want to uninstall this module?</target>
+        <note>Line: 71
+Comment: Confirm uninstall</note>
+      </trans-unit>
+      <trans-unit id="faaa79afdd5385b4ff3db080a88b0dc8">
+        <source>There was an error during the uninstallation.</source>
+        <target>There was an error during the uninstallation.</target>
+        <note>Line: 101</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/ps_mbo.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b9804794cbfeea33c6d9b2ce85100b48">
+        <source>Do you really want to uninstall this module?</source>
+        <target>Do you really want to uninstall this module?</target>
+        <note>Line: 586</note>
+      </trans-unit>
+      <trans-unit id="b2f31ef3065bf40b2da9fa8525c6adb9">
+        <source>Disable this module</source>
+        <target>Disable this module</target>
+        <note>Line: 588</note>
+      </trans-unit>
+      <trans-unit id="668c99c1164d5348f99c0878770b53a8">
+        <source>Enable this module for all shops</source>
+        <target>Enable this module for all shops</target>
+        <note>Line: 589</note>
+      </trans-unit>
+      <trans-unit id="112b842b7d5dda8d3fed05c0e5aaf983">
+        <source>Disable on mobiles</source>
+        <target>Disable on mobiles</target>
+        <note>Line: 592</note>
+      </trans-unit>
+      <trans-unit id="2ef92962bd1ac0c81675f10568ad5cca">
+        <source>Disable on tablets</source>
+        <target>Disable on tablets</target>
+        <note>Line: 593</note>
+      </trans-unit>
+      <trans-unit id="5e3ffb3123b3f23a33804d41e38745a0">
+        <source>Disable on computers</source>
+        <target>Disable on computers</target>
+        <note>Line: 594</note>
+      </trans-unit>
+      <trans-unit id="862e2caedb77ba14d86f180ca7fa90a8">
+        <source>Display on mobiles</source>
+        <target>Display on mobiles</target>
+        <note>Line: 595</note>
+      </trans-unit>
+      <trans-unit id="732ebdb0f33a8153b51ac58cac8f3563">
+        <source>Display on tablets</source>
+        <target>Display on tablets</target>
+        <note>Line: 596</note>
+      </trans-unit>
+      <trans-unit id="7f0f7c79f1d7b01b1d8a89f392e93d36">
+        <source>Display on computers</source>
+        <target>Display on computers</target>
+        <note>Line: 597</note>
+      </trans-unit>
+      <trans-unit id="f2a6c498fb90ee345d997f888fce3b18">
+        <source>Delete</source>
+        <target>Delete</target>
+        <note>Line: 600</note>
+      </trans-unit>
+      <trans-unit id="85687c63fd82afbc21632f288e53a6e4">
+        <source>This action will permanently remove the module from the server. Are you sure you want to do this?</source>
+        <target>This action will permanently remove the module from the server. Are you sure you want to do this?</target>
+        <note>Line: 604</note>
+      </trans-unit>
+      <trans-unit id="42667b4f4303551b1d51722fe58bf14c">
+        <source>PrestaShop Marketplace in your Back Office</source>
+        <target>PrestaShop Marketplace in your Back Office</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="598771837d403181383aa25c5b3ca84c">
+        <source>Discover the best PrestaShop modules to optimize your online store.</source>
+        <target>Discover the best PrestaShop modules to optimize your online store.</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="6b5f8217a806956477c81322bb07b9a9">
+        <source>There was an error during the installation.</source>
+        <target>There was an error during the installation.</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="757ae773751eb1eeefe7827b466e49dc">
+        <source>There was an error during the desinstallation.</source>
+        <target>There was an error during the desinstallation.</target>
+        <note>Line: 392</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/admin-end-content-theme.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bbb572a770006c9e0e57c9e5d4bcda90">
+        <source>Live from PrestaShop Addons!</source>
+        <target>Live from PrestaShop Addons!</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/module-toolbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="76881586f05f3b21d67b0c2332539634">
+        <source>Install a module</source>
+        <target>Install a module</target>
+        <note>Line: 5</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_mbo/views/templates/admin/page.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="75c9cc6412fa19e10f1e79edbcbde954">
+        <source>Service by</source>
+        <target>Service by</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="24a25a6b874647087c51ea00b7992def">
+        <source>Exit to PrestaShop Addons Marketplace</source>
+        <target>Exit to PrestaShop Addons Marketplace</target>
+        <note>Line: 150</note>
+      </trans-unit>
+      <trans-unit id="754475030b0733378b9347e8f9da8bf9">
+        <source>See all results for your search on</source>
+        <target>See all results for your search on</target>
+        <note>Line: 152</note>
+      </trans-unit>
+      <trans-unit id="3aaeb3f0458cf2580c5f75fefdb86ab6">
+        <source>PrestaShop Addons Marketplace</source>
+        <target>PrestaShop Addons Marketplace</target>
+        <note>Line: 153</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_themecusto/controllers/admin/AdminPsThemeCustoAdvanced.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1bdd228669c9dd995eb664737e60786e">
+        <source>You do not have permission to edit this.</source>
+        <target>You do not have permission to edit this.</target>
+        <note>Line: 537</note>
+      </trans-unit>
+      <trans-unit id="c7e728f436eee2692d6c6f756621a70e">
+        <source>An error occured, please check your zip file</source>
+        <target>An error occured, please check your zip file</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="7bdb8c4b5d9ade9ec5b5b84c0486fafa">
+        <source>The file is not valid.</source>
+        <target>The file is not valid.</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="8389b4fb9a4f4e8cde019f0b1ee4b7f1">
+        <source>Make sure you zip your edited theme files directly to the root of your child theme's folder before uploading it.</source>
+        <target>Make sure you zip your edited theme files directly to the root of your child theme's folder before uploading it.</target>
+        <note>Line: 196</note>
+      </trans-unit>
+      <trans-unit id="25e1f8db54571babe546ace313723927">
+        <source>Only CSS, YML and PNG files are accepted in the ZIP</source>
+        <target>Only CSS, YML and PNG files are accepted in the ZIP</target>
+        <note>Line: 205</note>
+      </trans-unit>
+      <trans-unit id="b132585b3eaed4cfca783ccabbb12bb1">
+        <source>There is some PHP files in your ZIP</source>
+        <target>There is some PHP files in your ZIP</target>
+        <note>Line: 207</note>
+      </trans-unit>
+      <trans-unit id="6b39dec7aaea7436f961638f45b9b38f">
+        <source>The theme already exists or the parent name in the config file is wrong</source>
+        <target>The theme already exists or the parent name in the config file is wrong</target>
+        <note>Line: 224</note>
+      </trans-unit>
+      <trans-unit id="77983919a6fbfc68624b1365066c2fed">
+        <source>You must enter the parent theme name in the theme.yml file. Furthermore, the parent name must be the current parent theme.</source>
+        <target>You must enter the parent theme name in the theme.yml file. Furthermore, the parent name must be the current parent theme.</target>
+        <note>Line: 233</note>
+      </trans-unit>
+      <trans-unit id="7e46d7414693424b67f64eb9a804e95d">
+        <source>The child theme has been added successfully.</source>
+        <target>The child theme has been added successfully.</target>
+        <note>Line: 240</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_themecusto/controllers/admin/AdminPsThemeCustoConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bcfaccebf745acfd5e75351095a5394a">
+        <source>Disable</source>
+        <target>Disable</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="2faec1f9f8cc7f8f40d521c4dd574f49">
+        <source>Enable</source>
+        <target>Enable</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="f1206f9fadc5ce41694f69129aecac26">
+        <source>Configure</source>
+        <target>Configure</target>
+        <note>Line: 282</note>
+      </trans-unit>
+      <trans-unit id="038bd38b5172a9ba90468070bdc4d4f3">
+        <source>Disable Mobile</source>
+        <target>Disable Mobile</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="8b1a3613ac33a07ab788b2656755110c">
+        <source>Enable Mobile</source>
+        <target>Enable Mobile</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="b61541208db7fa7dba42c85224405911">
+        <source>Menu</source>
+        <target>Menu</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="2d9b9a764fb0be4be10e1b2fce63f561">
+        <source>Slider</source>
+        <target>Slider</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="4c9a5b9683fc96c83f62635c954e808a">
+        <source>Home Products</source>
+        <target>Home Products</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="7ef25f7b93adc8bf024ed532d722f697">
+        <source>Text block</source>
+        <target>Text block</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="6ff29916f99fff9d2494d28e721ae77e">
+        <source>Banner</source>
+        <target>Banner</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="189b43cdd11a8e8db346c4d4885c7fed">
+        <source><![CDATA[Social &  Newsletter]]></source>
+        <target><![CDATA[Social &  Newsletter]]></target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="ded40f2a77c30efc6062db0cbd857746">
+        <source>Footer</source>
+        <target>Footer</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="a39a7bb20b87c1e818ff2d321d612c23">
+        <source>Create and manage Product Categories</source>
+        <target>Create and manage Product Categories</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="60328687faec0cab8613aa9d796cc0fe">
+        <source>Create here a full range of categories and subcategories to classify your products and manage your catalog easily.</source>
+        <target>Create here a full range of categories and subcategories to classify your products and manage your catalog easily.</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="a03facafa0612fe501fc66292d6510d7">
+        <source>Create content pages</source>
+        <target>Create content pages</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="81b5e93faa3b91bac0e79fda6865f8f3">
+        <source>Add and manage your content pages (CMS pages: Terms and conditions of use, Our stores, About us, etc.) as you want.</source>
+        <target>Add and manage your content pages (CMS pages: Terms and conditions of use, Our stores, About us, etc.) as you want.</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="c5a358d061895cc982600e71b9947a2e">
+        <source>Create Brands and Suppliers pages</source>
+        <target>Create Brands and Suppliers pages</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="60daf439ec64a846c2b5d13e6e7b1dda">
+        <source>This page allows you to create and manage your Brands and/or Suppliers pages.</source>
+        <target>This page allows you to create and manage your Brands and/or Suppliers pages.</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="7cd5fa3f9e9e911c6b60b9044436d227">
+        <source>Shop details</source>
+        <target>Shop details</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="c15614439ecc7d478eec1e4e12edc85b">
+        <source>Display additional information about your store or how to contact you to make it easy for your customers to reach you.</source>
+        <target>Display additional information about your store or how to contact you to make it easy for your customers to reach you.</target>
+        <note>Line: 120</note>
+      </trans-unit>
+      <trans-unit id="4b8a74f166975e0d8c67e68e0590ce10">
+        <source>Action on the module successfully completed</source>
+        <target>Action on the module successfully completed</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="80149ff14c961109480be108c06e80e9">
+        <source>Action on module failed</source>
+        <target>Action on module failed</target>
+        <note>Line: 172</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_themecusto/ps_themecusto.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="95db0d5190e9cdbed521ecf6ea2373ca">
+        <source>Theme Customization</source>
+        <target>Theme Customization</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="c3db892b3555ae0538402754d0c375d0">
+        <source><![CDATA[Easily configure and customize your homepage’s theme and main native modules. Feature available on Design > Theme & Logo page.]]></source>
+        <target><![CDATA[Easily configure and customize your homepage’s theme and main native modules. Feature available on Design > Theme & Logo page.]]></target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="f87b9438e8de65a83e7a3ef56a9d23fb">
+        <source>There was an error during the installation. Please contact us through Addons website</source>
+        <target>There was an error during the installation. Please contact us through Addons website</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="483e3e074a5d95afb68e454b8f675ddb">
+        <source>There was an error during the uninstall. Please contact us through Addons website</source>
+        <target>There was an error during the uninstall. Please contact us through Addons website</target>
+        <note>Line: 113</note>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Updated catalog with missing wordings
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9697
| How to test?  | 

The missing wordings are now available for translation:

![missing translations](https://user-images.githubusercontent.com/1009343/48289985-107dda00-e450-11e8-806c-73d38b7b41fb.png)

Incidentally, elements in the catalog files are now sorted alphabetically by original file path. Hopefully this will reduce the pain when reviewing subsequent catalog updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11345)
<!-- Reviewable:end -->
