### PR TITLE
Fix ID replacement in urls generated by symfony

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -400,7 +400,7 @@ var featuresCollection = (function() {
 
         if('' !== $(this).val()) {
           $.ajax({
-            url: $(this).attr('data-action').replace(/\/\d+((?=\?.*))?/, '/' + $(this).val()),
+            url: $(this).attr('data-action').replace(/\/\d+(?!.*\/\d+)((?=\?.*))?/, '/' + $(this).val()),
             success: function(response) {
               $selector.prop('disabled', response.length === 0);
               $selector.empty();
@@ -1164,7 +1164,7 @@ var attachmentProduct = (function() {
 
         $.ajax({
           type: 'POST',
-          url: $('#form_step6_attachment_product').attr('data-action').replace(/\/\d+(?=\?.*)/, '/' + id_product),
+          url: $('#form_step6_attachment_product').attr('data-action').replace(/\/\d+(?!.*\/\d+)((?=\?.*))?/, '/' + id_product),
           data: data,
           contentType: false,
           processData: false,

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -392,6 +392,11 @@ var featuresCollection = (function() {
         }).show();
       });
 
+      function replaceEndingIdFromUrl(url, newId)
+      {
+        return url.replace(/\/\d+(?!.*\/\d+)((?=\?.*))?/, '/' + newId);
+      }
+
       /** On feature selector event change, refresh possible values list */
       $(document).on('change', '.feature-collection select.feature-selector', function(event) {
         var that = event.currentTarget;
@@ -400,7 +405,7 @@ var featuresCollection = (function() {
 
         if('' !== $(this).val()) {
           $.ajax({
-            url: $(this).attr('data-action').replace(/\/\d+(?!.*\/\d+)((?=\?.*))?/, '/' + $(this).val()),
+            url: replaceEndingIdFromUrl($(this).attr('data-action'), $(this).val()),
             success: function(response) {
               $selector.prop('disabled', response.length === 0);
               $selector.empty();
@@ -1151,6 +1156,11 @@ var attachmentProduct = (function() {
         $('#form_step6_attachment_product_description').val('');
       }
 
+      function replaceEndingIdFromUrl(url, newId)
+      {
+        return url.replace(/\/\d+(?!.*\/\d+)((?=\?.*))?/, '/' + newId);
+      }
+
       /** add attachment */
       $('#form_step6_attachment_product_add').click(function() {
         var _this = $(this);
@@ -1164,7 +1174,7 @@ var attachmentProduct = (function() {
 
         $.ajax({
           type: 'POST',
-          url: $('#form_step6_attachment_product').attr('data-action').replace(/\/\d+(?!.*\/\d+)((?=\?.*))?/, '/' + id_product),
+          url: replaceEndingIdFromUrl($('#form_step6_attachment_product').attr('data-action'), id_product),
           data: data,
           contentType: false,
           processData: false,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | When PrestaShop was installed in a folder starting with numbers (ex: `1750rc1`) The url replacement used to add feature did not work correctly this resulting in a 404.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11621
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11644)
<!-- Reviewable:end -->
