### PR TITLE
Fix timezone standard is ignored

### DIFF
--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -123,7 +123,8 @@ require_once _PS_INSTALL_PATH_.'classes/exception.php';
 require_once _PS_INSTALL_PATH_.'classes/session.php';
 
 @set_time_limit(0);
-if (!@ini_get('date.timezone')) {
+// Work around flawed timezone standards conformance, mandatory in PHP 7
+if (!@ini_get('date.timezone') || @ini_get('date.timezone') == 'GMT') {
     @date_default_timezone_set('Europe/Paris');
     ini_set('date.timezone', 'UTC');
 }

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -125,8 +125,10 @@ require_once _PS_INSTALL_PATH_.'classes/session.php';
 @set_time_limit(0);
 // Work around lack of validation for timezone
 // standards conformance, mandatory in PHP 7
-@date_default_timezone_set('Europe/Paris');
-ini_set('date.timezone', 'UTC');
+if (!in_array(@ini_get('date.timezone'), timezone_identifiers_list()) {
+    @date_default_timezone_set('UTC');
+    ini_set('date.timezone', 'UTC');
+}
 
 // Try to improve memory limit if it's under 64M
 $current_memory_limit = psinstall_get_memory_limit();

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -125,7 +125,7 @@ require_once _PS_INSTALL_PATH_.'classes/session.php';
 @set_time_limit(0);
 // Work around lack of validation for timezone
 // standards conformance, mandatory in PHP 7
-if (!in_array(@ini_get('date.timezone'), timezone_identifiers_list()) {
+if (!in_array(@ini_get('date.timezone'), timezone_identifiers_list())) {
     @date_default_timezone_set('UTC');
     ini_set('date.timezone', 'UTC');
 }

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -123,11 +123,10 @@ require_once _PS_INSTALL_PATH_.'classes/exception.php';
 require_once _PS_INSTALL_PATH_.'classes/session.php';
 
 @set_time_limit(0);
-// Work around flawed timezone standards conformance, mandatory in PHP 7
-if (!@ini_get('date.timezone') || @ini_get('date.timezone') == 'GMT') {
-    @date_default_timezone_set('Europe/Paris');
-    ini_set('date.timezone', 'UTC');
-}
+// Work around lack of validation for timezone
+// standards conformance, mandatory in PHP 7
+@date_default_timezone_set('Europe/Paris');
+ini_set('date.timezone', 'UTC');
 
 // Try to improve memory limit if it's under 64M
 $current_memory_limit = psinstall_get_memory_limit();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This request solves the problem stated in bug report #12151
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Might break compatibility with end of life versions of PHP
| Deprecations? | No deprecations
| Fixed ticket? | Fixes #12151
| How to test?  | Follow the reproducible instructions in the bug report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12152)
<!-- Reviewable:end -->
