### PR TITLE
Simplify PHP unit expectations

### DIFF
--- a/tests-legacy/Integration/Core/Module/HookRepositoryTest.php
+++ b/tests-legacy/Integration/Core/Module/HookRepositoryTest.php
@@ -93,8 +93,8 @@ class HookRepositoryTest extends IntegrationTestCase
             $actual['displayTestHookName']
         );
 
-        $this->assertFalse(
-            array_key_exists('notADisplayTestHookName', $actual)
+        $this->assertArrayNotHasKey(
+            'notADisplayTestHookName', $actual
         );
     }
 

--- a/tests-legacy/Integration/ProductURLsTest.php
+++ b/tests-legacy/Integration/ProductURLsTest.php
@@ -115,6 +115,6 @@ class ProductURLsTest extends IntegrationTestCase
         parse_str($this->getURL(1, null)['query'], $query);
 
         $this->assertEquals(1, $query['id_product']);
-        $this->assertTrue(empty($query['id_product_attribute']));
+        $this->assertEmpty($query['id_product_attribute']);
     }
 }

--- a/tests-legacy/PrestaShopBundle/Translation/Factory/TranslationsFactoryTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Factory/TranslationsFactoryTest.php
@@ -70,7 +70,7 @@ class TranslationsFactoryTest extends TestCase
 
     public function testCreateCatalogueWithoutProviderFails()
     {
-        $this->setExpectedException('PrestaShopBundle\Translation\Factory\ProviderNotFoundException');
+        $this->expectException('PrestaShopBundle\Translation\Factory\ProviderNotFoundException');
         $expected = $this->factory
             ->createCatalogue($this->providerMock->getIdentifier())
         ;
@@ -89,7 +89,7 @@ class TranslationsFactoryTest extends TestCase
 
     public function testCreateTranslationsArrayWithoutProviderFails()
     {
-        $this->setExpectedException('PrestaShopBundle\Translation\Factory\ProviderNotFoundException');
+        $this->expectException('PrestaShopBundle\Translation\Factory\ProviderNotFoundException');
         $expected = $this->factory
             ->createTranslationsArray($this->providerMock->getIdentifier())
         ;

--- a/tests-legacy/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
+++ b/tests-legacy/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
@@ -152,7 +152,8 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
         $filepath = $this->defaultDir.'/moduleConfCrashFileSource.yml';
         $name = 'bankwire';
 
-        $this->setExpectedException('Exception', 'Missing source file');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('Missing source file');
         $this->getModuleSelfConfigurator()->module($name)->file($filepath)->configure();
     }
 
@@ -161,7 +162,8 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
         $filepath = $this->defaultDir.'/moduleConfCrashFileDestination.yml';
         $name = 'bankwire';
 
-        $this->setExpectedException('Exception', 'Missing destination file');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('Missing destination file');
         $this->getModuleSelfConfigurator()->module($name)->file($filepath)->configure();
     }
 
@@ -223,7 +225,8 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
         $filepath = $this->defaultDir.'/moduleConfCrashSql.yml';
         $name = 'bankwire';
 
-        $this->setExpectedException('Exception', 'Missing file path');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('Missing file path');
         $this->getModuleSelfConfigurator()->module($name)->file($filepath)->configure();
     }
 

--- a/tests-legacy/Unit/Adapter/Module/PrestaTrust/PrestaTrustCheckerTest.php
+++ b/tests-legacy/Unit/Adapter/Module/PrestaTrust/PrestaTrustCheckerTest.php
@@ -161,8 +161,8 @@ class PrestaTrustCheckerTest extends UnitTestCase
         $testedModule = $this->modules['module-verified-from-addons-api'];
         $presentedModule = $this->modulePresenter->present($testedModule);
 
-        $this->assertTrue(array_key_exists('picos', $presentedModule['attributes']));
-        $this->assertFalse(empty($presentedModule['attributes']['picos']));
+        $this->assertArrayHasKey('picos', $presentedModule['attributes']);
+        $this->assertNotEmpty($presentedModule['attributes']['picos']);
     }
 
     /**
@@ -177,8 +177,8 @@ class PrestaTrustCheckerTest extends UnitTestCase
         $testedModule = $this->modules['module-under-dev'];
         $presentedModule = $this->modulePresenter->present($testedModule);
 
-        $this->assertTrue(array_key_exists('picos', $presentedModule['attributes']));
-        $this->assertTrue(empty($presentedModule['attributes']['picos']));
+        $this->assertArrayHasKey('picos', $presentedModule['attributes']);
+        $this->assertEmpty($presentedModule['attributes']['picos']);
     }
 
     /**

--- a/tests-legacy/Unit/Classes/PrestaShopAutoloadTest.php
+++ b/tests-legacy/Unit/Classes/PrestaShopAutoloadTest.php
@@ -44,7 +44,7 @@ class PrestaShopAutoloadTest extends TestCase
 
     public function testGenerateIndex()
     {
-        $this->assertTrue(file_exists($this->file_index));
+        $this->assertFileExists($this->file_index);
         $data = include($this->file_index);
         $this->assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
     }
@@ -71,7 +71,7 @@ class PrestaShopAutoloadTest extends TestCase
             class Connection extends ConnectionCore {
         }');
         PrestaShopAutoload::getInstance()->generateIndex();
-        $this->assertTrue(file_exists($this->file_index));
+        $this->assertFileExists($this->file_index);
         $data = include($this->file_index);
         $this->assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
         $this->assertEquals($data['Connection']['override'], false);

--- a/tests-legacy/Unit/Classes/Smarty/TemplateFinderTest.php
+++ b/tests-legacy/Unit/Classes/Smarty/TemplateFinderTest.php
@@ -72,7 +72,7 @@ class TemplateFinderTest extends TestCase
 
     public function testNoFoundTemplateThrowException()
     {
-        $this->setExpectedException('\PrestaShopException');
+        $this->expectException('\PrestaShopException');
         $template = $this->templateFinder->getTemplate('catalog/listing/my-custom-list', 'custom', null, 'fr-FR');
     }
 }

--- a/tests-legacy/Unit/Classes/Tax/TaxRulesTaxManagerCoreTest.php
+++ b/tests-legacy/Unit/Classes/Tax/TaxRulesTaxManagerCoreTest.php
@@ -71,7 +71,7 @@ class TaxRulesTaxManagerCoreTest extends UnitTestCase
 
         // Then
         $this->assertEquals(TaxCalculator::COMBINE_METHOD, $tax_calculator->computation_method);
-        $this->assertTrue(is_array($tax_calculator->taxes));
+        $this->assertInternalType('array', $tax_calculator->taxes);
 
         foreach ($tax_calculator->taxes as $key => $tax) {
             $this->assertTrue($tax instanceof Tax);

--- a/tests-legacy/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests-legacy/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -76,49 +76,56 @@ class ModuleManagerTest extends TestCase
     public function testUninstallSuccessful()
     {
         $this->assertTrue($this->moduleManager->uninstall(self::INSTALLED_MODULE));
-        $this->setExpectedException('Exception', 'The module %module% must be installed first');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The module %module% must be installed first');
         $this->assertFalse($this->moduleManager->uninstall(self::UNINSTALLED_MODULE));
     }
 
     public function testUpgradeSuccessful()
     {
         $this->assertTrue($this->moduleManager->upgrade(self::INSTALLED_MODULE));
-        $this->setExpectedException('Exception', 'The module %module% must be installed first');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The module %module% must be installed first');
         $this->moduleManager->upgrade(self::UNINSTALLED_MODULE);
     }
 
     public function testDisableSuccessful()
     {
         $this->assertTrue($this->moduleManager->disable(self::INSTALLED_MODULE));
-        $this->setExpectedException('Exception', 'The module %module% must be installed first');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The module %module% must be installed first');
         $this->assertFalse($this->moduleManager->disable(self::UNINSTALLED_MODULE));
     }
 
     public function testEnableSuccessful()
     {
         $this->assertTrue($this->moduleManager->enable(self::INSTALLED_MODULE));
-        $this->setExpectedException('Exception', 'The module %module% must be installed first');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The module %module% must be installed first');
         $this->assertFalse($this->moduleManager->enable(self::UNINSTALLED_MODULE));
     }
 
     public function testDisableOnMobileSuccessful()
     {
         $this->assertTrue($this->moduleManager->disable_mobile(self::INSTALLED_MODULE));
-        $this->setExpectedException('Exception', 'The module %module% must be installed first');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The module %module% must be installed first');
         $this->assertFalse($this->moduleManager->disable_mobile(self::UNINSTALLED_MODULE));
     }
 
     public function testEnableOnMobileSuccessful()
     {
         $this->assertTrue($this->moduleManager->enable_mobile(self::INSTALLED_MODULE));
-        $this->setExpectedException('Exception', 'The module %module% must be installed first');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The module %module% must be installed first');
         $this->assertFalse($this->moduleManager->enable_mobile(self::UNINSTALLED_MODULE));
     }
 
     public function testResetSuccessful()
     {
         $this->assertTrue($this->moduleManager->reset(self::INSTALLED_MODULE));
-        $this->setExpectedException('Exception', 'The module %module% must be installed first');
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('The module %module% must be installed first');
         $this->assertFalse($this->moduleManager->reset(self::UNINSTALLED_MODULE));
     }
 

--- a/tests-legacy/Unit/Core/Addon/Module/ModuleRepositoryTest.php
+++ b/tests-legacy/Unit/Core/Addon/Module/ModuleRepositoryTest.php
@@ -181,7 +181,7 @@ class ModuleRepositoryTest extends UnitTestCase
         foreach ($all_modules as $name => $module) {
             // Each installed module must be found in the installed modules list
             if ($module->database->get('installed') == 1) {
-                $this->assertTrue(array_key_exists($name, $installed_modules), sprintf('Module %s not found in the filtered list !', $name));
+                $this->assertArrayHasKey($name, $installed_modules, sprintf('Module %s not found in the filtered list !', $name));
             }
         }
     }
@@ -204,7 +204,7 @@ class ModuleRepositoryTest extends UnitTestCase
         foreach ($all_modules as $name => $module) {
             // Each installed module must be found in the installed modules list
             if ($module->attributes->get('productType') == 'module' && $module->database->get('installed') == 0) {
-                $this->assertTrue(array_key_exists($name, $not_installed_modules), sprintf('Module %s not found in the filtered list !', $name));
+                $this->assertArrayHasKey($name, $not_installed_modules, sprintf('Module %s not found in the filtered list !', $name));
             }
         }
     }
@@ -229,7 +229,7 @@ class ModuleRepositoryTest extends UnitTestCase
             // Each installed module must be found in the installed modules list
             if ($module->database->get('installed') == 1
                 && $module->database->get('active') == 1) {
-                $this->assertTrue(array_key_exists($name, $installed_and_active_modules), sprintf('Module %s not found in the filtered list !', $name));
+                $this->assertArrayHasKey($name, $installed_and_active_modules, sprintf('Module %s not found in the filtered list !', $name));
             }
         }
     }
@@ -251,7 +251,7 @@ class ModuleRepositoryTest extends UnitTestCase
         foreach ($all_modules as $name => $module) {
             // Each installed module must be found in the installed modules list
             if ($module->attributes->get('productType') == 'module' && $module->database->get('installed') == 1  && $module->database->get('active') == 0) {
-                $this->assertTrue(array_key_exists($name, $not_active_modules), sprintf('Module %s not found in the filtered list !', $name));
+                $this->assertArrayHasKey($name, $not_active_modules, sprintf('Module %s not found in the filtered list !', $name));
             }
         }
     }
@@ -274,7 +274,7 @@ class ModuleRepositoryTest extends UnitTestCase
         foreach ($all_modules as $name => $module) {
             // Each installed module must be found in the installed modules list
             if ($module->database->get('installed') == 1 && $module->database->get('active') == 0) {
-                $this->assertTrue(array_key_exists($name, $installed_but_not_installed_modules), sprintf('Module %s not found in the filtered list !', $name));
+                $this->assertArrayHasKey($name, $installed_but_not_installed_modules, sprintf('Module %s not found in the filtered list !', $name));
             }
         }
     }
@@ -340,7 +340,7 @@ class ModuleRepositoryTest extends UnitTestCase
         $filters = new AddonListFilter();
         $filters->setType(AddonListFilterType::THEME);
 
-        $this->assertEquals(0, count($this->moduleRepositoryStub->getFilteredList($filters)));
+        $this->assertCount(0, $this->moduleRepositoryStub->getFilteredList($filters));
     }
 
     public function teardown()

--- a/tests-legacy/Unit/Core/Addon/Theme/ThemeRepositoryTest.php
+++ b/tests-legacy/Unit/Core/Addon/Theme/ThemeRepositoryTest.php
@@ -70,7 +70,7 @@ class ThemeRepositoryTest extends TestCase
 
     public function testGetInstanceByNameNotFound()
     {
-        $this->setExpectedException('PrestaShopException');
+        $this->expectException('PrestaShopException');
         $this->repository->getInstanceByName('not_found');
     }
 

--- a/tests-legacy/Unit/Core/Cldr/RepositoryTest.php
+++ b/tests-legacy/Unit/Core/Cldr/RepositoryTest.php
@@ -62,11 +62,11 @@ class RepositoryTest extends UnitTestCase
 
     public function testCacheFolderIsCreated()
     {
-        $this->assertFalse(file_exists($this->cldrCacheFolder));
+        $this->assertFileNotExists($this->cldrCacheFolder);
 
         mkdir($this->cldrCacheFolder, 0777, true);
 
-        $this->assertTrue(file_exists($this->cldrCacheFolder));
+        $this->assertFileExists($this->cldrCacheFolder);
     }
 
     public function testSetLocale()

--- a/tests-legacy/Unit/Core/Crypto/Core_Crypto_Hashing_Test.php
+++ b/tests-legacy/Unit/Core/Crypto/Core_Crypto_Hashing_Test.php
@@ -51,7 +51,7 @@ class Core_Crypto_Hashing_Test extends TestCase
 
     public function test_simple_encrypt()
     {
-        $this->assertTrue(is_string($this->hashing->hash("123", _COOKIE_KEY_)));
+        $this->assertInternalType('string', $this->hashing->hash("123", _COOKIE_KEY_));
     }
 
     public function test_simple_first_hash()

--- a/tests-legacy/Unit/Core/Filter/CollectionFilterTest.php
+++ b/tests-legacy/Unit/Core/Filter/CollectionFilterTest.php
@@ -29,7 +29,7 @@ namespace LegacyTests\Unit\Core\Filter;
 use PrestaShop\PrestaShop\Core\Filter\CollectionFilter;
 use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
 
-class CollectionFilterTest extends \PHPUnit_Framework_TestCase
+class CollectionFilterTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests-legacy/Unit/Core/Filter/HashMapWhitelistFilterTest.php
+++ b/tests-legacy/Unit/Core/Filter/HashMapWhitelistFilterTest.php
@@ -28,7 +28,7 @@ namespace LegacyTests\Unit\Core\Filter;
 
 use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
 
-class HashMapWhitelistFilterTest extends \PHPUnit_Framework_TestCase
+class HashMapWhitelistFilterTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests-legacy/Unit/Core/Foundation/Database/Core_Foundation_Database_EntityRepository_Test.php
+++ b/tests-legacy/Unit/Core/Foundation/Database/Core_Foundation_Database_EntityRepository_Test.php
@@ -51,10 +51,11 @@ class Core_Foundation_Database_EntityRepository_Test extends UnitTestCase
     }
 
     /**
-     * @expectedException \PrestaShop\PrestaShop\Core\Foundation\Database\Exception
      */
     public function test_call_to_invalid_method_throws_exception()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Foundation\Database\Exception::class);
+
         $this->repository->thisDoesNotExist();
     }
 

--- a/tests-legacy/Unit/Core/Foundation/FileSystem/Core_Foundation_FileSystem_FileSystemTest.php
+++ b/tests-legacy/Unit/Core/Foundation/FileSystem/Core_Foundation_FileSystem_FileSystemTest.php
@@ -57,18 +57,20 @@ class Core_Foundation_FileSystem_FileSystemTest extends UnitTestCase
     }
 
     /**
-     * @expectedException \PrestaShop\PrestaShop\Core\Foundation\Filesystem\Exception
      */
     public function test_joinPaths_one_path_throws()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Foundation\Filesystem\Exception::class);
+
         $this->fs->joinPaths('a');
     }
 
     /**
-     * @expectedException \PrestaShop\PrestaShop\Core\Foundation\Filesystem\Exception
      */
     public function test_joinPaths_zero_path_throws()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Foundation\Filesystem\Exception::class);
+
         $this->fs->joinPaths();
     }
 
@@ -112,19 +114,21 @@ class Core_Foundation_FileSystem_FileSystemTest extends UnitTestCase
 
     /**
      * Rationale: ls /some/non/existing/file => ls: cannot access /some/non/existing/file: No such file or directory
-     * @expectedException \PrestaShop\PrestaShop\Core\Foundation\Filesystem\Exception
      */
     public function test_listEntriesRecursively_throws_if_path_does_not_exist()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Foundation\Filesystem\Exception::class);
+
         $this->fs->listEntriesRecursively('/some/w/h/e/r/e/over/the/rainbow');
     }
 
     /**
      *
-     * @expectedException \PrestaShop\PrestaShop\Core\Foundation\Filesystem\Exception
      */
     public function test_listEntriesRecursively_throws_when_path_is_a_file()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Foundation\Filesystem\Exception::class);
+
         $this->fs->listEntriesRecursively(__FILE__);
     }
 }

--- a/tests-legacy/Unit/Core/Foundation/IoC/Core_Foundation_IoC_Container_Test.php
+++ b/tests-legacy/Unit/Core/Foundation/IoC/Core_Foundation_IoC_Container_Test.php
@@ -54,10 +54,11 @@ class Core_Foundation_IoC_Container_Test extends TestCase
     }
 
     /**
-     * @expectedException \PrestaShop\PrestaShop\Core\Foundation\IoC\Exception
      */
     public function test_cannot_bind_the_same_service_twice()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Foundation\IoC\Exception::class);
+
         $this->container->bind('foo', function () {});
         $this->container->bind('foo', function () {});
     }
@@ -112,10 +113,11 @@ class Core_Foundation_IoC_Container_Test extends TestCase
     }
 
     /**
-     * @expectedException \PrestaShop\PrestaShop\Core\Foundation\IoC\Exception
      */
     public function test_an_alias_cannot_be_changed()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Foundation\IoC\Exception::class);
+
         $this->container->aliasNamespace('Fixtures', 'LegacyTests\Unit\Core\Foundation\IoC\Fixtures');
         $this->container->aliasNamespace('Fixtures', 'LegacyTests\Unit\Core\Foundation\Other');
     }
@@ -135,26 +137,29 @@ class Core_Foundation_IoC_Container_Test extends TestCase
     }
 
     /**
-     * @expectedException \PrestaShop\PrestaShop\Core\Foundation\IoC\Exception
      */
     public function test_unbuildable_not_built()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Foundation\IoC\Exception::class);
+
         $this->container->make('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\UnBuildable');
     }
 
     /**
-     * @expectedException \PrestaShop\PrestaShop\Core\Foundation\IoC\Exception
      */
     public function test_non_existing_class_not_built()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Foundation\IoC\Exception::class);
+
         $this->container->make('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\AClassThatDoesntExistAtAll');
     }
 
     /**
-     * @expectedException \PrestaShop\PrestaShop\Core\Foundation\IoC\Exception
      */
     public function test_dependency_loop_doesnt_crash_container()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Foundation\IoC\Exception::class);
+
         /**
          * CycleA depends on CycleB,
          * CycleB depends on CycleA
@@ -199,10 +204,11 @@ class Core_Foundation_IoC_Container_Test extends TestCase
     }
 
     /**
-     * @expectedException Exception
      */
     public function test_container_doesnt_bind_strings_as_literal_values()
     {
+        $this->expectException(\Exception::class);
+
         $this->container->bind('value', 'a string which is not a class name');
         $this->container->make('value');
     }

--- a/tests-legacy/Unit/Core/Localization/Currency/RepositoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Currency/RepositoryTest.php
@@ -142,10 +142,11 @@ class RepositoryTest extends TestCase
      * When asking the currency repository for the corresponding Currency
      * Then an exception should be raised
      *
-     * @expectedException \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
      */
     public function testGetCurrencyWithUnknownCode()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException::class);
+
         $this->currencyRepository->getCurrency('foobar');
     }
 }

--- a/tests-legacy/Unit/Core/Localization/CurrencyTest.php
+++ b/tests-legacy/Unit/Core/Localization/CurrencyTest.php
@@ -131,10 +131,11 @@ class CurrencyTest extends TestCase
      * When requesting the currency symbol for the said locale code
      * Then an exception should be raised
      *
-     * @expectedException \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
      */
     public function testGetSymbolWithUnknownLocaleCode()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException::class);
+
         $this->currency->getSymbol('foobar');
     }
 
@@ -173,10 +174,11 @@ class CurrencyTest extends TestCase
      * When requesting the currency name for the said locale code
      * Then an exception should be raised
      *
-     * @expectedException  \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
      */
     public function testGetNameWithUnknownLocaleCode()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException::class);
+
         $this->currency->getName('foobar');
     }
 }

--- a/tests-legacy/Unit/Core/Localization/Locale/RepositoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Locale/RepositoryTest.php
@@ -120,10 +120,11 @@ class RepositoryTest extends TestCase
      * When asking the repository for the corresponding locale
      * Then an exception should be raised
      *
-     * @expectedException \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
      */
     public function testGetLocaleWithInvalidLocaleCode()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException::class);
+
         $this->localeRepository->getLocale('en-US');
     }
 }

--- a/tests-legacy/Unit/Core/Localization/LocaleTest.php
+++ b/tests-legacy/Unit/Core/Localization/LocaleTest.php
@@ -127,10 +127,11 @@ class LocaleTest extends TestCase
      *
      * For more formatting cases, @see \LegacyTests\Unit\Core\Localization\Number\FormatterTest
      *
-     * @expectedException \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
      */
     public function testFormatNumberWithInvalidRawNumber()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException::class);
+
         $this->cldrLocale->formatNumber('foobar');
     }
 
@@ -211,10 +212,11 @@ class LocaleTest extends TestCase
      *
      * @dataProvider provideInvalidPriceData
      *
-     * @expectedException \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
      */
     public function testFormatNumberWithInvalidPriceData($number, $currency)
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException::class);
+
         $this->cldrLocale->formatPrice($number, $currency);
     }
 

--- a/tests-legacy/Unit/Core/Localization/Specification/NumberTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/NumberTest.php
@@ -107,10 +107,11 @@ class NumberTest extends TestCase
      * When asking it a symbols list for a given INVALID numbering system
      * Then an exception souhd be raised
      *
-     * @expectedException \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
      */
     public function testGetSymbolsByNumberingSystemWithInvalidParameter()
     {
+        $this->expectException(\PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException::class);
+
         $this->latinNumberSpec->getSymbolsByNumberingSystem('foobar');
     }
 }

--- a/tests-legacy/Unit/PrestaShopBundle/MultishopCommandListenerTest.php
+++ b/tests-legacy/Unit/PrestaShopBundle/MultishopCommandListenerTest.php
@@ -122,8 +122,10 @@ class MultishopCommandListenerTest extends UnitTestCase
         $event   = new ConsoleCommandEvent($command, $input, $output);
 
         // Call ...
-        $this->setExpectedException(
-            'LogicException',
+        $this->expectException(
+            'LogicException'
+        );
+        $this->expectExceptionMessage(
             'Do not specify an ID shop and an ID group shop at the same time.'
         );
         $this->commandListener->onConsoleCommand($event);

--- a/tests-legacy/Unit/PrestaShopBundle/Utils/FloatParserTest.php
+++ b/tests-legacy/Unit/PrestaShopBundle/Utils/FloatParserTest.php
@@ -53,11 +53,12 @@ class FloatParserTest extends TestCase
      * Then an InvalidArgumentException should be thrown
      * @param mixed $value
      *
-     * @expectedException \InvalidArgumentException
      * @dataProvider provideInvalidValues
      */
     public function testItThrowsExceptionIfNotValid($value)
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         (new FloatParser())->fromString($value);
     }
 

--- a/tests-legacy/Unit/classes/CacheCoreTest.php
+++ b/tests-legacy/Unit/classes/CacheCoreTest.php
@@ -27,10 +27,10 @@
 namespace LegacyTests\Unit\Classes;
 
 use PrestaShop\PrestaShop\Adapter\Entity\CacheMemcache;
-use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_TestCase;
 use Cache;
 
-class CacheCoreTest extends TestCase
+class CacheCoreTest extends PHPUnit_Framework_TestCase
 {
     private $cacheArray = array();
 

--- a/tests-legacy/Unit/classes/CacheCoreTest.php
+++ b/tests-legacy/Unit/classes/CacheCoreTest.php
@@ -27,10 +27,10 @@
 namespace LegacyTests\Unit\Classes;
 
 use PrestaShop\PrestaShop\Adapter\Entity\CacheMemcache;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Cache;
 
-class CacheCoreTest extends PHPUnit_Framework_TestCase
+class CacheCoreTest extends TestCase
 {
     private $cacheArray = array();
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | ->setExpectedException* methods should be replaced by ->expectException* methods.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | /
| How to test?  | Everything should work the same.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11675)
<!-- Reviewable:end -->
