### PR TITLE
Simplify PHP unit construct

### DIFF
--- a/tests-legacy/Integration/classes/MediaCoreTest.php
+++ b/tests-legacy/Integration/classes/MediaCoreTest.php
@@ -38,7 +38,7 @@ class MediaCoreTest extends IntegrationTestCase
     {
         $domain = Configuration::get('PS_SHOP_DOMAIN');
         $result = Media::getJqueryPath('1.11');
-        $this->assertEquals(true, in_array('http://'.$domain.__PS_BASE_URI__.'js/jquery/jquery.noConflict.php?version=1.11', $result));
+        $this->assertTrue(in_array('http://'.$domain.__PS_BASE_URI__.'js/jquery/jquery.noConflict.php?version=1.11', $result));
     }
 
     protected function setUp()

--- a/tests-legacy/Unit/Classes/ToolsCoreTest.php
+++ b/tests-legacy/Unit/Classes/ToolsCoreTest.php
@@ -54,7 +54,7 @@ class ToolsCoreTest extends TestCase
     public function testGetValueDefaultValueIsFalse()
     {
         $this->setPostAndGet();
-        $this->assertEquals(false, Tools::getValue('hello'));
+        $this->assertFalse(Tools::getValue('hello'));
     }
 
     public function testGetValueUsesDefaultValue()
@@ -77,9 +77,9 @@ class ToolsCoreTest extends TestCase
             null => true
         ));
 
-        $this->assertEquals(false, Tools::getValue('', true));
-        $this->assertEquals(true, Tools::getValue(' '));
-        $this->assertEquals(false, Tools::getValue(null, true));
+        $this->assertFalse(Tools::getValue('', true));
+        $this->assertTrue(Tools::getValue(' '));
+        $this->assertFalse(Tools::getValue(null, true));
     }
 
     public function testGetValueStripsNullCharsFromReturnedStringsExamples()

--- a/tests-legacy/Unit/Core/Business/Product/ProductPresenterTest.php
+++ b/tests-legacy/Unit/Core/Business/Product/ProductPresenterTest.php
@@ -218,8 +218,7 @@ class ProductPresenterTest extends UnitTestCase
     {
         $this->product['id_product_attribute'] = 42;
         $this->settings->allow_add_variant_to_cart_from_listing = false;
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->getPresentedProductForListing('add_to_cart_url')
         );
     }
@@ -232,8 +231,7 @@ class ProductPresenterTest extends UnitTestCase
                 ['is_customized' => true, 'required' => true]
             ]
         ];
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->getPresentedProductForListing('add_to_cart_url')
         );
     }

--- a/tests-legacy/Unit/Core/Cart/Calculation/CartRules/CartRulesWithoutCodeTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/CartRules/CartRulesWithoutCodeTest.php
@@ -56,7 +56,7 @@ class CartRulesWithoutCodeTest extends AbstractCartCalculationTest
         }
         $cartRule = $this->getCartRuleFromFixtureId(1);
         $result   = $cartRule->checkValidity(\Context::getContext(), false, false);
-        $this->assertEquals(true, $result);
+        $this->assertTrue($result);
 
         $expectedTotal = (1 - $cartRulesData[14]['percent'] / 100)
                          * (1 - $cartRulesData[15]['percent'] / 100)

--- a/tests-legacy/Unit/Core/Localization/CurrencyTest.php
+++ b/tests-legacy/Unit/Core/Localization/CurrencyTest.php
@@ -61,8 +61,7 @@ class CurrencyTest extends TestCase
      */
     public function testIsActive()
     {
-        $this->assertSame(
-            true,
+        $this->assertTrue(
             $this->currency->isActive(),
             'Wrong result for isActive()'
         );


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PHPUnit assertion method calls like ->assertSame(true, $foo) should be written with dedicated method like ->assertTrue($foo).
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | /
| How to test?  | /

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11674)
<!-- Reviewable:end -->
