### PR TITLE
BO: add disabled language on admin product page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -383,7 +383,7 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         $productProvider = $this->get('prestashop.core.admin.data_provider.product_interface');
-        $languages = $this->get('prestashop.adapter.legacy.context')->getLanguages();
+        $languages = $this->get('prestashop.adapter.legacy.context')->getLanguages(false);
 
         /** @var $productProvider ProductInterfaceProvider */
         $productAdapter = $this->get('prestashop.adapter.data_provider.product');
@@ -595,7 +595,7 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         // languages for switch dropdown
-        $languages = $legacyContextService->getLanguages();
+        $languages = $legacyContextService->getLanguages(false);
 
         // generate url preview
         if ($product->active) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Like in the others admin pages, we have to allow disabled languages in the admin product product
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | visit the admin product page with a disabled language

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11896)
<!-- Reviewable:end -->
