### PR TITLE
Fix email processing in AdminCustomerThreadsController.php

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -437,8 +437,9 @@ class AdminCustomerThreadsControllerCore extends AdminController
                     }
                     $customer = new Customer($ct->id_customer);
                     $reply = Tools::getValue('reply_message');
-                    if (Configuration::get('PS_MAIL_TYPE') != Mail::TYPE_TEXT)
+                    if (Configuration::get('PS_MAIL_TYPE') == MAIL::TYPE_HTML) {
                         $reply = Tools::nl2br($reply);
+                    }
                     $params = array(
                         '{reply}' => $reply,
                         '{link}' => Tools::url(

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -436,8 +436,11 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         $file_attachment['mime'] = $_FILES['joinFile']['type'];
                     }
                     $customer = new Customer($ct->id_customer);
+                    $reply = Tools::getValue('reply_message');
+                    if (Configuration::get('PS_MAIL_TYPE') != Mail::TYPE_TEXT)
+                        $reply = Tools::nl2br($reply);
                     $params = array(
-                        '{reply}' => Tools::nl2br(Tools::getValue('reply_message')),
+                        '{reply}' => $reply,
                         '{link}' => Tools::url(
                             $this->context->link->getPageLink('contact', true, null, null, false, $ct->id_shop),
                             'id_customer_thread=' . (int) $ct->id . '&token=' . $ct->token


### PR DESCRIPTION
Processing customer service message with `Tools::nl2br` when HTML emails are disabled is senseless, will thrown '`<br/>`' strings into the email text. This is quick fix for that.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Process message content by `Tools::nl2br` only if HTML emails are enabled. It just checks configuration value and perform process on message content if needed. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Send an answer with line breaks to a customer when only txt emails are enabled. '`<br/>`' string will be thrown into the mail text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11586)
<!-- Reviewable:end -->
