### PR TITLE
Improve database connection character set for non-utf8 hostings

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -126,7 +126,7 @@ class DbPDOCore extends Db
         } catch (PDOException $e) {
             throw new PrestaShopException('Link to database cannot be established: ' . $e->getMessage());
         }
-        
+
         // UTF-8 support
         if (!$this->setCharsetUTF8($this->link)) {
             throw new PrestaShopDatabaseException(Tools::displayError('PrestaShop Fatal error: no utf-8 support. Please check your server configuration.'));
@@ -468,11 +468,12 @@ class DbPDOCore extends Db
 
         return ($result === false) ? false : true;
     }
-    
+
     /**
      * Sets UTF-8 to given connection.
      *
      * @param PDO $link connection instance
+     *
      * @return bool if setting UTF-8 charset was successful
      */
     public static function setCharsetUTF8($link)

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -476,7 +476,7 @@ class DbPDOCore extends Db
      *
      * @return bool if setting UTF-8 charset was successful
      */
-    public static function setCharsetUTF8($link)
+    public static function setCharsetUTF8(PDO $link)
     {
         return (bool) ($link->query('SET NAMES \'utf8\''));
     }

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -81,10 +81,7 @@ class DbPDOCore extends Db
         }
         $dsn .= ';charset=utf8';
 
-        return new PDO($dsn, $user, $password, array(
-            PDO::ATTR_TIMEOUT => $timeout,
-            PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
-            PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"));
+        return new PDO($dsn, $user, $password, array(PDO::ATTR_TIMEOUT => $timeout, PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true));
     }
 
     /**
@@ -128,6 +125,11 @@ class DbPDOCore extends Db
             $this->link = $this->getPDO($this->server, $this->user, $this->password, $this->database, 5);
         } catch (PDOException $e) {
             throw new PrestaShopException('Link to database cannot be established: ' . $e->getMessage());
+        }
+        
+        // UTF-8 support
+        if (!$this->setCharsetUTF8($this->link)) {
+            throw new PrestaShopDatabaseException(Tools::displayError('PrestaShop Fatal error: no utf-8 support. Please check your server configuration.'));
         }
 
         $this->link->exec('SET SESSION sql_mode = \'\'');
@@ -465,6 +467,17 @@ class DbPDOCore extends Db
         unset($link);
 
         return ($result === false) ? false : true;
+    }
+    
+    /**
+     * Sets UTF-8 to given connection.
+     *
+     * @param PDO $link connection instance
+     * @return bool if setting UTF-8 charset was successful
+     */
+    public static function setCharsetUTF8($link)
+    {
+        return ($link->query('SET NAMES \'utf8\'') === false) ? false : true;
     }
 
     /**

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -129,7 +129,7 @@ class DbPDOCore extends Db
 
         // UTF-8 support
         if (!$this->setCharsetUTF8($this->link)) {
-            throw new PrestaShopDatabaseException(Tools::displayError('PrestaShop Fatal error: no utf-8 support. Please check your server configuration.'));
+            throw new PrestaShopDatabaseException('Charset utf8 is not supported. Please check your database server configuration.');
         }
 
         $this->link->exec('SET SESSION sql_mode = \'\'');

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -478,7 +478,7 @@ class DbPDOCore extends Db
      */
     public static function setCharsetUTF8($link)
     {
-        return ($link->query('SET NAMES \'utf8\'') === false) ? false : true;
+        return $link->query('SET NAMES \'utf8\'') !== false;
     }
 
     /**

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -478,7 +478,7 @@ class DbPDOCore extends Db
      */
     public static function setCharsetUTF8($link)
     {
-        return $link->query('SET NAMES \'utf8\'') !== false;
+        return (bool)($link->query('SET NAMES \'utf8\''));
     }
 
     /**

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -478,7 +478,7 @@ class DbPDOCore extends Db
      */
     public static function setCharsetUTF8($link)
     {
-        return (bool)($link->query('SET NAMES \'utf8\''));
+        return (bool) ($link->query('SET NAMES \'utf8\''));
     }
 
     /**

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -82,7 +82,8 @@ class DbPDOCore extends Db
         $dsn .= ';charset=utf8';
 
         return new PDO($dsn, $user, $password, array(
-            PDO::ATTR_TIMEOUT => $timeout, PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
+            PDO::ATTR_TIMEOUT => $timeout,
+            PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
             PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"));
     }
 

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -81,7 +81,9 @@ class DbPDOCore extends Db
         }
         $dsn .= ';charset=utf8';
 
-        return new PDO($dsn, $user, $password, array(PDO::ATTR_TIMEOUT => $timeout, PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true));
+        return new PDO($dsn, $user, $password, array(
+            PDO::ATTR_TIMEOUT => $timeout, PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
+            PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"));
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Charset fix for hostings with default non-utf8 connections. Usually hosting provider cannot change it just for one account because it is single setting for multiple hosting accounts. Similar improvement was in PR #8117 but it doesn't help in all cases. Here https://stackoverflow.com/questions/4361459/php-pdo-charset-set-names/7325424 they say that the most elegant way to set correct charter set is to use PDO::MYSQL_ATTR_INIT_COMMAND in constructor.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | --
| How to test?  | Set Ukrainian site language while install. Set cp1251 default connection on database config. Turn on PDO php extension. Site will work incorrectly in cyryllic languages (not sure that for all hostings). Now it works correctly.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11648)
<!-- Reviewable:end -->
