### PR TITLE
Fix renderHooksArray

### DIFF
--- a/src/PrestaShopBundle/Service/Hook/RenderingHookEvent.php
+++ b/src/PrestaShopBundle/Service/Hook/RenderingHookEvent.php
@@ -81,7 +81,7 @@ class RenderingHookEvent extends HookEvent
     public function popContent()
     {
         $content = $this->currentContent;
-        $this->currentContent = '';
+        $this->currentContent = [];
 
         return $content;
     }

--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Twig;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
+use PrestaShop\PrestaShop\Core\Hook\RenderedHook;
 
 /**
  * This class is used by Twig_Environment and provide some methods callable from a twig template.
@@ -124,8 +125,8 @@ class HookExtension extends \Twig_Extension
         // The call to the render of the hooks is encapsulated into a ob management to avoid any call of echo from the
         // modules.
         ob_start();
+        /** @var RenderedHook $renderedHook */
         $renderedHook = $this->hookDispatcher->dispatchRenderingWithParameters($hookName, $hookParameters);
-        $renderedHook->outputContent();
         ob_clean();
 
         $render = [];
@@ -134,7 +135,7 @@ class HookExtension extends \Twig_Extension
             $render[] = [
                 'id' => $module,
                 'name' => $this->moduleDataProvider->getModuleName($module),
-                'content' => array_values($hookRender)[0],
+                'content' => $hookRender,
                 'attributes' => $moduleAttributes->all(),
             ];
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Hooks rendered via `renderhooksarray` are not properly displayed, this PR fixes a change that was made in a previous refacto Thanks to @dheerajwebkul for this fix
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11582
| How to test?  |

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11638)
<!-- Reviewable:end -->
