### PR TITLE
Isolate legacy tests into suites to fix develop branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -163,7 +163,9 @@
         ],
         "phpunit-legacy": [
             "@composer create-test-db",
-            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml"
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml --testsuite Unit",
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml --testsuite CoreCart",
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml --testsuite Integration"
         ],
         "unit-tests": [
             "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Unit/phpunit.xml"

--- a/tests-legacy/phpunit.xml
+++ b/tests-legacy/phpunit.xml
@@ -22,6 +22,10 @@
     <testsuites>
         <testsuite name="Unit">
             <directory>Unit</directory>
+            <exclude>Unit/Core/Cart</exclude>
+        </testsuite>
+        <testsuite name="CoreCart">
+            <directory>Unit/Core/Cart</directory>
         </testsuite>
         <testsuite name="Integration">
             <directory>Integration</directory>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Some legacy tests fail if the tests are executed as a whole. Probably a caching feature that overlaps and makes test A modifies test B output. This PR isolates the failing tests into a dedicated test suite to fix it.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Travis should be green

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12013)
<!-- Reviewable:end -->
