### PR TITLE
Fix customer/address delete resulting in error on cart page

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -221,6 +221,15 @@ class AddressCore extends ObjectModel
         }
 
         if (!$this->isUsed()) {
+            // keep pending carts, but unlink it from current address
+            $sql = 'UPDATE ' . _DB_PREFIX_ . 'cart
+                    SET id_address_delivery = 0
+                    WHERE id_address_delivery = ' . $this->id;
+            Db::getInstance()->execute($sql);
+            $sql = 'UPDATE ' . _DB_PREFIX_ . 'cart
+                    SET id_address_invoice = 0
+                    WHERE id_address_invoice = ' . $this->id;
+            Db::getInstance()->execute($sql);
             return parent::delete();
         } else {
             $this->deleted = true;

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -222,6 +222,7 @@ class AddressCore extends ObjectModel
 
         if (!$this->isUsed()) {
             $this->deleteCartAddress();
+
             return parent::delete();
         } else {
             $this->deleted = true;

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -221,21 +221,29 @@ class AddressCore extends ObjectModel
         }
 
         if (!$this->isUsed()) {
-            // keep pending carts, but unlink it from current address
-            $sql = 'UPDATE ' . _DB_PREFIX_ . 'cart
-                    SET id_address_delivery = 0
-                    WHERE id_address_delivery = ' . $this->id;
-            Db::getInstance()->execute($sql);
-            $sql = 'UPDATE ' . _DB_PREFIX_ . 'cart
-                    SET id_address_invoice = 0
-                    WHERE id_address_invoice = ' . $this->id;
-            Db::getInstance()->execute($sql);
+            $this->deleteCartAddress();
             return parent::delete();
         } else {
             $this->deleted = true;
 
             return $this->update();
         }
+    }
+
+    /**
+     * removes the address from carts using it, to avoid errors on not existing address
+     */
+    protected function deleteCartAddress()
+    {
+        // keep pending carts, but unlink it from current address
+        $sql = 'UPDATE ' . _DB_PREFIX_ . 'cart
+                    SET id_address_delivery = 0
+                    WHERE id_address_delivery = ' . $this->id;
+        Db::getInstance()->execute($sql);
+        $sql = 'UPDATE ' . _DB_PREFIX_ . 'cart
+                    SET id_address_invoice = 0
+                    WHERE id_address_invoice = ' . $this->id;
+        Db::getInstance()->execute($sql);
     }
 
     /**

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -289,7 +289,8 @@ class CustomerCore extends ObjectModel
             $addresses = $this->getAddresses((int) Configuration::get('PS_LANG_DEFAULT'));
             foreach ($addresses as $address) {
                 $obj = new Address((int) $address['id_address']);
-                $obj->delete();
+                $obj->deleted = true;
+                $obj->save();
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Fix php error on BO>carts when deleting a customer or an address used in abandonned cart
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/9782
| How to test?  | 1/ On FO create a customer account, add a product in cart, go to checkout and store an address on the cart. On BO go to customers and delete the customer with second delete option. go to orders>cart, no error should be displayed. 2/ Same FO process but on BO delete the address. Carts page should not display error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11416)
<!-- Reviewable:end -->
