### PR TITLE
Use Symfony Cache Clear in ModuleManager instead of deprecated CacheClearer

### DIFF
--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Addon\Module;
 
 use Exception;
-use PrestaShop\PrestaShop\Adapter\Cache\CacheClearer;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
@@ -36,6 +35,7 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager;
 use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
 use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShop\PrestaShop\Core\Addon\Module\Exception\UnconfirmedModuleActionException;
+use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use PrestaShopBundle\Event\ModuleManagementEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -96,9 +96,9 @@ class ModuleManager implements AddonManagerInterface
     private $actionParams;
 
     /**
-     * @var CacheClearer
+     * @var CacheClearerInterface
      */
-    private $cacheClearer;
+    private $symfonyCacheClearer;
 
     /**
      * Used to check if the cache has already been cleaned.
@@ -115,7 +115,7 @@ class ModuleManager implements AddonManagerInterface
      * @param ModuleZipManager $moduleZipManager
      * @param TranslatorInterface $translator
      * @param EventDispatcherInterface $eventDispatcher
-     * @param CacheClearer $cacheClearer
+     * @param CacheClearerInterface $symfonyCacheClearer
      */
     public function __construct(
         AdminModuleDataProvider $adminModuleProvider,
@@ -125,7 +125,7 @@ class ModuleManager implements AddonManagerInterface
         ModuleZipManager $moduleZipManager,
         TranslatorInterface $translator,
         EventDispatcherInterface $eventDispatcher,
-        CacheClearer $cacheClearer
+        CacheClearerInterface $symfonyCacheClearer
     ) {
         $this->adminModuleProvider = $adminModuleProvider;
         $this->moduleProvider = $modulesProvider;
@@ -134,7 +134,7 @@ class ModuleManager implements AddonManagerInterface
         $this->moduleZipManager = $moduleZipManager;
         $this->translator = $translator;
         $this->eventDispatcher = $eventDispatcher;
-        $this->cacheClearer = $cacheClearer;
+        $this->symfonyCacheClearer = $symfonyCacheClearer;
         $this->actionParams = new ParameterBag();
     }
 
@@ -810,7 +810,7 @@ class ModuleManager implements AddonManagerInterface
             return;
         }
 
-        $this->cacheClearer->clearSymfonyCache();
+        $this->symfonyCacheClearer->clear();
         $this->cacheCleared = true;
     }
 }

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -32,7 +32,6 @@ use Db;
 use Doctrine\Common\Cache\FilesystemCache;
 use GuzzleHttp\Client;
 use PrestaShop\PrestaShop\Adapter\Addons\AddonsDataProvider;
-use PrestaShop\PrestaShop\Adapter\Cache\CacheClearer;
 use PrestaShop\PrestaShop\Adapter\Cache\Clearer;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
@@ -44,7 +43,6 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
-use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerChain;
 use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
 use PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient;
@@ -113,12 +111,7 @@ class ModuleManagerBuilder
                     self::$moduleZipManager,
                     self::$translator,
                     new NullDispatcher(),
-                    new CacheClearer(
-                        new CacheClearerChain(),
-                        new Clearer\SymfonyCacheClearer(),
-                        new Clearer\MediaCacheClearer(),
-                        new Clearer\SmartyCacheClearer()
-                    )
+                    new Clearer\SymfonyCacheClearer()
                 );
             }
         }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -47,7 +47,7 @@ services:
             - "@prestashop.module.zip.manager"
             - "@translator"
             - "@event_dispatcher"
-            - "@prestashop.adapter.cache_clearer"
+            - "@prestashop.adapter.cache.clearer.symfony_cache_clearer"
 
     prestashop.module.zip.manager:
         class: PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager

--- a/tests-legacy/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests-legacy/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -27,8 +27,8 @@
 namespace LegacyTests\Core\Addon\Module;
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Adapter\Cache\CacheClearer;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManager;
+use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 
 class ModuleManagerTest extends TestCase
@@ -309,8 +309,7 @@ class ModuleManagerTest extends TestCase
 
     private function mockCacheClearer()
     {
-        $this->cacheClearerS = $this->getMockBuilder(CacheClearer::class)
-            ->disableOriginalConstructor()
+        $this->cacheClearerS = $this->getMockBuilder(CacheClearerInterface::class)
             ->getMock();
     }
 


### PR DESCRIPTION
This PR is the result of a discussion with @PierreRambaud and @jolelievre 

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Use Symfony Cache Clear in ModuleManager as CacheClearer is deprecated
| Type?         | refacto
| Category?     | CO
| BC breaks?    | yes ⚠️ 
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Module Manager usage should be unchanged. Every module action (install, enable, disable, configure, reset ...) should still work in the BO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12022)
<!-- Reviewable:end -->
