### PR TITLE
Add image dimensions in product metas

### DIFF
--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -35,6 +35,8 @@
   <meta property="og:site_name" content="{$shop.name}">
   <meta property="og:description" content="{$page.meta.description}">
   <meta property="og:image" content="{$product.cover.large.url}">
+  <meta property="og:image:width" content="{$product.cover.large.width}">
+  <meta property="og:image:height" content="{$product.cover.large.height}">
   <meta property="product:pretax_price:amount" content="{$product.price_tax_exc}">
   <meta property="product:pretax_price:currency" content="{$currency.iso_code}">
   <meta property="product:price:amount" content="{$product.price_amount}">


### PR DESCRIPTION
I added "og:image:width" and "og:image:height" property

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.5.x 
| Description?  | I added "og:image:width" and "og:image:height property for asynchronous scraping facebook request"
| Type?         | new feature
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? yes
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | No
| How to test?  | Yes, it's ok

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12084)
<!-- Reviewable:end -->
