### PR TITLE
Separate nightly tests and reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,5 +130,6 @@ after_deploy:
       gcloud compute instances stop --zone $GC_ZONE "${GC_INSTANCE_NAME}-${INSTANCE_TYPE}";
       gcloud compute instances add-metadata "${GC_INSTANCE_NAME}-${INSTANCE_TYPE}" --zone $GC_ZONE --metadata=TRAVIS_BRANCH=$TRAVIS_BRANCH && \
       gcloud compute instances add-metadata "${GC_INSTANCE_NAME}-${INSTANCE_TYPE}" --zone $GC_ZONE --metadata-from-file startup-tests-script=tests/E2E/scripts/run-nightly-tests.sh && \
+      gcloud compute instances add-metadata "${GC_INSTANCE_NAME}-${INSTANCE_TYPE}" --zone $GC_ZONE --metadata-from-file startup-reports-script=tests/E2E/scripts/run-nightly-reports.sh && \
       gcloud compute instances start --zone $GC_ZONE "${GC_INSTANCE_NAME}-${INSTANCE_TYPE}"
     fi

--- a/tests/E2E/scripts/run-nightly-reports.sh
+++ b/tests/E2E/scripts/run-nightly-reports.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# DO NOT EXECUTE THIS SCRIPT ON YOUR COMPUTER
+#
+# This script exists only because of Google compute instance.
+# Otherwise it will shutdown your computer.
+#
+
+set -x
+
+BRANCH=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/TRAVIS_BRANCH -H "Metadata-Flavor: Google")
+CURRENT_DATE="$(date +%Y-%m-%d)"
+DIR_PATH="/var/ps-reports/${CURRENT_DATE}"
+REPORT_NAME="${CURRENT_DATE}-${BRANCH}"
+REPORT_PATH="${DIR_PATH}/campaigns"
+
+if [ ! -d $DIR_PATH ]; then
+  # Always exit 0 since this script is ran
+  # under rc.local
+  exit 0
+fi
+
+cd "${DIR_PATH}/prestashop/tests/E2E"
+
+echo "Check for reports..."
+if [ -n "$(ls ${REPORT_PATH})" ]; then
+  mkdir -p "${DIR_PATH}/reports"
+  ./scripts/combine-reports.py "${REPORT_PATH}" "${DIR_PATH}/reports/${REPORT_NAME}.json"
+  nodejs ./node_modules/mochawesome-report-generator/bin/cli.js "${DIR_PATH}/reports/${REPORT_NAME}.json" -o "${DIR_PATH}/reports"
+
+  # Send file, remove directory, and shutdown if everything is ok
+  gsutil cp -r "${DIR_PATH}/reports" gs://prestashop-core-nightly && \
+  rm -rf $DIR_PATH && \
+  shutdown -h now
+fi

--- a/tests/E2E/scripts/run-nightly-tests.sh
+++ b/tests/E2E/scripts/run-nightly-tests.sh
@@ -1,70 +1,52 @@
 #!/bin/bash
-#
-# DO NOT EXECUTE THIS SCRIPT ON YOUR COMPUTER
-#
-# This script exists only because of Google compute instance.
-# Otherwise it will shutdown your computer.
-#
 
 set -x
 
 BRANCH=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/TRAVIS_BRANCH -H "Metadata-Flavor: Google")
-DIR_PATH=$(mktemp -d)
+CURRENT_DATE="$(date +%Y-%m-%d)"
+DIR_PATH="/var/ps-reports/${CURRENT_DATE}"
+REPORT_NAME="${CURRENT_DATE}-${BRANCH}"
 REPORT_PATH="${DIR_PATH}/campaigns"
-REPORT_OUTPUT_NAME="$(date +%Y-%m-%d)-${BRANCH}"
 
-exec &> >(tee -a "/var/log/ps-${REPORT_OUTPUT_NAME}.log")
+exec &> >(tee -a "/var/log/ps-${REPORT_NAME}.log")
 
-if [ -d $DIR_PATH ]; then
-  rm -rf $DIR_PATH
+if [ ! -d $DIR_PATH ]; then
+  mkdir -p $DIR_PATH
+  mkdir -p $REPORT_PATH
+  git clone https://github.com/PrestaShop/PrestaShop.git $DIR_PATH/prestashop
+  cd $DIR_PATH/prestashop
+  git checkout $BRANCH
 fi
-
-git clone https://github.com/PrestaShop/PrestaShop.git $DIR_PATH/prestashop
-
-cd $DIR_PATH/prestashop
-git checkout $BRANCH
-mkdir -p $REPORT_PATH
 
 echo "Clear docker..."
 docker system prune -f
 docker image prune -f
 docker volume prune -f
 
-
 cd "${DIR_PATH}/prestashop/tests/E2E"
 for test_directory in test/campaigns/full/*; do
-  if [ -d "${test_directory}" ]; then
-    if [ -z "$(docker ps -qa)" ]; then
-      # Make sure all containers are stopped
-      docker stop $(docker ps -qa)
-    fi
+  # Continue if it is not a directory
+  [ -d "${test_directory}" ] || continue
 
-    echo "Try to clear docker-compose instances..."
-    docker-compose down -v -t 100 || true
-
-    echo "Boot docker-compose instances..."
-    docker-compose up -d --build --force-recreate
-
-    echo "Run ${TEST_PATH}"
-    echo "Wait for docker-compose..."
-    sleep 10
-
-    TEST_PATH=${test_directory/test\/campaigns\//}
-    docker-compose exec -T -e TEST_PATH=$TEST_PATH tests /tmp/wait-for-it.sh --timeout=720 --strict prestashop-web:80 -- bash /tmp/run-tests.sh
-
-    if [ -f "mochawesome-report/mochawesome.json" ]; then
-      cp mochawesome-report/mochawesome.json "${REPORT_PATH}/${TEST_PATH//\//-}.json"
-    fi
+  if [ -z "$(docker ps -qa)" ]; then
+    # Make sure all containers are stopped
+    docker stop $(docker ps -qa)
   fi
+
+  echo "Boot docker-compose instances..."
+  docker-compose up -d --build --force-recreate
+
+  echo "Run ${TEST_PATH}"
+  echo "Wait for docker-compose..."
+  sleep 10
+
+  TEST_PATH=${test_directory/test\/campaigns\//}
+  docker-compose exec -T -e TEST_PATH=$TEST_PATH tests /tmp/wait-for-it.sh --timeout=720 --strict prestashop-web:80 -- bash /tmp/run-tests.sh
+
+  if [ -f "mochawesome-report/mochawesome.json" ]; then
+    cp mochawesome-report/mochawesome.json "${REPORT_PATH}/${TEST_PATH//\//-}.json"
+  fi
+
+  echo "Try to clear docker-compose instances..."
+  docker-compose down -v -t 100 || true
 done
-
-echo "Check for reports..."
-if [ -n "$(ls ${REPORT_PATH})" ]; then
-  mkdir -p "${DIR_PATH}/reports"
-  ./scripts/combine-reports.py "${REPORT_PATH}" "${REPORT_PATH}/${REPORT_OUTPUT_NAME}.json"
-  nodejs ./node_modules/mochawesome-report-generator/bin/cli.js "${REPORT_PATH}/${REPORT_OUTPUT_NAME}.json" -o "${DIR_PATH}/reports"
-  cp "${REPORT_PATH}/${REPORT_OUTPUT_NAME}.json" "${DIR_PATH}/reports"
-  gsutil cp -r "${DIR_PATH}/reports" gs://prestashop-core-nightly
-fi
-
-shutdown -h now


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Separate nightly tests and reports, make sure we can rerun gcloud sync if something failed.<br>One script to run tests and get reports<brOone script to combine and send to google cloud.<br>
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? |no
| How to test?  | Travis must be green. Look for nightly branch in https://console.cloud.google.com/storage/browser/prestashop-core-nightly/reports (these files can be removed after)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12324)
<!-- Reviewable:end -->
