### PR TITLE
Fix searching issue in the Credit Slips page

### DIFF
--- a/controllers/admin/AdminSlipController.php
+++ b/controllers/admin/AdminSlipController.php
@@ -51,6 +51,7 @@ class AdminSlipControllerCore extends AdminController
                 'title' => $this->trans('Order ID', array(), 'Admin.Orderscustomers.Feature'),
                 'align' => 'left',
                 'class' => 'fixed-width-md',
+                'filter_key' => 'a!id_order',
             ),
             'date_add' => array(
                 'title' => $this->trans('Date issued', array(), 'Admin.Orderscustomers.Feature'),


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the BO => Orders => Credit Slips page, when we try to filter with a wrong id order (for example "test") => an exception is displayed
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11921
| How to test?  | Go to BO => Orders => Credit Slips => You need to have more than 2 credit slips => Try to filter with a wrong order id

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11922)
<!-- Reviewable:end -->
