### PR TITLE
Description has a max length and can not exceeded

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -183,6 +183,11 @@ class ProductInformation extends CommonAbstractType
                     'attr' => [
                         'class' => 'serp-default-description',
                     ],
+                    'constraints' => [
+                        new TinyMceMaxLength([
+                            'max' => FormattedTextareaType::LIMIT_TEXT_UTF8,
+                        ]),
+                    ],
                 ],
                 'locales' => $this->locales,
                 'hideTabs' => true,

--- a/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
@@ -39,13 +39,18 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class FormattedTextareaType extends AbstractType
 {
     /**
+     * Max size of UTF-8 content in MySQL text column
+     */
+    const LIMIT_TEXT_UTF8 = 21844;
+
+    /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'autoload' => true, // Start automatically TinyMCE
-            'limit' => 21844, // size max of UTF-8 content in MySQL text column
+            'limit' => self::LIMIT_TEXT_UTF8,
         ]);
         $resolver->setAllowedTypes('limit', 'int');
         $resolver->setAllowedTypes('autoload', 'bool');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We add a max length for description due to MySQL text field limitation. We need to be consistent and display an error if max length exceeded. Reported by rl_lucian: https://www.prestashop.com/forums/topic/622846-unable-to-update-settings/#comment-2662574
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11936)
<!-- Reviewable:end -->
