### PR TITLE
Improve performance by avoiding parsing YAML files during ModuleManagerBuilder init

### DIFF
--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -156,7 +156,7 @@ class ModuleManagerBuilder
             return;
         }
 
-        $yamlParser = new YamlParser();
+        $yamlParser = new YamlParser(_PS_CACHE_DIR_);
 
         $config = $yamlParser->parse($this->getConfigDir() . DIRECTORY_SEPARATOR . 'config.yml');
         $prestashopAddonsConfig =

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -43,6 +43,7 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
+use PrestaShop\PrestaShop\Core\Util\File\YamlParser;
 use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
 use PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient;
@@ -157,30 +158,12 @@ class ModuleManagerBuilder
             return;
         }
 
-        $phpConfigFile = $this->getConfigDir() . '/config.php';
-        if (file_exists($phpConfigFile)
-            && filemtime($phpConfigFile) >= filemtime($this->getConfigDir() . DIRECTORY_SEPARATOR . 'config.yml')) {
-            $config = require $phpConfigFile;
-        } else {
-            $config = Yaml::parse(
-                file_get_contents(
-                    $this->getConfigDir() . DIRECTORY_SEPARATOR . 'config.yml'
-                )
-            );
+        $yamlParser = new YamlParser();
 
-            try {
-                $filesystem = new Filesystem();
-                $filesystem->dumpFile($phpConfigFile, '<?php return ' . var_export($config, true) . ';' . "\n");
-            } catch (IOException $e) {
-                return false;
-            }
-        }
+        $config = $yamlParser->parse($this->getConfigDir() . DIRECTORY_SEPARATOR . 'config.yml');
+        $prestashopAddonsConfig =
+            $yamlParser->parse($this->getConfigDir() . DIRECTORY_SEPARATOR . 'addons/categories.yml');
 
-        $prestashopAddonsConfig = Yaml::parse(
-            file_get_contents(
-                $this->getConfigDir() . DIRECTORY_SEPARATOR . 'addons/categories.yml'
-            )
-        );
         $clientConfig = $config['csa_guzzle']['clients']['addons_api']['config'];
 
         self::$translator = Context::getContext()->getTranslator();

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -48,11 +48,9 @@ use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
 use PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
 use Symfony\Component\Routing\Router;
-use Symfony\Component\Yaml\Yaml;
 
 class ModuleManagerBuilder
 {

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -156,11 +156,11 @@ class ModuleManagerBuilder
             return;
         }
 
-        $yamlParser = new YamlParser(_PS_CACHE_DIR_);
+        $yamlParser = new YamlParser((new Configuration())->get('_PS_CACHE_DIR_'));
 
-        $config = $yamlParser->parse($this->getConfigDir() . DIRECTORY_SEPARATOR . 'config.yml');
+        $config = $yamlParser->parse($this->getConfigDir() . '/config.yml');
         $prestashopAddonsConfig =
-            $yamlParser->parse($this->getConfigDir() . DIRECTORY_SEPARATOR . 'addons/categories.yml');
+            $yamlParser->parse($this->getConfigDir() . '/addons/categories.yml');
 
         $clientConfig = $config['csa_guzzle']['clients']['addons_api']['config'];
 
@@ -245,7 +245,7 @@ class ModuleManagerBuilder
 
     protected function getConfigDir()
     {
-        return _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'config';
+        return _PS_ROOT_DIR_ . '/app/config';
     }
 
     /**

--- a/src/Core/Util/File/YamlParser.php
+++ b/src/Core/Util/File/YamlParser.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Util\File;
+
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Yaml parser utility class
+ */
+final class YamlParser
+{
+    private $useCache;
+
+    /**
+     * YamlParser constructor.
+     *
+     * @param bool $useCache
+     */
+    public function __construct($useCache = true)
+    {
+        $this->useCache = $useCache;
+    }
+
+    /**
+     * Parse a YAML File and return the result
+     *
+     * @param string $sourceFile
+     * @param bool $forceRefresh
+     *
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     * @throws \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function parse($sourceFile, $forceRefresh = false)
+    {
+        if (!$this->useCache) {
+            return Yaml::parseFile($sourceFile);
+        }
+
+        $phpConfigFile = $this->getCacheFile($sourceFile);
+        // we set the debug flag to true to force the cache freshness check
+        $configCache = new ConfigCache($phpConfigFile, true);
+        if ($forceRefresh || !$configCache->isFresh()) {
+            $config = Yaml::parseFile($sourceFile);
+            $resources = array();
+            $resources[] = new FileResource($sourceFile);
+            $configCache->write('<?php return ' . var_export($config, true) . ';' . "\n", $resources);
+        } else {
+            $config = require $phpConfigFile;
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param string $sourceFile
+     *
+     * @return string
+     */
+    public function getCacheFile($sourceFile)
+    {
+        return _PS_CACHE_DIR_ . 'yaml/' . md5($sourceFile) . '.php';
+    }
+}

--- a/src/Core/Util/File/YamlParser.php
+++ b/src/Core/Util/File/YamlParser.php
@@ -72,7 +72,7 @@ final class YamlParser
             $config = Yaml::parseFile($sourceFile);
             $resources = array();
             $resources[] = new FileResource($sourceFile);
-            $configCache->write('<?php return ' . var_export($config, true) . ';' . "\n", $resources);
+            $configCache->write('<?php return ' . var_export($config, true) . ';' . PHP_EOL, $resources);
         } else {
             $config = require $phpConfigFile;
         }

--- a/src/Core/Util/File/YamlParser.php
+++ b/src/Core/Util/File/YamlParser.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop.
+ * 2007-2019 PrestaShop.
  *
  * NOTICE OF LICENSE
  *

--- a/src/Core/Util/File/YamlParser.php
+++ b/src/Core/Util/File/YamlParser.php
@@ -67,7 +67,7 @@ final class YamlParser
 
         $phpConfigFile = $this->getCacheFile($sourceFile);
         // we set the debug flag to true to force the cache freshness check
-        $configCache = new ConfigCache($phpConfigFile, _PS_MODE_DEV_);
+        $configCache = new ConfigCache($phpConfigFile, true);
         if (!$forceRefresh && $configCache->isFresh()) {
             return require $phpConfigFile;
         }

--- a/src/Core/Util/File/YamlParser.php
+++ b/src/Core/Util/File/YamlParser.php
@@ -67,7 +67,7 @@ final class YamlParser
 
         $phpConfigFile = $this->getCacheFile($sourceFile);
         // we set the debug flag to true to force the cache freshness check
-        $configCache = new ConfigCache($phpConfigFile, true);
+        $configCache = new ConfigCache($phpConfigFile, _PS_MODE_DEV_);
         if (!$forceRefresh && $configCache->isFresh()) {
             return require $phpConfigFile;
         }

--- a/src/Core/Util/File/YamlParser.php
+++ b/src/Core/Util/File/YamlParser.php
@@ -74,7 +74,7 @@ final class YamlParser
 
         $config = Yaml::parseFile($sourceFile);
         $resources = [
-            new FileResource($sourceFile)
+            new FileResource($sourceFile),
         ];
         $configCache->write('<?php return ' . var_export($config, true) . ';' . PHP_EOL, $resources);
 

--- a/src/Core/Util/File/YamlParser.php
+++ b/src/Core/Util/File/YamlParser.php
@@ -26,8 +26,11 @@
 
 namespace PrestaShop\PrestaShop\Core\Util\File;
 
+use InvalidArgumentException;
+use RuntimeException;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -35,15 +38,25 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class YamlParser
 {
+    /**
+     * @var string
+     */
+    private $cacheDir;
+
+    /**
+     * @var bool
+     */
     private $useCache;
 
     /**
      * YamlParser constructor.
      *
+     * @param string $cacheDir
      * @param bool $useCache
      */
-    public function __construct($useCache = true)
+    public function __construct($cacheDir, $useCache = true)
     {
+        $this->cacheDir = $cacheDir;
         $this->useCache = $useCache;
     }
 
@@ -55,9 +68,9 @@ final class YamlParser
      *
      * @return mixed The YAML converted to a PHP value
      *
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
-     * @throws \Symfony\Component\Yaml\Exception\ParseException
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
+     * @throws ParseException
      */
     public function parse($sourceFile, $forceRefresh = false)
     {
@@ -88,6 +101,10 @@ final class YamlParser
      */
     public function getCacheFile($sourceFile)
     {
-        return _PS_CACHE_DIR_ . 'yaml/' . md5($sourceFile) . '.php';
+        return sprintf(
+            '%syaml/%s.php',
+            $this->cacheDir,
+            md5($sourceFile)
+        );
     }
 }

--- a/tests-legacy/Unit/Core/Util/YamlParserTest.php
+++ b/tests-legacy/Unit/Core/Util/YamlParserTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace LegacyTests\Unit\Core\Util\File;
+
+use LegacyTests\TestCase\UnitTestCase;
+use PrestaShop\PrestaShop\Core\Util\File\YamlParser;
+
+class YamlParserTest extends UnitTestCase
+{
+    public function getConfigDir()
+    {
+        return _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'config';
+    }
+
+    /**
+     * @dataProvider getYamlFilesProvider
+     */
+    public function testParser($yamlFiles)
+    {
+        $yamlParser = new YamlParser(false);
+        $cacheFile = $yamlParser->getCacheFile($yamlFiles);
+        @unlink($cacheFile);
+
+        // no cache file
+        $config = $yamlParser->parse($yamlFiles);
+        $this->assertArrayHasKey('parameters', $config);
+        $this->assertFileNotExists($cacheFile);
+
+        // create the cache file
+        $yamlParser = new YamlParser(true);
+        $config = $yamlParser->parse($yamlFiles);
+        $this->assertArrayHasKey('parameters', $config);
+        $this->assertFileExists($cacheFile);
+        $cacheTime = filemtime($cacheFile);
+
+        // the source file hasn't changed, the cache file should be reused
+        $config = $yamlParser->parse($yamlFiles);
+        $this->assertArrayHasKey('parameters', $config);
+        $this->assertFileExists($cacheFile);
+        $this->assertEquals($cacheTime, filemtime($cacheFile));
+
+        // if source yaml change, the cache should be refreshed
+        sleep(1);
+        touch($yamlFiles);
+        $config = $yamlParser->parse($yamlFiles);
+        $this->assertArrayHasKey('parameters', $config);
+        $this->assertFileExists($cacheFile);
+        $this->assertNotEquals($cacheTime, filemtime($cacheFile));
+        $cacheTime = filemtime($cacheFile);
+
+        // if the forceRefresh flag is used, the cache should be refreshed
+        sleep(1);
+        $config = $yamlParser->parse($yamlFiles, true);
+        $this->assertArrayHasKey('parameters', $config);
+        $this->assertFileExists($cacheFile);
+        $this->assertNotEquals($cacheTime, filemtime($cacheFile));
+    }
+
+    /**
+     * Data provider
+     *
+     * @return array
+     */
+    public function getYamlFilesProvider()
+    {
+        return array(array($this->getConfigDir() . DIRECTORY_SEPARATOR . 'config.yml'));
+    }
+}

--- a/tests-legacy/Unit/Core/Util/YamlParserTest.php
+++ b/tests-legacy/Unit/Core/Util/YamlParserTest.php
@@ -77,6 +77,7 @@ class YamlParserTest extends UnitTestCase
         $this->assertFileExists($cacheFile);
         $cacheTime = filemtime($cacheFile);
 
+        sleep(1);
         // the source file hasn't changed, the cache file should be reused
         $config = $yamlParser->parse($yamlFiles);
         $this->assertArrayHasKey('parameters', $config);
@@ -84,8 +85,7 @@ class YamlParserTest extends UnitTestCase
         $this->assertEquals($cacheTime, filemtime($cacheFile));
 
         // if source yaml change, the cache should be refreshed
-        sleep(1);
-        touch($yamlFiles);
+        touch($yamlFiles, time()+1);
         $config = $yamlParser->parse($yamlFiles);
         $this->assertArrayHasKey('parameters', $config);
         $this->assertFileExists($cacheFile);

--- a/tests/Unit/Core/Util/YamlParserTest.php
+++ b/tests/Unit/Core/Util/YamlParserTest.php
@@ -33,6 +33,7 @@ class YamlParserTest extends UnitTestCase
 {
     /**
      * @param $yamlFiles
+     *
      * @return string
      */
     private function clearCacheFile($yamlFiles)
@@ -85,7 +86,7 @@ class YamlParserTest extends UnitTestCase
         $this->assertEquals($cacheTime, filemtime($cacheFile));
 
         // if source yaml change, the cache should be refreshed
-        touch($yamlFiles, time()+1);
+        touch($yamlFiles, time() + 1);
         $config = $yamlParser->parse($yamlFiles);
         $this->assertArrayHasKey('parameters', $config);
         $this->assertFileExists($cacheFile);

--- a/tests/Unit/Core/Util/YamlParserTest.php
+++ b/tests/Unit/Core/Util/YamlParserTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2019 PrestaShop
  *
  * NOTICE OF LICENSE
  *
@@ -46,7 +46,7 @@ class YamlParserTest extends UnitTestCase
 
     public function getConfigDir()
     {
-        return _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'config';
+        return _PS_ROOT_DIR_ . '/app/config';
     }
 
     /**
@@ -122,6 +122,6 @@ class YamlParserTest extends UnitTestCase
      */
     public function getYamlFilesProvider()
     {
-        return array(array($this->getConfigDir() . DIRECTORY_SEPARATOR . 'config.yml'));
+        return [[$this->getConfigDir() . '/config_test.yml']];
     }
 }

--- a/tests/Unit/Core/Util/YamlParserTest.php
+++ b/tests/Unit/Core/Util/YamlParserTest.php
@@ -38,7 +38,7 @@ class YamlParserTest extends UnitTestCase
      */
     private function clearCacheFile($yamlFiles)
     {
-        $yamlParser = new YamlParser(false);
+        $yamlParser = new YamlParser($this->getCacheDir(), false);
         $cacheFile = $yamlParser->getCacheFile($yamlFiles);
         @unlink($cacheFile);
 
@@ -50,13 +50,18 @@ class YamlParserTest extends UnitTestCase
         return _PS_ROOT_DIR_ . '/app/config';
     }
 
+    public function getCacheDir()
+    {
+        return _PS_ROOT_DIR_ . '/var/cache/test/';
+    }
+
     /**
      * @dataProvider getYamlFilesProvider
      */
     public function testParserNoCache($yamlFiles)
     {
         $cacheFile = $this->clearCacheFile($yamlFiles);
-        $yamlParser = new YamlParser(false);
+        $yamlParser = new YamlParser($this->getCacheDir(), false);
 
         // no cache file
         $config = $yamlParser->parse($yamlFiles);
@@ -72,7 +77,7 @@ class YamlParserTest extends UnitTestCase
         $cacheFile = $this->clearCacheFile($yamlFiles);
 
         // create the cache file
-        $yamlParser = new YamlParser(true);
+        $yamlParser = new YamlParser($this->getConfigDir(), true);
         $config = $yamlParser->parse($yamlFiles);
         $this->assertArrayHasKey('parameters', $config);
         $this->assertFileExists($cacheFile);
@@ -102,7 +107,7 @@ class YamlParserTest extends UnitTestCase
         $cacheFile = $this->clearCacheFile($yamlFiles);
 
         // create the cache file
-        $yamlParser = new YamlParser(true);
+        $yamlParser = new YamlParser($this->getConfigDir(), true);
         $config = $yamlParser->parse($yamlFiles);
         $this->assertArrayHasKey('parameters', $config);
         $this->assertFileExists($cacheFile);

--- a/tests/Unit/Core/Util/YamlParserTest.php
+++ b/tests/Unit/Core/Util/YamlParserTest.php
@@ -47,7 +47,7 @@ class YamlParserTest extends UnitTestCase
 
     public function getConfigDir()
     {
-        return _PS_ROOT_DIR_ . '/app/config';
+        return _PS_ROOT_DIR_ . '/app/config/';
     }
 
     public function getCacheDir()
@@ -77,7 +77,7 @@ class YamlParserTest extends UnitTestCase
         $cacheFile = $this->clearCacheFile($yamlFiles);
 
         // create the cache file
-        $yamlParser = new YamlParser($this->getConfigDir(), true);
+        $yamlParser = new YamlParser($this->getCacheDir(), true);
         $config = $yamlParser->parse($yamlFiles);
         $this->assertArrayHasKey('parameters', $config);
         $this->assertFileExists($cacheFile);
@@ -107,7 +107,7 @@ class YamlParserTest extends UnitTestCase
         $cacheFile = $this->clearCacheFile($yamlFiles);
 
         // create the cache file
-        $yamlParser = new YamlParser($this->getConfigDir(), true);
+        $yamlParser = new YamlParser($this->getCacheDir(), true);
         $config = $yamlParser->parse($yamlFiles);
         $this->assertArrayHasKey('parameters', $config);
         $this->assertFileExists($cacheFile);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | YAML files are not cached to avoid parsing them during ModuleManagerBuilder init. Introducing a new Util class to parse & cache the YAML files
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Run tests, load any FO page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11943)
<!-- Reviewable:end -->
