### PR TITLE
Display configure button only if module is configurable

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig
@@ -45,6 +45,7 @@
           {{ module.attributes.description|raw }}
         </p>
       </div>
+      {% if module.attributes.is_configurable %}
       <div class="col-12 col-sm-4 col-md-3 col-lg-2 mb-3">
         <div class="text-center">
           <a href="{{ path('admin_module_configure_action', {'module_name': module.attributes.name}) }}"
@@ -54,6 +55,7 @@
           </a>
         </div>
       </div>
+      {% endif %}
     </div>
   {% endfor %}
   </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Display the configure button of a module only if it is configurable
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #11420
| How to test?  | Install the module "Cash on delivery", go to the payment methods and try to configure the same module

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11421)
<!-- Reviewable:end -->
