### PR TITLE
Fix first attribute generation when not choosing first attribute

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/AttributeController.php
@@ -174,8 +174,20 @@ class AttributeController extends FrameworkBundleAdminController
         if (count($combinations)) {
             $defaultProductAttributeId = $product->getDefaultIdProductAttribute();
             if (!$defaultProductAttributeId) {
-                $firstAttributeCombination = reset($combinations[0]);
-                $product->setDefaultAttribute($firstAttributeCombination['id_product_attribute']);
+                /*
+                 * Combinations indexed by position, then attribute id
+                 * ex: $combinations = [
+                 *  3 => [ //4th position attribute
+                 *      45 => [ //product_attribute id
+                 *      ]
+                 *  ]
+                 * ]
+                 */
+                $firstPosition = array_keys($combinations)[0];
+                if (!empty($combinations[$firstPosition])) {
+                    $firstAttributeId = array_keys($combinations[$firstPosition])[0];
+                    $product->setDefaultAttribute($firstAttributeId);
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | There was a problem when creating a new combination (first one). The process which was setting the default combination tried to access a false index in an array (the array was associated by position, not starting at 0)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12393
| How to test?  | Go to a product, remove all its combinations. Try to add a new attribute (do not use the first of the list).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12402)
<!-- Reviewable:end -->
