### PR TITLE
Fix issue with deleting a category with subcategories on Multistore

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -390,7 +390,7 @@ class CategoryCore extends ObjectModel
         foreach ($allCat as $cat) {
             /* @var Category $cat */
             $cat->deleteLite();
-            if (!$this->hasMultishopEntries()) {
+            if (!$cat->hasMultishopEntries()) {
                 $cat->deleteImage();
                 $cat->cleanGroups();
                 $cat->cleanAssoProducts();


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When deleting a category, it checks if there are multishop entries first before deleting images etc. However, when deleting a category with subcategories, the images and other associations of the subcategories will not get deleted because the top category gets deleted last, and the code checks multishop entries with $this instead of the variable of the category $cat that just got deleted. This bugfix solves that.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/pull/11437
| How to test?  | In the admin: Enable multishop and create an extra shop so you have at least two. Then put your context on "all shops". Then create a category under "Home". Then add a subcategory under the new category with an image. Then go to "Home" and delete the top category you just created. You will see the image of the subcategory is not deleted without this fix.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11679)
<!-- Reviewable:end -->
