### PR TITLE
Refacto SearchParameters and SearchParametersResolver for pagination

### DIFF
--- a/src/Core/Search/SearchParametersInterface.php
+++ b/src/Core/Search/SearchParametersInterface.php
@@ -11,15 +11,26 @@ namespace PrestaShop\PrestaShop\Core\Search;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Contract that define how we can retrieve Grid filters
- * from an User request or Repository.
+ * Contract that define how we can retrieve Grid filters from an User request or Repository.
+ * IMPORTANT NOTE: these methods should ONLY return the filters of their respective scope (no
+ * default replacement) otherwise you can't know where the values exactly come from which make
+ * it impossible to fine tune overrides (which one has the priority).
  *
  * @see SearchParametersResolver class for usage.
  */
 interface SearchParametersInterface
 {
+    const FILTER_TYPES = array(
+        'limit',
+        'offset',
+        'orderBy',
+        'sortOrder',
+        'filters',
+    );
+
     /**
-     * Retrieve list of filters from User Request.
+     * Retrieve list of filters from User Request (ONLY those present in
+     * the request).
      *
      * @param Request $request
      * @param string $filterClass the filter class
@@ -29,7 +40,7 @@ interface SearchParametersInterface
     public function getFiltersFromRequest(Request $request, $filterClass);
 
     /**
-     * Retrieve list of filters from User searches.
+     * Retrieve list of filters from User searches (ONLY those saved in repository).
      *
      * @param int $employeeId
      * @param int $shopId

--- a/tests/Unit/Core/Search/SearchParametersTest.php
+++ b/tests/Unit/Core/Search/SearchParametersTest.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Search;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+use PrestaShop\PrestaShop\Core\Search\SearchParameters;
+use PrestaShopBundle\Entity\AdminFilter;
+use PrestaShopBundle\Entity\Repository\AdminFilterRepository;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class SearchParametersTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $searchParameters = new SearchParameters($this->buildAdminFilterRepositoryMock());
+        $this->assertNotNull($searchParameters);
+    }
+
+    public function testGetFiltersFromGetRequest()
+    {
+        $searchParameters = new SearchParameters($this->buildAdminFilterRepositoryMock());
+        $this->assertNotNull($searchParameters);
+
+        $expectedParameters = [
+            'limit' => 10,
+            'offset' => 10,
+            'unknownParameter' => 'plop',
+        ];
+        $requestMock = $this->buildRequestMock($expectedParameters);
+        /** @var SampleFilters $filters */
+        $filters = $searchParameters->getFiltersFromRequest($requestMock, SampleFilters::class);
+        $this->assertNotNull($filters);
+        $this->assertInstanceOf(SampleFilters::class, $filters);
+        $this->assertInstanceOf(SearchCriteriaInterface::class, $filters);
+        unset($expectedParameters['unknownParameter']);
+        $this->assertEquals($expectedParameters, $filters->all());
+        $this->assertEquals(10, $filters->getLimit());
+        $this->assertEquals(10, $filters->getOffset());
+        $this->assertNull($filters->getOrderBy());
+        $this->assertNull($filters->getOrderWay());
+        $this->assertNull($filters->getFilters());
+        $this->assertNull($filters->get('unknownParameter'));
+    }
+
+    public function testGetFiltersFromPostRequest()
+    {
+        $searchParameters = new SearchParameters($this->buildAdminFilterRepositoryMock());
+        $this->assertNotNull($searchParameters);
+
+        $expectedParameters = [
+            'orderBy' => 'name',
+            'sortOrder' => 'asc',
+            'filters' => [
+                'name' => 'test',
+            ],
+            'unknownParameter' => 'plop',
+        ];
+        $requestMock = $this->buildRequestMock($expectedParameters, true);
+        /** @var SampleFilters $filters */
+        $filters = $searchParameters->getFiltersFromRequest($requestMock, SampleFilters::class);
+        $this->assertNotNull($filters);
+        $this->assertInstanceOf(SampleFilters::class, $filters);
+        $this->assertInstanceOf(SearchCriteriaInterface::class, $filters);
+        unset($expectedParameters['unknownParameter']);
+        $this->assertEquals($expectedParameters, $filters->all());
+        $this->assertEquals('name', $filters->getOrderBy());
+        $this->assertEquals('asc', $filters->getOrderWay());
+        $this->assertEquals($expectedParameters['filters'], $filters->getFilters());
+        $this->assertNull($filters->getLimit());
+        $this->assertNull($filters->getOffset());
+        $this->assertNull($filters->get('unknownParameter'));
+    }
+
+    public function testGetFiltersFromRepository()
+    {
+        $expectedParameters = [
+            'limit' => 10,
+            'offset' => 10,
+        ];
+
+        $searchParameters = new SearchParameters($this->buildAdminFilterRepositoryMock($expectedParameters));
+        $this->assertNotNull($searchParameters);
+
+        /** @var SampleFilters $filters */
+        $filters = $searchParameters->getFiltersFromRepository(1, 1, 'ProductController', 'list', SampleFilters::class);
+        $this->assertNotNull($filters);
+        $this->assertInstanceOf(SampleFilters::class, $filters);
+        $this->assertInstanceOf(SearchCriteriaInterface::class, $filters);
+        $this->assertEquals($expectedParameters, $filters->all());
+        $this->assertEquals(10, $filters->getLimit());
+        $this->assertEquals(10, $filters->getOffset());
+        $this->assertNull($filters->getOrderBy());
+        $this->assertNull($filters->getOrderWay());
+        $this->assertNull($filters->getFilters());
+    }
+
+    /**
+     * @param array|null $filters
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|AdminFilterRepository
+     */
+    private function buildAdminFilterRepositoryMock(array $filters = null)
+    {
+        $repositoryMock = $this->getMockBuilder(AdminFilterRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        if (null !== $filters) {
+            $adminFilterMock = $this->getMockBuilder(AdminFilter::class)
+                ->disableOriginalConstructor()
+                ->getMock()
+            ;
+
+            $adminFilterMock
+                ->expects($this->once())
+                ->method('getFilter')
+                ->willReturn(json_encode($filters))
+            ;
+
+            $repositoryMock
+                ->expects($this->once())
+                ->method('findByEmployeeAndRouteParams')
+                ->willReturn($adminFilterMock)
+            ;
+        }
+
+        return $repositoryMock;
+    }
+
+    /**
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|Request
+     */
+    private function buildRequestMock(array $parameters, $postQuery = false)
+    {
+        $requestMock = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $parametersBagMock = $this->getMockBuilder(ParameterBag::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $parametersBagMock
+            ->method('has')
+            ->willReturnCallback(function ($parameter) use ($parameters) {
+                return isset($parameters[$parameter]);
+            })
+        ;
+        $parametersBagMock
+            ->method('get')
+            ->willReturnCallback(function ($parameter) use ($parameters) {
+                return $parameters[$parameter];
+            })
+        ;
+
+        $emptyParametersBagMock = $this->getMockBuilder(ParameterBag::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $emptyParametersBagMock
+            ->method('has')
+            ->willReturn(false)
+        ;
+
+        if ($postQuery) {
+            $requestMock->request = $parametersBagMock;
+            $requestMock->query = $emptyParametersBagMock;
+        } else {
+            $requestMock->query = $parametersBagMock;
+            $requestMock->request = $emptyParametersBagMock;
+        }
+
+        return $requestMock;
+    }
+}
+
+class SampleFilters extends Filters {
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaults()
+    {
+        return [
+            'limit' => 10,
+            'offset' => 0,
+            'orderBy' => 'id_sample',
+            'sortOrder' => 'desc',
+            'filters' => [],
+        ];
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Controller/ArgumentResolver/SearchParametersResolverTest.php
+++ b/tests/Unit/PrestaShopBundle/Controller/ArgumentResolver/SearchParametersResolverTest.php
@@ -1,0 +1,382 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\PrestaShopBundle\Controller\ArgumentResolver;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+use PrestaShop\PrestaShop\Core\Search\SearchParametersInterface;
+use PrestaShopBundle\Controller\ArgumentResolver\SearchParametersResolver;
+use PrestaShopBundle\Entity\AdminFilter;
+use PrestaShopBundle\Entity\Repository\AdminFilterRepository;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use PrestaShopBundle\Security\Admin\Employee;
+
+class SearchParametersResolverTest extends TestCase
+{
+    const EMPLOYEE_ID = 99;
+    const SHOP_ID = 13;
+
+    public function testConstructor()
+    {
+        $resolver = new SearchParametersResolver(
+            $this->buildSearchParametersMock(),
+            $this->buildTokenStorageMock(),
+            $this->buildAdminFilterRepositoryMock(),
+            self::SHOP_ID
+        );
+        $this->assertNotNull($resolver);
+    }
+
+    public function testSupports()
+    {
+        $requestMock = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        //With no employee
+        $resolver = new SearchParametersResolver(
+            $this->buildSearchParametersMock(),
+            $this->buildTokenStorageMock(),
+            $this->buildAdminFilterRepositoryMock(),
+            self::SHOP_ID
+        );
+        $this->assertNotNull($resolver);
+
+        $this->assertFalse($resolver->supports($requestMock, $this->buildArgumentMetaDataMock(SampleFilters::class)));
+
+        //With employee
+        $resolver = new SearchParametersResolver(
+            $this->buildSearchParametersMock(),
+            $this->buildTokenStorageMock(true),
+            $this->buildAdminFilterRepositoryMock(),
+            self::SHOP_ID
+        );
+        $this->assertNotNull($resolver);
+
+        $this->assertTrue($resolver->supports($requestMock, $this->buildArgumentMetaDataMock(SampleFilters::class)));
+        $this->assertFalse($resolver->supports($requestMock, $this->buildArgumentMetaDataMock(Employee::class)));
+    }
+
+    public function testResolveDefaults()
+    {
+        //With employee
+        $resolver = new SearchParametersResolver(
+            $this->buildSearchParametersMock(),
+            $this->buildTokenStorageMock(true),
+            $this->buildAdminFilterRepositoryMock(),
+            self::SHOP_ID
+        );
+        $this->assertNotNull($resolver);
+
+        $request = $this->buildRequestMock([]);
+
+        /** @var \Generator $yieldFilters */
+        $yieldFilters = $resolver->resolve($request, $this->buildArgumentMetaDataMock(SampleFilters::class));
+        /** @var SampleFilters $filters */
+        $filters = $yieldFilters->current();
+        $this->assertEquals(SampleFilters::getDefaults(), $filters->all());
+    }
+
+    public function testSavedParameters()
+    {
+        //With employee
+        $resolver = new SearchParametersResolver(
+            $this->buildSearchParametersMock(['limit' => 5, 'offset' => 20]),
+            $this->buildTokenStorageMock(true),
+            $this->buildAdminFilterRepositoryMock(),
+            self::SHOP_ID
+        );
+        $this->assertNotNull($resolver);
+
+        $request = $this->buildRequestMock([]);
+
+        /** @var \Generator $yieldFilters */
+        $yieldFilters = $resolver->resolve($request, $this->buildArgumentMetaDataMock(SampleFilters::class));
+        /** @var SampleFilters $filters */
+        $filters = $yieldFilters->current();
+        $this->assertNotEquals(SampleFilters::getDefaults(), $filters->all());
+        $this->assertEquals(5, $filters->getLimit());
+        $this->assertEquals(20, $filters->getOffset());
+    }
+
+    public function testRequestParameters()
+    {
+        $requestParameters = [
+            'orderBy' => 'name',
+            'sortOrder' => 'asc',
+            'filters' => [
+                'name' => 'test',
+            ],
+            'unknownParameter' => 'plop',
+        ];
+
+        //With employee
+        $resolver = new SearchParametersResolver(
+            $this->buildSearchParametersMock(null, $requestParameters),
+            $this->buildTokenStorageMock(true),
+            $this->buildAdminFilterRepositoryMock($requestParameters),
+            self::SHOP_ID
+        );
+        $this->assertNotNull($resolver);
+
+        //Request must be GET and have one of these three parameters (filters|limit|sortOrder)
+        $request = $this->buildRequestMock(['orderBy' => 'name']);
+
+        /** @var \Generator $yieldFilters */
+        $yieldFilters = $resolver->resolve($request, $this->buildArgumentMetaDataMock(SampleFilters::class));
+        /** @var SampleFilters $filters */
+        $filters = $yieldFilters->current();
+        $this->assertNotEquals(SampleFilters::getDefaults(), $filters->all());
+        $this->assertEquals('name', $filters->getOrderBy());
+        $this->assertEquals('asc', $filters->getOrderWay());
+        $this->assertEquals($requestParameters['filters'], $filters->getFilters());
+
+        //Default values
+        $this->assertEquals(42, $filters->getOffset());
+        $this->assertEquals(51, $filters->getLimit());
+    }
+
+    public function testRequestOverridesSaved()
+    {
+        $requestParameters = [
+            'orderBy' => 'name',
+            'sortOrder' => 'asc',
+            'filters' => [
+                'name' => 'test',
+            ],
+            'limit' => 33,
+            'unknownParameter' => 'plop',
+        ];
+        $savedParameters = [
+            'limit' => 5,
+            'offset' => 20
+        ];
+        $expectedParameters = array_merge($savedParameters, $requestParameters);
+
+        //With employee
+        $resolver = new SearchParametersResolver(
+            $this->buildSearchParametersMock($savedParameters, $requestParameters),
+            $this->buildTokenStorageMock(true),
+            $this->buildAdminFilterRepositoryMock($expectedParameters),
+            self::SHOP_ID
+        );
+        $this->assertNotNull($resolver);
+
+        //Request must be GET and have one of these three parameters (filters|limit|sortOrder)
+        $request = $this->buildRequestMock(['orderBy' => 'name']);
+
+        /** @var \Generator $yieldFilters */
+        $yieldFilters = $resolver->resolve($request, $this->buildArgumentMetaDataMock(SampleFilters::class));
+        /** @var SampleFilters $filters */
+        $filters = $yieldFilters->current();
+        $this->assertNotEquals(SampleFilters::getDefaults(), $filters->all());
+        $this->assertEquals('name', $filters->getOrderBy());
+        $this->assertEquals('asc', $filters->getOrderWay());
+        $this->assertEquals($requestParameters['filters'], $filters->getFilters());
+        $this->assertEquals(20, $filters->getOffset());
+        $this->assertEquals(33, $filters->getLimit());
+    }
+
+    private function buildArgumentMetaDataMock($type)
+    {
+        $argumentMetadataMock = $this->getMockBuilder(ArgumentMetadata::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $argumentMetadataMock
+            ->expects($this->once())
+            ->method('getType')
+            ->willReturn($type)
+        ;
+
+        return $argumentMetadataMock;
+    }
+
+    private function buildRequestMock(array $parameters = [], $postQuery = false)
+    {
+        $requestMock = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $parametersBagMock = $this->getMockBuilder(ParameterBag::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $parametersBagMock
+            ->method('has')
+            ->willReturnCallback(function ($parameter) use ($parameters) {
+                return isset($parameters[$parameter]);
+            })
+        ;
+        $parametersBagMock
+            ->method('get')
+            ->willReturnCallback(function ($parameter) use ($parameters) {
+                return $parameters[$parameter];
+            })
+        ;
+
+        $emptyParametersBagMock = $this->getMockBuilder(ParameterBag::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $emptyParametersBagMock
+            ->method('has')
+            ->willReturn(false)
+        ;
+
+        $requestMock
+            ->expects($this->once())
+            ->method('isMethod')
+            ->willReturn(!$postQuery)
+        ;
+        if ($postQuery) {
+            $requestMock->request = $parametersBagMock;
+            $requestMock->query = $emptyParametersBagMock;
+        } else {
+            $requestMock->query = $parametersBagMock;
+            $requestMock->request = $emptyParametersBagMock;
+        }
+
+        return $requestMock;
+    }
+
+    private function buildTokenStorageMock($withEmployee = false)
+    {
+        $tokenStorageMock = $this->getMockBuilder(TokenStorageInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        if ($withEmployee) {
+            $employeeMock = $this->getMockBuilder(Employee::class)
+                ->disableOriginalConstructor()
+                ->getMock()
+            ;
+
+            $employeeMock
+                ->method('getId')
+                ->willReturn(self::EMPLOYEE_ID)
+            ;
+
+            $tokenMock = $this->getMockBuilder(TokenInterface::class)
+                ->disableOriginalConstructor()
+                ->getMock()
+            ;
+            $tokenMock
+                ->expects($this->once())
+                ->method('getUser')
+                ->willReturn($employeeMock)
+            ;
+
+            $tokenStorageMock
+                ->expects($this->once())
+                ->method('getToken')
+                ->willReturn($tokenMock)
+            ;
+        }
+
+        return $tokenStorageMock;
+    }
+
+    private function buildSearchParametersMock(array $repoParameters = null, array $requestParameters = null)
+    {
+        $searchParametersMock = $this->getMockBuilder(SearchParametersInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        if (null !== $repoParameters) {
+            $repoFilters = new SampleFilters($repoParameters);
+            $searchParametersMock
+                ->expects($this->once())
+                ->method('getFiltersFromRepository')
+                ->willReturn($repoFilters)
+            ;
+        }
+
+        if (null !== $requestParameters) {
+            $requestFilters = new SampleFilters($requestParameters);
+            $searchParametersMock
+                ->expects($this->once())
+                ->method('getFiltersFromRequest')
+                ->willReturn($requestFilters)
+            ;
+        }
+
+        return $searchParametersMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|AdminFilterRepository
+     */
+    private function buildAdminFilterRepositoryMock(array $expectedParameters = null)
+    {
+        $repositoryMock = $this->getMockBuilder(AdminFilterRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        if (null !== $expectedParameters) {
+            $savedParameters = array_merge(SampleFilters::getDefaults(), $expectedParameters);
+            unset($savedParameters['offset']);
+            $repositoryMock
+                ->expects($this->once())
+                ->method('createOrUpdateByEmployeeAndRouteParams')
+                ->with(
+                    $this->equalTo(self::EMPLOYEE_ID),
+                    $this->equalTo(self::SHOP_ID),
+                    $this->equalTo($savedParameters)
+                )
+            ;
+        }
+
+        return $repositoryMock;
+    }
+}
+
+class SampleFilters extends Filters {
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaults()
+    {
+        return [
+            'limit' => 51,
+            'offset' => 42,
+            'orderBy' => 'id_sample',
+            'sortOrder' => 'desc',
+            'filters' => [],
+        ];
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | There was a bug on pagination for logs, this bug was actually larger than that and concerned all Grids. The `SearchParametersResolver` did not manage overriding rules properly, so when a request had parameters for pagination the former request with filters was ignored. Now the override rules are as follow: Default -> Saved -> Request
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12338
| How to test?  | Go to Advanced Parameters -> Logs, if you dont have enough stored logs you can perform Product modifications to create more or remove a product (for example). The pagination is supposed to work even when you perform a search or if you changer the order field.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12361)
<!-- Reviewable:end -->
