### PR TITLE
Add branch in nightly releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
         - mkdir -p /tmp/ps-release
         - php tools/build/CreateRelease.php --destination-dir=/tmp/ps-release
         - cd /tmp/ps-release
-          && today=`date +%Y-%m-%d-`; for i in *; do mv $i $today$i; done
+          && today=`date +%Y-%m-%d-`; for i in *; do mv $i $today$TRAVIS_BRANCH-$i; done
           && cd -
       if: type = cron
       deploy: 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Update the format of the release names, by including the source branch. This targets the branch `1.7.5.x` as it is currently targeted by the corn job. It will allow us to run the cron task on other branches in parallel.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | This impact the Travis builds triggered by the cron task. The core isn't modified by this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11762)
<!-- Reviewable:end -->
