### PR TITLE
Enable PHP CS Fixer on tests folder

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -4,6 +4,7 @@ $finder = PhpCsFixer\Finder::create()->in([
     __DIR__.'/src',
     __DIR__.'/classes',
     __DIR__.'/controllers',
+    __DIR__.'/tests',
 ]);
 
 return PhpCsFixer\Config::create()

--- a/tests/E2E/prepare-shop.php
+++ b/tests/E2E/prepare-shop.php
@@ -23,15 +23,14 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
 define('_PS_MODE_DEV_', false);
-require __DIR__.'/../../config/config.inc.php';
+require __DIR__ . '/../../config/config.inc.php';
 
 // useful variables
 
-$language   = Context::getContext()->language;
-$shop       = Context::getContext()->shop;
-$dbPrefix   = _DB_PREFIX_;
+$language = Context::getContext()->language;
+$shop = Context::getContext()->shop;
+$dbPrefix = _DB_PREFIX_;
 
 // Enable URL rewriting
 
@@ -94,9 +93,9 @@ function disableModule($moduleName)
 
 function hookModule($moduleName, $hookName)
 {
-    $dbPrefix   = _DB_PREFIX_;
-    $module     = Module::getInstanceByName($moduleName);
-    $moduleId   = $module->id;
+    $dbPrefix = _DB_PREFIX_;
+    $module = Module::getInstanceByName($moduleName);
+    $moduleId = $module->id;
     Db::getInstance()->execute(
         "DELETE FROM {$dbPrefix}hook_module WHERE id_module=$moduleId"
     );
@@ -135,7 +134,7 @@ echo "- added a required customizable text field to product #1\n";
 Language::checkAndAddLanguage('fr');
 echo "- added French language just so that we have 2\n";
 $languages = Language::getLanguages();
-echo "  Number of languages : ".count($languages)."\n";
+echo '  Number of languages : ' . count($languages) . "\n";
 
 $order = new Order(5);
 $history = new OrderHistory();

--- a/tests/Selenium/prepare-shop.php
+++ b/tests/Selenium/prepare-shop.php
@@ -23,15 +23,14 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
 define('_PS_MODE_DEV_', false);
-require __DIR__.'/../../config/config.inc.php';
+require __DIR__ . '/../../config/config.inc.php';
 
 // useful variables
 
-$language   = Context::getContext()->language;
-$shop       = Context::getContext()->shop;
-$dbPrefix   = _DB_PREFIX_;
+$language = Context::getContext()->language;
+$shop = Context::getContext()->shop;
+$dbPrefix = _DB_PREFIX_;
 
 // Enable URL rewriting
 
@@ -94,9 +93,9 @@ function disableModule($moduleName)
 
 function hookModule($moduleName, $hookName)
 {
-    $dbPrefix   = _DB_PREFIX_;
-    $module     = Module::getInstanceByName($moduleName);
-    $moduleId   = $module->id;
+    $dbPrefix = _DB_PREFIX_;
+    $module = Module::getInstanceByName($moduleName);
+    $moduleId = $module->id;
     Db::getInstance()->execute(
         "DELETE FROM {$dbPrefix}hook_module WHERE id_module=$moduleId"
     );
@@ -137,7 +136,7 @@ echo "- added a required customizable text field to product #1\n";
 Language::checkAndAddLanguage('fr');
 echo "- added French language just so that we have 2\n";
 $languages = Language::getLanguages();
-echo "  Number of languages : ".count($languages)."\n";
+echo '  Number of languages : ' . count($languages) . "\n";
 
 $order = new Order(5);
 $history = new OrderHistory();

--- a/tests/TestCase/ErrorsDataListener.php
+++ b/tests/TestCase/ErrorsDataListener.php
@@ -32,7 +32,7 @@ use PHPUnit_Framework_TestSuite;
 class ErrorsDataListener extends BaseTestListener
 {
     /**
-     * @var PhpErrorsCounter a dedicated error handler.
+     * @var PhpErrorsCounter a dedicated error handler
      */
     private $errorsCounter;
 
@@ -56,7 +56,7 @@ class ErrorsDataListener extends BaseTestListener
 
     public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
-        $this->suites++;
+        ++$this->suites;
         if (!$this->isRegistered) {
             $this->errorsCounter->registerErrorHandler();
             $this->isRegistered = true;
@@ -65,7 +65,7 @@ class ErrorsDataListener extends BaseTestListener
 
     public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
-        $this->suites--;
+        --$this->suites;
 
         if ($this->suites === 0) {
             printf(PHP_EOL . PHP_EOL . 'Current report of phpErrorsHandler:');

--- a/tests/TestCase/PhpErrorsCounter.php
+++ b/tests/TestCase/PhpErrorsCounter.php
@@ -41,7 +41,7 @@ class PhpErrorsCounter
     public function registerErrorHandler()
     {
         set_error_handler(function ($errorType) {
-            switch($errorType) {
+            switch ($errorType) {
                 case E_WARNING:
                     $this->warnings++;
                 break;
@@ -99,7 +99,7 @@ class PhpErrorsCounter
     }
 
     /**
-     * @return string a summary report of errors.
+     * @return string a summary report of errors
      */
     public function displaySummary()
     {

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
@@ -26,7 +26,6 @@
 
 namespace Tests\Unit\Core\Form\IdentifiableObject\DataProvider;
 
-use DateTime;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
@@ -98,7 +97,7 @@ class CustomerFormDataProviderTest extends TestCase
                 $this->returnValueMap([
                     [
                         'PS_CUSTOMER_GROUP', 3,
-                    ]
+                    ],
                 ])
             )
         ;

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -23,12 +23,11 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
 define('_PS_IN_TEST_', true);
 define('_PS_ROOT_DIR_', __DIR__ . '/../..');
-define('_PS_MODULE_DIR_', _PS_ROOT_DIR_.'/tests-legacy/resources/modules/');
-require_once dirname(__FILE__).'/../../config/defines.inc.php';
-require_once _PS_CONFIG_DIR_.'autoload.php';
+define('_PS_MODULE_DIR_', _PS_ROOT_DIR_ . '/tests-legacy/resources/modules/');
+require_once dirname(__FILE__) . '/../../config/defines.inc.php';
+require_once _PS_CONFIG_DIR_ . 'autoload.php';
 
 if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
     define('PHPUNIT_COMPOSER_INSTALL', __DIR__ . '/../../vendor/autoload.php');

--- a/tests/index.php
+++ b/tests/index.php
@@ -23,13 +23,12 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
 
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-
-header("Location: ../");
+header('Location: ../');
 exit;


### PR DESCRIPTION
Following @PierreRambaud suggestion

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Enable PHP CS Fixer for tests folder in order to keep our test code clean and smooth
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Travis should be green

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12060)
<!-- Reviewable:end -->
