### PR TITLE
Fix SQL exception when creating a product_option without values

### DIFF
--- a/classes/AttributeGroup.php
+++ b/classes/AttributeGroup.php
@@ -300,7 +300,7 @@ class AttributeGroupCore extends ObjectModel
             Db::getInstance()->execute(
                 '
                 DELETE FROM `' . _DB_PREFIX_ . 'attribute`
-                WHERE `id_attribute_group` = ' . (int)$this->id . '
+                WHERE `id_attribute_group` = ' . (int) $this->id . '
                 AND `id_attribute` NOT IN (' . implode(',', $ids) . ')'
             );
         }

--- a/classes/AttributeGroup.php
+++ b/classes/AttributeGroup.php
@@ -296,12 +296,14 @@ class AttributeGroupCore extends ObjectModel
         foreach ($values as $value) {
             $ids[] = (int) ($value['id']);
         }
-        Db::getInstance()->execute(
-            '
-			DELETE FROM `' . _DB_PREFIX_ . 'attribute`
-			WHERE `id_attribute_group` = ' . (int) $this->id . '
-			AND `id_attribute` NOT IN (' . implode(',', $ids) . ')'
-        );
+        if (!empty($ids)) {
+            Db::getInstance()->execute(
+                '
+                DELETE FROM `' . _DB_PREFIX_ . 'attribute`
+                WHERE `id_attribute_group` = ' . (int)$this->id . '
+                AND `id_attribute` NOT IN (' . implode(',', $ids) . ')'
+            );
+        }
         $ok = true;
         foreach ($values as $value) {
             $result = Db::getInstance()->execute(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you create a product_option without values through prestashop, it is going to execute a delete in () without any value.
| Type?         | bug fix
| Category?     |  WS 
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Just create a product_option through webservice, with no value associations as following:

```
<prestashop>
<product_option>
  <is_color_group>0</is_color_group>
  <group_type>select</group_type>
  <position>0</position>
  <name>
    <language id="1">Temp</language>
  </name>
  <public_name>
    <language id="1">Temp</language>
  </public_name>
  <associations>
    <product_option_values />
  </associations>
</product_option>
</prestashop>
````

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12201)
<!-- Reviewable:end -->
