### PR TITLE
When downloading a virtual good,  check if the order was made by the current user

### DIFF
--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -57,7 +57,7 @@ class GetFileControllerCore extends FrontController
 
             Tools::setCookieLanguage();
             if (!$this->context->customer->isLogged() && !Tools::getValue('secure_key') && !Tools::getValue('id_order')) {
-                Tools::redirect('index.php?controller=authentication&back=get-file.php&key=' . $key);
+                Tools::redirect('index.php?controller=authentication&back=get-file.php%26key=' . $key);
             } elseif (!$this->context->customer->isLogged() && Tools::getValue('secure_key') && Tools::getValue('id_order')) {
                 $order = new Order((int) Tools::getValue('id_order'));
                 if (!Validate::isLoadedObject($order)) {

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -95,10 +95,8 @@ class GetFileControllerCore extends FrontController
             // Check whether the order was made by the current user
             // If the order was made by a guest, skip this step
             $customer = new Customer((int) $order->id_customer);
-            if (!$customer->is_guest) {
-                if ($order->secure_key != $this->context->customer->secure_key) {
-                    Tools::redirect('index.php?controller=authentication&back=get-file.php%26key=' . $key);
-                }
+            if (!$customer->is_guest && $order->secure_key !== $this->context->customer->secure_key) {
+                Tools::redirect('index.php?controller=authentication&back=get-file.php%26key=' . $key);
             }
 
             /* Product no more present in catalog */

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -57,16 +57,18 @@ class GetFileControllerCore extends FrontController
 
             Tools::setCookieLanguage();
             if (!$this->context->customer->isLogged()) {
-                if (Tools::getValue('secure_key') && Tools::getValue('id_order')) {
-                    $order = new Order((int) Tools::getValue('id_order'));
-                    if (!Validate::isLoadedObject($order)) {
-                        $this->displayCustomError('Invalid key.');
-                    }
-                    if ($order->secure_key != Tools::getValue('secure_key')) {
-                        $this->displayCustomError('Invalid key.');
-                    }
+            	if (!Tools::getValue('secure_key') && !Tools::getValue('id_order')) {
+                	Tools::redirect('index.php?controller=authentication&back=get-file.php%26key=' . $key);
+                } elseif (Tools::getValue('secure_key') && Tools::getValue('id_order')) {
+                	$order = new Order((int) Tools::getValue('id_order'));
+	                if (!Validate::isLoadedObject($order)) {
+	                    $this->displayCustomError('Invalid key.');
+	                }
+	                if ($order->secure_key != Tools::getValue('secure_key')) {
+	                    $this->displayCustomError('Invalid key.');
+	                }
                 } else {
-                     Tools::redirect('index.php?controller=authentication&back=get-file.php%26key=' . $key);
+                	$this->displayCustomError('Invalid key.');
                 }
             }
 

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -57,18 +57,18 @@ class GetFileControllerCore extends FrontController
 
             Tools::setCookieLanguage();
             if (!$this->context->customer->isLogged()) {
-            	if (!Tools::getValue('secure_key') && !Tools::getValue('id_order')) {
-                	Tools::redirect('index.php?controller=authentication&back=get-file.php%26key=' . $key);
+                if (!Tools::getValue('secure_key') && !Tools::getValue('id_order')) {
+                    Tools::redirect('index.php?controller=authentication&back=get-file.php%26key=' . $key);
                 } elseif (Tools::getValue('secure_key') && Tools::getValue('id_order')) {
-                	$order = new Order((int) Tools::getValue('id_order'));
-	                if (!Validate::isLoadedObject($order)) {
-	                    $this->displayCustomError('Invalid key.');
-	                }
-	                if ($order->secure_key != Tools::getValue('secure_key')) {
-	                    $this->displayCustomError('Invalid key.');
-	                }
+                    $order = new Order((int) Tools::getValue('id_order'));
+                    if (!Validate::isLoadedObject($order)) {
+                        $this->displayCustomError('Invalid key.');
+                    }
+                    if ($order->secure_key != Tools::getValue('secure_key')) {
+                        $this->displayCustomError('Invalid key.');
+                    }
                 } else {
-                	$this->displayCustomError('Invalid key.');
+                    $this->displayCustomError('Invalid key.');
                 }
             }
 

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -73,7 +73,7 @@ class GetFileControllerCore extends FrontController
                 $this->displayCustomError('This product does not exist in our store.');
             }
 
-             /* check whether order has been paid, which is required to download the product */
+            /* check whether order has been paid, which is required to download the product */
             $order = new Order((int) $info['id_order']);
             $state = $order->getCurrentOrderState();
             if (!$state || !$state->paid) {

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -79,8 +79,8 @@ class GetFileControllerCore extends FrontController
             if (!$state || !$state->paid) {
                 $this->displayCustomError('This order has not been paid.');
             }
-            
-            /* check whether the order was made by the current user  */
+
+            /* check whether the order was made by the current user */
             if ($order->secure_key != $this->context->customer->secure_key) {
                 $this->displayCustomError('Invalid key.');
             }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | See below.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Download a virtual good without being logged in / without specifying the order_id or secure_key url parameter. 

Previously anyone with the correct link (correct &key=... URL parameter) could download a virtual good. Specifically:
- If no user was logged in, and either no order ID or no secure key was specified.
- If a user was logged in, but they used a download link from another user.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12023)
<!-- Reviewable:end -->
