### PR TITLE
Fix categories grid id

### DIFF
--- a/src/Core/Grid/Definition/Factory/CategoryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CategoryGridDefinitionFactory.php
@@ -98,7 +98,7 @@ final class CategoryGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getId()
     {
-        return 'Categories';
+        return 'categories';
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Makes categories grid id lower case since its used that way in javascript.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Actions that requires JS should work. For example when you click "Select all" it should select all checkboxes or when you change position it should work as expected.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11895)
<!-- Reviewable:end -->
