### PR TITLE
Fix translation on account creation email error

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -109,8 +109,8 @@ class CustomerFormCore extends AbstractForm
         $customer = $this->getCustomer();
         if ($id_customer && $id_customer != $customer->id) {
             $emailField->addError($this->translator->trans(
-                'The email is already used, please choose another one or sign in',
-                array(),
+                'The email "%mail%" is already used, please choose another one or sign in',
+                array('%mail%' => $emailField->getValue()),
                 'Shop.Notifications.Error'
             ));
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix translation if email is already registered on account creation
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Try to create an account with an already registered email

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12344)
<!-- Reviewable:end -->
