### PR TITLE
Make filtering of LazyArrays return a new instance

### DIFF
--- a/src/Adapter/Presenter/AbstractLazyArray.php
+++ b/src/Adapter/Presenter/AbstractLazyArray.php
@@ -214,6 +214,15 @@ abstract class AbstractLazyArray implements Iterator, ArrayAccess, Countable, Js
     }
 
     /**
+     * Needed to ensure that any changes to this object won't bleed to other instances
+     */
+    public function __clone()
+    {
+        $this->arrayAccessList = clone $this->arrayAccessList;
+        $this->arrayAccessIterator = clone $this->arrayAccessIterator;
+    }
+
+    /**
      * Get the value associated with the $index from the lazyArray.
      *
      * @param mixed $index

--- a/src/Core/Filter/HashMapWhitelistFilter.php
+++ b/src/Core/Filter/HashMapWhitelistFilter.php
@@ -164,6 +164,8 @@ class HashMapWhitelistFilter implements FilterInterface
     {
         // keep whitelisted items
         if ($subject instanceof AbstractLazyArray) {
+            // avoid modifying the original object
+            $subject = clone $subject;
             $subject->intersectKey($this->whitelistItems);
             // run nested filters
             foreach ($this->filters as $key => $filter) {

--- a/tests-legacy/Unit/Core/Filter/HashMapWhitelistFilterTest.php
+++ b/tests-legacy/Unit/Core/Filter/HashMapWhitelistFilterTest.php
@@ -26,6 +26,7 @@
 
 namespace LegacyTests\Unit\Core\Filter;
 
+use LegacyTests\Unit\Core\Filter\_Artifacts\TestLazyArray;
 use PrestaShop\PrestaShop\Core\Filter\HashMapWhitelistFilter;
 
 class HashMapWhitelistFilterTest extends \PHPUnit\Framework\TestCase
@@ -103,6 +104,30 @@ class HashMapWhitelistFilterTest extends \PHPUnit\Framework\TestCase
         ];
 
         $this->assertSame($expected, $filter->filter($subject));
+    }
+
+    public function testFilteringLazyArrayReturnsNewInstanceOfSubject()
+    {
+        $subject = new TestLazyArray();
+
+        $filter = new HashMapWhitelistFilter();
+        $filter->whitelist([
+            'some_property',
+        ]);
+
+        $filteredSubject = $filter->filter($subject);
+
+        $this->assertNotSame($subject, $filteredSubject);
+        $this->assertArrayNotHasKey(
+            'some_other_property',
+            $filteredSubject,
+            "The filtered subject still has properties that should have been filtered out"
+        );
+        $this->assertArrayHasKey(
+            'some_other_property',
+            $subject,
+            "The original subject has been altered"
+        );
     }
 
     public function provideTestCases()

--- a/tests-legacy/Unit/Core/Filter/_Artifacts/TestLazyArray.php
+++ b/tests-legacy/Unit/Core/Filter/_Artifacts/TestLazyArray.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace LegacyTests\Unit\Core\Filter\_Artifacts;
+
+use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+
+class TestLazyArray extends AbstractLazyArray
+{
+
+    /**
+     * @arrayAccess
+     */
+    public function getSomeProperty()
+    {
+        return 'some_property';
+    }
+
+    /**
+     * @arrayAccess
+     */
+    public function getSomeOtherProperty()
+    {
+        return 'some_other_property';
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Make filtering of LazyArrays return a new instance of said object. This prevents an unexpected modification of a deeply nested LazyArray.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | No regressions tests in the FO: Search a product, create an order.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12010)
<!-- Reviewable:end -->
