### PR TITLE
Force DNI fields required if associated Country needs it

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -332,15 +332,12 @@ class AddressCore extends ObjectModel
      */
     public function validateField($field, $value, $id_lang = null, $skip = array(), $human_errors = false)
     {
-        if (true !== ($error = parent::validateField($field, $value, $id_lang, $skip, $human_errors))) {
+        $error = parent::validateField($field, $value, $id_lang, $skip, $human_errors);
+        if (true !== $error || 'dni' !== $field) {
             return $error;
         }
 
-        //Special validation for dni, check if the country needs it
-        if ('dni' === $field) {
-            return true;
-        }
-
+        // Special validation for dni, check if the country needs it
         $result = (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
 			SELECT c.`need_identification_number`
 			FROM `' . _DB_PREFIX_ . 'country` c

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -348,10 +348,18 @@ class AddressCore extends ObjectModel
 
         if ($result && Tools::isEmpty($value)) {
             if ($human_errors) {
-                return $this->trans('The %s field is required.', array($this->displayFieldName($field, get_class($this))), 'Admin.Notifications.Error');
+                return $this->trans(
+                    'The %s field is required.',
+                    [$this->displayFieldName($field, get_class($this))],
+                    'Admin.Notifications.Error'
+                );
             }
 
-            return $this->trans('Property %s is empty.', array(get_class($this) . '->' . $field), 'Admin.Notifications.Error');
+            return $this->trans(
+                'Property %s is empty.',
+                [get_class($this) . '->' . $field],
+                'Admin.Notifications.Error'
+            );
         }
 
         return true;

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -328,7 +328,7 @@ class AddressCore extends ObjectModel
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function validateField($field, $value, $id_lang = null, $skip = array(), $human_errors = false)
     {

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -328,6 +328,34 @@ class AddressCore extends ObjectModel
     }
 
     /**
+     * @inheritdoc
+     */
+    public function validateField($field, $value, $id_lang = null, $skip = array(), $human_errors = false)
+    {
+        if (!($error = parent::validateField($field, $value, $id_lang, $skip, $human_errors))) {
+            return $error;
+        }
+
+        //Special validation for dni, check if the country needs it
+        if ('dni' === $field) {
+            $result = (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+			SELECT c.`need_identification_number`
+			FROM `' . _DB_PREFIX_ . 'country` c
+			WHERE c.`id_country` = ' . (int) $this->id_country);
+
+            if ($result && Tools::isEmpty($value)) {
+                if ($human_errors) {
+                    return $this->trans('The %s field is required.', array($this->displayFieldName($field, get_class($this))), 'Admin.Notifications.Error');
+                } else {
+                    return $this->trans('Property %s is empty.', array(get_class($this) . '->' . $field), 'Admin.Notifications.Error');
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Check if Address is used (at least one order placed).
      *
      * @return int Order count for this Address

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -332,24 +332,26 @@ class AddressCore extends ObjectModel
      */
     public function validateField($field, $value, $id_lang = null, $skip = array(), $human_errors = false)
     {
-        if (!($error = parent::validateField($field, $value, $id_lang, $skip, $human_errors))) {
+        if (true !== ($error = parent::validateField($field, $value, $id_lang, $skip, $human_errors))) {
             return $error;
         }
 
         //Special validation for dni, check if the country needs it
         if ('dni' === $field) {
-            $result = (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+            return true;
+        }
+
+        $result = (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
 			SELECT c.`need_identification_number`
 			FROM `' . _DB_PREFIX_ . 'country` c
 			WHERE c.`id_country` = ' . (int) $this->id_country);
 
-            if ($result && Tools::isEmpty($value)) {
-                if ($human_errors) {
-                    return $this->trans('The %s field is required.', array($this->displayFieldName($field, get_class($this))), 'Admin.Notifications.Error');
-                } else {
-                    return $this->trans('Property %s is empty.', array(get_class($this) . '->' . $field), 'Admin.Notifications.Error');
-                }
+        if ($result && Tools::isEmpty($value)) {
+            if ($human_errors) {
+                return $this->trans('The %s field is required.', array($this->displayFieldName($field, get_class($this))), 'Admin.Notifications.Error');
             }
+
+            return $this->trans('Property %s is empty.', array(get_class($this) . '->' . $field), 'Admin.Notifications.Error');
         }
 
         return true;

--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -90,27 +90,16 @@ class CustomerAddressFormCore extends AbstractForm
         // This form is very tricky: fields may change depending on which
         // country is being submitted!
         // So we first update the format if a new id_country was set.
-        $country = null;
         if (isset($params['id_country'])
             && $params['id_country'] != $this->formatter->getCountry()->id
         ) {
-            $country = new Country(
+            $this->formatter->setCountry(new Country(
                 $params['id_country'],
                 $this->language->id
-            );
-            $this->formatter->setCountry($country);
+            ));
         }
 
-        parent::fillWith($params);
-
-        //Check if this country needs identification number
-        if (null !== $country && $country->need_identification_number) {
-            if (($dni = $this->getField('dni'))) {
-                $dni->setRequired(true);
-            }
-        }
-
-        return $this;
+        return parent::fillWith($params);
     }
 
     public function validate()

--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -90,16 +90,27 @@ class CustomerAddressFormCore extends AbstractForm
         // This form is very tricky: fields may change depending on which
         // country is being submitted!
         // So we first update the format if a new id_country was set.
+        $country = null;
         if (isset($params['id_country'])
             && $params['id_country'] != $this->formatter->getCountry()->id
         ) {
-            $this->formatter->setCountry(new Country(
+            $country = new Country(
                 $params['id_country'],
                 $this->language->id
-            ));
+            );
+            $this->formatter->setCountry($country);
         }
 
-        return parent::fillWith($params);
+        parent::fillWith($params);
+
+        //Check if this country needs identification number
+        if (null !== $country && $country->need_identification_number) {
+            if (($dni = $this->getField('dni'))) {
+                $dni->setRequired(true);
+            }
+        }
+
+        return $this;
     }
 
     public function validate()

--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -98,7 +98,7 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
                     }
                 } elseif ($field === 'phone') {
                     $formField->setType('tel');
-                } elseif (($field === 'dni' && null !== $this->country)) {
+                } elseif ($field === 'dni' && null !== $this->country) {
                     if ($this->country->need_identification_number) {
                         $formField->setRequired(true);
                     }

--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -98,6 +98,10 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
                     }
                 } elseif ($field === 'phone') {
                     $formField->setType('tel');
+                } elseif (($field === 'dni' && null !== $this->country)) {
+                    if ($this->country->need_identification_number) {
+                        $formField->setRequired(true);
+                    }
                 }
             } elseif (count($fieldParts) === 2) {
                 list($entity, $entityField) = $fieldParts;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Some country needs the dni field in their customer addresses, but you can't force it on every countries So the address validation needs to check this field according to the country settings and for the required field if needed.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9891
| How to test?  | Go to International > Locations > Countries, select a country and set "Do you need a tax identification number?" to true, and you need to add "dni" in the address format or you won't be able to see (nor validate) the field. Try to enter an address in this country without dni you are blocked. When you try in another country everything is fine. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11726)
<!-- Reviewable:end -->
