### PR TITLE
For PHP7.2 + compatibility the constants need to be betweens apostrophe

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2034,7 +2034,7 @@ class ToolsCore
      */
     public static function refreshCACertFile()
     {
-        if ((time() - @filemtime(_PS_CACHE_CA_CERT_FILE_) > 1296000)) {
+        if ((time() - @filemtime('_PS_CACHE_CA_CERT_FILE_') > 1296000)) {
             $stream_context = @stream_context_create(
                 array(
                     'http' => array('timeout' => 3),
@@ -2053,7 +2053,7 @@ class ToolsCore
                 preg_match('/(.*-----BEGIN CERTIFICATE-----.*-----END CERTIFICATE-----){50}$/Uims', $ca_cert_content) &&
                 substr(rtrim($ca_cert_content), -1) == '-'
             ) {
-                file_put_contents(_PS_CACHE_CA_CERT_FILE_, $ca_cert_content);
+                file_put_contents('_PS_CACHE_CA_CERT_FILE_', $ca_cert_content);
             }
         }
     }
@@ -2074,7 +2074,7 @@ class ToolsCore
             curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
             curl_setopt($curl, CURLOPT_TIMEOUT, $curl_timeout);
             curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
-            curl_setopt($curl, CURLOPT_CAINFO, _PS_CACHE_CA_CERT_FILE_);
+            curl_setopt($curl, CURLOPT_CAINFO, '_PS_CACHE_CA_CERT_FILE_');
             curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($curl, CURLOPT_MAXREDIRS, 5);
 

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -194,7 +194,7 @@ class ModuleManagerBuilder
             \AppKernel::VERSION
         );
 
-        $marketPlaceClient->setSslVerification(_PS_CACHE_CA_CERT_FILE_);
+        $marketPlaceClient->setSslVerification('_PS_CACHE_CA_CERT_FILE_');
         if (file_exists($this->getConfigDir() . '/parameters.php')) {
             $parameters = require $this->getConfigDir() . '/parameters.php';
             if (array_key_exists('addons.api_client.verify_ssl', $parameters['parameters'])) {

--- a/src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php
+++ b/src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php
@@ -81,7 +81,7 @@ class AddOnsConfiguration implements ConfigurationInterface
                                     ->defaultValue(0)
                                 ->end()
                                 ->scalarNode('verify_ssl')
-                                    ->defaultValue(_PS_CACHE_CA_CERT_FILE_)
+                                    ->defaultValue('_PS_CACHE_CA_CERT_FILE_')
                                 ->end()
                             ->end()
                         ->end()


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.5.x 
| Description?  | From php 7.2 and higher, the constant _PS_CACHE_CA_CERT_FILE_ need to be between apostrophe or else the constant is undefined.
| Type?         | bug fix
| Category?     | CO 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | 
| How to test?  | Tested with PHP versions 7.0 / 7.1 / 7.2

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12120)
<!-- Reviewable:end -->
