### PR TITLE
fix of utf8 isuue for combinations page

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/AttributeRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeRepository.php
@@ -34,6 +34,16 @@ namespace PrestaShopBundle\Entity\Repository;
  */
 class AttributeRepository extends \Doctrine\ORM\EntityRepository
 {
+    
+    public function createQueryBuilder($alias, $indexBy = null)
+    {
+        $qb = parent::createQueryBuilder($alias, $indexBy);
+        
+        // support UTF8
+        $qb->getEntityManager()->getConnection()->executeQuery('SET NAMES \'UTF8\'');
+        return $qb;
+    }
+    
     public function findByLangAndShop($idLang, $idShop)
     {
         $attributeGroups = array();


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Charset fix for hostings with default non-utf8 connections on the admin combinations page and front page of product with combinations.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12371 .
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12426)
<!-- Reviewable:end -->
