### PR TITLE
fix getimagesize error when changing the satus of an order to payment…

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -123,7 +123,7 @@ abstract class HTMLTemplateCore
         $width = 0;
         $height = 0;
         if (!empty($path_logo)) {
-            list($width, $height) = getimagesize($path_logo);
+            list($width, $height) = @getimagesize($path_logo);
         }
 
         // Limit the height of the logo for the PDF render


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | After creating an order from the FO, when we try to change the status of this order to payment accepted an error is displayed, This issue occurs only when we use a **docker** environment.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |Fixes #11801 
| How to test?  | Go to FO -> Create an order -> Go to BO => Orders -> Change the status of this latest order to payment accepted -> OK.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11802)
<!-- Reviewable:end -->
