### PR TITLE
Fix shop name in the subject of mail

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -458,7 +458,7 @@ class MailCore extends ObjectModel
             );
 
             /* Create mail and attach differents parts */
-            $subject = '[' . Configuration::get('PS_SHOP_NAME', null, null, $idShop) . '] ' . $subject;
+            $subject = '[' . $shop->name . '] ' . $subject;
             $message->setSubject($subject);
 
             $message->setCharset('utf-8');
@@ -498,7 +498,7 @@ class MailCore extends ObjectModel
                 Context::getContext()->link = new Link();
             }
 
-            $templateVars['{shop_name}'] = Tools::safeOutput(Configuration::get('PS_SHOP_NAME', null, null, $idShop));
+            $templateVars['{shop_name}'] = Tools::safeOutput($shop->name);
             $templateVars['{shop_url}'] = Context::getContext()->link->getPageLink(
                 'index',
                 true,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The name of the shop is incorrect in the subject of the email "Product out of stock" or "Welcome", "Order confirmation",.. when multishop is enabled.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11081
| How to test?  | 1- Install the module ps_emailalert => 2- Enable the option out of stock => 3- Enable multishop ( share quantities is disabled ) => 4- Create a second shop with the name "Shop 2" => 5-Create a product "Prod" exist only in the Shop 2 => 6- Set the quantity of "Prod" to -2=> 7- An email is sent to the administrator to alert the out of stock of the product "PROD"
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11564)
<!-- Reviewable:end -->
