### PR TITLE
Fixed bug when X-Forwarded-Host HTTP header has more than one host

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -275,7 +275,12 @@ class ToolsCore
             $httpHost = $_SERVER['HTTP_HOST'];
         }
 
-        $host = (isset($_SERVER['HTTP_X_FORWARDED_HOST']) ? $_SERVER['HTTP_X_FORWARDED_HOST'] : $httpHost);
+        if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+            $host = trim(array_pop(explode(',', $_SERVER['HTTP_X_FORWARDED_HOST'])));
+        } else {
+            $host = $httpHost;
+        }
+
         if ($ignore_port && $pos = strpos($host, ':')) {
             $host = substr($host, 0, $pos);
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow multiple values in X-Forwarded-Host header
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

The HTTP header X-Forwarded-Host is not a standard header but come conventions are used by servers. For instance, Apache can include more than one host in this header.

See. https://httpd.apache.org/docs/current/en/mod/mod_proxy.html#x-headers

"Be careful when using these headers on the origin server, since they will contain more than one (comma-separated) value if the original request already contained one of these headers"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11810)
<!-- Reviewable:end -->
