### PR TITLE
Fix displayAdminProductsExtra hook content display in V1.7.5.0 beta

### DIFF
--- a/src/PrestaShopBundle/Service/Hook/RenderingHookEvent.php
+++ b/src/PrestaShopBundle/Service/Hook/RenderingHookEvent.php
@@ -81,7 +81,7 @@ class RenderingHookEvent extends HookEvent
     public function popContent()
     {
         $content = $this->currentContent;
-        $this->currentContent = '';
+        $this->currentContent = [];
 
         return $content;
     }

--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -134,7 +134,7 @@ class HookExtension extends \Twig_Extension
             $render[] = [
                 'id' => $module,
                 'name' => $this->moduleDataProvider->getModuleName($module),
-                'content' => array_values($hookRender)[0],
+                'content' => $hookRender,
                 'attributes' => $moduleAttributes->all(),
             ];
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | displayAdminProductsExtra form content not display in catalog product edit module page
| Type?         | bug fix 
| Category?     |  BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11582
| How to test?  | If we use DisplayAdminProductsExtra hook and return a form content it will display in catalog -> product Module tab 'Configure' button click

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11584)
<!-- Reviewable:end -->
