### PR TITLE
Fix admin translation redirect

### DIFF
--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -126,6 +126,7 @@ class TranslationRouteFinder
                 // If module is not using the new translation system -
                 // generate a legacy link for it
                 if (!$this->isModuleUsingNewTranslationSystem($moduleName)) {
+                    $language = $propertyAccessor->getValue($routeProperties, '[language]');
                     $route = $this->link->getAdminLink(
                         'AdminTranslations',
                         true,
@@ -133,6 +134,7 @@ class TranslationRouteFinder
                         [
                             'type' => self::MODULES,
                             'module' => $moduleName,
+                            'lang' => $language,
                         ]
                     );
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | fix language lost when redirecting to module translation edit (module using old translation system)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/11253
| How to test?  | install the module in the ticket. install another language. in BO go to international > translations. choose "module translation', your module and the new language. click "edit". change some translation, save. you should see a file [lang].php in the module directory>translations, containing key hash and the modified translation

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11463)
<!-- Reviewable:end -->
