### PR TITLE
Fix utf8 support for PDO connection

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -127,6 +127,11 @@ class DbPDOCore extends Db
             throw new PrestaShopException('Link to database cannot be established: ' . $e->getMessage());
         }
 
+        // UTF-8 support
+        if (!$this->link->query('SET NAMES \'utf8\'')) {
+            throw new PrestaShopDatabaseException(Tools::displayError('PrestaShop Fatal error: no utf-8 support. Please check your server configuration.'));
+        }
+
         $this->link->exec('SET SESSION sql_mode = \'\'');
 
         return $this->link;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | https://github.com/PrestaShop/PrestaShop/issues/12371#issuecomment-459119113 I think this affects all 1.7.x versions, but requires specific value of mysql server variable `init_connect` which in most cases is empty
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12371 #11155
| How to test?  | install prestashop locally with polish language, set mysql variable on the online server `init_connect = SET NAMES latin2`, move your local store to that server, check the effect 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12376)
<!-- Reviewable:end -->
