### PR TITLE
Don't show delivery information on cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -646,7 +646,7 @@ class CartCore extends ObjectModel
                         stock.`quantity` AS quantity_available, p.`width`, p.`height`, p.`depth`, stock.`out_of_stock`, p.`weight`,
                         p.`available_date`, p.`date_add`, p.`date_upd`, IFNULL(stock.quantity, 0) as quantity, pl.`link_rewrite`, cl.`link_rewrite` AS category,
                         CONCAT(LPAD(cp.`id_product`, 10, 0), LPAD(IFNULL(cp.`id_product_attribute`, 0), 10, 0), IFNULL(cp.`id_address_delivery`, 0), IFNULL(cp.`id_customization`, 0)) AS unique_id, cp.id_address_delivery,
-                        product_shop.advanced_stock_management, ps.product_supplier_reference supplier_reference');
+                        product_shop.advanced_stock_management, ps.product_supplier_reference supplier_reference, p.additional_delivery_times, pl.`delivery_in_stock`, pl.`delivery_out_stock`');
 
         // Build FROM
         $sql->from('cart_product', 'cp');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Product stock messages are not being sent when you bring the products from the cart.<br>The fields "additional_delivery_times", "delivery_in_stock" and "delivery_in_stock" are not returned in the query executed by the "getProducts" function of the "Cart" class.<br>PrestaShop still does not show this information in the FrontOffice cart, but other modules such as the One Page Checkout PS do show it, but it's necessary to send those fields mentioned above.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12280)
<!-- Reviewable:end -->
