### PR TITLE
Align grid search and reset buttons to the right

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -77,3 +77,8 @@ table .thead-default .column-headers th:last-child .grid-actions-header-text {
     padding-right: 14px;
   }
 }
+
+table .column-filters td:last-child .grid-search-button,
+table .column-filters td:last-child .grid-reset-button {
+  float: right;
+}

--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -69,3 +69,7 @@ table.grid-ordering-column tr.position-row-while-drag {
     }
   }
 }
+
+table .thead-default .column-headers th:last-child .grid-actions-header-text span {
+  padding-right: 14px;
+}

--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -70,6 +70,10 @@ table.grid-ordering-column tr.position-row-while-drag {
   }
 }
 
-table .thead-default .column-headers th:last-child .grid-actions-header-text span {
-  padding-right: 14px;
+table .thead-default .column-headers th:last-child .grid-actions-header-text {
+  float: right;
+
+  span {
+    padding-right: 14px;
+  }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Header/Content/action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Header/Content/action.html.twig
@@ -1,3 +1,3 @@
-<div class="float-right grid-actions-header-text">
+<div class="grid-actions-header-text">
   <span>{{ column.name }}</span>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Header/Content/action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Header/Content/action.html.twig
@@ -1,0 +1,3 @@
+<div class="float-right">
+  {{ column.name }}
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Header/Content/action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Header/Content/action.html.twig
@@ -1,3 +1,3 @@
-<div class="float-right">
-  {{ column.name }}
+<div class="float-right grid-actions-header-text">
+  <span>{{ column.name }}</span>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -355,7 +355,7 @@
 {% block search_and_reset_widget %}
     {% spaceless %}
         <button type="submit"
-                class="btn btn-primary d-block"
+                class="btn btn-primary d-block float-right"
                 title="{{ 'Search'|trans({}, 'Admin.Actions') }}"
                 name="{{ full_name }}[search]"
         >
@@ -364,9 +364,10 @@
         </button>
 
         {% if show_reset_button %}
+          <div class="clearfix"></div>
             <button type="reset"
                     name="{{ full_name }}[reset]"
-                    class="btn btn-link js-reset-search btn d-block"
+                    class="btn btn-link js-reset-search btn d-block float-right"
                     data-url="{{ reset_url }}"
                     data-redirect="{{ redirect_url }}"
             >

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -355,7 +355,7 @@
 {% block search_and_reset_widget %}
     {% spaceless %}
         <button type="submit"
-                class="btn btn-primary d-block float-right"
+                class="btn btn-primary grid-search-button d-block"
                 title="{{ 'Search'|trans({}, 'Admin.Actions') }}"
                 name="{{ full_name }}[search]"
         >
@@ -367,7 +367,7 @@
           <div class="clearfix"></div>
             <button type="reset"
                     name="{{ full_name }}[reset]"
-                    class="btn btn-link js-reset-search btn d-block float-right"
+                    class="btn btn-link js-reset-search btn d-block grid-reset-button"
                     data-url="{{ reset_url }}"
                     data-redirect="{{ redirect_url }}"
             >


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | it moves search and reset buttons to the right on all viewport widths and this change is included to all lists. Problem mentioned here https://github.com/PrestaShop/PrestaShop/pull/10774#issuecomment-437054938
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | just take a look to all migrated lists to see if the button in cases are in the right. As well, check the reset button if its also aligned to the right in all viewports

how it looks now:

![button_right](https://user-images.githubusercontent.com/17051250/50284853-0b567680-0463-11e9-9bbe-6f3d2b4390f1.png)

![reset_button](https://user-images.githubusercontent.com/17051250/50284882-232dfa80-0463-11e9-8eb4-e0d1443b64c3.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11877)
<!-- Reviewable:end -->
