### PR TITLE
php unit test case static method calls

### DIFF
--- a/tests-legacy/Integration/Adapter/AdapterDatabaseTest.php
+++ b/tests-legacy/Integration/Adapter/AdapterDatabaseTest.php
@@ -54,6 +54,6 @@ class AdapterDatabaseTest extends IntegrationTestCase
      */
     public function testValuesAreEscaped($expectedSanitizedValue, $unsafeInput)
     {
-        $this->assertEquals($expectedSanitizedValue, $this->db->escape($unsafeInput));
+        static::assertEquals($expectedSanitizedValue, $this->db->escape($unsafeInput));
     }
 }

--- a/tests-legacy/Integration/Core/Foundation/Entity/EntityManagerTest.php
+++ b/tests-legacy/Integration/Core/Foundation/Entity/EntityManagerTest.php
@@ -60,7 +60,7 @@ class EntityManagerTest extends IntegrationTestCase
 
     public function testExplicitlyDefinedRepositoryIsFoundByEntitymanager()
     {
-        $this->assertInstanceOf(
+        static::assertInstanceOf(
             '\\PrestaShop\\PrestaShop\\Core\\CMS\\CMSRoleRepository',
             $this->entityManager->getRepository('CMSRole')
         );
@@ -70,8 +70,8 @@ class EntityManagerTest extends IntegrationTestCase
     {
         $repository = $this->entityManager->getRepository('Product');
         $product = $repository->findOne(1);
-        $this->assertInstanceOf('Product', $product);
-        $this->assertEquals(1, $product->id);
+        static::assertInstanceOf('Product', $product);
+        static::assertEquals(1, $product->id);
     }
 
     public function testSaveDataMapperStyle()
@@ -87,7 +87,7 @@ class EntityManagerTest extends IntegrationTestCase
 
         $this->entityManager->save($entity);
 
-        $this->assertGreaterThan(0, $repository->findOneByName($name)->id);
+        static::assertGreaterThan(0, $repository->findOneByName($name)->id);
 
         // Clean DB !
         $this->entityManager->delete($entity);

--- a/tests-legacy/Integration/Core/Foundation/Entity/EntityTest.php
+++ b/tests-legacy/Integration/Core/Foundation/Entity/EntityTest.php
@@ -56,6 +56,6 @@ class EntityTest extends IntegrationTestCase
         $product->name = 'A Product';
         $product->price = 42.42;
         $product->link_rewrite = 'a-product';
-        $this->assertTrue($product->save());
+        static::assertTrue($product->save());
     }
 }

--- a/tests-legacy/Integration/Core/Module/HookRepositoryTest.php
+++ b/tests-legacy/Integration/Core/Module/HookRepositoryTest.php
@@ -72,7 +72,7 @@ class HookRepositoryTest extends IntegrationTestCase
             'displayTestHookName' => $modules,
         ]);
 
-        $this->assertEquals(
+        static::assertEquals(
             $modules,
             $this->hookRepository->getHooksWithModules()['displayTestHookName']
         );
@@ -87,12 +87,12 @@ class HookRepositoryTest extends IntegrationTestCase
 
         $actual = $this->hookRepository->getDisplayHooksWithModules();
 
-        $this->assertEquals(
+        static::assertEquals(
             ['ps_emailsubscription', 'ps_featuredproducts'],
             $actual['displayTestHookName']
         );
 
-        $this->assertArrayNotHasKey(
+        static::assertArrayNotHasKey(
             'notADisplayTestHookName',
             $actual
         );
@@ -110,7 +110,7 @@ class HookRepositoryTest extends IntegrationTestCase
             ],
         ]);
 
-        $this->assertEquals(
+        static::assertEquals(
             [
                 'ps_emailsubscription' => [
                     'except_pages' => ['category', 'product'],

--- a/tests-legacy/Integration/Core/Module/ModuleCacheTest.php
+++ b/tests-legacy/Integration/Core/Module/ModuleCacheTest.php
@@ -48,7 +48,7 @@ class ModuleCacheTest extends IntegrationTestCase
 
         // make sure the cache files are not regenerated
         // (same timestamp on the cache file between two subsequent call to getModulesOnDisk)
-        self::assertEquals($trustedFileCreationTime, $newTrustedFileCreationTime);
+        static::assertEquals($trustedFileCreationTime, $newTrustedFileCreationTime);
     }
 
     protected function tearDown()

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsControllerTest.php
@@ -82,25 +82,25 @@ class PositionsControllerTest extends WebTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertEquals(
+        static::assertEquals(
             Response::HTTP_FOUND,
             $response->getStatusCode()
         );
 
         $messages = self::$kernel->getContainer()->get('session')->getFlashBag()->all();
-        $this->assertArrayHasKey(
+        static::assertArrayHasKey(
             'error',
             $messages
         );
-        $this->assertContains(
+        static::assertContains(
             'This module cannot be loaded.',
             $messages['error']
         );
-        $this->assertContains(
+        static::assertContains(
             'Hook cannot be loaded.',
             $messages['error']
         );
-        $this->assertArrayNotHasKey(
+        static::assertArrayNotHasKey(
             'success',
             $messages
         );
@@ -120,21 +120,21 @@ class PositionsControllerTest extends WebTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertEquals(
+        static::assertEquals(
             Response::HTTP_FOUND,
             $response->getStatusCode()
         );
 
         $messages = self::$kernel->getContainer()->get('session')->getFlashBag()->all();
-        $this->assertArrayNotHasKey(
+        static::assertArrayNotHasKey(
             'error',
             $messages
         );
-        $this->assertArrayHasKey(
+        static::assertArrayHasKey(
             'success',
             $messages
         );
-        $this->assertContains(
+        static::assertContains(
             'The module was successfully removed from the hook.',
             $messages['success']
         );

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Improve/International/GeolocationControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Improve/International/GeolocationControllerTest.php
@@ -45,6 +45,6 @@ class GeolocationControllerTest extends WebTestCase
     {
         $this->client->request('GET', $this->router->generate('admin_geolocation_index'));
 
-        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        static::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
     }
 }

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/ModuleControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/ModuleControllerTest.php
@@ -55,14 +55,14 @@ class ModuleControllerTest extends WebTestCase
 
         $decodedContent = json_decode($responseContent, true);
 
-        $this->assertArrayHasKey($moduleName, $decodedContent);
+        static::assertArrayHasKey($moduleName, $decodedContent);
 
-        $this->assertArrayHasKey('status', $decodedContent[$moduleName]);
-        $this->assertFalse($decodedContent[$moduleName]['status']);
+        static::assertArrayHasKey('status', $decodedContent[$moduleName]);
+        static::assertFalse($decodedContent[$moduleName]['status']);
 
-        $this->assertArrayHasKey('msg', $decodedContent[$moduleName]);
+        static::assertArrayHasKey('msg', $decodedContent[$moduleName]);
 
-        $this->assertEquals($this->getExpectedErrorMessage(), $decodedContent[$moduleName]['msg']);
+        static::assertEquals($this->getExpectedErrorMessage(), $decodedContent[$moduleName]['msg']);
     }
 
     public function testImportModuleAction()
@@ -75,8 +75,8 @@ class ModuleControllerTest extends WebTestCase
 
         $decodedContent = json_decode($responseContent, true);
 
-        $this->assertArrayHasKey('msg', $decodedContent);
-        $this->assertEquals($this->getExpectedErrorMessage(), $decodedContent['msg']);
+        static::assertArrayHasKey('msg', $decodedContent);
+        static::assertEquals($this->getExpectedErrorMessage(), $decodedContent['msg']);
     }
 
     public function testRecommendedModules()
@@ -89,7 +89,7 @@ class ModuleControllerTest extends WebTestCase
         $this->client->request('GET', $recommendedModuleRoute);
 
         $response = $this->client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode());
+        static::assertEquals(200, $response->getStatusCode());
         Context::setInstanceForTesting($oldContext);
     }
 

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/ProductControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/ProductControllerTest.php
@@ -91,6 +91,6 @@ class ProductControllerTest extends WebTestCase
     protected function assertSessionFlagBagContainsFailureMessage()
     {
         $all = self::$kernel->getContainer()->get('session')->getFlashBag()->all();
-        $this->assertArrayHasKey('failure', $all);
+        static::assertArrayHasKey('failure', $all);
     }
 }

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
@@ -49,7 +49,7 @@ class DeliveryControllerTest extends WebTestCase
             )
         );
 
-        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        static::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
     }
 
     public function testSlipActionWithInvalidData()
@@ -70,11 +70,11 @@ class DeliveryControllerTest extends WebTestCase
             ]
         );
         $response = $this->client->getResponse();
-        $this->assertEquals(
+        static::assertEquals(
             Response::HTTP_OK,
             $response->getStatusCode()
         );
-        $this->assertContains('This value is not valid.', $response->getContent());
+        static::assertContains('This value is not valid.', $response->getContent());
     }
 
     public function testSlipActionWithValidData()
@@ -95,12 +95,12 @@ class DeliveryControllerTest extends WebTestCase
             ]
         );
         $response = $this->client->getResponse();
-        $this->assertEquals(
+        static::assertEquals(
             Response::HTTP_FOUND,
             $response->getStatusCode()
         );
 
-        $this->assertArrayHasKey(
+        static::assertArrayHasKey(
             'success',
             self::$kernel->getContainer()->get('session')->getFlashBag()->all()
         );
@@ -124,15 +124,15 @@ class DeliveryControllerTest extends WebTestCase
             ]
         );
         $response = $this->client->getResponse();
-        $this->assertEquals(
+        static::assertEquals(
             Response::HTTP_FOUND,
             $response->getStatusCode()
         );
-        $this->assertArrayHasKey(
+        static::assertArrayHasKey(
             'error',
             self::$kernel->getContainer()->get('session')->getFlashBag()->all()
         );
-        $this->assertContains('/sell/orders/delivery-slips/?_token', $response->getTargetUrl());
+        static::assertContains('/sell/orders/delivery-slips/?_token', $response->getTargetUrl());
     }
 
     public function testPdfActionWithEmptyData()
@@ -151,15 +151,15 @@ class DeliveryControllerTest extends WebTestCase
             ]
         );
         $response = $this->client->getResponse();
-        $this->assertEquals(
+        static::assertEquals(
             Response::HTTP_FOUND,
             $response->getStatusCode()
         );
 
-        $this->assertArrayHasKey(
+        static::assertArrayHasKey(
             'error',
             self::$kernel->getContainer()->get('session')->getFlashBag()->all()
         );
-        $this->assertContains('/sell/orders/delivery-slips/?_token', $response->getTargetUrl());
+        static::assertContains('/sell/orders/delivery-slips/?_token', $response->getTargetUrl());
     }
 }

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/SurvivalTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/SurvivalTest.php
@@ -97,7 +97,7 @@ class SurvivalTest extends WebTestCase
          *    // then display 'error.html' in a web browser.
          * }
          */
-        self::assertTrue(
+        static::assertTrue(
             $response->isSuccessful(),
             sprintf(
                 '%s page should be available, but status code is %s',
@@ -165,15 +165,15 @@ class SurvivalTest extends WebTestCase
             ])
             ->getMockForAbstractClass();
 
-        $tokenMock->expects($this->any())
+        $tokenMock->expects(static::any())
             ->method('getUser')
             ->willReturn($loggedEmployeeMock);
 
-        $tokenMock->expects($this->any())
+        $tokenMock->expects(static::any())
             ->method('getRoles')
             ->willReturn([]);
 
-        $tokenMock->expects($this->any())
+        $tokenMock->expects(static::any())
             ->method('isAuthenticated')
             ->willReturn(true);
 

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/ApiTestCase.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/ApiTestCase.php
@@ -221,7 +221,7 @@ abstract class ApiTestCase extends WebTestCase
 
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = self::$client->getResponse();
-        $this->assertEquals(400, $response->getStatusCode(), 'It should return a response with "Bad Request" Status.');
+        static::assertEquals(400, $response->getStatusCode(), 'It should return a response with "Bad Request" Status.');
     }
 
     /**
@@ -235,7 +235,7 @@ abstract class ApiTestCase extends WebTestCase
 
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = self::$client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
+        static::assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
     }
 
     /**
@@ -264,14 +264,14 @@ abstract class ApiTestCase extends WebTestCase
                 break;
 
             default:
-                $this->fail($message);
+                static::fail($message);
         }
 
-        $this->assertEquals($expectedStatusCode, $response->getStatusCode(), $message);
+        static::assertEquals($expectedStatusCode, $response->getStatusCode(), $message);
 
         $content = json_decode($response->getContent(), true);
 
-        $this->assertEquals(
+        static::assertEquals(
             JSON_ERROR_NONE,
             json_last_error(),
             'The response body should be a valid json document.'

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/AttributeControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/AttributeControllerTest.php
@@ -42,6 +42,6 @@ class AttributeControllerTest extends ApiTestCase
 
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = self::$client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
+        static::assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
     }
 }

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/CategoryControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/CategoryControllerTest.php
@@ -42,6 +42,6 @@ class CategoryControllerTest extends ApiTestCase
 
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = self::$client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
+        static::assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
     }
 }

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/FeatureControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/FeatureControllerTest.php
@@ -42,6 +42,6 @@ class FeatureControllerTest extends ApiTestCase
 
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = self::$client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
+        static::assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
     }
 }

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/Improve/Design/PositionsControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/Improve/Design/PositionsControllerTest.php
@@ -80,15 +80,15 @@ class PositionsControllerTest extends WebTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertEquals(
+        static::assertEquals(
             Response::HTTP_OK,
             $response->getStatusCode()
         );
 
         $json = json_decode($response->getContent(), true);
-        $this->assertArrayHasKey('hasError', $json['data']);
-        $this->assertTrue($json['data']['hasError']);
-        $this->assertEquals(['This module cannot be loaded.'], $json['data']['errors']);
+        static::assertArrayHasKey('hasError', $json['data']);
+        static::assertTrue($json['data']['hasError']);
+        static::assertEquals(['This module cannot be loaded.'], $json['data']['errors']);
     }
 
     public function testMoveHookPositionToBottomWithUnavailablePositions()
@@ -107,15 +107,15 @@ class PositionsControllerTest extends WebTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertEquals(
+        static::assertEquals(
             Response::HTTP_OK,
             $response->getStatusCode()
         );
 
         $json = json_decode($response->getContent(), true);
-        $this->assertArrayHasKey('hasError', $json['data']);
-        $this->assertTrue($json['data']['hasError']);
-        $this->assertEquals(['Cannot update module position.'], $json['data']['errors']);
+        static::assertArrayHasKey('hasError', $json['data']);
+        static::assertTrue($json['data']['hasError']);
+        static::assertEquals(['Cannot update module position.'], $json['data']['errors']);
     }
 
     public function testMoveHookPositionToBottom()
@@ -137,14 +137,14 @@ class PositionsControllerTest extends WebTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertEquals(
+        static::assertEquals(
             Response::HTTP_OK,
             $response->getStatusCode()
         );
 
         $json = json_decode($response->getContent(), true);
-        $this->assertArrayNotHasKey('hasError', $json['data']);
-        $this->assertEquals([], $json['data']);
+        static::assertArrayNotHasKey('hasError', $json['data']);
+        static::assertEquals([], $json['data']);
     }
 
     public function testMoveHookPositionToTop()
@@ -166,13 +166,13 @@ class PositionsControllerTest extends WebTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertEquals(
+        static::assertEquals(
             Response::HTTP_OK,
             $response->getStatusCode()
         );
 
         $json = json_decode($response->getContent(), true);
-        $this->assertArrayNotHasKey('hasError', $json['data']);
-        $this->assertEquals([], $json['data']);
+        static::assertArrayNotHasKey('hasError', $json['data']);
+        static::assertEquals([], $json['data']);
     }
 }

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/ManufacturerControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/ManufacturerControllerTest.php
@@ -42,6 +42,6 @@ class ManufacturerControllerTest extends ApiTestCase
 
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = self::$client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
+        static::assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
     }
 }

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
@@ -84,7 +84,7 @@ class StockManagementControllerTest extends ApiTestCase
         foreach ($routes as $route) {
             self::$client->request('GET', $route, array('page_index' => 0));
             $response = self::$client->getResponse();
-            $this->assertSame(400, $response->getStatusCode(), 'It should return a response with "Bad Request" Status.');
+            static::assertSame(400, $response->getStatusCode(), 'It should return a response with "Bad Request" Status.');
         }
     }
 
@@ -184,7 +184,7 @@ class StockManagementControllerTest extends ApiTestCase
 
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = self::$client->getResponse();
-        $this->assertSame(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
+        static::assertSame(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
 
         if ($expectedTotalPages) {
             $this->assertResponseHasTotalPages($parameters, $expectedTotalPages);
@@ -211,8 +211,8 @@ class StockManagementControllerTest extends ApiTestCase
 
         /** @var \Symfony\Component\HttpFoundation\ResponseHeaderBag $headers */
         $headers = $response->headers;
-        $this->assertTrue($headers->has('Total-Pages'), 'The response headers should contain the total pages.');
-        $this->assertSame(
+        static::assertTrue($headers->has('Total-Pages'), 'The response headers should contain the total pages.');
+        static::assertSame(
             $expectedTotalPages,
             $headers->get('Total-Pages'),
             sprintf(
@@ -303,27 +303,27 @@ class StockManagementControllerTest extends ApiTestCase
 
         $content = $this->assertResponseBodyValidJson(200);
 
-        $this->assertArrayHasKey(
+        static::assertArrayHasKey(
             'product_available_quantity',
             $content,
             'The response body should contain a "product_available_quantity" property.'
         );
-        $this->assertArrayHasKey(
+        static::assertArrayHasKey(
             'product_physical_quantity',
             $content,
             'The response body should contain a "product_physical_quantity" property.'
         );
-        $this->assertArrayHasKey(
+        static::assertArrayHasKey(
             'product_reserved_quantity',
             $content,
             'The response body should contain a "product_reserved_quantity" property.'
         );
-        $this->assertArrayHasKey(
+        static::assertArrayHasKey(
             'product_thumbnail',
             $content,
             'The response body should contain an "image_thumbnail_path" property.'
         );
-        $this->assertArrayHasKey(
+        static::assertArrayHasKey(
             'combination_thumbnail',
             $content,
             'The response body should contain an "image_thumbnail_path" property.'
@@ -360,17 +360,17 @@ class StockManagementControllerTest extends ApiTestCase
      */
     private function assertProductQuantity($expectedQuantities, $content)
     {
-        $this->assertSame(
+        static::assertSame(
             $expectedQuantities['available_quantity'],
             $content['product_available_quantity'],
             'The response body should contain the newly updated physical quantity.'
         );
-        $this->assertSame(
+        static::assertSame(
             $expectedQuantities['physical_quantity'],
             $content['product_physical_quantity'],
             'The response body should contain the newly updated quantity.'
         );
-        $this->assertSame(
+        static::assertSame(
             $expectedQuantities['reserved_quantity'],
             $content['product_reserved_quantity'],
             'The response body should contain the newly updated physical quantity.'
@@ -419,7 +419,7 @@ class StockManagementControllerTest extends ApiTestCase
         );
         $content = $this->assertResponseBodyValidJson(200);
 
-        $this->assertArrayHasKey(0, $content, 'The response content should have one item with key #0');
+        static::assertArrayHasKey(0, $content, 'The response content should have one item with key #0');
 
         $this->assertProductQuantity(
             array(
@@ -441,7 +441,7 @@ class StockManagementControllerTest extends ApiTestCase
         );
         $content = $this->assertResponseBodyValidJson(200);
 
-        $this->assertArrayHasKey(0, $content, 'The response content should have one item with key #0');
+        static::assertArrayHasKey(0, $content, 'The response content should have one item with key #0');
 
         $this->assertProductQuantity(
             array(

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/SupplierControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/SupplierControllerTest.php
@@ -42,6 +42,6 @@ class SupplierControllerTest extends ApiTestCase
 
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = self::$client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
+        static::assertEquals(200, $response->getStatusCode(), 'It should return a response with "OK" Status.');
     }
 }

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
@@ -44,7 +44,7 @@ class TranslationControllerTest extends ApiTestCase
 
         $cacheMock
             ->method('execute')
-            ->will($this->returnValue(true));
+            ->will(static::returnValue(true));
 
         self::$container->set('prestashop.cache.refresh', $cacheMock);
     }

--- a/tests-legacy/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -206,7 +206,7 @@ class LegacyUrlConverterTest extends LightWebTestCase
     public function testServiceExists()
     {
         $converter = self::$kernel->getContainer()->get('prestashop.bundle.routing.converter.legacy_url_converter');
-        $this->assertInstanceOf(LegacyUrlConverter::class, $converter);
+        static::assertInstanceOf(LegacyUrlConverter::class, $converter);
     }
 
     public function testLegacyWithRoute()
@@ -282,7 +282,7 @@ class LegacyUrlConverterTest extends LightWebTestCase
             $caughtExceptionMessage = sprintf('Unexpected exception %s: %s', get_class($e), $e->getMessage());
             $convertedUrl = null;
         }
-        $this->assertNull($caughtException, $caughtExceptionMessage);
+        static::assertNull($caughtException, $caughtExceptionMessage);
         $this->assertSameUrl($expectedUrl, $convertedUrl);
     }
 
@@ -385,7 +385,7 @@ class LegacyUrlConverterTest extends LightWebTestCase
         $legacyUrl = $this->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' .  \Dispatcher::getInstance()->createUrl('AdminAdminPreferences');
         $this->client->request('GET', $legacyUrl);
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isRedirection());
+        static::assertTrue($response->isRedirection());
         $location = $response->headers->get('location');
         $this->assertSameUrl('/configure/advanced/administration/', $location);
     }
@@ -395,7 +395,7 @@ class LegacyUrlConverterTest extends LightWebTestCase
         $legacyUrl = $this->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' .  \Dispatcher::getInstance()->createUrl('AdminLogin');
         $this->client->request('GET', $legacyUrl);
         $response = $this->client->getResponse();
-        $this->assertFalse($response->isRedirection());
+        static::assertFalse($response->isRedirection());
     }
 
     public function testPostParameters()
@@ -403,8 +403,8 @@ class LegacyUrlConverterTest extends LightWebTestCase
         $legacyUrl = $this->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' .  \Dispatcher::getInstance()->createUrl('AdminModulesPositions');
         $this->client->request('POST', $legacyUrl, ['submitAddToHook' => '']);
         $response = $this->client->getResponse();
-        $this->assertFalse($response->isRedirection());
-        $this->assertNull($response->headers->get('location'));
+        static::assertFalse($response->isRedirection());
+        static::assertNull($response->headers->get('location'));
     }
 
     /**
@@ -430,7 +430,7 @@ class LegacyUrlConverterTest extends LightWebTestCase
      */
     private function assertSameUrl($expectedUrl, $url, array $ignoredParameters = null)
     {
-        $this->assertNotNull($url);
+        static::assertNotNull($url);
         $parsedUrl = parse_url($url);
         $parameters = [];
         if (isset($parsedUrl['query'])) {
@@ -453,8 +453,8 @@ class LegacyUrlConverterTest extends LightWebTestCase
             'query' => http_build_query($parameters),
         ]);
 
-        $this->assertNotEmpty($parsedUrl['path']);
-        $this->assertTrue($expectedUrl == $cleanUrl, sprintf(
+        static::assertNotEmpty($parsedUrl['path']);
+        static::assertTrue($expectedUrl == $cleanUrl, sprintf(
             'Expected url %s is different with generated one: %s',
             $expectedUrl,
             $cleanUrl

--- a/tests-legacy/Integration/PrestaShopBundle/Service/DataProvider/MarketPlace/ApiClientTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Service/DataProvider/MarketPlace/ApiClientTest.php
@@ -58,7 +58,7 @@ class ApiClientTest extends KernelTestCase
 
     public function testGetNativeModules()
     {
-        $this->assertCount(0, $this->apiClient->getNativesModules());
+        static::assertCount(0, $this->apiClient->getNativesModules());
     }
 
     /**
@@ -90,7 +90,7 @@ class ApiClientTest extends KernelTestCase
             ->getMock();
 
         $clientMock->method('get')
-            ->with($this->anything())
+            ->with(static::anything())
             ->willReturn($responseMock);
 
         return $clientMock;

--- a/tests-legacy/Integration/PrestaShopBundle/Test/LightWebTestCase.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Test/LightWebTestCase.php
@@ -81,10 +81,10 @@ class LightWebTestCase extends TestCase
             ->getMock();
 
         $contextMock->method('getTranslator')
-            ->will(self::returnValue($this->translator));
+            ->will(static::returnValue($this->translator));
 
         $contextMock->method('getContext')
-            ->will(self::returnValue($contextMock));
+            ->will(static::returnValue($contextMock));
 
         $contextMock->employee = $employeeMock;
 
@@ -133,7 +133,7 @@ class LightWebTestCase extends TestCase
             ->getMock();
 
         $currencyDataProviderMock->method('getDefaultCurrencyIsoCode')
-            ->will(self::returnValue('en'));
+            ->will(static::returnValue('en'));
 
         $legacyContextMock = $this->getMockBuilder(LegacyContext::class)
             ->setMethods([
@@ -154,7 +154,7 @@ class LightWebTestCase extends TestCase
 
         $legacyContextMock->method('getLanguages')
             ->will(
-                self::returnValue(
+                static::returnValue(
                     [
                         [
                             'id_lang' => '1',
@@ -176,7 +176,7 @@ class LightWebTestCase extends TestCase
 
         $legacyContextMock->method('getLanguage')
             ->will(
-                self::returnValue($languageMock)
+                static::returnValue($languageMock)
             );
 
         self::$kernel->getContainer()->set('prestashop.adapter.data_provider.currency', $currencyDataProviderMock);
@@ -198,7 +198,7 @@ class LightWebTestCase extends TestCase
         );
 
         $configurationMock->method('get')
-            ->will(self::returnValueMap($values));
+            ->will(static::returnValueMap($values));
 
         self::$kernel->getContainer()->set('prestashop.adapter.legacy.configuration', $configurationMock);
     }

--- a/tests-legacy/Integration/ProductURLsTest.php
+++ b/tests-legacy/Integration/ProductURLsTest.php
@@ -82,7 +82,7 @@ class ProductURLsTest extends IntegrationTestCase
         $this->enableURLRewriting();
         $filename = basename($this->getURL(1, 2)['path']);
 
-        $this->assertEquals(
+        static::assertEquals(
             '1-2-hummingbird-printed-t-shirt.html',
             $filename
         );
@@ -93,7 +93,7 @@ class ProductURLsTest extends IntegrationTestCase
         $this->enableURLRewriting();
         $filename = basename($this->getURL(1, null)['path']);
 
-        $this->assertEquals(
+        static::assertEquals(
             '1-hummingbird-printed-t-shirt.html',
             $filename
         );
@@ -105,8 +105,8 @@ class ProductURLsTest extends IntegrationTestCase
         $query = [];
         parse_str($this->getURL(1, 6)['query'], $query);
 
-        $this->assertEquals(1, $query['id_product']);
-        $this->assertEquals(6, $query['id_product_attribute']);
+        static::assertEquals(1, $query['id_product']);
+        static::assertEquals(6, $query['id_product_attribute']);
     }
 
     public function testUrlIgnoresVariantIfNotSpecifiedWithoutUrlRewriting()
@@ -115,7 +115,7 @@ class ProductURLsTest extends IntegrationTestCase
         $query = [];
         parse_str($this->getURL(1, null)['query'], $query);
 
-        $this->assertEquals(1, $query['id_product']);
-        $this->assertEmpty($query['id_product_attribute']);
+        static::assertEquals(1, $query['id_product']);
+        static::assertEmpty($query['id_product_attribute']);
     }
 }

--- a/tests-legacy/Integration/SmartySettingsTest.php
+++ b/tests-legacy/Integration/SmartySettingsTest.php
@@ -50,7 +50,7 @@ class SmartySettingsTest extends IntegrationTestCase
     public function testALinkIsEscapedAutomatically()
     {
         $str = '<a>hello</a>';
-        $this->assertEquals(
+        static::assertEquals(
             '&lt;a&gt;hello&lt;/a&gt;',
             $this->escapeTemplateLocationComments(
                 $this->render('{$str}', ['str' => $str])
@@ -61,7 +61,7 @@ class SmartySettingsTest extends IntegrationTestCase
     public function testNofilterPreventsEscape()
     {
         $str = '<a>hello</a>';
-        $this->assertEquals(
+        static::assertEquals(
             $str,
             $this->escapeTemplateLocationComments(
                 $this->render('{$str nofilter}', ['str' => $str])
@@ -72,7 +72,7 @@ class SmartySettingsTest extends IntegrationTestCase
     public function testHtmlIsNotEscapedTwice()
     {
         $str = '<a>hello</a>';
-        $this->assertEquals(
+        static::assertEquals(
             '&lt;a&gt;hello&lt;/a&gt;',
             $this->escapeTemplateLocationComments(
                 $this->render('{$str|escape:"html"}', ['str' => $str])

--- a/tests-legacy/Integration/classes/CartGetOrderTotalTest.php
+++ b/tests-legacy/Integration/classes/CartGetOrderTotalTest.php
@@ -413,8 +413,8 @@ class CartGetOrderTotalTest extends IntegrationTestCase
 
         $cart->updateQty(1, $product->id);
 
-        $this->assertEquals(10, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
-        $this->assertEquals(12, $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
+        static::assertEquals(10, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
+        static::assertEquals(12, $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
     }
 
     public function testCartBothWithFreeCarrier()
@@ -425,8 +425,8 @@ class CartGetOrderTotalTest extends IntegrationTestCase
         $id_carrier = self::getIdCarrier('free');
 
         $cart->updateQty(1, $product->id);
-        $this->assertEquals(10, $cart->getOrderTotal(false, Cart::BOTH, null, $id_carrier));
-        $this->assertEquals(12, $cart->getOrderTotal(true, Cart::BOTH, null, $id_carrier));
+        static::assertEquals(10, $cart->getOrderTotal(false, Cart::BOTH, null, $id_carrier));
+        static::assertEquals(12, $cart->getOrderTotal(true, Cart::BOTH, null, $id_carrier));
     }
 
     public function testCartBothWithPaidCarrier()
@@ -437,8 +437,8 @@ class CartGetOrderTotalTest extends IntegrationTestCase
         $id_carrier = self::getIdCarrier('costs 2', 2, self::getIdTaxRulesGroup(10));
 
         $cart->updateQty(1, $product->id);
-        $this->assertEquals(12, $cart->getOrderTotal(false, Cart::BOTH, null, $id_carrier));
-        $this->assertEquals(13.2, $cart->getOrderTotal(true, Cart::BOTH, null, $id_carrier));
+        static::assertEquals(12, $cart->getOrderTotal(false, Cart::BOTH, null, $id_carrier));
+        static::assertEquals(13.2, $cart->getOrderTotal(true, Cart::BOTH, null, $id_carrier));
     }
 
     public function testBasicRoundTypeLine()
@@ -453,8 +453,8 @@ class CartGetOrderTotalTest extends IntegrationTestCase
         $cart->updateQty(1, $product_a->id);
         $cart->updateQty(1, $product_b->id);
 
-        $this->assertEquals(3.59, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
-        $this->assertEquals(4.29, $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
+        static::assertEquals(3.59, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
+        static::assertEquals(4.29, $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
     }
 
     public function testBasicRoundTypeTotal()
@@ -469,8 +469,8 @@ class CartGetOrderTotalTest extends IntegrationTestCase
         $cart->updateQty(1, $product_a->id);
         $cart->updateQty(1, $product_b->id);
 
-        $this->assertEquals(3.58, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
-        $this->assertEquals(4.30, $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
+        static::assertEquals(3.58, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
+        static::assertEquals(4.30, $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
     }
 
     public function testBasicCartRuleAmountBeforeTax()
@@ -485,11 +485,11 @@ class CartGetOrderTotalTest extends IntegrationTestCase
         $cart->updateQty(1, $product->id);
 
         // Control the result without the CartRule
-        $this->assertEquals(10, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
+        static::assertEquals(10, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
 
         // Check that the CartRule is applied
-        $this->assertEquals(5, $cart->getOrderTotal(false, Cart::BOTH, null, $id_carrier));
-        $this->assertEquals(6, $cart->getOrderTotal(true, Cart::BOTH, null, $id_carrier));
+        static::assertEquals(5, $cart->getOrderTotal(false, Cart::BOTH, null, $id_carrier));
+        static::assertEquals(6, $cart->getOrderTotal(true, Cart::BOTH, null, $id_carrier));
     }
 
     /**
@@ -513,8 +513,8 @@ class CartGetOrderTotalTest extends IntegrationTestCase
 
         $preTax = round(5 / (1 + (3 * 10 + 1 * 20) / (4 * 100)), 2);
 
-        $this->assertEquals($preTax, $cart->getOrderTotal(false, Cart::ONLY_SHIPPING, null, $id_carrier));
-        $this->assertEquals(5, $cart->getOrderTotal(true, Cart::ONLY_SHIPPING, null, $id_carrier));
+        static::assertEquals($preTax, $cart->getOrderTotal(false, Cart::ONLY_SHIPPING, null, $id_carrier));
+        static::assertEquals(5, $cart->getOrderTotal(true, Cart::ONLY_SHIPPING, null, $id_carrier));
     }
 
     /**
@@ -528,22 +528,22 @@ class CartGetOrderTotalTest extends IntegrationTestCase
 
         $cart->updateQty(1, $product->id);
 
-        $this->assertEquals(
+        static::assertEquals(
             $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS),
             $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS)
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             $cart->getOrderTotal(false, Cart::BOTH),
             $cart->getOrderTotal(true, Cart::BOTH)
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             $cart->getOrderTotal(false, Cart::ONLY_SHIPPING),
             $cart->getOrderTotal(true, Cart::ONLY_SHIPPING)
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             $cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS),
             $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS)
         );

--- a/tests-legacy/Integration/classes/ConfigurationCoreTest.php
+++ b/tests-legacy/Integration/classes/ConfigurationCoreTest.php
@@ -66,10 +66,10 @@ class ConfigurationCoreTest extends IntegrationTestCase
 
     public function testGetGlobalValue()
     {
-        $this->assertEquals('RESULT_NOT_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_NOT_OVERRIDDEN'));
-        $this->assertEquals('RESULT_GROUP_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_GROUP_OVERRIDDEN'));
-        $this->assertEquals('RESULT_SHOP_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_SHOP_OVERRIDDEN'));
-        $this->assertEquals('RESULT_GROUP_SHOP_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_GROUP_SHOP_OVERRIDDEN'));
-        $this->assertFalse(Configuration::getGlobalValue('PS_TEST_DOES_NOT_EXIST'));
+        static::assertEquals('RESULT_NOT_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_NOT_OVERRIDDEN'));
+        static::assertEquals('RESULT_GROUP_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_GROUP_OVERRIDDEN'));
+        static::assertEquals('RESULT_SHOP_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_SHOP_OVERRIDDEN'));
+        static::assertEquals('RESULT_GROUP_SHOP_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_GROUP_SHOP_OVERRIDDEN'));
+        static::assertFalse(Configuration::getGlobalValue('PS_TEST_DOES_NOT_EXIST'));
     }
 }

--- a/tests-legacy/Integration/classes/MediaCoreTest.php
+++ b/tests-legacy/Integration/classes/MediaCoreTest.php
@@ -38,7 +38,7 @@ class MediaCoreTest extends IntegrationTestCase
     {
         $domain = Configuration::get('PS_SHOP_DOMAIN');
         $result = Media::getJqueryPath('1.11');
-        $this->assertTrue(in_array('http://'.$domain.__PS_BASE_URI__.'js/jquery/jquery.noConflict.php?version=1.11', $result));
+        static::assertTrue(in_array('http://'.$domain.__PS_BASE_URI__.'js/jquery/jquery.noConflict.php?version=1.11', $result));
     }
 
     protected function setUp()
@@ -84,7 +84,7 @@ class MediaCoreTest extends IntegrationTestCase
     {
         $output = str_replace('//server/', '//'.$this->domain.'/', $output);
         $return = Media::minifyCSS($input, $fileuri, $import_url);
-        $this->assertEquals($output, $return, 'MinifyCSS failed for data input : '.$input.'; Expected : '.$output.'; Returns : '.$return);
+        static::assertEquals($output, $return, 'MinifyCSS failed for data input : '.$input.'; Expected : '.$output.'; Returns : '.$return);
     }
 
     /**
@@ -93,7 +93,7 @@ class MediaCoreTest extends IntegrationTestCase
     public function testReplaceByAbsoluteURLPattern($input, $fileuri, $output, $expected)
     {
         $return = preg_match(Media::$pattern_callback, $input, $matches);
-        $this->assertEquals((bool)$expected, (bool)$return, 'ReplaceByAbsoluteURLPattern failed for data input : '.$input.(isset($matches[2]) && $matches[2] ? '; Matches : '.$matches[2] : ''));
+        static::assertEquals((bool)$expected, (bool)$return, 'ReplaceByAbsoluteURLPattern failed for data input : '.$input.(isset($matches[2]) && $matches[2] ? '; Matches : '.$matches[2] : ''));
     }
 
     public function isJsInputsProvider()

--- a/tests-legacy/Integration/classes/SearchCoreTest.php
+++ b/tests-legacy/Integration/classes/SearchCoreTest.php
@@ -40,7 +40,7 @@ class SearchCoreTest extends IntegrationTestCase
         Configuration::set('PS_SEARCH_START', $withStart);
         Configuration::set('PS_SEARCH_END', !$withEnd); // Opposite of the meaning of start equivalent :)
         $return = Search::getSearchParamFromWord($word);
-        $this->assertEquals($expectedKeyWord, $return, 'Search::getSearchParamFromWord() failed for data input : '.$word.'; Expected : '.$expectedKeyWord.'; Returns : '.$return);
+        static::assertEquals($expectedKeyWord, $return, 'Search::getSearchParamFromWord() failed for data input : '.$word.'; Expected : '.$expectedKeyWord.'; Returns : '.$return);
     }
 
     public function keywordsProvider()

--- a/tests-legacy/Integration/classes/ShopCoreTest.php
+++ b/tests-legacy/Integration/classes/ShopCoreTest.php
@@ -43,6 +43,6 @@ class ShopCoreTest extends IntegrationTestCase
     public function testGetBaseURL()
     {
         $domain = Configuration::get('PS_SHOP_DOMAIN');
-        $this->assertEquals('http://'.$domain.__PS_BASE_URI__, $this->context->shop->getBaseURL(true));
+        static::assertEquals('http://'.$domain.__PS_BASE_URI__, $this->context->shop->getBaseURL(true));
     }
 }

--- a/tests-legacy/Integration/classes/db/DbTest.php
+++ b/tests-legacy/Integration/classes/db/DbTest.php
@@ -56,13 +56,13 @@ class DbTest extends IntegrationTestCase
         $this->second_slave = Db::getInstance(_PS_USE_SQL_SLAVE_);
 
         //Then
-        $this->assertNotSame($this->first_slave, $this->second_slave);
-        $this->assertNotSame($this->master, $this->second_slave);
-        $this->assertNotSame($this->master, $this->first_slave);
+        static::assertNotSame($this->first_slave, $this->second_slave);
+        static::assertNotSame($this->master, $this->second_slave);
+        static::assertNotSame($this->master, $this->first_slave);
 
         $this->assert_TwoCallsOnFirst_ThenOneOnSecondSlave();
 
-        $this->assertSame($this->master, Db::getInstance());
+        static::assertSame($this->master, Db::getInstance());
 
         $this->assert_TwoCallsOnFirst_ThenOneOnSecondSlave();
         $this->assert_TwoCallsOnFirst_ThenOneOnSecondSlave();
@@ -71,11 +71,11 @@ class DbTest extends IntegrationTestCase
     public function assert_TwoCallsOnFirst_ThenOneOnSecondSlave()
     {
         // Third and fourth calls are on first slave
-        $this->assertSame($this->first_slave, Db::getInstance(_PS_USE_SQL_SLAVE_));
-        $this->assertSame($this->first_slave, Db::getInstance(_PS_USE_SQL_SLAVE_));
+        static::assertSame($this->first_slave, Db::getInstance(_PS_USE_SQL_SLAVE_));
+        static::assertSame($this->first_slave, Db::getInstance(_PS_USE_SQL_SLAVE_));
 
         // Fifth call is on second slave
-        $this->assertSame($this->second_slave, Db::getInstance(_PS_USE_SQL_SLAVE_));
+        static::assertSame($this->second_slave, Db::getInstance(_PS_USE_SQL_SLAVE_));
     }
 
     public function loadSlaves($nb_servers = 0)

--- a/tests-legacy/Integration/classes/module/ModuleGetOverrideTest.php
+++ b/tests-legacy/Integration/classes/module/ModuleGetOverrideTest.php
@@ -60,7 +60,7 @@ class ModulesGetOverrideTest extends IntegrationTestCase
         $module = Module::getInstanceByName($moduleName);
 
         if ($module instanceof Module) {
-            self::assertEmpty($module->getOverrides());
+            static::assertEmpty($module->getOverrides());
         }
     }
 
@@ -70,9 +70,9 @@ class ModulesGetOverrideTest extends IntegrationTestCase
         $module = Module::getInstanceByName('pscsx3241');
         $overrides = $module->getOverrides();
 
-        self::assertContains('Cart', $overrides);
-        self::assertContains('AdminProductsController', $overrides);
-        self::assertCount(2, $overrides);
+        static::assertContains('Cart', $overrides);
+        static::assertContains('AdminProductsController', $overrides);
+        static::assertCount(2, $overrides);
 
         HelperModule::removeModule('pscsx3241');
     }

--- a/tests-legacy/Integration/classes/module/ModuleGetPossibleHooksListTest.php
+++ b/tests-legacy/Integration/classes/module/ModuleGetPossibleHooksListTest.php
@@ -47,10 +47,10 @@ class ModuleGetPossibleHooksListTest extends IntegrationTestCase
         Cache::clean('hook_alias');
         $possible_hooks_list = $module->getPossibleHooksList();
 
-        $this->assertCount(2, $possible_hooks_list);
+        static::assertCount(2, $possible_hooks_list);
 
-        $this->assertEquals('displayPaymentReturn', $possible_hooks_list[0]['name']);
-        $this->assertEquals('paymentOptions', $possible_hooks_list[1]['name']);
+        static::assertEquals('displayPaymentReturn', $possible_hooks_list[0]['name']);
+        static::assertEquals('paymentOptions', $possible_hooks_list[1]['name']);
     }
 
     public static function tearDownAfterClass()

--- a/tests-legacy/Integration/classes/module/ModuleOverrideInstallUninstallTest.php
+++ b/tests-legacy/Integration/classes/module/ModuleOverrideInstallUninstallTest.php
@@ -80,7 +80,7 @@ class ModuleOverrideInstallUninstallTest extends IntegrationTestCase
          * This test only checks that modules are installed properly.
          */
         foreach ($this->moduleNames as $name) {
-            $this->assertTrue((bool)$this->moduleManager->install($name), "Could not install $name");
+            static::assertTrue((bool)$this->moduleManager->install($name), "Could not install $name");
         }
     }
 
@@ -113,13 +113,13 @@ class ModuleOverrideInstallUninstallTest extends IntegrationTestCase
         $expected_override_cart = file_get_contents($ressource_path.'/Cart.php');
         $expected_override_admin_product = file_get_contents($ressource_path.'/AdminProductsController.php');
 
-        $this->assertEquals(
+        static::assertEquals(
             $this->cleanup($expected_override_cart),
             $this->cleanup($actual_override_cart),
             'Cart.php file different'
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             $this->cleanup($expected_override_admin_product),
             $this->cleanup($actual_override_admin_product),
             'AdminProductsController.php file different'
@@ -129,9 +129,9 @@ class ModuleOverrideInstallUninstallTest extends IntegrationTestCase
          *  uninstalled.
          */
         foreach ($this->moduleNames as $name) {
-            $this->assertTrue((bool)$this->moduleManager->uninstall($name), "Could not uninstall $name");
+            static::assertTrue((bool)$this->moduleManager->uninstall($name), "Could not uninstall $name");
         }
 
-        $this->assertFileNotExists($override_path_cart);
+        static::assertFileNotExists($override_path_cart);
     }
 }

--- a/tests-legacy/PrestaShopBundle/Command/ExportThemeCommandTest.php
+++ b/tests-legacy/PrestaShopBundle/Command/ExportThemeCommandTest.php
@@ -46,7 +46,7 @@ class ExportThemeCommandTest extends TestCase
         $helperSetMock = $this->mockHelperSet();
         $command->setHelperSet($helperSetMock);
 
-        $this->assertEquals(0, $commandTester->execute(array('theme'  => 'classic')));
+        static::assertEquals(0, $commandTester->execute(array('theme'  => 'classic')));
     }
 
     /**
@@ -106,7 +106,7 @@ class ExportThemeCommandTest extends TestCase
         $themeExporterMock = $this->mockThemeExporter();
 
         $containerMock->method('get')
-            ->will($this->returnCallback(function ($serviceId) use (
+            ->will(static::returnCallback(function ($serviceId) use (
                 $themeRepositoryMock,
                 $translatorMock,
                 $themeExporterMock

--- a/tests-legacy/PrestaShopBundle/Model/Product/AdminModelAdapterTest.php
+++ b/tests-legacy/PrestaShopBundle/Model/Product/AdminModelAdapterTest.php
@@ -206,16 +206,16 @@ class AdminModelAdapterTest extends KernelTestCase
      */
     public function testConstruct()
     {
-        $this->assertInstanceOf('PrestaShopBundle\Model\Product\AdminModelAdapter', $this->adminModelAdapter);
+        static::assertInstanceOf('PrestaShopBundle\Model\Product\AdminModelAdapter', $this->adminModelAdapter);
     }
 
     public function testGetFormData()
     {
-        $this->assertInternalType('array', $this->adminModelAdapter->getFormData($this->product));
+        static::assertInternalType('array', $this->adminModelAdapter->getFormData($this->product));
         $expectedArrayStructure = $this->fakeFormData();
 
         foreach ($expectedArrayStructure as $property => $value) {
-            $this->assertArrayHasKey(
+            static::assertArrayHasKey(
                 $property,
                 $this->adminModelAdapter->getFormData($this->product),
                 sprintf('The expected key %s was not found', $property)
@@ -225,7 +225,7 @@ class AdminModelAdapterTest extends KernelTestCase
 
     public function testGetModelData()
     {
-        $this->assertInternalType('array', $this->adminModelAdapter->getModelData($this->fakeFormData()));
+        static::assertInternalType('array', $this->adminModelAdapter->getModelData($this->fakeFormData()));
     }
 
     /**
@@ -261,8 +261,8 @@ class AdminModelAdapterTest extends KernelTestCase
         $actualReturn = $combinationDataProvider->completeCombination($this->fakeCombination(), $this->product);
 
         foreach ($expectedStructureReturn as $property => $value) {
-            $this->assertArrayHasKey($property, $actualReturn, sprintf('The expected key %s was not found', $property));
-            $this->assertEquals(
+            static::assertArrayHasKey($property, $actualReturn, sprintf('The expected key %s was not found', $property));
+            static::assertEquals(
                 $value,
                 $actualReturn[$property],
                 sprintf('The expected value for property %s is wrong', $property)

--- a/tests-legacy/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
@@ -109,24 +109,24 @@ class CacheProviderTest extends TestCase
         $cacheProvider = new CacheProvider($mockProvider, $this->buildSavingCache(), $this->buildCacheKeyGenerator());
 
         $legacyRoutes = $cacheProvider->getLegacyRoutes();
-        $this->assertCount(2, $legacyRoutes);
-        $this->assertNotEmpty($legacyRoutes['admin_products']);
-        $this->assertNotEmpty($legacyRoutes['admin_products_create']);
+        static::assertCount(2, $legacyRoutes);
+        static::assertNotEmpty($legacyRoutes['admin_products']);
+        static::assertNotEmpty($legacyRoutes['admin_products_create']);
 
         $legacyRoutes = $cacheProvider->getLegacyRoutes();
-        $this->assertCount(2, $legacyRoutes);
+        static::assertCount(2, $legacyRoutes);
     }
 
     public function testGetFromCache()
     {
         $cacheProvider = new CacheProvider($this->buildCachedRouterProvider(), $this->buildExistingCache(), $this->buildCacheKeyGenerator());
         $legacyRoutes = $cacheProvider->getLegacyRoutes();
-        $this->assertCount(2, $legacyRoutes);
-        $this->assertNotEmpty($legacyRoutes['admin_products']);
-        $this->assertNotEmpty($legacyRoutes['admin_products_create']);
+        static::assertCount(2, $legacyRoutes);
+        static::assertNotEmpty($legacyRoutes['admin_products']);
+        static::assertNotEmpty($legacyRoutes['admin_products_create']);
 
         $legacyRoutes = $cacheProvider->getLegacyRoutes();
-        $this->assertCount(2, $legacyRoutes);
+        static::assertCount(2, $legacyRoutes);
     }
 
     public function testWithRealCache()
@@ -135,16 +135,16 @@ class CacheProviderTest extends TestCase
         $mockProvider = $this->buildMockRouterProvider($this->legacyRoutes);
         $cacheProvider = new CacheProvider($mockProvider, $cache, $this->buildCacheKeyGenerator());
 
-        $this->assertFalse($cache->hasItem(self::CACHE_KEY));
+        static::assertFalse($cache->hasItem(self::CACHE_KEY));
         //Just perform the test twice to be sure the result and the cache are correct
         for ($i = 0; $i < 2; $i++) {
             $legacyRoutes = $cacheProvider->getLegacyRoutes();
-            $this->assertCount(2, $legacyRoutes);
-            $this->assertNotEmpty($legacyRoutes['admin_products']);
-            $this->assertNotEmpty($legacyRoutes['admin_products_create']);
-            $this->assertTrue($cache->hasItem(self::CACHE_KEY));
+            static::assertCount(2, $legacyRoutes);
+            static::assertNotEmpty($legacyRoutes['admin_products']);
+            static::assertNotEmpty($legacyRoutes['admin_products_create']);
+            static::assertTrue($cache->hasItem(self::CACHE_KEY));
             $cacheItem = $cache->getItem(self::CACHE_KEY);
-            $this->assertEquals($this->expectedCacheValue, $cacheItem->get());
+            static::assertEquals($this->expectedCacheValue, $cacheItem->get());
         }
 
         //Now empty the private field to force CacheProvider to call the cache
@@ -156,9 +156,9 @@ class CacheProviderTest extends TestCase
 
         //Retry to get the value, the cache will be used hence the mockRouterProvider won't be called
         $legacyRoutes = $cacheProvider->getLegacyRoutes();
-        $this->assertCount(2, $legacyRoutes);
-        $this->assertNotEmpty($legacyRoutes['admin_products']);
-        $this->assertNotEmpty($legacyRoutes['admin_products_create']);
+        static::assertCount(2, $legacyRoutes);
+        static::assertNotEmpty($legacyRoutes['admin_products']);
+        static::assertNotEmpty($legacyRoutes['admin_products_create']);
     }
 
     public function testGetControllersActions()
@@ -167,16 +167,16 @@ class CacheProviderTest extends TestCase
         $mockProvider = $this->buildMockRouterProvider($this->legacyRoutes);
         $cacheProvider = new CacheProvider($mockProvider, $cache, $this->buildCacheKeyGenerator());
 
-        $this->assertFalse($cache->hasItem(self::CACHE_KEY));
+        static::assertFalse($cache->hasItem(self::CACHE_KEY));
         //Just perform the test twice to be sure the result and the cache are correct
         for ($i = 0; $i < 2; $i++) {
             $controllerActions = $cacheProvider->getControllersActions();
-            $this->assertCount(1, $controllerActions);
-            $this->assertNotEmpty($controllerActions['AdminProducts']);
-            $this->assertNotEmpty($controllerActions['AdminProducts']['index']);
-            $this->assertTrue($cache->hasItem(self::CACHE_KEY));
+            static::assertCount(1, $controllerActions);
+            static::assertNotEmpty($controllerActions['AdminProducts']);
+            static::assertNotEmpty($controllerActions['AdminProducts']['index']);
+            static::assertTrue($cache->hasItem(self::CACHE_KEY));
             $cacheItem = $cache->getItem(self::CACHE_KEY);
-            $this->assertEquals($this->expectedCacheValue, $cacheItem->get());
+            static::assertEquals($this->expectedCacheValue, $cacheItem->get());
         }
 
         //Now empty the private field to force CacheProvider to call the cache
@@ -188,9 +188,9 @@ class CacheProviderTest extends TestCase
 
         //Retry to get the value, the cache will be used hence the mockRouterProvider won't be called
         $controllerActions = $cacheProvider->getControllersActions();
-        $this->assertCount(1, $controllerActions);
-        $this->assertNotEmpty($controllerActions['AdminProducts']);
-        $this->assertNotEmpty($controllerActions['AdminProducts']['index']);
+        static::assertCount(1, $controllerActions);
+        static::assertNotEmpty($controllerActions['AdminProducts']);
+        static::assertNotEmpty($controllerActions['AdminProducts']['index']);
     }
 
     /**
@@ -205,16 +205,16 @@ class CacheProviderTest extends TestCase
             ->getMock();
 
         $itemMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('isHit')
             ->willReturn(true);
 
         $itemMock
-            ->expects($this->never())
+            ->expects(static::never())
             ->method('set');
 
         $itemMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('get')
             ->willReturn($this->expectedCacheValue);
 
@@ -225,12 +225,12 @@ class CacheProviderTest extends TestCase
             ->getMock();
 
         $cacheMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('getItem')
             ->willReturn($itemMock);
 
         $cacheMock
-            ->expects($this->never())
+            ->expects(static::never())
             ->method('save');
 
         return $cacheMock;
@@ -248,17 +248,17 @@ class CacheProviderTest extends TestCase
             ->getMock();
 
         $itemMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('isHit')
             ->willReturn(false);
 
         $itemMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('set')
             ->with($this->expectedCacheValue);
 
         $itemMock
-            ->expects($this->never())
+            ->expects(static::never())
             ->method('get');
 
         //AdapterInterface mock
@@ -268,12 +268,12 @@ class CacheProviderTest extends TestCase
             ->getMock();
 
         $cacheMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('getItem')
             ->willReturn($itemMock);
 
         $cacheMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('save');
 
         return $cacheMock;
@@ -291,7 +291,7 @@ class CacheProviderTest extends TestCase
             ->getMock();
 
         $providerMock
-            ->expects($this->once()) //Very important to assert this method is only called once to create the cache
+            ->expects(static::once()) //Very important to assert this method is only called once to create the cache
             ->method('getLegacyRoutes')
             ->willReturn($legacyRoutes);
 
@@ -309,7 +309,7 @@ class CacheProviderTest extends TestCase
             ->getMock();
 
         $providerMock
-            ->expects($this->never()) //Very important to assert this method is only called once to create the cache
+            ->expects(static::never()) //Very important to assert this method is only called once to create the cache
             ->method('getLegacyRoutes');
 
         return $providerMock;

--- a/tests-legacy/PrestaShopBundle/Routing/Converter/LegacyRouteTest.php
+++ b/tests-legacy/PrestaShopBundle/Routing/Converter/LegacyRouteTest.php
@@ -34,104 +34,104 @@ class LegacyRouteTest extends TestCase
     public function testConstructor()
     {
         $legacyRoute = new LegacyRoute('product_index', ['AdminProduct'], []);
-        $this->assertEquals('product_index', $legacyRoute->getRouteName());
-        $this->assertEmpty($legacyRoute->getRouteParameters());
+        static::assertEquals('product_index', $legacyRoute->getRouteName());
+        static::assertEmpty($legacyRoute->getRouteParameters());
 
         $legacyLinks = $legacyRoute->getLegacyLinks();
-        $this->assertCount(1, $legacyLinks);
+        static::assertCount(1, $legacyLinks);
         $legacyLink = $legacyLinks[0];
-        $this->assertEquals('AdminProduct', $legacyLink['controller']);
-        $this->assertNull($legacyLink['action']);
+        static::assertEquals('AdminProduct', $legacyLink['controller']);
+        static::assertNull($legacyLink['action']);
 
         $controllersActions = $legacyRoute->getControllersActions();
-        $this->assertCount(1, $controllersActions);
-        $this->assertNotEmpty($controllersActions['AdminProduct']);
+        static::assertCount(1, $controllersActions);
+        static::assertNotEmpty($controllersActions['AdminProduct']);
 
         $controllerActions = $controllersActions['AdminProduct'];
-        $this->assertCount(1, $controllerActions);
-        $this->assertNotEmpty($controllerActions['index']);
-        $this->assertEquals('product_index', $controllerActions['index']);
+        static::assertCount(1, $controllerActions);
+        static::assertNotEmpty($controllerActions['index']);
+        static::assertEquals('product_index', $controllerActions['index']);
     }
 
     public function testConstructorAction()
     {
         $legacyRoute = new LegacyRoute('product_create', ['AdminProduct:create'], []);
-        $this->assertEquals('product_create', $legacyRoute->getRouteName());
-        $this->assertEmpty($legacyRoute->getRouteParameters());
+        static::assertEquals('product_create', $legacyRoute->getRouteName());
+        static::assertEmpty($legacyRoute->getRouteParameters());
 
         $legacyLinks = $legacyRoute->getLegacyLinks();
-        $this->assertCount(1, $legacyLinks);
+        static::assertCount(1, $legacyLinks);
         $legacyLink = $legacyLinks[0];
-        $this->assertEquals('AdminProduct', $legacyLink['controller']);
-        $this->assertEquals('create', $legacyLink['action']);
+        static::assertEquals('AdminProduct', $legacyLink['controller']);
+        static::assertEquals('create', $legacyLink['action']);
 
         $controllersActions = $legacyRoute->getControllersActions();
-        $this->assertCount(1, $controllersActions);
-        $this->assertNotEmpty($controllersActions['AdminProduct']);
+        static::assertCount(1, $controllersActions);
+        static::assertNotEmpty($controllersActions['AdminProduct']);
 
         $controllerActions = $controllersActions['AdminProduct'];
-        $this->assertCount(1, $controllerActions);
-        $this->assertNotEmpty($controllerActions['create']);
-        $this->assertEquals('product_create', $controllerActions['create']);
+        static::assertCount(1, $controllerActions);
+        static::assertNotEmpty($controllerActions['create']);
+        static::assertEquals('product_create', $controllerActions['create']);
     }
 
     public function testConstructorParameters()
     {
         $legacyRoute = new LegacyRoute('product_create', ['AdminProduct:create'], ['id_product' => 'productId']);
-        $this->assertEquals('product_create', $legacyRoute->getRouteName());
+        static::assertEquals('product_create', $legacyRoute->getRouteName());
         $routeParameters = $legacyRoute->getRouteParameters();
-        $this->assertNotEmpty($routeParameters);
-        $this->assertEquals('productId', $routeParameters['id_product']);
+        static::assertNotEmpty($routeParameters);
+        static::assertEquals('productId', $routeParameters['id_product']);
 
         $legacyLinks = $legacyRoute->getLegacyLinks();
-        $this->assertCount(1, $legacyLinks);
+        static::assertCount(1, $legacyLinks);
         $legacyLink = $legacyLinks[0];
-        $this->assertEquals('AdminProduct', $legacyLink['controller']);
-        $this->assertEquals('create', $legacyLink['action']);
+        static::assertEquals('AdminProduct', $legacyLink['controller']);
+        static::assertEquals('create', $legacyLink['action']);
 
         $controllersActions = $legacyRoute->getControllersActions();
-        $this->assertCount(1, $controllersActions);
-        $this->assertNotEmpty($controllersActions['AdminProduct']);
+        static::assertCount(1, $controllersActions);
+        static::assertNotEmpty($controllersActions['AdminProduct']);
 
         $controllerActions = $controllersActions['AdminProduct'];
-        $this->assertCount(1, $controllerActions);
-        $this->assertNotEmpty($controllerActions['create']);
-        $this->assertEquals('product_create', $controllerActions['create']);
+        static::assertCount(1, $controllerActions);
+        static::assertNotEmpty($controllerActions['create']);
+        static::assertEquals('product_create', $controllerActions['create']);
     }
 
     public function testConstructorAliases()
     {
         $legacyRoute = new LegacyRoute('product_create', ['AdminProduct:create', 'AdminProduct:new', 'SFProduct:new'], ['id_product' => 'productId']);
-        $this->assertEquals('product_create', $legacyRoute->getRouteName());
+        static::assertEquals('product_create', $legacyRoute->getRouteName());
         $routeParameters = $legacyRoute->getRouteParameters();
-        $this->assertNotEmpty($routeParameters);
-        $this->assertEquals('productId', $routeParameters['id_product']);
+        static::assertNotEmpty($routeParameters);
+        static::assertEquals('productId', $routeParameters['id_product']);
 
         $legacyLinks = $legacyRoute->getLegacyLinks();
-        $this->assertCount(3, $legacyLinks);
+        static::assertCount(3, $legacyLinks);
         $legacyLink = $legacyLinks[0];
-        $this->assertEquals('AdminProduct', $legacyLink['controller']);
-        $this->assertEquals('create', $legacyLink['action']);
+        static::assertEquals('AdminProduct', $legacyLink['controller']);
+        static::assertEquals('create', $legacyLink['action']);
         $legacyLink = $legacyLinks[1];
-        $this->assertEquals('AdminProduct', $legacyLink['controller']);
-        $this->assertEquals('new', $legacyLink['action']);
+        static::assertEquals('AdminProduct', $legacyLink['controller']);
+        static::assertEquals('new', $legacyLink['action']);
 
         $controllersActions = $legacyRoute->getControllersActions();
-        $this->assertCount(2, $controllersActions);
-        $this->assertNotEmpty($controllersActions['AdminProduct']);
-        $this->assertNotEmpty($controllersActions['SFProduct']);
+        static::assertCount(2, $controllersActions);
+        static::assertNotEmpty($controllersActions['AdminProduct']);
+        static::assertNotEmpty($controllersActions['SFProduct']);
 
         $controllerActions = $controllersActions['AdminProduct'];
-        $this->assertCount(2, $controllerActions);
-        $this->assertNotEmpty($controllerActions['create']);
-        $this->assertEquals('product_create', $controllerActions['create']);
-        $this->assertNotEmpty($controllerActions['new']);
-        $this->assertEquals('product_create', $controllerActions['new']);
+        static::assertCount(2, $controllerActions);
+        static::assertNotEmpty($controllerActions['create']);
+        static::assertEquals('product_create', $controllerActions['create']);
+        static::assertNotEmpty($controllerActions['new']);
+        static::assertEquals('product_create', $controllerActions['new']);
 
         $controllerActions = $controllersActions['SFProduct'];
-        $this->assertCount(1, $controllerActions);
-        $this->assertNotEmpty($controllerActions['new']);
-        $this->assertEquals('product_create', $controllerActions['new']);
+        static::assertCount(1, $controllerActions);
+        static::assertNotEmpty($controllerActions['new']);
+        static::assertEquals('product_create', $controllerActions['new']);
     }
 
     public function testStaticConstructor()
@@ -139,23 +139,23 @@ class LegacyRouteTest extends TestCase
         $legacyRoute = LegacyRoute::buildLegacyRoute('product_index', [
             '_legacy_link' => 'AdminProduct',
         ]);
-        $this->assertEquals('product_index', $legacyRoute->getRouteName());
-        $this->assertEmpty($legacyRoute->getRouteParameters());
+        static::assertEquals('product_index', $legacyRoute->getRouteName());
+        static::assertEmpty($legacyRoute->getRouteParameters());
 
         $legacyLinks = $legacyRoute->getLegacyLinks();
-        $this->assertCount(1, $legacyLinks);
+        static::assertCount(1, $legacyLinks);
         $legacyLink = $legacyLinks[0];
-        $this->assertEquals('AdminProduct', $legacyLink['controller']);
-        $this->assertNull($legacyLink['action']);
+        static::assertEquals('AdminProduct', $legacyLink['controller']);
+        static::assertNull($legacyLink['action']);
 
         $controllersActions = $legacyRoute->getControllersActions();
-        $this->assertCount(1, $controllersActions);
-        $this->assertNotEmpty($controllersActions['AdminProduct']);
+        static::assertCount(1, $controllersActions);
+        static::assertNotEmpty($controllersActions['AdminProduct']);
 
         $controllerActions = $controllersActions['AdminProduct'];
-        $this->assertCount(1, $controllerActions);
-        $this->assertNotEmpty($controllerActions['index']);
-        $this->assertEquals('product_index', $controllerActions['index']);
+        static::assertCount(1, $controllerActions);
+        static::assertNotEmpty($controllerActions['index']);
+        static::assertEquals('product_index', $controllerActions['index']);
     }
 
     public function testStaticConstructorAction()
@@ -163,23 +163,23 @@ class LegacyRouteTest extends TestCase
         $legacyRoute = LegacyRoute::buildLegacyRoute('product_create', [
             '_legacy_link' => 'AdminProduct:create',
         ]);
-        $this->assertEquals('product_create', $legacyRoute->getRouteName());
-        $this->assertEmpty($legacyRoute->getRouteParameters());
+        static::assertEquals('product_create', $legacyRoute->getRouteName());
+        static::assertEmpty($legacyRoute->getRouteParameters());
 
         $legacyLinks = $legacyRoute->getLegacyLinks();
-        $this->assertCount(1, $legacyLinks);
+        static::assertCount(1, $legacyLinks);
         $legacyLink = $legacyLinks[0];
-        $this->assertEquals('AdminProduct', $legacyLink['controller']);
-        $this->assertEquals('create', $legacyLink['action']);
+        static::assertEquals('AdminProduct', $legacyLink['controller']);
+        static::assertEquals('create', $legacyLink['action']);
 
         $controllersActions = $legacyRoute->getControllersActions();
-        $this->assertCount(1, $controllersActions);
-        $this->assertNotEmpty($controllersActions['AdminProduct']);
+        static::assertCount(1, $controllersActions);
+        static::assertNotEmpty($controllersActions['AdminProduct']);
 
         $controllerActions = $controllersActions['AdminProduct'];
-        $this->assertCount(1, $controllerActions);
-        $this->assertNotEmpty($controllerActions['create']);
-        $this->assertEquals('product_create', $controllerActions['create']);
+        static::assertCount(1, $controllerActions);
+        static::assertNotEmpty($controllerActions['create']);
+        static::assertEquals('product_create', $controllerActions['create']);
     }
 
     public function testStaticParameters()
@@ -190,25 +190,25 @@ class LegacyRouteTest extends TestCase
                 'id_product' => 'productId',
             ],
         ]);
-        $this->assertEquals('product_create', $legacyRoute->getRouteName());
+        static::assertEquals('product_create', $legacyRoute->getRouteName());
         $routeParameters = $legacyRoute->getRouteParameters();
-        $this->assertNotEmpty($routeParameters);
-        $this->assertEquals('productId', $routeParameters['id_product']);
+        static::assertNotEmpty($routeParameters);
+        static::assertEquals('productId', $routeParameters['id_product']);
 
         $legacyLinks = $legacyRoute->getLegacyLinks();
-        $this->assertCount(1, $legacyLinks);
+        static::assertCount(1, $legacyLinks);
         $legacyLink = $legacyLinks[0];
-        $this->assertEquals('AdminProduct', $legacyLink['controller']);
-        $this->assertEquals('create', $legacyLink['action']);
+        static::assertEquals('AdminProduct', $legacyLink['controller']);
+        static::assertEquals('create', $legacyLink['action']);
 
         $controllersActions = $legacyRoute->getControllersActions();
-        $this->assertCount(1, $controllersActions);
-        $this->assertNotEmpty($controllersActions['AdminProduct']);
+        static::assertCount(1, $controllersActions);
+        static::assertNotEmpty($controllersActions['AdminProduct']);
 
         $controllerActions = $controllersActions['AdminProduct'];
-        $this->assertCount(1, $controllerActions);
-        $this->assertNotEmpty($controllerActions['create']);
-        $this->assertEquals('product_create', $controllerActions['create']);
+        static::assertCount(1, $controllerActions);
+        static::assertNotEmpty($controllerActions['create']);
+        static::assertEquals('product_create', $controllerActions['create']);
     }
 
     public function testStaticAliases()
@@ -219,35 +219,35 @@ class LegacyRouteTest extends TestCase
                 'id_product' => 'productId',
             ],
         ]);
-        $this->assertEquals('product_create', $legacyRoute->getRouteName());
+        static::assertEquals('product_create', $legacyRoute->getRouteName());
         $routeParameters = $legacyRoute->getRouteParameters();
-        $this->assertNotEmpty($routeParameters);
-        $this->assertEquals('productId', $routeParameters['id_product']);
+        static::assertNotEmpty($routeParameters);
+        static::assertEquals('productId', $routeParameters['id_product']);
 
         $legacyLinks = $legacyRoute->getLegacyLinks();
-        $this->assertCount(3, $legacyLinks);
+        static::assertCount(3, $legacyLinks);
         $legacyLink = $legacyLinks[0];
-        $this->assertEquals('AdminProduct', $legacyLink['controller']);
-        $this->assertEquals('create', $legacyLink['action']);
+        static::assertEquals('AdminProduct', $legacyLink['controller']);
+        static::assertEquals('create', $legacyLink['action']);
         $legacyLink = $legacyLinks[1];
-        $this->assertEquals('AdminProduct', $legacyLink['controller']);
-        $this->assertEquals('new', $legacyLink['action']);
+        static::assertEquals('AdminProduct', $legacyLink['controller']);
+        static::assertEquals('new', $legacyLink['action']);
 
         $controllersActions = $legacyRoute->getControllersActions();
-        $this->assertCount(2, $controllersActions);
-        $this->assertNotEmpty($controllersActions['AdminProduct']);
-        $this->assertNotEmpty($controllersActions['SFProduct']);
+        static::assertCount(2, $controllersActions);
+        static::assertNotEmpty($controllersActions['AdminProduct']);
+        static::assertNotEmpty($controllersActions['SFProduct']);
 
         $controllerActions = $controllersActions['AdminProduct'];
-        $this->assertCount(2, $controllerActions);
-        $this->assertNotEmpty($controllerActions['create']);
-        $this->assertEquals('product_create', $controllerActions['create']);
-        $this->assertNotEmpty($controllerActions['new']);
-        $this->assertEquals('product_create', $controllerActions['new']);
+        static::assertCount(2, $controllerActions);
+        static::assertNotEmpty($controllerActions['create']);
+        static::assertEquals('product_create', $controllerActions['create']);
+        static::assertNotEmpty($controllerActions['new']);
+        static::assertEquals('product_create', $controllerActions['new']);
 
         $controllerActions = $controllersActions['SFProduct'];
-        $this->assertCount(1, $controllerActions);
-        $this->assertNotEmpty($controllerActions['new']);
-        $this->assertEquals('product_create', $controllerActions['new']);
+        static::assertCount(1, $controllerActions);
+        static::assertNotEmpty($controllerActions['new']);
+        static::assertEquals('product_create', $controllerActions['new']);
     }
 }

--- a/tests-legacy/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests-legacy/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -47,10 +47,10 @@ class LegacyUrlConverterTest extends TestCase
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
         ]);
-        $this->assertEquals('/products', $url);
+        static::assertEquals('/products', $url);
 
         $url = $converter->convertByUrl('?controller=AdminProducts');
-        $this->assertEquals('/products', $url);
+        static::assertEquals('/products', $url);
     }
 
     public function testIndexAlias()
@@ -61,10 +61,10 @@ class LegacyUrlConverterTest extends TestCase
             'controller' => 'AdminProducts',
             'action' => 'index',
         ]);
-        $this->assertEquals('/products', $url);
+        static::assertEquals('/products', $url);
 
         $url = $converter->convertByUrl('?controller=AdminProducts&action=index');
-        $this->assertEquals('/products', $url);
+        static::assertEquals('/products', $url);
     }
 
     public function testInsensitiveListAlias()
@@ -75,10 +75,10 @@ class LegacyUrlConverterTest extends TestCase
             'controller' => 'AdminProducts',
             'action' => 'LIST',
         ]);
-        $this->assertEquals('/products', $url);
+        static::assertEquals('/products', $url);
 
         $url = $converter->convertByUrl('?controller=AdminProducts&action=LIST');
-        $this->assertEquals('/products', $url);
+        static::assertEquals('/products', $url);
     }
 
     public function testAction()
@@ -89,10 +89,10 @@ class LegacyUrlConverterTest extends TestCase
             'controller' => 'AdminProducts',
             'action' => 'create',
         ]);
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
 
         $url = $converter->convertByUrl('?controller=AdminProducts&action=create');
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
     }
 
     public function testActionWithTrue()
@@ -103,10 +103,10 @@ class LegacyUrlConverterTest extends TestCase
             'controller' => 'AdminProducts',
             'create' => true,
         ]);
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
 
         $url = $converter->convertByUrl('?controller=AdminProducts&create=1');
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
     }
 
     public function testActionWithEmptyString()
@@ -117,10 +117,10 @@ class LegacyUrlConverterTest extends TestCase
             'controller' => 'AdminProducts',
             'create' => '',
         ]);
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
 
         $url = $converter->convertByUrl('?controller=AdminProducts&create');
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
     }
 
     public function testMultipleLegacyLinks()
@@ -135,19 +135,19 @@ class LegacyUrlConverterTest extends TestCase
         $url = $converter->convertByParameters([
             'controller' => 'AdminModulesManage',
         ]);
-        $this->assertEquals('/manage/{category}/{keyword}', $url);
+        static::assertEquals('/manage/{category}/{keyword}', $url);
 
         $url = $converter->convertByUrl('?controller=AdminModulesManage');
-        $this->assertEquals('/manage/{category}/{keyword}', $url);
+        static::assertEquals('/manage/{category}/{keyword}', $url);
 
         //Second controller
         $url = $converter->convertByParameters([
             'controller' => 'AdminModulesSf',
         ]);
-        $this->assertEquals('/manage/{category}/{keyword}', $url);
+        static::assertEquals('/manage/{category}/{keyword}', $url);
 
         $url = $converter->convertByUrl('?controller=AdminModulesSf');
-        $this->assertEquals('/manage/{category}/{keyword}', $url);
+        static::assertEquals('/manage/{category}/{keyword}', $url);
     }
 
     /**
@@ -169,7 +169,7 @@ class LegacyUrlConverterTest extends TestCase
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
+        static::assertNotNull($caughtException);
 
         try {
             $converter->convertByParameters([
@@ -179,7 +179,7 @@ class LegacyUrlConverterTest extends TestCase
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
+        static::assertNotNull($caughtException);
 
         try {
             $converter->convertByParameters([
@@ -189,35 +189,35 @@ class LegacyUrlConverterTest extends TestCase
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
+        static::assertNotNull($caughtException);
 
         try {
             $converter->convertByUrl('?controller=AdminProducts&action=create');
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
+        static::assertNotNull($caughtException);
 
         try {
             $converter->convertByUrl('?controller=AdminProducts&create=1');
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
+        static::assertNotNull($caughtException);
 
         try {
             $converter->convertByUrl('?controller=AdminProducts&create=');
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
+        static::assertNotNull($caughtException);
 
         try {
             $converter->convertByUrl('?controller=AdminProducts&create');
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
+        static::assertNotNull($caughtException);
     }
 
     /**
@@ -231,10 +231,10 @@ class LegacyUrlConverterTest extends TestCase
         $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
         $converter = new LegacyUrlConverter($router, new RouterProvider($router));
         $convertedUrl = $converter->convertByUrl('?controller=AdminProducts&id_product=1');
-        $this->assertEquals('/products', $convertedUrl);
+        static::assertEquals('/products', $convertedUrl);
 
         $convertedUrl = $converter->convertByUrl('?controller=AdminProducts&product_id=1');
-        $this->assertEquals('/products', $convertedUrl);
+        static::assertEquals('/products', $convertedUrl);
     }
 
     public function testActionWithArgument()
@@ -254,15 +254,15 @@ class LegacyUrlConverterTest extends TestCase
             'id_product' => 2,
         ]);
         //Mock returns the original path but the parameters are checked
-        $this->assertEquals('/products/edit/{id}', $url);
+        static::assertEquals('/products/edit/{id}', $url);
 
         //Mock returns the original path but the parameters are checked
         $url = $converter->convertByUrl('?controller=AdminProducts&action=edit&id_product=2');
-        $this->assertEquals('/products/edit/{id}', $url);
+        static::assertEquals('/products/edit/{id}', $url);
 
         //Try with id parameter like in route
         $url = $converter->convertByUrl('?controller=AdminProducts&action=edit&id=2');
-        $this->assertEquals('/products/edit/{id}', $url);
+        static::assertEquals('/products/edit/{id}', $url);
     }
 
     public function testActionWithArgumentWithoutMatching()
@@ -282,11 +282,11 @@ class LegacyUrlConverterTest extends TestCase
             'id' => '42',
         ]);
         //Mock returns the original path but the parameters are checked
-        $this->assertEquals('/products/edit/{id}', $url);
+        static::assertEquals('/products/edit/{id}', $url);
 
         //Mock returns the original path but the parameters are checked
         $url = $converter->convertByUrl('?controller=AdminProducts&action=edit&id=42');
-        $this->assertEquals('/products/edit/{id}', $url);
+        static::assertEquals('/products/edit/{id}', $url);
     }
 
     public function testConvertByRequest()
@@ -305,19 +305,19 @@ class LegacyUrlConverterTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $contextMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('fromRequest')
             ->with(
-                $this->equalTo($request)
+                static::equalTo($request)
             );
         $router
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('getContext')
             ->willReturn($contextMock);
 
         $converter = new LegacyUrlConverter($router, new RouterProvider($router));
         $url = $converter->convertByRequest($request);
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
     }
 
     public function testMissingController()
@@ -347,9 +347,9 @@ class LegacyUrlConverterTest extends TestCase
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
-        $this->assertInstanceOf(RouteNotFoundException::class, $caughtException);
-        $this->assertEquals('Could not find a route matching for legacy controller: AdminModules', $caughtException->getMessage());
+        static::assertNotNull($caughtException);
+        static::assertInstanceOf(RouteNotFoundException::class, $caughtException);
+        static::assertEquals('Could not find a route matching for legacy controller: AdminModules', $caughtException->getMessage());
     }
 
     public function testActionNotFound()
@@ -368,9 +368,9 @@ class LegacyUrlConverterTest extends TestCase
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
-        $this->assertInstanceOf(RouteNotFoundException::class, $caughtException);
-        $this->assertEquals('Could not find a route matching for legacy action: AdminProducts:configure', $caughtException->getMessage());
+        static::assertNotNull($caughtException);
+        static::assertInstanceOf(RouteNotFoundException::class, $caughtException);
+        static::assertEquals('Could not find a route matching for legacy action: AdminProducts:configure', $caughtException->getMessage());
     }
 
     /**
@@ -399,33 +399,33 @@ class LegacyUrlConverterTest extends TestCase
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
         ]);
-        $this->assertEquals('/products', $url);
+        static::assertEquals('/products', $url);
 
         //Test index by url
         $url = $converter->convertByUrl('?controller=AdminProducts');
-        $this->assertEquals('/products', $url);
+        static::assertEquals('/products', $url);
 
         //Test create by parameter action
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
             'action' => 'add',
         ]);
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
 
         //Test create by boolean value
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
             'add' => true,
         ]);
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
 
         //Test url create by parameter action
         $url = $converter->convertByUrl('?controller=AdminProducts&action=add');
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
 
         //Test url create by boolean value
         $url = $converter->convertByUrl('?controller=AdminProducts&add');
-        $this->assertEquals('/products/create', $url);
+        static::assertEquals('/products/create', $url);
     }
 
     /**
@@ -464,16 +464,16 @@ class LegacyUrlConverterTest extends TestCase
             $mockRouter
                 ->method('generate')
                 ->with(
-                    $this->equalTo($routeName),
-                    $this->equalTo($expectedParameters)
+                    static::equalTo($routeName),
+                    static::equalTo($expectedParameters)
                 )
                 ->willReturn($routePath);
         } else {
             $mockRouter
                 ->method('generate')
                 ->with(
-                    $this->equalTo($routeName),
-                    $this->anything()
+                    static::equalTo($routeName),
+                    static::anything()
                 )
                 ->willReturn($routePath);
         }
@@ -500,7 +500,7 @@ class LegacyUrlConverterTest extends TestCase
 
         $mockRouter
             ->method('generate')
-            ->will($this->returnCallback(
+            ->will(static::returnCallback(
                 function($routeName) use ($routeCollection) {
                     $route = $routeCollection->get($routeName);
 

--- a/tests-legacy/PrestaShopBundle/Routing/Converter/RouterProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Routing/Converter/RouterProviderTest.php
@@ -55,19 +55,19 @@ class RouterProviderTest extends TestCase
         ]);
         $routerProvider = new RouterProvider($router);
         $legacyRoutes = $routerProvider->getLegacyRoutes();
-        $this->assertCount(2, $legacyRoutes);
-        $this->assertNotEmpty($legacyRoutes['admin_products']);
+        static::assertCount(2, $legacyRoutes);
+        static::assertNotEmpty($legacyRoutes['admin_products']);
 
         /** @var LegacyRoute $legacyRoute */
         $legacyRoute = $legacyRoutes['admin_products'];
-        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
-        $this->assertSame(['AdminProducts' => [
+        static::assertEquals('admin_products', $legacyRoute->getRouteName());
+        static::assertSame(['AdminProducts' => [
             'index' => 'admin_products',
         ]], $legacyRoute->getControllersActions());
 
         $legacyRoute = $legacyRoutes['admin_products_create'];
-        $this->assertEquals('admin_products_create', $legacyRoute->getRouteName());
-        $this->assertSame(['AdminProducts' => [
+        static::assertEquals('admin_products_create', $legacyRoute->getRouteName());
+        static::assertSame(['AdminProducts' => [
             'add' => 'admin_products_create',
             'create' => 'admin_products_create',
         ]], $legacyRoute->getControllersActions());
@@ -100,8 +100,8 @@ class RouterProviderTest extends TestCase
         ]);
         $routerProvider = new RouterProvider($router);
         $controllersActions = $routerProvider->getControllersActions();
-        $this->assertCount(2, $controllersActions);
-        $this->assertSame([
+        static::assertCount(2, $controllersActions);
+        static::assertSame([
             'AdminProducts' => [
                 'index' => 'admin_products',
                 'add' => 'admin_products_create',
@@ -141,8 +141,8 @@ class RouterProviderTest extends TestCase
         ]);
         $routerProvider = new RouterProvider($router);
         $controllerActions = $routerProvider->getActionsByController('AdminProducts');
-        $this->assertCount(3, $controllerActions);
-        $this->assertSame(['index', 'add', 'create'], $controllerActions);
+        static::assertCount(3, $controllerActions);
+        static::assertSame(['index', 'add', 'create'], $controllerActions);
     }
 
     public function testGetLegacyRouteByAction()
@@ -172,28 +172,28 @@ class RouterProviderTest extends TestCase
         ]);
         $routerProvider = new RouterProvider($router);
         $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminProducts', 'index');
-        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+        static::assertEquals('admin_products', $legacyRoute->getRouteName());
 
         $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminProducts', 'list');
-        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+        static::assertEquals('admin_products', $legacyRoute->getRouteName());
 
         $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminProducts', '');
-        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+        static::assertEquals('admin_products', $legacyRoute->getRouteName());
 
         $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminProducts', null);
-        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+        static::assertEquals('admin_products', $legacyRoute->getRouteName());
 
         $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminProducts', 'add');
-        $this->assertEquals('admin_products_create', $legacyRoute->getRouteName());
+        static::assertEquals('admin_products_create', $legacyRoute->getRouteName());
 
         $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminProducts', 'create');
-        $this->assertEquals('admin_products_create', $legacyRoute->getRouteName());
+        static::assertEquals('admin_products_create', $legacyRoute->getRouteName());
 
         $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminCategories', 'create');
-        $this->assertEquals('admin_categories_create', $legacyRoute->getRouteName());
+        static::assertEquals('admin_categories_create', $legacyRoute->getRouteName());
 
         $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminCategories', 'add');
-        $this->assertEquals('admin_categories_create', $legacyRoute->getRouteName());
+        static::assertEquals('admin_categories_create', $legacyRoute->getRouteName());
     }
 
     public function testControllerNotFound()
@@ -222,8 +222,8 @@ class RouterProviderTest extends TestCase
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
-        $this->assertEquals('Could not find a route matching for legacy controller: AdminCategories', $caughtException->getMessage());
+        static::assertNotNull($caughtException);
+        static::assertEquals('Could not find a route matching for legacy controller: AdminCategories', $caughtException->getMessage());
 
         $caughtException = null;
 
@@ -232,8 +232,8 @@ class RouterProviderTest extends TestCase
         } catch (RouteNotFoundException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
-        $this->assertEquals('Could not find a route matching for legacy action: AdminProducts:edit', $caughtException->getMessage());
+        static::assertNotNull($caughtException);
+        static::assertEquals('Could not find a route matching for legacy action: AdminProducts:edit', $caughtException->getMessage());
     }
 
     /**
@@ -250,13 +250,13 @@ class RouterProviderTest extends TestCase
             ->getMock();
 
         $mockRouter
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('getRouteCollection')
             ->willReturn($routeCollection);
 
         $mockRouter
             ->method('generate')
-            ->will($this->returnCallback(
+            ->will(static::returnCallback(
                 function($routeName) use ($routeCollection) {
                     $route = $routeCollection->get($routeName);
 

--- a/tests-legacy/PrestaShopBundle/Routing/Converter/RoutingCacheKeyGeneratorTest.php
+++ b/tests-legacy/PrestaShopBundle/Routing/Converter/RoutingCacheKeyGeneratorTest.php
@@ -72,8 +72,8 @@ class RoutingCacheKeyGeneratorTest extends TestCase
 
         $generator = new RoutingCacheKeyGenerator([$this->filesTestDir . DIRECTORY_SEPARATOR . 'admin'], []);
         $lastModifications = $generator->getLastModifications();
-        $this->assertCount(6, $lastModifications);
-        $this->assertSame([
+        static::assertCount(6, $lastModifications);
+        static::assertSame([
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'admin/improve/international/translations.yml',
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'admin/sell/catalog/products/products.yml',
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'admin/configure/advanced_parameters/webservice.yml',
@@ -85,8 +85,8 @@ class RoutingCacheKeyGeneratorTest extends TestCase
         $this->fs->touch($this->filesTestDir . DIRECTORY_SEPARATOR . 'admin/improve/payment/payment_methods.yaml');
 
         $lastModifications = $generator->getLastModifications();
-        $this->assertCount(6, $lastModifications);
-        $this->assertSame([
+        static::assertCount(6, $lastModifications);
+        static::assertSame([
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'admin/improve/payment/payment_methods.yaml',
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'admin/improve/international/translations.yml',
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'admin/sell/catalog/products/products.yml',
@@ -114,7 +114,7 @@ class RoutingCacheKeyGeneratorTest extends TestCase
         $this->generateFiles($testFiles, $originalTime);
 
         $generator = new RoutingCacheKeyGenerator([$this->filesTestDir . DIRECTORY_SEPARATOR . 'admin'], []);
-        $this->assertEquals($originalTime + 3200, $generator->getLatestModificationTime());
+        static::assertEquals($originalTime + 3200, $generator->getLatestModificationTime());
     }
 
     public function testCacheKeyCoreFile()
@@ -136,7 +136,7 @@ class RoutingCacheKeyGeneratorTest extends TestCase
 
         $generator = new RoutingCacheKeyGenerator([$this->filesTestDir . DIRECTORY_SEPARATOR . 'admin'], []);
         $cacheKey = $generator->getCacheKey();
-        $this->assertEquals('PrestaShopBundle_Routing_Converter_' . ($originalTime + 3200), $cacheKey);
+        static::assertEquals('PrestaShopBundle_Routing_Converter_' . ($originalTime + 3200), $cacheKey);
     }
 
     public function testModuleFilesOrder()
@@ -157,8 +157,8 @@ class RoutingCacheKeyGeneratorTest extends TestCase
 
         $generator = new RoutingCacheKeyGenerator([], $modules);
         $lastModifications = $generator->getLastModifications();
-        $this->assertCount(4, $lastModifications);
-        $this->assertSame([
+        static::assertCount(4, $lastModifications);
+        static::assertSame([
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'modules/ps_linklist/config/routes.yml',
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'modules/ps_viewedproducs/config/routes.yml',
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'modules/ps_gamification/config/routes.yml',
@@ -168,8 +168,8 @@ class RoutingCacheKeyGeneratorTest extends TestCase
         $this->fs->touch($this->filesTestDir . DIRECTORY_SEPARATOR . 'modules/ps_gamification/config/routes.yml');
 
         $lastModifications = $generator->getLastModifications();
-        $this->assertCount(4, $lastModifications);
-        $this->assertSame([
+        static::assertCount(4, $lastModifications);
+        static::assertSame([
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'modules/ps_gamification/config/routes.yml',
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'modules/ps_linklist/config/routes.yml',
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'modules/ps_viewedproducs/config/routes.yml',
@@ -195,7 +195,7 @@ class RoutingCacheKeyGeneratorTest extends TestCase
         ];
 
         $generator = new RoutingCacheKeyGenerator([], $modules);
-        $this->assertEquals($originalTime + 42, $generator->getLatestModificationTime());
+        static::assertEquals($originalTime + 42, $generator->getLatestModificationTime());
     }
 
     public function testCacheKeyModulesFile()
@@ -217,7 +217,7 @@ class RoutingCacheKeyGeneratorTest extends TestCase
 
         $generator = new RoutingCacheKeyGenerator([], $modules);
         $cacheKey = $generator->getCacheKey();
-        $this->assertEquals('PrestaShopBundle_Routing_Converter_' . ($originalTime + 42), $cacheKey);
+        static::assertEquals('PrestaShopBundle_Routing_Converter_' . ($originalTime + 42), $cacheKey);
     }
 
     public function testCoreAndModules()
@@ -246,8 +246,8 @@ class RoutingCacheKeyGeneratorTest extends TestCase
 
         $generator = new RoutingCacheKeyGenerator([$this->filesTestDir . DIRECTORY_SEPARATOR . 'admin'], $modules);
         $lastModifications = $generator->getLastModifications();
-        $this->assertCount(8, $lastModifications);
-        $this->assertSame([
+        static::assertCount(8, $lastModifications);
+        static::assertSame([
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'admin/improve/international/translations.yml',
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'modules/ps_linklist/config/routes.yml',
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'admin/sell/catalog/products/products.yml',
@@ -258,31 +258,31 @@ class RoutingCacheKeyGeneratorTest extends TestCase
             $this->filesTestDir . DIRECTORY_SEPARATOR . 'modules/ps_featuredproducts/config/routes.yaml',
         ], array_keys($lastModifications));
 
-        $this->assertEquals($originalTime + 3200, $generator->getLatestModificationTime());
-        $this->assertEquals('PrestaShopBundle_Routing_Converter_' . ($originalTime + 3200), $generator->getCacheKey());
+        static::assertEquals($originalTime + 3200, $generator->getLatestModificationTime());
+        static::assertEquals('PrestaShopBundle_Routing_Converter_' . ($originalTime + 3200), $generator->getCacheKey());
 
         $this->fs->touch($this->filesTestDir . DIRECTORY_SEPARATOR . 'admin/improve/international/translations.yml', $originalTime);
 
-        $this->assertEquals($originalTime + 42, $generator->getLatestModificationTime());
-        $this->assertEquals('PrestaShopBundle_Routing_Converter_' . ($originalTime + 42), $generator->getCacheKey());
+        static::assertEquals($originalTime + 42, $generator->getLatestModificationTime());
+        static::assertEquals('PrestaShopBundle_Routing_Converter_' . ($originalTime + 42), $generator->getCacheKey());
 
         $now = time();
         $this->fs->touch($this->filesTestDir . DIRECTORY_SEPARATOR . 'modules/ps_featuredproducts/config/routes.yaml', $now);
-        $this->assertEquals($now, $generator->getLatestModificationTime());
-        $this->assertEquals('PrestaShopBundle_Routing_Converter_' . $now, $generator->getCacheKey());
+        static::assertEquals($now, $generator->getLatestModificationTime());
+        static::assertEquals('PrestaShopBundle_Routing_Converter_' . $now, $generator->getCacheKey());
     }
 
     public function testNoRouteFiles()
     {
         $generator = new RoutingCacheKeyGenerator([], []);
         $lastModifications = $generator->getLastModifications();
-        $this->assertNotNull($lastModifications);
-        $this->assertEmpty($lastModifications);
+        static::assertNotNull($lastModifications);
+        static::assertEmpty($lastModifications);
 
-        $this->assertNull($generator->getLatestModificationTime());
+        static::assertNull($generator->getLatestModificationTime());
 
         $cacheKey = $generator->getCacheKey();
-        $this->assertEquals('PrestaShopBundle_Routing_Converter', $cacheKey);
+        static::assertEquals('PrestaShopBundle_Routing_Converter', $cacheKey);
     }
 
     public function testProdEnvironment()
@@ -310,10 +310,10 @@ class RoutingCacheKeyGeneratorTest extends TestCase
         ];
 
         $generator = new RoutingCacheKeyGenerator([$this->filesTestDir . DIRECTORY_SEPARATOR . 'admin'], $modules);
-        $this->assertEquals('PrestaShopBundle_Routing_Converter_' . ($originalTime + 3200), $generator->getCacheKey());
+        static::assertEquals('PrestaShopBundle_Routing_Converter_' . ($originalTime + 3200), $generator->getCacheKey());
 
         $generator = new RoutingCacheKeyGenerator([$this->filesTestDir . DIRECTORY_SEPARATOR . 'admin'], $modules, 'prod');
-        $this->assertEquals('PrestaShopBundle_Routing_Converter', $generator->getCacheKey());
+        static::assertEquals('PrestaShopBundle_Routing_Converter', $generator->getCacheKey());
     }
 
     /**

--- a/tests-legacy/PrestaShopBundle/Routing/YamlRoutesInModuleTest.php
+++ b/tests-legacy/PrestaShopBundle/Routing/YamlRoutesInModuleTest.php
@@ -74,10 +74,10 @@ class YamlRoutesInModuleTest extends KernelTestCase
         $router = $this->container->get('router');
         $route = $router->getRouteCollection()->get('demo_admin_demo');
 
-        self::assertInstanceOf(Route::class, $route);
+        static::assertInstanceOf(Route::class, $route);
 
-        self::assertEquals('/modules/demo/demo', $route->getPath());
-        self::assertEquals([
+        static::assertEquals('/modules/demo/demo', $route->getPath());
+        static::assertEquals([
             '_controller' => 'PsTest\Controller\Admin\DemoController::demoAction',
         ], $route->getDefaults());
     }

--- a/tests-legacy/PrestaShopBundle/Service/Hook/HookDispatcherTest.php
+++ b/tests-legacy/PrestaShopBundle/Service/Hook/HookDispatcherTest.php
@@ -63,16 +63,16 @@ class HookDispatcherTest extends KernelTestCase
 
         $hookDisptacher->addListener('test_test', array($this, 'listenerCallback'));
         $hookDisptacher->dispatch('unknown_hook_name');
-        $this->assertFalse($this->testedListenerCallbackCalled);
+        static::assertFalse($this->testedListenerCallbackCalled);
         $hookDisptacher->dispatch('test_test');
-        $this->assertTrue($this->testedListenerCallbackCalled);
+        static::assertTrue($this->testedListenerCallbackCalled);
     }
 
     private $testedListenerCallbackCalled = false;
 
     public function listenerCallback(Event $event, $eventName)
     {
-        $this->assertEquals('test_test', $eventName);
+        static::assertEquals('test_test', $eventName);
         $this->testedListenerCallbackCalled = true;
     }
 
@@ -89,7 +89,7 @@ class HookDispatcherTest extends KernelTestCase
         $hookDispatcher->addListener('test_test_2', array($this, 'listenerCallback2b'));
         $event = $hookDispatcher->dispatch('test_test_2', new RenderingHookEvent());
 
-        $this->assertArraySubset(array(
+        static::assertArraySubset(array(
             'listenerCallback2' => ['result_test_2'],
             'overriden_listener_name' => ['result_test_2b'],
         ), $event->getContent());
@@ -97,13 +97,13 @@ class HookDispatcherTest extends KernelTestCase
 
     public function listenerCallback2(RenderingHookEvent $event, $eventName)
     {
-        $this->assertEquals('test_test_2', $eventName);
+        static::assertEquals('test_test_2', $eventName);
         $event->setContent(['result_test_2']);
     }
 
     public function listenerCallback2b(RenderingHookEvent $event, $eventName)
     {
-        $this->assertEquals('test_test_2', $eventName);
+        static::assertEquals('test_test_2', $eventName);
         $event->setContent(['result_test_2b'], 'overriden_listener_name');
     }
 }

--- a/tests-legacy/PrestaShopBundle/Translation/Exporter/ThemeExporterTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Exporter/ThemeExporterTest.php
@@ -121,17 +121,17 @@ class ThemeExporterTest extends TestCase
 
         $messages = $catalogue->all();
         $domain = 'ShopActions.' . self::LOCALE;
-        $this->assertArrayHasKey($domain, $messages);
+        static::assertArrayHasKey($domain, $messages);
 
-        $this->assertArrayHasKey('Edit Product', $messages[$domain]);
-        $this->assertArrayHasKey('Add Product', $messages[$domain]);
-        $this->assertArrayHasKey('Delete Product', $messages[$domain]);
+        static::assertArrayHasKey('Edit Product', $messages[$domain]);
+        static::assertArrayHasKey('Add Product', $messages[$domain]);
+        static::assertArrayHasKey('Delete Product', $messages[$domain]);
 
-        $this->assertArrayHasKey('Override Me', $messages[$domain]);
-        $this->assertSame('Overridden', $messages[$domain]['Override Me']);
+        static::assertArrayHasKey('Override Me', $messages[$domain]);
+        static::assertSame('Overridden', $messages[$domain]['Override Me']);
 
-        $this->assertArrayHasKey('Override Me Twice', $messages[$domain]);
-        $this->assertSame('Overridden Twice', $messages[$domain]['Override Me Twice']);
+        static::assertArrayHasKey('Override Me Twice', $messages[$domain]);
+        static::assertSame('Overridden Twice', $messages[$domain]['Override Me Twice']);
     }
 
     protected function mockThemeExtractor()

--- a/tests-legacy/PrestaShopBundle/Translation/Extractor/ThemeExtractorTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Extractor/ThemeExtractorTest.php
@@ -85,7 +85,7 @@ class ThemeExtractorTest extends KernelTestCase
             ->extract($this->getFakeTheme());
 
         $legacyTranslationFile = self::$legacyFolder.'/en-US.php';
-        $this->assertTrue($this->filesystem->exists($legacyTranslationFile));
+        static::assertTrue($this->filesystem->exists($legacyTranslationFile));
     }
 
     public function testExtractWithXliffFormat()
@@ -101,7 +101,7 @@ class ThemeExtractorTest extends KernelTestCase
             self::$xliffFolder.'/en-US/Shop/Foo/Bar.xlf',
         ));
 
-        $this->assertTrue($isFilesExists);
+        static::assertTrue($isFilesExists);
     }
 
     private function getFakeTheme()

--- a/tests-legacy/PrestaShopBundle/Translation/Factory/ThemeTranslationsFactoryTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Factory/ThemeTranslationsFactoryTest.php
@@ -67,19 +67,19 @@ class ThemeTranslationsFactoryTest extends TestCase
     public function testCreateCatalogue($theme, $locale)
     {
         $this->themeProviderMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('setThemeName')
             ->with($theme)
             ->willReturn($this->themeProviderMock);
 
         $this->themeProviderMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('setLocale')
             ->with($locale)
             ->willReturn($this->themeProviderMock);
 
         $this->themeProviderMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('getMessageCatalogue');
 
         $this->factory->createCatalogue($theme, $locale);
@@ -107,13 +107,13 @@ class ThemeTranslationsFactoryTest extends TestCase
     public function testCreateTranslationsArray($theme, $locale)
     {
         $this->themeProviderMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('setThemeName')
             ->with($theme)
             ->willReturn($this->themeProviderMock);
 
         $this->themeProviderMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('setLocale')
             ->with($locale)
             ->willReturn($this->themeProviderMock);
@@ -205,27 +205,27 @@ class ThemeTranslationsFactoryTest extends TestCase
             ->getMock();
 
         $providerMock
-            ->expects($this->any())
+            ->expects(static::any())
             ->method('getIdentifier')
             ->willReturn($providerIdentifier);
 
         $providerMock
-            ->expects($this->any())
+            ->expects(static::any())
             ->method('getLocale')
             ->willReturn($locale);
 
         $providerMock
-            ->expects($this->any())
+            ->expects(static::any())
             ->method('getXliffCatalogue')
             ->willReturn($this->getXliffCatalogue());
 
         $providerMock
-            ->expects($this->any())
+            ->expects(static::any())
             ->method('getDatabaseCatalogue')
             ->willReturn($this->getDatabaseCatalogue());
 
         $providerMock
-            ->expects($this->any())
+            ->expects(static::any())
             ->method('getMessageCatalogue')
             ->willReturn($this->getMessageCatalogue());
 
@@ -234,16 +234,16 @@ class ThemeTranslationsFactoryTest extends TestCase
 
     protected function assertPropertiesTranslations($locale)
     {
-        $this->assertInternalType('array', $this->translations);
+        static::assertInternalType('array', $this->translations);
 
         $domain = 'messages.' . $locale;
-        $this->assertArrayHasKey($domain, $this->translations);
+        static::assertArrayHasKey($domain, $this->translations);
 
         $domain = 'ShopFront.' . $locale;
-        $this->assertArrayHasKey($domain, $this->translations);
+        static::assertArrayHasKey($domain, $this->translations);
 
         $domain = 'DefaultDomain.' . $locale;
-        $this->assertArrayHasKey($domain, $this->translations);
+        static::assertArrayHasKey($domain, $this->translations);
     }
 
     /**
@@ -251,7 +251,7 @@ class ThemeTranslationsFactoryTest extends TestCase
      */
     protected function assertTranslationsContainThemeMessages($locale)
     {
-        $this->assertSame(
+        static::assertSame(
             array(
                 'xlf' => null,
                 'db' => null,
@@ -260,7 +260,7 @@ class ThemeTranslationsFactoryTest extends TestCase
             'It should provide with default translations.'
         );
 
-        $this->assertSame(
+        static::assertSame(
             array(
                 'xlf' => null,
                 'db' => null,
@@ -275,7 +275,7 @@ class ThemeTranslationsFactoryTest extends TestCase
      */
     protected function assertTranslationsContainCatalogueMessages($locale)
     {
-        $this->assertSame(
+        static::assertSame(
             array(
                 'xlf' => 'Add to Cart override xliff',
                 'db' => null,
@@ -284,7 +284,7 @@ class ThemeTranslationsFactoryTest extends TestCase
             'It should provide with translations from XLIFF catalogue overriding the defaults.'
         );
 
-        $this->assertSame(
+        static::assertSame(
             array(
                 'xlf' => 'Bar override xlif',
                 'db' => null,
@@ -299,7 +299,7 @@ class ThemeTranslationsFactoryTest extends TestCase
      */
     protected function assertTranslationsContainDefaultAndDatabaseMessages($locale)
     {
-        $this->assertSame(
+        static::assertSame(
             array(
                 'xlf' => 'Default MESSAGE override xliff',
                 'db' => 'Default override database',
@@ -308,7 +308,7 @@ class ThemeTranslationsFactoryTest extends TestCase
             'It should provide with translations from XLIFF catalogue overriding the defaults and database overrides.'
         );
 
-        $this->assertSame(
+        static::assertSame(
             array(
                 'xlf' => 'Baz override xliff',
                 'db' => 'Baz is updated from database!',

--- a/tests-legacy/PrestaShopBundle/Translation/Factory/TranslationsFactoryTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Factory/TranslationsFactoryTest.php
@@ -48,7 +48,7 @@ class TranslationsFactoryTest extends TestCase
             ->willReturn('mock');
 
         $this->providerMock->method('setLocale')
-            ->will($this->returnSelf());
+            ->will(static::returnSelf());
 
         $this->providerMock->method('getMessageCatalogue')
             ->willReturn(new MessageCatalogue('en-US'));
@@ -76,7 +76,7 @@ class TranslationsFactoryTest extends TestCase
         $expected = $this->factory
             ->createCatalogue($this->providerMock->getIdentifier());
 
-        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expected);
+        static::assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expected);
     }
 
     public function testCreateTranslationsArrayWithoutProviderFails()

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/BackOfficeProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/BackOfficeProviderTest.php
@@ -51,21 +51,21 @@ class BackOfficeProviderTest extends TestCase
     {
         // The xliff file contains 38 keys
         $expectedReturn = $this->provider->getMessageCatalogue();
-        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
+        static::assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
 
         // Check integrity of translations
-        $this->assertArrayHasKey('AdminActions.en-US', $expectedReturn->all());
-        $this->assertArrayHasKey('ModulesWirePaymentAdmin.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('AdminActions.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('ModulesWirePaymentAdmin.en-US', $expectedReturn->all());
 
         $adminTranslations = $expectedReturn->all('AdminActions.en-US');
-        $this->assertCount(38, $adminTranslations);
-        $this->assertArrayHasKey('Download file', $adminTranslations);
-        $this->assertSame('Download file', $adminTranslations['Download file']);
+        static::assertCount(38, $adminTranslations);
+        static::assertArrayHasKey('Download file', $adminTranslations);
+        static::assertSame('Download file', $adminTranslations['Download file']);
 
         $moduleTranslations = $expectedReturn->all('ModulesWirePaymentAdmin.en-US');
-        $this->assertCount(20, $moduleTranslations);
-        $this->assertArrayHasKey('No currency has been set for this module.', $moduleTranslations);
-        $this->assertSame(
+        static::assertCount(20, $moduleTranslations);
+        static::assertArrayHasKey('No currency has been set for this module.', $moduleTranslations);
+        static::assertSame(
             'No currency has been set for this module.',
             $moduleTranslations['No currency has been set for this module.']
         );

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/FrontOfficeProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/FrontOfficeProviderTest.php
@@ -51,23 +51,23 @@ class FrontOfficeProviderTest extends TestCase
     {
         // The xliff file contains 6 keys
         $expectedReturn = $this->provider->getMessageCatalogue();
-        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
+        static::assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
 
         // Check integrity of translations
-        $this->assertArrayHasKey('ShopNotificationsWarning.en-US', $expectedReturn->all());
-        $this->assertArrayHasKey('ModulesShoppingCartShop.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('ShopNotificationsWarning.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('ModulesShoppingCartShop.en-US', $expectedReturn->all());
 
-        $this->assertCount(4, $expectedReturn->all());
+        static::assertCount(4, $expectedReturn->all());
 
         $frontTranslations = $expectedReturn->all('ShopNotificationsWarning.en-US');
-        $this->assertCount(6, $frontTranslations);
-        $this->assertArrayHasKey('You do not have any vouchers.', $frontTranslations);
-        $this->assertSame('You do not have any vouchers.', $frontTranslations['You do not have any vouchers.']);
+        static::assertCount(6, $frontTranslations);
+        static::assertArrayHasKey('You do not have any vouchers.', $frontTranslations);
+        static::assertSame('You do not have any vouchers.', $frontTranslations['You do not have any vouchers.']);
 
         $moduleTranslations = $expectedReturn->all('ModulesShoppingCartShop.en-US');
-        $this->assertCount(1, $moduleTranslations);
-        $this->assertArrayHasKey('Customers who bought this product also bought:', $moduleTranslations);
-        $this->assertSame(
+        static::assertCount(1, $moduleTranslations);
+        static::assertArrayHasKey('Customers who bought this product also bought:', $moduleTranslations);
+        static::assertSame(
             'Customers who bought this product also bought:',
             $moduleTranslations['Customers who bought this product also bought:']
         );

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/ModuleProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/ModuleProviderTest.php
@@ -56,20 +56,20 @@ class ModuleProviderTest extends TestCase
     public function testGetMessageCatalogue()
     {
         $expectedReturn = $this->provider->getMessageCatalogue();
-        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
+        static::assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
 
         // Check integrity of translations
-        $this->assertArrayHasKey('ModulesWirePaymentAdmin.en-US', $expectedReturn->all());
-        $this->assertArrayHasKey('ModulesWirePaymentShop.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('ModulesWirePaymentAdmin.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('ModulesWirePaymentShop.en-US', $expectedReturn->all());
 
         $moduleAdminTranslations = $expectedReturn->all('ModulesWirePaymentAdmin.en-US');
-        $this->assertCount(20, $moduleAdminTranslations);
-        $this->assertArrayHasKey('Wire payment', $moduleAdminTranslations);
-        $this->assertSame('Wire payment', $moduleAdminTranslations['Wire payment']);
+        static::assertCount(20, $moduleAdminTranslations);
+        static::assertArrayHasKey('Wire payment', $moduleAdminTranslations);
+        static::assertSame('Wire payment', $moduleAdminTranslations['Wire payment']);
 
         $moduleFrontTranslations = $expectedReturn->all('ModulesWirePaymentShop.en-US');
-        $this->assertCount(4, $moduleFrontTranslations);
-        $this->assertArrayHasKey('Pay by bank wire', $moduleFrontTranslations);
-        $this->assertSame('Pay by bank wire', $moduleFrontTranslations['Pay by bank wire']);
+        static::assertCount(4, $moduleFrontTranslations);
+        static::assertArrayHasKey('Pay by bank wire', $moduleFrontTranslations);
+        static::assertSame('Pay by bank wire', $moduleFrontTranslations['Pay by bank wire']);
     }
 }

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/ModulesProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/ModulesProviderTest.php
@@ -50,20 +50,20 @@ class ModulesProviderTest extends TestCase
     public function testGetMessageCatalogue()
     {
         $expectedReturn = $this->provider->getMessageCatalogue();
-        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
+        static::assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
 
         // Check integrity of translations
-        $this->assertArrayHasKey('ModulesWirePaymentAdmin.en-US', $expectedReturn->all());
-        $this->assertArrayHasKey('ModulesWirePaymentShop.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('ModulesWirePaymentAdmin.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('ModulesWirePaymentShop.en-US', $expectedReturn->all());
 
         $moduleAdminTranslations = $expectedReturn->all('ModulesCheckPaymentAdmin.en-US');
-        $this->assertCount(9, $moduleAdminTranslations);
-        $this->assertArrayHasKey('Payments by check', $moduleAdminTranslations);
-        $this->assertSame('Payments by check', $moduleAdminTranslations['Payments by check']);
+        static::assertCount(9, $moduleAdminTranslations);
+        static::assertArrayHasKey('Payments by check', $moduleAdminTranslations);
+        static::assertSame('Payments by check', $moduleAdminTranslations['Payments by check']);
 
         $moduleFrontTranslations = $expectedReturn->all('ModulesCheckPaymentShop.en-US');
-        $this->assertCount(15, $moduleFrontTranslations);
-        $this->assertArrayHasKey('Pay by check', $moduleFrontTranslations);
-        $this->assertSame('Pay by check', $moduleFrontTranslations['Pay by check']);
+        static::assertCount(15, $moduleFrontTranslations);
+        static::assertArrayHasKey('Pay by check', $moduleFrontTranslations);
+        static::assertSame('Pay by check', $moduleFrontTranslations['Pay by check']);
     }
 }

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/SearchProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/SearchProviderTest.php
@@ -53,14 +53,14 @@ class SearchProviderTest extends TestCase
     {
         // The xliff file contains 38 keys
         $expectedReturn = $this->provider->getMessageCatalogue();
-        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
+        static::assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
 
         // Check integrity of translations
-        $this->assertArrayHasKey('AdminActions.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('AdminActions.en-US', $expectedReturn->all());
 
         $adminTranslations = $expectedReturn->all('AdminActions.en-US');
-        $this->assertCount(38, $adminTranslations);
-        $this->assertArrayHasKey('Download file', $adminTranslations);
-        $this->assertSame('Download file', $adminTranslations['Download file']);
+        static::assertCount(38, $adminTranslations);
+        static::assertArrayHasKey('Download file', $adminTranslations);
+        static::assertSame('Download file', $adminTranslations['Download file']);
     }
 }

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/ThemeProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/ThemeProviderTest.php
@@ -52,15 +52,15 @@ class ThemeProviderTest extends TestCase
     {
         // The xliff file contains 29 keys
         $expectedReturn = $this->provider->getMessageCatalogue();
-        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
+        static::assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $expectedReturn);
 
         // Check integrity of translations
-        $this->assertArrayHasKey('ShopTheme.en-US', $expectedReturn->all());
-        $this->assertArrayHasKey('ShopThemeCustomerAccount.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('ShopTheme.en-US', $expectedReturn->all());
+        static::assertArrayHasKey('ShopThemeCustomerAccount.en-US', $expectedReturn->all());
         $translations = $expectedReturn->all('ShopTheme.en-US');
 
-        $this->assertCount(29, $translations);
-        $this->assertArrayHasKey('Contact us', $translations);
-        $this->assertSame('Contact us', $translations['Contact us']);
+        static::assertCount(29, $translations);
+        static::assertArrayHasKey('Contact us', $translations);
+        static::assertSame('Contact us', $translations['Contact us']);
     }
 }

--- a/tests-legacy/PrestaShopBundle/Twig/Locator/ModuleTemplateLoaderTest.php
+++ b/tests-legacy/PrestaShopBundle/Twig/Locator/ModuleTemplateLoaderTest.php
@@ -68,13 +68,13 @@ class ModuleTemplateLoaderTest extends TestCase
 
     public function testGetPaths()
     {
-        self::assertCount(
+        static::assertCount(
             2,
             $this->loader->getPaths('Product'),
             'Two templates for the namespace "Product" should be found.'
         );
 
-        self::assertCount(
+        static::assertCount(
             3,
             $this->loader->getPaths('PrestaShop'),
             'One templates should be found.'
@@ -89,7 +89,7 @@ class ModuleTemplateLoaderTest extends TestCase
      */
     public function testGetSourceContext($sourceContent, $twigPathAsked, $successMessage)
     {
-        self::assertEquals(
+        static::assertEquals(
             $sourceContent . PHP_EOL,
             $this->loader->getSourceContext($twigPathAsked)->getCode(),
             $successMessage
@@ -113,7 +113,7 @@ class ModuleTemplateLoaderTest extends TestCase
     {
         $loader = new ModuleTemplateLoader([]);
 
-        self::assertEquals(array(), $loader->getPaths());
+        static::assertEquals(array(), $loader->getPaths());
     }
 
     /**
@@ -123,10 +123,10 @@ class ModuleTemplateLoaderTest extends TestCase
     {
         $loader = new ModuleTemplateLoader([]);
 
-        self::assertEquals([], $loader->getNamespaces());
+        static::assertEquals([], $loader->getNamespaces());
 
         $loader->addPath(sys_get_temp_dir(), 'named');
 
-        self::assertEquals(['named'], $loader->getNamespaces());
+        static::assertEquals(['named'], $loader->getNamespaces());
     }
 }

--- a/tests-legacy/Unit/Adapter/AdapterServiceLocatorTest.php
+++ b/tests-legacy/Unit/Adapter/AdapterServiceLocatorTest.php
@@ -38,7 +38,7 @@ class AdapterServiceLocatorTest extends TestCase
             new Container()
         );
 
-        $this->assertInstanceOf(
+        static::assertInstanceOf(
             '\\PrestaShop\\PrestaShop\\Core\\Foundation\\IoC\\Container',
             ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Foundation\\IoC\\Container')
         );

--- a/tests-legacy/Unit/Adapter/Admin/UrlGeneratorTest.php
+++ b/tests-legacy/Unit/Adapter/Admin/UrlGeneratorTest.php
@@ -53,7 +53,7 @@ class UrlGeneratorTest extends UnitTestCase
 
         // the following route contains a "_legacy" equivalent
         list($controller, $parameters) = $generator->getLegacyOptions('admin_product_catalog');
-        $this->assertEquals('AdminProducts', $controller);
-        $this->assertCount(0, $parameters);
+        static::assertEquals('AdminProducts', $controller);
+        static::assertCount(0, $parameters);
     }
 }

--- a/tests-legacy/Unit/Adapter/Cart/CartPresenterTest.php
+++ b/tests-legacy/Unit/Adapter/Cart/CartPresenterTest.php
@@ -65,7 +65,7 @@ class CartPresenterTest extends UnitTestCase
      */
     public function testProductAttributesAreProperlyConverted($asString, $asArray)
     {
-        $this->assertSame(
+        static::assertSame(
             $asArray,
             $this->invokeMethod(
                 $this->cartPresenter,

--- a/tests-legacy/Unit/Adapter/Module/AdminModuleDataProviderTest.php
+++ b/tests-legacy/Unit/Adapter/Module/AdminModuleDataProviderTest.php
@@ -127,7 +127,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
     {
         $modules = $this->adminModuleDataProvider->getCatalogModules();
 
-        $this->assertGreaterThan(0, count($modules), sprintf('%s expected a list of modules, received none.', self::NOTICE));
+        static::assertGreaterThan(0, count($modules), sprintf('%s expected a list of modules, received none.', self::NOTICE));
     }
 
     public function testSearchCanResultNoResultsOk()
@@ -135,7 +135,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
         $filters = array('search' => 'doge');
         $modules = $this->adminModuleDataProvider->getCatalogModules($filters);
 
-        $this->assertCount(0, $modules, sprintf('%s expected 0 modules, received %s.', self::NOTICE, count($modules)));
+        static::assertCount(0, $modules, sprintf('%s expected 0 modules, received %s.', self::NOTICE, count($modules)));
     }
 
     public function testSearchWithUnknownFilterCriteriaReturnAllOk()
@@ -145,7 +145,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
 
         $modules = $this->adminModuleDataProvider->getCatalogModules();
 
-        $this->assertSame($modulesWithFilter, $modules, sprintf('%s expected undefined filter have no effect on search.', self::NOTICE));
+        static::assertSame($modulesWithFilter, $modules, sprintf('%s expected undefined filter have no effect on search.', self::NOTICE));
     }
 
     public function testSearchForASpecificModuleOk()
@@ -153,7 +153,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
         $filters = array('search' => 'advancedpack');
         $modules = $this->adminModuleDataProvider->getCatalogModules($filters);
 
-        $this->assertCount(1, $modules);
+        static::assertCount(1, $modules);
     }
 
     public function testSearchForASpecificModuleHaveMultipleResultsOk()
@@ -161,7 +161,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
         $filters = array('search' => 'payment advanced');
         $modules = $this->adminModuleDataProvider->getCatalogModules($filters);
 
-        $this->assertCount(3, $modules);
+        static::assertCount(3, $modules);
     }
 
     public function testCallToAddonsShouldReturnSameResultOk()
@@ -183,7 +183,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
         $modules = $mock->getCatalogModules();
         $modules2 = $mock->getCatalogModules();
 
-        $this->assertEquals($modules2, $modules);
+        static::assertEquals($modules2, $modules);
     }
 
     public function teardown()

--- a/tests-legacy/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
+++ b/tests-legacy/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
@@ -79,7 +79,7 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
     public function testSuccessfulConfiguration()
     {
         $name = 'bankwire';
-        $this->assertTrue($this->getModuleSelfConfigurator()->module($name)->configure());
+        static::assertTrue($this->getModuleSelfConfigurator()->module($name)->configure());
     }
 
     public function testFileExists()
@@ -88,11 +88,11 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
 
         $name = 'ganalytics';
         // Default file - Non existing
-        $this->assertNotEmpty($moduleSelfConfigurator->module($name)->validate());
+        static::assertNotEmpty($moduleSelfConfigurator->module($name)->validate());
 
         // Specific file - Non existing
         $filepath = '/path/to/the/file.yml';
-        $this->assertNotEmpty($moduleSelfConfigurator->module($name)->file($filepath)->validate());
+        static::assertNotEmpty($moduleSelfConfigurator->module($name)->file($filepath)->validate());
     }
 
     public function testModuleInstallationRequirementPass()
@@ -101,29 +101,29 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
         $name = 'ganalytics';
         $filepath = $this->defaultDir.'/moduleConfExample.yml';
         $result = $this->getModuleSelfConfigurator()->module($name)->file($filepath)->validate();
-        $this->assertEmpty($result, 'Failed to pass the module for the following reasons: '.var_export($result, true));
+        static::assertEmpty($result, 'Failed to pass the module for the following reasons: '.var_export($result, true));
     }
 
     public function testModuleInstallationRequirementFail()
     {
         // Module installed
         $name = 'ganalytics';
-        $this->assertNotEmpty($this->getModuleSelfConfigurator()->module($name)->validate());
+        static::assertNotEmpty($this->getModuleSelfConfigurator()->module($name)->validate());
     }
 
     public function testFileToUse()
     {
-        $this->assertNull($this->getModuleSelfConfigurator()->getFile());
+        static::assertNull($this->getModuleSelfConfigurator()->getFile());
 
         $filepath = '/path/to/the/file.yml';
-        $this->assertEquals($filepath, $this->getModuleSelfConfigurator()->file($filepath)->getFile());
+        static::assertEquals($filepath, $this->getModuleSelfConfigurator()->file($filepath)->getFile());
     }
 
     public function testAllValid()
     {
         $filepath = $this->defaultDir.'/moduleConfExample.yml';
         $name = 'bankwire';
-        $this->assertEmpty($this->getModuleSelfConfigurator()->module($name)->file($filepath)->validate());
+        static::assertEmpty($this->getModuleSelfConfigurator()->module($name)->file($filepath)->validate());
     }
 
     public function testConfigurationUpdate()
@@ -131,9 +131,9 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
         $filepath = $this->defaultDir.'/moduleConfExampleConfStep.yml';
         $name = 'bankwire';
         // Test before
-        $this->assertNull($this->configuration->get('PAYPAL_SANDBOX'));
-        $this->assertTrue($this->getModuleSelfConfigurator()->module($name)->file($filepath)->configure());
-        $this->assertEquals(1, $this->configuration->get('PAYPAL_SANDBOX'));
+        static::assertNull($this->configuration->get('PAYPAL_SANDBOX'));
+        static::assertTrue($this->getModuleSelfConfigurator()->module($name)->file($filepath)->configure());
+        static::assertEquals(1, $this->configuration->get('PAYPAL_SANDBOX'));
     }
 
     public function testConfigurationDelete()
@@ -142,9 +142,9 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
         $name = 'bankwire';
         // Test before
         $this->configuration->set('PAYPAL_ONBOARDING', 1);
-        $this->assertEquals(1, $this->configuration->get('PAYPAL_ONBOARDING'));
-        $this->assertTrue($this->getModuleSelfConfigurator()->module($name)->file($filepath)->configure());
-        $this->assertNull($this->configuration->get('PAYPAL_ONBOARDING'));
+        static::assertEquals(1, $this->configuration->get('PAYPAL_ONBOARDING'));
+        static::assertTrue($this->getModuleSelfConfigurator()->module($name)->file($filepath)->configure());
+        static::assertNull($this->configuration->get('PAYPAL_ONBOARDING'));
     }
 
     public function testFilesExceptionMissingSource()
@@ -177,16 +177,16 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
         $mockFilesystem = $this->getMockBuilder('\Symfony\Component\Filesystem\Filesystem')
             ->getMock();
 
-        $mockFilesystem->expects($this->exactly(2))
+        $mockFilesystem->expects(static::exactly(2))
             ->method('copy')
             ->withConsecutive(
                 [
-                    $this->equalTo($basePath.'/modules/ganalytics/ganalytics.php'),
-                    $this->equalTo($basePath.'/modules/ganalytics/ganalytics_copy.php'),
+                    static::equalTo($basePath.'/modules/ganalytics/ganalytics.php'),
+                    static::equalTo($basePath.'/modules/ganalytics/ganalytics_copy.php'),
                 ],
                 [
-                    $this->equalTo('http://localhost/img/logo.png'),
-                    $this->equalTo($basePath.'/modules/ganalytics/another-logo.png'),
+                    static::equalTo('http://localhost/img/logo.png'),
+                    static::equalTo($basePath.'/modules/ganalytics/another-logo.png'),
                 ]
             );
 
@@ -212,12 +212,12 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
         $filepath = $this->defaultDir.'/moduleConfExampleSqlStep.yml';
         $name = 'ganalytics';
 
-        $this->assertTrue($this->getModuleSelfConfigurator()->module($name)->file($filepath)->configure());
+        static::assertTrue($this->getModuleSelfConfigurator()->module($name)->file($filepath)->configure());
         // Check files are equals
-        $this->assertTrue(in_array('TRUNCATE TABLE `ps_doge_army`', $this->connection->executedSql));
-        $this->assertTrue(in_array('UPDATE `ps_doge` SET `wow` = 1', $this->connection->executedSql));
-        $this->assertFalse(in_array('UPDATE `ps_doge` SET `wow` = 1;', $this->connection->executedSql));
-        $this->assertTrue(in_array('TRUNCATE TABLE `ps_lolcat_army`', $this->connection->executedSql));
+        static::assertTrue(in_array('TRUNCATE TABLE `ps_doge_army`', $this->connection->executedSql));
+        static::assertTrue(in_array('UPDATE `ps_doge` SET `wow` = 1', $this->connection->executedSql));
+        static::assertFalse(in_array('UPDATE `ps_doge` SET `wow` = 1;', $this->connection->executedSql));
+        static::assertTrue(in_array('TRUNCATE TABLE `ps_lolcat_army`', $this->connection->executedSql));
     }
 
     public function testSqlExceptionMissingFile()
@@ -241,7 +241,7 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
         $mock = $this->getMockBuilder('\MyComplexModuleConfiguration')
                      ->setMethods(array('run'))
                      ->getMock();
-        $mock->expects($this->exactly(2))
+        $mock->expects(static::exactly(2))
              ->method('run');
 
         // Redefine self configuratrion as mock
@@ -254,12 +254,12 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
             ->getMock();
 
         $moduleSelfConfigurator
-            ->expects($this->exactly(2))
+            ->expects(static::exactly(2))
             ->method('loadPhpFile')
             ->with($php_filepath)
-            ->will($this->returnValue($mock));
+            ->will(static::returnValue($mock));
 
-        $this->assertTrue($moduleSelfConfigurator->module($name)->file($filepath)->configure());
+        static::assertTrue($moduleSelfConfigurator->module($name)->file($filepath)->configure());
     }
 
     // MOCK

--- a/tests-legacy/Unit/Adapter/Module/PrestaTrust/PrestaTrustCheckerTest.php
+++ b/tests-legacy/Unit/Adapter/Module/PrestaTrust/PrestaTrustCheckerTest.php
@@ -104,10 +104,10 @@ class PrestaTrustCheckerTest extends UnitTestCase
 
         $this->apiClientS
             ->method('setShopUrl')
-            ->will($this->returnValue($this->apiClientS));
+            ->will(static::returnValue($this->apiClientS));
         $this->apiClientS
             ->method('getPrestaTrustCheck')
-            ->will($this->returnValue($this->prestatrustApiResults));
+            ->will(static::returnValue($this->prestatrustApiResults));
 
         $this->translatorS = $this->getMockBuilder('Symfony\Component\Translation\Translator')
             ->disableOriginalConstructor()
@@ -115,7 +115,7 @@ class PrestaTrustCheckerTest extends UnitTestCase
 
         $this->translatorS
             ->method('trans')
-            ->will($this->returnArgument(0));
+            ->will(static::returnArgument(0));
 
         $cache = new ArrayCache();
         $cache->save('module-verified-from-addons-api', (object)array('hash' => '366d25acf8172ef93c7086c3ee78f9a2f3e7870356df498d34bda30fb294ae3b'));
@@ -144,7 +144,7 @@ class PrestaTrustCheckerTest extends UnitTestCase
         $testedModule = clone $this->modules['module-under-dev'];
         $this->prestatrustChecker->loadDetailsIntoModule($testedModule);
 
-        $this->assertFalse($testedModule->attributes->has('prestatrust'));
+        static::assertFalse($testedModule->attributes->has('prestatrust'));
     }
 
     /**
@@ -162,8 +162,8 @@ class PrestaTrustCheckerTest extends UnitTestCase
         $testedModule = $this->modules['module-verified-from-addons-api'];
         $presentedModule = $this->modulePresenter->present($testedModule);
 
-        $this->assertArrayHasKey('picos', $presentedModule['attributes']);
-        $this->assertNotEmpty($presentedModule['attributes']['picos']);
+        static::assertArrayHasKey('picos', $presentedModule['attributes']);
+        static::assertNotEmpty($presentedModule['attributes']['picos']);
     }
 
     /**
@@ -178,8 +178,8 @@ class PrestaTrustCheckerTest extends UnitTestCase
         $testedModule = $this->modules['module-under-dev'];
         $presentedModule = $this->modulePresenter->present($testedModule);
 
-        $this->assertArrayHasKey('picos', $presentedModule['attributes']);
-        $this->assertEmpty($presentedModule['attributes']['picos']);
+        static::assertArrayHasKey('picos', $presentedModule['attributes']);
+        static::assertEmpty($presentedModule['attributes']['picos']);
     }
 
     /**
@@ -197,7 +197,7 @@ class PrestaTrustCheckerTest extends UnitTestCase
 
         $presentedModule = $this->modulePresenter->present($testedModule);
 
-        $this->assertEquals(
+        static::assertEquals(
             (object)array(
                 'hash' => '366d25acf8172ef93c7086c3ee78f9a2f3e7870356df498d34bda30fb294ae3b',
                 'check_list' => array(

--- a/tests-legacy/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
+++ b/tests-legacy/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
@@ -143,7 +143,7 @@ class ModuleTabRegisterTest extends UnitTestCase
             ->getMock();
         $this->tabRegister
             ->method('getModuleAdminControllersFilename')
-            ->will($this->returnValueMap($this->moduleAdminControllers));
+            ->will(static::returnValueMap($this->moduleAdminControllers));
     }
 
     public function testWorkingTabsAreOk()
@@ -155,7 +155,7 @@ class ModuleTabRegisterTest extends UnitTestCase
                     continue;
                 }
                 $data = new ParameterBag($tab);
-                $this->assertTrue($this->invokeMethod($this->tabRegister, 'checkIsValid', array($moduleName, $data)));
+                static::assertTrue($this->invokeMethod($this->tabRegister, 'checkIsValid', array($moduleName, $data)));
             }
         }
     }
@@ -173,11 +173,11 @@ class ModuleTabRegisterTest extends UnitTestCase
                 try {
                     $this->invokeMethod($this->tabRegister, 'checkIsValid', array($moduleName, $data));
                 } catch (\Exception $e) {
-                    $this->assertEquals($e->getMessage(), $tab['exception']);
+                    static::assertEquals($e->getMessage(), $tab['exception']);
 
                     continue;
                 }
-                $this->fail('Expected Exception "'.$tab['exception'].'" has not been raised.');
+                static::fail('Expected Exception "'.$tab['exception'].'" has not been raised.');
             }
         }
     }
@@ -190,7 +190,7 @@ class ModuleTabRegisterTest extends UnitTestCase
             // We test there is no unexpected tab to register
             // Be aware, it also include which can throw an exception later when being validated
             foreach($tabs as $tab) {
-                $this->assertTrue(
+                static::assertTrue(
                         in_array($tab['class_name'], $this->expectedTabsToAdd[$moduleName]),
                         'Module '.$moduleName.' should not register '.$tab['class_name']
                 );
@@ -203,7 +203,7 @@ class ModuleTabRegisterTest extends UnitTestCase
                         continue 2;
                     }
                 }
-                $this->fail('ModuleAdminController '.$moduleAdminController.' is expected but not found in the list to register!');
+                static::fail('ModuleAdminController '.$moduleAdminController.' is expected but not found in the list to register!');
             }
         }
     }
@@ -212,7 +212,7 @@ class ModuleTabRegisterTest extends UnitTestCase
     {
         $names = 'doge';
         $expectedResult = array(1 => $names, 2 => $names, 3 => $names);
-        $this->assertEquals($expectedResult, $this->invokeMethod($this->tabRegister, 'getTabNames', array($names)));
+        static::assertEquals($expectedResult, $this->invokeMethod($this->tabRegister, 'getTabNames', array($names)));
     }
 
     public function testTabNames()
@@ -223,6 +223,6 @@ class ModuleTabRegisterTest extends UnitTestCase
             'de' => 'eine Name',
         );
         $expectedResult = array(1 => $names['fr'], 2 => $names['en'], 3 => $names['en']);
-        $this->assertEquals($expectedResult, $this->invokeMethod($this->tabRegister, 'getTabNames', array($names)));
+        static::assertEquals($expectedResult, $this->invokeMethod($this->tabRegister, 'getTabNames', array($names)));
     }
 }

--- a/tests-legacy/Unit/Adapter/ToolsTest.php
+++ b/tests-legacy/Unit/Adapter/ToolsTest.php
@@ -46,7 +46,7 @@ class ToolsTest extends TestCase
     public function testBcAdd($leftOperand, $rightOperand, $scale, $expectedResult)
     {
         $result = (new Tools())->bcadd($leftOperand, $rightOperand, $scale);
-        $this->assertSame($expectedResult, $result);
+        static::assertSame($expectedResult, $result);
     }
 
     public function provideTestCasesForBcAdd()

--- a/tests-legacy/Unit/Classes/AmountTest.php
+++ b/tests-legacy/Unit/Classes/AmountTest.php
@@ -35,8 +35,8 @@ class AmountTest extends TestCase
     {
         $amount = new AmountImmutable(2.3, 3.5);
 
-        $this->assertEquals(2.3, $amount->getTaxIncluded());
-        $this->assertEquals(3.5, $amount->getTaxExcluded());
+        static::assertEquals(2.3, $amount->getTaxIncluded());
+        static::assertEquals(3.5, $amount->getTaxExcluded());
     }
 
     public function testAdd()
@@ -45,14 +45,14 @@ class AmountTest extends TestCase
         $amount1 = new AmountImmutable(4.6, 7.2);
         $amount2 = $amount->add($amount1);
 
-        $this->assertEquals(2.3, $amount->getTaxIncluded());
-        $this->assertEquals(3.5, $amount->getTaxExcluded());
+        static::assertEquals(2.3, $amount->getTaxIncluded());
+        static::assertEquals(3.5, $amount->getTaxExcluded());
 
-        $this->assertEquals(4.6, $amount1->getTaxIncluded());
-        $this->assertEquals(7.2, $amount1->getTaxExcluded());
+        static::assertEquals(4.6, $amount1->getTaxIncluded());
+        static::assertEquals(7.2, $amount1->getTaxExcluded());
 
-        $this->assertEquals(6.9, $amount2->getTaxIncluded());
-        $this->assertEquals(10.7, $amount2->getTaxExcluded());
+        static::assertEquals(6.9, $amount2->getTaxIncluded());
+        static::assertEquals(10.7, $amount2->getTaxExcluded());
     }
 
     public function testSub()
@@ -61,13 +61,13 @@ class AmountTest extends TestCase
         $amount1 = new AmountImmutable(4.8, 7.2);
         $amount2 = $amount1->sub($amount);
 
-        $this->assertEquals(2.3, $amount->getTaxIncluded());
-        $this->assertEquals(3.5, $amount->getTaxExcluded());
+        static::assertEquals(2.3, $amount->getTaxIncluded());
+        static::assertEquals(3.5, $amount->getTaxExcluded());
 
-        $this->assertEquals(4.8, $amount1->getTaxIncluded());
-        $this->assertEquals(7.2, $amount1->getTaxExcluded());
+        static::assertEquals(4.8, $amount1->getTaxIncluded());
+        static::assertEquals(7.2, $amount1->getTaxExcluded());
 
-        $this->assertEquals(2.5, $amount2->getTaxIncluded());
-        $this->assertEquals(3.7, $amount2->getTaxExcluded());
+        static::assertEquals(2.5, $amount2->getTaxIncluded());
+        static::assertEquals(3.7, $amount2->getTaxExcluded());
     }
 }

--- a/tests-legacy/Unit/Classes/AssetsCoreTest.php
+++ b/tests-legacy/Unit/Classes/AssetsCoreTest.php
@@ -99,10 +99,10 @@ class AssetsCoreTest extends TestCase
             }
         }
 
-        $this->assertSame($toBeFound, $found);
+        static::assertSame($toBeFound, $found);
 
         if ($toBeFound) {
-            $this->assertSame($expectedAsset['path'], $this->testsPath.$expectedPath);
+            static::assertSame($expectedAsset['path'], $this->testsPath.$expectedPath);
         }
 
     }

--- a/tests-legacy/Unit/Classes/Checkout/CheckoutAddressesStepTest.php
+++ b/tests-legacy/Unit/Classes/Checkout/CheckoutAddressesStepTest.php
@@ -79,7 +79,7 @@ class CheckoutAddressesStepTest extends UnitTestCase
 
     private function assertTemplateParametersInclude(array $what, array $requestParams = [])
     {
-        $this->assertArraySubset(
+        static::assertArraySubset(
             $what,
             $this->step->handleRequest($requestParams)->getTemplateParameters()
         );

--- a/tests-legacy/Unit/Classes/HookTest.php
+++ b/tests-legacy/Unit/Classes/HookTest.php
@@ -34,16 +34,16 @@ class HookTest extends UnitTestCase
 {
     public function testIsDisplayHookNameDisplayHooksStartWithDisplay()
     {
-        $this->assertTrue(Hook::isDisplayHookName('displaySomething'));
+        static::assertTrue(Hook::isDisplayHookName('displaySomething'));
     }
 
     public function testIsDisplayHookNameDisplayHooksCannotStartWithAction()
     {
-        $this->assertFalse(Hook::isDisplayHookName('actionDoWeirdStuff'));
+        static::assertFalse(Hook::isDisplayHookName('actionDoWeirdStuff'));
     }
 
     public function testIsDisplayHookNameHeaderIsNotADisplayHook()
     {
-        $this->assertFalse(Hook::isDisplayHookName('header'));
+        static::assertFalse(Hook::isDisplayHookName('header'));
     }
 }

--- a/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
+++ b/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
@@ -67,7 +67,7 @@ class ModuleCoreTest extends TestCase
 
         // then
         $crawler = new Crawler($htmlOutput);
-        $this->assertContains($error, $crawler->filter('.module_error')->text());
+        static::assertContains($error, $crawler->filter('.module_error')->text());
     }
 
     public function testDisplayErrorShouldReturnMultipleErrors()
@@ -86,6 +86,6 @@ class ModuleCoreTest extends TestCase
 
         // then
         $crawler = new Crawler($htmlOutput);
-        $this->assertCount(3, $crawler->filter('.module_error li'));
+        static::assertCount(3, $crawler->filter('.module_error li'));
     }
 }

--- a/tests-legacy/Unit/Classes/PhpEncryptionLegacyEngineTest.php
+++ b/tests-legacy/Unit/Classes/PhpEncryptionLegacyEngineTest.php
@@ -37,7 +37,7 @@ class PhpEncryptionLegacyEngineTest extends TestCase
     public function setUp()
     {
         if (version_compare(PHP_VERSION, '7.1', '>=')) {
-            $this->markTestSkipped('Legacy encryption with mcrypt is deprecated from PHP 7.1.');
+            static::markTestSkipped('Legacy encryption with mcrypt is deprecated from PHP 7.1.');
         }
 
         $key = \Defuse\Crypto\Key::createNewRandomKey();
@@ -47,6 +47,6 @@ class PhpEncryptionLegacyEngineTest extends TestCase
     public function testEncryptAndDecrypt()
     {
         $encryptedValue = $this->engine->encrypt(self::FOO);
-        $this->assertSame(self::FOO, $this->engine->decrypt($encryptedValue));
+        static::assertSame(self::FOO, $this->engine->decrypt($encryptedValue));
     }
 }

--- a/tests-legacy/Unit/Classes/PhpEncryptionTest.php
+++ b/tests-legacy/Unit/Classes/PhpEncryptionTest.php
@@ -43,6 +43,6 @@ class PhpEncryptionTest extends TestCase
     public function testEncryptAndDecrypt()
     {
         $encryptedValue = $this->engine->encrypt(self::FOO);
-        $this->assertSame(self::FOO, $this->engine->decrypt($encryptedValue));
+        static::assertSame(self::FOO, $this->engine->decrypt($encryptedValue));
     }
 }

--- a/tests-legacy/Unit/Classes/PrestaShopAutoloadTest.php
+++ b/tests-legacy/Unit/Classes/PrestaShopAutoloadTest.php
@@ -44,16 +44,16 @@ class PrestaShopAutoloadTest extends TestCase
 
     public function testGenerateIndex()
     {
-        $this->assertFileExists($this->file_index);
+        static::assertFileExists($this->file_index);
         $data = include $this->file_index;
-        $this->assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
+        static::assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
     }
 
     public function testLoad()
     {
         PrestaShopAutoload::getInstance()->load('RequestSql');
-        $this->assertTrue(class_exists('RequestSqlCore', false));
-        $this->assertTrue(class_exists('RequestSql', false));
+        static::assertTrue(class_exists('RequestSqlCore', false));
+        static::assertTrue(class_exists('RequestSql', false));
     }
 
     /**
@@ -73,21 +73,21 @@ class PrestaShopAutoloadTest extends TestCase
         }'
         );
         PrestaShopAutoload::getInstance()->generateIndex();
-        $this->assertFileExists($this->file_index);
+        static::assertFileExists($this->file_index);
         $data = include $this->file_index;
-        $this->assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
-        $this->assertEquals($data['Connection']['override'], false);
+        static::assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
+        static::assertEquals($data['Connection']['override'], false);
         Configuration::updateGlobalValue('PS_DISABLE_OVERRIDES', 0);
         PrestaShopAutoload::getInstance()->generateIndex();
         $data = include $this->file_index;
-        $this->assertEquals($data['Connection']['override'], true);
+        static::assertEquals($data['Connection']['override'], true);
     }
 
     public function testClassFromCoreDirShouldntBeLoaded()
     {
         PrestaShopAutoload::getInstance()->load('\\PrestaShop\\PrestaShop\\Core\\Payment\\PaymentOption');
 
-        $this->assertFalse(class_exists('\\PrestaShop\\PrestaShop\\Core\\Payment\\PaymentOption', false));
+        static::assertFalse(class_exists('\\PrestaShop\\PrestaShop\\Core\\Payment\\PaymentOption', false));
     }
 
     public static function tearDownAfterClass()

--- a/tests-legacy/Unit/Classes/Smarty/TemplateFinderTest.php
+++ b/tests-legacy/Unit/Classes/Smarty/TemplateFinderTest.php
@@ -49,25 +49,25 @@ class TemplateFinderTest extends TestCase
     public function testTheTemplateFoundForACategoryPageWithId()
     {
         $template = $this->templateFinder->getTemplate('catalog/listing/product-list', 'category', 9, 'fr-FR');
-        $this->assertEquals($template, 'catalog/listing/category-9.tpl');
+        static::assertEquals($template, 'catalog/listing/category-9.tpl');
     }
 
     public function testTheTemplateFoundForACategoryPageWithNoneExistingId()
     {
         $template = $this->templateFinder->getTemplate('catalog/listing/product-list', 'category', 8, 'fr-FR');
-        $this->assertEquals($template, 'catalog/listing/category.tpl');
+        static::assertEquals($template, 'catalog/listing/category.tpl');
     }
 
     public function testTheTemplateFoundForANoneExistingCategory()
     {
         $template = $this->templateFinder->getTemplate('catalog/listing/product-list', 'category-test', 8, 'fr-FR');
-        $this->assertEquals($template, 'catalog/listing/product-list.tpl');
+        static::assertEquals($template, 'catalog/listing/product-list.tpl');
     }
 
     public function testWrongTemplateFallback()
     {
         $template = $this->templateFinder->getTemplate('catalog/listing/srg-list', 'category', false, 'fr-FR');
-        $this->assertEquals($template, 'catalog/listing/category.tpl');
+        static::assertEquals($template, 'catalog/listing/category.tpl');
     }
 
     public function testNoFoundTemplateThrowException()

--- a/tests-legacy/Unit/Classes/Tax/AverageTaxOfProductsTaxCalculatorTest.php
+++ b/tests-legacy/Unit/Classes/Tax/AverageTaxOfProductsTaxCalculatorTest.php
@@ -51,6 +51,6 @@ class AverageTaxOfProductsTaxCalculatorTest extends UnitTestCase
             2 => round(7 * 10  / (20 + 10) * 0.2, 2),
         );
 
-        $this->assertEquals($expected, $amounts);
+        static::assertEquals($expected, $amounts);
     }
 }

--- a/tests-legacy/Unit/Classes/Tax/TaxCalculatorCoreTest.php
+++ b/tests-legacy/Unit/Classes/Tax/TaxCalculatorCoreTest.php
@@ -45,7 +45,7 @@ class TaxCalculatorCoreTest extends TestCase
 
         $totalRate = $tax_calculator->getTotalRate();
 
-        $this->assertEquals(26.1, $totalRate);
+        static::assertEquals(26.1, $totalRate);
     }
 
     public function testGetTotalRateBug()
@@ -61,6 +61,6 @@ class TaxCalculatorCoreTest extends TestCase
 
         $totalRate = $tax_calculator->getTotalRate();
 
-        $this->assertEquals(27.233, $totalRate);
+        static::assertEquals(27.233, $totalRate);
     }
 }

--- a/tests-legacy/Unit/Classes/Tax/TaxRulesTaxManagerCoreTest.php
+++ b/tests-legacy/Unit/Classes/Tax/TaxRulesTaxManagerCoreTest.php
@@ -70,13 +70,13 @@ class TaxRulesTaxManagerCoreTest extends UnitTestCase
         $tax_calculator = $tax_rules_tax_manager->getTaxCalculator();
 
         // Then
-        $this->assertEquals(TaxCalculator::COMBINE_METHOD, $tax_calculator->computation_method);
-        $this->assertInternalType('array', $tax_calculator->taxes);
+        static::assertEquals(TaxCalculator::COMBINE_METHOD, $tax_calculator->computation_method);
+        static::assertInternalType('array', $tax_calculator->taxes);
 
         foreach ($tax_calculator->taxes as $key => $tax) {
-            $this->assertTrue($tax instanceof Tax);
-            $this->assertEquals($this->tax_rows[$key]['id_tax'], $tax->id);
-            $this->assertEquals($this->tax_rows[$key]['rate'], $tax->rate);
+            static::assertTrue($tax instanceof Tax);
+            static::assertEquals($this->tax_rows[$key]['id_tax'], $tax->id);
+            static::assertEquals($this->tax_rows[$key]['rate'], $tax->rate);
         }
     }
 }

--- a/tests-legacy/Unit/Classes/ToolsCoreTest.php
+++ b/tests-legacy/Unit/Classes/ToolsCoreTest.php
@@ -48,25 +48,25 @@ class ToolsCoreTest extends TestCase
     public function testGetValueBaseCase()
     {
         $this->setPostAndGet(array('hello' => 'world'));
-        $this->assertEquals('world', Tools::getValue('hello'));
+        static::assertEquals('world', Tools::getValue('hello'));
     }
 
     public function testGetValueDefaultValueIsFalse()
     {
         $this->setPostAndGet();
-        $this->assertFalse(Tools::getValue('hello'));
+        static::assertFalse(Tools::getValue('hello'));
     }
 
     public function testGetValueUsesDefaultValue()
     {
         $this->setPostAndGet();
-        $this->assertEquals('I AM DEFAULT', Tools::getValue('hello', 'I AM DEFAULT'));
+        static::assertEquals('I AM DEFAULT', Tools::getValue('hello', 'I AM DEFAULT'));
     }
 
     public function testGetValuePrefersPost()
     {
         $this->setPostAndGet(array('hello' => 'world'), array('hello' => 'cruel world'));
-        $this->assertEquals('world', Tools::getValue('hello'));
+        static::assertEquals('world', Tools::getValue('hello'));
     }
 
     public function testGetValueAcceptsOnlyTruthyStringsAsKeys()
@@ -77,9 +77,9 @@ class ToolsCoreTest extends TestCase
             null => true,
         ));
 
-        $this->assertFalse(Tools::getValue('', true));
-        $this->assertTrue(Tools::getValue(' '));
-        $this->assertFalse(Tools::getValue(null, true));
+        static::assertFalse(Tools::getValue('', true));
+        static::assertTrue(Tools::getValue(' '));
+        static::assertFalse(Tools::getValue(null, true));
     }
 
     public function testGetValueStripsNullCharsFromReturnedStringsExamples()
@@ -100,19 +100,19 @@ class ToolsCoreTest extends TestCase
          * Check it cleans values stored in POST
          */
         $this->setPostAndGet(array('rawString' => $rawString));
-        $this->assertEquals($cleanedString, Tools::getValue('rawString'));
+        static::assertEquals($cleanedString, Tools::getValue('rawString'));
 
         /**
          * Check it cleans values stored in GET
          */
         $this->setPostAndGet(array(), array('rawString' => $rawString));
-        $this->assertEquals($cleanedString, Tools::getValue('rawString'));
+        static::assertEquals($cleanedString, Tools::getValue('rawString'));
 
         /**
          * Check it cleans default values too
          */
         $this->setPostAndGet();
-        $this->assertEquals($cleanedString, Tools::getValue('NON EXISTING KEY', $rawString));
+        static::assertEquals($cleanedString, Tools::getValue('NON EXISTING KEY', $rawString));
     }
 
     public function testSpreadAmountExamples()
@@ -207,7 +207,7 @@ class ToolsCoreTest extends TestCase
         $res2 = Tools::getDirectoriesWithReaddir($path);
         sort($res1);
         sort($res2);
-        $this->assertEquals(
+        static::assertEquals(
             $res1,
             $res2,
             'Results differ between getDirectoriesWithGlob and getDirectoriesWithReaddir for path '.$path
@@ -215,7 +215,7 @@ class ToolsCoreTest extends TestCase
 
         $haveFilesTest = ($res1 !== []);
 
-        $this->assertEquals($haveFiles, $haveFilesTest);
+        static::assertEquals($haveFiles, $haveFilesTest);
     }
 
     public function dirProvider()
@@ -229,7 +229,7 @@ class ToolsCoreTest extends TestCase
     public function testSpreadAmount($expectedRows, $amount, $precision, $rows, $column)
     {
         Tools::spreadAmount($amount, $precision, $rows, $column);
-        $this->assertEquals(array_values($expectedRows), array_values($rows));
+        static::assertEquals(array_values($expectedRows), array_values($rows));
     }
 
     /**
@@ -324,7 +324,7 @@ class ToolsCoreTest extends TestCase
     public function testToCamelCase($source, $expected, $firstCharUpperCase)
     {
         $actual = Tools::toCamelCase($source, $firstCharUpperCase);
-        $this->assertEquals($expected, $actual, "Expected $source to be $expected in camel case, got $actual instead.");
+        static::assertEquals($expected, $actual, "Expected $source to be $expected in camel case, got $actual instead.");
     }
 
     public static function tearDownAfterClass() {
@@ -336,7 +336,7 @@ class ToolsCoreTest extends TestCase
      * @dataProvider testStrReplaceFirstProvider
      */
     public function testStrReplaceFirst($search, $replace, $subject, $cur, $expected) {
-        $this->assertEquals($expected, Tools::StrReplaceFirst($search, $replace, $subject, $cur));
+        static::assertEquals($expected, Tools::StrReplaceFirst($search, $replace, $subject, $cur));
     }
 
     /**
@@ -347,7 +347,7 @@ class ToolsCoreTest extends TestCase
      */
     public function testExtractUrlDomain($url, $expectedDomain)
     {
-        $this->assertSame($expectedDomain, Tools::extractHost($url));
+        static::assertSame($expectedDomain, Tools::extractHost($url));
     }
 
     public function domainProvider()

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -36,12 +36,12 @@ class ValidateCoreTest extends TestCase
      */
     public function testIsIp2Long($expected, $input)
     {
-        $this->assertEquals($expected, Validate::isIp2Long($input));
+        static::assertEquals($expected, Validate::isIp2Long($input));
     }
 
     public function testIsAnything()
     {
-        $this->assertTrue(Validate::isAnything());
+        static::assertTrue(Validate::isAnything());
     }
 
     // TODO: Write test for testIsModuleUrl()
@@ -55,7 +55,7 @@ class ValidateCoreTest extends TestCase
      */
     public function testIsEmail($expected, $input)
     {
-        $this->assertSame($expected, Validate::isEmail($input));
+        static::assertSame($expected, Validate::isEmail($input));
     }
 
     /**
@@ -63,7 +63,7 @@ class ValidateCoreTest extends TestCase
      */
     public function testIsBirthDate($expected, $input)
     {
-        $this->assertSame($expected, Validate::isBirthDate($input));
+        static::assertSame($expected, Validate::isBirthDate($input));
     }
 
     /**
@@ -71,7 +71,7 @@ class ValidateCoreTest extends TestCase
      */
     public function testIsDateOrNull($expected, $input)
     {
-        $this->assertSame($expected, Validate::isDateOrNull($input));
+        static::assertSame($expected, Validate::isDateOrNull($input));
     }
 
     /**
@@ -79,7 +79,7 @@ class ValidateCoreTest extends TestCase
      */
     public function testIsMd5($expected, $input)
     {
-        $this->assertSame($expected, Validate::isMd5($input));
+        static::assertSame($expected, Validate::isMd5($input));
     }
 
     /**
@@ -87,7 +87,7 @@ class ValidateCoreTest extends TestCase
      */
     public function testIsSha1($expected, $input)
     {
-        $this->assertSame($expected, Validate::isSha1($input));
+        static::assertSame($expected, Validate::isSha1($input));
     }
 
     /**
@@ -95,7 +95,7 @@ class ValidateCoreTest extends TestCase
      */
     public function testIsFloat($expected, $input)
     {
-        $this->assertSame($expected, Validate::isFloat($input));
+        static::assertSame($expected, Validate::isFloat($input));
     }
 
     /**
@@ -103,7 +103,7 @@ class ValidateCoreTest extends TestCase
      */
     public function testIsUnsignedFloat($expected, $input)
     {
-        $this->assertSame($expected, Validate::isUnsignedFloat($input));
+        static::assertSame($expected, Validate::isUnsignedFloat($input));
     }
 
     /**
@@ -112,7 +112,7 @@ class ValidateCoreTest extends TestCase
      */
     public function testIsOptFloat($expected, $input)
     {
-        $this->assertSame($expected, Validate::isOptFloat($input));
+        static::assertSame($expected, Validate::isOptFloat($input));
     }
 
     // --- providers ---

--- a/tests-legacy/Unit/Controller/Admin/AdminTabsControllerTest.php
+++ b/tests-legacy/Unit/Controller/Admin/AdminTabsControllerTest.php
@@ -77,9 +77,9 @@ class AdminTabsControllerTest extends UnitTestCase
             ->setMethods(array('getFamily'))
             ->getMock();
 
-        $cookieMock->expects($this->once())
+        $cookieMock->expects(static::once())
             ->method('getFamily')
-            ->with($this->anything())
+            ->with(static::anything())
             ->willReturn(array());
 
         $this->context->cookie = $cookieMock;
@@ -92,16 +92,16 @@ class AdminTabsControllerTest extends UnitTestCase
             ->setMethods(array('query', 'executeS', 'getMsgError'))
             ->getMock();
 
-        $dbMock->expects($this->any())
+        $dbMock->expects(static::any())
             ->method('query')
-            ->with($this->callback(function ($subject) {
+            ->with(static::callback(function ($subject) {
                 // It should check if multi-shop is active
                 return strpos($subject, 'PS_MULTISHOP_FEATURE_ACTIVE') !== false;
             }));
 
-        $dbMock->expects($this->any())
+        $dbMock->expects(static::any())
             ->method('executeS')
-            ->with($this->callback(function ($subject) {
+            ->with(static::callback(function ($subject) {
                 if ($subject instanceof DbQuery) {
                     $builtQuery = $subject->build();
 
@@ -120,7 +120,7 @@ class AdminTabsControllerTest extends UnitTestCase
                     strpos($subject, 'hook_alias') !== false;
 
             }))
-            ->will($this->returnCallback(function ($subject) {
+            ->will(static::returnCallback(function ($subject) {
                 if (strpos($subject, 'authorization') !== false) {
                     return array();
                 } else {

--- a/tests-legacy/Unit/Controller/FrontController/ProductControllerTest.php
+++ b/tests-legacy/Unit/Controller/FrontController/ProductControllerTest.php
@@ -121,10 +121,10 @@ class ProductControllerTest extends IntegrationTestCase
         $priceFormatter = new PriceFormatter();
 
         foreach ($expected as $expectedLevel => $expectedValues) {
-            $this->assertArrayHasKey($expectedLevel, $result);
+            static::assertArrayHasKey($expectedLevel, $result);
             foreach ($expectedValues as $expectedKey => $expectedValue) {
-                $this->assertArrayHasKey($expectedKey, $result[$expectedLevel]);
-                $this->assertEquals($priceFormatter->format($expectedValue), $result[$expectedLevel][$expectedKey]);
+                static::assertArrayHasKey($expectedKey, $result[$expectedLevel]);
+                static::assertEquals($priceFormatter->format($expectedValue), $result[$expectedLevel][$expectedKey]);
             }
         }
     }

--- a/tests-legacy/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests-legacy/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -72,21 +72,21 @@ class ModuleManagerTest extends TestCase
 
     public function testInstallSuccessful()
     {
-        $this->assertTrue($this->moduleManager->install(self::UNINSTALLED_MODULE));
-        $this->assertTrue($this->moduleManager->install(self::INSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->install(self::UNINSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->install(self::INSTALLED_MODULE));
     }
 
     public function testUninstallSuccessful()
     {
-        $this->assertTrue($this->moduleManager->uninstall(self::INSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->uninstall(self::INSTALLED_MODULE));
         $this->expectException('Exception');
         $this->expectExceptionMessage('The module %module% must be installed first');
-        $this->assertFalse($this->moduleManager->uninstall(self::UNINSTALLED_MODULE));
+        static::assertFalse($this->moduleManager->uninstall(self::UNINSTALLED_MODULE));
     }
 
     public function testUpgradeSuccessful()
     {
-        $this->assertTrue($this->moduleManager->upgrade(self::INSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->upgrade(self::INSTALLED_MODULE));
         $this->expectException('Exception');
         $this->expectExceptionMessage('The module %module% must be installed first');
         $this->moduleManager->upgrade(self::UNINSTALLED_MODULE);
@@ -94,61 +94,61 @@ class ModuleManagerTest extends TestCase
 
     public function testDisableSuccessful()
     {
-        $this->assertTrue($this->moduleManager->disable(self::INSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->disable(self::INSTALLED_MODULE));
         $this->expectException('Exception');
         $this->expectExceptionMessage('The module %module% must be installed first');
-        $this->assertFalse($this->moduleManager->disable(self::UNINSTALLED_MODULE));
+        static::assertFalse($this->moduleManager->disable(self::UNINSTALLED_MODULE));
     }
 
     public function testEnableSuccessful()
     {
-        $this->assertTrue($this->moduleManager->enable(self::INSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->enable(self::INSTALLED_MODULE));
         $this->expectException('Exception');
         $this->expectExceptionMessage('The module %module% must be installed first');
-        $this->assertFalse($this->moduleManager->enable(self::UNINSTALLED_MODULE));
+        static::assertFalse($this->moduleManager->enable(self::UNINSTALLED_MODULE));
     }
 
     public function testDisableOnMobileSuccessful()
     {
-        $this->assertTrue($this->moduleManager->disable_mobile(self::INSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->disable_mobile(self::INSTALLED_MODULE));
         $this->expectException('Exception');
         $this->expectExceptionMessage('The module %module% must be installed first');
-        $this->assertFalse($this->moduleManager->disable_mobile(self::UNINSTALLED_MODULE));
+        static::assertFalse($this->moduleManager->disable_mobile(self::UNINSTALLED_MODULE));
     }
 
     public function testEnableOnMobileSuccessful()
     {
-        $this->assertTrue($this->moduleManager->enable_mobile(self::INSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->enable_mobile(self::INSTALLED_MODULE));
         $this->expectException('Exception');
         $this->expectExceptionMessage('The module %module% must be installed first');
-        $this->assertFalse($this->moduleManager->enable_mobile(self::UNINSTALLED_MODULE));
+        static::assertFalse($this->moduleManager->enable_mobile(self::UNINSTALLED_MODULE));
     }
 
     public function testResetSuccessful()
     {
-        $this->assertTrue($this->moduleManager->reset(self::INSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->reset(self::INSTALLED_MODULE));
         $this->expectException('Exception');
         $this->expectExceptionMessage('The module %module% must be installed first');
-        $this->assertFalse($this->moduleManager->reset(self::UNINSTALLED_MODULE));
+        static::assertFalse($this->moduleManager->reset(self::UNINSTALLED_MODULE));
     }
 
     public function testIsEnabled()
     {
-        $this->assertTrue($this->moduleManager->isEnabled(self::INSTALLED_MODULE));
-        $this->assertFalse($this->moduleManager->isEnabled(self::UNINSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->isEnabled(self::INSTALLED_MODULE));
+        static::assertFalse($this->moduleManager->isEnabled(self::UNINSTALLED_MODULE));
     }
 
     public function testIsInstalled()
     {
-        $this->assertTrue($this->moduleManager->isInstalled(self::INSTALLED_MODULE));
-        $this->assertFalse($this->moduleManager->isInstalled(self::UNINSTALLED_MODULE));
+        static::assertTrue($this->moduleManager->isInstalled(self::INSTALLED_MODULE));
+        static::assertFalse($this->moduleManager->isInstalled(self::UNINSTALLED_MODULE));
     }
 
     public function testRemoveModuleFromDisk()
     {
         $modules = [self::INSTALLED_MODULE, self::UNINSTALLED_MODULE];
         foreach ($modules as $module) {
-            $this->assertSame($this->moduleManager->removeModuleFromDisk($module), $this->moduleUpdaterS->removeModuleFromDisk($module));
+            static::assertSame($this->moduleManager->removeModuleFromDisk($module), $this->moduleUpdaterS->removeModuleFromDisk($module));
         }
     }
 
@@ -198,7 +198,7 @@ class ModuleManagerTest extends TestCase
 
         $this->moduleProviderS
             ->method('can')
-            ->will($this->returnValueMap($providerAuthorizations));
+            ->will(static::returnValueMap($providerAuthorizations));
 
         $isInstalledValues = [
             [
@@ -210,7 +210,7 @@ class ModuleManagerTest extends TestCase
         ];
         $this->moduleProviderS
             ->method('isInstalled')
-            ->will($this->returnValueMap($isInstalledValues));
+            ->will(static::returnValueMap($isInstalledValues));
 
         $isEnabledValues = [
             [self::INSTALLED_MODULE, true],
@@ -219,7 +219,7 @@ class ModuleManagerTest extends TestCase
 
         $this->moduleProviderS
             ->method('isEnabled')
-            ->will($this->returnValueMap($isEnabledValues));
+            ->will(static::returnValueMap($isEnabledValues));
     }
 
     private function mockModuleUpdater()
@@ -285,7 +285,7 @@ class ModuleManagerTest extends TestCase
 
         $this->moduleZipManagerS
             ->method('getName')
-            ->will($this->returnArgument(0));
+            ->will(static::returnArgument(0));
 
         $this->moduleZipManagerS
             ->method('storeInModulesFolder');
@@ -299,7 +299,7 @@ class ModuleManagerTest extends TestCase
 
         $this->translatorS
             ->method('trans')
-            ->will($this->returnArgument(0));
+            ->will(static::returnArgument(0));
     }
 
     private function mockDispatcher()

--- a/tests-legacy/Unit/Core/Addon/Module/ModuleRepositoryTest.php
+++ b/tests-legacy/Unit/Core/Addon/Module/ModuleRepositoryTest.php
@@ -102,7 +102,7 @@ class ModuleRepositoryTest extends UnitTestCase
             ->getMock();
         $this->translatorStub
             ->method('trans')
-            ->will($this->returnArgument(0));
+            ->will(static::returnArgument(0));
 
         $this->adminModuleDataProviderStub = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider')
             ->setConstructorArgs(array($this->translatorStub, $this->logger, $this->addonsDataProviderS, $this->categoriesProviderS, $this->moduleDataProviderStub))
@@ -146,7 +146,7 @@ class ModuleRepositoryTest extends UnitTestCase
          */
         $this->moduleRepositoryStub
             ->method('generateCacheFile')
-            ->will($this->returnArgument(0));
+            ->will(static::returnArgument(0));
 
         /*
          * End of mocking for modules folder
@@ -155,7 +155,7 @@ class ModuleRepositoryTest extends UnitTestCase
 
     public function testGetAtLeastOneModuleFromUniverse()
     {
-        $this->assertGreaterThan(0, count($this->moduleRepositoryStub->getList()));
+        static::assertGreaterThan(0, count($this->moduleRepositoryStub->getList()));
     }
 
     public function testGetOnlyInstalledModules()
@@ -170,13 +170,13 @@ class ModuleRepositoryTest extends UnitTestCase
 
         // Each module MUST have its database installed attribute as true
         foreach ($installed_modules as $module) {
-            $this->assertTrue($module->database->get('installed') == 1);
+            static::assertTrue($module->database->get('installed') == 1);
         }
 
         foreach ($all_modules as $name => $module) {
             // Each installed module must be found in the installed modules list
             if ($module->database->get('installed') == 1) {
-                $this->assertArrayHasKey($name, $installed_modules, sprintf('Module %s not found in the filtered list !', $name));
+                static::assertArrayHasKey($name, $installed_modules, sprintf('Module %s not found in the filtered list !', $name));
             }
         }
     }
@@ -193,13 +193,13 @@ class ModuleRepositoryTest extends UnitTestCase
 
         // Each module MUST have its database installed attribute as true
         foreach ($not_installed_modules as $module) {
-            $this->assertTrue($module->database->get('installed') == 0);
+            static::assertTrue($module->database->get('installed') == 0);
         }
 
         foreach ($all_modules as $name => $module) {
             // Each installed module must be found in the installed modules list
             if ($module->attributes->get('productType') == 'module' && $module->database->get('installed') == 0) {
-                $this->assertArrayHasKey($name, $not_installed_modules, sprintf('Module %s not found in the filtered list !', $name));
+                static::assertArrayHasKey($name, $not_installed_modules, sprintf('Module %s not found in the filtered list !', $name));
             }
         }
     }
@@ -216,15 +216,15 @@ class ModuleRepositoryTest extends UnitTestCase
 
         // Each module MUST have its database installed and enabled attributes as true
         foreach ($installed_and_active_modules as $module) {
-            $this->assertTrue($module->database->get('installed') == 1);
-            $this->assertTrue($module->database->get('active') == 1);
+            static::assertTrue($module->database->get('installed') == 1);
+            static::assertTrue($module->database->get('active') == 1);
         }
 
         foreach ($all_modules as $name => $module) {
             // Each installed module must be found in the installed modules list
             if ($module->database->get('installed') == 1
                 && $module->database->get('active') == 1) {
-                $this->assertArrayHasKey($name, $installed_and_active_modules, sprintf('Module %s not found in the filtered list !', $name));
+                static::assertArrayHasKey($name, $installed_and_active_modules, sprintf('Module %s not found in the filtered list !', $name));
             }
         }
     }
@@ -240,13 +240,13 @@ class ModuleRepositoryTest extends UnitTestCase
         $not_active_modules = $this->moduleRepositoryStub->getFilteredList($filters);
 
         foreach ($not_active_modules as $module) {
-            $this->assertTrue($module->database->get('active') == 0);
+            static::assertTrue($module->database->get('active') == 0);
         }
 
         foreach ($all_modules as $name => $module) {
             // Each installed module must be found in the installed modules list
             if ($module->attributes->get('productType') == 'module' && $module->database->get('installed') == 1  && $module->database->get('active') == 0) {
-                $this->assertArrayHasKey($name, $not_active_modules, sprintf('Module %s not found in the filtered list !', $name));
+                static::assertArrayHasKey($name, $not_active_modules, sprintf('Module %s not found in the filtered list !', $name));
             }
         }
     }
@@ -262,14 +262,14 @@ class ModuleRepositoryTest extends UnitTestCase
         $installed_but_not_installed_modules = $this->moduleRepositoryStub->getFilteredList($filters);
 
         foreach ($installed_but_not_installed_modules as $module) {
-            $this->assertTrue($module->database->get('installed') == 1, $module->attributes->get('name').' marked as not installed ><');
-            $this->assertTrue($module->database->get('active') == 0, $module->attributes->get('name').' marked as enabled ><');
+            static::assertTrue($module->database->get('installed') == 1, $module->attributes->get('name').' marked as not installed ><');
+            static::assertTrue($module->database->get('active') == 0, $module->attributes->get('name').' marked as enabled ><');
         }
 
         foreach ($all_modules as $name => $module) {
             // Each installed module must be found in the installed modules list
             if ($module->database->get('installed') == 1 && $module->database->get('active') == 0) {
-                $this->assertArrayHasKey($name, $installed_but_not_installed_modules, sprintf('Module %s not found in the filtered list !', $name));
+                static::assertArrayHasKey($name, $installed_but_not_installed_modules, sprintf('Module %s not found in the filtered list !', $name));
             }
         }
     }
@@ -281,7 +281,7 @@ class ModuleRepositoryTest extends UnitTestCase
 
         // Each module must have its origin attribute
         foreach ($this->moduleRepositoryStub->getFilteredList($filters) as $module) {
-            $this->assertTrue($module->attributes->has('origin'), $module->attributes->get('name').' has not an origin attribute');
+            static::assertTrue($module->attributes->has('origin'), $module->attributes->get('name').' has not an origin attribute');
         }
     }
 
@@ -292,7 +292,7 @@ class ModuleRepositoryTest extends UnitTestCase
 
         // Each module must have its origin attribute
         foreach ($this->moduleRepositoryStub->getFilteredList($filters) as $module) {
-            $this->assertFalse($module->attributes->has('origin'), $module->attributes->get('name').' has an origin attribute, but should not');
+            static::assertFalse($module->attributes->has('origin'), $module->attributes->get('name').' has an origin attribute, but should not');
         }
     }
 
@@ -303,7 +303,7 @@ class ModuleRepositoryTest extends UnitTestCase
 
         // Each module must have its origin attribute
         foreach ($this->moduleRepositoryStub->getFilteredList($filters) as $module) {
-            $this->assertFalse($module->attributes->has('origin'), $module->attributes->get('name').' has an origin attribute, but should not !');
+            static::assertFalse($module->attributes->has('origin'), $module->attributes->get('name').' has an origin attribute, but should not !');
         }
     }
 
@@ -316,7 +316,7 @@ class ModuleRepositoryTest extends UnitTestCase
         $filters->setType(AddonListFilterType::MODULE);
 
         foreach ($this->moduleRepositoryStub->getFilteredList($filters) as $module) {
-            $this->assertTrue($module->attributes->get('productType') == 'module', $module->attributes->get('name').' has a product type "'.$module->attributes->get('productType').'"');
+            static::assertTrue($module->attributes->get('productType') == 'module', $module->attributes->get('name').' has a product type "'.$module->attributes->get('productType').'"');
         }
     }
 
@@ -326,7 +326,7 @@ class ModuleRepositoryTest extends UnitTestCase
         $filters->setType(AddonListFilterType::SERVICE);
 
         foreach ($this->moduleRepositoryStub->getFilteredList($filters) as $module) {
-            $this->assertTrue($module->attributes->get('productType') == 'service');
+            static::assertTrue($module->attributes->get('productType') == 'service');
         }
     }
 
@@ -335,7 +335,7 @@ class ModuleRepositoryTest extends UnitTestCase
         $filters = new AddonListFilter();
         $filters->setType(AddonListFilterType::THEME);
 
-        $this->assertCount(0, $this->moduleRepositoryStub->getFilteredList($filters));
+        static::assertCount(0, $this->moduleRepositoryStub->getFilteredList($filters));
     }
 
     public function teardown()

--- a/tests-legacy/Unit/Core/Addon/Theme/ThemeRepositoryTest.php
+++ b/tests-legacy/Unit/Core/Addon/Theme/ThemeRepositoryTest.php
@@ -62,7 +62,7 @@ class ThemeRepositoryTest extends TestCase
     public function testGetInstanceByName()
     {
         $expectedTheme = $this->repository->getInstanceByName('classic');
-        $this->assertInstanceOf(
+        static::assertInstanceOf(
             'PrestaShop\PrestaShop\Core\Addon\Theme\Theme',
             $expectedTheme,
             self::NOTICE.sprintf('expected `getInstanceByName to return Theme, get %s`', gettype($expectedTheme))
@@ -78,21 +78,21 @@ class ThemeRepositoryTest extends TestCase
     public function testGetList()
     {
         $themeList = $this->repository->getList();
-        $this->assertInternalType('array', $themeList);
-        $this->assertInstanceOf('PrestaShop\PrestaShop\Core\Addon\Theme\Theme', current($themeList));
+        static::assertInternalType('array', $themeList);
+        static::assertInstanceOf('PrestaShop\PrestaShop\Core\Addon\Theme\Theme', current($themeList));
     }
 
     public function testGetListExcluding()
     {
         $themeListWithoutRestrictions = $this->repository->GetListExcluding([]);
         $themeListWithoutClassic = $this->repository->GetListExcluding(['classic']);
-        $this->assertEquals(
+        static::assertEquals(
             $themeListWithoutRestrictions,
             $this->repository->getList(),
             self::NOTICE.sprintf('expected list excluding without args to return complete list of themes `see ThemeRepository::getListExcluding`')
         );
 
-        $this->assertCount(
+        static::assertCount(
             (count($themeListWithoutRestrictions) - 1),
             $themeListWithoutClassic,
             self::NOTICE.sprintf('expected list excluding with classic to list of themes without classic')

--- a/tests-legacy/Unit/Core/Addon/Theme/ThemeValidatorTest.php
+++ b/tests-legacy/Unit/Core/Addon/Theme/ThemeValidatorTest.php
@@ -59,19 +59,19 @@ class ThemeValidatorTest extends TestCase
     public function testIsValidWithValidTheme()
     {
         $isValid = $this->validator->isValid($this->getTheme());
-        $this->assertTrue($isValid, self::NOTICE.sprintf('expected isValid to return true when theme is valid, got %s', gettype($isValid)));
+        static::assertTrue($isValid, self::NOTICE.sprintf('expected isValid to return true when theme is valid, got %s', gettype($isValid)));
     }
 
     public function testIsValidWithInvalidThemeMissingFiles()
     {
         $isValid = $this->validator->isValid($this->getTheme('missfiles'));
-        $this->assertFalse($isValid, self::NOTICE.sprintf('expected isValid to return false when theme is invalid, got %s', gettype($isValid)));
+        static::assertFalse($isValid, self::NOTICE.sprintf('expected isValid to return false when theme is invalid, got %s', gettype($isValid)));
     }
 
     public function testIsValidWithInvalidThemeMissingProperties()
     {
         $isValid = $this->validator->isValid($this->getTheme('missconfig'));
-        $this->assertFalse($isValid, self::NOTICE.sprintf('expected isValid to return false when theme is invalid, got %s', gettype($isValid)));
+        static::assertFalse($isValid, self::NOTICE.sprintf('expected isValid to return false when theme is invalid, got %s', gettype($isValid)));
     }
 
     private function getTheme($name = 'valid')

--- a/tests-legacy/Unit/Core/Business/Checkout/TermsAndConditionsTest.php
+++ b/tests-legacy/Unit/Core/Business/Checkout/TermsAndConditionsTest.php
@@ -40,7 +40,7 @@ class TermsAndConditionsTest extends UnitTestCase
 
     public function testSetTextInsertsLinks()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'hello <a href="http://www.world.com" id="cta-ho-0">world</a>',
             $this->terms->setIdentifier('ho')->setText('hello [world]', "http://www.world.com")->format()
         );
@@ -48,7 +48,7 @@ class TermsAndConditionsTest extends UnitTestCase
 
     public function testSetTextInsertsSeveralLinks()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'hello <a href="http://www.world.com" id="cta-hey-0">world</a> <a href="http://yay.com" id="cta-hey-1">yay</a>',
             $this->terms->setIdentifier('hey')->setText('hello [world] [yay]', "http://www.world.com", "http://yay.com")->format()
         );
@@ -56,7 +56,7 @@ class TermsAndConditionsTest extends UnitTestCase
 
     public function testSetTextJustDoesntAddLinksWhenMissing()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'hello world',
             $this->terms->setText('hello [world]')->format()
         );

--- a/tests-legacy/Unit/Core/Business/Payment/PaymentOptionFormDecoratorTest.php
+++ b/tests-legacy/Unit/Core/Business/Payment/PaymentOptionFormDecoratorTest.php
@@ -55,14 +55,14 @@ class PaymentOptionFormDecoratorTest extends UnitTestCase
 </div>";
 
         $act = $decorator->addHiddenSubmitButton($form, 'OPTION_ID');
-        $this->assertStringStartsWith('<div>', $act);
+        static::assertStringStartsWith('<div>', $act);
         $this->assertSameHTML($exp, $act);
     }
 
     public function testAddHiddenSubmitButtonReturnsFalseWhenMultipleForms()
     {
         $decorator = new PaymentOptionFormDecorator();
-        $this->assertFalse(
+        static::assertFalse(
             $decorator->addHiddenSubmitButton(
                 '<form></form><form></form>',
                 'OPTION_ID'
@@ -84,7 +84,7 @@ class PaymentOptionFormDecoratorTest extends UnitTestCase
 
     private function assertSameHTML($exp, $act)
     {
-        $this->assertEquals(
+        static::assertEquals(
             $this->normalizeHTML($exp),
             $this->normalizeHTML($act)
         );

--- a/tests-legacy/Unit/Core/Business/Product/ProductPresenterTest.php
+++ b/tests-legacy/Unit/Core/Business/Product/ProductPresenterTest.php
@@ -129,13 +129,13 @@ class ProductPresenterTest extends UnitTestCase
     public function testPriceShouldBeShownInCatalogMode()
     {
         $this->settings->catalog_mode = true;
-        $this->assertTrue($this->getPresentedProduct('show_price'));
+        static::assertTrue($this->getPresentedProduct('show_price'));
     }
 
     public function testPriceShouldShownInRestrictedCountryMode()
     {
         $this->settings->restricted_country_mode = true;
-        $this->assertTrue($this->getPresentedProduct('show_price'));
+        static::assertTrue($this->getPresentedProduct('show_price'));
     }
 
     public function testPriceShouldNotBeShownIfProductNotAvailableForOrder()
@@ -143,19 +143,19 @@ class ProductPresenterTest extends UnitTestCase
         $this->product['available_for_order'] = false;
         $this->product['show_price'] = false;
 
-        $this->assertFalse($this->getPresentedProduct('show_price'));
+        static::assertFalse($this->getPresentedProduct('show_price'));
 
         $this->product['available_for_order'] = false;
         $this->product['show_price'] = true;
 
-        $this->assertTrue($this->getPresentedProduct('show_price'));
+        static::assertTrue($this->getPresentedProduct('show_price'));
     }
 
     public function testPriceIsTaxExcluded()
     {
         $this->settings->include_taxes = false;
         $this->product['price_tax_exc'] = 8;
-        $this->assertStringStartsWith(
+        static::assertStringStartsWith(
             '#8',
             $this->getPresentedProduct('price')
         );
@@ -165,7 +165,7 @@ class ProductPresenterTest extends UnitTestCase
     {
         $this->settings->include_taxes = true;
         $this->product['price'] = 16;
-        $this->assertStringStartsWith(
+        static::assertStringStartsWith(
             '#16',
             $this->getPresentedProduct('price')
         );
@@ -174,7 +174,7 @@ class ProductPresenterTest extends UnitTestCase
     public function testCannotAddToCartIfNotCustomized()
     {
         $this->product['customization_required'] = true;
-        $this->assertNotEquals(
+        static::assertNotEquals(
             'http://add-to-cart.url',
             $this->getPresentedProduct('add_to_cart_url')
         );
@@ -188,7 +188,7 @@ class ProductPresenterTest extends UnitTestCase
                 ['is_customized' => true, 'required' => true],
             ],
         ];
-        $this->assertEquals(
+        static::assertEquals(
             'http://add-to-cart.url',
             $this->getPresentedProduct('add_to_cart_url')
         );
@@ -203,7 +203,7 @@ class ProductPresenterTest extends UnitTestCase
                 ['is_customized' => false, 'required' => false],
             ],
         ];
-        $this->assertEquals(
+        static::assertEquals(
             'http://add-to-cart.url',
             $this->getPresentedProduct('add_to_cart_url')
         );
@@ -213,7 +213,7 @@ class ProductPresenterTest extends UnitTestCase
     {
         $this->product['id_product_attribute'] = 42;
         $this->settings->allow_add_variant_to_cart_from_listing = false;
-        $this->assertNull(
+        static::assertNull(
             $this->getPresentedProductForListing('add_to_cart_url')
         );
     }
@@ -226,7 +226,7 @@ class ProductPresenterTest extends UnitTestCase
                 ['is_customized' => true, 'required' => true],
             ],
         ];
-        $this->assertNull(
+        static::assertNull(
             $this->getPresentedProductForListing('add_to_cart_url')
         );
     }
@@ -235,7 +235,7 @@ class ProductPresenterTest extends UnitTestCase
     {
         $this->product['id_product_attribute'] = 42;
         $this->settings->allow_add_variant_to_cart_from_listing = true;
-        $this->assertEquals(
+        static::assertEquals(
             'http://add-to-cart.url',
             $this->getPresentedProductForListing('add_to_cart_url')
         );
@@ -244,7 +244,7 @@ class ProductPresenterTest extends UnitTestCase
     public function testProductHasOnlineOnlyFlagIfItIsOnlineOnly()
     {
         $this->product['online_only'] = true;
-        $this->assertEquals(
+        static::assertEquals(
             ['online-only' => [
                 'type'  => 'online-only',
                 'label' => 'some label',
@@ -256,7 +256,7 @@ class ProductPresenterTest extends UnitTestCase
     public function testProductHasDiscountFlagIfItHasADiscount()
     {
         $this->product['reduction'] = true;
-        $this->assertEquals(
+        static::assertEquals(
             ['discount' => [
                 'type'  => 'discount',
                 'label' => 'some label',
@@ -269,7 +269,7 @@ class ProductPresenterTest extends UnitTestCase
     {
         $this->product['reduction'] = true;
         $this->product['on_sale'] = true;
-        $this->assertEquals(
+        static::assertEquals(
             ['on-sale' => [
                 'type'  => 'on-sale',
                 'label' => 'some label',
@@ -281,7 +281,7 @@ class ProductPresenterTest extends UnitTestCase
     public function testProductHasNewFlagIfItIsNew()
     {
         $this->product['new'] = true;
-        $this->assertEquals(
+        static::assertEquals(
             ['new' => [
                 'type'  => 'new',
                 'label' => 'some label',
@@ -294,7 +294,7 @@ class ProductPresenterTest extends UnitTestCase
     {
         $this->product['show_condition'] = true;
         $this->product['condition'] = 'new';
-        $this->assertEquals(
+        static::assertEquals(
             [
                 'type'  => 'new',
                 'label' => 'some label',
@@ -309,7 +309,7 @@ class ProductPresenterTest extends UnitTestCase
         $this->product['online_only'] = true;
         $this->product['available_for_order'] = false;
         $this->product['show_price'] = false;
-        $this->assertEquals(
+        static::assertEquals(
             [],
             $this->getPresentedProduct('flags')
         );

--- a/tests-legacy/Unit/Core/Business/Product/Search/PaginationTest.php
+++ b/tests-legacy/Unit/Core/Business/Product/Search/PaginationTest.php
@@ -42,7 +42,7 @@ class PaginationTest extends Testcase
             ->setPagesCount(10)
             ->setPage(5);
 
-        $this->assertEquals([
+        static::assertEquals([
             ['type' => 'previous', 'clickable' => true, 'page' => 4,      'current' => false],
             ['type' => 'page', 'clickable' => true, 'page' => 1,      'current' => false],
             ['type' => 'spacer', 'clickable' => false, 'page' => null,   'current' => false],
@@ -61,7 +61,7 @@ class PaginationTest extends Testcase
             ->setPagesCount(10)
             ->setPage(1);
 
-        $this->assertEquals([
+        static::assertEquals([
             ['type' => 'previous', 'clickable' => false, 'page' => 1,      'current' => false],
             ['type' => 'page', 'clickable' => false, 'page' => 1,      'current' => true],
             ['type' => 'page', 'clickable' => true, 'page' => 2,      'current' => false],
@@ -78,7 +78,7 @@ class PaginationTest extends Testcase
             ->setPagesCount(10)
             ->setPage(10);
 
-        $this->assertEquals([
+        static::assertEquals([
             ['type' => 'previous', 'clickable' => true, 'page' => 9,     'current' => false],
             ['type' => 'page', 'clickable' => true, 'page' => 1,     'current' => false],
             ['type' => 'spacer', 'clickable' => false, 'page' => null,  'current' => false],
@@ -95,7 +95,7 @@ class PaginationTest extends Testcase
             ->setPagesCount(1)
             ->setPage(1);
 
-        $this->assertEquals([
+        static::assertEquals([
             ['type' => 'previous', 'clickable' => false, 'page' => 1,     'current' => false],
             ['type' => 'page', 'clickable' => false, 'page' => 1,     'current' => true],
             ['type' => 'next', 'clickable' => false, 'page' => 1,     'current' => false],

--- a/tests-legacy/Unit/Core/Business/Product/Search/SearchTest.php
+++ b/tests-legacy/Unit/Core/Business/Product/Search/SearchTest.php
@@ -43,7 +43,7 @@ class SearchTest extends Testcase
     {
         $result = Search::extractKeyWords($input, $langId);
         // array_values used to prevent issues with indexes keeped from array_unique
-        $this->assertEquals($expected, array_values($result));
+        static::assertEquals($expected, array_values($result));
     }
 
     public function searchStringProvider()

--- a/tests-legacy/Unit/Core/Business/Product/Search/SortOrderTest.php
+++ b/tests-legacy/Unit/Core/Business/Product/Search/SortOrderTest.php
@@ -33,12 +33,12 @@ class SortOrderTest extends TestCase
 {
     public function testToLegacyOrderByProductName()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'name',
             (new SortOrder('product', 'name'))->toLegacyOrderBy(false)
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             'pl.name',
             (new SortOrder('product', 'name'))->toLegacyOrderBy(true)
         );
@@ -46,12 +46,12 @@ class SortOrderTest extends TestCase
 
     public function testToLegacyOrderByProductPrice()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'price',
             (new SortOrder('product', 'price'))->toLegacyOrderBy(false)
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             'p.price',
             (new SortOrder('product', 'price'))->toLegacyOrderBy(true)
         );
@@ -59,12 +59,12 @@ class SortOrderTest extends TestCase
 
     public function testToLegacyOrderByProductPosition()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'position',
             (new SortOrder('product', 'position'))->toLegacyOrderBy(false)
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             'cp.position',
             (new SortOrder('product', 'position'))->toLegacyOrderBy(true)
         );
@@ -72,12 +72,12 @@ class SortOrderTest extends TestCase
 
     public function testToLegacyOrderByManufacturerName()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'manufacturer_name',
             (new SortOrder('manufacturer', 'name'))->toLegacyOrderBy(false)
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             'm.name',
             (new SortOrder('manufacturer', 'name'))->toLegacyOrderBy(true)
         );
@@ -85,7 +85,7 @@ class SortOrderTest extends TestCase
 
     public function testToLegacyOrderWayAsc()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'asc',
             (new SortOrder('product', 'name', 'asc'))->toLegacyOrderWay()
         );
@@ -93,7 +93,7 @@ class SortOrderTest extends TestCase
 
     public function testToLegacyOrderWayDesc()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'desc',
             (new SortOrder('product', 'name', 'desc'))->toLegacyOrderWay()
         );
@@ -119,13 +119,13 @@ class SortOrderTest extends TestCase
         $opt = new SortOrder($data['entity'], $data['field'], $data['direction']);
 
         $encoded = $opt->toString();
-        $this->assertInternalType('string', $encoded);
+        static::assertInternalType('string', $encoded);
 
         $unserialized = SortOrder::newFromString($encoded);
 
         $arr = $unserialized->toArray();
-        $this->assertEquals($data['entity'],    $arr['entity']);
-        $this->assertEquals($data['field'],     $arr['field']);
-        $this->assertEquals($data['direction'], $arr['direction']);
+        static::assertEquals($data['entity'],    $arr['entity']);
+        static::assertEquals($data['field'],     $arr['field']);
+        static::assertEquals($data['direction'], $arr['direction']);
     }
 }

--- a/tests-legacy/Unit/Core/Business/Product/Search/URLFragmentSerializerTest.php
+++ b/tests-legacy/Unit/Core/Business/Product/Search/URLFragmentSerializerTest.php
@@ -40,8 +40,8 @@ class URLFragmentSerializerTest extends Testcase
 
     private function doTest($expected, array $fragment)
     {
-        $this->assertEquals($expected, $this->serializer->serialize($fragment));
-        $this->assertEquals($fragment, $this->serializer->unserialize($expected));
+        static::assertEquals($expected, $this->serializer->serialize($fragment));
+        static::assertEquals($fragment, $this->serializer->unserialize($expected));
     }
 
     public function testSerializeSingleMonovaluedFragment()

--- a/tests-legacy/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
+++ b/tests-legacy/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
@@ -67,7 +67,7 @@ class AddRuleTest extends AbstractCartTest
         $expectedProductCountAfterRules
     ) {
         $this->addProductsToCart($productData);
-        $this->assertEquals($expectedProductCount, Cart::getNbProducts($this->cart->id));
+        static::assertEquals($expectedProductCount, Cart::getNbProducts($this->cart->id));
         $result = true;
         foreach ($cartRuleData as $cartRuleId) {
             $cartRule                = $this->getCartRuleFromFixtureId($cartRuleId);
@@ -75,9 +75,9 @@ class AddRuleTest extends AbstractCartTest
             $this->cartRulesInCart[] = $cartRule;
             $this->cart->addCartRule($cartRule->id);
         }
-        $this->assertEquals($shouldRulesBeApplied, $result);
-        $this->assertTrue(CartRule::haveCartRuleToday(0));
-        $this->assertEquals($expectedProductCountAfterRules, Cart::getNbProducts($this->cart->id));
+        static::assertEquals($shouldRulesBeApplied, $result);
+        static::assertTrue(CartRule::haveCartRuleToday(0));
+        static::assertEquals($expectedProductCountAfterRules, Cart::getNbProducts($this->cart->id));
     }
 
     public function cartRuleValidityProvider()

--- a/tests-legacy/Unit/Core/Cart/Adding/Product/AddCombinationTest.php
+++ b/tests-legacy/Unit/Core/Cart/Adding/Product/AddCombinationTest.php
@@ -38,14 +38,14 @@ class AddCombinationTest extends AbstractCartTest
         $product     = new Product($combination->id_product);
 
         $nbProduct = Product::getQuantity($product->id, $combination->id, null, $this->cart, null);
-        $this->assertEquals(500, $nbProduct);
+        static::assertEquals(500, $nbProduct);
 
         $result = $this->cart->updateQty(11, $product->id, $combination->id, null);
-        $this->assertTrue($result);
+        static::assertTrue($result);
         $qty = $this->cart->getProductQuantity($product->id, $combination->id, null);
-        $this->assertEquals(11, $qty['quantity']);
+        static::assertEquals(11, $qty['quantity']);
         $nbProduct = Product::getQuantity($product->id, $combination->id, null, $this->cart, null);
-        $this->assertEquals(489, $nbProduct);
+        static::assertEquals(489, $nbProduct);
     }
 
     public function testCombinationCannotBeAddedInCartIfMoreThanStock()
@@ -54,11 +54,11 @@ class AddCombinationTest extends AbstractCartTest
         $product     = new Product($combination->id_product);
 
         $result = $this->cart->updateQty(600, $product->id, $combination->id);
-        $this->assertFalse($result);
+        static::assertFalse($result);
         $qty = $this->cart->getProductQuantity($product->id, $combination->id, null);
-        $this->assertEquals(0, $qty['quantity']);
+        static::assertEquals(0, $qty['quantity']);
         $nbProduct = Product::getQuantity($product->id, $combination->id, null, $this->cart, null);
-        $this->assertEquals(500, $nbProduct);
+        static::assertEquals(500, $nbProduct);
     }
 
     public function testCombinationCanBeAddedInCartIfMoreThanStockButAvailableWhenOutOfStock()
@@ -72,11 +72,11 @@ class AddCombinationTest extends AbstractCartTest
         $product->save();
 
         $result = $this->cart->updateQty(600, $product->id, $combination->id);
-        $this->assertTrue($result);
+        static::assertTrue($result);
         $qty = $this->cart->getProductQuantity($product->id, $combination->id, null);
-        $this->assertEquals(600, $qty['quantity']);
+        static::assertEquals(600, $qty['quantity']);
         $nbProduct = Product::getQuantity($product->id, $combination->id, null, $this->cart, null);
-        $this->assertEquals(-100, $nbProduct);
+        static::assertEquals(-100, $nbProduct);
 
         Configuration::set('PS_ORDER_OUT_OF_STOCK', $oldOrderOutOfStock);
     }

--- a/tests-legacy/Unit/Core/Cart/Adding/Product/AddCustomizationTest.php
+++ b/tests-legacy/Unit/Core/Cart/Adding/Product/AddCustomizationTest.php
@@ -69,16 +69,16 @@ class AddCustomizationTest extends AbstractCartTest
         $customization      = $this->addCustomization($product);
 
         $nbProduct = Product::getQuantity($product->id, null, null, $this->cart, null);
-        $this->assertEquals(30, $nbProduct);
+        static::assertEquals(30, $nbProduct);
 
         $result = $this->cart->updateQty(11, $product->id, null, $customization->id);
-        $this->assertTrue($result);
+        static::assertTrue($result);
         $qty = $this->cart->getProductQuantity($product->id, null, $customization->id);
-        $this->assertEquals(11, $qty['quantity']);
+        static::assertEquals(11, $qty['quantity']);
         $qty = $this->cart->getProductQuantity($product->id, null, null);
-        $this->assertEquals(0, $qty['quantity']);
+        static::assertEquals(0, $qty['quantity']);
         $nbProduct = Product::getQuantity($product->id, null, null, $this->cart, $customization->id);
-        $this->assertEquals(19, $nbProduct);
+        static::assertEquals(19, $nbProduct);
     }
 
     public function testCustomizationCannotBeAddedInCartIfMoreThanStock()
@@ -88,11 +88,11 @@ class AddCustomizationTest extends AbstractCartTest
         $customization      = $this->addCustomization($product);
 
         $result = $this->cart->updateQty(41, $product->id, null, $customization->id);
-        $this->assertFalse($result);
+        static::assertFalse($result);
         $qty = $this->cart->getProductQuantity($product->id, null, $customization->id);
-        $this->assertEquals(0, $qty['quantity']);
+        static::assertEquals(0, $qty['quantity']);
         $nbProduct = Product::getQuantity($product->id, null, null, $this->cart, $customization->id);
-        $this->assertEquals(30, $nbProduct);
+        static::assertEquals(30, $nbProduct);
     }
 
     public function testCustomizationCanBeAddedInCartIfMoreThanStockButAvailableWhenOutOfStock()
@@ -107,11 +107,11 @@ class AddCustomizationTest extends AbstractCartTest
         $product->save();
 
         $result = $this->cart->updateQty(41, $product->id, null, $customization->id);
-        $this->assertTrue($result);
+        static::assertTrue($result);
         $qty = $this->cart->getProductQuantity($product->id, null, $customization->id);
-        $this->assertEquals(41, $qty['quantity']);
+        static::assertEquals(41, $qty['quantity']);
         $nbProduct = Product::getQuantity($product->id, null, null, $this->cart, $customization->id);
-        $this->assertEquals(-11, $nbProduct);
+        static::assertEquals(-11, $nbProduct);
 
         Configuration::set('PS_ORDER_OUT_OF_STOCK', $oldOrderOutOfStock);
     }

--- a/tests-legacy/Unit/Core/Cart/Adding/Product/AddPackTest.php
+++ b/tests-legacy/Unit/Core/Cart/Adding/Product/AddPackTest.php
@@ -88,45 +88,45 @@ class AddPackTest extends AbstractCartTest
         Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PACK_ONLY);
         $nbPack    = Product::getQuantity($this->pack->id);
         $nbProduct = Product::getQuantity($this->productInPack->id);
-        $this->assertEquals(10, $nbPack);
-        $this->assertEquals(50, $nbProduct);
+        static::assertEquals(10, $nbPack);
+        static::assertEquals(50, $nbProduct);
 
         // Pack type decrement products only
         Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PRODUCTS_ONLY);
         $nbPack    = Product::getQuantity($this->pack->id);
         $nbProduct = Product::getQuantity($this->productInPack->id);
-        $this->assertEquals(5, $nbPack);
-        $this->assertEquals(50, $nbProduct);
+        static::assertEquals(5, $nbPack);
+        static::assertEquals(50, $nbProduct);
 
         // Pack type decrement pack and products
         Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PACK_BOTH);
         $nbPack    = Product::getQuantity($this->pack->id);
         $nbProduct = Product::getQuantity($this->productInPack->id);
-        $this->assertEquals(5, $nbPack);
-        $this->assertEquals(50, $nbProduct);
+        static::assertEquals(5, $nbPack);
+        static::assertEquals(50, $nbProduct);
     }
 
     public function testPackIsInStock()
     {
         // Pack type decrement pack only
         Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PACK_ONLY);
-        $this->assertTrue(Pack::isInStock($this->pack->id, 10));
-        $this->assertFalse(Pack::isInStock($this->pack->id, 11));
+        static::assertTrue(Pack::isInStock($this->pack->id, 10));
+        static::assertFalse(Pack::isInStock($this->pack->id, 11));
 
         // Pack type decrement products only
         Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PRODUCTS_ONLY);
-        $this->assertTrue(Pack::isInStock($this->pack->id, 5));
-        $this->assertFalse(Pack::isInStock($this->pack->id, 6));
+        static::assertTrue(Pack::isInStock($this->pack->id, 5));
+        static::assertFalse(Pack::isInStock($this->pack->id, 6));
 
         // Pack type decrement pack and products
         Configuration::set('PS_PACK_STOCK_TYPE', Pack::STOCK_TYPE_PACK_BOTH);
-        $this->assertTrue(Pack::isInStock($this->pack->id, 5));
-        $this->assertFalse(Pack::isInStock($this->pack->id, 6));
+        static::assertTrue(Pack::isInStock($this->pack->id, 5));
+        static::assertFalse(Pack::isInStock($this->pack->id, 6));
     }
 
     public function testPackIsPack()
     {
-        $this->assertTrue(Pack::isPack($this->pack->id));
+        static::assertTrue(Pack::isPack($this->pack->id));
     }
 
     public function testProductsQuantitiesInCart()
@@ -165,30 +165,30 @@ class AddPackTest extends AbstractCartTest
         $packLeftExpected,
         $productLeftExpected
     ) {
-        $this->assertTrue($this->cart->updateQty(2, $this->pack->id));
-        $this->assertTrue($this->cart->updateQty(30, $this->productInPack->id));
+        static::assertTrue($this->cart->updateQty(2, $this->pack->id));
+        static::assertTrue($this->cart->updateQty(30, $this->productInPack->id));
 
         $nbPackInCart    = $this->cart->getProductQuantity($this->pack->id);
         $nbProductInCart = $this->cart->getProductQuantity($this->productInPack->id);
 
-        $this->assertEquals($packQuantity, $nbPackInCart['quantity']);
-        $this->assertEquals($packDeepQuantity, $nbPackInCart['deep_quantity']);
-        $this->assertEquals($productQuantity, $nbProductInCart['quantity']);
-        $this->assertEquals($productDeepQuantity, $nbProductInCart['deep_quantity']);
+        static::assertEquals($packQuantity, $nbPackInCart['quantity']);
+        static::assertEquals($packDeepQuantity, $nbPackInCart['deep_quantity']);
+        static::assertEquals($productQuantity, $nbProductInCart['quantity']);
+        static::assertEquals($productDeepQuantity, $nbProductInCart['deep_quantity']);
 
         $cartProducts = $this->cart->getProducts(true);
-        $this->assertCount(2, $cartProducts);
+        static::assertCount(2, $cartProducts);
 
         foreach ($cartProducts as $cartProduct) {
-            $this->assertContains($cartProduct['id_product'], [$this->pack->id, $this->productInPack->id]);
+            static::assertContains($cartProduct['id_product'], [$this->pack->id, $this->productInPack->id]);
 
             if ($cartProduct['id_product'] == $this->pack->id) {
-                $this->assertEquals(
+                static::assertEquals(
                     $packLeftExpected,
                     Product::getQuantity($cartProduct['id_product'], null, null, $this->cart)
                 );
             } else {
-                $this->assertEquals(
+                static::assertEquals(
                     $productLeftExpected,
                     Product::getQuantity($cartProduct['id_product'], null, null, $this->cart)
                 );
@@ -203,27 +203,27 @@ class AddPackTest extends AbstractCartTest
     {
         // Test pack out of stock disabled
         StockAvailable::setProductOutOfStock($this->pack->id, false);
-        $this->assertFalse($this->cart->updateQty(11, $this->pack->id));
+        static::assertFalse($this->cart->updateQty(11, $this->pack->id));
         $outOfStock = StockAvailable::outOfStock($this->pack->id);
-        $this->assertEquals(0, $this->pack->isAvailableWhenOutOfStock($outOfStock));
+        static::assertEquals(0, $this->pack->isAvailableWhenOutOfStock($outOfStock));
 
         // Test pack out of stock enabled
         StockAvailable::setProductOutOfStock($this->pack->id, true);
-        $this->assertTrue($this->cart->updateQty(11, $this->pack->id));
+        static::assertTrue($this->cart->updateQty(11, $this->pack->id));
         $outOfStock = StockAvailable::outOfStock($this->pack->id);
-        $this->assertEquals(1, $this->pack->isAvailableWhenOutOfStock($outOfStock));
+        static::assertEquals(1, $this->pack->isAvailableWhenOutOfStock($outOfStock));
 
         // Test pack out of stock disabled
         StockAvailable::setProductOutOfStock($this->productInPack->id, false);
-        $this->assertFalse($this->cart->updateQty(51, $this->productInPack->id));
+        static::assertFalse($this->cart->updateQty(51, $this->productInPack->id));
         $outOfStock = StockAvailable::outOfStock($this->productInPack->id);
-        $this->assertEquals(0, $this->pack->isAvailableWhenOutOfStock($outOfStock));
+        static::assertEquals(0, $this->pack->isAvailableWhenOutOfStock($outOfStock));
 
         // Test pack out of stock enabled
         StockAvailable::setProductOutOfStock($this->productInPack->id, true);
-        $this->assertTrue($this->cart->updateQty(51, $this->productInPack->id));
+        static::assertTrue($this->cart->updateQty(51, $this->productInPack->id));
         $outOfStock = StockAvailable::outOfStock($this->productInPack->id);
-        $this->assertEquals(1, $this->pack->isAvailableWhenOutOfStock($outOfStock));
+        static::assertEquals(1, $this->pack->isAvailableWhenOutOfStock($outOfStock));
     }
 
     public function testUnableToAddPackOutOfStock()
@@ -232,26 +232,26 @@ class AddPackTest extends AbstractCartTest
         $this->pack->pack_stock_type = Pack::STOCK_TYPE_PACK_ONLY;
         $this->pack->update();
         StockAvailable::setProductOutOfStock($this->pack->id, false);
-        $this->assertTrue($this->cart->updateQty(9, $this->pack->id));
-        $this->assertFalse(Pack::isInStock($this->pack->id, 2, $this->cart));
-        $this->assertTrue(Pack::isInStock($this->pack->id, 1, $this->cart));
+        static::assertTrue($this->cart->updateQty(9, $this->pack->id));
+        static::assertFalse(Pack::isInStock($this->pack->id, 2, $this->cart));
+        static::assertTrue(Pack::isInStock($this->pack->id, 1, $this->cart));
         $this->resetCart();
 
         // Pack type decrement product only
         $this->pack->pack_stock_type = Pack::STOCK_TYPE_PRODUCTS_ONLY;
         $this->pack->update();
         StockAvailable::setProductOutOfStock($this->pack->id, false);
-        $this->assertTrue($this->cart->updateQty(40, $this->productInPack->id));
-        $this->assertFalse(Pack::isInStock($this->pack->id, 2, $this->cart));
-        $this->assertTrue(Pack::isInStock($this->pack->id, 1, $this->cart));
+        static::assertTrue($this->cart->updateQty(40, $this->productInPack->id));
+        static::assertFalse(Pack::isInStock($this->pack->id, 2, $this->cart));
+        static::assertTrue(Pack::isInStock($this->pack->id, 1, $this->cart));
         $this->resetCart();
 
         // Pack type decrement pack and product
         $this->pack->pack_stock_type = Pack::STOCK_TYPE_PACK_BOTH;
         $this->pack->update();
         StockAvailable::setProductOutOfStock($this->pack->id, false);
-        $this->assertTrue($this->cart->updateQty(40, $this->productInPack->id));
-        $this->assertFalse(Pack::isInStock($this->pack->id, 2, $this->cart));
-        $this->assertTrue(Pack::isInStock($this->pack->id, 1, $this->cart));
+        static::assertTrue($this->cart->updateQty(40, $this->productInPack->id));
+        static::assertFalse(Pack::isInStock($this->pack->id, 2, $this->cart));
+        static::assertTrue(Pack::isInStock($this->pack->id, 1, $this->cart));
     }
 }

--- a/tests-legacy/Unit/Core/Cart/Adding/Product/AddStandardProductTest.php
+++ b/tests-legacy/Unit/Core/Cart/Adding/Product/AddStandardProductTest.php
@@ -37,14 +37,14 @@ class AddStandardProductTest extends AbstractCartTest
         $product = $this->getProductFromFixtureId(1);
 
         $nbProduct = Product::getQuantity($product->id, null, null, $this->cart, null);
-        $this->assertEquals(1000, $nbProduct);
+        static::assertEquals(1000, $nbProduct);
 
         $result = $this->cart->updateQty(11, $product->id);
-        $this->assertTrue($result);
+        static::assertTrue($result);
         $qty = $this->cart->getProductQuantity($product->id, null, null);
-        $this->assertEquals(11, $qty['quantity']);
+        static::assertEquals(11, $qty['quantity']);
         $nbProduct = Product::getQuantity($product->id, null, null, $this->cart, null);
-        $this->assertEquals(989, $nbProduct);
+        static::assertEquals(989, $nbProduct);
     }
 
     public function testProductCannotBeAddedInCartIfMoreThanStock()
@@ -52,11 +52,11 @@ class AddStandardProductTest extends AbstractCartTest
         $product = $this->getProductFromFixtureId(1);
 
         $result = $this->cart->updateQty(1100, $product->id);
-        $this->assertFalse($result);
+        static::assertFalse($result);
         $qty = $this->cart->getProductQuantity($product->id, null, null);
-        $this->assertEquals(0, $qty['quantity']);
+        static::assertEquals(0, $qty['quantity']);
         $nbProduct = Product::getQuantity($product->id, null, null, $this->cart, null);
-        $this->assertEquals(1000, $nbProduct);
+        static::assertEquals(1000, $nbProduct);
     }
 
     public function testProductCanBeAddedInCartIfMoreThanStockButAvailableWhenOutOfStock()
@@ -69,11 +69,11 @@ class AddStandardProductTest extends AbstractCartTest
         $product->save();
 
         $result = $this->cart->updateQty(1100, $product->id);
-        $this->assertTrue($result);
+        static::assertTrue($result);
         $qty = $this->cart->getProductQuantity($product->id, null, null);
-        $this->assertEquals(1100, $qty['quantity']);
+        static::assertEquals(1100, $qty['quantity']);
         $nbProduct = Product::getQuantity($product->id, null, null, $this->cart, null);
-        $this->assertEquals(-100, $nbProduct);
+        static::assertEquals(-100, $nbProduct);
 
         Configuration::set('PS_ORDER_OUT_OF_STOCK', $oldOrderOutOfStock);
     }
@@ -102,8 +102,8 @@ class AddStandardProductTest extends AbstractCartTest
             $id_address_delivery = 0
         );
 
-        $this->assertEquals($expected, $result);
-        $this->assertEquals($quantityExpected, $cartProductQuantity['quantity']);
+        static::assertEquals($expected, $result);
+        static::assertEquals($quantityExpected, $cartProductQuantity['quantity']);
     }
 
     public function updateQuantitiesProvider()

--- a/tests-legacy/Unit/Core/Cart/Calculation/AbstractCartCalculationTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/AbstractCartCalculationTest.php
@@ -43,10 +43,10 @@ abstract class AbstractCartCalculationTest extends AbstractCartTest
         $expectedTotal = round($expectedTotal, 1);
         $totalV1       = round($totalV1, 1);
         if (!$knownToFailOnV1) {
-            $this->assertEquals($expectedTotal, $totalV1, 'V1 fail (tax incl)');
+            static::assertEquals($expectedTotal, $totalV1, 'V1 fail (tax incl)');
         }
         $totalV2 = round($totalV2, 1);
-        $this->assertEquals($expectedTotal, $totalV2, 'V2 fail (tax incl)');
+        static::assertEquals($expectedTotal, $totalV2, 'V2 fail (tax incl)');
     }
 
     protected function compareCartTotalTaxExcl($expectedTotal, $knownToFailOnV1 = false)
@@ -58,9 +58,9 @@ abstract class AbstractCartCalculationTest extends AbstractCartTest
         $expectedTotal = round($expectedTotal, 1);
         $totalV1       = round($totalV1, 1);
         if (!$knownToFailOnV1) {
-            $this->assertEquals($expectedTotal, $totalV1, 'V1 fail (tax excl)');
+            static::assertEquals($expectedTotal, $totalV1, 'V1 fail (tax excl)');
         }
         $totalV2 = round($totalV2, 1);
-        $this->assertEquals($expectedTotal, $totalV2, 'V2 fail (tax excl)');
+        static::assertEquals($expectedTotal, $totalV2, 'V2 fail (tax excl)');
     }
 }

--- a/tests-legacy/Unit/Core/Cart/Calculation/Carrier/CarrierTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/Carrier/CarrierTest.php
@@ -49,7 +49,7 @@ class CarrierTest extends AbstractCarrierTest
         $this->setCartAddress($addressId);
 
         // assertions
-        $this->assertEquals($expectedShippingFees, $this->cart->getPackageShippingCost($this->cart->id_carrier));
+        static::assertEquals($expectedShippingFees, $this->cart->getPackageShippingCost($this->cart->id_carrier));
         $this->compareCartTotalTaxIncl($expectedTotal);
     }
 
@@ -72,7 +72,7 @@ class CarrierTest extends AbstractCarrierTest
         $this->setCartAddress($addressId);
 
         // assertions
-        $this->assertEquals(
+        static::assertEquals(
             round($expectedShippingFees, 1),
             round($this->cart->getPackageShippingCost($this->cart->id_carrier), 1)
         );

--- a/tests-legacy/Unit/Core/Cart/Calculation/Carrier/CartRulesCarrierSpecificTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/Carrier/CartRulesCarrierSpecificTest.php
@@ -58,7 +58,7 @@ class CartRulesCarrierSpecificTest extends AbstractCarrierTest
         $this->setCartCarrierFromFixtureId($carrierId);
         $this->setCartAddress($addressId);
         $result = $this->addCartRulesToCart($cartRuleData);
-        $this->assertTrue($result);
+        static::assertTrue($result);
 
         // assertions
         $this->compareCartTotalTaxIncl($expectedTotal);

--- a/tests-legacy/Unit/Core/Cart/Calculation/Carrier/RuleWhenChangingCarrierTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/Carrier/RuleWhenChangingCarrierTest.php
@@ -96,24 +96,24 @@ class RuleWhenChangingCarrierTest extends AbstractCarrierTest
         // tests
         $cartRule = $this->getCartRuleFromFixtureId(2);
         $result   = $cartRule->checkValidity(\Context::getContext(), false, false);
-        $this->assertFalse($result);
+        static::assertFalse($result);
 
         $cartRule = $this->getCartRuleFromFixtureId(1);
         $result   = $cartRule->checkValidity(\Context::getContext(), false, false);
-        $this->assertTrue($result);
+        static::assertTrue($result);
         $this->cartRulesInCart[] = $cartRule;
         $result                  = $this->cart->addCartRule($cartRule->id);
-        $this->assertTrue($result);
+        static::assertTrue($result);
         $cartRules = $this->cart->getCartRules();
-        $this->assertCount(1, $cartRules);
+        static::assertCount(1, $cartRules);
 
         $result = $cartRule->checkValidity(\Context::getContext(), false, false);
-        $this->assertFalse($result);
+        static::assertFalse($result);
         $this->cartRulesInCart[] = $cartRule;
         $result                  = $this->cart->addCartRule($cartRule->id);
-        $this->assertFalse($result);
+        static::assertFalse($result);
         $cartRules = $this->cart->getCartRules();
-        $this->assertCount(1, $cartRules);
+        static::assertCount(1, $cartRules);
     }
 
     public function testCarrierSpecificCartRuleNotCorresponding()
@@ -126,7 +126,7 @@ class RuleWhenChangingCarrierTest extends AbstractCarrierTest
         // tests
         $cartRule = $this->getCartRuleFromFixtureId(2);
         $result   = $cartRule->checkValidity(\Context::getContext(), false, false);
-        $this->assertFalse($result);
+        static::assertFalse($result);
     }
 
     public function testCarrierSpecificCartRuleRemovedWhenChangingCarrier()
@@ -140,14 +140,14 @@ class RuleWhenChangingCarrierTest extends AbstractCarrierTest
         $cartRule                = $this->getCartRuleFromFixtureId(1);
         $this->cartRulesInCart[] = $cartRule;
         $result                  = $this->cart->addCartRule($cartRule->id);
-        $this->assertTrue($result);
+        static::assertTrue($result);
         $cartRules = $this->cart->getCartRules();
-        $this->assertCount(1, $cartRules);
+        static::assertCount(1, $cartRules);
 
         $this->setCartCarrierFromFixtureId(1);
 
         $cartRules = $this->cart->getCartRules();
-        $this->assertCount(0, $cartRules);
+        static::assertCount(0, $cartRules);
     }
 
     public function testCarrierSpecificCartRuleWithoutCodeSetAndUnset()
@@ -159,12 +159,12 @@ class RuleWhenChangingCarrierTest extends AbstractCarrierTest
         // tests
         $this->setCartCarrierFromFixtureId(2);
         $cartRules = $this->cart->getCartRules();
-        $this->assertCount(0, $cartRules);
+        static::assertCount(0, $cartRules);
         $this->setCartCarrierFromFixtureId(3);
         $cartRules = $this->cart->getCartRules();
-        $this->assertCount(1, $cartRules);
+        static::assertCount(1, $cartRules);
         $this->setCartCarrierFromFixtureId(2);
         $cartRules = $this->cart->getCartRules();
-        $this->assertCount(0, $cartRules);
+        static::assertCount(0, $cartRules);
     }
 }

--- a/tests-legacy/Unit/Core/Cart/Calculation/CartRules/CartRulesGiftTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/CartRules/CartRulesGiftTest.php
@@ -50,7 +50,7 @@ class CartRulesGiftTest extends AbstractCartCalculationTest
         $this->addProductsToCart($productData);
         $this->addCartRulesToCart($cartRuleData);
         $this->compareCartTotalTaxIncl($expectedTotal, $knownToFailOnV1);
-        $this->assertEquals($expectedProductCount, \Cart::getNbProducts($this->cart->id));
+        static::assertEquals($expectedProductCount, \Cart::getNbProducts($this->cart->id));
     }
 
     public function cartWithGiftProvider()

--- a/tests-legacy/Unit/Core/Cart/Calculation/CartRules/CartRulesWithoutCodeTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/CartRules/CartRulesWithoutCodeTest.php
@@ -55,7 +55,7 @@ class CartRulesWithoutCodeTest extends AbstractCartCalculationTest
         }
         $cartRule = $this->getCartRuleFromFixtureId(1);
         $result   = $cartRule->checkValidity(\Context::getContext(), false, false);
-        $this->assertTrue($result);
+        static::assertTrue($result);
 
         $expectedTotal = (1 - $cartRulesData[14]['percent'] / 100)
                          * (1 - $cartRulesData[15]['percent'] / 100)

--- a/tests-legacy/Unit/Core/Cart/Calculation/Modes/RoundingModeTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/Modes/RoundingModeTest.php
@@ -85,9 +85,9 @@ class RoundingModeTest extends AbstractCartCalculationTest
         $this->addProductsToCart($productData);
         $this->addCartRulesToCart($cartRuleData);
         $totalV1 = $this->cart->getOrderTotalV1();
-        $this->assertEquals($expectedTotal, $totalV1, 'V1 fail (tax incl)');
+        static::assertEquals($expectedTotal, $totalV1, 'V1 fail (tax incl)');
         $totalV2 = $this->cart->getOrderTotal();
-        $this->assertEquals($expectedTotal, $totalV2, 'V2 fail (tax excl)');
+        static::assertEquals($expectedTotal, $totalV2, 'V2 fail (tax excl)');
     }
 
     public function roundingModeDataProvider()

--- a/tests-legacy/Unit/Core/Cart/Calculation/Modes/RoundingTypeTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/Modes/RoundingTypeTest.php
@@ -82,9 +82,9 @@ class RoundingTypeTest extends AbstractCartCalculationTest
         $this->addProductsToCart($productData);
         $this->addCartRulesToCart($cartRuleData);
         $totalV1 = $this->cart->getOrderTotalV1();
-        $this->assertEquals($expectedTotal, $totalV1, 'V1 fail (tax incl)');
+        static::assertEquals($expectedTotal, $totalV1, 'V1 fail (tax incl)');
         $totalV2 = $this->cart->getOrderTotal();
-        $this->assertEquals($expectedTotal, $totalV2, 'V2 fail (tax excl)');
+        static::assertEquals($expectedTotal, $totalV2, 'V2 fail (tax excl)');
     }
 
     public function roundingTypeDataProvider()

--- a/tests-legacy/Unit/Core/Cldr/RepositoryTest.php
+++ b/tests-legacy/Unit/Core/Cldr/RepositoryTest.php
@@ -62,11 +62,11 @@ class RepositoryTest extends UnitTestCase
 
     public function testCacheFolderIsCreated()
     {
-        $this->assertFileNotExists($this->cldrCacheFolder);
+        static::assertFileNotExists($this->cldrCacheFolder);
 
         mkdir($this->cldrCacheFolder, 0777, true);
 
-        $this->assertFileExists($this->cldrCacheFolder);
+        static::assertFileExists($this->cldrCacheFolder);
     }
 
     public function testSetLocale()
@@ -74,14 +74,14 @@ class RepositoryTest extends UnitTestCase
         $this->locale = 'fr';
         $this->localeRepository = $this->repository->locales[$this->locale];
 
-        $this->assertEquals($this->locale, 'fr');
-        $this->assertEquals($this->localeRepository->__get('code'), 'fr');
+        static::assertEquals($this->locale, 'fr');
+        static::assertEquals($this->localeRepository->__get('code'), 'fr');
     }
 
     public function testSetRegion()
     {
         $this->region = 'FR';
-        $this->assertEquals($this->region, 'FR');
+        static::assertEquals($this->region, 'FR');
     }
 
     public function testGetCurrencyIsoCodeNum()
@@ -89,23 +89,23 @@ class RepositoryTest extends UnitTestCase
         $code = 'EUR';
         $currencies = $this->repository->supplemental['codeMappings'];
 
-        $this->assertEquals($currencies[$code]['_numeric'], '978');
+        static::assertEquals($currencies[$code]['_numeric'], '978');
     }
 
     public function testGetCurrencyWithoutCode()
     {
         $territory = $this->repository->territories[$this->region];
 
-        $this->assertEquals($territory->code, 'FR');
+        static::assertEquals($territory->code, 'FR');
 
         $code = (string)$territory->currency;
 
-        $this->assertEquals($code, 'EUR');
+        static::assertEquals($code, 'EUR');
 
         $currency = new Currency($this->repository, $code);
         $localized_currency = $currency->localize($this->locale);
 
-        $this->assertEquals($localized_currency->name, 'euro');
+        static::assertEquals($localized_currency->name, 'euro');
     }
 
     public function testGetCurrencyWithCode()
@@ -115,14 +115,14 @@ class RepositoryTest extends UnitTestCase
         $currency = new Currency($this->repository, $code);
         $localized_currency = $currency->localize($this->locale);
 
-        $this->assertEquals($localized_currency->name, 'euro');
+        static::assertEquals($localized_currency->name, 'euro');
     }
 
     public function testGetAllCurrencies()
     {
         $currencies = $this->repository->supplemental['codeMappings'];
 
-        $this->assertCount(486, $currencies);
+        static::assertCount(486, $currencies);
 
         $datas = array();
         foreach ($currencies as $k => $v) {
@@ -132,6 +132,6 @@ class RepositoryTest extends UnitTestCase
             $datas[] = $k;
         }
 
-        $this->assertCount(177, $datas);
+        static::assertCount(177, $datas);
     }
 }

--- a/tests-legacy/Unit/Core/Crypto/Core_Crypto_Hashing_Test.php
+++ b/tests-legacy/Unit/Core/Crypto/Core_Crypto_Hashing_Test.php
@@ -45,18 +45,18 @@ class Core_Crypto_Hashing_Test extends TestCase
 
     public function testSimpleCheckHashMd5()
     {
-        $this->assertTrue($this->hashing->checkHash("123", md5(_COOKIE_KEY_."123"), _COOKIE_KEY_));
-        $this->assertFalse($this->hashing->checkHash("23", md5(_COOKIE_KEY_."123"), _COOKIE_KEY_));
+        static::assertTrue($this->hashing->checkHash("123", md5(_COOKIE_KEY_."123"), _COOKIE_KEY_));
+        static::assertFalse($this->hashing->checkHash("23", md5(_COOKIE_KEY_."123"), _COOKIE_KEY_));
     }
 
     public function testSimpleEncrypt()
     {
-        $this->assertInternalType('string', $this->hashing->hash("123", _COOKIE_KEY_));
+        static::assertInternalType('string', $this->hashing->hash("123", _COOKIE_KEY_));
     }
 
     public function testSimpleFirstHash()
     {
-        $this->assertTrue($this->hashing->isFirstHash("123", $this->hashing->hash("123", _COOKIE_KEY_), _COOKIE_KEY_));
-        $this->assertFalse($this->hashing->isFirstHash("123", md5("123", _COOKIE_KEY_), _COOKIE_KEY_));
+        static::assertTrue($this->hashing->isFirstHash("123", $this->hashing->hash("123", _COOKIE_KEY_), _COOKIE_KEY_));
+        static::assertFalse($this->hashing->isFirstHash("123", md5("123", _COOKIE_KEY_), _COOKIE_KEY_));
     }
 }

--- a/tests-legacy/Unit/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandlerTest.php
+++ b/tests-legacy/Unit/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandlerTest.php
@@ -48,8 +48,8 @@ class GetSqlRequestSettingsHandlerTest extends TestCase
         $getSqlRequestSettingsHandler = new GetSqlRequestSettingsHandler($configuration);
         $sqlRequestSettings = $getSqlRequestSettingsHandler->handle(new GetSqlRequestSettings());
 
-        $this->assertInstanceOf(SqlRequestSettings::class, $sqlRequestSettings);
-        $this->assertEquals($expectedValue, $sqlRequestSettings->getFileEncoding());
+        static::assertInstanceOf(SqlRequestSettings::class, $sqlRequestSettings);
+        static::assertEquals($expectedValue, $sqlRequestSettings->getFileEncoding());
     }
 
     public function getInvalidConfiguration()

--- a/tests-legacy/Unit/Core/Filter/CollectionFilterTest.php
+++ b/tests-legacy/Unit/Core/Filter/CollectionFilterTest.php
@@ -47,7 +47,7 @@ class CollectionFilterTest extends \PHPUnit\Framework\TestCase
 
         $result = $filter->filter($subject);
 
-        $this->assertSame($expectedResult, $result);
+        static::assertSame($expectedResult, $result);
     }
 
     public function provideTestCases()

--- a/tests-legacy/Unit/Core/Filter/HashMapWhitelistFilterTest.php
+++ b/tests-legacy/Unit/Core/Filter/HashMapWhitelistFilterTest.php
@@ -44,7 +44,7 @@ class HashMapWhitelistFilterTest extends \PHPUnit\Framework\TestCase
 
         $result = $filter->filter($subject);
 
-        $this->assertSame($expectedResult, $result);
+        static::assertSame($expectedResult, $result);
     }
 
     public function testKeysCanBeRemovedFromWhitelist()
@@ -65,7 +65,7 @@ class HashMapWhitelistFilterTest extends \PHPUnit\Framework\TestCase
             'bar' => null,
         ];
 
-        $this->assertSame($expected, $filter->filter($subject));
+        static::assertSame($expected, $filter->filter($subject));
 
         // remove 'foo' from whitelist and filter again
         $filter->removeFromWhitelist('foo');
@@ -73,7 +73,7 @@ class HashMapWhitelistFilterTest extends \PHPUnit\Framework\TestCase
             'bar' => null,
         ];
 
-        $this->assertSame($expected, $filter->filter($subject));
+        static::assertSame($expected, $filter->filter($subject));
     }
 
     public function testKeysCanBeAddedToWhitelist()
@@ -93,7 +93,7 @@ class HashMapWhitelistFilterTest extends \PHPUnit\Framework\TestCase
             'foo' => 'something',
         ];
 
-        $this->assertSame($expected, $filter->filter($subject));
+        static::assertSame($expected, $filter->filter($subject));
 
         // add 'bar' to the whitelist and filter again
         $filter->whitelist(['bar']);
@@ -102,7 +102,7 @@ class HashMapWhitelistFilterTest extends \PHPUnit\Framework\TestCase
             'bar' => null,
         ];
 
-        $this->assertSame($expected, $filter->filter($subject));
+        static::assertSame($expected, $filter->filter($subject));
     }
 
     public function provideTestCases()

--- a/tests-legacy/Unit/Core/Foundation/Database/EntityManager/Core_Foundation_Database_EntityManager_QueryBuilder_Test.php
+++ b/tests-legacy/Unit/Core/Foundation/Database/EntityManager/Core_Foundation_Database_EntityManager_QueryBuilder_Test.php
@@ -47,25 +47,25 @@ class Core_Foundation_Database_EntityManager_QueryBuilder_Test extends UnitTestC
 
     public function testQuoteNumberNotQuoted()
     {
-        $this->assertEquals('escaped', $this->queryBuilder->quote(42));
-        $this->assertEquals('escaped', $this->queryBuilder->quote(4.2));
+        static::assertEquals('escaped', $this->queryBuilder->quote(42));
+        static::assertEquals('escaped', $this->queryBuilder->quote(4.2));
     }
 
     public function testQuoteStringQuoted()
     {
-        $this->assertEquals('\'escaped\'', $this->queryBuilder->quote('hello'));
+        static::assertEquals('\'escaped\'', $this->queryBuilder->quote('hello'));
     }
 
     public function testBuildWhereConditionsANDJustOneCondition()
     {
-        $this->assertEquals("name = 'escaped'", $this->queryBuilder->buildWhereConditions('AND', array(
+        static::assertEquals("name = 'escaped'", $this->queryBuilder->buildWhereConditions('AND', array(
             'name' => 'some string',
         )));
     }
 
     public function testBuildWhereConditionsANDTwoConditions()
     {
-        $this->assertEquals("name = 'escaped' AND num = escaped", $this->queryBuilder->buildWhereConditions('AND', array(
+        static::assertEquals("name = 'escaped' AND num = escaped", $this->queryBuilder->buildWhereConditions('AND', array(
             'name' => 'some string',
             'num' => 123456,
         )));
@@ -73,7 +73,7 @@ class Core_Foundation_Database_EntityManager_QueryBuilder_Test extends UnitTestC
 
     public function testBuildWhereConditionsArrayValue()
     {
-        $this->assertEquals("stuff IN ('escaped', escaped, escaped)", $this->queryBuilder->buildWhereConditions('AND', array(
+        static::assertEquals("stuff IN ('escaped', escaped, escaped)", $this->queryBuilder->buildWhereConditions('AND', array(
             'stuff' => array('a string', 123, 456452),
         )));
     }

--- a/tests-legacy/Unit/Core/Foundation/FileSystem/Core_Foundation_FileSystem_FileSystemTest.php
+++ b/tests-legacy/Unit/Core/Foundation/FileSystem/Core_Foundation_FileSystem_FileSystemTest.php
@@ -42,7 +42,7 @@ class Core_Foundation_FileSystem_FileSystemTest extends UnitTestCase
 
     public function testJoinPathsTwoPaths()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'a' . DIRECTORY_SEPARATOR . 'b',
             $this->fs->joinPaths('a', 'b')
         );
@@ -50,7 +50,7 @@ class Core_Foundation_FileSystem_FileSystemTest extends UnitTestCase
 
     public function testJoinPathsThreePaths()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'a' . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'c',
             $this->fs->joinPaths('a', 'b', 'c')
         );
@@ -76,7 +76,7 @@ class Core_Foundation_FileSystem_FileSystemTest extends UnitTestCase
 
     public function testJoinPathsNormalizesDirectorySeparators()
     {
-        $this->assertEquals(
+        static::assertEquals(
             'a' . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'd',
             $this->fs->joinPaths('a\\', 'b///', 'c\\', 'd/')
         );
@@ -92,7 +92,7 @@ class Core_Foundation_FileSystem_FileSystemTest extends UnitTestCase
             $this->fs->joinPaths($this->fixturesPath, 'toplevel.txt'),
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             $expectedPaths,
             array_keys($this->fs->listEntriesRecursively($this->fixturesPath))
         );
@@ -106,7 +106,7 @@ class Core_Foundation_FileSystem_FileSystemTest extends UnitTestCase
             $this->fs->joinPaths($this->fixturesPath, 'toplevel.txt'),
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             $expectedPaths,
             array_keys($this->fs->listFilesRecursively($this->fixturesPath))
         );

--- a/tests-legacy/Unit/Core/Foundation/IoC/Core_Foundation_IoC_Container_Test.php
+++ b/tests-legacy/Unit/Core/Foundation/IoC/Core_Foundation_IoC_Container_Test.php
@@ -49,7 +49,7 @@ class Core_Foundation_IoC_Container_Test extends TestCase
             return 'FOO';
         });
 
-        $this->assertEquals('FOO', $this->container->make('foo'));
+        static::assertEquals('FOO', $this->container->make('foo'));
     }
 
     /**
@@ -71,7 +71,7 @@ class Core_Foundation_IoC_Container_Test extends TestCase
         $first = $this->container->make('different');
         $second = $this->container->make('different');
 
-        $this->assertNotSame($first, $second);
+        static::assertNotSame($first, $second);
     }
 
     public function testBindByClosureInstanceSharedIfExplicitelyRequired()
@@ -83,21 +83,21 @@ class Core_Foundation_IoC_Container_Test extends TestCase
         $first = $this->container->make('same');
         $second = $this->container->make('same');
 
-        $this->assertSame($first, $second);
+        static::assertSame($first, $second);
     }
 
     public function testBindClassName()
     {
         $this->container->bind('dummy', 'LegacyTests\Unit\Core\Foundation\IoC\Fixtures\Dummy');
 
-        $this->assertEquals('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\Dummy', get_class(
+        static::assertEquals('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\Dummy', get_class(
             $this->container->make('dummy')
         ));
     }
 
     public function testMakeWithoutBind()
     {
-        $this->assertEquals('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\Dummy', get_class(
+        static::assertEquals('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\Dummy', get_class(
             $this->container->make('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\Dummy')
         ));
     }
@@ -106,7 +106,7 @@ class Core_Foundation_IoC_Container_Test extends TestCase
     {
         $this->container->aliasNamespace('Fixtures', 'LegacyTests\Unit\Core\Foundation\IoC\Fixtures');
 
-        $this->assertEquals('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\Dummy', get_class(
+        static::assertEquals('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\Dummy', get_class(
             $this->container->make('Fixtures:Dummy')
         ));
     }
@@ -123,14 +123,14 @@ class Core_Foundation_IoC_Container_Test extends TestCase
 
     public function testDepsAreFetchedAutomagically()
     {
-        $this->assertEquals('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\ClassWithDep', get_class(
+        static::assertEquals('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\ClassWithDep', get_class(
             $this->container->make('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\ClassWithDep')
         ));
     }
 
     public function testDepsAreFetchedAutomagicallyWhenDependsOnThingWithADefaultValue()
     {
-        $this->assertEquals('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\ClassWithDepAndDefault', get_class(
+        static::assertEquals('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\ClassWithDepAndDefault', get_class(
             $this->container->make('LegacyTests\Unit\Core\Foundation\IoC\Fixtures\ClassWithDepAndDefault')
         ));
     }
@@ -178,7 +178,7 @@ class Core_Foundation_IoC_Container_Test extends TestCase
         $instance = $this->container->make(
             'LegacyTests\Unit\Core\Foundation\IoC\Fixtures\ClassDependingOnClosureBuiltDep'
         );
-        $this->assertEquals(42, $instance->getDep()->getValue());
+        static::assertEquals(42, $instance->getDep()->getValue());
     }
 
     /**
@@ -199,7 +199,7 @@ class Core_Foundation_IoC_Container_Test extends TestCase
     public function testContainerCanBindValuesDirectly($value)
     {
         $this->container->bind('value', $value);
-        $this->assertSame($value, $this->container->make('value'));
+        static::assertSame($value, $this->container->make('value'));
     }
 
     /**

--- a/tests-legacy/Unit/Core/Foundation/VersionTest.php
+++ b/tests-legacy/Unit/Core/Foundation/VersionTest.php
@@ -75,27 +75,27 @@ class VersionTest extends TestCase
 
     public function testGetVersion()
     {
-        $this->assertSame(self::VERSION, $this->version->getVersion());
+        static::assertSame(self::VERSION, $this->version->getVersion());
     }
 
     public function testGetMajorVersionString()
     {
-        $this->assertSame(self::MAJOR_VERSION_STRING, $this->version->getMajorVersionString());
+        static::assertSame(self::MAJOR_VERSION_STRING, $this->version->getMajorVersionString());
     }
 
     public function testGetMajorVersion()
     {
-        $this->assertSame(self::MAJOR_VERSION, $this->version->getMajorVersion());
+        static::assertSame(self::MAJOR_VERSION, $this->version->getMajorVersion());
     }
 
     public function testGetMinorVersion()
     {
-        $this->assertSame(self::MINOR_VERSION, $this->version->getMinorVersion());
+        static::assertSame(self::MINOR_VERSION, $this->version->getMinorVersion());
     }
 
     public function testGetReleaseVersion()
     {
-        $this->assertSame(self::RELEASE_VERSION, $this->version->getReleaseVersion());
+        static::assertSame(self::RELEASE_VERSION, $this->version->getReleaseVersion());
     }
 
     /**
@@ -106,7 +106,7 @@ class VersionTest extends TestCase
      */
     public function testCompareGreaterVersion($version, $result)
     {
-        $this->assertEquals($result, $this->version->isGreaterThan($version));
+        static::assertEquals($result, $this->version->isGreaterThan($version));
     }
 
     public function getCompareGreater()
@@ -135,7 +135,7 @@ class VersionTest extends TestCase
      */
     public function testCompareGreaterEqualVersion($version, $result)
     {
-        $this->assertEquals($result, $this->version->isGreaterThanOrEqualTo($version));
+        static::assertEquals($result, $this->version->isGreaterThanOrEqualTo($version));
     }
 
     public function getCompareGreaterEqual()
@@ -164,7 +164,7 @@ class VersionTest extends TestCase
      */
     public function testCompareLessVersion($version, $result)
     {
-        $this->assertEquals($result, $this->version->isLessThan($version));
+        static::assertEquals($result, $this->version->isLessThan($version));
     }
 
     public function getCompareLess()
@@ -193,7 +193,7 @@ class VersionTest extends TestCase
      */
     public function testCompareGreaterAnotherVersion($version, $result)
     {
-        $this->assertEquals($result, $this->anotherVersion->isGreaterThan($version), self::ANOTHER_VERSION.' > '.$version . ' must be ' . ($result ? 'true' : 'false'));
+        static::assertEquals($result, $this->anotherVersion->isGreaterThan($version), self::ANOTHER_VERSION.' > '.$version . ' must be ' . ($result ? 'true' : 'false'));
     }
 
     public function getAnotherCompareGreater()
@@ -211,7 +211,7 @@ class VersionTest extends TestCase
      */
     public function testCompareLessEqualVersion($version, $result)
     {
-        $this->assertEquals($result, $this->version->isLessThanOrEqualTo($version));
+        static::assertEquals($result, $this->version->isLessThanOrEqualTo($version));
     }
 
     public function getCompareLessEqual()
@@ -240,7 +240,7 @@ class VersionTest extends TestCase
      */
     public function testCompareEqualVersion($version, $result)
     {
-        $this->assertEquals($result, $this->version->isEqualTo($version));
+        static::assertEquals($result, $this->version->isEqualTo($version));
     }
 
     public function getCompareEqual()
@@ -269,7 +269,7 @@ class VersionTest extends TestCase
      */
     public function testCompareNotEqualVersion($version, $result)
     {
-        $this->assertEquals($result, $this->version->isNotEqualTo($version));
+        static::assertEquals($result, $this->version->isNotEqualTo($version));
     }
 
     public function getCompareNotEqual()

--- a/tests-legacy/Unit/Core/Grid/Column/ColumnCollectionTest.php
+++ b/tests-legacy/Unit/Core/Grid/Column/ColumnCollectionTest.php
@@ -40,7 +40,7 @@ class ColumnCollectionTest extends TestCase
             ->add($this->createColumnMock('second'))
             ->add($this->createColumnMock('third'));
 
-        $this->assertEquals([
+        static::assertEquals([
             'first',
             'second',
             'third',
@@ -59,7 +59,7 @@ class ColumnCollectionTest extends TestCase
             ->addBefore('second', $this->createColumnMock('before_second'))
             ->addBefore('third', $this->createColumnMock('before_third'));
 
-        $this->assertEquals([
+        static::assertEquals([
             'before_first',
             'first',
             'before_second',
@@ -81,7 +81,7 @@ class ColumnCollectionTest extends TestCase
             ->addAfter('second', $this->createColumnMock('after_second'))
             ->addAfter('third', $this->createColumnMock('after_third'));
 
-        $this->assertEquals([
+        static::assertEquals([
             'before_first',
             'first',
             'after_first',
@@ -105,7 +105,7 @@ class ColumnCollectionTest extends TestCase
         $columns->remove('third');
         $columns->remove('non_existing');
 
-        $this->assertCount(7, $columns);
+        static::assertCount(7, $columns);
     }
 
     public function testMixingMethodsProducesCollectionWithCorrectColumnPositions()
@@ -124,7 +124,7 @@ class ColumnCollectionTest extends TestCase
             ->add($this->createColumnMock('third'))
             ->addAfter('second', $this->createColumnMock('after_second'));
 
-        $this->assertEquals([
+        static::assertEquals([
             'before_first',
             'before_first_2',
             'before_first_3',
@@ -148,7 +148,7 @@ class ColumnCollectionTest extends TestCase
             ->addBefore('second', $this->createColumnMock('7'))
             ->add($this->createColumnMock(5));
 
-        $this->assertEquals([
+        static::assertEquals([
             2,
             3,
             1,
@@ -182,8 +182,8 @@ class ColumnCollectionTest extends TestCase
 
         $columnsArray = $columns->toArray();
 
-        $this->assertInternalType('array', $columnsArray);
-        $this->assertCount(3, $columnsArray);
+        static::assertInternalType('array', $columnsArray);
+        static::assertCount(3, $columnsArray);
     }
 
     /**

--- a/tests-legacy/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
+++ b/tests-legacy/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
@@ -42,7 +42,7 @@ class DoctrineGridDataFactoryTest extends TestCase
     public function testItProvidesGridData()
     {
         $hookDispatcher = $this->createHookDispatcherMock();
-        $hookDispatcher->expects($this->once())
+        $hookDispatcher->expects(static::once())
             ->method('dispatchWithParameters');
 
         $queryParser = $this->createQueryParserMock();
@@ -58,12 +58,12 @@ class DoctrineGridDataFactoryTest extends TestCase
 
         $data = $doctrineGridDataFactory->getData($criteria);
 
-        $this->assertInstanceOf(GridDataInterface::class, $data);
-        $this->assertInstanceOf(RecordCollectionInterface::class, $data->getRecords());
+        static::assertInstanceOf(GridDataInterface::class, $data);
+        static::assertInstanceOf(RecordCollectionInterface::class, $data->getRecords());
 
-        $this->assertEquals(4, $data->getRecordsTotal());
-        $this->assertCount(2, $data->getRecords());
-        $this->assertEquals('SELECT * FROM ps_test WHERE id = 1', $data->getQuery());
+        static::assertEquals(4, $data->getRecordsTotal());
+        static::assertCount(2, $data->getRecords());
+        static::assertEquals('SELECT * FROM ps_test WHERE id = 1', $data->getQuery());
     }
 
     /**

--- a/tests-legacy/Unit/Core/Grid/Definition/Factory/AbstractGridDefinitionFactoryTest.php
+++ b/tests-legacy/Unit/Core/Grid/Definition/Factory/AbstractGridDefinitionFactoryTest.php
@@ -47,15 +47,15 @@ class AbstractGridDefinitionFactoryTest extends TestCase
         $definitionFactory = $this->getMockForAbstractClass(AbstractGridDefinitionFactory::class);
 
         $definitionFactory
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('getName')
             ->willReturn('Test name');
         $definitionFactory
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('getId')
             ->willReturn('test_id');
         $definitionFactory
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('getColumns')
             ->willReturn($this->getColumns());
 
@@ -66,27 +66,27 @@ class AbstractGridDefinitionFactoryTest extends TestCase
     {
         $hookDispatcherMock = $this->createMock(HookDispatcherInterface::class);
         $hookDispatcherMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('dispatchWithParameters')
             ->withConsecutive(
-                [$this->equalTo('actionTestIdGridDefinitionModifier')],
-                [$this->isType('array'), $this->arrayHasKey('definition')]
+                [static::equalTo('actionTestIdGridDefinitionModifier')],
+                [static::isType('array'), static::arrayHasKey('definition')]
             );
 
         $this->definitionFactory->setHookDispatcher($hookDispatcherMock);
 
         $definition = $this->definitionFactory->getDefinition();
 
-        $this->assertInstanceOf(GridDefinitionInterface::class, $definition);
-        $this->assertInstanceOf(BulkActionCollectionInterface::class, $definition->getBulkActions());
-        $this->assertInstanceOf(GridActionCollectionInterface::class, $definition->getGridActions());
+        static::assertInstanceOf(GridDefinitionInterface::class, $definition);
+        static::assertInstanceOf(BulkActionCollectionInterface::class, $definition->getBulkActions());
+        static::assertInstanceOf(GridActionCollectionInterface::class, $definition->getGridActions());
 
-        $this->assertEquals($definition->getId(), 'test_id');
-        $this->assertEquals($definition->getName(), 'Test name');
-        $this->assertCount(3, $definition->getColumns());
-        $this->assertCount(0, $definition->getGridActions());
-        $this->assertCount(0, $definition->getBulkActions());
-        $this->assertCount(0, $definition->getFilters()->all());
+        static::assertEquals($definition->getId(), 'test_id');
+        static::assertEquals($definition->getName(), 'Test name');
+        static::assertCount(3, $definition->getColumns());
+        static::assertCount(0, $definition->getGridActions());
+        static::assertCount(0, $definition->getBulkActions());
+        static::assertCount(0, $definition->getFilters()->all());
     }
 
     private function getColumns()

--- a/tests-legacy/Unit/Core/Grid/Filter/FilterCollectionTest.php
+++ b/tests-legacy/Unit/Core/Grid/Filter/FilterCollectionTest.php
@@ -36,7 +36,7 @@ class FilterCollectionTest extends TestCase
     {
         $filters = new FilterCollection();
 
-        $this->assertEmpty($filters->all());
+        static::assertEmpty($filters->all());
 
         return $filters;
     }
@@ -50,7 +50,7 @@ class FilterCollectionTest extends TestCase
         $filters->add($this->getFilterMock('second'));
         $filters->add($this->getFilterMock('third'));
 
-        $this->assertCount(3, $filters->all());
+        static::assertCount(3, $filters->all());
 
         return $filters;
     }
@@ -62,7 +62,7 @@ class FilterCollectionTest extends TestCase
     {
         $filters->remove('second');
 
-        $this->assertCount(2, $filters->all());
+        static::assertCount(2, $filters->all());
     }
 
     private function getFilterMock($name)

--- a/tests-legacy/Unit/Core/Grid/Position/GridPositionUpdaterTest.php
+++ b/tests-legacy/Unit/Core/Grid/Position/GridPositionUpdaterTest.php
@@ -62,11 +62,11 @@ class GridPositionUpdaterTest extends TestCase
         } catch (PositionException $e) {
             $caughtException = $e;
         }
-        $this->assertNotNull($caughtException);
-        $this->assertInstanceOf(PositionUpdateException::class, $caughtException);
-        $this->assertEquals('Could not update #%i', $caughtException->getKey());
-        $this->assertEquals('Admin.Catalog.Notification', $caughtException->getDomain());
-        $this->assertSame([5], $caughtException->getParameters());
+        static::assertNotNull($caughtException);
+        static::assertInstanceOf(PositionUpdateException::class, $caughtException);
+        static::assertEquals('Could not update #%i', $caughtException->getKey());
+        static::assertEquals('Admin.Catalog.Notification', $caughtException->getDomain());
+        static::assertSame([5], $caughtException->getParameters());
     }
 
     /**
@@ -97,8 +97,8 @@ class GridPositionUpdaterTest extends TestCase
         $updaterMock
             ->method('getCurrentPositions')
             ->with(
-                $this->isInstanceOf(PositionDefinitionInterface::class),
-                $this->equalTo(42)
+                static::isInstanceOf(PositionDefinitionInterface::class),
+                static::equalTo(42)
             )
             ->willReturn([
                 1 => 0,
@@ -109,8 +109,8 @@ class GridPositionUpdaterTest extends TestCase
         $updaterMock
             ->method('updatePositions')
             ->with(
-                $this->isInstanceOf(PositionDefinitionInterface::class),
-                $this->equalTo([
+                static::isInstanceOf(PositionDefinitionInterface::class),
+                static::equalTo([
                     1 => 0,
                     5 => 2,
                     42 => 1,
@@ -126,8 +126,8 @@ class GridPositionUpdaterTest extends TestCase
         $updaterMock
             ->method('getCurrentPositions')
             ->with(
-                $this->isInstanceOf(PositionDefinitionInterface::class),
-                $this->equalTo(42)
+                static::isInstanceOf(PositionDefinitionInterface::class),
+                static::equalTo(42)
             )
             ->willReturn([
                 1 => 0,
@@ -138,8 +138,8 @@ class GridPositionUpdaterTest extends TestCase
         $updaterMock
             ->method('updatePositions')
             ->with(
-                $this->isInstanceOf(PositionDefinitionInterface::class),
-                $this->equalTo([
+                static::isInstanceOf(PositionDefinitionInterface::class),
+                static::equalTo([
                     1 => 0,
                     5 => 2,
                     42 => 1,

--- a/tests-legacy/Unit/Core/Grid/Position/PositionUpdateFactoryTest.php
+++ b/tests-legacy/Unit/Core/Grid/Position/PositionUpdateFactoryTest.php
@@ -49,14 +49,14 @@ class PositionUpdateFactoryTest extends TestCase
         $positionUpdate = $positionUpdateFactory->buildPositionUpdate($data, $definition);
         /** @var PositionModificationCollectionInterface $collection */
         $collection = $positionUpdate->getPositionModificationCollection();
-        $this->assertNotNull($collection);
-        $this->assertEquals(1, $collection->count());
+        static::assertNotNull($collection);
+        static::assertEquals(1, $collection->count());
         /** @var PositionModificationInterface $positionModification */
         $positionModification = $collection->current();
-        $this->assertEquals(1, $positionModification->getId());
-        $this->assertEquals(1, $positionModification->getOldPosition());
-        $this->assertEquals(2, $positionModification->getNewPosition());
-        $this->assertNull($positionUpdate->getParentId());
+        static::assertEquals(1, $positionModification->getId());
+        static::assertEquals(1, $positionModification->getOldPosition());
+        static::assertEquals(2, $positionModification->getNewPosition());
+        static::assertNull($positionUpdate->getParentId());
     }
 
     public function testHandleDataWithParent()
@@ -73,14 +73,14 @@ class PositionUpdateFactoryTest extends TestCase
         $positionUpdate = $positionUpdateFactory->buildPositionUpdate($data, $definition);
         /** @var PositionModificationCollectionInterface $collection */
         $collection = $positionUpdate->getPositionModificationCollection();
-        $this->assertNotNull($collection);
-        $this->assertEquals(1, $collection->count());
+        static::assertNotNull($collection);
+        static::assertEquals(1, $collection->count());
         /** @var PositionModificationInterface $positionModification */
         $positionModification = $collection->current();
-        $this->assertEquals(1, $positionModification->getId());
-        $this->assertEquals(1, $positionModification->getOldPosition());
-        $this->assertEquals(2, $positionModification->getNewPosition());
-        $this->assertEquals(42, $positionUpdate->getParentId());
+        static::assertEquals(1, $positionModification->getId());
+        static::assertEquals(1, $positionModification->getOldPosition());
+        static::assertEquals(2, $positionModification->getNewPosition());
+        static::assertEquals(42, $positionUpdate->getParentId());
     }
 
     public function testDataPositionsValidation()
@@ -143,14 +143,14 @@ class PositionUpdateFactoryTest extends TestCase
         }
 
         if (null === $expectedErrorKey) {
-            $this->assertNull($caughtException);
+            static::assertNull($caughtException);
         } else {
-            $this->assertNotNull($caughtException);
-            $this->assertInstanceOf(PositionDataException::class, $caughtException);
-            $this->assertEquals($expectedErrorKey, $caughtException->getKey());
-            $this->assertEquals('Admin.Notifications.Failure', $caughtException->getDomain());
+            static::assertNotNull($caughtException);
+            static::assertInstanceOf(PositionDataException::class, $caughtException);
+            static::assertEquals($expectedErrorKey, $caughtException->getKey());
+            static::assertEquals('Admin.Notifications.Failure', $caughtException->getDomain());
             if (null !== $expectedErrorParameters) {
-                $this->assertSame($expectedErrorParameters, $caughtException->getParameters());
+                static::assertSame($expectedErrorParameters, $caughtException->getParameters());
             }
         }
     }

--- a/tests-legacy/Unit/Core/Grid/Presenter/GridPresenterTest.php
+++ b/tests-legacy/Unit/Core/Grid/Presenter/GridPresenterTest.php
@@ -71,13 +71,13 @@ class GridPresenterTest extends TestCase
             'filters' => [],
         ];
 
-        $this->assertInternalType('array', $presentedGrid);
+        static::assertInternalType('array', $presentedGrid);
 
         foreach ($expectedPresentedGrid as $itemName => $innerStruct) {
-            $this->assertArrayHasKey($itemName, $presentedGrid);
+            static::assertArrayHasKey($itemName, $presentedGrid);
 
             foreach ($innerStruct as $innerItemName) {
-                $this->assertArrayHasKey($innerItemName, $presentedGrid[$itemName]);
+                static::assertArrayHasKey($innerItemName, $presentedGrid[$itemName]);
             }
         }
     }

--- a/tests-legacy/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
+++ b/tests-legacy/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
@@ -56,7 +56,7 @@ class DoctrineQueryParserTest extends TestCase
 
         $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation = 'OK' AND energy = 'none'";
 
-        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+        static::assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
     }
 
     /**
@@ -88,7 +88,7 @@ class DoctrineQueryParserTest extends TestCase
 
         $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation IN ('great', 'good', 'ok', 'nok', 'none')";
 
-        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+        static::assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
     }
 
     /**
@@ -122,7 +122,7 @@ class DoctrineQueryParserTest extends TestCase
 
         $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation IS NULL";
 
-        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+        static::assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
     }
 
     public function testParseWithBooleanNamedParameters()
@@ -134,7 +134,7 @@ class DoctrineQueryParserTest extends TestCase
 
         $expectedQuery = "SELECT tests FROM pierre_rambaud WHERE motivation = FALSE";
 
-        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+        static::assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
 
         $preparedQuery2 = 'SELECT tests FROM pierre_rambaud WHERE energy = :energy';
         $queryParameters2 = [
@@ -143,7 +143,7 @@ class DoctrineQueryParserTest extends TestCase
 
         $expectedQuery2 = "SELECT tests FROM pierre_rambaud WHERE energy = TRUE";
 
-        $this->assertSame($expectedQuery2, $this->queryParser->parse($preparedQuery2, $queryParameters2));
+        static::assertSame($expectedQuery2, $this->queryParser->parse($preparedQuery2, $queryParameters2));
     }
 
     public function testParseWithUnsupportedTypeMustThrowAnException()
@@ -168,7 +168,7 @@ class DoctrineQueryParserTest extends TestCase
 
         $expectedQuery = "SELECT * FROM product WHERE id_product = 2";
 
-        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+        static::assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
 
         $preparedQuery = 'SELECT * FROM product WHERE price = :price';
         $queryParameters = [
@@ -177,6 +177,6 @@ class DoctrineQueryParserTest extends TestCase
 
         $expectedQuery = "SELECT * FROM product WHERE price = 3.99";
 
-        $this->assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
+        static::assertSame($expectedQuery, $this->queryParser->parse($preparedQuery, $queryParameters));
     }
 }

--- a/tests-legacy/Unit/Core/Hook/HookDispatcherTest.php
+++ b/tests-legacy/Unit/Core/Hook/HookDispatcherTest.php
@@ -59,9 +59,9 @@ class HookDispatcherTest extends TestCase
 
         // stub adapter expectations
         $this->hookDispatcherAdapter
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('dispatchForParameters')
-            ->with($this->equalTo('hookName'), $this->equalTo([]));
+            ->with(static::equalTo('hookName'), static::equalTo([]));
 
         $this->hookDispatcher->dispatchHook($hook);
     }
@@ -70,9 +70,9 @@ class HookDispatcherTest extends TestCase
     {
         // stub adapter expectations
         $this->hookDispatcherAdapter
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('dispatchForParameters')
-            ->with($this->equalTo('fooHook'), $this->equalTo(['bar' => 'Bar']));
+            ->with(static::equalTo('fooHook'), static::equalTo(['bar' => 'Bar']));
 
         $this->hookDispatcher->dispatchWithParameters('fooHook', ['bar' => 'Bar']);
     }
@@ -86,7 +86,7 @@ class HookDispatcherTest extends TestCase
 
         // stub adapter expectations
         $this->hookDispatcherAdapter
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('renderForParameters')
             ->with(
                 $hook->getName(),
@@ -96,9 +96,9 @@ class HookDispatcherTest extends TestCase
 
         $renderedHook = $this->hookDispatcher->dispatchRendering($hook);
 
-        $this->assertInstanceOf(RenderedHook::class, $renderedHook);
-        $this->assertEquals($hook, $renderedHook->getHook());
-        $this->assertEquals([], $renderedHook->getContent());
+        static::assertInstanceOf(RenderedHook::class, $renderedHook);
+        static::assertEquals($hook, $renderedHook->getHook());
+        static::assertEquals([], $renderedHook->getContent());
     }
 
     public function testDispatchRenderingWithParameters()
@@ -110,7 +110,7 @@ class HookDispatcherTest extends TestCase
 
         // stub adapter expectations
         $this->hookDispatcherAdapter
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('renderForParameters')
             ->with(
                 $hook->getName(),
@@ -120,9 +120,9 @@ class HookDispatcherTest extends TestCase
 
         $renderedHook = $this->hookDispatcher->dispatchRenderingWithParameters('Baz', ['hello' => 'World']);
 
-        $this->assertInstanceOf(RenderedHook::class, $renderedHook);
-        $this->assertEquals($hook, $renderedHook->getHook());
-        $this->assertEquals(['hello' => 'World'], $renderedHook->getContent());
+        static::assertInstanceOf(RenderedHook::class, $renderedHook);
+        static::assertEquals($hook, $renderedHook->getHook());
+        static::assertEquals(['hello' => 'World'], $renderedHook->getContent());
     }
 
     private function createHook($name = 'hookName', $parameters = [])

--- a/tests-legacy/Unit/Core/Hook/RenderedHookTest.php
+++ b/tests-legacy/Unit/Core/Hook/RenderedHookTest.php
@@ -54,22 +54,22 @@ class RenderedHookTest extends TestCase
 
     public function testGetHook()
     {
-        $this->assertInstanceOf(HookInterface::class, $this->renderedHook->getHook());
-        $this->assertSame($this->hookStub, $this->renderedHook->getHook());
+        static::assertInstanceOf(HookInterface::class, $this->renderedHook->getHook());
+        static::assertSame($this->hookStub, $this->renderedHook->getHook());
     }
 
     public function testGetContent()
     {
-        $this->assertInternalType('array', $this->renderedHook->getContent());
-        $this->assertSame($this->content(), $this->renderedHook->getContent());
+        static::assertInternalType('array', $this->renderedHook->getContent());
+        static::assertSame($this->content(), $this->renderedHook->getContent());
     }
 
     public function testOutputContent()
     {
         /** @see RenderedHookTest::content() */
         $expected = '<h1>Hello World</h1><p>How are you?</p> '; // one extra space in the end is intended.
-        $this->assertInternalType('string', $this->renderedHook->outputContent());
-        $this->assertSame($expected, $this->renderedHook->outputContent());
+        static::assertInternalType('string', $this->renderedHook->outputContent());
+        static::assertSame($expected, $this->renderedHook->outputContent());
     }
 
     /**

--- a/tests-legacy/Unit/Core/Image/Parser/ImageTagSourceParserTest.php
+++ b/tests-legacy/Unit/Core/Image/Parser/ImageTagSourceParserTest.php
@@ -48,7 +48,7 @@ class ImageTagSourceParserTest extends TestCase
     {
         $parsedSource = $this->parser->parse($imageTag);
 
-        $this->assertSame($expectedSource, $parsedSource);
+        static::assertSame($expectedSource, $parsedSource);
     }
 
     public function getTestCases()

--- a/tests-legacy/Unit/Core/Localization/Currency/RepositoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Currency/RepositoryTest.php
@@ -101,11 +101,11 @@ class RepositoryTest extends TestCase
     {
         $currency = $this->currencyRepository->getCurrency($currencyCode);
         foreach ($expectedNames as $localeCode => $name) {
-            $this->assertSame($name, $currency->getName($localeCode));
+            static::assertSame($name, $currency->getName($localeCode));
         }
 
         foreach ($expectedSymbols as $localeCode => $symbol) {
-            $this->assertSame($symbol, $currency->getSymbol($localeCode));
+            static::assertSame($symbol, $currency->getSymbol($localeCode));
         }
     }
 

--- a/tests-legacy/Unit/Core/Localization/CurrencyTest.php
+++ b/tests-legacy/Unit/Core/Localization/CurrencyTest.php
@@ -61,7 +61,7 @@ class CurrencyTest extends TestCase
      */
     public function testIsActive()
     {
-        $this->assertTrue(
+        static::assertTrue(
             $this->currency->isActive(),
             'Wrong result for isActive()'
         );
@@ -74,7 +74,7 @@ class CurrencyTest extends TestCase
      */
     public function testGetConversionRate()
     {
-        $this->assertSame(
+        static::assertSame(
             1,
             $this->currency->getConversionRate(),
             'Wrong result for getConversionRate()'
@@ -88,7 +88,7 @@ class CurrencyTest extends TestCase
      */
     public function testGetIsoCode()
     {
-        $this->assertSame(
+        static::assertSame(
             'EUR',
             $this->currency->getIsoCode(),
             'Wrong result for getIsoCode()'
@@ -102,7 +102,7 @@ class CurrencyTest extends TestCase
      */
     public function testGetNumericIsoCode()
     {
-        $this->assertSame(
+        static::assertSame(
             978,
             $this->currency->getNumericIsoCode(),
             'Wrong result for getNumericIsoCode()'
@@ -117,7 +117,7 @@ class CurrencyTest extends TestCase
     public function testGetSymbol()
     {
         /** @noinspection PhpUnhandledExceptionInspection */
-        $this->assertSame(
+        static::assertSame(
             '€',
             $this->currency->getSymbol('fr-FR'),
             'Wrong result for getSymbol()'
@@ -145,7 +145,7 @@ class CurrencyTest extends TestCase
      */
     public function testGetDecimalPrecision()
     {
-        $this->assertSame(
+        static::assertSame(
             2,
             $this->currency->getDecimalPrecision(),
             'Wrong result for getDecimalPrecision()'
@@ -160,7 +160,7 @@ class CurrencyTest extends TestCase
     public function testGetName()
     {
         /** @noinspection PhpUnhandledExceptionInspection */
-        $this->assertSame(
+        static::assertSame(
             'euro',
             $this->currency->getName('fr-FR'),
             'Wrong result for getName()'

--- a/tests-legacy/Unit/Core/Localization/Locale/RepositoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Locale/RepositoryTest.php
@@ -111,8 +111,8 @@ class RepositoryTest extends TestCase
     {
         $locale = $this->localeRepository->getLocale('fr-FR');
 
-        $this->assertInstanceOf(Locale::class, $locale);
-        $this->assertSame('fr-FR', $locale->getCode());
+        static::assertInstanceOf(Locale::class, $locale);
+        static::assertSame('fr-FR', $locale->getCode());
     }
 
     /**

--- a/tests-legacy/Unit/Core/Localization/LocaleCacheDataLayerTest.php
+++ b/tests-legacy/Unit/Core/Localization/LocaleCacheDataLayerTest.php
@@ -67,12 +67,12 @@ class LocaleCacheDataLayerTest extends TestCase
         $cachedData = $this->layer->read('fooBar');
         /** @noinspection end */
 
-        $this->assertInstanceOf(
+        static::assertInstanceOf(
             LocaleData::class,
             $cachedData
         );
 
-        $this->assertSame(
+        static::assertSame(
             ['bar', 'baz'],
             $cachedData->foo
         );
@@ -82,6 +82,6 @@ class LocaleCacheDataLayerTest extends TestCase
         $cachedData = $this->layer->read('unknown');
         /** @noinspection end */
 
-        $this->assertNull($cachedData);
+        static::assertNull($cachedData);
     }
 }

--- a/tests-legacy/Unit/Core/Localization/LocaleTest.php
+++ b/tests-legacy/Unit/Core/Localization/LocaleTest.php
@@ -117,7 +117,7 @@ class LocaleTest extends TestCase
     {
         $formattedNumber = $this->cldrLocale->formatNumber($number);
 
-        $this->assertSame($expected, $formattedNumber);
+        static::assertSame($expected, $formattedNumber);
     }
 
     /**
@@ -179,7 +179,7 @@ class LocaleTest extends TestCase
     {
         $price = $this->cldrLocale->formatPrice($number, $currencyCode);
 
-        $this->assertSame($expected, $price);
+        static::assertSame($expected, $price);
     }
 
     /**

--- a/tests-legacy/Unit/Core/Localization/Number/FormatterTest.php
+++ b/tests-legacy/Unit/Core/Localization/Number/FormatterTest.php
@@ -85,7 +85,7 @@ class FormatterTest extends TestCase
         $formatter       = $this->buildFormatter($localeParams);
         $formattedNumber = $formatter->format($number, $numberSpecification);
 
-        $this->assertSame($expectedResult, $formattedNumber);
+        static::assertSame($expectedResult, $formattedNumber);
     }
 
     protected function buildFormatter($localeParams)

--- a/tests-legacy/Unit/Core/Localization/ReaderTest.php
+++ b/tests-legacy/Unit/Core/Localization/ReaderTest.php
@@ -59,31 +59,31 @@ class ReaderTest extends TestCase
     {
         $localeData = $this->reader->readLocaleData($localeCode);
 
-        $this->assertInstanceOf(LocaleData::class, $localeData);
+        static::assertInstanceOf(LocaleData::class, $localeData);
 
         $dns = $localeData->defaultNumberingSystem;
 
-        $this->assertEquals(
+        static::assertEquals(
             $expectedData['defaultNumberingSystem'],
             $dns,
             'Wrong group separator'
         );
-        $this->assertEquals(
+        static::assertEquals(
             $expectedData['digitsGroupSeparator'],
             $localeData->numberSymbols[$dns]->group,
             'Wrong group separator'
         );
-        $this->assertEquals(
+        static::assertEquals(
             $expectedData['decimalSeparator'],
             $localeData->numberSymbols[$dns]->decimal,
             'Wrong decimal separator'
         );
-        $this->assertEquals(
+        static::assertEquals(
             $expectedData['decimalPattern'],
             $localeData->decimalPatterns[$dns],
             'Wrong decimal pattern'
         );
-        $this->assertEquals(
+        static::assertEquals(
             $expectedData['currencyPattern'],
             $localeData->currencyPatterns[$dns],
             'Wrong currency pattern'

--- a/tests-legacy/Unit/Core/Localization/Specification/NumberTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/NumberTest.php
@@ -78,7 +78,7 @@ class NumberTest extends TestCase
      */
     public function testGetAllSymbolsReturnsAListOfSymbols()
     {
-        $this->assertSame(
+        static::assertSame(
             [
                 'latin' => $this->latinSymbolList,
                 'arab'  => $this->arabSymbolList,
@@ -95,7 +95,7 @@ class NumberTest extends TestCase
     public function testGetSymbolsByNumberingSystem()
     {
         /** @noinspection PhpUnhandledExceptionInspection */
-        $this->assertSame(
+        static::assertSame(
             $this->latinSymbolList,
             $this->latinNumberSpec->getSymbolsByNumberingSystem('latin')
         );

--- a/tests-legacy/Unit/Core/Module/HookConfiguratorTest.php
+++ b/tests-legacy/Unit/Core/Module/HookConfiguratorTest.php
@@ -76,7 +76,7 @@ class HookConfiguratorTest extends UnitTestCase
             ],
         ]);
 
-        $this->assertEquals($expected, $actual);
+        static::assertEquals($expected, $actual);
     }
 
     public function testSingleModuleAppendedToHookWithExceptions()
@@ -111,7 +111,7 @@ class HookConfiguratorTest extends UnitTestCase
             ],
         ]);
 
-        $this->assertEquals($expected, $actual);
+        static::assertEquals($expected, $actual);
     }
 
     public function testMultipleModulesAppendedToHook()
@@ -138,7 +138,7 @@ class HookConfiguratorTest extends UnitTestCase
             ],
         ]);
 
-        $this->assertEquals($expected, $actual);
+        static::assertEquals($expected, $actual);
     }
 
     public function testMultipleTildeInHookModuleList()
@@ -167,7 +167,7 @@ class HookConfiguratorTest extends UnitTestCase
             ],
         ]);
 
-        $this->assertEquals($expected, $actual);
+        static::assertEquals($expected, $actual);
     }
 
     public function testSingleModulePrependedToHook()
@@ -192,7 +192,7 @@ class HookConfiguratorTest extends UnitTestCase
             ],
         ]);
 
-        $this->assertEquals($expected, $actual);
+        static::assertEquals($expected, $actual);
     }
 
     public function testMultipleModulesPrependedToHook()
@@ -219,7 +219,7 @@ class HookConfiguratorTest extends UnitTestCase
             ],
         ]);
 
-        $this->assertEquals($expected, $actual);
+        static::assertEquals($expected, $actual);
     }
 
     public function testModulesHookedAreReplaced()
@@ -244,7 +244,7 @@ class HookConfiguratorTest extends UnitTestCase
             ],
         ]);
 
-        $this->assertEquals($expected, $actual);
+        static::assertEquals($expected, $actual);
     }
 
     public function testWhenAModuleIsHookedItIsUnhookedFromCurrentDisplayHooks()
@@ -272,7 +272,7 @@ class HookConfiguratorTest extends UnitTestCase
             ],
         ]);
 
-        $this->assertEquals($expected, $actual);
+        static::assertEquals($expected, $actual);
     }
 
     public function testNewHookIsCreated()
@@ -284,7 +284,7 @@ class HookConfiguratorTest extends UnitTestCase
         ];
         $this->setCurrentDisplayHooksConfiguration([]);
 
-        $this->assertEquals(
+        static::assertEquals(
             $config,
             $this
                 ->hookConfigurator

--- a/tests-legacy/Unit/Core/Payment/Core_Payment_PaymentOptionTest.php
+++ b/tests-legacy/Unit/Core/Payment/Core_Payment_PaymentOptionTest.php
@@ -49,7 +49,7 @@ class Core_Payment_PaymentOptionTest extends UnitTestCase
             'inputs'    => array('key' => 42),
         );
 
-        $this->assertEquals(
+        static::assertEquals(
             array($newOption),
             PaymentOption::convertLegacyOption($legacyOption)
         );
@@ -75,7 +75,7 @@ class Core_Payment_PaymentOptionTest extends UnitTestCase
 
         $legacyOption = array($singleLegacyOption, $singleLegacyOption);
 
-        $this->assertEquals(
+        static::assertEquals(
             array($newOption, $newOption),
             PaymentOption::convertLegacyOption($legacyOption)
         );

--- a/tests-legacy/Unit/Core/Search/ControllerActionTest.php
+++ b/tests-legacy/Unit/Core/Search/ControllerActionTest.php
@@ -38,7 +38,7 @@ class ControllerActionTest extends TestCase
      */
     public function testGetFromString($fqcn, $result)
     {
-        self::assertEquals($result, ControllerAction::fromString($fqcn));
+        static::assertEquals($result, ControllerAction::fromString($fqcn));
     }
 
     /**

--- a/tests-legacy/Unit/Core/Stock/Core_Stock_StockManagerTest.php
+++ b/tests-legacy/Unit/Core/Stock/Core_Stock_StockManagerTest.php
@@ -200,9 +200,9 @@ class StockAvailableTest extends UnitTestCase
         $stockManager = new StockManager();
         $stockManager->updatePackQuantity($pack, $pack->stock_available, $delta);
 
-        $this->assertEquals($expected[0], $pack->stock_available->quantity);
+        static::assertEquals($expected[0], $pack->stock_available->quantity);
         foreach ($products as $k => $product) {
-            $this->assertEquals($expected[$k+1], $product[0]->stock_available->quantity);
+            static::assertEquals($expected[$k+1], $product[0]->stock_available->quantity);
         }
     }
 
@@ -292,9 +292,9 @@ class StockAvailableTest extends UnitTestCase
         $stockAvailable->update();
         $stockManager->updatePacksQuantityContainingProduct($products[0][0], $products[0][1], $stockAvailable);
 
-        $this->assertEquals($expected[0], $pack->stock_available->quantity);
+        static::assertEquals($expected[0], $pack->stock_available->quantity);
         foreach ($products as $k => $product) {
-            $this->assertEquals($expected[$k+1], $product[0]->stock_available->quantity);
+            static::assertEquals($expected[$k+1], $product[0]->stock_available->quantity);
         }
     }
 
@@ -400,9 +400,9 @@ class StockAvailableTest extends UnitTestCase
         $stockManager = new StockManager();
         $stockManager->updateQuantity($productToUpdate, $productAttributeToUpdate, $delta);
 
-        $this->assertEquals($expected[0], $pack->stock_available->quantity);
+        static::assertEquals($expected[0], $pack->stock_available->quantity);
         foreach ($products as $k => $product) {
-            $this->assertEquals($expected[$k+1], $product[0]->stock_available->quantity);
+            static::assertEquals($expected[$k+1], $product[0]->stock_available->quantity);
         }
     }
 }

--- a/tests-legacy/Unit/PrestaShopBundle/Api/QueryParamsCollectionTest.php
+++ b/tests-legacy/Unit/PrestaShopBundle/Api/QueryParamsCollectionTest.php
@@ -70,10 +70,10 @@ class QueryParamsCollectionTest extends TestCase
                 $pageSize,
                 array()
             );
-            $this->fail('Invalid pagination params should raise an exception');
+            static::fail('Invalid pagination params should raise an exception');
         } catch (Exception $exception) {
             $expectedInstanceOf = '\PrestaShopBundle\Exception\InvalidPaginationParamsException';
-            $this->assertInstanceOf(
+            static::assertInstanceOf(
                 $expectedInstanceOf,
                 $exception,
                 sprintf('It should raise an instance of %s', $expectedInstanceOf)
@@ -133,9 +133,9 @@ class QueryParamsCollectionTest extends TestCase
 
         $expectedSqlClauses[2] = array(QueryParamsCollection::SQL_CLAUSE_WHERE => '');
 
-        $this->assertInternalType('array', $sqlParts);
+        static::assertInternalType('array', $sqlParts);
 
-        $this->assertEquals($expectedSqlClauses, $sqlParts);
+        static::assertEquals($expectedSqlClauses, $sqlParts);
     }
 
     /**
@@ -174,9 +174,9 @@ class QueryParamsCollectionTest extends TestCase
         $expectedSqlClauses[1]['product_id'] = 1;
         $expectedSqlClauses[2] = array(QueryParamsCollection::SQL_CLAUSE_WHERE => 'AND {product_id} = :product_id');
 
-        $this->assertInternalType('array', $sqlParts);
+        static::assertInternalType('array', $sqlParts);
 
-        $this->assertEquals($expectedSqlClauses, $sqlParts);
+        static::assertEquals($expectedSqlClauses, $sqlParts);
     }
 
     /**
@@ -249,7 +249,7 @@ class QueryParamsCollectionTest extends TestCase
             array('_attributes' => $this->mockAttributes(array())->reveal())
         ));
         $this->queryParams = $this->queryParams->fromRequest($requestMock->reveal());
-        $this->assertEquals(
+        static::assertEquals(
             $expectedSql,
             $this->queryParams->getSqlFilters(),
             $message

--- a/tests-legacy/Unit/PrestaShopBundle/MultishopCommandListenerTest.php
+++ b/tests-legacy/Unit/PrestaShopBundle/MultishopCommandListenerTest.php
@@ -77,9 +77,9 @@ class MultishopCommandListenerTest extends UnitTestCase
     public function testDefaultMultishopContext()
     {
         Shop::resetContext();
-        $this->assertFalse($this->multishopContext->isShopContext(), 'isShopContext');
-        $this->assertFalse($this->multishopContext->isShopGroupContext(), 'isShopGroupContext');
-        $this->assertFalse($this->multishopContext->isAllContext(), 'isAllContext');
+        static::assertFalse($this->multishopContext->isShopContext(), 'isShopContext');
+        static::assertFalse($this->multishopContext->isShopGroupContext(), 'isShopGroupContext');
+        static::assertFalse($this->multishopContext->isAllContext(), 'isAllContext');
     }
 
     public function testSetShopID()
@@ -94,7 +94,7 @@ class MultishopCommandListenerTest extends UnitTestCase
         $this->commandListener->onConsoleCommand($event);
 
         // Check!
-        $this->assertTrue($this->multishopContext->isShopContext(), 'isShopContext');
+        static::assertTrue($this->multishopContext->isShopContext(), 'isShopContext');
     }
 
     public function testSetShopGroupID()
@@ -109,7 +109,7 @@ class MultishopCommandListenerTest extends UnitTestCase
         $this->commandListener->onConsoleCommand($event);
 
         // Check!
-        $this->assertTrue($this->multishopContext->isShopGroupContext());
+        static::assertTrue($this->multishopContext->isShopGroupContext());
     }
 
     public function testExceptionWhenIdShopAndIdShopGroupSet()

--- a/tests-legacy/Unit/PrestaShopBundle/Utils/FloatParserTest.php
+++ b/tests-legacy/Unit/PrestaShopBundle/Utils/FloatParserTest.php
@@ -43,7 +43,7 @@ class FloatParserTest extends TestCase
      */
     public function testItParsesNumbersFromString($string, $expected)
     {
-        $this->assertSame($expected, (new FloatParser())->fromString($string));
+        static::assertSame($expected, (new FloatParser())->fromString($string));
     }
 
     /**

--- a/tests-legacy/Unit/classes/CacheCoreTest.php
+++ b/tests-legacy/Unit/classes/CacheCoreTest.php
@@ -105,17 +105,17 @@ class CacheCoreTest extends TestCase
             $queryHash = Cache::getInstance()->getQueryHash($query);
 
             // check the query is in the cache
-            $this->assertArrayHasKey($queryHash, $this->cacheArray);
+            static::assertArrayHasKey($queryHash, $this->cacheArray);
 
             $tableLists = Cache::getInstance()->getTables($query);
             foreach ($tableLists as $table) {
                 $tableCacheKey = Cache::getInstance()->getTableMapCacheKey($table);
 
                 // check the table cache key is in the cache
-                $this->assertArrayHasKey($tableCacheKey, $this->cacheArray);
+                static::assertArrayHasKey($tableCacheKey, $this->cacheArray);
 
                 // check the query hash is in the table map
-                $this->assertArrayHasKey($queryHash, $this->cacheArray[$tableCacheKey]);
+                static::assertArrayHasKey($queryHash, $this->cacheArray[$tableCacheKey]);
             }
         }
     }
@@ -136,7 +136,7 @@ class CacheCoreTest extends TestCase
             Cache::getInstance()->setQuery($query, array('queryResult '.$i));
         }
 
-        $this->assertCount(4, $this->cacheArray);
+        static::assertCount(4, $this->cacheArray);
 
         foreach ($queries as $query) {
             $tableLists = Cache::getInstance()->getTables($query);
@@ -144,17 +144,17 @@ class CacheCoreTest extends TestCase
                 $tableCacheKey = Cache::getInstance()->getTableMapCacheKey($table);
 
                 // check the table cache key is in the cache
-                $this->assertArrayHasKey($tableCacheKey, $this->cacheArray);
+                static::assertArrayHasKey($tableCacheKey, $this->cacheArray);
 
                 // check the query hash is in the table map
-                $this->assertCount(2, $this->cacheArray[$tableCacheKey]);
+                static::assertCount(2, $this->cacheArray[$tableCacheKey]);
             }
 
             break;
         }
 
         // check the cache only contains two keys (+ 2 table keys)
-        $this->assertCount(4, $this->cacheArray);
+        static::assertCount(4, $this->cacheArray);
     }
 
     /**
@@ -181,7 +181,7 @@ class CacheCoreTest extends TestCase
         Cache::getInstance()->incrementQueryCounter($queries[3]);
         Cache::getInstance()->incrementQueryCounter($queries[3]);
 
-        $this->assertCount(6, $this->cacheArray);
+        static::assertCount(6, $this->cacheArray);
 
         // inserting a new entry should update the query counter, and the LRU logic
         // should evict 0 and 2 query from the cache
@@ -189,19 +189,19 @@ class CacheCoreTest extends TestCase
 
         // check the cache only contains the query 1 3 and 4
         $queryHash = Cache::getInstance()->getQueryHash($queries[1]);
-        $this->assertArrayHasKey($queryHash, $this->cacheArray);
+        static::assertArrayHasKey($queryHash, $this->cacheArray);
 
         $queryHash = Cache::getInstance()->getQueryHash($queries[3]);
-        $this->assertArrayHasKey($queryHash, $this->cacheArray);
+        static::assertArrayHasKey($queryHash, $this->cacheArray);
 
         $queryHash = Cache::getInstance()->getQueryHash($queries[4]);
-        $this->assertArrayHasKey($queryHash, $this->cacheArray);
+        static::assertArrayHasKey($queryHash, $this->cacheArray);
 
         $queryHash = Cache::getInstance()->getQueryHash($queries[0]);
-        $this->assertArrayNotHasKey($queryHash, $this->cacheArray);
+        static::assertArrayNotHasKey($queryHash, $this->cacheArray);
 
         $queryHash = Cache::getInstance()->getQueryHash($queries[2]);
-        $this->assertArrayNotHasKey($queryHash, $this->cacheArray);
+        static::assertArrayNotHasKey($queryHash, $this->cacheArray);
 
         // 1 should have a counter set to 2
         $this->checkTableCacheMapCounter($queries[1], 2);
@@ -231,22 +231,22 @@ class CacheCoreTest extends TestCase
         $tableMapKey = Cache::getInstance()->getTableMapCacheKey('ps_configuration');
         $invalidatedKeys = $this->cacheArray[$tableMapKey];
 
-        $this->assertArrayHasKey($tableMapKey, $this->cacheArray);
+        static::assertArrayHasKey($tableMapKey, $this->cacheArray);
 
         Cache::getInstance()->deleteQuery('SELECT name FROM ps_configuration WHERE id = 1');
 
-        $this->assertArrayNotHasKey($tableMapKey, $this->cacheArray);
+        static::assertArrayNotHasKey($tableMapKey, $this->cacheArray);
 
         foreach (array_keys($invalidatedKeys) as $invalidatedKey) {
-            $this->assertArrayNotHasKey($invalidatedKey, $this->cacheArray);
+            static::assertArrayNotHasKey($invalidatedKey, $this->cacheArray);
         }
 
         $validTableMapKey = Cache::getInstance()->getTableMapCacheKey('ps_confiture');
-        $this->assertArrayHasKey($validTableMapKey, $this->cacheArray);
+        static::assertArrayHasKey($validTableMapKey, $this->cacheArray);
 
         Cache::getInstance()->deleteQuery('SELECT name FROM ps_confiture WHERE id = 1');
 
-        $this->assertArrayNotHasKey($validTableMapKey, $this->cacheArray);
+        static::assertArrayNotHasKey($validTableMapKey, $this->cacheArray);
 
         // now check invalidation why full deletion of entry from "other table"
         foreach ($queries as $query) {
@@ -256,14 +256,14 @@ class CacheCoreTest extends TestCase
         $tableMapKey = Cache::getInstance()->getTableMapCacheKey('ps_configuration');
         $invalidatedKeys = $this->cacheArray[$tableMapKey];
 
-        $this->assertArrayHasKey($tableMapKey, $this->cacheArray);
+        static::assertArrayHasKey($tableMapKey, $this->cacheArray);
 
         // all entries from both ps_configuration AND ps_confiture will be deleted
         Cache::getInstance()->deleteQuery('SELECT name FROM ps_configuration WHERE id = 1');
 
-        $this->assertArrayNotHasKey($tableMapKey, $this->cacheArray);
+        static::assertArrayNotHasKey($tableMapKey, $this->cacheArray);
         $otherTableMapKey = Cache::getInstance()->getTableMapCacheKey('ps_confiture');
-        $this->assertArrayNotHasKey($otherTableMapKey, $this->cacheArray);
+        static::assertArrayNotHasKey($otherTableMapKey, $this->cacheArray);
     }
 
     private function checkTableCacheMapCounter($query, $counter)
@@ -274,10 +274,10 @@ class CacheCoreTest extends TestCase
             $tableCacheKey = Cache::getInstance()->getTableMapCacheKey($table);
 
             // check the table cache key is in the cache
-            $this->assertArrayHasKey($tableCacheKey, $this->cacheArray);
+            static::assertArrayHasKey($tableCacheKey, $this->cacheArray);
 
             // check the query hash is in the table map
-            $this->assertEquals($counter, $this->cacheArray[$tableCacheKey][$queryHash]['count']);
+            static::assertEquals($counter, $this->cacheArray[$tableCacheKey][$queryHash]['count']);
         }
     }
 

--- a/tests/Unit/Core/Webservice/ServerRequirementsCheckerTest.php
+++ b/tests/Unit/Core/Webservice/ServerRequirementsCheckerTest.php
@@ -60,7 +60,7 @@ class ServerRequirementsCheckerTest extends TestCase
         $this->mockedTranslator = $this->createMock(TranslatorInterface::class);
         $this->mockedTranslator
             ->method('trans')
-            ->will($this->returnArgument(0));
+            ->will(static::returnArgument(0));
 
         $this->mockedConfiguration = $this->createMock(Configuration::class);
         $this->mockedHostingInformation = $this->createMock(HostingInformation::class);
@@ -75,7 +75,7 @@ class ServerRequirementsCheckerTest extends TestCase
 
         $errors = $this->createNewServerRequirementsChecker()->checkForErrors();
 
-        $this->assertContains('To avoid operating problems, please use an Apache server.', $errors);
+        static::assertContains('To avoid operating problems, please use an Apache server.', $errors);
     }
 
     public function testNoErrorsAreReturnedWhenUsingApacheWebServer()
@@ -86,29 +86,29 @@ class ServerRequirementsCheckerTest extends TestCase
 
         $errors = $this->createNewServerRequirementsChecker()->checkForErrors();
 
-        $this->assertNotContains('To avoid operating problems, please use an Apache server.', $errors);
+        static::assertNotContains('To avoid operating problems, please use an Apache server.', $errors);
     }
 
     public function testNoErrorsAreReturnedWhenSslIsEnabled()
     {
         $this->mockedConfiguration
             ->method('getBoolean')
-            ->will($this->returnValue(true));
+            ->will(static::returnValue(true));
 
         $errors = $this->createNewServerRequirementsChecker()->checkForErrors();
 
-        $this->assertNotContains('It is preferable to use SSL (https:) for webservice calls, as it avoids the "man in the middle" type security issues.', $errors);
+        static::assertNotContains('It is preferable to use SSL (https:) for webservice calls, as it avoids the "man in the middle" type security issues.', $errors);
     }
 
     public function testThatErrorIsReturnedWhenSslIsNotEnabled()
     {
         $this->mockedConfiguration
             ->method('getBoolean')
-            ->will($this->returnValue(false));
+            ->will(static::returnValue(false));
 
         $errors = $this->createNewServerRequirementsChecker()->checkForErrors();
 
-        $this->assertContains('It is preferable to use SSL (https:) for webservice calls, as it avoids the "man in the middle" type security issues.', $errors);
+        static::assertContains('It is preferable to use SSL (https:) for webservice calls, as it avoids the "man in the middle" type security issues.', $errors);
     }
 
     /**

--- a/tools/build/tests/Unit/Library/InstallUnpacker/classes/VersionNumberTest.php
+++ b/tools/build/tests/Unit/Library/InstallUnpacker/classes/VersionNumberTest.php
@@ -32,29 +32,29 @@ class VersionNumberTest extends TestCase
     {
         $number = new VersionNumber(1.7, 2, 3);
 
-        $this->assertEquals(1.7, $number->getMajor());
-        $this->assertEquals(2, $number->getMinor());
-        $this->assertEquals(3, $number->getPatch());
+        static::assertEquals(1.7, $number->getMajor());
+        static::assertEquals(2, $number->getMinor());
+        static::assertEquals(3, $number->getPatch());
     }
 
     public function testToString()
     {
         $number = new VersionNumber(1.6, 1, 21);
 
-        $this->assertEquals('1.6.1.21', $number->__toString());
+        static::assertEquals('1.6.1.21', $number->__toString());
     }
 
     public function testFromStringGoodUsecases()
     {
-        $this->assertEquals(
+        static::assertEquals(
             '1.6.1.20',
             VersionNumber::fromString('1.6.1.20')->__toString()
         );
-        $this->assertEquals(
+        static::assertEquals(
             '1.7.0.0',
             VersionNumber::fromString('1.7.0.0')->__toString()
         );
-        $this->assertEquals(
+        static::assertEquals(
             '1.8.4.2',
             VersionNumber::fromString('1.8.4.2')->__toString()
         );
@@ -89,7 +89,7 @@ class VersionNumberTest extends TestCase
         $number1 = new VersionNumber(1.6, 2, 3);
         $number2 = new VersionNumber(1.6, 2, 3);
 
-        $this->assertEquals(0, $number1->compare($number2));
+        static::assertEquals(0, $number1->compare($number2));
     }
 
     public function testCompareHigher()
@@ -97,17 +97,17 @@ class VersionNumberTest extends TestCase
         $number1 = new VersionNumber(1.7, 2, 3);
         $number2 = new VersionNumber(1.6, 2, 3);
 
-        $this->assertEquals(1, $number1->compare($number2));
+        static::assertEquals(1, $number1->compare($number2));
 
         $number3 = new VersionNumber(1.8, 2, 3);
         $number4 = new VersionNumber(1.8, 1, 3);
 
-        $this->assertEquals(1, $number3->compare($number4));
+        static::assertEquals(1, $number3->compare($number4));
 
         $number5 = new VersionNumber(1.8, 2, 3);
         $number6 = new VersionNumber(1.8, 2, 1);
 
-        $this->assertEquals(1, $number5->compare($number6));
+        static::assertEquals(1, $number5->compare($number6));
     }
 
     public function testCompareLower()
@@ -115,16 +115,16 @@ class VersionNumberTest extends TestCase
         $number1 = new VersionNumber(1.5, 2, 3);
         $number2 = new VersionNumber(1.6, 2, 3);
 
-        $this->assertEquals(-1, $number1->compare($number2));
+        static::assertEquals(-1, $number1->compare($number2));
 
         $number3 = new VersionNumber(1.8, 2, 3);
         $number4 = new VersionNumber(1.8, 5, 3);
 
-        $this->assertEquals(-1, $number3->compare($number4));
+        static::assertEquals(-1, $number3->compare($number4));
 
         $number5 = new VersionNumber(1.8, 2, 3);
         $number6 = new VersionNumber(1.8, 2, 7);
 
-        $this->assertEquals(-1, $number5->compare($number6));
+        static::assertEquals(-1, $number5->compare($number6));
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Calls to PHPUnit\Framework\TestCase static methods must all be of the same type, either `$this->`, `self::` or `static::.`
| Type?         | improvement
| Category?     | TE
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | /
| How to test?  | /

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11864)
<!-- Reviewable:end -->
