### PR TITLE
Attribute min not allowed on element input at this point, change type from text to number

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -30,7 +30,7 @@
       <div class="product-quantity clearfix">
         <div class="qty">
           <input
-            type="text"
+            type="number"
             name="qty"
             id="quantity_wanted"
             value="{$product.quantity_wanted}"
@@ -70,7 +70,7 @@
         {/if}
       </span>
     {/block}
-    
+
     {block name='product_minimal_quantity'}
       <p class="product-minimal-quantity">
         {if $product.minimal_quantity > 1}

--- a/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -126,7 +126,7 @@
                 data-up-url="{$product.up_quantity_url}"
                 data-update-url="{$product.update_quantity_url}"
                 data-product-id="{$product.id_product}"
-                type="text"
+                type="number"
                 value="{$product.quantity}"
                 name="product-quantity-spin"
                 min="{$product.minimal_quantity}"


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | HTML5 Validation fix, min requires input to be number, it was text.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | N/A
| How to test?  | Install classic theme and check validation errors have gone with validator

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12403)
<!-- Reviewable:end -->
