### PR TITLE
Clear cache on module action

### DIFF
--- a/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
+++ b/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
@@ -58,8 +58,6 @@ class ModuleTabManagementSubscriber implements EventSubscriberInterface
         return [
             ModuleManagementEvent::INSTALL => 'onModuleInstall',
             ModuleManagementEvent::UNINSTALL => 'onModuleUninstall',
-            ModuleManagementEvent::ENABLE => 'onModuleEnable',
-            ModuleManagementEvent::DISABLE => 'onModuleDisable',
         ];
     }
 
@@ -75,22 +73,6 @@ class ModuleTabManagementSubscriber implements EventSubscriberInterface
      * @param ModuleManagementEvent $event
      */
     public function onModuleUninstall(ModuleManagementEvent $event)
-    {
-        $this->moduleTabUnregister->unregisterTabs($event->getModule());
-    }
-
-    /**
-     * @param ModuleManagementEvent $event
-     */
-    public function onModuleEnable(ModuleManagementEvent $event)
-    {
-        $this->moduleTabRegister->registerTabs($event->getModule());
-    }
-
-    /**
-     * @param ModuleManagementEvent $event
-     */
-    public function onModuleDisable(ModuleManagementEvent $event)
     {
         $this->moduleTabUnregister->unregisterTabs($event->getModule());
     }

--- a/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
+++ b/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
@@ -58,6 +58,8 @@ class ModuleTabManagementSubscriber implements EventSubscriberInterface
         return [
             ModuleManagementEvent::INSTALL => 'onModuleInstall',
             ModuleManagementEvent::UNINSTALL => 'onModuleUninstall',
+            ModuleManagementEvent::ENABLE => 'onModuleEnable',
+            ModuleManagementEvent::DISABLE => 'onModuleDisable',
         ];
     }
 
@@ -73,6 +75,22 @@ class ModuleTabManagementSubscriber implements EventSubscriberInterface
      * @param ModuleManagementEvent $event
      */
     public function onModuleUninstall(ModuleManagementEvent $event)
+    {
+        $this->moduleTabUnregister->unregisterTabs($event->getModule());
+    }
+
+    /**
+     * @param ModuleManagementEvent $event
+     */
+    public function onModuleEnable(ModuleManagementEvent $event)
+    {
+        $this->moduleTabRegister->registerTabs($event->getModule());
+    }
+
+    /**
+     * @param ModuleManagementEvent $event
+     */
+    public function onModuleDisable(ModuleManagementEvent $event)
     {
         $this->moduleTabUnregister->unregisterTabs($event->getModule());
     }

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -184,8 +184,8 @@ class ModuleTabRegister
             $this->logger->warning('Tab attribute "ParentClassName" is deprecated. You must use "parent_class_name" instead.');
         }
         //Check if the tab was already added manually
-        if ($this->tabRepository->findOneIdByClassName($className)) {
-            throw new Exception(sprintf('Try to register an already existing tab %s', $className));
+        if (!empty($this->tabRepository->findOneIdByClassName($className))) {
+            throw new Exception(sprintf('Cannot register tab "%s" because it already exists', $className));
         }
 
         return true;

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -80,6 +80,14 @@ class ModuleTabRegister
      */
     private $languages;
 
+    /**
+     * @param TabRepository $tabRepository
+     * @param LangRepository $langRepository
+     * @param LoggerInterface $logger
+     * @param TranslatorInterface $translator
+     * @param Filesystem $filesystem
+     * @param array $languages
+     */
     public function __construct(TabRepository $tabRepository, LangRepository $langRepository, LoggerInterface $logger, TranslatorInterface $translator, Filesystem $filesystem, array $languages)
     {
         $this->langRepository = $langRepository;

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -183,6 +183,10 @@ class ModuleTabRegister
         if ($data->has('ParentClassName') && !$data->has('parent_class_name')) {
             $this->logger->warning('Tab attribute "ParentClassName" is deprecated. You must use "parent_class_name" instead.');
         }
+        //Check if the tab was already added manually
+        if (Tab::getIdFromClassName($className)) {
+            throw new Exception(sprintf('Try to register an already existing tab %s', $className));
+        }
 
         return true;
     }

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -184,7 +184,7 @@ class ModuleTabRegister
             $this->logger->warning('Tab attribute "ParentClassName" is deprecated. You must use "parent_class_name" instead.');
         }
         //Check if the tab was already added manually
-        if (Tab::getIdFromClassName($className)) {
+        if ($this->tabRepository->findOneIdByClassName($className)) {
             throw new Exception(sprintf('Try to register an already existing tab %s', $className));
         }
 

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Addon\Module;
 
 use Exception;
+use PrestaShop\PrestaShop\Adapter\Cache\CacheClearer;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
@@ -39,7 +40,6 @@ use PrestaShopBundle\Event\ModuleManagementEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\Translation\TranslatorInterface;
-use Tools;
 
 class ModuleManager implements AddonManagerInterface
 {
@@ -96,6 +96,11 @@ class ModuleManager implements AddonManagerInterface
     private $actionParams;
 
     /**
+     * @var CacheClearer
+     */
+    private $cacheClearer;
+
+    /**
      * Used to check if the cache has already been cleaned.
      *
      * @var bool
@@ -110,6 +115,7 @@ class ModuleManager implements AddonManagerInterface
      * @param ModuleZipManager $moduleZipManager
      * @param TranslatorInterface $translator
      * @param EventDispatcherInterface $eventDispatcher
+     * @param CacheClearer $cacheClearer
      */
     public function __construct(
         AdminModuleDataProvider $adminModuleProvider,
@@ -118,7 +124,8 @@ class ModuleManager implements AddonManagerInterface
         ModuleRepository $moduleRepository,
         ModuleZipManager $moduleZipManager,
         TranslatorInterface $translator,
-        EventDispatcherInterface $eventDispatcher
+        EventDispatcherInterface $eventDispatcher,
+        CacheClearer $cacheClearer
     ) {
         $this->adminModuleProvider = $adminModuleProvider;
         $this->moduleProvider = $modulesProvider;
@@ -127,7 +134,7 @@ class ModuleManager implements AddonManagerInterface
         $this->moduleZipManager = $moduleZipManager;
         $this->translator = $translator;
         $this->eventDispatcher = $eventDispatcher;
-
+        $this->cacheClearer = $cacheClearer;
         $this->actionParams = new ParameterBag();
     }
 
@@ -785,7 +792,7 @@ class ModuleManager implements AddonManagerInterface
             return;
         }
 
-        Tools::clearAllCache();
+        $this->cacheClearer->clearSymfonyCache();
         $this->cacheCleared = true;
     }
 }

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -599,7 +599,7 @@ class ModuleManager implements AddonManagerInterface
 
         $module = $this->moduleRepository->getModule($name);
         try {
-            $result =  $module->onMobileEnable();
+            $result = $module->onMobileEnable();
         } catch (Exception $e) {
             throw new Exception(
                 $this->translator->trans(

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Addon\Module;
 
 use Context;
 use Db;
+use PrestaShop\PrestaShop\Adapter\Cache\CacheClearer;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use Doctrine\Common\Cache\FilesystemCache;
 use PrestaShop\PrestaShop\Adapter\Configuration;
@@ -109,7 +110,8 @@ class ModuleManagerBuilder
                     $this->buildRepository(),
                     self::$moduleZipManager,
                     self::$translator,
-                    new NullDispatcher()
+                    new NullDispatcher(),
+                    new CacheClearer()
                 );
             }
         }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -47,6 +47,7 @@ services:
             - "@prestashop.module.zip.manager"
             - "@translator"
             - "@event_dispatcher"
+            - "@prestashop.adapter.cache_clearer"
 
     prestashop.module.zip.manager:
         class: PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -25,6 +25,7 @@ services:
 
     prestashop.adapter.check_missing_files:
         class: 'PrestaShop\PrestaShop\Adapter\Requirement\CheckMissingOrUpdatedFiles'
+
     prestashop.adapter.cache_clearer:
         class: 'PrestaShop\PrestaShop\Adapter\Cache\CacheClearer'
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
@@ -7,6 +7,7 @@ services:
 
     prestashop.bundle.routing.converter.legacy_url_converter:
         class: 'PrestaShopBundle\Routing\Converter\LegacyUrlConverter'
+        public: true
         arguments:
             - '@router'
             - '@prestashop.bundle.routing.converter.cache_provider'

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -26,6 +26,7 @@
 
 namespace Tests\Core\Addon\Module;
 
+use PrestaShop\PrestaShop\Adapter\Cache\CacheClearer;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManager;
 use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use PHPUnit\Framework\TestCase;
@@ -44,6 +45,7 @@ class ModuleManagerTest extends TestCase
     private $translatorS;
     private $dispatcherS;
     private $employeeS;
+    private $cacheClearerS;
 
     public function setUp()
     {
@@ -56,7 +58,8 @@ class ModuleManagerTest extends TestCase
             $this->moduleRepositoryS,
             $this->moduleZipManagerS,
             $this->translatorS,
-            $this->dispatcherS
+            $this->dispatcherS,
+            $this->cacheClearerS
         );
     }
 
@@ -152,6 +155,7 @@ class ModuleManagerTest extends TestCase
         $this->mockTranslator();
         $this->mockDispatcher();
         $this->mockEmployee();
+        $this->mockCacheClearer();
     }
 
     private function mockAdminModuleProvider()
@@ -294,6 +298,12 @@ class ModuleManagerTest extends TestCase
     private function mockDispatcher()
     {
         $this->dispatcherS = new NullDispatcher();
+    }
+
+    private function mockCacheClearer()
+    {
+        $this->cacheClearerS = $this->getMockBuilder(CacheClearer::class)
+            ->getMock();
     }
 
     private function mockEmployee()


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  |Clear cache each time an action is performed on a module (install, uninstall, enable, disable, ...)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11557
| How to test?  | You can use ps_linklist in its versions [v2.1.5](https://github.com/PrestaShop/ps_linklist/releases/tag/v2.1.5) and the last version (soon to be merged) which you can download here [ps_linklist.zip](https://github.com/PrestaShop/PrestaShop/files/2634305/ps_linklist.zip) And follow the instructions from the issue You can also try to enable/disable the module IMPORTANT: you must test these features with an upgraded module (meaning some old code remains in the module folder) AND with a fresh install (you need to uninstall the module and check the option to remove the folder, then reinstall)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11572)
<!-- Reviewable:end -->
