### PR TITLE
Check if intl is installed in installer

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -89,6 +89,7 @@ class ConfigurationTestCore
                 'simplexml' => false,
                 'zip' => false,
                 'fileinfo' => false,
+                'intl' => false,
             ));
         }
 
@@ -110,6 +111,7 @@ class ConfigurationTestCore
             'dom' => false,
             'pdo_mysql' => false,
             'fopen' => false,
+            'intl' => false,
         );
     }
 
@@ -162,6 +164,11 @@ class ConfigurationTestCore
     public static function test_mysql_support()
     {
         return extension_loaded('mysql') || extension_loaded('mysqli') || extension_loaded('pdo_mysql');
+    }
+
+    public static function test_intl()
+    {
+        return extension_loaded('intl');
     }
 
     public static function test_pdo_mysql()

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -103,7 +103,8 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                         'simplexml' => $this->translator->trans('SimpleXML extension is not loaded', array(), 'Install'),
                         'zip' => $this->translator->trans('ZIP extension is not enabled', array(), 'Install'),
                         'fileinfo' => $this->translator->trans('Fileinfo extension is not enabled', array(), 'Install'),
-                    )
+                        'intl' => $this->translator->trans('Intl extension is not loaded', array(), 'Install'),
+                    ),
                 ),
                 array(
                     'title' => $this->translator->trans('Required Apache configuration', array(), 'Install'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Check if intl extension is loaded before running installer
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to install with and without intl extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11937)
<!-- Reviewable:end -->
