### PR TITLE
Force refresh of tinymce editors in product page step 1

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -74,7 +74,23 @@ $(document).ready(function() {
     $('[data-toggle="tooltip"]').tooltip('hide');
     $('[data-toggle="popover"]').popover('hide');
   });
+
+  $('.summary-description-container a[data-toggle="tab"]').on('shown.bs.tab', resetEditor);
 });
+
+/**
+ * Reset active tinyMce editor (triggered when switch language, or switching tabs)
+ */
+function resetEditor() {
+  const languageEditorsSelector = '.summary-description-container .panel.active div.translation-field.active textarea.autoload_rte';
+  $(languageEditorsSelector).each(function(index, textarea) {
+    const editor = tinyMCE.get(textarea.id);
+    if (editor) {
+      //Reset content to force refresh of editor
+      editor.setContent(editor.getContent());
+    }
+  });
+}
 
 /**
  * Manage show or hide fields
@@ -746,15 +762,9 @@ var form = (function() {
   function switchLanguage(iso_code) {
     $('div.translations.tabbable > div > div.translation-field:not(.translation-label-' + iso_code + ')').removeClass('show active');
 
-    const languageEditorsSelector = 'div.translations.tabbable > div > div.translation-field.translation-label-' + iso_code;
-    $(languageEditorsSelector).addClass('show active');
-    $(languageEditorsSelector + ' textarea.autoload_rte').each(function(index, textarea) {
-      var editor = tinyMCE.get(textarea.id);
-      if (editor) {
-        //Reset content to force refresh of editor
-        editor.setContent(editor.getContent());
-      }
-    });
+    const langueTabSelector = 'div.translations.tabbable > div > div.translation-field.translation-label-' + iso_code;
+    $(langueTabSelector).addClass('show active');
+    resetEditor();
   }
 
   function updateMissingTranslatedNames() {

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -746,6 +746,14 @@ var form = (function() {
   function switchLanguage(iso_code) {
     $('div.translations.tabbable > div > div.translation-field:not(.translation-label-' + iso_code + ')').removeClass('show active');
     $('div.translations.tabbable > div > div.translation-field.translation-label-' + iso_code).addClass('show active');
+    //Force refresh tinymce editors
+    $('div.translations.tabbable > div > div.translation-field.translation-label-' + iso_code + ' textarea.autoload_rte').each(function(index, textarea) {
+      var editor = tinyMCE.get(textarea.id);
+      if (editor) {
+        //Reset content to force refresh of editor
+        editor.setContent(editor.getContent());
+      }
+    });
   }
 
   function updateMissingTranslatedNames() {

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -745,9 +745,10 @@ var form = (function() {
 
   function switchLanguage(iso_code) {
     $('div.translations.tabbable > div > div.translation-field:not(.translation-label-' + iso_code + ')').removeClass('show active');
-    $('div.translations.tabbable > div > div.translation-field.translation-label-' + iso_code).addClass('show active');
-    //Force refresh tinymce editors
-    $('div.translations.tabbable > div > div.translation-field.translation-label-' + iso_code + ' textarea.autoload_rte').each(function(index, textarea) {
+
+    const languageEditorsSelector = 'div.translations.tabbable > div > div.translation-field.translation-label-' + iso_code;
+    $(languageEditorsSelector).addClass('show active');
+    $(languageEditorsSelector + ' textarea.autoload_rte').each(function(index, textarea) {
       var editor = tinyMCE.get(textarea.id);
       if (editor) {
         //Reset content to force refresh of editor


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | When switching language on the product page (step 1), the summary and description editors sometimes appear empty, whereas they should not be. Probably TinyMCE does not like to be initialized while invisible so we force the refresh when showing it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12053 
| How to test?  | Be sure to have 5 to 6 languages installed, go to a product edition page and switch the language thanks to the top select box. The summary/description editor should switch correctly without hiding their content.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12234)
<!-- Reviewable:end -->
