### PR TITLE
Refacto ThemeCatalogController to use annotations

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeCatalogController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Improve\Design;
 
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -36,6 +37,8 @@ class ThemeCatalogController extends FrameworkBundleAdminController
 {
     /**
      * Displays themes from Addons under "Improve > Design > Themes Catalog".
+     *
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @param Request $request
      *


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Refactor Controller to use latest conventions about annotations
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |  Page "Improve > Design > Themes Catalog" should behave like before, **especially access rules**. This Controller controls themes shown by Addons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12077)
<!-- Reviewable:end -->
