### PR TITLE
[POC] Introduce virtual product fixtures for cart calculations tests

### DIFF
--- a/tests-legacy/Unit/Core/Cart/AbstractCartTest.php
+++ b/tests-legacy/Unit/Core/Cart/AbstractCartTest.php
@@ -52,7 +52,7 @@ abstract class AbstractCartTest extends IntegrationTestCase
     const DEFAULT_WRAPPING_FEE = 0;
 
     const PRODUCT_FIXTURES = [
-        1 => ['price' => 19.812],
+        1 => ['price' => 19.812, 'isVirtual' => true],
         2 => ['price' => 32.388],
         3 => ['price' => 31.188],
         4 => ['price' => 35.567, 'outOfStock' => true],
@@ -192,6 +192,10 @@ abstract class AbstractCartTest extends IntegrationTestCase
             $product->price    = $productFixture['price'];
             $product->name     = 'product name';
             $product->quantity = !empty($productFixture['quantity']) ? $productFixture['quantity'] : 1000;
+
+            if (!empty($productFixture['isVirtual'])) {
+                $product->is_virtual = $productFixture['isVirtual'];
+            }
 
             if (!empty($productFixture['outOfStock'])) {
                 $product->out_of_stock = 0;


### PR DESCRIPTION
This POC fails ... for bad reasons !
Looks like cart calculations go crazy when using a virtual product 🤔 I think calculations should be the same, not matter virtual or not (for cart rules which dont target specific virtual usecases of course) ?

@tomlev the fun begins here 😄

Failing bash command:
```
php72 -d date.timezone=UTC -d memory_limit=-1 ./vendor/bin/phpunit -c tests-legacy/phpunit.xml --filter CartRulesSpecificAmount

Time: 9.81 seconds, Memory: 38.00MB

There was 1 failure:

1) LegacyTests\Unit\Core\Cart\Calculation\CartRules\CartRulesSpecificAmountTest::testCartWithOneProductSpecificCartRulesAmount with data set "one product in cart, quantity 1, one specific 5€ voucher on product #2" (array(1), 26.812, array(8), false)
V1 fail (tax incl)
Failed asserting that 19.8 matches expected 26.8.

/Users/mFerment/www/prestashop/PrestaShop/tests-legacy/Unit/Core/Cart/Calculation/AbstractCartCalculationTest.php:46
/Users/mFerment/www/prestashop/PrestaShop/tests-legacy/Unit/Core/Cart/Calculation/CartRules/CartRulesSpecificAmountTest.php:51

FAILURES!
Tests: 2, Assertions: 3, Failures: 1.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12405)
<!-- Reviewable:end -->
