### PR TITLE
Added .gif support

### DIFF
--- a/themes/classic/_dev/webpack.config.js
+++ b/themes/classic/_dev/webpack.config.js
@@ -60,7 +60,7 @@ let config = {
         })
       },
       {
-        test: /.(png|woff(2)?|eot|ttf|svg)(\?[a-z0-9=\.]+)?$/,
+        test: /.(png|woff(2)?|eot|ttf|svg|gif)(\?[a-z0-9=\.]+)?$/,
         use: [
           {
             loader: 'file-loader',


### PR DESCRIPTION
Currently, if you place a `.gif` file inside `img` theme folder it will trigger an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11575)
<!-- Reviewable:end -->
