### PR TITLE
Fix static cache reset on ObjectModel

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -171,6 +171,15 @@ class AddressCore extends ObjectModel
     }
 
     /**
+     * reset static cache (eg unit testing purpose).
+     */
+    public static function resetStaticCache()
+    {
+        static::$_idZones = array();
+        static::$_idCountries = array();
+    }
+
+    /**
      * @see ObjectModel::add()
      */
     public function add($autodate = true, $null_values = false)

--- a/classes/Attribute.php
+++ b/classes/Attribute.php
@@ -79,9 +79,8 @@ class AttributeCore extends ObjectModel
      */
     public function __construct($id = null, $idLang = null, $idShop = null)
     {
-        $this->image_dir = _PS_COL_IMG_DIR_;
-
         parent::__construct($id, $idLang, $idShop);
+        $this->image_dir = _PS_COL_IMG_DIR_;
     }
 
     /**

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -98,9 +98,9 @@ class CurrencyCore extends ObjectModel
      */
     public function __construct($id = null, $idLang = null, $idShop = null)
     {
-        $this->cldr = Tools::getCldr(Context::getContext());
-
         parent::__construct($id, $idLang, $idShop);
+
+        $this->cldr = Tools::getCldr(Context::getContext());
 
         if ($this->iso_code) {
             $cldrCurrency = $this->cldr->getCurrency($this->iso_code);

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -218,8 +218,8 @@ class CustomerCore extends ObjectModel
      */
     public function __construct($id = null)
     {
-        $this->id_default_group = (int) Configuration::get('PS_CUSTOMER_GROUP');
         parent::__construct($id);
+        $this->id_default_group = (int) Configuration::get('PS_CUSTOMER_GROUP');
     }
 
     /**
@@ -545,8 +545,13 @@ class CustomerCore extends ObjectModel
      * @param int $idCustomer Customer ID
      * @param int $idAddress Address ID
      */
-    public static function resetAddressCache($idCustomer, $idAddress)
+    public static function resetAddressCache($idCustomer = null, $idAddress = null)
     {
+        if ($idCustomer === null || $idAddress === null) {
+            self::$_customerHasAddress = array();
+            self::$_customer_groups = array();
+            self::$_defaultGroupId = array();
+        }
         $key = (int) $idCustomer . '-' . (int) $idAddress;
         if (array_key_exists($key, self::$_customerHasAddress)) {
             unset(self::$_customerHasAddress[$key]);

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -186,6 +186,14 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     }
 
     /**
+     * reset static cache (eg unit testing purpose).
+     */
+    public static function resetStaticCache()
+    {
+        static::$loaded_classes = array();
+    }
+
+    /**
      * Returns object validation rules (fields validity).
      *
      * @param string $class Child class name for static use (optional)

--- a/composer.json
+++ b/composer.json
@@ -163,9 +163,7 @@
         ],
         "phpunit-legacy": [
             "@composer create-test-db",
-            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml --testsuite Unit",
-            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml --testsuite CoreCart",
-            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml --testsuite Integration"
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml"
         ],
         "unit-tests": [
             "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Unit/phpunit.xml"

--- a/tests-legacy/Unit/ContextMocker.php
+++ b/tests-legacy/Unit/ContextMocker.php
@@ -26,6 +26,7 @@
 
 namespace LegacyTests\Unit;
 
+use Address;
 use Cache;
 use Carrier;
 use Cart;
@@ -33,8 +34,10 @@ use CartRule;
 use Configuration;
 use Context;
 use Currency;
+use Customer;
 use Language;
 use Link;
+use ObjectModel;
 use Pack;
 use Phake;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
@@ -92,6 +95,9 @@ class ContextMocker
         SymfonyContainer::resetStaticCache();
         Pack::resetStaticCache();
         Tools::$round_mode = null;
+        Customer::resetAddressCache();
+        Address::resetStaticCache();
+        ObjectModel::resetStaticCache();
 
         $this->contextBackup = Context::getContext();
         $context             = clone $this->contextBackup;

--- a/tests-legacy/Unit/Core/Cart/CartToOrder/CartToOrderTest.php
+++ b/tests-legacy/Unit/Core/Cart/CartToOrder/CartToOrderTest.php
@@ -93,14 +93,10 @@ class CartToOrderTest extends CartTaxesTest
     )
     {
         // prepare cart
-        $this->cart->id_address_delivery = $addressId;
         $this->resetCart();
+        $this->cart->id_address_delivery = $addressId;
         $this->addProductsToCart($productData);
         $this->addCartRulesToCart($cartRuleData);
-
-        // need to update secret_key in order to get payment working
-        $this->cart->secure_key = md5('xxx');
-        $this->cart->update();
 
         // need to set customer to have a valid email
         $customer = new Customer();
@@ -131,6 +127,11 @@ class CartToOrderTest extends CartTaxesTest
 
         // tests
         $order = Order::getByCartId($this->cart->id);
+        // compare global cart/order total
+        $this->assertEquals($this->cart->getOrderTotal(false), $order->total_paid_tax_excl);
+        $this->assertEquals($this->cart->getOrderTotal(true), $order->total_paid_tax_incl);
+
+        // specific comparisons
         $this->assertEquals($expected_totalProduct_taxIncl, $order->total_products_wt);
         $this->assertEquals($expected_totalProduct_taxExcl, $order->total_products);
         $this->assertEquals($expected_totalDiscount_taxExcl, $order->total_discounts_tax_excl);
@@ -208,7 +209,7 @@ class CartToOrderTest extends CartTaxesTest
                 'expected_discounts_taxExcl' => [57.29],
                 'expected_newVoucherValue' => 0,
             ],
-            '3 product in cart, 3 cart rules' => [
+            '3 product in cart, 2 cart rules' => [
                 'products' => [1 => 1, 2 => 1, 3 => 2],
                 'cartRules' => [1, 2],
                 'addressId' => CartTaxesTest::ADDRESS_ID_1,

--- a/tests-legacy/phpunit.xml
+++ b/tests-legacy/phpunit.xml
@@ -26,10 +26,6 @@
     <testsuites>
         <testsuite name="Unit">
             <directory>Unit</directory>
-            <exclude>Unit/Core/Cart</exclude>
-        </testsuite>
-        <testsuite name="CoreCart">
-            <directory>Unit/Core/Cart</directory>
         </testsuite>
         <testsuite name="Integration">
             <directory>Integration</directory>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix coupling between tests by properly reset more static caches, restore unique test suite (revert https://github.com/PrestaShop/PrestaShop/pull/12013)
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Run unit tests
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12079)
<!-- Reviewable:end -->
