### PR TITLE
RTL fixes: profile, select and notification dropdown, popover tooltips, stock quantity arrows

### DIFF
--- a/admin-dev/themes/default/public/theme.rtlfix
+++ b/admin-dev/themes/default/public/theme.rtlfix
@@ -106,24 +106,24 @@ svg {
 
 /* fix notification dropdown */
 .notification-center .dropdown-menu {
-  right: auto !important;
+  right: auto;
   left: 85px !important;
 }
 
 /* fix popover */
 .popover {
-  right: auto !important;
-  left: 5px !important;
+  right: auto;
+  left: 5px;
   margin-right: 0;
   margin-left: 8px;
 }
 .popover .arrow {
-  left: -8px !important;
-  right: auto !important;
-  transform: scaleX(-1) !important;
+  left: -8px;
+  right: auto;
+  transform: scaleX(-1);
 }
 
 /* fix stock quantity arrow direction */
 .stock-app .stock-overview .table .qty-update .material-icons {
-  transform: scaleX(-1) !important;
+  transform: scaleX(-1);
 }

--- a/admin-dev/themes/default/public/theme.rtlfix
+++ b/admin-dev/themes/default/public/theme.rtlfix
@@ -103,3 +103,27 @@ svg {
 #header_infos #header_logo {
   background-position: right;
 }
+
+/* fix notification dropdown */
+.notification-center .dropdown-menu {
+  right: auto !important;
+  left: 85px !important;
+}
+
+/* fix popover */
+.popover {
+  right: auto !important;
+  left: 5px !important;
+  margin-right: 0;
+  margin-left: 8px;
+}
+.popover .arrow {
+  left: -8px !important;
+  right: auto !important;
+  transform: scaleX(-1) !important;
+}
+
+/* fix stock quantity arrow direction */
+.stock-app .stock-overview .table .qty-update .material-icons {
+  transform: scaleX(-1) !important;
+}

--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -10,3 +10,15 @@
 .main-header > .logo {
   background-position: right;
 }
+
+/* fix profile menu position */
+.employee-dropdown .dropdown-menu {
+  right: auto !important;
+  left: .3em!important;
+}
+
+/* fix select dropdown */
+.select2-container--open .select2-dropdown {
+  right: auto;
+  left: 0;
+}

--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -19,30 +19,30 @@
 
 /* fix select dropdown */
 .select2-container--open .select2-dropdown {
-  right: auto !important;
+  right: auto;
   left: 0;
 }
 
 /* fix notification dropdown */
 .notification-center .dropdown-menu {
-  right: auto !important;
+  right: auto;
   left: 85px !important;
 }
 
 /* fix popover */
 .popover {
-  right: auto !important;
-  left: 5px !important;
+  right: auto;
+  left: 5px;
   margin-right: 0;
   margin-left: 8px;
 }
 .popover .arrow {
-  left: -8px !important;
-  right: auto !important;
-  transform: scaleX(-1) !important;
+  left: -8px;
+  right: auto;
+  transform: scaleX(-1);
 }
 
 /* fix stock quantity arrow direction */
 .stock-app .stock-overview .table .qty-update .material-icons {
-  transform: scaleX(-1) !important;
+  transform: scaleX(-1);
 }

--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -14,11 +14,35 @@
 /* fix profile menu position */
 .employee-dropdown .dropdown-menu {
   right: auto !important;
-  left: .3em!important;
+  left: .3em !important;
 }
 
 /* fix select dropdown */
 .select2-container--open .select2-dropdown {
-  right: auto;
+  right: auto !important;
   left: 0;
+}
+
+/* fix notification dropdown */
+.notification-center .dropdown-menu {
+  right: auto !important;
+  left: 85px !important;
+}
+
+/* fix popover */
+.popover {
+  right: auto !important;
+  left: 5px !important;
+  margin-right: 0;
+  margin-left: 8px;
+}
+.popover .arrow {
+  left: -8px !important;
+  right: auto !important;
+  transform: scaleX(-1) !important;
+}
+
+/* fix stock quantity arrow direction */
+.stock-app .stock-overview .table .qty-update .material-icons {
+  transform: scaleX(-1) !important;
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | In RTL languages the profile dropdown menu was offset, similar problem for select dropdown boxes. The solution is to override the generated CSS files thanks to PrestaShop rtlfix files (which are appended at the end of generated css files). In this case the problem comes from the `right` css property which needs to be set to `auto`, and in some cases settings `left` to 0 is also necessary.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12138 and #11403
| How to test?  | Install an RTL language to generate the css files. If you already had one first you need to remove al the generated `*_rtl.css` files (or they won't be regenerated), then either install a new RTL language or uninstall yours and the reinstall it (the generation process only works on install)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12370)
<!-- Reviewable:end -->
