### PR TITLE
Fix deprecation notices reported by Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "PrestaShop/PrestaShop",
+    "name": "prestashop/prestashop",
     "description": "PrestaShop offers a free, fully scalable, Open Source e-commerce solution.",
     "type": "project",
     "require": {
@@ -8,7 +8,7 @@
         "ext-fileinfo": "*",
         "ext-intl": "*",
         "ext-zip": "*",
-        "beberlei/DoctrineExtensions": "^1.0",
+        "beberlei/doctrineextensions": "^1.0",
         "composer/ca-bundle": "^1.0",
         "composer/installers": "^1.0.21",
         "csa/guzzle-bundle": "~1.3",
@@ -121,7 +121,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",
         "johnkary/phpunit-speedtrap": "^1.1",
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "phake/phake": "@stable",
         "phpunit/phpunit": "~5.7",
         "symfony/phpunit-bridge": "^3.0"


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix the deprecation notices reported on `composer` commands.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Composer install & update are still working.


## Issues fixed:

```
$ composer install
Deprecation warning: Your package name PrestaShop/PrestaShop is invalid, it should not contain uppercase characters. We suggest using presta-shop/presta-shop instead. Make sure you fix this as Composer 2.0 will error.
Deprecation warning: require.beberlei/DoctrineExtensions is invalid, it should not contain uppercase characters. Please use beberlei/doctrineextensions instead. Make sure you fix this as Composer 2.0 will error.
Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.
[...]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12369)
<!-- Reviewable:end -->
