### PR TITLE
PHP unit set up tear down visibility

### DIFF
--- a/tests-legacy/Integration/Adapter/AdapterDatabaseTest.php
+++ b/tests-legacy/Integration/Adapter/AdapterDatabaseTest.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Adapter\Database;
 
 class AdapterDatabaseTest extends IntegrationTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->db = new Database();

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsControllerTest.php
@@ -41,7 +41,7 @@ class PositionsControllerTest extends WebTestCase
     protected $moduleId;
     protected $hookId;
 
-    public function setUp()
+    protected function setUp()
     {
         Cache::clear();
         Module::clearStaticCache();

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Improve/International/GeolocationControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Improve/International/GeolocationControllerTest.php
@@ -34,7 +34,7 @@ use LegacyTests\Integration\PrestaShopBundle\Test\WebTestCase;
  */
 class GeolocationControllerTest extends WebTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/ModuleControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/ModuleControllerTest.php
@@ -34,7 +34,7 @@ use LegacyTests\Integration\PrestaShopBundle\Test\WebTestCase;
  */
 class ModuleControllerTest extends WebTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->enableDemoMode();

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/ProductControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/ProductControllerTest.php
@@ -33,7 +33,7 @@ use LegacyTests\Integration\PrestaShopBundle\Test\WebTestCase;
  */
 class ProductControllerTest extends WebTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->enableDemoMode();

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
@@ -34,7 +34,7 @@ use LegacyTests\Integration\PrestaShopBundle\Test\WebTestCase;
  */
 class DeliveryControllerTest extends WebTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->enableDemoMode();

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/SurvivalTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/SurvivalTest.php
@@ -54,7 +54,7 @@ class SurvivalTest extends WebTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->tokenStorage = self::$kernel->getContainer()->get('security.token_storage');
@@ -63,7 +63,7 @@ class SurvivalTest extends WebTestCase
     /**
      * {@inheritdoc}
      */
-    public function tearDown()
+    protected function tearDown()
     {
         self::$kernel->getContainer()->set('security.token_storage', $this->tokenStorage);
         parent::tearDown();

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/ApiTestCase.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/ApiTestCase.php
@@ -53,7 +53,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected static $container;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -72,7 +72,7 @@ abstract class ApiTestCase extends WebTestCase
         self::$client = $client;
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
 

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/Improve/Design/PositionsControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/Improve/Design/PositionsControllerTest.php
@@ -42,7 +42,7 @@ class PositionsControllerTest extends WebTestCase
     protected $otherModuleId;
     protected $hookId;
 
-    public function setUp()
+    protected function setUp()
     {
         Cache::clear();
         Module::clearStaticCache();

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
@@ -36,7 +36,7 @@ use PrestaShopBundle\Api\QueryStockParamsCollection;
  */
 class StockManagementControllerTest extends ApiTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
@@ -34,7 +34,7 @@ namespace LegacyTests\Integration\PrestaShopBundle\Controller\Api;
  */
 class TranslationControllerTest extends ApiTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests-legacy/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -40,7 +40,7 @@ class LegacyUrlConverterTest extends LightWebTestCase
     /** @var Link */
     private $link;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->initContainerInstance();

--- a/tests-legacy/Integration/PrestaShopBundle/Service/DataProvider/MarketPlace/ApiClientTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Service/DataProvider/MarketPlace/ApiClientTest.php
@@ -40,7 +40,7 @@ class ApiClientTest extends KernelTestCase
      */
     protected $apiClient;
 
-    public function setUp()
+    protected function setUp()
     {
         $kernel = $this->createKernel();
         $kernel->boot();

--- a/tests-legacy/Integration/PrestaShopBundle/Test/LightWebTestCase.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Test/LightWebTestCase.php
@@ -64,7 +64,7 @@ class LightWebTestCase extends TestCase
      */
     protected $translator;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->client = self::createClient();

--- a/tests-legacy/Integration/SmartySettingsTest.php
+++ b/tests-legacy/Integration/SmartySettingsTest.php
@@ -32,7 +32,7 @@ class SmartySettingsTest extends IntegrationTestCase
 {
     private $smarty;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         global $smarty;

--- a/tests-legacy/Integration/classes/CartGetOrderTotalTest.php
+++ b/tests-legacy/Integration/classes/CartGetOrderTotalTest.php
@@ -377,7 +377,7 @@ class CartGetOrderTotalTest extends IntegrationTestCase
     /**
      * Provide sensible defaults for tests that don't specify them.
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests-legacy/Integration/classes/ConfigurationCoreTest.php
+++ b/tests-legacy/Integration/classes/ConfigurationCoreTest.php
@@ -60,7 +60,7 @@ class ConfigurationCoreTest extends IntegrationTestCase
         }
     }
 
-    public function teardown()
+    protected function teardown()
     {
     }
 

--- a/tests-legacy/Integration/classes/db/DbTest.php
+++ b/tests-legacy/Integration/classes/db/DbTest.php
@@ -38,7 +38,7 @@ class DbTest extends IntegrationTestCase
 
     private $master;
 
-    public function tearDown()
+    protected function tearDown()
     {
         Db::$_slave_servers_loaded = false;
         Db::$_servers = null;

--- a/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
+++ b/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
@@ -40,7 +40,7 @@ class ControllerTest extends TestCase
 {
     private $context;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->declareRequiredConstants();
         $this->requireAliasesFunctions();
@@ -54,7 +54,7 @@ class ControllerTest extends TestCase
         ServiceLocator::setServiceContainerInstance($containerProphecy->reveal());
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         Context::setInstanceForTesting($this->context);
     }

--- a/tests-legacy/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
@@ -54,7 +54,7 @@ class CacheProviderTest extends TestCase
      */
     private $legacyRoutes;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->expectedFlattenArray = [

--- a/tests-legacy/PrestaShopBundle/Routing/Converter/RoutingCacheKeyGeneratorTest.php
+++ b/tests-legacy/PrestaShopBundle/Routing/Converter/RoutingCacheKeyGeneratorTest.php
@@ -41,14 +41,14 @@ class RoutingCacheKeyGeneratorTest extends TestCase
     private $fs;
     private $filesTestDir;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->fs = new Filesystem();
         $this->filesTestDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'routing';
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         $this->cleanTestDir();

--- a/tests-legacy/PrestaShopBundle/Routing/YamlRoutesInModuleTest.php
+++ b/tests-legacy/PrestaShopBundle/Routing/YamlRoutesInModuleTest.php
@@ -46,7 +46,7 @@ class YamlRoutesInModuleTest extends KernelTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $kernel = self::createKernel();
         $kernel->boot();
@@ -63,7 +63,7 @@ class YamlRoutesInModuleTest extends KernelTestCase
     /**
      * {@inheritdoc}
      */
-    public function tearDown()
+    protected function tearDown()
     {
         HelperModule::removeModule('demo');
         $this->module->onUninstall();

--- a/tests-legacy/PrestaShopBundle/Translation/Exporter/ThemeExporterTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Exporter/ThemeExporterTest.php
@@ -64,7 +64,7 @@ class ThemeExporterTest extends TestCase
 
     private $finderMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->mockThemeExtractor();
 

--- a/tests-legacy/PrestaShopBundle/Translation/Extractor/ThemeExtractorTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Extractor/ThemeExtractorTest.php
@@ -52,7 +52,7 @@ class ThemeExtractorTest extends KernelTestCase
         self::$xliffFolder = self::$rootDir.'/translations';
     }
 
-    public function setUp()
+    protected function setUp()
     {
         self::bootKernel();
 
@@ -64,7 +64,7 @@ class ThemeExtractorTest extends KernelTestCase
         $this->themeExtractor->setThemeProvider($themeProvider);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         if (file_exists(self::$legacyFolder)) {
             $this->filesystem->remove(self::$legacyFolder);

--- a/tests-legacy/PrestaShopBundle/Translation/Factory/ThemeTranslationsFactoryTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Factory/ThemeTranslationsFactoryTest.php
@@ -48,7 +48,7 @@ class ThemeTranslationsFactoryTest extends TestCase
 
     private $translations;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->themeProviderMock = $this->getMockBuilder('PrestaShopBundle\Translation\Provider\ThemeProvider')
             ->disableOriginalConstructor()

--- a/tests-legacy/PrestaShopBundle/Translation/Factory/TranslationsFactoryTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Factory/TranslationsFactoryTest.php
@@ -38,7 +38,7 @@ class TranslationsFactoryTest extends TestCase
     private $factory;
     private $providerMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->providerMock = $this->getMockBuilder('PrestaShopBundle\Translation\Provider\AbstractProvider')
             ->disableOriginalConstructor()

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/BackOfficeProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/BackOfficeProviderTest.php
@@ -38,7 +38,7 @@ class BackOfficeProviderTest extends TestCase
     private $provider;
     private static $resourcesDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')
             ->getMock();

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/FrontOfficeProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/FrontOfficeProviderTest.php
@@ -38,7 +38,7 @@ class FrontOfficeProviderTest extends TestCase
     private $provider;
     private static $resourcesDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')
             ->getMock();

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/ModuleProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/ModuleProviderTest.php
@@ -42,7 +42,7 @@ class ModuleProviderTest extends TestCase
     private $moduleName;
     private static $resourcesDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')
             ->getMock();

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/ModulesProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/ModulesProviderTest.php
@@ -38,7 +38,7 @@ class ModulesProviderTest extends TestCase
     private $provider;
     private static $resourcesDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')
             ->getMock();

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/SearchProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/SearchProviderTest.php
@@ -38,7 +38,7 @@ class SearchProviderTest extends TestCase
     private $provider;
     private static $resourcesDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')
             ->getMock();

--- a/tests-legacy/PrestaShopBundle/Translation/Provider/ThemeProviderTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Provider/ThemeProviderTest.php
@@ -38,7 +38,7 @@ class ThemeProviderTest extends TestCase
     private $provider;
     private static $resourcesDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')
             ->getMock();

--- a/tests-legacy/TestCase/UnitTestCase.php
+++ b/tests-legacy/TestCase/UnitTestCase.php
@@ -206,7 +206,7 @@ class UnitTestCase extends \PHPUnit\Framework\TestCase
         return $this->sfKernel;
     }
 
-    public function teardown()
+    protected function teardown()
     {
         Cache::deleteTestingInstance();
         Db::deleteTestingInstance();

--- a/tests-legacy/Unit/Adapter/Admin/UrlGeneratorTest.php
+++ b/tests-legacy/Unit/Adapter/Admin/UrlGeneratorTest.php
@@ -34,7 +34,7 @@ class UrlGeneratorTest extends UnitTestCase
 {
     private $legacyContext;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests-legacy/Unit/Adapter/Cart/CartPresenterTest.php
+++ b/tests-legacy/Unit/Adapter/Cart/CartPresenterTest.php
@@ -39,7 +39,7 @@ class CartPresenterTest extends UnitTestCase
 
     private $previousSeparator;
 
-    public function setup()
+    protected function setup()
     {
         parent::setup();
         $this->previousSeparator = Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR');
@@ -47,7 +47,7 @@ class CartPresenterTest extends UnitTestCase
         $this->cartPresenter = new CartPresenter();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         Configuration::set('PS_ATTRIBUTE_ANCHOR_SEPARATOR', $this->previousSeparator);
         parent::tearDown();

--- a/tests-legacy/Unit/Adapter/Module/AdminModuleDataProviderTest.php
+++ b/tests-legacy/Unit/Adapter/Module/AdminModuleDataProviderTest.php
@@ -41,7 +41,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
     private $adminModuleDataProvider;
     private $moduleDataProviderS;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -186,7 +186,7 @@ class AdminModuleDataProviderTest extends UnitTestCase
         $this->assertEquals($modules2, $modules);
     }
 
-    public function teardown()
+    protected function teardown()
     {
         parent::teardown();
 

--- a/tests-legacy/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
+++ b/tests-legacy/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
@@ -54,7 +54,7 @@ class ModuleSelfConfiguratorTest extends UnitTestCase
 
     public $defaultDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->configuration = new ConfigurationMock();
         $this->connection = new ConnectionMock(array(), new Driver());

--- a/tests-legacy/Unit/Adapter/Module/PrestaTrust/PrestaTrustCheckerTest.php
+++ b/tests-legacy/Unit/Adapter/Module/PrestaTrust/PrestaTrustCheckerTest.php
@@ -60,7 +60,7 @@ class PrestaTrustCheckerTest extends UnitTestCase
      */
     protected $modulePresenter;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setup();
         if (!defined('__PS_BASE_URI__')) {

--- a/tests-legacy/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
+++ b/tests-legacy/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
@@ -124,7 +124,7 @@ class ModuleTabRegisterTest extends UnitTestCase
      */
     protected $tabRegister;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests-legacy/Unit/Classes/AssetsCoreTest.php
+++ b/tests-legacy/Unit/Classes/AssetsCoreTest.php
@@ -39,7 +39,7 @@ class AssetsCoreTest extends TestCase
 
     private $testsPath;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests-legacy/Unit/Classes/Checkout/CheckoutAddressesStepTest.php
+++ b/tests-legacy/Unit/Classes/Checkout/CheckoutAddressesStepTest.php
@@ -39,7 +39,7 @@ class CheckoutAddressesStepTest extends UnitTestCase
     private $step;
     private $session;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $context = new Context();

--- a/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
+++ b/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
@@ -49,7 +49,7 @@ class ModuleCoreTest extends TestCase
 									</div>
 								</div>';
 
-    public function setUp()
+    protected function setUp()
     {
         if (!defined('_PS_VERSION_')) {
             define('_PS_VERSION_', '1.6.1.0');

--- a/tests-legacy/Unit/Classes/PhpEncryptionLegacyEngineTest.php
+++ b/tests-legacy/Unit/Classes/PhpEncryptionLegacyEngineTest.php
@@ -34,7 +34,7 @@ class PhpEncryptionLegacyEngineTest extends TestCase
     const FOO = 'foo';
     private $engine;
 
-    public function setUp()
+    protected function setUp()
     {
         if (version_compare(PHP_VERSION, '7.1', '>=')) {
             $this->markTestSkipped('Legacy encryption with mcrypt is deprecated from PHP 7.1.');

--- a/tests-legacy/Unit/Classes/PhpEncryptionTest.php
+++ b/tests-legacy/Unit/Classes/PhpEncryptionTest.php
@@ -34,7 +34,7 @@ class PhpEncryptionTest extends TestCase
     const FOO = 'foo';
     private $engine;
 
-    public function setUp()
+    protected function setUp()
     {
         $randomKey = PhpEncryption::createNewRandomKey();
         $this->engine = new PhpEncryption($randomKey);

--- a/tests-legacy/Unit/Controller/Admin/AdminTabsControllerTest.php
+++ b/tests-legacy/Unit/Controller/Admin/AdminTabsControllerTest.php
@@ -37,7 +37,7 @@ class AdminTabsControllerTest extends UnitTestCase
 {
     private $controller;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests-legacy/Unit/Controller/FrontController/ProductControllerTest.php
+++ b/tests-legacy/Unit/Controller/FrontController/ProductControllerTest.php
@@ -39,7 +39,7 @@ class ProductControllerTest extends IntegrationTestCase
 
     private $controller;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->contextMocker = new ContextMocker();
@@ -47,7 +47,7 @@ class ProductControllerTest extends IntegrationTestCase
         $this->controller = new \ProductControllerCore();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         $this->contextMocker->resetContext();

--- a/tests-legacy/Unit/Core/Addon/Module/ModuleManagerInstallTest.php
+++ b/tests-legacy/Unit/Core/Addon/Module/ModuleManagerInstallTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\TestCase;
 
 class ModuleManagerInstallTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
     }

--- a/tests-legacy/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests-legacy/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -47,7 +47,7 @@ class ModuleManagerTest extends TestCase
     private $employeeS;
     private $cacheClearerS;
 
-    public function setUp()
+    protected function setUp()
     {
         // Mocks
         $this->initMocks();
@@ -63,7 +63,7 @@ class ModuleManagerTest extends TestCase
         );
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         // destroy Mocks
         $this->destroyMocks();

--- a/tests-legacy/Unit/Core/Addon/Module/ModuleRepositoryTest.php
+++ b/tests-legacy/Unit/Core/Addon/Module/ModuleRepositoryTest.php
@@ -50,7 +50,7 @@ class ModuleRepositoryTest extends UnitTestCase
 
     private $http_host_not_found = false;
 
-    public function setUp()
+    protected function setUp()
     {
         if (!defined('__PS_BASE_URI__')) {
             define('__PS_BASE_URI__', 'http://www.example.com/shop');
@@ -338,7 +338,7 @@ class ModuleRepositoryTest extends UnitTestCase
         $this->assertCount(0, $this->moduleRepositoryStub->getFilteredList($filters));
     }
 
-    public function teardown()
+    protected function teardown()
     {
         parent::teardown();
 

--- a/tests-legacy/Unit/Core/Business/Checkout/TermsAndConditionsTest.php
+++ b/tests-legacy/Unit/Core/Business/Checkout/TermsAndConditionsTest.php
@@ -33,7 +33,7 @@ class TermsAndConditionsTest extends UnitTestCase
 {
     private $terms;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->terms = new TermsAndConditions();
     }

--- a/tests-legacy/Unit/Core/Business/Product/ProductPresenterTest.php
+++ b/tests-legacy/Unit/Core/Business/Product/ProductPresenterTest.php
@@ -51,7 +51,7 @@ class ProductPresenterTest extends UnitTestCase
     private $product;
     private $language;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->settings = new ProductPresentationSettings();

--- a/tests-legacy/Unit/Core/Business/Product/Search/PaginationTest.php
+++ b/tests-legacy/Unit/Core/Business/Product/Search/PaginationTest.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Core\Product\Search\Pagination;
 
 class PaginationTest extends Testcase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->pagination = new Pagination();
     }

--- a/tests-legacy/Unit/Core/Business/Product/Search/URLFragmentSerializerTest.php
+++ b/tests-legacy/Unit/Core/Business/Product/Search/URLFragmentSerializerTest.php
@@ -33,7 +33,7 @@ class URLFragmentSerializerTest extends Testcase
 {
     private $serializer;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->serializer = new URLFragmentSerializer();
     }

--- a/tests-legacy/Unit/Core/Cart/AbstractCartTest.php
+++ b/tests-legacy/Unit/Core/Cart/AbstractCartTest.php
@@ -118,7 +118,7 @@ abstract class AbstractCartTest extends IntegrationTestCase
      */
     protected $customizationFields = [];
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->cart              = new CartOld();
@@ -132,7 +132,7 @@ abstract class AbstractCartTest extends IntegrationTestCase
         $this->insertCartRulesFromFixtures();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->resetCart();
 

--- a/tests-legacy/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
+++ b/tests-legacy/Unit/Core/Cart/Adding/CartRule/AddRuleTest.php
@@ -35,14 +35,14 @@ class AddRuleTest extends AbstractCartTest
 {
     protected $cartRulesFeatureActive;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->cartRulesFeatureActive = Configuration::get('PS_CART_RULE_FEATURE_ACTIVE');
         Configuration::set('PS_CART_RULE_FEATURE_ACTIVE', true);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         Configuration::set('PS_CART_RULE_FEATURE_ACTIVE', $this->cartRulesFeatureActive);

--- a/tests-legacy/Unit/Core/Cart/Adding/Product/AddCustomizationTest.php
+++ b/tests-legacy/Unit/Core/Cart/Adding/Product/AddCustomizationTest.php
@@ -35,7 +35,7 @@ class AddCustomizationTest extends AbstractCartTest
 {
     protected $customizations = [];
 
-    public function tearDown()
+    protected function tearDown()
     {
         foreach ($this->customizations as $customization) {
             $customization->delete();

--- a/tests-legacy/Unit/Core/Cart/Adding/Product/AddPackTest.php
+++ b/tests-legacy/Unit/Core/Cart/Adding/Product/AddPackTest.php
@@ -61,7 +61,7 @@ class AddPackTest extends AbstractCartTest
     /**
      * Populate pack and product in pack properties from the test database
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         // store previous config values
@@ -72,7 +72,7 @@ class AddPackTest extends AbstractCartTest
         $this->productInPack = $this->getProductFromFixtureId(self::ID_PRODUCT_IN_PACK_FIXTURE);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         // restore previous config values
         foreach (array_keys($this->oldConfig) as $k) {

--- a/tests-legacy/Unit/Core/Cart/Calculation/Carrier/AbstractCarrierTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/Carrier/AbstractCarrierTest.php
@@ -147,7 +147,7 @@ abstract class AbstractCarrierTest extends AbstractCartCalculationTest
      */
     protected $addresses = [];
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -176,7 +176,7 @@ abstract class AbstractCarrierTest extends AbstractCartCalculationTest
 
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->cart->id_carrier          = 0;
         $this->cart->id_address_delivery = 0;

--- a/tests-legacy/Unit/Core/Cart/Calculation/Currencies/CurrencyTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/Currencies/CurrencyTest.php
@@ -58,14 +58,14 @@ class CurrencyTest extends AbstractCartCalculationTest
 
     protected $defaultCurrencyId;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->defaultCurrencyId = Configuration::get('PS_CURRENCY_DEFAULT');
 
         parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         /*
         // do not delete currencies here : theyr are only soft deleted, and it creates conflicts when recreating with same iso code

--- a/tests-legacy/Unit/Core/Cart/Calculation/Modes/RoundingModeTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/Modes/RoundingModeTest.php
@@ -42,7 +42,7 @@ class RoundingModeTest extends AbstractCartCalculationTest
      */
     protected $defaultRoundingMode;
 
-    public function setUp()
+    protected function setUp()
     {
         // using Configuration instead of Adapter\Configuration because of different behavior
         $this->defaultRoundingMode = Configuration::get('PS_PRICE_ROUND_MODE');
@@ -50,7 +50,7 @@ class RoundingModeTest extends AbstractCartCalculationTest
         parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         // using Configuration instead of Adapter\Configuration because of different behavior
         Configuration::set('PS_PRICE_ROUND_MODE', $this->defaultRoundingMode);

--- a/tests-legacy/Unit/Core/Cart/Calculation/Modes/RoundingTypeTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/Modes/RoundingTypeTest.php
@@ -40,7 +40,7 @@ class RoundingTypeTest extends AbstractCartCalculationTest
      */
     protected $defaultRoundingType;
 
-    public function setUp()
+    protected function setUp()
     {
         // using Configuration instead of Adapter\Configuration because of different behavior
         $this->defaultRoundingType = Configuration::get('PS_ROUND_TYPE');
@@ -48,7 +48,7 @@ class RoundingTypeTest extends AbstractCartCalculationTest
         parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         // using Configuration instead of Adapter\Configuration because of different behavior
         Configuration::set('PS_ROUND_TYPE', $this->defaultRoundingType);

--- a/tests-legacy/Unit/Core/Cart/Calculation/Products/CartGiftWrappingTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/Products/CartGiftWrappingTest.php
@@ -35,7 +35,7 @@ class CartGiftWrappingTest extends AbstractCartCalculationTest
     protected $previousGiftWrapping;
     protected $previousGiftWrappingPrice;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->previousGiftWrapping      = Configuration::get('PS_GIFT_WRAPPING');
@@ -44,7 +44,7 @@ class CartGiftWrappingTest extends AbstractCartCalculationTest
         Configuration::set('PS_GIFT_WRAPPING_PRICE', static::GIFT_WRAPPING_PRICE);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         Configuration::set('PS_GIFT_WRAPPING', $this->previousGiftWrapping);

--- a/tests-legacy/Unit/Core/Cart/Calculation/SpecificPriceRules/AbstractSpecificPriceRuleTest.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/SpecificPriceRules/AbstractSpecificPriceRuleTest.php
@@ -43,7 +43,7 @@ abstract class AbstractSpecificPriceRuleTest extends AbstractCartCalculationTest
      */
     protected $specificPriceRules = [];
 
-    public function tearDown()
+    protected function tearDown()
     {
         foreach ($this->specificPriceRules as $rule) {
             $rule->resetApplication();

--- a/tests-legacy/Unit/Core/Cldr/RepositoryTest.php
+++ b/tests-legacy/Unit/Core/Cldr/RepositoryTest.php
@@ -38,7 +38,7 @@ class RepositoryTest extends UnitTestCase
     private $locale;
     private $region;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->cldrCacheFolder = _PS_CACHE_DIR_.'cldr-test';
         $this->locale = 'fr';

--- a/tests-legacy/Unit/Core/Crypto/Core_Crypto_Hashing_Test.php
+++ b/tests-legacy/Unit/Core/Crypto/Core_Crypto_Hashing_Test.php
@@ -35,7 +35,7 @@ use PrestaShop\PrestaShop\Core\Crypto\Hashing;
  */
 class Core_Crypto_Hashing_Test extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!defined('_COOKIE_KEY_')) {
             define('_COOKIE_KEY_', '2349123849231-4123');

--- a/tests-legacy/Unit/Core/Foundation/Database/Core_Foundation_Database_EntityRepository_Test.php
+++ b/tests-legacy/Unit/Core/Foundation/Database/Core_Foundation_Database_EntityRepository_Test.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Foundation\Database\EntityMetaData;
 
 class Core_Foundation_Database_EntityRepository_Test extends UnitTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $mockEntityManager = Phake::mock('\\PrestaShop\\PrestaShop\\Core\\Foundation\\Database\\EntityManager');
 

--- a/tests-legacy/Unit/Core/Foundation/Database/EntityManager/Core_Foundation_Database_EntityManager_QueryBuilder_Test.php
+++ b/tests-legacy/Unit/Core/Foundation/Database/EntityManager/Core_Foundation_Database_EntityManager_QueryBuilder_Test.php
@@ -34,7 +34,7 @@ class Core_Foundation_Database_EntityManager_QueryBuilder_Test extends UnitTestC
 {
     private $queryBuilder;
 
-    public function setUp()
+    protected function setUp()
     {
         $mockDb = Phake::mock('\\PrestaShop\\PrestaShop\\Core\\Foundation\\Database\\DatabaseInterface');
 

--- a/tests-legacy/Unit/Core/Foundation/FileSystem/Core_Foundation_FileSystem_FileSystemTest.php
+++ b/tests-legacy/Unit/Core/Foundation/FileSystem/Core_Foundation_FileSystem_FileSystemTest.php
@@ -34,7 +34,7 @@ class Core_Foundation_FileSystem_FileSystemTest extends UnitTestCase
     private $fs;
     private $fixturesPath;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->fs = new FileSystem();
         $this->fixturesPath = __DIR__ . DIRECTORY_SEPARATOR . 'fixtures';

--- a/tests-legacy/Unit/Core/Foundation/IoC/Core_Foundation_IoC_Container_Test.php
+++ b/tests-legacy/Unit/Core/Foundation/IoC/Core_Foundation_IoC_Container_Test.php
@@ -38,7 +38,7 @@ class Core_Foundation_IoC_Container_Test extends TestCase
      */
     private $container;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->container = new Container();
     }

--- a/tests-legacy/Unit/Core/Foundation/VersionTest.php
+++ b/tests-legacy/Unit/Core/Foundation/VersionTest.php
@@ -54,7 +54,7 @@ class VersionTest extends TestCase
     const ANOTHER_MINOR_VERSION = 3;
     const ANOTHER_RELEASE_VERSION = 4;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->version = new Version(
             self::VERSION,

--- a/tests-legacy/Unit/Core/Grid/Definition/Factory/AbstractGridDefinitionFactoryTest.php
+++ b/tests-legacy/Unit/Core/Grid/Definition/Factory/AbstractGridDefinitionFactoryTest.php
@@ -42,7 +42,7 @@ class AbstractGridDefinitionFactoryTest extends TestCase
      */
     private $definitionFactory;
 
-    public function setUp()
+    protected function setUp()
     {
         $definitionFactory = $this->getMockForAbstractClass(AbstractGridDefinitionFactory::class);
 

--- a/tests-legacy/Unit/Core/Grid/Presenter/GridPresenterTest.php
+++ b/tests-legacy/Unit/Core/Grid/Presenter/GridPresenterTest.php
@@ -48,7 +48,7 @@ class GridPresenterTest extends TestCase
      */
     private $gridPresenter;
 
-    public function setUp()
+    protected function setUp()
     {
         $hookDispatcherMock = $this->createMock(HookDispatcherInterface::class);
         $this->gridPresenter = new GridPresenter($hookDispatcherMock);

--- a/tests-legacy/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
+++ b/tests-legacy/Unit/Core/Grid/Query/DoctrineQueryParserTest.php
@@ -41,7 +41,7 @@ class DoctrineQueryParserTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->queryParser = new DoctrineQueryParser();
     }

--- a/tests-legacy/Unit/Core/Hook/HookDispatcherTest.php
+++ b/tests-legacy/Unit/Core/Hook/HookDispatcherTest.php
@@ -46,7 +46,7 @@ class HookDispatcherTest extends TestCase
      */
     private $hookDispatcher;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->hookDispatcherAdapter = $this->createMock(HookDispatcherAdapter::class);
         $this->hookDispatcher = new HookDispatcher($this->hookDispatcherAdapter);

--- a/tests-legacy/Unit/Core/Hook/RenderedHookTest.php
+++ b/tests-legacy/Unit/Core/Hook/RenderedHookTest.php
@@ -45,7 +45,7 @@ class RenderedHookTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->hookStub = $this->createMock(HookInterface::class);
 

--- a/tests-legacy/Unit/Core/Image/Parser/ImageTagSourceParserTest.php
+++ b/tests-legacy/Unit/Core/Image/Parser/ImageTagSourceParserTest.php
@@ -36,7 +36,7 @@ class ImageTagSourceParserTest extends TestCase
      */
     private $parser;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new ImageTagSourceParser('/my-shop/');
     }

--- a/tests-legacy/Unit/Core/Module/HookConfiguratorTest.php
+++ b/tests-legacy/Unit/Core/Module/HookConfiguratorTest.php
@@ -35,7 +35,7 @@ class HookConfiguratorTest extends UnitTestCase
     private $hookConfigurator;
     private $hookRepository;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->hookRepository = Phake::mock(
             'PrestaShop\PrestaShop\Core\Module\HookRepository'

--- a/tests-legacy/Unit/PrestaShopBundle/Api/QueryParamsCollectionTest.php
+++ b/tests-legacy/Unit/PrestaShopBundle/Api/QueryParamsCollectionTest.php
@@ -47,7 +47,7 @@ class QueryParamsCollectionTest extends TestCase
      */
     private $queryParams;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->prophet = new Prophet();
         $this->queryParams = new QueryStockParamsCollection();

--- a/tests-legacy/Unit/PrestaShopBundle/MultishopCommandListenerTest.php
+++ b/tests-legacy/Unit/PrestaShopBundle/MultishopCommandListenerTest.php
@@ -54,7 +54,7 @@ class MultishopCommandListenerTest extends UnitTestCase
      */
     protected $contextMocker;
 
-    public function setUp()
+    protected function setUp()
     {
 
         $this->contextMocker = new ContextMocker();
@@ -68,7 +68,7 @@ class MultishopCommandListenerTest extends UnitTestCase
         $this->multishopContext = $this->sfKernel->getContainer()->get('prestashop.adapter.shop.context');
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         $this->contextMocker->resetContext();

--- a/tests-legacy/Unit/classes/CacheCoreTest.php
+++ b/tests-legacy/Unit/classes/CacheCoreTest.php
@@ -33,7 +33,7 @@ class CacheCoreTest extends TestCase
 {
     private $cacheArray = array();
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -50,7 +50,7 @@ class CacheCoreTest extends TestCase
         Cache::setInstanceForTesting($memcachedMock);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->cacheArray = array();
     }

--- a/tests/Unit/Core/Webservice/ServerRequirementsCheckerTest.php
+++ b/tests/Unit/Core/Webservice/ServerRequirementsCheckerTest.php
@@ -55,7 +55,7 @@ class ServerRequirementsCheckerTest extends TestCase
      */
     private $mockedPhpExtensionChecker;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->mockedTranslator = $this->createMock(TranslatorInterface::class);
         $this->mockedTranslator


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Changes the visibility of the `setUp()` and `tearDown()` functions of PHPUnit to `protected`, to match the PHPUnit TestCase.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | /
| How to test?  | /

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11865)
<!-- Reviewable:end -->
