### PR TITLE
Fix undefined INTL_IDNA_VARIANT_UTS46 if intl ICU < 4.6

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -864,6 +864,9 @@ class MailCore extends ObjectModel
     /**
      * Automatically convert email to Punycode.
      *
+     * Try to use INTL_IDNA_VARIANT_UTS46 only if defined, else use INTL_IDNA_VARIANT_2003
+     * See https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003
+     *
      * @param string $to Email address
      *
      * @return string
@@ -875,7 +878,19 @@ class MailCore extends ObjectModel
             return $to;
         }
 
-        return $address[0] . '@' . idn_to_ascii($address[1], 0, INTL_IDNA_VARIANT_UTS46);
+        if (defined('INTL_IDNA_VARIANT_UTS46')) {
+            return $address[0] . '@' . idn_to_ascii($address[1], 0, INTL_IDNA_VARIANT_UTS46);
+        }
+
+        /*
+         * INTL_IDNA_VARIANT_2003 const will be removed in PHP 8.
+         * See https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003
+         */
+        if (defined('INTL_IDNA_VARIANT_2003')) {
+            return $address[0] . '@' . idn_to_ascii($address[1], 0, INTL_IDNA_VARIANT_2003);
+        }
+
+        return $address[0] . '@' . idn_to_ascii($address[1]);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | #11579 introduced `INTL_IDNA_VARIANT_UTS46`  in the `idn_to_ascii` function, in order to comply with PHP 7.2 standards.<br>However, this broke e-mail sending for servers running an outdated ICU version (< 4.6). Figures out, there are more shared hostings that run outdated ICU versions with new PHP versions than expected and we should expect to see more and more issues regarding mail sending as more people will upgrade to PS 1.7.5.0. <br>This PR aims to silently fix this issue. If `INTL_IDNA_VARIANT_UTS46` is defined, use it to comply with PHP 7.2 standards. If it's not defined, then use the old `INTL_IDNA_VARIANT_2003` as long as it is [still supported by PHP](https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003) (up to the next major release, which will be 8.0.0). In PHP 7.2.0 up to 7.4.0, using `INTL_IDNA_VARIANT_2003` will trigger `E_DEPRECATED` notices while still being the default for the `idn_to_ascii` function and still working. From PHP 7.4.0 up to next major release, the default will be `INTL_IDNA_VARIANT_UTS46` but `INTL_IDNA_VARIANT_2003` will still work with warnings. From PHP 8.0.0, we cannot longer use `INTL_IDNA_VARIANT_2003` so we'll use the current default. If a server will run the outdated ICU <4.6 and PHP >= 8.0.0, an Exception will be triggered, but untill PS will be compatible with PHP 8.0 there is enough time to for most hosts to upgrade their ICU version.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Does it break backward compatibility?no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes #11933, #11949
| How to test?  | Try to send an email from the order page from a server running intl ICU < 4.6. With this fix, it will work. Without, you will get an error 500 both in BO and in FO when customer tries to register, reset password, etc.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11995)
<!-- Reviewable:end -->
