### PR TITLE
WIP: Force refresh in categories api calls to have the categories translated

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -252,6 +252,8 @@ class AdminModuleDataProvider implements ModuleInterface
      */
     public function generateAddonsUrls(AddonsCollection $addons, $specific_action = null)
     {
+        $this->categoriesProvider->refreshCategories();
+
         foreach ($addons as $addon) {
             $urls = array();
             foreach ($this->moduleActions as $action) {

--- a/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php
@@ -81,6 +81,12 @@ class CategoriesProvider
         return self::$categoriesFromApi;
     }
 
+    public function refreshCategories()
+    {
+        self::$categories = null;
+        self::$categoriesFromApi = null;
+    }
+
     /**
      * Return the list of categories with the associated modules.
      *
@@ -90,6 +96,8 @@ class CategoriesProvider
      */
     public function getCategoriesMenu($modules)
     {
+        $this->refreshCategories();
+
         if (null === self::$categories) {
             // The Root category is "Categories"
             $categoriesListing = $this->getCategories();


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Force refresh in api modules categories call to have the correct translation
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11440
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11599)
<!-- Reviewable:end -->
