### PR TITLE
Add advice when lint fails + Display all files in error in Travis lint job

### DIFF
--- a/tests-legacy/check_file_syntax.sh
+++ b/tests-legacy/check_file_syntax.sh
@@ -17,7 +17,7 @@ php bin/console lint:yaml .t9n.yml
 yaml_trad=$?
 
 # Check our current PHP Coding Style rules
-php ./vendor/bin/php-cs-fixer fix --dry-run --stop-on-violation --show-progress=dot
+php ./vendor/bin/php-cs-fixer fix --dry-run --diff --diff-format=udiff
 coding_styles=$?
 
 if [[ "$php" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad" == "0" && "$coding_styles" == "0" ]]; then

--- a/tests-legacy/check_file_syntax.sh
+++ b/tests-legacy/check_file_syntax.sh
@@ -25,5 +25,10 @@ if [[ "$php" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes
   exit 0;
 else
   echo -e "\e[91mSYNTAX TESTS FAILED"
+  if [[ "$coding_styles" -ne "0" ]]; then
+   echo -e "\e[39mRun PHP CS Fixer from your PrestaShop folder to fix the lint issues:";
+   echo -e '- Linux: "php ./vendor/bin/php-cs-fixer fix"';
+   echo -e '- Windows: "vendor\\bin\\php-cs-fixer fix"';
+  fi
   exit 255;
 fi


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When the lint jobs fails on Travis, we should tell the contributor how to fix the issue.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | To be tested locally by running `bash tests-legacy/check_file_syntax.sh`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11920)
<!-- Reviewable:end -->
