### PR TITLE
Migrate customers searching via ajax

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -475,10 +475,13 @@
 
 	function searchCustomers()
 	{
-    var customer_search = $('#customer').val();
+	  var $customer_search_input = $('#customer');
+    var customer_search = $customer_search_input.val();
+    var customer_search_url = $customer_search_input.data('customers-search-url');
+
 		$.ajax({
-			type:"POST",
-			url : "{$link->getAdminLink('AdminCustomers')}",
+			type:"GET",
+			url : customer_search_url,
 			async: true,
 			dataType: "json",
 			data : {
@@ -1112,7 +1115,7 @@
 				<div class="row">
 					<div class="col-lg-6">
 						<div class="input-group">
-							<input type="text" id="customer" value="" />
+							<input type="text" id="customer" value="" data-customers-search-url="{$customersSearchUrl|escape:'html':'UTF-8'}" />
 							<span class="input-group-addon">
 								<i class="icon-search"></i>
 							</span>

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -24,6 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 use PrestaShop\PrestaShop\Adapter\StockManager;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 /**
  * @property Order $object
@@ -251,6 +252,7 @@ class AdminOrdersControllerCore extends AdminController
         }
 
         $this->context->smarty->assign(array(
+            'customersSearchUrl' => SymfonyContainer::getInstance()->get('router')->generate('admin_customers_search'),
             'recyclable_pack' => (int) Configuration::get('PS_RECYCLABLE_PACK'),
             'gift_wrapping' => (int) Configuration::get('PS_GIFT_WRAPPING'),
             'cart' => $cart,

--- a/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
+++ b/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
@@ -60,13 +60,13 @@ final class SearchCustomersHandler implements SearchCustomersHandlerInterface
 
             foreach ($customersResult as $customerArray) {
                 if ($customerArray['active']) {
-                    $result['fullname_and_email'] = sprintf(
+                    $customerArray['fullname_and_email'] = sprintf(
                         '%s %s - %s',
                         $customerArray['firstname'],
                         $customerArray['lastname'],
                         $customerArray['email']
                     );
-                    $customers[$result['id_customer']] = $result;
+                    $customers[$customerArray['id_customer']] = $customerArray;
                 }
             }
         }

--- a/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
+++ b/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Customer\QueryHandler;
+
+use Customer;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers;
+use PrestaShop\PrestaShop\Core\Domain\Customer\QueryHandler\SearchCustomersHandlerInterface;
+
+/**
+ * Handles command that searches for customers
+ *
+ * @internal
+ */
+final class SearchCustomersHandler implements SearchCustomersHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(SearchCustomers $query)
+    {
+        $queries = explode(' ', $query->getQuery());
+        $queries = array_unique($queries);
+
+        $customers = [];
+
+        foreach ($queries as $searchQuery) {
+            if (empty($searchQuery)) {
+                continue;
+            }
+
+            $limit = 50;
+            $customersResult = Customer::searchByName($searchQuery, $limit);
+            if (!is_array($customersResult)) {
+                continue;
+            }
+
+            foreach ($customersResult as $customerArray) {
+                if ($customerArray['active']) {
+                    $result['fullname_and_email'] = sprintf(
+                        '%s %s - %s',
+                        $customerArray['firstname'],
+                        $customerArray['lastname'],
+                        $customerArray['email']
+                    );
+                    $customers[$result['id_customer']] = $result;
+                }
+            }
+        }
+
+        return $customers;
+    }
+}

--- a/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
+++ b/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryHandler\SearchCustomersHandlerInterface;
 
 /**
- * Handles command that searches for customers
+ * Handles query that searches for customers by given phrases
  *
  * @internal
  */
@@ -42,18 +42,17 @@ final class SearchCustomersHandler implements SearchCustomersHandlerInterface
      */
     public function handle(SearchCustomers $query)
     {
-        $queries = explode(' ', $query->getQuery());
-        $queries = array_unique($queries);
+        $limit = 50;
+        $phrases = array_unique($query->getPhrases());
 
         $customers = [];
 
-        foreach ($queries as $searchQuery) {
-            if (empty($searchQuery)) {
+        foreach ($phrases as $searchPhrase) {
+            if (empty($searchPhrase)) {
                 continue;
             }
 
-            $limit = 50;
-            $customersResult = Customer::searchByName($searchQuery, $limit);
+            $customersResult = Customer::searchByName($searchPhrase, $limit);
             if (!is_array($customersResult)) {
                 continue;
             }

--- a/src/Core/Domain/Customer/Query/SearchCustomers.php
+++ b/src/Core/Domain/Customer/Query/SearchCustomers.php
@@ -26,29 +26,43 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Customer\Query;
 
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
+
 /**
- * Searchers for customers by query matching on first name, last name, email and id
+ * Searchers for customers by phrases matching customer's first name, last name, email and id
  */
 class SearchCustomers
 {
     /**
-     * @var string
+     * @var string[]
      */
-    private $query;
+    private $phrases;
 
     /**
-     * @param string $query
+     * @param string[] $phrases
      */
-    public function __construct($query)
+    public function __construct(array $phrases)
     {
-        $this->query = $query;
+        $this->assertPhrasesAreNotEmpty($phrases);
+
+        $this->phrases = $phrases;
     }
 
     /**
-     * @return string
+     * @return string[]
      */
-    public function getQuery()
+    public function getPhrases()
     {
-        return $this->query;
+        return $this->phrases;
+    }
+
+    /**
+     * @param string[] $phrases
+     */
+    private function assertPhrasesAreNotEmpty(array $phrases)
+    {
+        if (empty($phrases)) {
+            throw new CustomerException('Phrases cannot be empty when searching customers.');
+        }
     }
 }

--- a/src/Core/Domain/Customer/Query/SearchCustomers.php
+++ b/src/Core/Domain/Customer/Query/SearchCustomers.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Customer\Query;
+
+/**
+ * Searchers for customers by query matching on first name, last name, email and id
+ */
+class SearchCustomers
+{
+    /**
+     * @var string
+     */
+    private $query;
+
+    /**
+     * @param string $query
+     */
+    public function __construct($query)
+    {
+        $this->query = $query;
+    }
+
+    /**
+     * @return string
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+}

--- a/src/Core/Domain/Customer/QueryHandler/SearchCustomersHandlerInterface.php
+++ b/src/Core/Domain/Customer/QueryHandler/SearchCustomersHandlerInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Customer\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers;
+
+/**
+ * Interface for service that handlers customers searching command
+ */
+interface SearchCustomersHandlerInterface
+{
+    /**
+     * @param SearchCustomers $query
+     *
+     * @return array
+     */
+    public function handle(SearchCustomers $query);
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -323,6 +323,8 @@ class CustomerController extends AbstractAdminController
     /**
      * Search for customers by query.
      *
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     *
      * @param Request $request
      *
      * @return JsonResponse

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -26,20 +26,33 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Customer;
 
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\BulkDeleteCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\BulkDisableCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\BulkEnableCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\DeleteCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\EditCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SavePrivateNoteForCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\TransformGuestToCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Dto\EditableCustomer;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerDefaultGroupAccessException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerTransformationException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetRequiredFieldsForCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\DuplicateCustomerEmailException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetRequiredFieldsForCustomer;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers;
+use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\ViewableCustomer;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerDeleteMethod;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForViewing;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
+use PrestaShopBundle\Form\Admin\Sell\Customer\DeleteCustomersType;
 use PrestaShopBundle\Form\Admin\Sell\Customer\PrivateNoteType;
 use PrestaShopBundle\Form\Admin\Sell\Customer\RequiredFieldsType;
 use PrestaShopBundle\Form\Admin\Sell\Customer\TransferGuestAccountType;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -330,9 +330,10 @@ class CustomerController extends AbstractAdminController
     public function searchAction(Request $request)
     {
         $query = $request->query->get('customer_search');
+        $phrases = explode(' ', $query);
         $isRequestFromLegacyPage = !$request->query->has('sf2');
 
-        $customers = $this->getQueryBus()->handle(new SearchCustomers($query));
+        $customers = $this->getQueryBus()->handle(new SearchCustomers($phrases));
 
         // if call is made from legacy page
         // it will return response so legacy can understand it

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -164,7 +164,7 @@ class ProductSpecificPrice extends CommonAbstractType
                 'sp_id_customer',
                 TypeaheadCustomerCollectionType::class,
                 [
-                    'remote_url' => $this->context->getAdminLink('AdminCustomers', true) . '&sf2=1&ajax=1&tab=AdminCustomers&action=searchCustomers&customer_search=%QUERY',
+                    'remote_url' => $this->router->generate('admin_customers_search', ['sf2' => 1]) . '&customer_search=%QUERY',
                     'mapping_value' => 'id_customer',
                     'mapping_name' => 'fullname_and_email',
                     'placeholder' => $this->translator->trans('All customers', [], 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -164,6 +164,8 @@ class ProductSpecificPrice extends CommonAbstractType
                 'sp_id_customer',
                 TypeaheadCustomerCollectionType::class,
                 [
+                    // "%QUERY" is appended to url in order to avoid "%" sign being encoded into "%25",
+                    // it used as a placeholder to replace with actual query in JS
                     'remote_url' => $this->router->generate('admin_customers_search', ['sf2' => 1]) . '&customer_search=%QUERY',
                     'mapping_value' => 'id_customer',
                     'mapping_name' => 'fullname_and_email',

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer/customers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer/customers.yml
@@ -5,7 +5,7 @@ admin_customers_index:
     _controller: PrestaShopBundle:Admin/Sell/Customer/Customer:index
     _legacy_controller: AdminCustomers
 
-admin_customers_search:
+admin_customers_filter:
   path: /
   methods: [POST]
   defaults:
@@ -120,4 +120,11 @@ admin_customers_export:
   methods: [GET]
   defaults:
     _controller: PrestaShopBundle:Admin/Sell/Customer/Customer:export
+    _legacy_controller: AdminCustomers
+
+admin_customers_search:
+  path: /search
+  methods: [GET]
+  defaults:
+    _controller: PrestaShopBundle:Admin/Sell/Customer/Customer:search
     _legacy_controller: AdminCustomers

--- a/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
@@ -81,3 +81,9 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Customer\CommandHandler\BulkDeleteCustomerHandler'
     tags:
       - { name: tactician.handler, command: 'PrestaShop\PrestaShop\Core\Domain\Customer\Command\BulkDeleteCustomerCommand' }
+
+  prestashop.adapter.customer.query_handler.search_customers:
+    class: 'PrestaShop\PrestaShop\Adapter\Customer\QueryHandler\SearchCustomersHandler'
+    tags:
+      - name: tactician.handler
+        command: 'PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers'


### PR DESCRIPTION
<!--
Comment: reviewed, discussion going on
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Migrates searching of customers. It is used at 2 places: 1. when creating order in BO to search for customer 2. when creating Specific price and searching for customer
| Type?         | refacto
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially https://github.com/PrestaShop/PrestaShop/issues/10560
| How to test?  | Searching for customers in described places (1. when creating order in BO to search for customer 2. when creating Specific price and searching for customer) should work the same : no regressions. Please check what happens when someone attempts to search for a customer _but he does not have access to the Customers page_.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11783)
<!-- Reviewable:end -->
