### PR TITLE
Add Category form builder & handler

### DIFF
--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -35,14 +35,6 @@ class AdminLegacyLayoutControllerCore extends AdminController
 
     public function __construct($controllerName = '', $title = '', $headerToolbarBtn = array(), $displayType = '', $showContentHeader = true, $headerTabContent = '', $enableSidebar = false, $helpLink = '')
     {
-        // Compatibility with legacy behavior.
-        // Languages can only be used in "All shops" context.
-        // This makes sure that user cannot switch shop contexts
-        // when on Languages page.
-        if ('AdminLanguages' === $controllerName) {
-            $this->multishop_context = Shop::CONTEXT_ALL;
-        }
-
         parent::__construct($controllerName, 'new-theme');
 
         $this->title = $title;
@@ -57,6 +49,14 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $this->enableSidebar = $enableSidebar;
         $this->helpLink = $helpLink;
         $this->php_self = $controllerName;
+
+        // Compatibility with legacy behavior.
+        // Languages can only be used in "All shops" context.
+        // This makes sure that user cannot switch shop contexts
+        // when on Languages page.
+        if ('AdminLanguages' === $controllerName) {
+            $this->multishop_context = Shop::CONTEXT_ALL;
+        }
     }
 
     public function setMedia($isNewTheme = false)

--- a/src/Core/Form/IdentifiableObject/DataHandler/AbstractCategoryFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/AbstractCategoryFormDataHandler.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\AbstractCategoryCommand;
+
+/**
+ * Encapsulates common behavior for category / root category form data handling
+ */
+abstract class AbstractCategoryFormDataHandler implements FormDataHandlerInterface
+{
+    /**
+     * @param AbstractCategoryCommand $command
+     * @param array $data
+     */
+    protected function populateCommandWithData(AbstractCategoryCommand $command, array $data)
+    {
+        if (null !== $data['description']) {
+            $command->setLocalizedDescriptions($data['description']);
+        }
+
+        if (null !== $data['meta_title']) {
+            $command->setLocalizedMetaTitles($data['meta_title']);
+        }
+
+        if (null !== $data['meta_description']) {
+            $command->setLocalizedMetaDescriptions($data['meta_description']);
+        }
+
+        if (null !== $data['meta_keyword']) {
+            $command->setLocalizedMetaKeywords($data['meta_keyword']);
+        }
+
+        if (null !== $data['group_association']) {
+            $command->setAssociatedGroupIds($data['group_association']);
+        }
+
+        if (null !== $data['shop_association']) {
+            $command->setAssociatedShopIds($data['shop_association']);
+        }
+
+        if (null !== $data['cover_image']) {
+            $command->setCoverImage($data['cover_image']);
+        }
+
+        if (null !== $data['thumbnail_image']) {
+            $command->setThumbnailImage($data['thumbnail_image']);
+        }
+
+        if (null !== $data['menu_thumbnail_images']) {
+            $command->setMenuThumbnailImages($data['menu_thumbnail_images']);
+        }
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataHandler/CategoryFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CategoryFormDataHandler.php
@@ -32,7 +32,7 @@ use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 
 /**
- * Creates/updates category from data submited in category form
+ * Creates/updates category from data submitted in category form
  */
 final class CategoryFormDataHandler extends AbstractCategoryFormDataHandler
 {

--- a/src/Core/Form/IdentifiableObject/DataHandler/CategoryFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CategoryFormDataHandler.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
-use PrestaShop\PrestaShop\Core\Domain\Category\Command\AbstractCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\AddCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;

--- a/src/Core/Form/IdentifiableObject/DataHandler/CategoryFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CategoryFormDataHandler.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\AbstractCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\AddCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
+
+/**
+ * Creates/updates category from data submited in category form
+ */
+final class CategoryFormDataHandler implements FormDataHandlerInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    /**
+     * @param CommandBusInterface $commandBus
+     */
+    public function __construct(CommandBusInterface $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $data)
+    {
+        $command = new AddCategoryCommand(
+            $data['name'],
+            $data['link_rewrite'],
+            (bool) $data['active'],
+            (int) $data['id_parent']
+        );
+
+        $this->populateCommandWithData($command, $data);
+
+        /** @var CategoryId $categoryId */
+        $categoryId = $this->commandBus->handle($command);
+
+        return $categoryId->getValue();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update($categoryId, array $data)
+    {
+        $command = new EditCategoryCommand($categoryId);
+
+        $this->populateCommandWithData($command, $data);
+
+        if (null !== $data['id_parent']) {
+            $command->setParentCategoryId($data['id_parent']);
+        }
+
+        /** @var CategoryId $categoryId */
+        $categoryId = $this->commandBus->handle($command);
+
+        return $categoryId->getValue();
+    }
+
+    /**
+     * @param AbstractCategoryCommand $command
+     * @param array $data
+     */
+    private function populateCommandWithData(AbstractCategoryCommand $command, array $data)
+    {
+        if (null !== $data['description']) {
+            $command->setLocalizedDescriptions($data['description']);
+        }
+
+        if (null !== $data['meta_title']) {
+            $command->setLocalizedMetaTitles($data['meta_title']);
+        }
+
+        if (null !== $data['meta_description']) {
+            $command->setLocalizedMetaDescriptions($data['meta_description']);
+        }
+
+        if (null !== $data['meta_keyword']) {
+            $command->setLocalizedMetaKeywords($data['meta_keyword']);
+        }
+
+        if (null !== $data['group_association']) {
+            $command->setAssociatedGroupIds($data['group_association']);
+        }
+
+        if (null !== $data['shop_association']) {
+            $command->setAssociatedShopIds($data['shop_association']);
+        }
+
+        if (null !== $data['cover_image']) {
+            $command->setCoverImage($data['cover_image']);
+        }
+
+        if (null !== $data['thumbnail_image']) {
+            $command->setThumbnailImage($data['thumbnail_image']);
+        }
+
+        if (null !== $data['menu_thumbnail_images']) {
+            $command->setMenuThumbnailImages($data['menu_thumbnail_images']);
+        }
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataHandler/RootCategoryFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/RootCategoryFormDataHandler.php
@@ -27,15 +27,14 @@
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
-use PrestaShop\PrestaShop\Core\Domain\Category\Command\AbstractCategoryCommand;
-use PrestaShop\PrestaShop\Core\Domain\Category\Command\AddCategoryCommand;
-use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\AddRootCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditRootCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 
 /**
- * Creates/updates category from data submited in category form
+ * Creates/updates root category from data submited in category form
  */
-final class CategoryFormDataHandler extends AbstractCategoryFormDataHandler
+final class RootCategoryFormDataHandler extends AbstractCategoryFormDataHandler
 {
     /**
      * @var CommandBusInterface
@@ -55,11 +54,10 @@ final class CategoryFormDataHandler extends AbstractCategoryFormDataHandler
      */
     public function create(array $data)
     {
-        $command = new AddCategoryCommand(
+        $command = new AddRootCategoryCommand(
             $data['name'],
             $data['link_rewrite'],
-            (bool) $data['active'],
-            (int) $data['id_parent']
+            $data['active']
         );
 
         $this->populateCommandWithData($command, $data);
@@ -73,19 +71,14 @@ final class CategoryFormDataHandler extends AbstractCategoryFormDataHandler
     /**
      * {@inheritdoc}
      */
-    public function update($categoryId, array $data)
+    public function update($rootCategoryId, array $data)
     {
-        $command = new EditCategoryCommand($categoryId);
+        $command = new EditRootCategoryCommand($rootCategoryId);
 
         $this->populateCommandWithData($command, $data);
 
-        if (null !== $data['id_parent']) {
-            $command->setParentCategoryId($data['id_parent']);
-        }
+        $this->commandBus->handle($command);
 
-        /** @var CategoryId $categoryId */
-        $categoryId = $this->commandBus->handle($command);
-
-        return $categoryId->getValue();
+        return $rootCategoryId;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/CategoryFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CategoryFormDataProvider.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\EditableCategory;
+use PrestaShop\PrestaShop\Core\Domain\Group\Query\GetDefaultGroups;
+use PrestaShop\PrestaShop\Core\Domain\Group\QueryResult\DefaultGroups;
+
+/**
+ * Provides data for category add/edit category forms
+ */
+final class CategoryFormDataProvider implements FormDataProviderInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $queryBus;
+
+    /**
+     * @var int
+     */
+    private $contextShopId;
+
+    /**
+     * @param CommandBusInterface $queryBus
+     * @param int $contextShopId
+     */
+    public function __construct(CommandBusInterface $queryBus, $contextShopId)
+    {
+        $this->queryBus = $queryBus;
+        $this->contextShopId = $contextShopId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData($categoryId)
+    {
+        /** @var EditableCategory $editableCategory */
+        $editableCategory = $this->queryBus->handle(new GetCategoryForEditing($categoryId));
+
+        return [
+            'name' => $editableCategory->getName(),
+            'active' => $editableCategory->isActive(),
+            'id_parent' => $editableCategory->getParentId(),
+            'description' => $editableCategory->getDescription(),
+            'meta_title' => $editableCategory->getMetaTitle(),
+            'meta_description' => $editableCategory->getMetaDescription(),
+            'meta_keyword' => $editableCategory->getMetaKeywords(),
+            'link_rewrite' => $editableCategory->getLinkRewrite(),
+            'group_association' => $editableCategory->getGroupAssociationIds(),
+            'shop_association' => $editableCategory->getShopAssociationIds(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultData()
+    {
+        /** @var DefaultGroups $defaultGroups */
+        $defaultGroups = $this->queryBus->handle(new GetDefaultGroups());
+
+        return [
+            'group_association' => [
+                $defaultGroups->getVisitorsGroup()->getGroupId()->getValue(),
+                $defaultGroups->getGuestsGroup()->getGroupId()->getValue(),
+                $defaultGroups->getCustomersGroup()->getGroupId()->getValue(),
+            ],
+            'shop_association' => [
+                $this->contextShopId,
+            ],
+        ];
+    }
+}

--- a/src/Core/Grid/Definition/Factory/CategoryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CategoryGridDefinitionFactory.php
@@ -133,7 +133,7 @@ final class CategoryGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setName($this->trans('Name', [], 'Admin.Global'))
                 ->setOptions([
                     'field' => 'name',
-                    'route' => 'admin_category_edit',
+                    'route' => 'admin_categories_edit',
                     'route_param_name' => 'categoryId',
                     'route_param_field' => 'id_category',
                 ])
@@ -151,7 +151,7 @@ final class CategoryGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setOptions([
                     'field' => 'active',
                     'primary_field' => 'id_category',
-                    'route' => 'admin_category_process_status_toggle',
+                    'route' => 'admin_categories_toggle_status',
                     'route_param_name' => 'categoryId',
                 ])
             )
@@ -257,7 +257,7 @@ final class CategoryGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setName($this->trans('Export', [], 'Admin.Actions'))
                 ->setIcon('cloud_download')
                 ->setOptions([
-                    'route' => 'admin_category_export',
+                    'route' => 'admin_categories_export',
                 ])
             )
             ->add(
@@ -287,21 +287,21 @@ final class CategoryGridDefinitionFactory extends AbstractGridDefinitionFactory
                 (new SubmitBulkAction('enable_selection'))
                 ->setName($this->trans('Enable selection', [], 'Admin.Actions'))
                 ->setOptions([
-                    'submit_route' => 'admin_category_process_bulk_status_enable',
+                    'submit_route' => 'admin_categories_bulk_enable_status',
                 ])
             )
             ->add(
                 (new SubmitBulkAction('disable_selection'))
                 ->setName($this->trans('Disable selection', [], 'Admin.Actions'))
                 ->setOptions([
-                    'submit_route' => 'admin_category_process_bulk_status_disable',
+                    'submit_route' => 'admin_categories_bulk_disable_status',
                 ])
             )
             ->add(
                 (new DeleteCategoriesBulkAction('delete_selection'))
                 ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
                 ->setOptions([
-                    'categories_bulk_delete_route' => 'admin_category_process_bulk_delete',
+                    'categories_bulk_delete_route' => 'admin_categories_bulk_delete',
                 ])
             );
     }
@@ -317,7 +317,7 @@ final class CategoryGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setName($this->trans('View', [], 'Admin.Actions'))
                 ->setIcon('zoom_in')
                 ->setOptions([
-                    'route' => 'admin_category_listing',
+                    'route' => 'admin_categories_index',
                     'route_param_name' => 'id_category',
                     'route_param_field' => 'id_category',
                     'accessibility_checker' => $this->categoryForViewAccessibilityChecker,
@@ -328,7 +328,7 @@ final class CategoryGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setName($this->trans('Edit', [], 'Admin.Actions'))
                 ->setIcon('edit')
                 ->setOptions([
-                    'route' => 'admin_category_edit',
+                    'route' => 'admin_categories_edit',
                     'route_param_name' => 'categoryId',
                     'route_param_field' => 'id_category',
                 ])
@@ -339,7 +339,7 @@ final class CategoryGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setIcon('delete')
                 ->setOptions([
                     'category_id_field' => 'id_category',
-                    'category_delete_route' => 'admin_category_process_delete',
+                    'category_delete_route' => 'admin_categories_delete',
                 ])
             );
     }

--- a/src/Core/Grid/Filter/CategoryFilterFormFactory.php
+++ b/src/Core/Grid/Filter/CategoryFilterFormFactory.php
@@ -97,7 +97,7 @@ final class CategoryFilterFormFactory implements GridFilterFormFactoryInterface
         }
 
         $newCategoryFormBuilder->setAction(
-            $this->urlGenerator->generate('admin_category_listing_search', $queryParams)
+            $this->urlGenerator->generate('admin_categories_search', $queryParams)
         );
 
         return $newCategoryFormBuilder->getForm();

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -668,13 +668,10 @@ class CategoryController extends FrameworkBundleAdminController
     private function getErrorMessages()
     {
         return [
-            CannotDeleteImageException::class =>
-                $this->trans('Unable to delete associated images.', 'Admin.Notifications.Error'),
-            CategoryNotFoundException::class =>
-                $this->trans('The object cannot be loaded (or found)', 'Admin.Notifications.Error'),
+            CannotDeleteImageException::class => $this->trans('Unable to delete associated images.', 'Admin.Notifications.Error'),
+            CategoryNotFoundException::class => $this->trans('The object cannot be loaded (or found)', 'Admin.Notifications.Error'),
             CategoryConstraintException::class => [
-                CategoryConstraintException::EMPTY_BULK_DELETE_DATA =>
-                    $this->trans('You must select at least one element to delete.', 'Admin.Notifications.Error'),
+                CategoryConstraintException::EMPTY_BULK_DELETE_DATA => $this->trans('You must select at least one element to delete.', 'Admin.Notifications.Error'),
                 CategoryConstraintException::TOO_MANY_MENU_THUMBNAILS => sprintf(
                     '%s %s',
                     $this->trans('An error occurred while uploading the image:', 'Admin.Catalog.Notification'),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -397,7 +397,7 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @return JsonResponse
      */
-    public function processStatusToggleAction(Request $request, $categoryId)
+    public function toggleStatusAction(Request $request, $categoryId)
     {
         if ($this->isDemoModeEnabled()) {
             return $this->json([
@@ -448,7 +448,7 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      */
-    public function processBulkStatusEnableAction(Request $request)
+    public function bulkEnableStatusAction(Request $request)
     {
         try {
             $categoryIds = array_map(function ($categoryId) {
@@ -484,7 +484,7 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      */
-    public function processBulkStatusDisableAction(Request $request)
+    public function bulkDisableStatusAction(Request $request)
     {
         try {
             $categoryIds = array_map(function ($categoryId) {
@@ -520,7 +520,7 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      */
-    public function processBulkDeleteAction(Request $request)
+    public function bulkDeleteAction(Request $request)
     {
         $deleteCategoriesForm = $this->createForm(DeleteCategoriesType::class);
         $deleteCategoriesForm->handleRequest($request);
@@ -565,7 +565,7 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      */
-    public function processDeleteAction(Request $request)
+    public function deleteAction(Request $request)
     {
         $deleteCategoriesForm = $this->createForm(DeleteCategoriesType::class);
         $deleteCategoriesForm->handleRequest($request);

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -99,7 +99,7 @@ class CategoryController extends FrameworkBundleAdminController
             'enableSidebar' => true,
             'categoriesGrid' => $this->presentGrid($categoryGrid),
             'categoriesKpi' => $categoriesKpiFactory->build(),
-            'layoutHeaderToolbarBtn' => $this->getCategoryToolbarButtons($request),
+            'layoutHeaderToolbarBtn' => $this->getCategoryToolbarButtons(),
             'currentCategoryView' => $categoryViewData,
             'deleteCategoriesForm' => $deleteCategoriesForm->createView(),
         ]);
@@ -895,34 +895,22 @@ class CategoryController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param Request $request
-     *
      * @return array
      */
-    protected function getCategoryToolbarButtons(Request $request)
+    protected function getCategoryToolbarButtons()
     {
         $toolbarButtons = [];
 
-        if ($this->get('prestashop.adapter.feature.multistore')->isActive()) {
+        if ($this->get('prestashop.adapter.feature.multistore')->isUsed()) {
             $toolbarButtons['add_root'] = [
-                'href' => $this->getAdminLink('AdminCategories', [
-                    'addcategoryroot' => 1,
-                ]),
+                'href' => $this->generateUrl('admin_category_add_root'),
                 'desc' => $this->trans('Add new root category', 'Admin.Catalog.Feature'),
                 'icon' => 'add_circle_outline',
             ];
         }
 
-        $urlParams = [
-            'addcategory' => 1,
-        ];
-
-        if ($request->query->has('id_category')) {
-            $urlParams['id_parent'] = $request->query->get('id_category');
-        }
-
         $toolbarButtons['add'] = [
-            'href' => $this->getAdminLink('AdminCategories', $urlParams),
+            'href' => $this->generateUrl('admin_category_add'),
             'desc' => $this->trans('Add new category', 'Admin.Catalog.Feature'),
             'icon' => 'add_circle_outline',
         ];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -123,7 +123,7 @@ class CategoryController extends FrameworkBundleAdminController
             if (null !== $handlerResult->getIdentifiableObjectId()) {
                 $this->addFlash('success', $this->trans('Successful creation.', 'Admin.Notifications.Success'));
 
-                return $this->redirectToRoute('admin_category_listing');
+                return $this->redirectToRoute('admin_categories_index');
             }
         } catch (CategoryException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
@@ -167,7 +167,7 @@ class CategoryController extends FrameworkBundleAdminController
             if (null !== $handlerResult->getIdentifiableObjectId()) {
                 $this->addFlash('success', $this->trans('Successful creation.', 'Admin.Notifications.Success'));
 
-                return $this->redirectToRoute('admin_category_listing');
+                return $this->redirectToRoute('admin_categories_index');
             }
         } catch (CategoryException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
@@ -203,12 +203,12 @@ class CategoryController extends FrameworkBundleAdminController
             $editableCategory = $this->getQueryBus()->handle(new GetCategoryForEditing((int) $categoryId));
 
             if ($editableCategory->isRootCategory()) {
-                return $this->redirectToRoute('admin_category_edit_root', ['categoryId' => $categoryId]);
+                return $this->redirectToRoute('admin_categories_edit_root', ['categoryId' => $categoryId]);
             }
         } catch (CategoryException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
-            return $this->redirectToRoute('admin_category_listing');
+            return $this->redirectToRoute('admin_categories_index');
         }
 
         try {
@@ -227,7 +227,7 @@ class CategoryController extends FrameworkBundleAdminController
             if (null !== $handlerResult->getIdentifiableObjectId()) {
                 $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
 
-                return $this->redirectToRoute('admin_category_listing');
+                return $this->redirectToRoute('admin_categories_index');
             }
         } catch (CategoryException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
@@ -266,12 +266,12 @@ class CategoryController extends FrameworkBundleAdminController
             $editableCategory = $this->getQueryBus()->handle(new GetCategoryForEditing((int) $categoryId));
 
             if (!$editableCategory->isRootCategory()) {
-                return $this->redirectToRoute('admin_category_edit', ['categoryId' => $categoryId]);
+                return $this->redirectToRoute('admin_categories_edit', ['categoryId' => $categoryId]);
             }
         } catch (CategoryNotFoundException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
-            return $this->redirectToRoute('admin_category_listing');
+            return $this->redirectToRoute('admin_categories_index');
         }
 
         $rootCategoryFormBuilder =
@@ -288,7 +288,7 @@ class CategoryController extends FrameworkBundleAdminController
             if (null !== $handlerResult->getIdentifiableObjectId()) {
                 $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
 
-                return $this->redirectToRoute('admin_category_listing');
+                return $this->redirectToRoute('admin_categories_index');
             }
         } catch (CategoryException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
@@ -324,7 +324,7 @@ class CategoryController extends FrameworkBundleAdminController
     {
         if (!$this->isCsrfTokenValid('delete-cover-image', $request->request->get('_csrf_token'))) {
             return $this->redirectToRoute('admin_security_compromised', [
-                'uri' => $this->generateUrl('admin_category_edit', [
+                'uri' => $this->generateUrl('admin_categories_edit', [
                     'categoryId' => $categoryId,
                 ], UrlGeneratorInterface::ABSOLUTE_URL),
             ]);
@@ -341,7 +341,7 @@ class CategoryController extends FrameworkBundleAdminController
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
-        return $this->redirectToRoute('admin_category_edit', [
+        return $this->redirectToRoute('admin_categories_edit', [
             'categoryId' => $categoryId,
         ]);
     }
@@ -364,7 +364,7 @@ class CategoryController extends FrameworkBundleAdminController
     {
         if (!$this->isCsrfTokenValid('delete-menu-thumbnail', $request->request->get('_csrf_token'))) {
             return $this->redirectToRoute('admin_security_compromised', [
-                'uri' => $this->generateUrl('admin_category_edit', [
+                'uri' => $this->generateUrl('admin_categories_edit', [
                     'categoryId' => $categoryId,
                 ], UrlGeneratorInterface::ABSOLUTE_URL),
             ]);
@@ -384,7 +384,7 @@ class CategoryController extends FrameworkBundleAdminController
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
-        return $this->redirectToRoute('admin_category_edit', [
+        return $this->redirectToRoute('admin_categories_edit', [
             'categoryId' => $categoryId,
         ]);
     }
@@ -439,10 +439,10 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @AdminSecurity(
      *     "is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     redirectRoute="admin_category_listing",
+     *     redirectRoute="admin_categories_index",
      *     message="You do not have permission to update this."
      * )
-     * @DemoRestricted(redirectRoute="admin_category_listing")
+     * @DemoRestricted(redirectRoute="admin_categories_index")
      *
      * @param Request $request
      *
@@ -467,7 +467,7 @@ class CategoryController extends FrameworkBundleAdminController
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
-        return $this->redirectToRoute('admin_category_listing');
+        return $this->redirectToRoute('admin_categories_index');
     }
 
     /**
@@ -475,10 +475,10 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @AdminSecurity(
      *     "is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     redirectRoute="admin_category_listing",
+     *     redirectRoute="admin_categories_index",
      *     message="You do not have permission to update this."
      * )
-     * @DemoRestricted(redirectRoute="admin_category_listing")
+     * @DemoRestricted(redirectRoute="admin_categories_index")
      *
      * @param Request $request
      *
@@ -503,7 +503,7 @@ class CategoryController extends FrameworkBundleAdminController
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
-        return $this->redirectToRoute('admin_category_listing');
+        return $this->redirectToRoute('admin_categories_index');
     }
 
     /**
@@ -511,10 +511,10 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @AdminSecurity(
      *     "is_granted('delete', request.get('_legacy_controller'))",
-     *     redirectRoute="admin_category_listing",
+     *     redirectRoute="admin_categories_index",
      *     message="You do not have permission to delete this."
      * )
-     * @DemoRestricted(redirectRoute="admin_category_listing")
+     * @DemoRestricted(redirectRoute="admin_categories_index")
      *
      * @param Request $request
      *
@@ -548,7 +548,7 @@ class CategoryController extends FrameworkBundleAdminController
             }
         }
 
-        return $this->redirectToRoute('admin_category_listing');
+        return $this->redirectToRoute('admin_categories_index');
     }
 
     /**
@@ -556,10 +556,10 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @AdminSecurity(
      *     "is_granted('delete', request.get('_legacy_controller'))",
-     *     redirectRoute="admin_category_listing",
+     *     redirectRoute="admin_categories_index",
      *     message="You do not have permission to delete this."
      * )
-     * @DemoRestricted(redirectRoute="admin_category_listing")
+     * @DemoRestricted(redirectRoute="admin_categories_index")
      *
      * @param Request $request
      *
@@ -587,7 +587,7 @@ class CategoryController extends FrameworkBundleAdminController
             }
         }
 
-        return $this->redirectToRoute('admin_category_listing');
+        return $this->redirectToRoute('admin_categories_index');
     }
 
     /**
@@ -595,10 +595,10 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @AdminSecurity(
      *     "is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     redirectRoute="admin_category_listing",
+     *     redirectRoute="admin_categories_index",
      *     message="You do not have permission to view this."
      * )
-     * @DemoRestricted(redirectRoute="admin_category_listing")
+     * @DemoRestricted(redirectRoute="admin_categories_index")
      *
      * @param CategoryFilters $filters
      *
@@ -645,14 +645,14 @@ class CategoryController extends FrameworkBundleAdminController
 
         if ($this->get('prestashop.adapter.feature.multistore')->isUsed()) {
             $toolbarButtons['add_root'] = [
-                'href' => $this->generateUrl('admin_category_add_root'),
+                'href' => $this->generateUrl('admin_categories_add_root'),
                 'desc' => $this->trans('Add new root category', 'Admin.Catalog.Feature'),
                 'icon' => 'add_circle_outline',
             ];
         }
 
         $toolbarButtons['add'] = [
-            'href' => $this->generateUrl('admin_category_add'),
+            'href' => $this->generateUrl('admin_categories_add'),
             'desc' => $this->trans('Add new category', 'Admin.Catalog.Feature'),
             'icon' => 'add_circle_outline',
         ];

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
@@ -85,10 +85,6 @@ abstract class AbstractCategoryType extends TranslatorAwareType
                 'required' => false,
                 'data' => true,
             ])
-            ->add('description', TranslatableType::class, [
-                'type' => TextareaType::class,
-                'required' => false,
-            ])
             ->add('cover_image', FileType::class, [
                 'required' => false,
             ])

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/CategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/CategoryType.php
@@ -27,6 +27,8 @@
 namespace PrestaShopBundle\Form\Admin\Catalog\Category;
 
 use PrestaShopBundle\Form\Admin\Type\CategoryChoiceTreeType;
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -47,7 +49,12 @@ class CategoryType extends AbstractCategoryType
                 // when using CategoryType to edit category
                 // user should not be able to select that category as parent
                 'disabled_values' => null !== $options['id_category'] ? [$options['id_category']] : [],
-            ]);
+            ])
+            ->add('description', TranslatableType::class, [
+                'type' => TextareaType::class,
+                'required' => false,
+            ])
+        ;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/categories.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/categories.yml
@@ -19,35 +19,35 @@ admin_categories_bulk_enable_status:
     path: /bulk-status-enable
     methods: [POST]
     defaults:
-        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:processBulkStatusEnable
+        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:bulkEnableStatus
         _legacy_controller: AdminCategories
 
 admin_categories_bulk_disable_status:
     path: /bulk-status-disable
     methods: [POST]
     defaults:
-        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:processBulkStatusDisable
+        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:bulkDisableStatus
         _legacy_controller: AdminCategories
 
 admin_categories_toggle_status:
     path: /{categoryId}/toggle-status
     methods: [POST]
     defaults:
-        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:processStatusToggle
+        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:toggleStatus
         _legacy_controller: AdminCategories
 
 admin_categories_bulk_delete:
     path: /bulk-delete
     methods: [POST]
     defaults:
-        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:processBulkDelete
+        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:bulkDelete
         _legacy_controller: AdminCategories
 
 admin_categories_delete:
     path: /delete
     methods: [POST]
     defaults:
-        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:processDelete
+        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:delete
         _legacy_controller: AdminCategories
 
 admin_categories_export:

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/categories.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/categories.yml
@@ -1,77 +1,77 @@
-admin_category_listing:
+admin_categories_index:
     path: /
     methods: [GET, POST]
     defaults:
         _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:index
         _legacy_controller: AdminCategories
 
-admin_category_listing_search:
+admin_categories_search:
     path: /search
     methods: [POST]
     defaults:
         _controller: PrestaShopBundle:Admin\Common:searchGrid
         gridDefinitionFactoryService: prestashop.core.grid.definition.factory.category
-        redirectRoute: admin_category_listing
+        redirectRoute: admin_categories_index
         redirectQueryParamsToKeep:
             - 'id_category'
 
-admin_category_process_bulk_status_enable:
+admin_categories_bulk_enable_status:
     path: /bulk-status-enable
     methods: [POST]
     defaults:
         _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:processBulkStatusEnable
         _legacy_controller: AdminCategories
 
-admin_category_process_bulk_status_disable:
+admin_categories_bulk_disable_status:
     path: /bulk-status-disable
     methods: [POST]
     defaults:
         _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:processBulkStatusDisable
         _legacy_controller: AdminCategories
 
-admin_category_process_status_toggle:
-    path: /toggle-status/{categoryId}
+admin_categories_toggle_status:
+    path: /{categoryId}/toggle-status
     methods: [POST]
     defaults:
         _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:processStatusToggle
         _legacy_controller: AdminCategories
 
-admin_category_process_bulk_delete:
+admin_categories_bulk_delete:
     path: /bulk-delete
     methods: [POST]
     defaults:
         _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:processBulkDelete
         _legacy_controller: AdminCategories
 
-admin_category_process_delete:
+admin_categories_delete:
     path: /delete
     methods: [POST]
     defaults:
         _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:processDelete
         _legacy_controller: AdminCategories
 
-admin_category_export:
+admin_categories_export:
     path: /export
     methods: [GET]
     defaults:
       _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:export
       _legacy_controller: AdminCategories
 
-admin_category_add:
+admin_categories_add:
     path: /new
     methods: [GET, POST]
     defaults:
         _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:add
         _legacy_controller: AdminCategories
 
-admin_category_add_root:
+admin_categories_add_root:
     path: /new-root
     methods: [GET, POST]
     defaults:
         _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:addRoot
         _legacy_controller: AdminCategories
 
-admin_category_edit:
+admin_categories_edit:
     path: /{categoryId}/edit
     methods: [GET, POST]
     defaults:
@@ -80,7 +80,7 @@ admin_category_edit:
     requirements:
         categoryId: \d+
 
-admin_category_edit_root:
+admin_categories_edit_root:
     path: /{categoryId}/edit-root
     methods: [GET, POST]
     defaults:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -49,3 +49,10 @@ services:
     arguments:
       - 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta\MetaType'
       - '@prestashop.core.form.identifiable_object.data_provider.meta_form_data_provider'
+
+  prestashop.core.form.identifiable_object.builder.category_form_builder:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
+    factory: 'prestashop.core.form.builder.form_builder_factory:create'
+    arguments:
+      - 'PrestaShopBundle\Form\Admin\Catalog\Category\CategoryType'
+      - '@prestashop.core.form.identifiable_object.data_provider.category_form_data_provider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -56,3 +56,10 @@ services:
     arguments:
       - 'PrestaShopBundle\Form\Admin\Catalog\Category\CategoryType'
       - '@prestashop.core.form.identifiable_object.data_provider.category_form_data_provider'
+
+  prestashop.core.form.identifiable_object.builder.root_category_form_builder:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
+    factory: 'prestashop.core.form.builder.form_builder_factory:create'
+    arguments:
+      - 'PrestaShopBundle\Form\Admin\Catalog\Category\RootCategoryType'
+      - '@prestashop.core.form.identifiable_object.data_provider.category_form_data_provider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -39,3 +39,8 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CategoryFormDataHandler'
     arguments:
       - '@prestashop.core.command_bus'
+
+  prestashop.core.form.identifiable_object.data_handler.root_category_form_data_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\RootCategoryFormDataHandler'
+    arguments:
+      - '@prestashop.core.command_bus'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -34,3 +34,8 @@ services:
     arguments:
       - '@prestashop.core.command_bus'
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
+
+  prestashop.core.form.identifiable_object.data_handler.category_form_data_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CategoryFormDataHandler'
+    arguments:
+      - '@prestashop.core.command_bus'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -38,3 +38,9 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\MetaFormDataProvider'
     arguments:
       - '@prestashop.core.query_bus'
+
+  prestashop.core.form.identifiable_object.data_provider.category_form_data_provider:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CategoryFormDataProvider'
+    arguments:
+      - '@prestashop.core.query_bus'
+      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
@@ -44,3 +44,9 @@ services:
     factory: 'prestashop.core.form.identifiable_object.handler.form_handler_factory:create'
     arguments:
       - '@prestashop.core.form.identifiable_object.meta_form_data_handler'
+
+  prestashop.core.form.identifiable_object.handler.category_form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler'
+    factory: 'prestashop.core.form.identifiable_object.handler.form_handler_factory:create'
+    arguments:
+      - '@prestashop.core.form.identifiable_object.data_handler.category_form_data_handler'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
@@ -50,3 +50,9 @@ services:
     factory: 'prestashop.core.form.identifiable_object.handler.form_handler_factory:create'
     arguments:
       - '@prestashop.core.form.identifiable_object.data_handler.category_form_data_handler'
+
+  prestashop.core.form.identifiable_object.handler.root_category_form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler'
+    factory: 'prestashop.core.form.identifiable_object.handler.form_handler_factory:create'
+    arguments:
+      - '@prestashop.core.form.identifiable_object.data_handler.root_category_form_data_handler'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -58,7 +58,7 @@ services:
         parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
         arguments:
             - "@=service('router').generate('admin_common_reset_search', {'controller': 'category', 'action': 'index'})"
-            - "@=service('router').generate('admin_category_listing')"
+            - "@=service('router').generate('admin_categories_index')"
             - '@prestashop.adapter.shop.context'
             - '@prestashop.adapter.grid.action.row.accessibility_checker.category_for_view'
         public: true

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig
@@ -37,7 +37,7 @@
                   {{ 'Edit'|trans({}, 'Admin.Actions') }}
                 </a>
               {% else %}
-                <a href="{{ path('admin_category_listing', {'id_category': category.id_category}) }}">
+                <a href="{{ path('admin_categories_index', {'id_category': category.id_category}) }}">
                   {{ category.name }}
                 </a>
               {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/category_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/category_form.html.twig
@@ -64,12 +64,14 @@
       </div>
       {% endif %}
 
+      {% if categoryForm.description is defined %}
       <div class="form-group row">
         {{ ps.label_with_help(('Description'|trans({}, 'Admin.Global')), ('Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}')) }}
         <div class="col-sm">
           {{ form_widget(categoryForm.description) }}
         </div>
       </div>
+      {% endif %}
 
       <div class="form-group row">
         {{ ps.label_with_help(('Category Cover Image'|trans), ('This is the main image for your category, displayed in the category page. The category description will overlap this image and appear in its top-left corner.'|trans({}, 'Admin.Catalog.Help'))) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_block.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_block.html.twig
@@ -44,7 +44,7 @@
         </div>
         <div class="card-footer">
           <a class="btn btn-secondary btn-sm"
-             href="{{ path('admin_category_listing') }}"
+             href="{{ path('admin_categories_index') }}"
           >
             <i class="material-icons">cancel</i>
             {{ 'Cancel'|trans({}, 'Admin.Actions') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig
@@ -35,7 +35,7 @@
 } %}
   {% block content %}
     <div class="modal-body">
-      {{ form_start(deleteCategoriesForm, {'action': path('admin_category_process_delete')}) }}
+      {{ form_start(deleteCategoriesForm, {'action': path('admin_categories_delete')}) }}
 
       <div class="form-group mb-0">
         {{ form_widget(deleteCategoriesForm.delete_mode) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -62,7 +62,7 @@
       {% if categoryForm.id_parent is defined %}
       <div class="form-group row">
         <label class="form-control-label">
-          {{ 'Parent category'|trans }}
+          {{ 'Parent category'|trans({}, 'Admin.Catalog.Feature') }}
         </label>
         <div class="col-sm">
           {{ form_widget(categoryForm.id_parent) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -34,9 +34,15 @@
   <div class="card-block row">
     <div class="card-text">
       <div class="form-group row">
-        {{ ps.label_with_help(('Name'|trans({}, 'Admin.Global')), ('Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}')) }}
+        <label class="form-control-label">
+          <span class="text-danger">*</span>
+          {{ 'Name'|trans({}, 'Admin.Global') }}
+        </label>
         <div class="col-sm">
           {{ form_widget(categoryForm.name) }}
+          <small class="form-text">
+            {{ 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}
+          </small>
         </div>
       </div>
 
@@ -66,33 +72,52 @@
 
       {% if categoryForm.description is defined %}
       <div class="form-group row">
-        {{ ps.label_with_help(('Description'|trans({}, 'Admin.Global')), ('Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}')) }}
+        <label class="form-control-label">
+          {{ 'Description'|trans({}, 'Admin.Global') }}
+        </label>
         <div class="col-sm">
           {{ form_widget(categoryForm.description) }}
+          <small class="form-text">
+            {{ 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}
+          </small>
         </div>
       </div>
       {% endif %}
 
       <div class="form-group row">
-        {{ ps.label_with_help(('Category Cover Image'|trans), ('This is the main image for your category, displayed in the category page. The category description will overlap this image and appear in its top-left corner.'|trans({}, 'Admin.Catalog.Help'))) }}
+        <label class="form-control-label">
+          {{ 'Category Cover Image'|trans({}, 'Admin.Catalog.Feature') }}
+        </label>
         <div class="col-sm">
           {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/cover_image.html.twig' %}
 
           {{ form_widget(categoryForm.cover_image) }}
+
+          <small class="form-text">
+            {{ 'This is the main image for your category, displayed in the category page. The category description will overlap this image and appear in its top-left corner.'|trans({}, 'Admin.Catalog.Help') }}
+          </small>
         </div>
       </div>
 
       <div class="form-group row">
-        {{ ps.label_with_help(('Category thumbnail'|trans), ('Displays a small image in the parent category\'s page, if the theme allows it.'|trans({}, 'Admin.Catalog.Help'))) }}
+        <label class="form-control-label">
+          {{ 'Category thumbnail'|trans({}, 'Admin.Catalog.Feature') }}
+        </label>
         <div class="col-sm">
           {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/thumbnail_image.html.twig' %}
 
           {{ form_widget(categoryForm.thumbnail_image) }}
+
+          <small class="form-text">
+            {{ 'Displays a small image in the parent category\'s page, if the theme allows it.'|trans({}, 'Admin.Catalog.Help') }}
+          </small>
         </div>
       </div>
 
       <div class="form-group row">
-        {{ ps.label_with_help(('Menu thumbnails'|trans), ('The category thumbnail appears in the menu as a small image representing the category, if the theme allows it.'|trans({}, 'Admin.Catalog.Help'))) }}
+        <label class="form-control-label">
+          {{ 'Menu thumbnails'|trans({}, 'Admin.Catalog.Feature') }}
+        </label>
         <div class="col-sm">
           {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/menu_thumbnail_images.html.twig' %}
 
@@ -107,44 +132,72 @@
               </p>
             </div>
           {% endif %}
+          <small class="form-text">
+            {{ 'The category thumbnail appears in the menu as a small image representing the category, if the theme allows it.'|trans({}, 'Admin.Catalog.Help') }}
+          </small>
         </div>
       </div>
 
       {{ renderhook('displayBackOfficeCategory') }}
 
       <div class="form-group row">
-        {{ ps.label_with_help(('Meta title'|trans({}, 'Admin.Global')), ('Forbidden characters:'|trans({}, 'Admin.Notifications.Info')) ~ ' <>;=#{}') }}
+        <label class="form-control-label">
+          {{ 'Meta title'|trans({}, 'Admin.Global') }}
+        </label>
         <div class="col-sm">
           {{ form_widget(categoryForm.meta_title) }}
+          <small class="form-text">{{ 'Forbidden characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}</small>
         </div>
       </div>
 
       <div class="form-group row">
-        {{ ps.label_with_help(('Meta description'|trans({}, 'Admin.Global')), ('Forbidden characters:'|trans({}, 'Admin.Notifications.Info')) ~ ' <>;=#{}') }}
+        <label class="form-control-label">
+          {{ 'Meta description'|trans({}, 'Admin.Global') }}
+        </label>
         <div class="col-sm">
           {{ form_widget(categoryForm.meta_description) }}
+          <small class="form-text">
+            {{ 'Forbidden characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}
+          </small>
         </div>
       </div>
 
       <div class="form-group row">
-        {{ ps.label_with_help(('Meta keywords'|trans({}, 'Admin.Global')), ('To add tags, click in the field, write something, and then press the "Enter" key.'|trans({}, 'Admin.Shopparameters.Help')) ~ ('Forbidden characters:'|trans({}, 'Admin.Notifications.Info')) ~ ' <>;=#{}') }}
+        <label class="form-control-label">
+          {{ 'Meta keywords'|trans({}, 'Admin.Global') }}
+        </label>
         <div class="col-sm">
           {{ form_widget(categoryForm.meta_keyword) }}
+          <small class="form-text">
+            {{ 'To add tags, click in the field, write something, and then press the "Enter" key.'|trans({}, 'Admin.Shopparameters.Help') ~ ('Forbidden characters:'|trans({}, 'Admin.Notifications.Info')) ~ ' <>;=#{}' }}
+          </small>
         </div>
       </div>
 
       <div class="form-group row">
-        {{ ps.label_with_help(('Friendly URL'|trans({}, 'Admin.Global')), ('Only letters, numbers, underscore (_) and the minus (-) character are allowed.'|trans({}, 'Admin.Catalog.Help'))) }}
+        <label class="form-control-label">
+          <span class="text-danger">*</span>
+          {{ 'Friendly URL'|trans({}, 'Admin.Global') }}
+        </label>
         <div class="col-sm">
           {{ form_widget(categoryForm.link_rewrite) }}
+          <small class="form-text">
+            {{ 'Only letters, numbers, underscore (_) and the minus (-) character are allowed.'|trans({}, 'Admin.Catalog.Help') }}
+          </small>
         </div>
       </div>
 
       <div class="form-group row">
-        {{ ps.label_with_help(('Group access'|trans), ('Mark all of the customer groups which you would like to have access to this category.'|trans({}, 'Admin.Catalog.Help'))) }}
+        <label class="form-control-label">
+          {{ 'Group access'|trans({}, 'Admin.Global') }}
+        </label>
         <div class="col-sm">
           {{ form_widget(categoryForm.group_association) }}
-          <div class="alert alert-info">
+          <small class="form-text">
+            {{ 'Mark all of the customer groups which you would like to have access to this category.'|trans({}, 'Admin.Catalog.Help') }}
+          </small>
+
+          <div class="alert alert-info mt-3">
             <p class="mb-1">
               <strong>{{ 'You now have three default customer groups.'|trans({}, 'Admin.Catalog.Help') }}</strong>
             </p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -86,7 +86,7 @@
 
       <div class="form-group row">
         <label class="form-control-label">
-          {{ 'Category Cover Image'|trans({}, 'Admin.Catalog.Feature') }}
+          {{ 'Category cover image'|trans({}, 'Admin.Catalog.Feature') }}
         </label>
         <div class="col-sm">
           {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/cover_image.html.twig' %}
@@ -146,7 +146,7 @@
         </label>
         <div class="col-sm">
           {{ form_widget(categoryForm.meta_title) }}
-          <small class="form-text">{{ 'Forbidden characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}</small>
+          <small class="form-text">{{ 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}</small>
         </div>
       </div>
 
@@ -157,7 +157,7 @@
         <div class="col-sm">
           {{ form_widget(categoryForm.meta_description) }}
           <small class="form-text">
-            {{ 'Forbidden characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}
+            {{ 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}
           </small>
         </div>
       </div>
@@ -169,7 +169,7 @@
         <div class="col-sm">
           {{ form_widget(categoryForm.meta_keyword) }}
           <small class="form-text">
-            {{ 'To add tags, click in the field, write something, and then press the "Enter" key.'|trans({}, 'Admin.Shopparameters.Help') ~ ('Forbidden characters:'|trans({}, 'Admin.Notifications.Info')) ~ ' <>;=#{}' }}
+            {{ 'To add tags, click in the field, write something, and then press the "Enter" key.'|trans({}, 'Admin.Shopparameters.Help') ~ ('Invalid characters:'|trans({}, 'Admin.Notifications.Info')) ~ ' <>;=#{}' }}
           </small>
         </div>
       </div>
@@ -189,7 +189,7 @@
 
       <div class="form-group row">
         <label class="form-control-label">
-          {{ 'Group access'|trans({}, 'Admin.Global') }}
+          {{ 'Group access'|trans({}, 'Admin.Catalog.Feature') }}
         </label>
         <div class="col-sm">
           {{ form_widget(categoryForm.group_association) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/listing_panel_footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/listing_panel_footer.html.twig
@@ -29,7 +29,7 @@
   {% endif %}
 
   <div class="card-footer">
-    <a href="{{ path('admin_category_listing', params|default({})) }}" class="btn btn-outline-secondary">
+    <a href="{{ path('admin_categories_index', params|default({})) }}" class="btn btn-outline-secondary">
       <i class="material-icons">arrow_back</i>
       {{ 'Back to list'|trans({}, 'Admin.Actions') }}
     </a>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/add.html.twig
@@ -30,7 +30,7 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/category_form.html.twig' %}
+      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' %}
     </div>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/add_root.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/add_root.html.twig
@@ -30,7 +30,7 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/category_form.html.twig' with {'categoryForm': rootCategoryForm} %}
+      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {'categoryForm': rootCategoryForm} %}
     </div>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/edit.html.twig
@@ -30,7 +30,7 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/category_form.html.twig' with {
+      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {
         'categoryForm': editCategoryForm,
         'thumbnailImage': editableCategory.thumbnailImage,
         'coverImage': editableCategory.coverImage,

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/edit_root.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/edit_root.html.twig
@@ -30,7 +30,7 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/category_form.html.twig' with {
+      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {
         'categoryForm': editRootCategoryForm,
         'thumbnailImage': editableCategory.thumbnailImage,
         'coverImage': editableCategory.coverImage,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Forms handlers were introduced in https://github.com/PrestaShop/PrestaShop/pull/10974 but categories were not using them. This PR adds from handling system for Categories. In addition, it fixes routes/actions naming according to our naming convention.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #10194 
| How to test?  | Category edition page should behave like before. It can be accessed at `/admin-dev/index.php/sell/catalog/categories/1/edit`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12346)
<!-- Reviewable:end -->
