### PR TITLE
Properly set names to utf8 closing #9975

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -81,7 +81,7 @@ class DbPDOCore extends Db
         }
         $dsn .= ';charset=utf8';
 
-        return new PDO($dsn, $user, $password, array(PDO::ATTR_TIMEOUT => $timeout, PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true));
+        return new PDO($dsn, $user, $password, array(PDO::ATTR_TIMEOUT => $timeout, PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true, PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"));
     }
 
     /**
@@ -125,6 +125,11 @@ class DbPDOCore extends Db
             $this->link = $this->getPDO($this->server, $this->user, $this->password, $this->database, 5);
         } catch (PDOException $e) {
             throw new PrestaShopException('Link to database cannot be established: ' . $e->getMessage());
+        }
+        
+        // UTF-8 support
+        if ($this->link->exec('SET NAMES \'utf8\'') === false) {
+			throw new PrestaShopException('PrestaShop Fatal error: no utf-8 support. Please check your server configuration.'.$e->getMessage());
         }
 
         $this->link->exec('SET SESSION sql_mode = \'\'');


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This one solves the issue with wrong encoding when not all server encodings are set to UTF8. This is not the full solution however, other files part of Symphony framework should be edited too as fallows: vendor\doctrine\dbal\lib\Doctrine\DBAL\DriverManager.php after line 154 add: $params['driverOptions'] = array(1002=>'SET NAMES utf8'); vendor\doctrine\dbal\lib\Doctrine\DBAL\Driver\DrizzlePDOMySql\Driver.php  replace line 35 with: public function connect(array $params, $username = null, $password = null, array $driverOptions = array(PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8")) vendor\doctrine\dbal\lib\Doctrine\DBAL\Driver\PDOMySql\Driver.php replace line 37 with: public function connect(array $params, $username = null, $password = null, array $driverOptions = array(PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"))
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11446)
<!-- Reviewable:end -->
