### PR TITLE
Make pre-commit execute linter only if php files have been staged

### DIFF
--- a/.github/contrib/pre-commit
+++ b/.github/contrib/pre-commit
@@ -15,7 +15,7 @@ then
 fi
 SFILES=${SFILES:-$STAGED_FILES_CMD}
 
-if [[ -n $SFILES ]]
+if [ -n "$SFILES" ]
 then
   echo "Checking PHP Lint..."
   for FILE in $SFILES

--- a/.github/contrib/pre-commit
+++ b/.github/contrib/pre-commit
@@ -1,8 +1,12 @@
 #!/bin/sh
 
+RED=`tput setaf 1`
+RESET=`tput sgr0`
+
 PHP_BINARY=`which php`
 STAGED_FILES_CMD=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep '\.php$'`
 PROJECT_PATH=$(cd "$( dirname "$0" )/../../" && pwd)
+CS_FIXER="./vendor/bin/php-cs-fixer fix"
 
 # Determine if a file list is passed
 if [ "$#" -eq 1 ]
@@ -29,8 +33,21 @@ then
   done
 
   echo "Running PHP CS Fixer..."
-  $PHP_BINARY ./vendor/bin/php-cs-fixer fix --show-progress=dot
-  exit $?
+
+  $PHP_BINARY $CS_FIXER --verbose --dry-run --show-progress=dots
+
+  if [ $? != 0 ]
+  then
+    printf "\n${RED}Some files need to be fixed!${RESET}\n\n"
+    echo "Please run the following script to fix them. Afterwards, add the changed files and commit again:"
+    echo "
+
+    php $CS_FIXER
+
+    "
+
+    exit 2
+  fi
 
 else
   echo "No modified PHP files to check."

--- a/.github/contrib/pre-commit
+++ b/.github/contrib/pre-commit
@@ -34,7 +34,7 @@ then
 
   echo "Running PHP CS Fixer..."
 
-  $PHP_BINARY $CS_FIXER --verbose --dry-run --show-progress=dots
+  $PHP_BINARY $CS_FIXER --dry-run
 
   if [ $? != 0 ]
   then
@@ -45,7 +45,6 @@ then
     php $CS_FIXER
 
     "
-
     exit 2
   fi
 

--- a/.github/contrib/pre-commit
+++ b/.github/contrib/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 PHP_BINARY=`which php`
-STAGED_FILES_CMD=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep \\\\.php`
+STAGED_FILES_CMD=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep '\.php$'`
 PROJECT_PATH=$(cd "$( dirname "$0" )/../../" && pwd)
 
 # Determine if a file list is passed
@@ -15,19 +15,23 @@ then
 fi
 SFILES=${SFILES:-$STAGED_FILES_CMD}
 
+if [[ -n $SFILES ]]
+then
+  echo "Checking PHP Lint..."
+  for FILE in $SFILES
+  do
+    $PHP_BINARY -l -d display_errors=0 $PROJECT_PATH/$FILE
+    if [ $? != 0 ]
+    then
+      echo "Error(s), please fix it before commit."
+      exit 1
+    fi
+  done
 
-echo "Checking PHP Lint..."
-for FILE in $SFILES
-do
-  $PHP_BINARY -l -d display_errors=0 $PROJECT_PATH/$FILE
-  if [ $? != 0 ]
-  then
-    echo "Error(s), please fix it before commit."
-    exit 1
-  fi
-done
+  echo "Running PHP CS Fixer..."
+  $PHP_BINARY ./vendor/bin/php-cs-fixer fix --show-progress=dot
+  exit $?
 
-echo "Running PHP CS Fixer..."
-$PHP_BINARY ./vendor/bin/php-cs-fixer fix
-
-exit $?
+else
+  echo "No modified PHP files to check."
+fi


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Currently, the pre-commit hook executes php-cs-fixer even if there are no modified php files. This PR makes it so it will only be executed if php files have been changed and staged for commit.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | No QA test needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12031)
<!-- Reviewable:end -->
