### PR TITLE
Do not stripslashes value from _GET & _POST

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -25,6 +25,7 @@
  */
 use PrestaShop\PrestaShop\Adapter\CoreException;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
+use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 
 /**
  * Class EmployeeCore.
@@ -340,8 +341,8 @@ class EmployeeCore extends ObjectModel
             return false;
         }
 
-        /** @var \PrestaShop\PrestaShop\Core\Crypto\Hashing $crypto */
-        $crypto = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Crypto\\Hashing');
+        /** @var Hashing $crypto */
+        $crypto = ServiceLocator::get(Hashing::class);
 
         $passwordHash = $result['passwd'];
         $shouldCheckPassword = null !== $plaintextPassword;

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -521,7 +521,7 @@ class ToolsCore
      */
     public static function getValue($key, $default_value = false)
     {
-        if (!isset($key) || empty($key) || !is_string($key)) {
+        if (empty($key) || !is_string($key)) {
             return false;
         }
 
@@ -532,7 +532,7 @@ class ToolsCore
         }
 
         if (is_string($value)) {
-            return stripslashes(urldecode(preg_replace('/((\%5C0+)|(\%00+))/i', '', urlencode($value))));
+            return urldecode(preg_replace('/((\%5C0+)|(\%00+))/i', '', urlencode($value)));
         }
 
         return $value;

--- a/tests-legacy/Unit/Classes/ToolsCoreTest.php
+++ b/tests-legacy/Unit/Classes/ToolsCoreTest.php
@@ -88,6 +88,7 @@ class ToolsCoreTest extends TestCase
             array("\0", ''),
             array("haxx\0r", 'haxxr'),
             array("haxx\0\0\0r", 'haxxr'),
+            array('1234\5678', '1234\5678'),
         );
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since magicquote gpc is no more used we can remove this test.<br/>More, only replace the nullbyte with "\0" because it can be written in different ways such as 000, \x00, \z, \u0000...
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11959
| How to test?  | Follow ticket instruction.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11962)
<!-- Reviewable:end -->
