### PR TITLE
Loop Redirects for Canonical Redirection if HTTP Request crosses more than one Reverse Proxies

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -785,8 +785,9 @@ class FrontControllerCore extends Controller
         }
 
         $canonical_url = preg_replace('/#.*$/', '', $canonical_url);
-
-        $match_url = rawurldecode(Tools::getCurrentUrlProtocolPrefix() . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+        $host = Tools::getHttpHost();
+        
+        $match_url = rawurldecode(Tools::getCurrentUrlProtocolPrefix() . $host . $_SERVER['REQUEST_URI']);
         if (!preg_match('/^' . Tools::pRegexp(rawurldecode($canonical_url), '/') . '([&?].*)?$/', $match_url)) {
             $params = array();
             $url_details = parse_url($canonical_url);


### PR DESCRIPTION
The Host of the current url of your request, created to perform a match with the canonical url, is not generated respecting checks performed by the method Tools::getHttpHost(). This cause always a mismatch if your host is behind two or more proxies.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch      |  1.7.5.x 
| Type        | bug fix
| Description | FrontController, at the moment, does not respect the check of the real hostname, causing a loop redirect on all child controllers that have to match a canonical url. This problem happens in more complex network infrastructures having different reverse proxies, especially in cloud environments.
| Category     | FO
| How to test  | You can test this problem i.e. in an Azure Platform, if your domain points to a FrontDoor Service with Azure and it redirects the request to an internal host having another reverse proxy server(like Nginx, Apache Traffic Server) beyond your Server Web.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12306)
<!-- Reviewable:end -->
