### PR TITLE
Fix specific price duplication

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4248,7 +4248,7 @@ class ProductCore extends ObjectModel
      * @param int $id_product_old Old product id
      * @param int $id_product_new New product id
      */
-    public static function duplicateAttributes($id_product_old, $id_product_new)
+    public static function duplicateAttributes($id_product_old, $id_product_new, &$attributes_associations = array())
     {
         $return = true;
         $combination_images = array();
@@ -4289,6 +4289,7 @@ class ProductCore extends ObjectModel
             $return &= $combination->save();
 
             $id_product_attribute_new = (int) $combination->id;
+            $attributes_associations[$id_product_attribute_old] = $id_product_attribute_new;
 
             if ($result_images = Product::_getAttributeImageAssociations($id_product_attribute_old)) {
                 $combination_images['old'][$id_product_attribute_old] = $result_images;
@@ -4569,11 +4570,11 @@ class ProductCore extends ObjectModel
         return $customizations;
     }
 
-    public static function duplicateSpecificPrices($old_product_id, $product_id)
+    public static function duplicateSpecificPrices($old_product_id, $product_id, $attributes_associations = array())
     {
         foreach (SpecificPrice::getIdsByProductId((int) $old_product_id) as $data) {
             $specific_price = new SpecificPrice((int) $data['id_specific_price']);
-            if (!$specific_price->duplicate((int) $product_id)) {
+            if (!$specific_price->duplicate((int)$product_id, $attributes_associations)) {
                 return false;
             }
         }

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -210,10 +210,10 @@ class SpecificPriceCore extends ObjectModel
     {
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 			SELECT `id_specific_price`
-			FROM `' . _DB_PREFIX_ . 'specific_price`
-			WHERE `id_product` = ' . (int) $id_product . '
-			AND id_product_attribute=' . (int) $id_product_attribute . '
-			AND id_cart=' . (int) $id_cart);
+			FROM `'._DB_PREFIX_.'specific_price`
+			WHERE `id_product` = '.(int)$id_product.
+			(($id_product_attribute !== false) ? ' AND id_product_attribute='.(int)$id_product_attribute : '')
+			.' AND id_cart='.(int)$id_cart);
     }
 
     /**

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -707,10 +707,13 @@ class SpecificPriceCore extends ObjectModel
      *
      * @return bool
      */
-    public function duplicate($id_product = false)
+    public function duplicate($id_product = false, $attributes_associations = array())
     {
         if ($id_product) {
             $this->id_product = (int) $id_product;
+        }
+        if ($this->id_product_attribute && isset($attributes_associations[$this->id_product_attribute])) {
+            $this->id_product_attribute = $attributes_associations[$this->id_product_attribute];
         }
         unset($this->id);
         // specific price row may already have been created for catalog specific price rule

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -535,11 +535,11 @@ class AdminProductsControllerCore extends AdminController
             if ($product->add()
             && Category::duplicateProductCategories($id_product_old, $product->id)
             && Product::duplicateSuppliers($id_product_old, $product->id)
-            && ($combination_images = Product::duplicateAttributes($id_product_old, $product->id)) !== false
+            && ($combination_images = Product::duplicateAttributes($id_product_old, $product->id, $attributes_associations)) !== false
             && GroupReduction::duplicateReduction($id_product_old, $product->id)
             && Product::duplicateAccessories($id_product_old, $product->id)
             && Product::duplicateFeatures($id_product_old, $product->id)
-            && Product::duplicateSpecificPrices($id_product_old, $product->id)
+            && Product::duplicateSpecificPrices($id_product_old, $product->id, $attributes_associations)
             && Pack::duplicate($id_product_old, $product->id)
             && Product::duplicateCustomizationFields($id_product_old, $product->id)
             && Product::duplicateTags($id_product_old, $product->id)

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -196,11 +196,11 @@ class AdminProductDataUpdater implements ProductInterface
         if ($product->add()
             && Category::duplicateProductCategories($id_product_old, $product->id)
             && Product::duplicateSuppliers($id_product_old, $product->id)
-            && ($combination_images = Product::duplicateAttributes($id_product_old, $product->id)) !== false
+            && ($combination_images = Product::duplicateAttributes($id_product_old, $product->id, $attributes_associations)) !== false
             && GroupReduction::duplicateReduction($id_product_old, $product->id)
             && Product::duplicateAccessories($id_product_old, $product->id)
             && Product::duplicateFeatures($id_product_old, $product->id)
-            && Product::duplicateSpecificPrices($id_product_old, $product->id)
+            && Product::duplicateSpecificPrices($id_product_old, $product->id, $attributes_associations)
             && Pack::duplicate($id_product_old, $product->id)
             && Product::duplicateCustomizationFields($id_product_old, $product->id)
             && Product::duplicateTags($id_product_old, $product->id)


### PR DESCRIPTION
If specific prices do have id_product_attribute set, they will not be copied as it should on the new product

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When duplicating a product, if that product has combinations and has specific prices set per combination (with id_product_attribute != 0), those specific prices won't be duplicated, because id_product_attribute is not updated with the new id_product_attribute of the second product.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Set a specific price on a product with combinations, and set that the specific price is available only for a certain combination, then duplicate the product. That specific price will not be copied over to the new product.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12250)
<!-- Reviewable:end -->
