### PR TITLE
Refacto ProductPreferencesController to use annotations

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
@@ -27,8 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use PrestaShopBundle\Security\Voter\PageVoter;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -39,33 +38,19 @@ use Symfony\Component\HttpFoundation\Response;
 class ProductPreferencesController extends FrameworkBundleAdminController
 {
     /**
-     * Show product preferences form.
-     *
      * @param Request $request
      *
-     * @Template("@PrestaShop/Admin/Configure/ShopParameters/product_preferences.html.twig")
+     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller'))")
      *
-     * @return array|Response
+     * @return Response
      */
     public function indexAction(Request $request)
     {
         $legacyController = $request->attributes->get('_legacy_controller');
 
-        if (!in_array(
-            $this->authorizationLevel($legacyController),
-            [
-                PageVoter::LEVEL_READ,
-                PageVoter::LEVEL_UPDATE,
-                PageVoter::LEVEL_CREATE,
-                PageVoter::LEVEL_DELETE,
-            ]
-        )) {
-            return $this->redirectToDefaultPage();
-        }
-
         $form = $this->get('prestashop.admin.product_preferences.form_handler')->getForm();
 
-        return [
+        return $this->render('@PrestaShop/Admin/Configure/ShopParameters/product_preferences.html.twig', [
             'layoutHeaderToolbarBtn' => [],
             'layoutTitle' => $this->trans('Product Settings', 'Admin.Navigation.Menu'),
             'requireAddonsSearch' => true,
@@ -75,11 +60,16 @@ class ProductPreferencesController extends FrameworkBundleAdminController
             'help_link' => $this->generateSidebarLink($legacyController),
             'requireFilterStatus' => false,
             'form' => $form->createView(),
-        ];
+        ]);
     }
 
     /**
      * Process product preferences form.
+     *
+     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to update this.",
+     *     redirectRoute="admin_product_preferences"
+     * )
      *
      * @param Request $request
      *
@@ -87,21 +77,6 @@ class ProductPreferencesController extends FrameworkBundleAdminController
      */
     public function processAction(Request $request)
     {
-        $legacyController = $request->attributes->get('_legacy_controller');
-
-        if (!in_array(
-            $this->authorizationLevel($legacyController),
-            [
-                PageVoter::LEVEL_UPDATE,
-                PageVoter::LEVEL_CREATE,
-                PageVoter::LEVEL_DELETE,
-            ]
-        )) {
-            $this->addFlash('error', $this->trans('You do not have permission to edit this.', 'Admin.Notifications.Error'));
-
-            return $this->redirectToRoute('admin_product_preferences');
-        }
-
         $formHandler = $this->get('prestashop.admin.product_preferences.form_handler');
 
         $form = $formHandler->getForm();

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
@@ -40,7 +40,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
     /**
      * @param Request $request
      *
-     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @return Response
      */


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Refactor Controller to use latest conventions about annotations
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |  Symfony page "Configure > Shop Parameters > Product Settings" should behave like before. **Access rules** updated: you could access the page previously if you had read, create, update or delete rights. Now only read right grants you access to display the page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12076)
<!-- Reviewable:end -->
