### PR TITLE
Fixed display issue where the .header-toolbar would display above the…

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -4,7 +4,7 @@
   top: $size-header-height;
   left: $size-navbar-width;
   right: 0;
-  z-index: 1100; // 1070 is the highest z-index in bootstrap v4.0.0 (help popover)
+  z-index: 1000; // 1070 is the highest z-index in bootstrap v4.0.0 (help popover)
   border-bottom: 0.0625rem solid $color-separator;
 
   transition: left .5s ease; // transition when collapsing the nav menu


### PR DESCRIPTION

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.5.0
| Description?  | Fixes a display issue where nav dropdowns render behind the header toolbar due to the header toolbar and nav having the same z-index. Img of bug: ![image](https://user-images.githubusercontent.com/1468721/48556463-ae5c2380-e8ec-11e8-9201-d176cba1d78e.png)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | could not find an open issue for it
| How to test?  | build the new-theme

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11405)
<!-- Reviewable:end -->
