### PR TITLE
Keep first try of translator initialization in memory

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -349,10 +349,7 @@ class ContextCore
         }
 
         $translator = $this->getTranslatorFromLocale($this->language->locale);
-        // In case we have at least 1 translated message, we return the current translator.
-        if (count($translator->getCatalogue($this->language->locale)->all())) {
-            $this->translator = $translator;
-        }
+        $this->translator = $translator;
 
         return $translator;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Keep in memory first try of translator initialization. This prevent too many & unnecessary loads of catalog
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Translations are still working

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11559)
<!-- Reviewable:end -->
