### PR TITLE
Allow administrators to add the keyword "categories" in SEO & URLS (product link)

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -215,7 +215,7 @@ class LinkCore
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['category'] = (!$category) ? $product->category : $category;
             $cats = array();
-            foreach ($product->getParentCategories($idLang) as $cat) {
+            foreach ($product->getProductCategoriesFull($product->id, $idLang) as $cat) {
                 if (!in_array($cat['id_category'], Link::$category_disable_rewrite)) {
                     //remove root and home category from the URL
                     $cats[] = $cat['link_rewrite'];


### PR DESCRIPTION
| Questions | Answers
| ------------ | -------------
| Branch | 1.7.5.x
| Description | Change function for display correctly all categories and subcategories in URL. This allow the administrator to add the keyword 'categories' in the SEO & URLs and then display all categories and subcategories in URL.
| Type | improvement
| Category | BO



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12356)
<!-- Reviewable:end -->
