### PR TITLE
Fix use of array_merge in HookFinder->addExpectedInstanceClasses

### DIFF
--- a/src/PrestaShopBundle/Service/Hook/HookFinder.php
+++ b/src/PrestaShopBundle/Service/Hook/HookFinder.php
@@ -162,7 +162,7 @@ class HookFinder
     public function addExpectedInstanceClasses($expectedInstanceClasses)
     {
         if (is_array($expectedInstanceClasses)) {
-            array_merge($this->expectedInstanceClasses, $expectedInstanceClasses);
+            $this->expectedInstanceClasses = array_merge($this->expectedInstanceClasses, $expectedInstanceClasses);
         } else {
             $this->expectedInstanceClasses[] = $expectedInstanceClasses;
         }

--- a/tests/Unit/PrestaShopBundle/Service/Hook/HookFinderTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Hook/HookFinderTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\PrestaShopBundle\Service\Hook;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Service\Hook\HookFinder;
+
+class HookFinderTest extends TestCase
+{
+    public function testAddOneExpectedClass()
+    {
+        $finder = new HookFinder();
+        $finder->addExpectedInstanceClasses(__CLASS__);
+
+        $this->assertSame(
+            array(__CLASS__),
+            $finder->getExpectedInstanceClasses()
+        );
+    }
+
+    public function testAddSeveralExpectedClass()
+    {
+        $finder = new HookFinder();
+        $finder->addExpectedInstanceClasses(__CLASS__);
+        $finder->addExpectedInstanceClasses([HookFinder::class, TestCase::class]);
+
+        $this->assertSame(
+            array(__CLASS__, HookFinder::class, TestCase::class),
+            $finder->getExpectedInstanceClasses()
+        );
+    }
+}


### PR DESCRIPTION
Observed: Would not modify expectedInstanceClasses.
- array_merge returns a new array and does not modify the original
Expected: Modify expectedInstanceClasses as documented.

This was detected via static analysis (Phan), I'm not sure what the
impact of fixing this would be in real applications.

Within this codebase, addExpectedInstanceClasses is called only once, with a string

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Calling addExpectedInstanceClasses with an array was a no-op. 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no?
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Call addExpectedInstanceClasses with an array, then verify getExpectedInstanceClasses. No existing tests were found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12397)
<!-- Reviewable:end -->
