### PR TITLE
Add breadcrumb to the search results page

### DIFF
--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -92,4 +92,15 @@ class SearchControllerCore extends ProductListingFrontController
     {
         return $this->getTranslator()->trans('Search results', array(), 'Shop.Theme.Catalog');
     }
+
+    public function getBreadcrumbLinks()
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+        $breadcrumb['links'][] = array(
+            'title' => $this->getTranslator()->trans('Search results', array(), 'Shop.Theme.Catalog'),
+            'url' => $this->context->link->getPageLink('search'),
+        );
+
+        return $breadcrumb;
+    }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | add the missing breadcrumb function
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Visit search results page and look at the breadcrumb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12211)
<!-- Reviewable:end -->
