### PR TITLE
Correct logo width on small screens in theme classic

### DIFF
--- a/themes/classic/assets/css/error.css
+++ b/themes/classic/assets/css/error.css
@@ -8,7 +8,7 @@
   -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3); }
-#layout-error .logo {
+#layout-error .logo > img{
   max-width: 100%;
   height: auto; }
 @media (min-width: 1200px) {

--- a/themes/classic/assets/css/error.css
+++ b/themes/classic/assets/css/error.css
@@ -8,6 +8,9 @@
   -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3); }
+#layout-error .logo {
+  max-width: 100%;
+  height: auto; }
 @media (min-width: 1200px) {
   #layout-error {
     margin: 126px 0 0 0;


### PR DESCRIPTION
The logo reduced its size if necessary so that it fits inside the screen

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Correct logo width on small screens in theme classic
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | none.
| How to test?  | Activate maintenance mode and resize the window of your internet browser.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11551)
<!-- Reviewable:end -->
