### PR TITLE
Fix provider warehouse routes

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/suppliers.yml
@@ -1,5 +1,5 @@
 admin_supplier_refresh_product_supplier_combination_form:
-    path:     /refresh-combination-form/{idProduct}/{supplierIds}
+    path:     /refresh-product-supplier-combination-form/{idProduct}/{supplierIds}
     methods:  [GET]
     defaults:
         _controller: PrestaShopBundle:Admin/Supplier:refreshProductSupplierCombinationForm

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/warehouses.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/warehouses.yml
@@ -1,5 +1,5 @@
 admin_warehouse_refresh_product_warehouse_combination_form:
-    path:     /refresh-combination-form/{idProduct}
+    path:     /refresh-product-warehouse-combination-form/{idProduct}
     methods:  [GET]
     defaults:
         _controller: PrestaShopBundle:Admin/Warehouse:refreshProductWarehouseCombinationForm


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Some routes paths were wrongly renamed, so the product page was calling the warehouse url instead of the provider one
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12366
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12372)
<!-- Reviewable:end -->
