### PR TITLE
Fix lang table multi-store data issue

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -542,6 +542,8 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             if (count($this->id_shop_list)) {
                 $id_shop_list = $this->id_shop_list;
             }
+        } else {
+            $id_shop_list = Shop::getCompleteListOfShopsID();
         }
 
         // Database insertion
@@ -574,7 +576,6 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         if (!empty($this->def['multilang'])) {
             $fields = $this->getFieldsLang();
             if ($fields && is_array($fields)) {
-                $shops = Shop::getCompleteListOfShopsID();
                 $asso = Shop::getAssoTable($this->def['table'] . '_lang');
                 foreach ($fields as $field) {
                     foreach (array_keys($field) as $key) {
@@ -585,7 +586,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                     $field[$this->def['primary']] = (int) $this->id;
 
                     if ($asso !== false && $asso['type'] == 'fk_shop') {
-                        foreach ($shops as $id_shop) {
+                        foreach ($id_shop_list as $id_shop) {
                             $field['id_shop'] = (int) $id_shop;
                             $result &= Db::getInstance()->insert($this->def['table'] . '_lang', $field);
                         }

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -537,13 +537,13 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             $this->date_upd = date('Y-m-d H:i:s');
         }
 
+        $id_shop_list = Shop::getCompleteListOfShopsID();
+
         if (Shop::isTableAssociated($this->def['table'])) {
             $id_shop_list = Shop::getContextListShopID();
             if (count($this->id_shop_list)) {
                 $id_shop_list = $this->id_shop_list;
             }
-        } else {
-            $id_shop_list = Shop::getCompleteListOfShopsID();
         }
 
         // Database insertion


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | With a multi-store set up, adding a product or category to an individual store will put a line for each of the stores into the object_lang table.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9606
| How to test?  | Create a multi-store - Create a category/product in an individual store - only lines with associated stores will be added to object_lang table rather than for all stores.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11876)
<!-- Reviewable:end -->
