### PR TITLE
Right side block of attribute and attribute does not appear when not Attributes where not created on default shop

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -607,8 +607,8 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         $doctrine = $this->getDoctrine()->getManager();
-        $language = empty($languages[0]) ? ['id_lang' => 1, 'id_shop' => 1] : $languages[0];
-        $attributeGroups = $doctrine->getRepository('PrestaShopBundle:Attribute')->findByLangAndShop((int) $language['id_lang'], (int) $language['id_shop']);
+        $languageId = empty($languages[0]) ? 1 : $languages[0]['id_lang'];
+        $attributeGroups = $doctrine->getRepository('PrestaShopBundle:Attribute')->findByLangAndShop((int) $languageId, (int) $this->get('prestashop.adapter.shop.context')->getContextShopID());
 
         $drawerModules = (new HookFinder())->setHookName('displayProductPageDrawer')
             ->setParams(['product' => $product])


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In Multi-Shop context, Right side block of attribute and attribute does not appear when not Attributes where not created on default shop
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Please see below

How to test
- créate a prestashop multistore, and multilang
- create non-shared atribute and attributes groups,
- go on admin product page , and try to create a combination product,
- you should be able to select correctly attributes acccording to your BO current context
- ( previously, only default shop attributes where available for all shops )

This issue is similar : https://github.com/PrestaShop/PrestaShop/pull/10924 , applyinng a patch to have correctly attributes both on multishop and multilang Presthop instance

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12162)
<!-- Reviewable:end -->
