### PR TITLE
[POC] Allow the module developers to complete the Front Office container

### DIFF
--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -65,7 +65,7 @@ class ContainerBuilder
         $container->compile();
 
         $dumper = new PhpDumper($container);
-        file_put_contents($file, $dumper->dump(array('class' => $containerName)));
+        file_put_contents($file, $dumper->dump(['class' => $containerName]));
 
         return $container;
     }

--- a/src/Adapter/DependencyInjection/FileLoader/YamlByTagFileLoader.php
+++ b/src/Adapter/DependencyInjection/FileLoader/YamlByTagFileLoader.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\DependencyInjection\FileLoader;
+
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+/**
+ * Load only files with the right tag on the selected Container
+ */
+final class YamlByTagFileLoader extends YamlFileLoader
+{
+    public function loadFile($file)
+    {
+        $configuration = parent::loadFile($file);
+
+        if (array_key_exists('services', $configuration)) {
+            $services = $configuration['services'];
+
+            $configuration['services'] = array_filter($services, function ($service) {
+                return array_key_exists('tags', $service) && in_array('front', $service['tags'], true);
+            });
+        }
+
+        return $configuration;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As a module developer, I want to be able to register new services available in the Front Office.
| Type?         | feature
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | In a module, create a class and then declare a service with the "front" tag.

```yaml
# your-module/config/services.yml
services:
    # The service will be available even in hooks dispatched in Front Office,
    # and in Front Controllers.
    tab_manager:
        class: MasterClass\Utils\TabManager
        tags: ['front']
```


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11852)
<!-- Reviewable:end -->
