### PR TITLE
Features Associated to a products should always be Related to a Feature

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -875,6 +875,9 @@ class AdminProductsControllerCore extends AdminController
                 $features = isset($form['step1']['features']) ? $form['step1']['features'] : array();
                 if (is_array($features)) {
                     foreach ($features as $feature) {
+                        if (!(int)($feature['feature'])) {
+                            continue;
+                        }
                         if (!empty($feature['value'])) {
                             $product->addFeaturesToDB($feature['feature'], $feature['value']);
                         } elseif ($defaultValue = $this->checkFeatures($languages, $feature)) {

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -875,7 +875,7 @@ class AdminProductsControllerCore extends AdminController
                 $features = isset($form['step1']['features']) ? $form['step1']['features'] : array();
                 if (is_array($features)) {
                     foreach ($features as $feature) {
-                        if (!(int)($feature['feature'])) {
+                        if (!(int) ($feature['feature'])) {
                             continue;
                         }
                         if (!empty($feature['value'])) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Features Associated to a products should always be Related to a Feature ( if not, they beceome un-deletable , and self-duplicate them on product Saving) , more details below
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Go on BO , One Admin product page, try to add Features do the product

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

- Description of the Bug :
- On one Admin product page , you can associated features, to product, whihout selecting the mandatory field "Feature"
![image](https://user-images.githubusercontent.com/3170104/52064377-d6b30000-2574-11e9-9c9a-a1c1f88a36c3.png)

- this is saved whith no verification ( id_feature = 0 )
When saving Again the product, 
this mistake can never been deleted by Merchant,
as on : (legacy) Product::deleteFeatures() there is a check :
```
        // Delete product features
        $result = Db::getInstance()->execute('
    		DELETE `'._DB_PREFIX_.'feature_product` FROM `'._DB_PREFIX_.'feature_product`
    		WHERE `id_product` = '.(int)$this->id.(!$all_shops ? '
                AND `id_feature` IN (
                    SELECT `id_feature`
                    FROM `'._DB_PREFIX_.'feature_shop`
                    WHERE `id_shop` = '.(int)Context::getContext()->shop->id.'
                )' : ''))
```
So During each product saving, this bad association duplicate himself more and more ( * 2 each time), as on the screen below (you see the bug, when you refresh the admin product page)
![image](https://user-images.githubusercontent.com/3170104/52064728-7bcdd880-2575-11e9-8fdf-dfbe8dd7e83b.png)

( this patch may be improved to inform the merchant that the Feature field is mandatory )
regards

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12388)
<!-- Reviewable:end -->
