### PR TITLE
[WIP] Introduce CheckServiceDefinitionsCommand

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -14,6 +14,7 @@ set_time_limit(0);
 
 require __DIR__.'/../vendor/autoload.php';
 require_once __DIR__.'/../autoload.php';
+require_once _PS_CONFIG_DIR_.'alias.php';
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');

--- a/src/PrestaShopBundle/Command/CheckServiceDefinitionsCommand.php
+++ b/src/PrestaShopBundle/Command/CheckServiceDefinitionsCommand.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * 2007-2019 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class CheckServiceDefinitionsCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('prestashop:debug:services-container')
+            ->setDescription('Looks for issues in services');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $serviceIds = $this->getPrestaShopContainerBuilder()->getServiceIds();
+        $errors = [];
+
+        foreach ($serviceIds as $serviceId) {
+            try {
+                $call = $this->getContainer()->get($serviceId);
+            } catch (\Exception $e) {
+                $errors[] = $e;
+            }
+        }
+
+        var_dump($errors);
+    }
+
+    /**
+     * Load the Symfony container with PrestaShop services
+     *
+     * @return ContainerBuilder
+     *
+     * @todo: be able to target PrestaShop services defined outside of PrestaShopBundle
+     */
+    protected function getPrestaShopContainerBuilder()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yml');
+
+        return $container;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/feature.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/feature.yml
@@ -19,11 +19,6 @@ services:
         arguments:
             - '@prestashop.adapter.legacy.configuration'
 
-    prestashop.adapter.feature.multishop:
-        class: 'PrestaShop\PrestaShop\Adapter\Feature\MultishopFeature'
-        arguments:
-            - '@prestashop.adapter.legacy.configuration'
-
     prestashop.adapter.feature.multistore:
         class: 'PrestaShop\PrestaShop\Adapter\Feature\MultistoreFeature'
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
@@ -10,6 +10,7 @@ services:
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminLanguages")'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "enabled_languages"})'
+        tags: ['web-only']
 
     prestashop.adapter.kpi.main_country:
         class: PrestaShop\PrestaShop\Adapter\Kpi\MainCountryKpi
@@ -17,6 +18,7 @@ services:
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "main_country"})'
+        tags: ['web-only']
 
     prestashop.adapter.kpi.translations:
         class: PrestaShop\PrestaShop\Adapter\Kpi\TranslationsKpi
@@ -24,6 +26,7 @@ services:
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "frontoffice_translations"})'
+        tags: ['web-only']
 
     prestashop.adapter.kpi.disabled_categories:
         class: PrestaShop\PrestaShop\Adapter\Kpi\DisabledCategoriesKpi
@@ -31,6 +34,7 @@ services:
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "disabled_categories"})'
+        tags: ['web-only']
 
     prestashop.adapter.kpi.empty_categories:
         class: PrestaShop\PrestaShop\Adapter\Kpi\EmptyCategoriesKpi
@@ -39,6 +43,7 @@ services:
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "empty_categories"})'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminTracking")'
+        tags: ['web-only']
 
     prestashop.adapter.kpi.top_category:
         class: PrestaShop\PrestaShop\Adapter\Kpi\TopCategoryKpi
@@ -47,6 +52,7 @@ services:
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "top_category"})'
             - "@=service('prestashop.adapter.legacy.context').getContext().employee.id_lang"
+        tags: ['web-only']
 
     prestashop.adapter.kpi.average_products_in_category:
         class: PrestaShop\PrestaShop\Adapter\Kpi\AverageProductsInCategoryKpi
@@ -54,6 +60,7 @@ services:
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "products_per_category"})'
+        tags: ['web-only']
 
     prestashop.adapter.kpi.most_common_customers_gender:
         class: 'PrestaShop\PrestaShop\Adapter\Kpi\MostCommonCustomersGenderKpi'
@@ -61,6 +68,7 @@ services:
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "customer_main_gender"})'
+        tags: ['web-only']
 
     prestashop.adapter.kpi.average_customer_age:
         class: 'PrestaShop\PrestaShop\Adapter\Kpi\AverageCustomerAgeKpi'
@@ -68,6 +76,7 @@ services:
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "avg_customer_age"})'
+        tags: ['web-only']
 
     prestashop.adapter.kpi.order_per_customer:
         class: 'PrestaShop\PrestaShop\Adapter\Kpi\OrdersPerCustomerKpi'
@@ -75,6 +84,7 @@ services:
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "orders_per_customer"})'
+        tags: ['web-only']
 
     prestashop.adapter.kpi.newsletter_registrations:
         class: 'PrestaShop\PrestaShop\Adapter\Kpi\NewsletterRegistrationsKpi'
@@ -82,3 +92,4 @@ services:
             - '@translator'
             - '@prestashop.adapter.legacy.kpi_configuration'
             - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "newsletter_registrations"})'
+        tags: ['web-only']

--- a/src/PrestaShopBundle/Resources/config/services/adapter/pdf/generator.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/pdf/generator.yml
@@ -7,3 +7,4 @@ services:
         arguments:
             - "@=service('prestashop.adapter.legacy.context').getSmarty()"
             - '@prestashop.adapter.pdf.type_provider.invoice'
+        tags: ['web-only']

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -62,6 +62,7 @@ services:
             - 'OrdersInvoicesByDate'
             - '@prestashop.adapter.data_provider.order_invoice'
             - '@prestashop.adapter.pdf.generator.invoice'
+        tags: ['web-only'] # as it relies on PDFGenerator
 
     prestashop.admin.order.invoices.by_status.form_handler:
         class: 'PrestaShopBundle\Form\Admin\Sell\Order\Invoices\InvoiceByStatusFormHandler'
@@ -74,6 +75,7 @@ services:
             - 'OrdersInvoicesByStatus'
             - '@prestashop.adapter.data_provider.order_invoice'
             - '@prestashop.adapter.pdf.generator.invoice'
+        tags: ['web-only'] # as it relies on PDFGenerator
 
     prestashop.admin.order.invoices.options.form_handler:
         class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -548,13 +548,6 @@ services:
         tags:
             - { name: form.type }
 
-    form.type.shop.traffic_seo.meta:
-        class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta\MetaType'
-        parent: 'form.type.translatable.aware'
-        public: true
-        tags:
-            - { name: form.type }
-
     form.type.catalog.abstract_category:
         class: 'PrestaShopBundle\Form\Admin\Catalog\Category\AbstractCategoryType'
         abstract: true

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -34,7 +34,7 @@ services:
         public: true
 
     prestashop.core.grid.query_builder.webservice:
-        class: 'PrestaShop\PrestaShop\Core\Grid\Query\WebserviceQueryBuilder'
+        class: 'PrestaShop\PrestaShop\Core\Grid\Query\WebserviceKeyQueryBuilder'
         parent: 'prestashop.core.grid.abstract_query_builder'
         arguments:
             - '@prestashop.core.query.doctrine_search_criteria_applicator'

--- a/src/PrestaShopBundle/Resources/config/services/core/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/kpi.yml
@@ -13,6 +13,7 @@ services:
             - '@prestashop.adapter.kpi.enabled_languages'
             - '@prestashop.adapter.kpi.main_country'
             - '@prestashop.adapter.kpi.translations'
+        tags: ['web-only']
 
     prestashop.core.kpi_row.factory.categories:
         class: PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactory
@@ -21,6 +22,7 @@ services:
           - '@prestashop.adapter.kpi.empty_categories'
           - '@prestashop.adapter.kpi.top_category'
           - '@prestashop.adapter.kpi.average_products_in_category'
+        tags: ['web-only']
 
     prestashop.core.kpi_row.factory.customers:
         class: PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactory
@@ -29,3 +31,4 @@ services:
             - '@prestashop.adapter.kpi.average_customer_age'
             - '@prestashop.adapter.kpi.order_per_customer'
             - '@prestashop.adapter.kpi.newsletter_registrations'
+        tags: ['web-only']


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Introduce CheckServiceDefinitionsCommand that attempts to build every available Symfony service for PrestaShop. The goal is to check each of them is buildable. Maybe also add some checks (for example the service definition is valid, to detect [this kind of errors](https://github.com/PrestaShop/PrestaShop/pull/12125) ). It should be called by Travis in the end.
| Type?         | new feature
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No QA needed as this is a new code safety check

**This PR is in work-in-progress: it will be finished when the Command outputs no issue** (so I have to fix all found issues before the PR can be merged).

To run the Command: `bin/console prestashop:debug:services-container`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12127)
<!-- Reviewable:end -->
