### PR TITLE
Allow to override the CustomerFormatter class

### DIFF
--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -27,15 +27,15 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class CustomerFormatterCore implements FormFormatterInterface
 {
-    private $translator;
-    private $language;
+    protected $translator;
+    protected $language;
 
-    private $ask_for_birthdate = true;
-    private $ask_for_partner_optin = true;
-    private $partner_optin_is_required = true;
-    private $ask_for_password = true;
-    private $password_is_required = true;
-    private $ask_for_new_password = false;
+    protected $ask_for_birthdate = true;
+    protected $ask_for_partner_optin = true;
+    protected $partner_optin_is_required = true;
+    protected $ask_for_password = true;
+    protected $password_is_required = true;
+    protected $ask_for_new_password = false;
 
     public function __construct(
         TranslatorInterface $translator,
@@ -247,7 +247,7 @@ class CustomerFormatterCore implements FormFormatterInterface
         return $this->addConstraints($format);
     }
 
-    private function addConstraints(array $format)
+    protected function addConstraints(array $format)
     {
         $constraints = Customer::$definition['fields'];
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | This is currently not possible to override the CustomerFormatter class because of the private properties
 Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11910)
<!-- Reviewable:end -->
