### PR TITLE
Add .gif support to webpack.config.js

### DIFF
--- a/themes/classic/_dev/webpack.config.js
+++ b/themes/classic/_dev/webpack.config.js
@@ -60,7 +60,7 @@ let config = {
         })
       },
       {
-        test: /.(png|woff(2)?|eot|ttf|svg)(\?[a-z0-9=\.]+)?$/,
+        test: /.(png|woff(2)?|eot|ttf|svg|gif)(\?[a-z0-9=\.]+)?$/,
         use: [
           {
             loader: 'file-loader',


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When compiling the assets it will trigger errors if using `.gif` files.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Use a `.gif` file inside `img` theme folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11576)
<!-- Reviewable:end -->
