### PR TITLE
Add an rtlfix file to correctly hide the right side bar in rtl languages

### DIFF
--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -1,0 +1,1 @@
+.sidebar.sidebar-right {-webkit-transform: translate(-100%,0);-moz-transform: translate(-100%,0);-ms-transform: translate(-100%,0);-o-transform: translate(-100%,0);transform: translate(-100%,0);}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Add an rtlfix file to correctly hide the right side bar in rtl languages because CSSJanus has a bug when two translations are declared one after each other
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11112
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11384)
<!-- Reviewable:end -->
