### PR TITLE
Disable oProxyCommand when imap.enable_insecure_rsh does not exists

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1224,4 +1224,20 @@ class ValidateCore
     {
         return (bool) preg_match('/^[\w-]{3,255}$/u', $theme_name);
     }
+
+    /**
+     * Check if enable_insecure_rsh exists in
+     * this PHP version otherwise disable the
+     * oProxyCommand option.
+     *
+     * @return boolean
+     */
+    public static function isValidImapUrl($imapUrl)
+    {
+        if (false === ini_get('imap.enable_insecure_rsh')) {
+            return preg_match('~^((?!oProxyCommand).)*$~i', $imapUrl);
+        }
+
+        return true;
+    }
 }

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1230,7 +1230,7 @@ class ValidateCore
      * this PHP version otherwise disable the
      * oProxyCommand option.
      *
-     * @return boolean
+     * @return bool
      */
     public static function isValidImapUrl($imapUrl)
     {

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -167,6 +167,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         'title' => $this->trans('IMAP URL', array(), 'Admin.Catalog.Feature'),
                         'hint' => $this->trans('URL for your IMAP server (ie.: mail.server.com).', array(), 'Admin.Catalog.Help'),
                         'type' => 'text',
+                        'validation' => 'isValidImapUrl',
                     ),
                     'PS_SAV_IMAP_PORT' => array(
                         'title' => $this->trans('IMAP port', array(), 'Admin.Catalog.Feature'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Disable oProxyCommand when imap.enable_insecure_rsh does not exists.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | try to add `x -oProxyCommand="test"` in imap url.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11533)
<!-- Reviewable:end -->
