### PR TITLE
Installation persian fixed

### DIFF
--- a/classes/Country.php
+++ b/classes/Country.php
@@ -471,7 +471,12 @@ class CountryCore extends ObjectModel
         }
 
         if (!count($countries)) {
-            $countries = Country::getCountries((int) Context::getContext()->cookie->id_lang);
+            if (null !== Context::getContext()->cookie) {
+                $id_lang = (int) Context::getContext()->cookie->id_lang;
+            } else {
+                $id_lang = (int) Context::getContext()->language->id;
+            }
+            $countries = Country::getCountries($id_lang);
         }
 
         if (!count($modules)) {

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -1049,10 +1049,21 @@ class Install extends AbstractInstall
                 continue;
             }
 
-            if (!$moduleManager->install($module_name)) {
+            $moduleException = null;
+            try {
+                $moduleInstalled = $moduleManager->install($module_name);
+            } catch (\PrestaShopException $e) {
+                $moduleInstalled = false;
+                $moduleException = $e->getMessage();
+            }
+
+            if (!$moduleInstalled) {
                 /*$module_errors = $module->getErrors();
                 if (empty($module_errors)) {*/
                 $module_errors = [$this->translator->trans('Cannot install module "%module%"', array('%module%' => $module_name), 'Install')];
+                if (null !== $moduleException) {
+                    $module_errors[] = $moduleException;
+                }
                 /*}*/
                 $errors[$module_name] = $module_errors;
             }

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -64,6 +64,7 @@ use PrestaShopBundle\Service\Database\Upgrade as UpgradeDatabase;
 
 class Install extends AbstractInstall
 {
+    const FALLBACK_LANGUAGE = 'en';
     const SETTINGS_FILE = 'config/settings.inc.php';
     const BOOTSTRAP_FILE = 'config/bootstrap.php';
 
@@ -449,6 +450,7 @@ class Install extends AbstractInstall
                         }
                     }
                 }
+                $iso_codes_to_install[] = self::FALLBACK_LANGUAGE;
                 $iso_codes_to_install = array_unique($iso_codes_to_install);
             } else {
                 $iso_codes_to_install = null;

--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -41,8 +41,6 @@ use PrestaShop\PrestaShop\Adapter\Entity\DbQuery;
 
 class XmlLoader
 {
-    const FALLBACK_LANGUAGE = 'en';
-
     /**
      * @var LanguageList
      */
@@ -276,7 +274,7 @@ class XmlLoader
                 if ($iso == $this->language->getLanguageIso()) {
                     $default_lang = $id_lang;
                 }
-                if ($iso == self::FALLBACK_LANGUAGE) {
+                if ($iso == Install::FALLBACK_LANGUAGE) {
                     $fallback_lang = $id_lang;
                 }
 
@@ -371,16 +369,16 @@ class XmlLoader
 
     protected function getFallBackToDefaultLanguage($iso)
     {
-        return file_exists($this->lang_path . $iso . '/data/') ? $iso : self::FALLBACK_LANGUAGE;
+        return file_exists($this->lang_path . $iso . '/data/') ? $iso : Install::FALLBACK_LANGUAGE;
     }
 
     protected function getFallBackToDefaultEntityLanguage($iso, $entity)
     {
-        if ($this->getFallBackToDefaultLanguage($iso) === self::FALLBACK_LANGUAGE) {
-            return self::FALLBACK_LANGUAGE;
+        if ($this->getFallBackToDefaultLanguage($iso) === Install::FALLBACK_LANGUAGE) {
+            return Install::FALLBACK_LANGUAGE;
         }
 
-        return file_exists($this->lang_path . $this->getFallBackToDefaultLanguage($iso) . '/data/' . $entity . '.xml') ? $iso : self::FALLBACK_LANGUAGE;
+        return file_exists($this->lang_path . $this->getFallBackToDefaultLanguage($iso) . '/data/' . $entity . '.xml') ? $iso : Install::FALLBACK_LANGUAGE;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | The installation process blocked when installing ps_mbo, this happened because the Tab `Module Catalog` didn't have any translation in persians, thus the validation stated that the field name was empty. To patch this issue during the installation process when data is injected in database if no translation is found for an entity field then we fallback on the english value. On the side a change was made to avoid using cookie during the installation to get the language, and a better management of errors during module installation.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11354
| How to test?  | Clone the branch and go to the install-dev address, try to install PrestaShop in persian and go to the end of the process.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11441)
<!-- Reviewable:end -->
