### PR TITLE
Fix issue order message UTF8 problem

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -995,7 +995,7 @@ class ToolsCore
             return array_map(array('Tools', 'htmlentitiesUTF8'), $string);
         }
 
-        return htmlentities((string) $string, $type, 'utf-8');
+        return htmlspecialchars((string) $string, $type, 'utf-8');
     }
 
     public static function htmlentitiesDecodeUTF8($string)


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Order message which is added by a customer on delivery step not working correctly with UTF8.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9726
| How to test?  | Follow ticket instruction.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12103)
<!-- Reviewable:end -->
