### PR TITLE
Fix cart quantity check when using a customization field

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1255,7 +1255,7 @@ class CartCore extends ObjectModel
         $parentSql = 'SELECT
             COALESCE(SUM(first_level_quantity) + SUM(pack_quantity), 0) as deep_quantity,
             COALESCE(SUM(first_level_quantity), 0) as quantity
-          FROM (' . $firstUnionSql . ' UNION ' . $secondUnionSql . ') as q';
+          FROM (' . $firstUnionSql . ($productIsPack ? ' UNION ' . $secondUnionSql : '') . ') as q';
 
         return Db::getInstance()->getRow($parentSql);
     }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1234,7 +1234,6 @@ class CartCore extends ObjectModel
         }
         $commonWhere = '
             WHERE cp.`id_product_attribute` = ' . (int) $idProductAttribute . '
-            AND cp.`id_customization` = ' . (int) $idCustomization . '
             AND cp.`id_cart` = ' . (int) $this->id;
 
         if (Configuration::get('PS_ALLOW_MULTISHIPPING') && $this->isMultiAddressDelivery()) {
@@ -1242,6 +1241,7 @@ class CartCore extends ObjectModel
         }
 
         if ($idCustomization) {
+            $commonWhere .= ' AND cp.`id_customization` = ' . (int) $idCustomization;
             $commonWhere .= ' AND c.`id_customization` = ' . (int) $idCustomization;
         }
         $firstUnionSql .= $commonWhere;

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -582,8 +582,7 @@ class CartControllerCore extends FrontController
             $this->id_product,
             $this->id_product_attribute,
             null,
-            $this->context->cart,
-            $this->customization_id
+            $this->context->cart
         );
 
         return $productQuantity < 0;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When checking remaining stock quantity, we should check the product quantity as a whole including customized/non customized entries
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Set product stock to 1 for example then save a customization and add it to cart. The product page should display the "out of stock" message.

Previous behaviour: if you have a customization in cart, it will not be counted which allows the user to add a non customized product and vice versa

Plus: I fixed the qty check query when product is not a pack (https://github.com/PrestaShop/PrestaShop/commit/e80339a0d679c12619b0515a6d1a5a904f969d76), it used to give a quantity of 0



![2019-01-02_11-02](https://user-images.githubusercontent.com/793712/50587368-f1169280-0e7d-11e9-956d-639860e8e5d3.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11996)
<!-- Reviewable:end -->
