### PR TITLE
Fix SQL update when last_connection_date is null

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -644,10 +644,12 @@ class EmployeeCore extends ObjectModel
     public static function setLastConnectionDate($idEmployee)
     {
         return Db::getInstance()->execute('
-			UPDATE `' . _DB_PREFIX_ . 'employee`
-			SET `last_connection_date` = CURRENT_DATE()
-			WHERE `id_employee` = ' . (int) $idEmployee . ' AND `last_connection_date`< CURRENT_DATE()
-		');
+            UPDATE `' . _DB_PREFIX_ . 'employee`
+            SET `last_connection_date` = CURRENT_DATE()
+            WHERE `id_employee` = ' . (int) $idEmployee . '
+            AND (`last_connection_date` < CURRENT_DATE()
+            OR `last_connection_date` IS NULL)
+        ');
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow last connexion date to be updated when original value is NULL (not a date)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Log in in your back office, then look at your column `last_connection_date` in your datebase, table `ps_employee`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11469)
<!-- Reviewable:end -->
