### PR TITLE
Changes the behaviour of sequential percent price discounts

### DIFF
--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -41,6 +41,13 @@ use PrestaShop\PrestaShop\Adapter\Tools;
  */
 class CartRow
 {
+
+    /**
+     * Following PS 1.6 behaviour, sequential % discounts should be applied to initial price, rather than 
+     * to already discounted by previous rules 
+     */
+    const APPLY_PERCENT_TO_INITIAL_PRICE = true;
+
     /**
      * row round mode by item.
      */
@@ -431,8 +438,18 @@ class CartRow
         if ($percent < 0 || $percent > 100) {
             throw new \Exception('Invalid percentage discount given: ' . $percent);
         }
-        $discountTaxIncluded = $this->finalTotalPrice->getTaxIncluded() * $percent / 100;
-        $discountTaxExcluded = $this->finalTotalPrice->getTaxExcluded() * $percent / 100;
+
+        if (self::APPLY_PERCENT_TO_INITIAL_PRICE) {
+            $rowData              = $this->getRowData();
+            $quantity             = (int) $rowData['cart_quantity'];
+            $discountTaxIncluded = $this->getInitialUnitPrice()->getTaxIncluded() * $quantity * $percent / 100;
+            $discountTaxExcluded = $this->getInitialUnitPrice()->getTaxExcluded() * $quantity * $percent / 100;
+        }
+        else {
+            $discountTaxIncluded = $this->finalTotalPrice->getTaxIncluded() * $percent / 100;
+            $discountTaxExcluded = $this->finalTotalPrice->getTaxExcluded() * $percent / 100;
+        }
+
         $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
         $this->applyFlatDiscount($amount);
 


### PR DESCRIPTION


In PS 1.6 all percent discounts were applied to ORIGINAL price. In 1.7, this behaviour was changed (probably unintentionally) - now next percent discount apllies to already dicounted by previous rule price. (Thus percent discounts are multiplied rather then added as it were per ver 1.6). This behaviour conflict with the info presented in back office and in the invoice.

This simple local change restores 1.6 behaviour

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | see screenshots below
| Type?         | bug fix 
| Category?     | CO 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Please indicate how to best verify that this PR is correct.


A cart in PS 1.6.1.4:

Total price = 60
Discounts: (20% = 12) + (15% = 9) + (5% = 3) = 24


![cart-1 6](https://user-images.githubusercontent.com/12764829/48769920-ce0c9680-ecb4-11e8-8153-6a6a9ed860a4.PNG)

PS 1.7.4.2
Total price = 60
Discounts: (20% = 12) + (15%*(60*80%) = 7.2) + (5%*(60*80%)*(60*85%) = 2.04) = 21.24

![cart-1 7](https://user-images.githubusercontent.com/12764829/48769962-e977a180-ecb4-11e8-9388-e0f0b8455d12.PNG)

PS 1.7.4.2 - incorrect sum in backoffice!
![backoffice-1 7](https://user-images.githubusercontent.com/12764829/48769987-fdbb9e80-ecb4-11e8-9c17-17d725b3a146.PNG)
PS 1.7.4.2 - incorrect sum in invoice!
![invoice-1 7](https://user-images.githubusercontent.com/12764829/48769995-02805280-ecb5-11e8-9a86-20fde085acb0.PNG)

Now the corrected version for 1.7.*:
![cart-1 7-corrected](https://user-images.githubusercontent.com/12764829/48770044-1b890380-ecb5-11e8-9736-18856e070fb7.PNG)
![backoffice-1 7-corrected](https://user-images.githubusercontent.com/12764829/48770046-1e83f400-ecb5-11e8-8f13-e46a2580e113.PNG)




<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11444)
<!-- Reviewable:end -->
