### PR TITLE
Introduce HelperList title_icon property

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -121,10 +121,21 @@
 	<input type="hidden" id="submitFilter{$list_id}" name="submitFilter{$list_id}" value="0"/>
 	<input type="hidden" name="page" value="{$page|intval}"/>
 	<input type="hidden" name="selected_pagination" value="{$selected_pagination|intval}"/>
+
 	{block name="override_form_extra"}{/block}
+
 	<div class="panel col-lg-12">
 		<div class="panel-heading">
-			{if isset($icon)}<i class="{$icon}"></i> {/if}{if is_array($title)}{$title|end|escape:'html':'UTF-8'}{else}{$title|escape:'html':'UTF-8'}{/if}
+			{if isset($icon)}
+				<i class="{$icon}"></i>
+			{/if}
+
+			{if is_array($title)}
+				{$title|end|escape:'html':'UTF-8'}
+			{else}
+				{$title|escape:'html':'UTF-8'}
+			{/if}
+
 			{if isset($toolbar_btn) && count($toolbar_btn) >0}
 				<span class="badge">{$list_total}</span>
 				<span class="panel-heading-action">

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -70,6 +70,9 @@ class HelperListCore extends Helper
 
     public $table_id;
 
+    /** @var string */
+    public $title_icon = null;
+
     /**
      * @var array Customize list display
      *
@@ -742,6 +745,10 @@ class HelperListCore extends Helper
             'has_bulk_actions' => $this->hasBulkActions($has_value),
             'filters_has_value' => (bool) $has_value,
         ));
+
+        if (null !== $this->title_icon) {
+            Context::getContext()->smarty->assign(['icon' => $this->title_icon]);
+        }
 
         $isMultiShopActive = Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE');
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Introduce title_icon property for HelperList
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/11886
| How to test?  | Follow below instructions to check the feature

## How to use it ?
This allows to set a `title_icon` property that can be used to render an icon at the left of the title of a list generated by HelperList

The smarty variable was already here: https://github.com/PrestaShop/PrestaShop/blob/develop/admin-dev/themes/default/template/helpers/list/list_header.tpl#L127
but could not be used by a HelperList.

Now you can control it:
```
        $helper = new HelperList();
        $helper->shopLinkType = '';
        $helper->simple_header = false;
        ...
        $helper->title_icon = 'icon-cogs';
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11899)
<!-- Reviewable:end -->
