### PR TITLE
Update access rules for SystemInformationController and MemcacheServer

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php
@@ -33,6 +33,7 @@ use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
 
 /**
  * Responsible of "Configure > Advanced Parameters > Performance" servers block management.
@@ -41,12 +42,18 @@ class MemcacheServerController extends FrameworkBundleAdminController
 {
     const CONTROLLER_NAME = 'AdminPerformance';
 
+    /**
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     *
+     * @return JsonResponse
+     */
     public function listAction()
     {
         return new JsonResponse($this->getMemcacheManager()->getServers());
     }
 
     /**
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      * @DemoRestricted(redirectRoute="admin_servers_test")
      *
      * @param Request $request
@@ -71,6 +78,7 @@ class MemcacheServerController extends FrameworkBundleAdminController
     }
 
     /**
+     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message="Access denied.")
      * @DemoRestricted(redirectRoute="admin_servers_test")
      *
      * @param Request $request
@@ -129,6 +137,7 @@ class MemcacheServerController extends FrameworkBundleAdminController
     }
 
     /**
+     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="Access denied.")
      * @DemoRestricted(redirectRoute="admin_servers_test")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
@@ -68,6 +68,8 @@ class SystemInformationController extends FrameworkBundleAdminController
     }
 
     /**
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     *
      * @return JsonResponse
      */
     public function displayCheckFilesAction()


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Update access rules for these 2 controllers
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See below

## How to test

Before this PR, you could see "changed files" block from "Configure > Advanced Parameters > Information" page (which is loaded through an AJAX call) and you could use the cache server actions (add a server, test a server, delete a server) from "Configure > Advanced Parameters > Performance" page (last block) **without having the proper access rights**. This PR secures these 2 items.

See screenshot below

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12316)
<!-- Reviewable:end -->
