### PR TITLE
Use env variable for admin dir with default value in assets build script

### DIFF
--- a/tools/assets/build.sh
+++ b/tools/assets/build.sh
@@ -6,9 +6,10 @@
 
 #http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euo pipefail
+ADMIN_DIR="${ADMIN_DIR:-admin-dev}"
 
-if [[ ! -d "admin-dev" ]]; then
-  echo "Could not find directory 'admin-dev'. Make sure to launch this script from the root directory of PrestaShop"
+if [[ ! -d $ADMIN_DIR ]]; then
+  echo "Could not find directory '$ADMIN_DIR'. Make sure to launch this script from the root directory of PrestaShop"
   return 1
 fi
 
@@ -24,19 +25,19 @@ function build {
 
 #echo ">>> Building admin bundle..."
 
-#cd "$BASE_DIRECTORY/admin-dev"
+#cd "$BASE_DIRECTORY/$ADMIN_DIR"
 
 #build
 
 echo ">>> Building admin default theme..."
 
-cd "$BASE_DIRECTORY/admin-dev/themes/default"
+cd "$BASE_DIRECTORY/$ADMIN_DIR/themes/default"
 
 build
 
 echo ">>> Building admin new theme..."
 
-cd "$BASE_DIRECTORY/admin-dev/themes/new-theme"
+cd "$BASE_DIRECTORY/$ADMIN_DIR/themes/new-theme"
 
 build
 


### PR DESCRIPTION
no BC break

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | use env variable for admin dir with default value
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | --
| How to test?  | sh tools/assets/build.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11919)
<!-- Reviewable:end -->
