### PR TITLE
Fix Error 500 from API request with PHP 7.2

### DIFF
--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -40,7 +40,7 @@ class WebserviceOutputJSON implements WebserviceOutputInterface
     /**
      * Current association
      */
-    protected $currentAssociatedEntity;
+    protected $currentAssociatedEntity = array();
 
     /**
      * Json content

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -183,7 +183,7 @@ class WebserviceRequestCore
     public static $ws_current_classname;
 
 
-    public static $shopIDs;
+    public static $shopIDs = array();
 
 
     public function getOutputEnabled()


### PR DESCRIPTION
line [794](https://github.com/PrestaShop/PrestaShop/blob/1.6.1.x/classes/webservice/WebserviceRequest.php#L794) assumes that self::$shopIDs is an array that can be counted.
But self::$shopIDs is null and the following error appears:
[PHP Warning #2] count(): Parameter must be an array or an object that implements Countable (/home/dn31hhgo/public_html/directorio/classes/webservice/WebserviceRequest.php, line 794)

(This is a back-port from 1.7.4.x as it turns out 1.6.1.x is also affected)

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | This issue affects anyone running PS on PHP 7.2.x
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11227
| How to test?  | Enable WS and visit /api

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11228)
<!-- Reviewable:end -->

Reference to the 1.7.4.x cherrypick:
https://github.com/PrestaShop/PrestaShop/pull/11228
And the original PR