### PR TITLE
Fix link to the shop on backoffice

### DIFF
--- a/admin-dev/themes/default/template/helpers/shops_list/list.tpl
+++ b/admin-dev/themes/default/template/helpers/shops_list/list.tpl
@@ -47,12 +47,12 @@
                             {$shop_data['name']}
                         </a>
 
-                        {if $shop_data['uri'] == NULL}
+                        {if $shop_data['fulluri'] == NULL}
                             <a class="link-shop" href="{$link->getAdminLink('AdminShop', true)|escape:'html':'UTF-8'}" target="_blank">
                                 <i class="material-icons">&#xE869;</i>
                             </a>
                         {else}
-                            <a class="link-shop" href="{$shop_data['uri']}" target="_blank">
+                            <a class="link-shop" href="{$shop_data['fulluri']}" target="_blank">
                                 <i class="material-icons">&#xE8F4;</i>
                             </a>
                         {/if}

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -703,6 +703,8 @@ class ShopCore extends ObjectModel
                 }
 
                 $row = $row + array('theme_name' => '');
+				$domain_with_protocol = (Configuration::get('PS_SSL_ENABLED', null, $row['id_shop_group'], $row['id_shop']) 
+										&& $row['domain_ssl'] ? 'https://'. $row['domain_ssl'] : 'http://' . $row['domain'];
 
                 self::$shops[$row['id_shop_group']]['shops'][$row['id_shop']] = array(
                     'id_shop' =>        $row['id_shop'],
@@ -713,7 +715,8 @@ class ShopCore extends ObjectModel
                     'domain' =>            $row['domain'],
                     'domain_ssl' =>        $row['domain_ssl'],
                     'uri' =>            $row['physical_uri'].$row['virtual_uri'],
-                    'active' =>            $row['active'],
+					'active' =>            $row['active'],
+					'fulluri' =>	  ($row['physical_uri'].$row['virtual_uri']) ? $domain_with_protocol.$row['physical_uri'].$row['virtual_uri'] : null,
                 );
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Invalid link to store if the store is on a different domain than currently used in backoffice.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Two shops in multistore with a different domains. Link in the navigation should be with different domain for each shop. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12410)
<!-- Reviewable:end -->
