### PR TITLE
Improve install warning message for beta builds

### DIFF
--- a/tools/build/Library/InstallUnpacker/classes/Download.php
+++ b/tools/build/Library/InstallUnpacker/classes/Download.php
@@ -115,7 +115,7 @@ class Download
     }
 
     /**
-     * @return string
+     * @return VersionNumber
      */
     public function getLatestStableAvailableVersion()
     {
@@ -124,7 +124,7 @@ class Download
         $branch = $this->getLatestStableBranchObjectFromFeed($feed);
         $versionNumberAsString = (string) $branch->num;
 
-        return VersionNumber::fromString($versionNumberAsString)->__toString();
+        return VersionNumber::fromString($versionNumberAsString);
     }
 
     /**

--- a/tools/build/Library/InstallUnpacker/classes/InstallManager.php
+++ b/tools/build/Library/InstallUnpacker/classes/InstallManager.php
@@ -76,7 +76,7 @@ class InstallManager
     }
 
     /**
-     * @return string
+     * @return VersionNumber
      *
      * @throws \RuntimeException
      */

--- a/tools/build/Library/InstallUnpacker/index_template.php
+++ b/tools/build/Library/InstallUnpacker/index_template.php
@@ -83,8 +83,8 @@ if (isset($_GET['run']) && ($_GET['run'] === 'check-version')) {
 
         $latestVersionAvailable = $installManager->getLatestStableAvailableVersion();
 
-        $isThisTheLatestAvailableVersion = (_PS_VERSION_ === $latestVersionAvailable);
-        if ($isThisTheLatestAvailableVersion) {
+        $isThisTheLatestStableAvailableVersion = ($latestVersionAvailable->compare(VersionNumber::fromString(_PS_VERSION_)) < 1);
+        if ($isThisTheLatestStableAvailableVersion) {
             die(json_encode([
                 'thereIsAMoreRecentPSVersionAndItCanBeInstalled' => false,
             ]));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Modify warning message at install step to prevent beta testers to use the last stable version instead of the beta version.
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/11335
| How to test?  | Once the code has been approved, please ping me and I will build a beta release test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11357)
<!-- Reviewable:end -->
