### PR TITLE
Update module & service link in upgrade

### DIFF
--- a/install-dev/upgrade/php/ps_1751_update_module_sf_tab.php
+++ b/install-dev/upgrade/php/ps_1751_update_module_sf_tab.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * 2007-2019 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2019 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * File copied from ps_update_tabs.php and modified for only adding modules related tabs
+ */
+function ps_1751_update_module_sf_tab()
+{
+    // Rename parent module tab (= Module manager)
+    include_once 'clean_tabs_15.php';
+    $adminModulesParentTabId = Db::getInstance()->getValue(
+        'SELECT id_tab FROM '._DB_PREFIX_.'tab WHERE class_name = "AdminModulesSf"'
+    );
+    if (!empty($adminModulesParentTabId)) {
+        renameTab(
+            $adminModulesParentTabId,
+            [
+                'fr' => 'Gestionnaire de modules',
+                'es' => 'Gestor de módulos',
+                'en' => 'Module Manager',
+                'gb' => 'Module Manager',
+                'de' => 'Modulmanager',
+                'it' => 'Gestione moduli',
+            ]
+        );
+    }
+}

--- a/install-dev/upgrade/sql/1.7.5.1.sql
+++ b/install-dev/upgrade/sql/1.7.5.1.sql
@@ -9,3 +9,5 @@ ALTER TABLE `PREFIX_product`
 
 ALTER TABLE `PREFIX_order_detail`
   CHANGE `product_supplier_reference` `product_supplier_reference` varchar(64) DEFAULT NULL;
+
+/* PHP:ps_1751_update_module_sf_tab(); */;

--- a/install-dev/upgrade/sql/1.7.5.1.sql
+++ b/install-dev/upgrade/sql/1.7.5.1.sql
@@ -10,4 +10,10 @@ ALTER TABLE `PREFIX_product`
 ALTER TABLE `PREFIX_order_detail`
   CHANGE `product_supplier_reference` `product_supplier_reference` varchar(64) DEFAULT NULL;
 
+-- Update default links in quick access
+UPDATE `PREFIX_quick_access` SET `link` = "index.php/improve/modules/manage"
+  WHERE link = "index.php/module/manage";
+UPDATE `PREFIX_quick_access` SET `link` = "index.php/sell/catalog/products/new"
+  WHERE link = "index.php/product/new";
+
 /* PHP:ps_1751_update_module_sf_tab(); */;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Update the link name "Module & services" and the default links in quick access
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #11905 & #11934
| How to test?  | Upgrade a shop with this sql file, the link in the BO menu should be renamed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12016)
<!-- Reviewable:end -->
