### PR TITLE
Unify algorithm for calculating average tax rate for products in a cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -380,13 +380,13 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Calculate average Tax rate in Cart.
+     * Calculate average Tax rate in Cart, as a percentage.
      *
      * @deprecated since version 1.7.6. Use $cart->getAverageProductsTaxRate() instead.
      *
      * @param mixed $cart Cart ID or Cart Object
      *
-     * @return float Average Tax used in Cart
+     * @return float Average Tax used in Cart (eg. 20.0 for 20% average rate)
      */
     public static function getTaxesAverageUsed($cart)
     {
@@ -406,11 +406,11 @@ class CartCore extends ObjectModel
             return 0;
         }
 
-        return $cart->getAverageProductsTaxRate();
+        return $cart->getAverageProductsTaxRate() * 100;
     }
 
     /**
-     * Returns the average Tax rate for all products in the cart.
+     * Returns the average Tax rate for all products in the cart, as a multiplier.
      *
      * The arguments are optional and only serve as return values in case caller needs the details.
      *
@@ -419,7 +419,7 @@ class CartCore extends ObjectModel
      * @param float|null $cartAmountTaxIncluded If the reference is given, it will be updated with the
      *                                          total amount in the Cart including Taxes
      *
-     * @return float Average Tax Rate on Products
+     * @return float Average Tax Rate on Products (eg. 0.2 for 20% average rate)
      */
     public function getAverageProductsTaxRate(&$cartAmountTaxExcluded = null, &$cartAmountTaxIncluded = null)
     {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -382,12 +382,19 @@ class CartCore extends ObjectModel
     /**
      * Calculate average Tax rate in Cart.
      *
+     * @deprecated since version 1.7.6. Use $cart->getAverageProductsTaxRate() instead.
+     *
      * @param mixed $cart Cart ID or Cart Object
      *
      * @return float Average Tax used in Cart
      */
     public static function getTaxesAverageUsed($cart)
     {
+        @trigger_error(
+            'Cart::getTaxesAverageUsed() is deprecated since version 1.7.6. Use $cart->getAverageProductsTaxRate() instead.',
+            E_USER_DEPRECATED
+        );
+
         if (!is_object($cart)) {
             $cart = new Cart((int) $cart);
         }
@@ -399,41 +406,12 @@ class CartCore extends ObjectModel
             return 0;
         }
 
-        $products = $cart->getProducts();
-        $total_products_average = 0;
-        $ratio_tax = 0;
-
-        if (!count($products)) {
-            return 0;
-        }
-
-        foreach ($products as $product) {
-            // products refer to the cart details
-
-            if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_invoice') {
-                $address_id = (int) $cart->id_address_invoice;
-            } else {
-                $address_id = (int) $product['id_address_delivery'];
-            } // Get delivery address of the product from the cart
-            if (!Address::addressExists($address_id)) {
-                $address_id = null;
-            }
-
-            $total_products_average += $product['total_wt'];
-            $ratio_tax += $product['total_wt'] * Tax::getProductTaxRate(
-                    (int) $product['id_product'],
-                    (int) $address_id
-                );
-        }
-
-        if ($total_products_average > 0) {
-            return $ratio_tax / $total_products_average;
-        }
-
-        return 0;
+        return $cart->getAverageProductsTaxRate();
     }
 
     /**
+     * Returns the average Tax rate for all products in the cart.
+     *
      * The arguments are optional and only serve as return values in case caller needs the details.
      *
      * @param float|null $cartAmountTaxExcluded If the reference is given, it will be updated with the


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There are currently two methods for calculating the average tax rate in a cart, `Cart::getTaxesAverageUsed()` and `$cart->getAverageProductsTaxRate()`. They used a different algorithm to calculate it, but it more or less ended up in "sum of all products without tax / sum of all taxes applied". This PR unifies the behavior and depreciates the static method.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Add many products to a cart, ideally with different tax rates, and with some reductions. In the order detail (FO), the reduction amount should be correct (or at least no different from before :trollface:)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12014)
<!-- Reviewable:end -->
