### PR TITLE
Display the right front url in multistore menu

### DIFF
--- a/admin-dev/themes/default/template/helpers/shops_list/list.tpl
+++ b/admin-dev/themes/default/template/helpers/shops_list/list.tpl
@@ -55,7 +55,7 @@
                                     <i class="material-icons">&#xE869;</i>
                                 </a>
                             {else}
-                                <a class="link-shop" href="{$shop_data['uri']}" target="_blank">
+                                <a class="link-shop" href="{$link->getBaseLink($shop_data['id_shop'])}" target="_blank">
                                    <i class="material-icons">&#xE8F4;</i>
                                 </a>
                             {/if}

--- a/admin-dev/themes/new-theme/template/helpers/shops_list/list.tpl
+++ b/admin-dev/themes/new-theme/template/helpers/shops_list/list.tpl
@@ -50,7 +50,7 @@
                               <i class="material-icons">&#xE869;</i>
                             </a>
                         {else}
-                            <a class="link-shop" href="{$shop_data['uri']}" target="_blank">
+                            <a class="link-shop" href="{$link->getBaseLink($shop_data['id_shop'])}" target="_blank">
                               <i class="material-icons">&#xE8F4;</i>
                             </a>
                         {/if}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The front url in multistore menu was incorrect, it didn't use the specific domain of each shop.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11493
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11535)
<!-- Reviewable:end -->
