### PR TITLE
Move PositionColumn in its original folder

### DIFF
--- a/src/Core/Grid/Column/Type/Common/PositionColumn.php
+++ b/src/Core/Grid/Column/Type/Common/PositionColumn.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Grid\Column\Type\Catalog;
+namespace PrestaShop\PrestaShop\Core\Grid\Column\Type\Common;
 
 use PrestaShop\PrestaShop\Core\Grid\Column\AbstractColumn;
 use PrestaShop\PrestaShop\Core\Grid\Position\GridPositionUpdater;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As soon as a class has been released, it cannot be removed in the next version without creating backward compatibility issues. It seems this issue is caused by some changes not properly merged into `develop`.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #12093
| How to test?  | Module `ps_linklist` works as on 1.7.5.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12367)
<!-- Reviewable:end -->
