### PR TITLE
Refactor MaintenanceController to use annotations

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MaintenanceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MaintenanceController.php
@@ -42,7 +42,7 @@ class MaintenanceController extends FrameworkBundleAdminController
     const CONTROLLER_NAME = 'AdminMaintenance';
 
     /**
-     * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param FormInterface $form


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Refactor Controller to use latest conventions about annotations and fix access rules
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |  Page "Configure > Shop Parameters > General > Maintenance" should behave like before, but access rules have been fixed. See below.

Access rules changes:
- before, anybody could see it
- before, someone with either read, create, update or delete right could modify it
- now (with the PR) you need read right to see the page
- now, you need either create, update or delete right to modify the page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12099)
<!-- Reviewable:end -->
