### PR TITLE
Fix Broken Authentication and Session Management

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -747,6 +747,14 @@ class CustomerCore extends ObjectModel
         if (!Validate::isUnsignedId($idCustomer)) {
             die(Tools::displayError());
         }
+
+        // Check that customers password hasn't changed since last login
+        $context = Context::getContext();
+        if ($passwordHash != $context->cookie->__get('passwd')) {
+            $context->customer->logout();
+            return false;
+        }
+
         $cacheId = 'Customer::checkPassword' . (int) $idCustomer . '-' . $passwordHash;
         if (!Cache::isStored($cacheId)) {
             $sql = new DbQuery();

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -751,7 +751,6 @@ class CustomerCore extends ObjectModel
         // Check that customers password hasn't changed since last login
         $context = Context::getContext();
         if ($passwordHash != $context->cookie->__get('passwd')) {
-            $context->customer->logout();
             return false;
         }
 

--- a/classes/form/CustomerPersister.php
+++ b/classes/form/CustomerPersister.php
@@ -131,6 +131,10 @@ class CustomerPersisterCore
             }
         }
 
+        if ($customer->email != $this->context->customer->email) {
+            $customer->removeResetPasswordToken();
+        }
+
         $ok = $customer->save();
 
         if ($ok) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | All previous passwords resettled by links should automatically expire once a user changes his email address or his password.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12040 
| How to test?  | See issue #12040

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

I started working on this before realising that this issue was marked for the version 1.7.6. I created the PR anyway, it will be possible to use it later.

I'm pretty sure that I fix the first problem describe in the issue. But I'm not as confident about the second problem (clear all sessions after an user change his password, except the one he used to change it). I worked for me but let me know if you wanted to do it in another way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12391)
<!-- Reviewable:end -->
