### PR TITLE
Fix wrong protocol in the File Manager Dialog

### DIFF
--- a/admin-dev/filemanager/dialog.php
+++ b/admin-dev/filemanager/dialog.php
@@ -347,9 +347,9 @@ if (isset($_POST['submit'])) {
     ?>"/>
 	<input type="hidden" id="descending" value="<?php echo $descending ? "true" : "false";
     ?>"/>
-	<?php $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https" : "http";
+	<?php $protocol = Tools::getShopProtocol();
     ?>
-	<input type="hidden" id="current_url" value="<?php echo str_replace(array('&filter='.$filter), array(''), $protocol."://".$_SERVER['HTTP_HOST'].Tools::safeOutput($_SERVER['REQUEST_URI']));
+	<input type="hidden" id="current_url" value="<?php echo str_replace(array('&filter='.$filter), array(''), $protocol.$_SERVER['HTTP_HOST'].Tools::safeOutput($_SERVER['REQUEST_URI']));
     ?>"/>
 	<input type="hidden" id="lang_show_url" value="<?php echo Tools::safeOutput(lang_Show_url);
     ?>"/>

--- a/admin-dev/filemanager/dialog.php
+++ b/admin-dev/filemanager/dialog.php
@@ -347,7 +347,7 @@ if (isset($_POST['submit'])) {
     ?>"/>
 	<input type="hidden" id="descending" value="<?php echo $descending ? "true" : "false";
     ?>"/>
-	<?php $protocol = 'http';
+	<?php $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https" : "http";
     ?>
 	<input type="hidden" id="current_url" value="<?php echo str_replace(array('&filter='.$filter), array(''), $protocol."://".$_SERVER['HTTP_HOST'].Tools::safeOutput($_SERVER['REQUEST_URI']));
     ?>"/>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | The URL protocol has hard-code to "HTTP". I have change it to check for HTTPS by using the $_SERVER['HTTPS'].
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| How to test?  | Open the file dialog in the product description

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11526)
<!-- Reviewable:end -->
