### PR TITLE
Fix bug on pdf logo path

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -123,7 +123,7 @@ abstract class HTMLTemplateCore
         $width = 0;
         $height = 0;
         if (!empty($path_logo)) {
-            list($width, $height) = getimagesize(_PS_ROOT_DIR_.$path_logo);
+            list($width, $height) = getimagesize($path_logo);
         }
 
         // Limit the height of the logo for the PDF render

--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -123,7 +123,7 @@ abstract class HTMLTemplateCore
         $width = 0;
         $height = 0;
         if (!empty($path_logo)) {
-            list($width, $height) = getimagesize($path_logo);
+            list($width, $height) = getimagesize(_PS_ROOT_DIR_.$path_logo);
         }
 
         // Limit the height of the logo for the PDF render

--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -106,7 +106,7 @@ abstract class HTMLTemplateCore
             $logo = _PS_IMG_ . Configuration::get('PS_LOGO', null, null, $id_shop);
         }
 
-         return Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . $logo;
+        return Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . $logo;
     }
 
     /**

--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -106,7 +106,7 @@ abstract class HTMLTemplateCore
             $logo = _PS_IMG_ . Configuration::get('PS_LOGO', null, null, $id_shop);
         }
 
-        return $logo;
+         return Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . $logo;
     }
 
     /**

--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -101,9 +101,9 @@ abstract class HTMLTemplateCore
         $id_shop = (int) $this->shop->id;
 
         if (Configuration::get('PS_LOGO_INVOICE', null, null, $id_shop) != false && file_exists(_PS_IMG_DIR_ . Configuration::get('PS_LOGO_INVOICE', null, null, $id_shop))) {
-            $logo = _PS_IMG_DIR_ . Configuration::get('PS_LOGO_INVOICE', null, null, $id_shop);
+            $logo = _PS_IMG_ . Configuration::get('PS_LOGO_INVOICE', null, null, $id_shop);
         } elseif (Configuration::get('PS_LOGO', null, null, $id_shop) != false && file_exists(_PS_IMG_DIR_ . Configuration::get('PS_LOGO', null, null, $id_shop))) {
-            $logo = _PS_IMG_DIR_ . Configuration::get('PS_LOGO', null, null, $id_shop);
+            $logo = _PS_IMG_ . Configuration::get('PS_LOGO', null, null, $id_shop);
         }
 
         return $logo;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix bug on pdf logo path in invoice for example. Change absolute to relative path on img src attribute
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Generate an invoice. The logo must be displayed without overlapping the text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11691)
<!-- Reviewable:end -->
