### PR TITLE
Changes the redirection url after store update

### DIFF
--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -521,7 +521,7 @@ class AdminShopUrlControllerCore extends AdminController
         }
 
         if ($this->redirect_shop_url) {
-            $this->redirect_after = $object->getBaseURI() . basename(_PS_ADMIN_DIR_) . '/' . $this->context->link->getAdminLink('AdminShopUrl');
+            $this->redirect_after = $this->context->link->getAdminLink('AdminShopUrl');
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | After updating a multistore settings the redirection url was incorrect (double url concatenated in the url)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11364
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11478)
<!-- Reviewable:end -->
