### PR TITLE
Manufacturer Part Number missing in product codes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,6 @@
 GitHub contributors:
 --------------------------------
+- (d)oekia
 - 0kph
 - 123monsite-regis
 - 1RV34
@@ -15,6 +16,8 @@ GitHub contributors:
 - Alban L
 - Aleksander Palyan
 - Alessandro Corbelli
+- Alex Even
+- Alex Sampaio
 - Alexander Galaydyuk
 - Alexander Grosul
 - Alexander Otchenashev
@@ -22,13 +25,10 @@ GitHub contributors:
 - Alexandra Even
 - Alexandre Alouit
 - Alexandre Segura
-- Alexandr Simonchik
 - alexdee2007
 - AlexEven
-- Alex Even
 - Alexey Svistunov
 - alexey-svistunov
-- Alex Sampaio
 - alexsimple
 - Alfakom-MK
 - Alfonso Jimenez
@@ -36,18 +36,21 @@ GitHub contributors:
 - Alphacom IT Solutions - Macedonia
 - amatosg
 - Amazzing
+- Anas Mammeri
 - anat
 - Anatole
 - Andrew
+- Andy Pieters
+- anegoda1995
 - Angel Guzman Maeso
 - Anthony Girard
+- antoin_m
 - Antoine LA
 - Antoine Mille
 - Antoine THOMAS
-- antoin_m
 - Antonino Di Bella
-- antoniofr
 - Antonio Intagliata
+- antoniofr
 - AntonLejon
 - Armando Salvador Perez
 - Arnaud Lemercier
@@ -58,11 +61,13 @@ GitHub contributors:
 - Axome
 - Aylab
 - Aymeric AUBERTON
+- azisyus
 - Azouz-Jribi
 - Balestrino
 - Bastien Bieri
 - bbsimon
 - bellini13
+- Ben Wallis
 - Benjamin PONGY
 - bercik999
 - Bersam Karbasion
@@ -76,15 +81,16 @@ GitHub contributors:
 - Burhan
 - Caleydon Media
 - cam.lafit
+- can
 - Captain FLAM
 - Captain-FLAM
 - Carlos Addis
 - Casper Olsen
 - cava89
 - ccauw
+- Cedric Mouleyre
 - cedricfontaine
 - cedricgeffroy
-- Cedric Mouleyre
 - cgordenne
 - cgordenne_wepika
 - Chafik
@@ -92,7 +98,6 @@ GitHub contributors:
 - Chris
 - Chris Gurk
 - Christian Kubitza
-- christianverardi
 - Christian Verardi
 - ChristopheBoucaut
 - CINS
@@ -112,7 +117,6 @@ GitHub contributors:
 - Cristiano Verardi
 - Cyril Dussert
 - damien
-- DamienMetzger
 - Damien Metzger
 - Damien PIQUET
 - Damon Skelhorn
@@ -125,20 +129,21 @@ GitHub contributors:
 - Dany Maillard
 - dariusakafest
 - David
-- Davide
 - David Eschmeyer
 - David Gasperoni
-- David-Julian BUCH
 - David Sivocha
+- David-Julian BUCH
+- Davide
 - Davy Rolink
+- de saint leger
 - Debusschere Alexandre
 - Denis Yurevich
 - Denver Prophit Jr.
-- de saint leger
 - Desbouche Christophe
 - DevNet
 - devyk
 - Dh42
+- Dhavalkumar Prajapati
 - Dheeraj
 - Dheeraj Sharma
 - Dickriven Chellemboyee
@@ -149,43 +154,38 @@ GitHub contributors:
 - dks295
 - dlage
 - doekia
-- (d)oekia
 - DOEO
 - DogSports
 - Dragan Skrbic
 - DRC
-- dreammeup
 - Dream me up
 - DrySs
-- DrySs'
 - dSevere
 - Dustin
 - Dvir Julius
 - Dvir-Julius
+- e-gaulue
 - ecomm360
 - edamart
 - Edouard Gaulue
-- e-gaulue
+- el-tenkova
 - elationbase
 - eleazar
 - Elitius
-- el-tenkova
 - Emiliano 'AlberT' Gabrielli
 - Emilien Puget
 - emilien-puget
 - emily-d
 - Eolia
-- erickturcios
 - Eric Le Lay
 - Eric Rouvier
+- erickturcios
 - Erwan
 - Etienne Samson
 - Fabien Serny
 - Fabio Chelly
 - Fatma BOUCHEKOI
-- fatmaBouchekoua
 - Fatma Bouchekoua
-- fatma.bouchekoua
 - fchellypresta
 - Felipe Uribe
 - fetis
@@ -199,13 +199,14 @@ GitHub contributors:
 - Florian Nolte
 - Flowster
 - fojtcz
-- fouratachour
 - Fourat ACHOUR
 - fram
 - Francisco Jiménez Cabrera
+- FranckRIBEIRO
 - FrancMunoz
 - Francois Gaillard
 - Francois-Marie de Jouvencel
+- Fransuisse
 - Frederic BENOIST
 - Gabriel Arama
 - Gabriel Schwardy
@@ -232,21 +233,22 @@ GitHub contributors:
 - gskema
 - Guilhem Fanton
 - Guillaume DELOINCE
+- Guillaume Durand
 - Guillaume Germain
-- GuillaumeKadolis
 - Guillaume Lafarge
 - Guillaume Leseur
 - Guillaume Marsille
 - Guillaume P
+- GuillaumeKadolis
 - Guisardo
 - Gustavo
 - Gytis
 - Gytis Skėma
+- Ha!*!*y
 - ha99y
 - hadjedjvincent
 - hadrich-hatem
 - harelguy
-- Ha!*!*y
 - hhennes
 - hibatallahAouadni
 - hiousi
@@ -262,36 +264,39 @@ GitHub contributors:
 - iqit-commerce
 - ironwo0d
 - Ish Gupta
+- Ishiki
 - ITBpro.com
 - Ivan
-- ivancasasempere
 - Ivan Shcherbakov
+- ivancasasempere
+- J. Danse
 - Jachym Tousek
 - janisVincent
 - Jaume
 - Javsmile
-- J. Danse
 - jbroutier
 - JEAN
 - jeanbe
 - jeckyl
 - Jeremie Tabet
 - Jeroen Dewaele
+- Jérôme H
 - Jerome Herry
-- jeromenadaud
 - Jérôme Nadaud
-- Jerome Nadaud
+- jeromenadaud
 - jessylenne
 - jestemradek
+- jf-viguier
 - jGissinger
 - Joan
 - Joan Juvanteny
 - joce
-- jocelyn fournier
+- Jocelyn Fournier
+- Joe Siwiak
 - Joel Sanchez
 - joemartin247
 - Joep Hendrix
-- Joe Siwiak
+- Johannes Schramm
 - Jonadabe
 - Jonatan Nunez
 - Jonathan Danse
@@ -301,10 +306,10 @@ GitHub contributors:
 - joseantgv
 - jtogrul
 - Juan G. Jordan
+- JuanjoSCu
 - Juha Remes
 - Julien
 - Julien Bouchez
-- julienbourdeau
 - Julien Bourdeau
 - Julien Deniau
 - Julien Martin
@@ -326,6 +331,7 @@ GitHub contributors:
 - Lathanao
 - ldecoker
 - Lea Mendes Da Silva
+- Leandro F. L
 - Leo
 - Lesley Paone
 - LittleBigDev
@@ -334,17 +340,19 @@ GitHub contributors:
 - Louise Bonnard
 - lozal2244
 - Luc
-- LucasC
+- Luc Vandesype
+- Luca T.
 - Lucas CERDAN
 - Lucas Rolff
-- Luca T.
-- Luc Vandesype
-- LyoNick
+- LucasC
 - Lyo Nick
+- LyoNick
+- M-Mommsen
 - M03G
 - MacRoy
 - Madef
 - Madman
+- mahdi
 - Mahdi Shad
 - Mainmich
 - makk1ntosh
@@ -359,16 +367,19 @@ GitHub contributors:
 - Marek Hanuš
 - Marion François
 - Marius
-- MarkC
 - Mark Wienk
-- martinfojtik
+- MarkC
 - Martin Fojtik
+- martinfojtik
 - Mateusz Nastalski
+- Mathias Reker
 - Mathieu Ferment
 - matiasiglesias
 - Mats Rynge
+- Matt75
 - Matteo
 - Matteo Spreafico
+- Matthieu Mota
 - MatthieuB
 - MattLoyeD
 - mauglee
@@ -376,10 +387,10 @@ GitHub contributors:
 - Maxence
 - Maxence de Flotte
 - Maxime
+- Maxime - Vaisonet
 - maxime aknin
 - Maxime Biloé
 - Maxime Morel-Bailly
-- Maxime - Vaisonet
 - Maxime Vasse
 - Mbechezi Mlanawo
 - mchelh
@@ -388,6 +399,7 @@ GitHub contributors:
 - MDWeb
 - Mehdi
 - Mehdi Badrani
+- mehdi-ghezal
 - Mehrshad
 - mehrshadz
 - melvin
@@ -408,7 +420,6 @@ GitHub contributors:
 - minic studio
 - Mirko Esposito
 - misthero
-- M-Mommsen
 - Molka DJEMAL
 - moncef102
 - montes
@@ -438,14 +449,15 @@ GitHub contributors:
 - okom3pom
 - oleacorner
 - Olivier Bonvalet
+- Oskar Andersson
 - Otto Nascarella
 - Pablo Borowicz
 - paeddl
-- Panagiotis Tigas
-- panesarsandeep
 - Pan P
 - Pan P.
 - Pan Ploenes
+- Panagiotis Tigas
+- panesarsandeep
 - Patanock
 - Patrick Mettraux
 - Patrick Weinstein
@@ -453,9 +465,11 @@ GitHub contributors:
 - pbirnzain
 - Pedro Câmara
 - Pedro J. Parra
+- Pedro Rendeiro
+- PedroRendeiro
 - Per Lejontand
-- peterept
 - Peter Schaeffer
+- peterept
 - Petyuska
 - PhpMadman
 - Pierre
@@ -468,11 +482,11 @@ GitHub contributors:
 - Piotr Moćko
 - Pliciweb - Nicolas
 - Praneeth Nidarshan
+- Presta Module
 - PrestaEdit
 - PrestaLab
 - PrestaMagician
 - prestamodule
-- Presta Module
 - PrestanceDesign
 - Prestanesia
 - prestarocket
@@ -492,8 +506,8 @@ GitHub contributors:
 - Rafael Cunha
 - Raphael
 - Raphael Droz
-- raphael-homann
 - Raphael Malie
+- raphael-homann
 - raulgundin
 - rav88
 - rdy4ever
@@ -509,19 +523,23 @@ GitHub contributors:
 - Robbie Thompson
 - robert
 - Rokas
+- Rokas Zygmantas
 - Roland Schütz
 - romainberger
 - Roman Gusev
 - Roy
 - RS
 - Ruben Martins
+- Rudra Sarkar
 - runningz
+- s-duval
 - Sacha
 - Sacha FROMENT
 - sadlyblue
 - sagaradonis
-- Samir Shah
+- sallemiines
 - Sam Sanchez
+- Samir Shah
 - Samy Rabih
 - sandu
 - sandu velea
@@ -529,14 +547,16 @@ GitHub contributors:
 - Šarūnas Jonušas
 - Saycile
 - sbordun
-- s-duval
 - Seb
 - Sebastien
 - Sébastien Bareyre
 - Sebastien Bocahu
+- Sébastien LE BRUCHEC
 - Sebastien Monterisi
 - Sébastien Rufer
 - SebSept
+- seleda
+- Sergey P
 - Sergio Quinonez
 - Serhat Durum
 - Serhii Polishchuk
@@ -548,6 +568,7 @@ GitHub contributors:
 - Shipow
 - Shudrum
 - sidhujag
+- Simone
 - sjousse
 - sLorenzini
 - smartdatasoft
@@ -581,23 +602,26 @@ GitHub contributors:
 - Thoma
 - thoma202
 - Thomas
-- thomas-aw
 - Thomas Blanc
 - Thomas Ferney
 - Thomas LEVIANDIER
 - Thomas N
 - Thomas Nabord
+- thomas-aw
 - Threef
 - tiledcode
 - timactive
 - timsit
 - tmackay
 - TMMeilleur
+- tolispy
+- Tom Panier
+- Tomas
+- Tomas Ilginis
 - Tomas Liska
 - Tomas Votruba
 - Tomasz Slominski
 - tomek
-- Tom Panier
 - Tony BOTALLA
 - Travis-CI
 - tucoinfo
@@ -612,20 +636,21 @@ GitHub contributors:
 - venditdevs
 - Vincent Augagneur
 - Vincent Beudez
-- vincentbz
 - Vincent HADJEDJ
 - Vincent Schoener
 - Vincent Terenti
 - Vincent Van den Brink
+- vincentbz
 - vinvin27
 - vinzter
 - Vitaly Kondratiev
 - vitekj
 - vmamykin
 - Wayann
+- Web Premiere
+- web-plus
 - webbax
 - webmake
-- web-plus
 - Wojciech Grzebieniowski
 - Xavier
 - Xavier Borderie
@@ -638,11 +663,13 @@ GitHub contributors:
 - Yannick Armand
 - Yolandavdvegt
 - Yoozio
+- yosra.akrout
 - Yuri Blanc
 - zimmi1
 - ZiZuu.com
 - Zollner Robert
 - zuzul
+
 
 SVN contributors:
 --------------------------------

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -24,6 +24,370 @@ International Registered Trademark & Property of PrestaShop SA
 Release Notes for PrestaShop 1.7
 --------------------------------
 ####################################
+#   v1.7.5.0 - (2018-11-08)
+####################################
+- Back Office:
+  - New feature:
+    - #10906: Add new native module ps_faviconnotificationbo
+    - #10414: Link modules routes, position column and extension, GridPositionUpdater
+    - #10422: Add stock location through ps_stock_available table
+    - #10234: Migration of Shop parameters -> Traffic & Seo -> Seo & urls page
+    - #9444: Add search engine result preview on product page
+    - #10208: Migration of Advanced Parameters -> Webservice -> listing
+    - #9465: Enable 'edit specific price' button on BO Product page which opens a pop-in
+    - #9449: Migration of Improve -> International -> Translations page
+    - #9305: Introduce ToggleColumn for Grid component
+    - #9310: Migrate "Configure > Advanced Parameters > Webservices" - part 1 (configuration form)
+    - #9457: Enable Logs page
+    - #9377: Migrate E-mail page
+    - #8984: Introduced advanced and reusable search system
+    - #9153: Be able to declare modern controllers in modules
+    - #9192: Migrate Payment methods page
+  - Improvement:
+    - #11035: Optimize legacy links in dev mode
+    - #11063: Improve PositionColumn to allow more route params
+    - #10868: Manage backward compatibility of legacy links
+    - #10901: Make Logger stdout configurable using env variables
+    - #10725: Hide delete button on ordered cart
+    - #10569: Update Grid definition Ids
+    - #10529: Implement empty states aka Showcase blocks
+    - #10440: Change categories in Module Manager
+    - #10485: Minor migrated Webservice improvements
+    - #9287: Separate module action buttons
+    - #10426: Handle boolean returns from RequestSql validation
+    - #10416: Improve perceived form horizontal alignment
+    - #10311: Small improvements for Webservice list
+    - #10358: Update list and settings layout
+    - #10265: Move Logs page JS to appropriate location
+    - #9471: Build Back Office default theme using Webpack 4
+    - #10170: Small ux optimizations
+    - #9454: Notifications tab + new hierarchy
+    - #9451: Replace PrestaTrust property with setter
+    - #9228: Migrate module positions
+    - #9447: Migrate Backup page
+    - #9430: Update modern forms layout
+    - #8710: Improved Product catalogAction
+    - #9206: Migrate "Configure > Advanced Parameters > Database > SQL Manager" page
+    - #9397: Update style of forms on new pages
+    - #8690: Improved performance of Product List page
+    - #9410: Improve grid search and reset buttons
+    - #9306: Add a link to the addons' favicon generator
+    - #9242: Introducing reusable way to display KPIs blocks in Back Office modern pages
+    - #9225: Migrate "Improve > Payment > Preferences" page
+    - #9210: Duplicate array keys
+    - #9137: Improve routing of PrestaShop application
+    - #9139: Migrate Sell > Orders > Delivery Slips
+  - Bug fix:
+    - #11182: The deletion of themes must depends on Employee permissions
+    - #10898: Fixed performance rights on Performance Clear Cache action
+    - #11136: Fix param name on email delete all bulk action
+    - #11123: Make the E2E tests wait for the first load of the BO with welcome module enabled
+    - #11111: Revert "Apply quotes around the column names would make all the SQL r…
+    - #11071: Avoid glitch on checkbox click
+    - #10991: Fix sorting issue in the SQL Manager page
+    - #10861: Fix fixed height of TinyMce fields
+    - #10718: Add missing styles on empty state SEO & Traffic page
+    - #11032: Min height product image dropzone
+    - #10936: Prevent unvalidated form without checkboxes
+    - #10436: Style issue on BO
+    - #10968: Fix General options configuration
+    - #10967: Fix Bad annotations (backport of #10939)
+    - #10949: Update help panel position on legacy pages
+    - #10856: Fatal error when saving product with tags
+    - #10946: Allow errors without field to be displayed on product form
+    - #10950: Update module breadcrumb in category page
+    - #10810: Allow URL in search result preview to be live updated
+    - #10684: Avoid displaying the addon modal twice, change form names/IDs to avoid collision
+    - #10857: Use parent javascripts used for displaying help
+    - #10862: Fixes bug when filter reset functionality sometimes does not work
+    - #10751:  [BO] Fix bug when filter stores by name or address
+    - #10835: Fix import module
+    - #10814: Restore legacy sql manager page 175
+    - #10778: Enable pagination when offset is set
+    - #10788: Allow url in search preview to use several lines
+    - #10796: Reuse getAdminLink instead of copy pasting its content
+    - #10752: Use the right PrestaShop namespace for twig templates
+    - #10735: Module translations aren't working when using Smarty Extend into TPL in BO
+    - #10741: Fix import form alignment
+    - #10728: FilterParametersUpdater manages filters in a better way
+    - #10462: Fix wrong display of the brand page
+    - #10726: Module manager improvement (search, categories, configure button)
+    - #10736: Use new routes for quick access
+    - #10681: Fix module catalog js & css issues
+    - #10705: Move position column template
+    - #10656: Fix grid ids in migrated JS
+    - #10601: Use attr('data-') instead of data
+    - #10448: Fatal error while adding tags
+    - #10382: Bug when advanced stock management is enabled in Product Shipping page
+    - #10571: Fix broken service definition
+    - #8237: Fixed bug in AdminGroupsController when adding ModulesRestrictions to group in multishop configuration
+    - #10435: Removed onclick from URL column in BO Shop URLs
+    - #10427: Get link of the first ACTIVE tab in nav
+    - #10295: Display the company name in outstanding orders
+    - #10291: Fix the display of textarea in the category page
+    - #10375: Fix category tree in BO Products Catalog page
+    - #10361: Only load Vue Serp component if available
+    - #10135: PDF documents unformatted
+    - #9324: Fixed the Show SQL query action
+    - #10202: Fix 'edit specific price' modal behavior bugs and display
+    - #9453: Allow import entity to be preselected
+    - #10322: Wrong variable name
+    - #10326: Manage getAdminBaseLink in LegacyContext::getAdminLink
+    - #10302: Images aren't displayed in combinations with new products
+    - #10281: Fixed minor issues on Logs Grid page
+    - #10260: Fix help sidebar not working in the Stock page
+    - #10223: Fixed DB backup page
+    - #10221: Product Page: fix visual glitches in categories filter
+    - #10242: Fix wrong translations
+    - #10233: HookDispatcher dispatchMultiple doesn't exists anymore
+    - #10169: Images aren't displayed in combinations
+    - #10201: Errors when saving memcached configuration
+    - #10165: Add form handler for Translations settings forms
+    - #10139: Remove legacy AdminBackup controller
+    - #9352: Fix 'recommended modules' popin behavior in BO
+    - #9466: Fix combination generation
+    - #10042: With undefined function call (Fixed #10041)
+    - #9450: Modify Link::getAdminLink in MultipleShop mode
+    - #9407: Display NOK PrestaShop requirements
+    - #9455: Removed all translations errors from localization page
+    - #9334: Fix sample file download & fields load via ajax in Import
+    - #9399: Fix ajax in 500 in product page
+    - #9389: Fixed path to updated files in System Information page
+    - #9259: Make PrestaShop fully compatible with Twig 2+
+    - #9369: Combinations not working when token is disabled
+    - #9318: Make documentation link on the dashboard point to the 1.7 docs instead of 1.6
+    - #9333: Small fixes for Sell -> Orders -> Invoices page
+    - #9267: Unable to copy theme translations
+    - #9286: Grid/reset action
+    - #9300: Fix grid sorting by
+    - #9265: Can't upload an image in the product page
+    - #9255: Fix rendering of theme catalog page
+    - #9235: Corrects a bug when importing store contacts
+    - #9215: Adapted module URLs for new routing
+    - #9195: Fixed mixed up display in some cases at partial refunds
+    - #9198: Add use statement for AppKernel
+    - #9171: Fixed namespace of Delivery Slips controller
+    - #9170: Fix smarty condition count
+    - #9149: Error with quota fields
+
+- Front Office:
+  - Improvement:
+    - #11156: Rollback product canonical
+    - #11084: Update modules for new 1.7.5 version
+    - #11015: Adding/Deleting voucher on checkout payment step should refresh amount on payment block
+    - #10229: Mobile Menu: improve UX/UI of the mobile menu
+    - #10484: Fix: classic theme footer block design #10483
+    - #9459: Show the category block in the list page on first page only
+    - #9472: Modify category pagination for SEO purposes
+    - #9362: Add breadcrumb to the contact page
+    - #9456: Modify product canonical url and title value
+    - #10207: Voucher button is too long in Cart
+    - #9458: Change brand and supplier default rule for SEO purposes
+    - #9463: Change the default redirection behaviour to product category
+    - #9417: Override CustomerAddressForm->submit method more easily
+    - #9097: Fix phone fieldtype
+    - #9110: Make checkbox labels clickable on the classic theme
+  - Bug fix:
+    - #11055: Fix minimum quantity blocking
+    - #10812: Display the specific reference for each combination's product
+    - #10447: Double h1 tag on category page
+    - #10750: Do not display product Reference if empty
+    - #10428: Fixes issue #10417 incorrect argument order
+    - #10438: Fix for Issue #10433 : Update lastName and firstName max size
+    - #10267: Product List: pack flag visual problem
+    - #10350: Fix empty row when social title is empty
+    - #10347: Fix htaccess to support Apache 2.4 webservers
+    - #10352: Fix htaccess to support Apache 2.4 webservers
+    - #10279: Check minimal quantity
+    - #10254: Fix getTotalWeight Notice
+    - #10232: Generate front core assets
+    - #10230: Add magic methods on LazyArray classes for object-like use
+    - #9387: Fix for browser back button on product page
+    - #10195: Fix the bootstrap classes for left-column ID
+    - #9405: Error when adding product in cart or editing quantity
+    - #9469: Do not display product Specific References if empty
+    - #9462: Fix wrong rules in robots.txt
+    - #9441: Fix 403 error when accessing localhost using IPv6 (Maxmind Database exists)
+    - #9422: Add missing appendArray in OrderReturnLazyArray (BOOM-6039)
+    - #9433: Add customizations field in product whitelist
+    - #9445: Change out of stock condition with greater or equals
+    - #9446: Fix welcome page variable injection by adding missing %
+    - #9429: Add formatted field file_size_formatted in attachments
+    - #9390: Combination issue while trying to change size on a product page
+    - #9403: Convert ProductLazyArray when using render function
+    - #9368: Detect if there is already GET param in URL
+    - #9372: Update OrderFollowController.php
+    - #9381: Fix label "Use this address for invoice too'"
+    - #9373: Prevent users from doubleclick on Payment button from #9351
+    - #9276: Fix product quantity in order return details table
+    - #9353: Correctly handle hyphens in search index
+    - #9219: Fix delivery time not shown
+    - #9214: Fix products pagination without URL rewriting
+    - #9211: Updated page parameter name in Link and Meta classes
+    - #9069: Fix gift wrapping fees
+
+- Core:
+  - New feature:
+    - #9281: Allow overriding of every part of Grid templates
+    - #9460: Implementation of CQRS in SqlManager page
+    - #10241: Add Tactician command/query bus
+    - #9344: Add function to display information message
+    - #9230: Migration of Sell > Orders > Invoices page
+    - #9094: Migrate Improve > Shipping > Preferences controller
+    - #8990: Introduced Grid system
+    - #9116: Migrate localization page
+    - #9174: Added a service to manage PrestaShop versions (may deprecate _PS_VERSION_)
+    - #9121: Make commands from PrestaShop modules available in PrestaShop application
+    - #9007: Migrate Shop parameters -> Order settings page
+  - Improvement:
+    - #11068: Prevent CS Fixer from adding a trailing dot to the first paragraph of phpdoc
+    - #11078: Update dependency for security reason
+    - #10905: Update catalog
+    - #10883: Missing translations
+    - #10863: Update translations catalog for 1.7.5
+    - #10662: Update native modules
+    - #10464: Undeclared property in the PaymentModule class
+    - #9292: Update pull-request template with additional PR types
+    - #9402: Improve grid data providers
+    - #9356: Add new variable in product.php, to sort features in front
+    - #10219: Minor grid improvements
+    - #8744: Prefer Hook::coreRenderWidget
+    - #10151: Replaced Forge URL with GitHub issues
+    - #9396: Update version to 1.7.5.0
+    - #10138: Avoid a DB query in Address:isUsed() in case of new Address
+    - #9470: Refactored the Grid component
+    - #10110: Replace Forge with GitHub issues in PR template
+    - #9440: Ease CustomerAddressForm customization
+    - #9437: Introducing HookDispatcherInterface
+    - #9554: Update links to use GitHub issues in README.md and CONTRIBUTING.md
+    - #9467: Build core theme using Webpack 4 and jQuery 2.2.4
+    - #9461: Update Readme
+    - #9442: Decouple filters and columns
+    - #9428: Added a new hook to custom SwiftMessage before sending mail
+    - #9452: Small naming update in grid
+    - #7612: Added new actionFrontControllerSetVariables hook
+    - #9291: Small FrameworkBundleAdminController clean up
+    - #9426: Add comment line to Address.php
+    - #9432:  Make it unnecessary to append a '_' to the controller name when using the AdminSecurity annotation
+    - #9424: Issues templates
+    - #9404: Add gsitemap
+    - #9320: Phpdocs2
+    - #9384: Update README.md
+    - #9342: Make grid.js more extendable
+    - #8904: Add new presenter implementation optimized for performances (lazy loading)
+    - #9319: Phpdocs
+    - #9250: Implement addBefore() & addAfter() methods of ColumnCollection
+    - #9264: Avoid AJAX request if we didn't have a refresh URL in the core cart JS file
+    - #9293: Rename routing file catalog.yml to _catalog.yml to follow routing structure
+    - #9282: Cleanup ModuleTemplateLoader
+    - #9283: Update column naming
+    - #9256: Improve resolving of column options
+    - #9254: Merge 1.7.4.x in develop
+    - #9201: Refactor Version class and client code and add unit tests
+    - #9208: Glob and scandir without sorting are faster
+    - #9229: Merge 1.7.4.x in develop
+    - #9207: Replace array_push calls behaving as $array[] since it works faster than invoking functions in PHP
+    - #9199: Introduced Survival tests for new modern pages
+    - #9205: Improve form choice providers
+    - #9209: Callable calls in loops, repetitive calls
+    - #9204: Remove leftover routing files
+    - #9176: Migrate "Improve > International > Localization > Geolocation" page
+    - #9066: Refactor Dispatcher::useDefaultController()
+    - #9182: Merge 1.7.4.x in develop
+    - #9154: Migrate Theme Catalog Page of Design Section
+    - #9162: Remove useless line for meta_title
+    - #8956: Add customization ID to cart ajax response and updateCart event data
+    - #9163: Case mismatch in class/function/method call
+    - #9155: Updated contributor list
+    - #9146: Merge 1.7.4.x in develop
+    - #9037: Permit IDE completion with PHP doc
+    - #9096: Clean up service yml files
+    - #9067: Refactor Controller class (minor changes)
+    - #9115: 1.7.4.x into develop
+    - #9109: 1.7.4.x into develop
+    - #9053: Add missing package-lock.json files
+    - #9091: Update develop with 1.7.4.x changes
+    - #9056: Deprecate polyfill function array_replace()
+    - #9068: Refactor Cart::checkQuantities()
+    - #9062: Improved errors management if Dev mode is enabled
+    - #9071: Refactor AbstractCartTest
+    - #9061: Removed redundant checks and added docblock in Tools::getIsset function
+    - #9035: Add package-lock.json file
+  - Bug fix:
+    - #10446: Increase max size of reference, meta_title, meta_description email, password, firstname, lastname and company.
+    - #11066: Fix wording in wrong domain
+    - #11076: Fix wordings
+    - #10933: Fix translation catalog
+    - #11030: Harmonize migrated controllers
+    - #10865: Fix compatibility with PHP 5.6 for PS exception
+    - #10840: Update Smarty and Symfony to latest
+    - #10837: Remove rebuild of SymfonyRequirements file after every composer run
+    - #10795: Use https only for API calls and limit use of guzzle
+    - #10696: Check $sfRouter before using it
+    - #10743: Execute query modification hook before fetching data
+    - #10376: Update HTML purifier
+    - #10419: Change Javascript indent to 2 spaces, per AirBnb rules
+    - #10363: Fix undefined method in query parser
+    - #10337: Remove hard-coded-version in assets URL
+    - #9475: Make title different from meta title on CMS for SEO purpose
+    - #10287: Fixed pre-commit hook script
+    - #10227: Fixed error with inheritance
+    - #9343: Fix function comment of Module class
+    - #10200: Bring back Addons Catalog controller
+    - #10218: Fix falsy value returned by upgrade script
+    - #10182: Fix deprecated call to Tools::replaceByAbsoluteURL
+    - #10155: Fix trusted modules cache creation
+    - #9474: Files from translations folder can not be accessed
+    - #9436: Remove unused taxes
+    - #9244: Fixed Apache Optimization
+    - #9285: Allow more than 36 products per page
+    - #9386: Merge 1.7.4.2 into develop
+    - #9047: Fixed nginx config for symfony controllers
+    - #9289: Version/update release creator
+    - #9145: Bug correction when changing shipped state
+    - #9231: Fixed missing call of ObjectModel hooks in CMSCategory::delete()
+    - #9257: Allow overriding getRobotsContent in Tools.php
+    - #9234: Fix override handling when PS_DISABLE_OVERRIDES is used
+    - #9243: Fix show sql action in logs page
+    - #9120: Fix empty text transformer to not treat zero as empty text
+    - #9241: Fix Version service namespace usage
+    - #9203: Fixed bug with friendly URLs and Media Servers
+    - #9190: Fixed DataConfigurationInterface PHPDoc
+    - #9105: Check if key exists before checking the value
+    - #9156: Fix missing security event listeners registration
+    - #9140: Update composer dependencies
+    - #9122: Add safety returns after ajaxRender calls
+    - #9039: Ajax will never die
+    - #9095: Fix translations order settings and remove unused templates
+    - #9050: Fix HookConfigurator: Filter certain non-arrays from theme.yml
+    - #9098: Rename variable $producPropertiesCache (fix typo)
+
+- Installer:
+  - New feature:
+    - #9401: Check at installation if PrestaShop version is the latest
+  - Improvement:
+    - #10909: Made the installed theme configurable
+    - #9340: Update rel="noopener noreferrer"
+    - #10106: Add Galician language in the installer
+    - #10104: Add Latvian language in the installer
+    - #9414: Add arabic language in installer
+    - #9411: Indian Localization improved
+  - Bug fix:
+    - #11206: Installer: always clean test assets even if filesystem tests fail, an…
+    - #11209: Ignore irrelevant SF warning aout composer at install
+    - #10296: Init Kernel when possible during installation process
+    - #10410: Fix fixtures inconsistencies
+    - #9464: Fix geolocation whitelist
+    - #9425: Fix step name retrieved in the installer
+    - #9409: Symfony requirements file now compatible with PHP 7.2
+
+- Web Services:
+  - Bug fix:
+    - #10117: Fix bug shipping number is empty in {followup}
+    - #9439: Fix Error 500 from API request with PHP 7.2
+    - #9202: Preserve position in category when adding a new Product using Web services
+
+####################################
 #   v1.7.4.3 - (2018-07-27)
 ####################################
 - Core:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Manufacturer Part Number is missing in the product codes section.<BR>An additional field in which you can enter the manufacturer's number (digits or letters) will improve the indexing and searching. It will also have a positive effect on SEO.<br>The SKU number is used to identify the product internally in the online and stationary store. Practically, it does not have to be visible to the customer.<br>The MPN number is used to identify a specific product of a given manufacturer. Here you can apply the "mpn" field according to Schema.org<br>Cataloging can be very useful in stores offering automotive spare parts, but also in other industries.<br>You could add extra filed to enter MPN in the Product Options tab, just near EAN, UPC and ISBN codes.

| Type?         | new feature
| Category?     | CO
| BC breaks?    | yes
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11498)
<!-- Reviewable:end -->
