### PR TITLE
Can't sort tax included for now

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
@@ -57,7 +57,7 @@
             {{ ps.sortable_column_header("Price (tax excl.)"|trans({}, 'Admin.Catalog.Feature'), 'price', orderBy, sortOrder) }}
           </th>
           <th scope="col" class="text-center" style="width: 9%">
-            {{ ps.sortable_column_header("Price (tax incl.)"|trans({}, 'Admin.Catalog.Feature'), 'price', orderBy, sortOrder) }}
+            {{ "Price (tax incl.)"|trans({}, 'Admin.Catalog.Feature') }}
           </th>
 
           {% if 'PS_STOCK_MANAGEMENT'|configuration %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We can't sort the final_price because it is calculated after the sql sort: https://github.com/PrestaShop/PrestaShop/blob/develop/src/Adapter/Product/AdminProductDataProvider.php#L370 we need to define if we need to allow to sort this field and which way we will do that.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11925 
| How to test?  | Follow ticket instruction.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11932)
<!-- Reviewable:end -->
