### PR TITLE
Allow override of _PS_DEBUG_PROFILING_

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -39,7 +39,9 @@ if (_PS_MODE_DEV_ === true) {
     define('_PS_DEBUG_SQL_', false);
 }
 
-define('_PS_DEBUG_PROFILING_', false);
+if (!defined('_PS_DEBUG_PROFILING_')) {
+    define('_PS_DEBUG_PROFILING_', false);
+}
 define('_PS_MODE_DEMO_', false);
 
 $currentDir = dirname(__FILE__);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow to override _PS_DEBUG_PROFILING_ constant in defines_custom.inc.php
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Just add ```define( '_PS_DEBUG_PROFILING_', true );``` in defines_custom.inc.php

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11653)
<!-- Reviewable:end -->
