### PR TITLE
Introduces new File type input design for all new and migrated back-office pages 

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -65,13 +65,9 @@
     width: 150px;
   }
 
-  .form-error-icon {
-    font-size: 20px;
+  .custom-file {
+    input {
+      outline: none;
+    }
   }
-
-  .clickable-avatar {
-    height: 100px;
-    width: 100px;
-  }
-
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -73,7 +73,7 @@ services:
     prestashop.twig.extension.context_iso_code_provider_extension:
       class: PrestaShopBundle\Twig\ContextIsoCodeProviderExtension
       arguments:
-        - "@=service('prestashop.adapter.legacy.context').getContext().language.iso_code"
+        - "@=service('prestashop.adapter.legacy.context').getContext().language ? service('prestashop.adapter.legacy.context').getContext().language.iso_code : 'en'"
       properties:
         logger: "@logger"
         translator: "@translator"

--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -69,3 +69,13 @@ services:
             - '@prestashop.core.util.helper_card.documentation_link_provider'
         tags:
             - { name: twig.extension }
+
+    prestashop.twig.extension.context_iso_code_provider_extension:
+      class: PrestaShopBundle\Twig\ContextIsoCodeProviderExtension
+      arguments:
+        - "@=service('prestashop.adapter.legacy.context').getContext().language.iso_code"
+      properties:
+        logger: "@logger"
+        translator: "@translator"
+      tags:
+        - { name: twig.extension }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
@@ -71,16 +71,22 @@
 
     <div class="form-group js-file-upload-form-group">
       <label class="form-control-label">{{ 'Select a file to import'|trans }}</label>
-      {{ form_errors(importForm.file) }}
-      {{ form_widget(importForm.file, {'attr': {'class': 'js-import-file', 'data-max-file-upload-size': maxFileUploadSize }}) }}
-      <span>{{ 'or'|trans({}, 'Admin.Global') }}</span>
-      <button type="button"
-              class="btn btn-outline-primary btn-sm js-from-files-history-btn"
-              {% if importFileNames is empty %}disabled{% endif %}
-      >
-        <span class="badge badge-primary js-files-history-number">{{ importFileNames|length }}</span>
-        {{ 'Choose from history / FTP'|trans({}, 'Admin.Advparameters.Feature') }}
-      </button>
+      <div class="row">
+        <div class="col">
+          {{ form_errors(importForm.file) }}
+          {{ form_widget(importForm.file, {'attr': {'class': 'js-import-file', 'data-max-file-upload-size': maxFileUploadSize }}) }}
+        </div>
+        <div class="col pt-sm-2 pt-md-0">
+          <span>{{ 'or'|trans({}, 'Admin.Global') }}</span>
+          <button type="button"
+                  class="btn btn-outline-primary btn-sm js-from-files-history-btn"
+                  {% if importFileNames is empty %}disabled{% endif %}
+          >
+            <span class="badge badge-primary js-files-history-number">{{ importFileNames|length }}</span>
+            {{ 'Choose from history / FTP'|trans({}, 'Admin.Advparameters.Feature') }}
+          </button>
+        </div>
+      </div>
       <small class="form-text">{{ 'Allowed formats: .csv, .xls, .xlsx, .xlst, .ods, .ots'|trans({}, 'Admin.Advparameters.Help') }}</small>
       <small class="form-text">{{ 'Only UTF-8 and ISO 8859-1 encodings are allowed'|trans({}, 'Admin.Advparameters.Help') }}</small>
       <small class="form-text">{{ 'You can also upload your file via FTP to the following directory: %s .'|trans({'%s': importDirectory}, 'Admin.Advparameters.Help') }}</small>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
@@ -76,7 +76,7 @@
           {{ form_errors(importForm.file) }}
           {{ form_widget(importForm.file, {'attr': {'class': 'js-import-file', 'data-max-file-upload-size': maxFileUploadSize }}) }}
         </div>
-        <div class="col pt-sm-2 pt-md-0">
+        <div class="col">
           <span>{{ 'or'|trans({}, 'Admin.Global') }}</span>
           <button type="button"
                   class="btn btn-outline-primary btn-sm js-from-files-history-btn"

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -704,7 +704,7 @@
   <div class="custom-file">
     {% set attr = attr|merge({
       class: (attr.class|default('') ~ ' custom-file-input')|trim,
-      'data-multiple-files-text': '%count% files'|trans({}, 'Admin.Global'),
+      'data-multiple-files-text': '%count% file(s)'|trans({}, 'Admin.Global'),
       'data-locale': get_context_iso_code()
     }) -%}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -173,8 +173,8 @@
         <ul class="category-tree">
             <li class="form-control-label text-right main-category">{{ "Main category"|trans({}, 'Admin.Catalog.Feature') }}</li>
             {%- for child in choices %}
-                {{ block('choice_tree_item_widget') }}
-            {% endfor -%}
+            {{ block('choice_tree_item_widget') }}
+        {% endfor -%}
         </ul>
     </div>
 {%- endblock choice_tree_widget %}
@@ -222,15 +222,15 @@
     {{ form_errors(form) }}
     <div class="translations tabbable" id="{{ form.vars.id }}">
         {% if hideTabs == false and form|length > 1 %}
-            <ul class="translationsLocales nav nav-pills">
-                {% for translationsFields in form %}
-                    <li class="nav-item">
-                        <a href="#" class="{% if defaultLocale.id_lang == translationsFields.vars.name %}active{% endif %} nav-link" data-toggle="tab" data-target=".translationsFields-{{ translationsFields.vars.id }}">
-                            {{ translationsFields.vars.label|capitalize }}
-                        </a>
-                    </li>
-                {% endfor %}
-            </ul>
+        <ul class="translationsLocales nav nav-pills">
+            {% for translationsFields in form %}
+                <li class="nav-item">
+                    <a href="#" class="{% if defaultLocale.id_lang == translationsFields.vars.name %}active{% endif %} nav-link" data-toggle="tab" data-target=".translationsFields-{{ translationsFields.vars.id }}">
+                        {{ translationsFields.vars.label|capitalize }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
         {% endif %}
 
         <div class="translationsFields tab-content">
@@ -268,67 +268,67 @@
         {% endfor %}
 
         {% if not hide_locales %}
-            <div class="dropdown">
-                <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
-                        type="button"
-                        data-toggle="dropdown"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                        id="{{ form.vars.id }}"
-                >
-                    {{ form.vars.default_locale.iso_code }}
-                </button>
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
+                    type="button"
+                    data-toggle="dropdown"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    id="{{ form.vars.id }}"
+            >
+                {{ form.vars.default_locale.iso_code }}
+            </button>
 
-                <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
-                    {% for locale in locales %}
-                        <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
-                    {% endfor %}
-                </div>
+            <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+                {% for locale in locales %}
+                    <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
+                {% endfor %}
             </div>
+        </div>
         {% endif %}
     </div>
 {%- endblock translate_text_widget %}
 
 {% block translate_textarea_widget -%}
-    {{ form_errors(form) }}
-    <div class="input-group locale-input-group js-locale-input-group">
-        {% for textarea in form %}
-            {% set classes = textarea.vars.attr.class|default('') ~ ' js-locale-input'%}
-            {% set classes = classes ~ ' js-locale-' ~ textarea.vars.label %}
+  {{ form_errors(form) }}
+  <div class="input-group locale-input-group js-locale-input-group">
+    {% for textarea in form %}
+      {% set classes = textarea.vars.attr.class|default('') ~ ' js-locale-input'%}
+      {% set classes = classes ~ ' js-locale-' ~ textarea.vars.label %}
 
-            {% if default_locale.id_lang != textarea.vars.name %}
-                {% set classes = classes ~ ' d-none' %}
-            {% endif %}
+      {% if default_locale.id_lang != textarea.vars.name %}
+        {% set classes = classes ~ ' d-none' %}
+      {% endif %}
 
-            <div class="{{ classes }}">
-                {{ form_widget(textarea, {attr: {'class': classes|trim}}) }}
-            </div>
-        {% endfor %}
+      <div class="{{ classes }}">
+        {{ form_widget(textarea, {attr: {'class': classes|trim}}) }}
+      </div>
+    {% endfor %}
 
-        {% if show_locale_select %}
-            <div class="dropdown">
-                <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
-                        type="button"
-                        data-toggle="dropdown"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                        id="{{ form.vars.id }}"
-                >
-                    {{ form.vars.default_locale.iso_code }}
-                </button>
+    {% if show_locale_select %}
+      <div class="dropdown">
+        <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
+                type="button"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+                id="{{ form.vars.id }}"
+        >
+          {{ form.vars.default_locale.iso_code }}
+        </button>
 
-                <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
-                    {% for locale in locales %}
-                        <span class="dropdown-item js-locale-item"
-                              data-locale="{{ locale.iso_code }}"
-                        >
+        <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+          {% for locale in locales %}
+            <span class="dropdown-item js-locale-item"
+                  data-locale="{{ locale.iso_code }}"
+            >
               {{ locale.name }}
             </span>
-                    {% endfor %}
-                </div>
-            </div>
-        {% endif %}
-    </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
+  </div>
 {%- endblock translate_textarea_widget %}
 
 {% block date_picker_widget %}
@@ -346,10 +346,10 @@
 {% endblock date_picker_widget %}
 
 {% block date_range_widget %}
-    {% spaceless %}
-        {{ form_widget(form.from) }}
-        {{ form_widget(form.to) }}
-    {% endspaceless %}
+  {% spaceless %}
+    {{ form_widget(form.from) }}
+    {{ form_widget(form.to) }}
+  {% endspaceless %}
 {% endblock date_range_widget %}
 
 {% block search_and_reset_widget %}
@@ -359,20 +359,20 @@
                 title="{{ 'Search'|trans({}, 'Admin.Actions') }}"
                 name="{{ full_name }}[search]"
         >
-            <i class="material-icons">search</i>
-            {{ 'Search'|trans({}, 'Admin.Actions') }}
+          <i class="material-icons">search</i>
+          {{ 'Search'|trans({}, 'Admin.Actions') }}
         </button>
 
         {% if show_reset_button %}
-            <div class="clearfix"></div>
+          <div class="clearfix"></div>
             <button type="reset"
                     name="{{ full_name }}[reset]"
                     class="btn btn-link js-reset-search btn d-block grid-reset-button float-right"
                     data-url="{{ reset_url }}"
                     data-redirect="{{ redirect_url }}"
             >
-                <i class="material-icons">clear</i>
-                {{ 'Reset'|trans({}, 'Admin.Actions') }}
+              <i class="material-icons">clear</i>
+              {{ 'Reset'|trans({}, 'Admin.Actions') }}
             </button>
         {% endif %}
     {% endspaceless %}
@@ -380,7 +380,7 @@
 
 {% block switch_widget %}
     {% spaceless %}
-        <span class="ps-switch">
+    <span class="ps-switch">
         {% for choice in choices %}
             {% set inputId = id ~'_' ~ choice.value %}
             <input id="{{inputId}}" {{ block('attributes') }} name="{{ full_name }}" value="{{ choice.value }}" {%- if choice is selectedchoice(value) -%}checked="" {%- endif -%} {%- if disabled -%}disabled="" {%- endif -%} type="radio">
@@ -396,28 +396,28 @@
         <small>{{ 'There is no attachment yet.'|trans({}, 'Admin.Catalog.Notification') }}</small>
     </div>
     <div id="product-attachments" class="panel panel-default">
-        <div class="panel-body js-options-with-attachments {{ form|length == 0 ? 'hide' : '' }}">
-            <div>
-                <table id="product-attachment-file" class="table">
-                    <thead class="thead-default">
-                    <tr>
-                        <th class="col-md-3"><input type="checkbox" id="product-attachment-files-check" /> {{ 'Title'|trans({}, 'Admin.Global') }}</th>
-                        <th class="col-md-6">{{ 'File name'|trans({}, 'Admin.Global') }}</th>
-                        <th class="col-md-2">{{ 'Type'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {%- for child in form %}
-                        <tr>
-                            <td class="col-md-3">{{ form_widget(child) }}</td>
-                            <td class="col-md-6 file-name"><span>{{ form.vars.attr.data[loop.index0]['file_name'] }}</span></td>
-                            <td class="col-md-2">{{ form.vars.attr.data[loop.index0]['mime'] }}</td>
-                        </tr>
-                    {% endfor -%}
-                    </tbody>
-                </table>
-            </div>
+      <div class="panel-body js-options-with-attachments {{ form|length == 0 ? 'hide' : '' }}">
+        <div>
+          <table id="product-attachment-file" class="table">
+            <thead class="thead-default">
+              <tr>
+                <th class="col-md-3"><input type="checkbox" id="product-attachment-files-check" /> {{ 'Title'|trans({}, 'Admin.Global') }}</th>
+                <th class="col-md-6">{{ 'File name'|trans({}, 'Admin.Global') }}</th>
+                <th class="col-md-2">{{ 'Type'|trans({}, 'Admin.Catalog.Feature') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+            {%- for child in form %}
+              <tr>
+                <td class="col-md-3">{{ form_widget(child) }}</td>
+                <td class="col-md-6 file-name"><span>{{ form.vars.attr.data[loop.index0]['file_name'] }}</span></td>
+                <td class="col-md-2">{{ form.vars.attr.data[loop.index0]['mime'] }}</td>
+              </tr>
+            {% endfor -%}
+            </tbody>
+          </table>
         </div>
+      </div>
     </div>
 {% endblock %}
 
@@ -445,30 +445,30 @@
 {% block checkbox_radio_label %}
     {# Do not display the label if widget is not defined in order to prevent double label rendering #}
     {% if widget is defined %}
-        {% if required %}
-            {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
-        {% endif %}
-        {% if parent_label_class is defined %}
-            {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
-        {% endif %}
-        {% if label is not same as(false) and label is empty %}
-            {% set label = name|humanize %}
-        {% endif %}
+      {% if required %}
+        {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
+      {% endif %}
+      {% if parent_label_class is defined %}
+          {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
+      {% endif %}
+      {% if label is not same as(false) and label is empty %}
+          {% set label = name|humanize %}
+      {% endif %}
 
-        {% if material_design is defined %}
-            <div class="md-checkbox md-checkbox-inline">
-                <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-                {{- widget|raw -}}
-                <i class="md-checkbox-control"></i>
-                {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
-                </label>
-            </div>
-        {% else %}
-            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-            {{- widget|raw -}}
-            {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
-            </label>
-        {% endif %}
+      {% if material_design is defined %}
+        <div class="md-checkbox md-checkbox-inline">
+          <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+          {{- widget|raw -}}
+          <i class="md-checkbox-control"></i>
+          {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
+          </label>
+        </div>
+      {% else %}
+      <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+        {{- widget|raw -}}
+        {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
+      </label>
+      {% endif %}
     {% endif %}
 {% endblock checkbox_radio_label %}
 
@@ -526,31 +526,31 @@
 
 {% block form_errors -%}
     {% if errors|length > 0 -%}
-        <div class="alert alert-danger">
-            {%- if errors|length > 1 -%}
-                <ul class="alert-text">
-                    {%- for error in errors -%}
-                        <li> {{
-                            error.messagePluralization is null
-                            ? error.messageTemplate|trans(error.messageParameters, 'form_error')
-                            : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
-                            }}
-                        </li>
-                    {%- endfor -%}
-                </ul>
-            {%- else -%}
-                <div class="alert-text">
-                    {%- for error in errors -%}
-                        <p> {{
-                            error.messagePluralization is null
-                            ? error.messageTemplate|trans(error.messageParameters, 'form_error')
-                            : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
-                            }}
-                        </p>
-                    {%- endfor -%}
-                </div>
-            {%- endif -%}
-        </div>
+    <div class="alert alert-danger">
+        {%- if errors|length > 1 -%}
+            <ul class="alert-text">
+                {%- for error in errors -%}
+                    <li> {{
+                        error.messagePluralization is null
+                        ? error.messageTemplate|trans(error.messageParameters, 'form_error')
+                        : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
+                        }}
+                    </li>
+                {%- endfor -%}
+            </ul>
+        {%- else -%}
+            <div class="alert-text">
+            {%- for error in errors -%}
+                <p> {{
+                    error.messagePluralization is null
+                    ? error.messageTemplate|trans(error.messageParameters, 'form_error')
+                    : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
+                    }}
+                </p>
+            {%- endfor -%}
+            </div>
+        {%- endif -%}
+    </div>
     {%- endif %}
 {%- endblock form_errors %}
 
@@ -558,172 +558,172 @@
 {# Material design widgets #}
 
 {% block material_choice_table_widget %}
-    {% spaceless %}
-        <div class="choice-table">
-            <table class="table table-bordered mb-0">
-                <thead>
-                <tr>
-                    <th class="checkbox">
-                        <div class="md-checkbox">
-                            <label>
-                                <input type="checkbox" class="js-choice-table-select-all">
-                                <i class="md-checkbox-control"></i>
-                                {{ 'Select all'|trans({}, 'Admin.Actions') }}
-                            </label>
-                        </div>
-                    </th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for child in form %}
-                    <tr>
-                        <td>
-                            {{ form_widget(child, {'material_design': true}) }}
-                        </td>
-                    </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% endspaceless %}
+  {% spaceless %}
+    <div class="choice-table">
+      <table class="table table-bordered mb-0">
+        <thead>
+          <tr>
+            <th class="checkbox">
+              <div class="md-checkbox">
+                <label>
+                  <input type="checkbox" class="js-choice-table-select-all">
+                  <i class="md-checkbox-control"></i>
+                  {{ 'Select all'|trans({}, 'Admin.Actions') }}
+                </label>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for child in form %}
+          <tr>
+            <td>
+              {{ form_widget(child, {'material_design': true}) }}
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endspaceless %}
 {% endblock material_choice_table_widget %}
 
 {% block material_multiple_choice_table_widget %}
-    {% spaceless %}
-        <div class="choice-table table-responsive">
-            <table class="table">
-                <thead>
-                <tr>
-                    <th>{{ label }}</th>
-                    {% for child_choice in form %}
-                        <th class="text-center">
-                            {% if child_choice.vars.multiple %}
-                                <a href="#"
-                                   class="js-multiple-choice-table-select-column"
-                                   data-column-num="{{ loop.index + 1 }}"
-                                   data-column-checked="false"
-                                >
-                                    {{ child_choice.vars.label }}
-                                </a>
-                            {% else %}
-                                {{ child_choice.vars.label }}
-                            {% endif %}
-                        </th>
-                    {% endfor %}
-                </tr>
-                </thead>
-                <tbody>
-                {% for choice_name, choice_value in choices %}
-                    <tr>
-                        <td>
-                            {{ choice_name }}
-                        </td>
-                        {% for child_choice_name, child_choice in form %}
-                            <td class="text-center">
-                                {% if child_choice_entry_index_mapping[choice_value][child_choice_name] is defined %}
-                                    {% set entry_index = child_choice_entry_index_mapping[choice_value][child_choice_name] %}
+  {% spaceless %}
+    <div class="choice-table table-responsive">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>{{ label }}</th>
+            {% for child_choice in form %}
+              <th class="text-center">
+                {% if child_choice.vars.multiple %}
+                  <a href="#"
+                     class="js-multiple-choice-table-select-column"
+                     data-column-num="{{ loop.index + 1 }}"
+                     data-column-checked="false"
+                  >
+                    {{ child_choice.vars.label }}
+                  </a>
+                {% else %}
+                  {{ child_choice.vars.label }}
+                {% endif %}
+              </th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+        {% for choice_name, choice_value in choices %}
+          <tr>
+            <td>
+              {{ choice_name }}
+            </td>
+            {% for child_choice_name, child_choice in form %}
+              <td class="text-center">
+                {% if child_choice_entry_index_mapping[choice_value][child_choice_name] is defined %}
+                  {% set entry_index = child_choice_entry_index_mapping[choice_value][child_choice_name] %}
 
-                                    {% if child_choice.vars.multiple %}
-                                        {{ form_widget(child_choice[entry_index], {'material_design': true}) }}
-                                    {% else %}
-                                        {{ form_widget(child_choice[entry_index]) }}
-                                    {% endif %}
-                                {% else %}
-                                    --
-                                {% endif %}
-                            </td>
-                        {% endfor %}
-                    </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% endspaceless %}
+                  {% if child_choice.vars.multiple %}
+                    {{ form_widget(child_choice[entry_index], {'material_design': true}) }}
+                  {% else %}
+                    {{ form_widget(child_choice[entry_index]) }}
+                  {% endif %}
+                {% else %}
+                  --
+                {% endif %}
+              </td>
+            {% endfor %}
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endspaceless %}
 {% endblock material_multiple_choice_table_widget %}
 
 {% block translatable_widget -%}
-    {{ form_errors(form) }}
-    <div class="input-group locale-input-group js-locale-input-group d-flex">
-        {% for translateField in form %}
-            {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
-            {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
-            {% if default_locale.id_lang != translateField.vars.name %}
-                {% set classes = classes ~ ' d-none' %}
-            {% endif %}
-            <div class="{{ classes }}" style="flex-grow: 1;">
-                {{ form_widget(translateField) }}
-            </div>
-        {% endfor %}
-        {% if not hide_locales %}
-            <div class="dropdown">
-                <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
-                        type="button"
-                        data-toggle="dropdown"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                        id="{{ form.vars.id }}"
-                >
-                    {{ form.vars.default_locale.iso_code }}
-                </button>
-                <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
-                    {% for locale in locales %}
-                        <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
-                    {% endfor %}
-                </div>
-            </div>
-        {% endif %}
-    </div>
+  {{ form_errors(form) }}
+  <div class="input-group locale-input-group js-locale-input-group d-flex">
+    {% for translateField in form %}
+      {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
+      {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
+      {% if default_locale.id_lang != translateField.vars.name %}
+        {% set classes = classes ~ ' d-none' %}
+      {% endif %}
+      <div class="{{ classes }}" style="flex-grow: 1;">
+        {{ form_widget(translateField) }}
+      </div>
+    {% endfor %}
+    {% if not hide_locales %}
+      <div class="dropdown">
+        <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
+                type="button"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+                id="{{ form.vars.id }}"
+        >
+          {{ form.vars.default_locale.iso_code }}
+        </button>
+        <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+          {% for locale in locales %}
+            <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
+  </div>
 {%- endblock translatable_widget %}
 
 {% block birthday_widget %}
-    {% if widget == 'single_text' %}
-        {{- block('form_widget_simple') -}}
-    {% else -%}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
-        {% if datetime is not defined or not datetime -%}
-            <div {{ block('widget_container_attributes') -}}>
-        {%- endif %}
+  {% if widget == 'single_text' %}
+    {{- block('form_widget_simple') -}}
+  {% else -%}
+    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
+    {% if datetime is not defined or not datetime -%}
+      <div {{ block('widget_container_attributes') -}}>
+    {%- endif %}
 
-        {% set yearWidget = '<div class="col pl-0">' ~ form_widget(form.year) ~ '</div>'|raw %}
-        {% set monthWidget = '<div class="col">' ~ form_widget(form.month) ~ '</div>'|raw %}
-        {% set dayWidget = '<div class="col pr-0">' ~ form_widget(form.day) ~ '</div>'|raw %}
+    {% set yearWidget = '<div class="col pl-0">' ~ form_widget(form.year) ~ '</div>'|raw %}
+    {% set monthWidget = '<div class="col">' ~ form_widget(form.month) ~ '</div>'|raw %}
+    {% set dayWidget = '<div class="col pr-0">' ~ form_widget(form.day) ~ '</div>'|raw %}
 
-        {{- date_pattern|replace({
-            '{{ year }}': yearWidget,
-            '{{ month }}': monthWidget,
-            '{{ day }}': dayWidget,
-        })|raw -}}
+    {{- date_pattern|replace({
+      '{{ year }}': yearWidget,
+      '{{ month }}': monthWidget,
+      '{{ day }}': dayWidget,
+    })|raw -}}
 
-        {% if datetime is not defined or not datetime -%}
-            </div>
-        {%- endif -%}
-    {% endif %}
+    {% if datetime is not defined or not datetime -%}
+      </div>
+    {%- endif -%}
+  {% endif %}
 {% endblock birthday_widget %}
 
 {% block file_widget %}
-    <div class="custom-file">
-        {% set attr = attr|merge({
-            class: (attr.class|default('') ~ ' custom-file-input')|trim,
-            'data-multiple-files-text': '%count% files'|trans({}, 'Admin.Global'),
-            'data-locale': get_context_iso_code()
-        }) -%}
+  <div class="custom-file">
+    {% set attr = attr|merge({
+      class: (attr.class|default('') ~ ' custom-file-input')|trim,
+      'data-multiple-files-text': '%count% files'|trans({}, 'Admin.Global'),
+      'data-locale': get_context_iso_code()
+    }) -%}
 
-        {{ form_widget(form, {'attr': attr}) }}
+    {{ form_widget(form, {'attr': attr}) }}
 
-        <label class="custom-file-label" for="{{ form.vars.id }}">
-            {% set attributes = form.vars.attr %}
+    <label class="custom-file-label" for="{{ form.vars.id }}">
+      {% set attributes = form.vars.attr %}
 
-            {% if (attributes.placeholder is not defined) %}
+      {% if (attributes.placeholder is not defined) %}
 
-                {% if (attributes.multiple is not defined) %}
-                    {{ 'Choose file'|trans({}, 'Shop.Theme.Actions') }}
-                {% else %}
-                    {{ 'Choose files'|trans({}, 'Shop.Theme.Actions') }}
-                {% endif %}
+        {% if (attributes.multiple is not defined) %}
+          {{ 'Choose file'|trans({}, 'Shop.Theme.Actions') }}
+        {% else %}
+          {{ 'Choose files'|trans({}, 'Shop.Theme.Actions') }}
+        {% endif %}
 
-            {% else %}
-                {{ attributes.placeholder }}
-            {% endif %}
-        </label>
-    </div>
+      {% else %}
+        {{ attributes.placeholder }}
+      {% endif %}
+    </label>
+  </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -29,701 +29,701 @@
 {# Widgets #}
 
 {% block form_widget_simple -%}
-  {% if type is not defined or 'file' != type %}
-    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
-  {% endif %}
-  {{- parent() -}}
+    {% if type is not defined or 'file' != type %}
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
+    {% endif %}
+    {{- parent() -}}
 {%- endblock form_widget_simple %}
 
 {% block textarea_widget -%}
-  {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
-  {{- parent() -}}
+    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
+    {{- parent() -}}
 {%- endblock textarea_widget %}
 
 {% block button_widget -%}
-  {% set attr = attr|merge({class: (attr.class|default('btn-default') ~ ' btn')|trim}) %}
-  {{- parent() -}}
+    {% set attr = attr|merge({class: (attr.class|default('btn-default') ~ ' btn')|trim}) %}
+    {{- parent() -}}
 {%- endblock %}
 
 {% block money_widget -%}
-  <div class="input-group money-type">
-    {% set prepend = '{{' == money_pattern[0:2] %}
-    {% if not prepend %}
-      <div class="input-group-prepend">
-        <span class="input-group-text">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
-      </div>
-    {% endif %}
-    {{- block('form_widget_simple') -}}
-    {% if prepend %}
-      <div class="input-group-append">
-        <span class="input-group-text">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
-      </div>
-    {% endif %}
-  </div>
+    <div class="input-group money-type">
+        {% set prepend = '{{' == money_pattern[0:2] %}
+        {% if not prepend %}
+            <div class="input-group-prepend">
+                <span class="input-group-text">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
+            </div>
+        {% endif %}
+        {{- block('form_widget_simple') -}}
+        {% if prepend %}
+            <div class="input-group-append">
+                <span class="input-group-text">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
+            </div>
+        {% endif %}
+    </div>
 {%- endblock money_widget %}
 
 {% block percent_widget -%}
-  <div class="input-group">
-    {{- block('form_widget_simple') -}}
-    <div class="input-group-append">
-      <span class="input-group-text">%</span>
+    <div class="input-group">
+        {{- block('form_widget_simple') -}}
+        <div class="input-group-append">
+            <span class="input-group-text">%</span>
+        </div>
     </div>
-  </div>
 {%- endblock percent_widget %}
 
 {% block datetime_widget -%}
-  {% if widget == 'single_text' %}
-    {{- block('form_widget_simple') -}}
-  {% else -%}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
-    <div {{ block('widget_container_attributes') }}>
-      {{- form_errors(form.date) -}}
-      {{- form_errors(form.time) -}}
-      {{- form_widget(form.date, { datetime: true } ) -}}
-      {{- form_widget(form.time, { datetime: true } ) -}}
-    </div>
-  {%- endif %}
+    {% if widget == 'single_text' %}
+        {{- block('form_widget_simple') -}}
+    {% else -%}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
+        <div {{ block('widget_container_attributes') }}>
+            {{- form_errors(form.date) -}}
+            {{- form_errors(form.time) -}}
+            {{- form_widget(form.date, { datetime: true } ) -}}
+            {{- form_widget(form.time, { datetime: true } ) -}}
+        </div>
+    {%- endif %}
 {%- endblock datetime_widget %}
 
 {% block date_widget -%}
-  {% if widget == 'single_text' %}
-    {{- block('form_widget_simple') -}}
-  {% else -%}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
-    {% if datetime is not defined or not datetime -%}
-      <div {{ block('widget_container_attributes') -}}>
-    {%- endif %}
-    {{- date_pattern|replace({
-      '{{ year }}': form_widget(form.year),
-      '{{ month }}': form_widget(form.month),
-      '{{ day }}': form_widget(form.day),
-    })|raw -}}
-    {% if datetime is not defined or not datetime -%}
-      </div>
-    {%- endif -%}
-  {% endif %}
+    {% if widget == 'single_text' %}
+        {{- block('form_widget_simple') -}}
+    {% else -%}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
+        {% if datetime is not defined or not datetime -%}
+            <div {{ block('widget_container_attributes') -}}>
+        {%- endif %}
+        {{- date_pattern|replace({
+            '{{ year }}': form_widget(form.year),
+            '{{ month }}': form_widget(form.month),
+            '{{ day }}': form_widget(form.day),
+        })|raw -}}
+        {% if datetime is not defined or not datetime -%}
+            </div>
+        {%- endif -%}
+    {% endif %}
 {%- endblock date_widget %}
 
 {% block time_widget -%}
-  {% if widget == 'single_text' %}
-    {{- block('form_widget_simple') -}}
-  {% else -%}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
-    {% if datetime is not defined or false == datetime -%}
-      <div {{ block('widget_container_attributes') -}}>
-    {%- endif -%}
-    {{- form_widget(form.hour) }}:{{ form_widget(form.minute) }}{% if with_seconds %}:{{ form_widget(form.second) }}{% endif %}
-    {% if datetime is not defined or false == datetime -%}
-      </div>
-    {%- endif -%}
-  {% endif %}
+    {% if widget == 'single_text' %}
+        {{- block('form_widget_simple') -}}
+    {% else -%}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
+        {% if datetime is not defined or false == datetime -%}
+            <div {{ block('widget_container_attributes') -}}>
+        {%- endif -%}
+        {{- form_widget(form.hour) }}:{{ form_widget(form.minute) }}{% if with_seconds %}:{{ form_widget(form.second) }}{% endif %}
+        {% if datetime is not defined or false == datetime -%}
+            </div>
+        {%- endif -%}
+    {% endif %}
 {%- endblock time_widget %}
 
 {% block choice_widget_collapsed -%}
-  {% set attr = attr|merge({class: (attr.class|default('') ~ ' custom-select')|trim}) %}
-  {{- parent() -}}
+    {% set attr = attr|merge({class: (attr.class|default('') ~ ' custom-select')|trim}) %}
+    {{- parent() -}}
 {%- endblock %}
 
 {% block choice_widget_expanded -%}
-  {% if '-inline' in label_attr.class|default('') -%}
-    <div class="control-group">
-      {%- for child in form %}
-        {{- form_widget(child, {
-          parent_label_class: label_attr.class|default(''),
-          translation_domain: choice_translation_domain,
-        }) -}}
-      {% endfor -%}
-    </div>
-  {%- else -%}
-    <div {{ block('widget_container_attributes') }}>
-      {%- for child in form %}
-        {{- form_widget(child, {
-          parent_label_class: label_attr.class|default(''),
-          translation_domain: choice_translation_domain,
-        }) -}}
-      {% endfor -%}
-    </div>
-  {%- endif %}
+    {% if '-inline' in label_attr.class|default('') -%}
+        <div class="control-group">
+            {%- for child in form %}
+                {{- form_widget(child, {
+                    parent_label_class: label_attr.class|default(''),
+                    translation_domain: choice_translation_domain,
+                }) -}}
+            {% endfor -%}
+        </div>
+    {%- else -%}
+        <div {{ block('widget_container_attributes') }}>
+            {%- for child in form %}
+                {{- form_widget(child, {
+                    parent_label_class: label_attr.class|default(''),
+                    translation_domain: choice_translation_domain,
+                }) -}}
+            {% endfor -%}
+        </div>
+    {%- endif %}
 {%- endblock choice_widget_expanded %}
 
 {% block checkbox_widget -%}
-  {% set parent_label_class = parent_label_class|default('') -%}
-  {% if 'checkbox-inline' in parent_label_class %}
-    {{- form_label(form, null, { widget: parent() }) -}}
-  {% else -%}
-    <div class="checkbox">
-      {{- form_label(form, null, { widget: parent() }) -}}
-    </div>
-  {%- endif %}
+    {% set parent_label_class = parent_label_class|default('') -%}
+    {% if 'checkbox-inline' in parent_label_class %}
+        {{- form_label(form, null, { widget: parent() }) -}}
+    {% else -%}
+        <div class="checkbox">
+            {{- form_label(form, null, { widget: parent() }) -}}
+        </div>
+    {%- endif %}
 {%- endblock checkbox_widget %}
 
 {% block radio_widget -%}
-  {%- set parent_label_class = parent_label_class|default('') -%}
-  {% if 'radio-inline' in parent_label_class %}
-    {{- form_label(form, null, { widget: parent() }) -}}
-  {% else -%}
-    <div class="radio">
-      {{- form_label(form, null, { widget: parent() }) -}}
-    </div>
-  {%- endif %}
+    {%- set parent_label_class = parent_label_class|default('') -%}
+    {% if 'radio-inline' in parent_label_class %}
+        {{- form_label(form, null, { widget: parent() }) -}}
+    {% else -%}
+        <div class="radio">
+            {{- form_label(form, null, { widget: parent() }) -}}
+        </div>
+    {%- endif %}
 {%- endblock radio_widget %}
 
 {% block choice_tree_widget -%}
-  <div {{ block('widget_container_attributes') }} class="category-tree-overflow">
-    <ul class="category-tree">
-      <li class="form-control-label text-right main-category">{{ "Main category"|trans({}, 'Admin.Catalog.Feature') }}</li>
-      {%- for child in choices %}
-        {{ block('choice_tree_item_widget') }}
-      {% endfor -%}
-    </ul>
-  </div>
+    <div {{ block('widget_container_attributes') }} class="category-tree-overflow">
+        <ul class="category-tree">
+            <li class="form-control-label text-right main-category">{{ "Main category"|trans({}, 'Admin.Catalog.Feature') }}</li>
+            {%- for child in choices %}
+                {{ block('choice_tree_item_widget') }}
+            {% endfor -%}
+        </ul>
+    </div>
 {%- endblock choice_tree_widget %}
 
 {% block choice_tree_item_widget -%}
-  <li>
-    {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
-    {% if multiple -%}
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
-          {% if child.active is defined and child.active == 0 %}
-            <i>{{ child.name }}</i>
-          {%- else -%}
-            {{ child.name }}
-          {% endif %}
-          {% if defaultCategory is defined %}
-            <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />
-          {% endif %}
-        </label>
-      </div>
-    {%- else -%}
-      <div class="radio">
-        <label>
-          <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category">
-          {{ child.name }}
-          {% if defaultCategory is defined %}
-            <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />
-          {% endif %}
-        </label>
-      </div>
-    {%- endif %}
-    {% if child.children is defined %}
-      <ul>
-        {% for item in child.children %}
-          {% set child = item %}
-          {{ block('choice_tree_item_widget') }}
-        {% endfor -%}
-      </ul>
-    {% endif %}
-  </li>
+    <li>
+        {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
+        {% if multiple -%}
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
+                    {% if child.active is defined and child.active == 0 %}
+                        <i>{{ child.name }}</i>
+                    {%- else -%}
+                        {{ child.name }}
+                    {% endif %}
+                    {% if defaultCategory is defined %}
+                        <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />
+                    {% endif %}
+                </label>
+            </div>
+        {%- else -%}
+            <div class="radio">
+                <label>
+                    <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category">
+                    {{ child.name }}
+                    {% if defaultCategory is defined %}
+                        <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />
+                    {% endif %}
+                </label>
+            </div>
+        {%- endif %}
+        {% if child.children is defined %}
+            <ul>
+                {% for item in child.children %}
+                    {% set child = item %}
+                    {{ block('choice_tree_item_widget') }}
+                {% endfor -%}
+            </ul>
+        {% endif %}
+    </li>
 {%- endblock choice_tree_item_widget %}
 
 {% block translatefields_widget %}
-  {{ form_errors(form) }}
-  <div class="translations tabbable" id="{{ form.vars.id }}">
-    {% if hideTabs == false and form|length > 1 %}
-      <ul class="translationsLocales nav nav-pills">
-        {% for translationsFields in form %}
-          <li class="nav-item">
-            <a href="#" class="{% if defaultLocale.id_lang == translationsFields.vars.name %}active{% endif %} nav-link" data-toggle="tab" data-target=".translationsFields-{{ translationsFields.vars.id }}">
-              {{ translationsFields.vars.label|capitalize }}
-            </a>
-          </li>
-        {% endfor %}
-      </ul>
-    {% endif %}
+    {{ form_errors(form) }}
+    <div class="translations tabbable" id="{{ form.vars.id }}">
+        {% if hideTabs == false and form|length > 1 %}
+            <ul class="translationsLocales nav nav-pills">
+                {% for translationsFields in form %}
+                    <li class="nav-item">
+                        <a href="#" class="{% if defaultLocale.id_lang == translationsFields.vars.name %}active{% endif %} nav-link" data-toggle="tab" data-target=".translationsFields-{{ translationsFields.vars.id }}">
+                            {{ translationsFields.vars.label|capitalize }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
 
-    <div class="translationsFields tab-content">
-      {% for translationsFields in form %}
-        <div class="translationsFields-{{ translationsFields.vars.id }} tab-pane translation-field {% if hideTabs == false and form|length > 1 %}panel panel-default{% endif %} {% if defaultLocale.id_lang == translationsFields.vars.name %}show active{% endif %} {% if not form.vars.valid %}field-error{% endif %} translation-label-{{ translationsFields.vars.label }}">
-          {{ form_errors(translationsFields) }}
-          {{ form_widget(translationsFields) }}
+        <div class="translationsFields tab-content">
+            {% for translationsFields in form %}
+                <div class="translationsFields-{{ translationsFields.vars.id }} tab-pane translation-field {% if hideTabs == false and form|length > 1 %}panel panel-default{% endif %} {% if defaultLocale.id_lang == translationsFields.vars.name %}show active{% endif %} {% if not form.vars.valid %}field-error{% endif %} translation-label-{{ translationsFields.vars.label }}">
+                    {{ form_errors(translationsFields) }}
+                    {{ form_widget(translationsFields) }}
+                </div>
+            {% endfor %}
         </div>
-      {% endfor %}
     </div>
-  </div>
 {% endblock %}
 
 {% block translate_fields_widget -%}
-  {% if type is not defined or 'file' != type %}
-    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
-  {% endif %}
-  {{- parent() -}}
+    {% if type is not defined or 'file' != type %}
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
+    {% endif %}
+    {{- parent() -}}
 {%- endblock translate_fields_widget %}
 
 {% block translate_text_widget -%}
-  {{ form_errors(form) }}
-  <div class="input-group locale-input-group js-locale-input-group">
-    {% for translateField in form %}
-      {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
-      {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
+    {{ form_errors(form) }}
+    <div class="input-group locale-input-group js-locale-input-group">
+        {% for translateField in form %}
+            {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
+            {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
 
-      {% if default_locale.id_lang != translateField.vars.name %}
-        {% set classes = classes ~ ' d-none' %}
-      {% endif %}
+            {% if default_locale.id_lang != translateField.vars.name %}
+                {% set classes = classes ~ ' d-none' %}
+            {% endif %}
 
-      {% set attr = translateField.vars.attr %}
+            {% set attr = translateField.vars.attr %}
 
-      {{ form_widget(translateField, {attr: {'class': classes|trim}}) }}
-    {% endfor %}
+            {{ form_widget(translateField, {attr: {'class': classes|trim}}) }}
+        {% endfor %}
 
-    {% if not hide_locales %}
-      <div class="dropdown">
-        <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
-                type="button"
-                data-toggle="dropdown"
-                aria-haspopup="true"
-                aria-expanded="false"
-                id="{{ form.vars.id }}"
-        >
-          {{ form.vars.default_locale.iso_code }}
-        </button>
+        {% if not hide_locales %}
+            <div class="dropdown">
+                <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
+                        type="button"
+                        data-toggle="dropdown"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        id="{{ form.vars.id }}"
+                >
+                    {{ form.vars.default_locale.iso_code }}
+                </button>
 
-        <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
-          {% for locale in locales %}
-            <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
-          {% endfor %}
-        </div>
-      </div>
-    {% endif %}
-  </div>
+                <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+                    {% for locale in locales %}
+                        <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
+                    {% endfor %}
+                </div>
+            </div>
+        {% endif %}
+    </div>
 {%- endblock translate_text_widget %}
 
 {% block translate_textarea_widget -%}
-  {{ form_errors(form) }}
-  <div class="input-group locale-input-group js-locale-input-group">
-    {% for textarea in form %}
-      {% set classes = textarea.vars.attr.class|default('') ~ ' js-locale-input'%}
-      {% set classes = classes ~ ' js-locale-' ~ textarea.vars.label %}
+    {{ form_errors(form) }}
+    <div class="input-group locale-input-group js-locale-input-group">
+        {% for textarea in form %}
+            {% set classes = textarea.vars.attr.class|default('') ~ ' js-locale-input'%}
+            {% set classes = classes ~ ' js-locale-' ~ textarea.vars.label %}
 
-      {% if default_locale.id_lang != textarea.vars.name %}
-        {% set classes = classes ~ ' d-none' %}
-      {% endif %}
+            {% if default_locale.id_lang != textarea.vars.name %}
+                {% set classes = classes ~ ' d-none' %}
+            {% endif %}
 
-      <div class="{{ classes }}">
-        {{ form_widget(textarea, {attr: {'class': classes|trim}}) }}
-      </div>
-    {% endfor %}
+            <div class="{{ classes }}">
+                {{ form_widget(textarea, {attr: {'class': classes|trim}}) }}
+            </div>
+        {% endfor %}
 
-    {% if show_locale_select %}
-      <div class="dropdown">
-        <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
-                type="button"
-                data-toggle="dropdown"
-                aria-haspopup="true"
-                aria-expanded="false"
-                id="{{ form.vars.id }}"
-        >
-          {{ form.vars.default_locale.iso_code }}
-        </button>
+        {% if show_locale_select %}
+            <div class="dropdown">
+                <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
+                        type="button"
+                        data-toggle="dropdown"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        id="{{ form.vars.id }}"
+                >
+                    {{ form.vars.default_locale.iso_code }}
+                </button>
 
-        <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
-          {% for locale in locales %}
-            <span class="dropdown-item js-locale-item"
-                  data-locale="{{ locale.iso_code }}"
-            >
+                <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+                    {% for locale in locales %}
+                        <span class="dropdown-item js-locale-item"
+                              data-locale="{{ locale.iso_code }}"
+                        >
               {{ locale.name }}
             </span>
-          {% endfor %}
-        </div>
-      </div>
-    {% endif %}
-  </div>
+                    {% endfor %}
+                </div>
+            </div>
+        {% endif %}
+    </div>
 {%- endblock translate_textarea_widget %}
 
 {% block date_picker_widget %}
-  {% spaceless %}
-    {%  set attr = attr|merge({'class': ((attr.class|default('') ~ ' datepicker')|trim)}) %}
-    <div class="input-group datepicker">
-      <input type="text" class="form-control" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
-      <div class="input-group-append">
-        <div class="input-group-text">
-          <i class="material-icons">date_range</i>
+    {% spaceless %}
+        {%  set attr = attr|merge({'class': ((attr.class|default('') ~ ' datepicker')|trim)}) %}
+        <div class="input-group datepicker">
+            <input type="text" class="form-control" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+            <div class="input-group-append">
+                <div class="input-group-text">
+                    <i class="material-icons">date_range</i>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-  {% endspaceless %}
+    {% endspaceless %}
 {% endblock date_picker_widget %}
 
 {% block date_range_widget %}
-  {% spaceless %}
-    {{ form_widget(form.from) }}
-    {{ form_widget(form.to) }}
-  {% endspaceless %}
+    {% spaceless %}
+        {{ form_widget(form.from) }}
+        {{ form_widget(form.to) }}
+    {% endspaceless %}
 {% endblock date_range_widget %}
 
 {% block search_and_reset_widget %}
-  {% spaceless %}
-    <button type="submit"
-            class="btn btn-primary grid-search-button d-block float-right"
-            title="{{ 'Search'|trans({}, 'Admin.Actions') }}"
-            name="{{ full_name }}[search]"
-    >
-      <i class="material-icons">search</i>
-      {{ 'Search'|trans({}, 'Admin.Actions') }}
-    </button>
+    {% spaceless %}
+        <button type="submit"
+                class="btn btn-primary grid-search-button d-block float-right"
+                title="{{ 'Search'|trans({}, 'Admin.Actions') }}"
+                name="{{ full_name }}[search]"
+        >
+            <i class="material-icons">search</i>
+            {{ 'Search'|trans({}, 'Admin.Actions') }}
+        </button>
 
-    {% if show_reset_button %}
-      <div class="clearfix"></div>
-      <button type="reset"
-              name="{{ full_name }}[reset]"
-              class="btn btn-link js-reset-search btn d-block grid-reset-button float-right"
-              data-url="{{ reset_url }}"
-              data-redirect="{{ redirect_url }}"
-      >
-        <i class="material-icons">clear</i>
-        {{ 'Reset'|trans({}, 'Admin.Actions') }}
-      </button>
-    {% endif %}
-  {% endspaceless %}
+        {% if show_reset_button %}
+            <div class="clearfix"></div>
+            <button type="reset"
+                    name="{{ full_name }}[reset]"
+                    class="btn btn-link js-reset-search btn d-block grid-reset-button float-right"
+                    data-url="{{ reset_url }}"
+                    data-redirect="{{ redirect_url }}"
+            >
+                <i class="material-icons">clear</i>
+                {{ 'Reset'|trans({}, 'Admin.Actions') }}
+            </button>
+        {% endif %}
+    {% endspaceless %}
 {% endblock search_and_reset_widget %}
 
 {% block switch_widget %}
-  {% spaceless %}
-    <span class="ps-switch">
+    {% spaceless %}
+        <span class="ps-switch">
         {% for choice in choices %}
-          {% set inputId = id ~'_' ~ choice.value %}
-          <input id="{{inputId}}" {{ block('attributes') }} name="{{ full_name }}" value="{{ choice.value }}" {%- if choice is selectedchoice(value) -%}checked="" {%- endif -%} {%- if disabled -%}disabled="" {%- endif -%} type="radio">
-          <label for="{{inputId}}">{{ choice.label|trans({}, choice_translation_domain) }}</label>
+            {% set inputId = id ~'_' ~ choice.value %}
+            <input id="{{inputId}}" {{ block('attributes') }} name="{{ full_name }}" value="{{ choice.value }}" {%- if choice is selectedchoice(value) -%}checked="" {%- endif -%} {%- if disabled -%}disabled="" {%- endif -%} type="radio">
+            <label for="{{inputId}}">{{ choice.label|trans({}, choice_translation_domain) }}</label>
         {% endfor %}
         <span class="slide-button"></span>
     </span>
-  {% endspaceless %}
+    {% endspaceless %}
 {% endblock switch_widget %}
 
 {% block _form_step6_attachments_widget %}
-  <div class="js-options-no-attachments {{ form|length > 0 ? 'hide' : '' }}">
-    <small>{{ 'There is no attachment yet.'|trans({}, 'Admin.Catalog.Notification') }}</small>
-  </div>
-  <div id="product-attachments" class="panel panel-default">
-    <div class="panel-body js-options-with-attachments {{ form|length == 0 ? 'hide' : '' }}">
-      <div>
-        <table id="product-attachment-file" class="table">
-          <thead class="thead-default">
-          <tr>
-            <th class="col-md-3"><input type="checkbox" id="product-attachment-files-check" /> {{ 'Title'|trans({}, 'Admin.Global') }}</th>
-            <th class="col-md-6">{{ 'File name'|trans({}, 'Admin.Global') }}</th>
-            <th class="col-md-2">{{ 'Type'|trans({}, 'Admin.Catalog.Feature') }}</th>
-          </tr>
-          </thead>
-          <tbody>
-          {%- for child in form %}
-            <tr>
-              <td class="col-md-3">{{ form_widget(child) }}</td>
-              <td class="col-md-6 file-name"><span>{{ form.vars.attr.data[loop.index0]['file_name'] }}</span></td>
-              <td class="col-md-2">{{ form.vars.attr.data[loop.index0]['mime'] }}</td>
-            </tr>
-          {% endfor -%}
-          </tbody>
-        </table>
-      </div>
+    <div class="js-options-no-attachments {{ form|length > 0 ? 'hide' : '' }}">
+        <small>{{ 'There is no attachment yet.'|trans({}, 'Admin.Catalog.Notification') }}</small>
     </div>
-  </div>
+    <div id="product-attachments" class="panel panel-default">
+        <div class="panel-body js-options-with-attachments {{ form|length == 0 ? 'hide' : '' }}">
+            <div>
+                <table id="product-attachment-file" class="table">
+                    <thead class="thead-default">
+                    <tr>
+                        <th class="col-md-3"><input type="checkbox" id="product-attachment-files-check" /> {{ 'Title'|trans({}, 'Admin.Global') }}</th>
+                        <th class="col-md-6">{{ 'File name'|trans({}, 'Admin.Global') }}</th>
+                        <th class="col-md-2">{{ 'Type'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {%- for child in form %}
+                        <tr>
+                            <td class="col-md-3">{{ form_widget(child) }}</td>
+                            <td class="col-md-6 file-name"><span>{{ form.vars.attr.data[loop.index0]['file_name'] }}</span></td>
+                            <td class="col-md-2">{{ form.vars.attr.data[loop.index0]['mime'] }}</td>
+                        </tr>
+                    {% endfor -%}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {# Labels #}
 
 {% block form_label -%}
-  {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' control-label')|trim}) -%}
-  {{- parent() -}}
+    {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' control-label')|trim}) -%}
+    {{- parent() -}}
 {%- endblock form_label %}
 
 {% block choice_label -%}
-  {# remove the checkbox-inline and radio-inline class, it's only useful for embed labels #}
-  {%- set label_attr = label_attr|merge({class: label_attr.class|default('')|replace({'checkbox-inline': '', 'radio-inline': ''})|trim}) -%}
-  {{- block('form_label') -}}
+    {# remove the checkbox-inline and radio-inline class, it's only useful for embed labels #}
+    {%- set label_attr = label_attr|merge({class: label_attr.class|default('')|replace({'checkbox-inline': '', 'radio-inline': ''})|trim}) -%}
+    {{- block('form_label') -}}
 {% endblock %}
 
 {% block checkbox_label -%}
-  {{- block('checkbox_radio_label') -}}
+    {{- block('checkbox_radio_label') -}}
 {%- endblock checkbox_label %}
 
 {% block radio_label -%}
-  {{- block('checkbox_radio_label') -}}
+    {{- block('checkbox_radio_label') -}}
 {%- endblock radio_label %}
 
 {% block checkbox_radio_label %}
-  {# Do not display the label if widget is not defined in order to prevent double label rendering #}
-  {% if widget is defined %}
-    {% if required %}
-      {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
-    {% endif %}
-    {% if parent_label_class is defined %}
-      {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
-    {% endif %}
-    {% if label is not same as(false) and label is empty %}
-      {% set label = name|humanize %}
-    {% endif %}
+    {# Do not display the label if widget is not defined in order to prevent double label rendering #}
+    {% if widget is defined %}
+        {% if required %}
+            {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
+        {% endif %}
+        {% if parent_label_class is defined %}
+            {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
+        {% endif %}
+        {% if label is not same as(false) and label is empty %}
+            {% set label = name|humanize %}
+        {% endif %}
 
-    {% if material_design is defined %}
-      <div class="md-checkbox md-checkbox-inline">
-        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-        {{- widget|raw -}}
-        <i class="md-checkbox-control"></i>
-        {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
-        </label>
-      </div>
-    {% else %}
-      <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-      {{- widget|raw -}}
-      {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
-      </label>
+        {% if material_design is defined %}
+            <div class="md-checkbox md-checkbox-inline">
+                <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+                {{- widget|raw -}}
+                <i class="md-checkbox-control"></i>
+                {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
+                </label>
+            </div>
+        {% else %}
+            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+            {{- widget|raw -}}
+            {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
+            </label>
+        {% endif %}
     {% endif %}
-  {% endif %}
 {% endblock checkbox_radio_label %}
 
 {# Rows #}
 
 {% block form_row -%}
-  <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
-    {{- form_label(form) -}}
-    {{- form_widget(form) -}}
-    {{- form_errors(form) -}}
-  </div>
+    <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
+        {{- form_label(form) -}}
+        {{- form_widget(form) -}}
+        {{- form_errors(form) -}}
+    </div>
 {%- endblock form_row %}
 
 {% block button_row -%}
-  <div class="form-group">
-    {{- form_widget(form) -}}
-  </div>
+    <div class="form-group">
+        {{- form_widget(form) -}}
+    </div>
 {%- endblock button_row %}
 
 {% block choice_row -%}
-  {% set force_error = true %}
-  {{- block('form_row') }}
+    {% set force_error = true %}
+    {{- block('form_row') }}
 {%- endblock choice_row %}
 
 {% block date_row -%}
-  {% set force_error = true %}
-  {{- block('form_row') }}
+    {% set force_error = true %}
+    {{- block('form_row') }}
 {%- endblock date_row %}
 
 {% block time_row -%}
-  {% set force_error = true %}
-  {{- block('form_row') }}
+    {% set force_error = true %}
+    {{- block('form_row') }}
 {%- endblock time_row %}
 
 {% block datetime_row -%}
-  {% set force_error = true %}
-  {{- block('form_row') }}
+    {% set force_error = true %}
+    {{- block('form_row') }}
 {%- endblock datetime_row %}
 
 {% block checkbox_row -%}
-  <div class="form-group{% if not valid %} has-error{% endif %}">
-    {{- form_widget(form) -}}
-    {{- form_errors(form) -}}
-  </div>
+    <div class="form-group{% if not valid %} has-error{% endif %}">
+        {{- form_widget(form) -}}
+        {{- form_errors(form) -}}
+    </div>
 {%- endblock checkbox_row %}
 
 {% block radio_row -%}
-  <div class="form-group{% if not valid %} has-error{% endif %}">
-    {{- form_widget(form) -}}
-    {{- form_errors(form) -}}
-  </div>
+    <div class="form-group{% if not valid %} has-error{% endif %}">
+        {{- form_widget(form) -}}
+        {{- form_errors(form) -}}
+    </div>
 {%- endblock radio_row %}
 
 {# Errors #}
 
 {% block form_errors -%}
-  {% if errors|length > 0 -%}
-    <div class="alert alert-danger">
-      {%- if errors|length > 1 -%}
-        <ul class="alert-text">
-          {%- for error in errors -%}
-            <li> {{
-              error.messagePluralization is null
-              ? error.messageTemplate|trans(error.messageParameters, 'form_error')
-              : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
-              }}
-            </li>
-          {%- endfor -%}
-        </ul>
-      {%- else -%}
-        <div class="alert-text">
-          {%- for error in errors -%}
-            <p> {{
-              error.messagePluralization is null
-              ? error.messageTemplate|trans(error.messageParameters, 'form_error')
-              : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
-              }}
-            </p>
-          {%- endfor -%}
+    {% if errors|length > 0 -%}
+        <div class="alert alert-danger">
+            {%- if errors|length > 1 -%}
+                <ul class="alert-text">
+                    {%- for error in errors -%}
+                        <li> {{
+                            error.messagePluralization is null
+                            ? error.messageTemplate|trans(error.messageParameters, 'form_error')
+                            : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
+                            }}
+                        </li>
+                    {%- endfor -%}
+                </ul>
+            {%- else -%}
+                <div class="alert-text">
+                    {%- for error in errors -%}
+                        <p> {{
+                            error.messagePluralization is null
+                            ? error.messageTemplate|trans(error.messageParameters, 'form_error')
+                            : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
+                            }}
+                        </p>
+                    {%- endfor -%}
+                </div>
+            {%- endif -%}
         </div>
-      {%- endif -%}
-    </div>
-  {%- endif %}
+    {%- endif %}
 {%- endblock form_errors %}
 
 
 {# Material design widgets #}
 
 {% block material_choice_table_widget %}
-  {% spaceless %}
-    <div class="choice-table">
-      <table class="table table-bordered mb-0">
-        <thead>
-        <tr>
-          <th class="checkbox">
-            <div class="md-checkbox">
-              <label>
-                <input type="checkbox" class="js-choice-table-select-all">
-                <i class="md-checkbox-control"></i>
-                {{ 'Select all'|trans({}, 'Admin.Actions') }}
-              </label>
-            </div>
-          </th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for child in form %}
-          <tr>
-            <td>
-              {{ form_widget(child, {'material_design': true}) }}
-            </td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% endspaceless %}
+    {% spaceless %}
+        <div class="choice-table">
+            <table class="table table-bordered mb-0">
+                <thead>
+                <tr>
+                    <th class="checkbox">
+                        <div class="md-checkbox">
+                            <label>
+                                <input type="checkbox" class="js-choice-table-select-all">
+                                <i class="md-checkbox-control"></i>
+                                {{ 'Select all'|trans({}, 'Admin.Actions') }}
+                            </label>
+                        </div>
+                    </th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for child in form %}
+                    <tr>
+                        <td>
+                            {{ form_widget(child, {'material_design': true}) }}
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endspaceless %}
 {% endblock material_choice_table_widget %}
 
 {% block material_multiple_choice_table_widget %}
-  {% spaceless %}
-    <div class="choice-table table-responsive">
-      <table class="table">
-        <thead>
-        <tr>
-          <th>{{ label }}</th>
-          {% for child_choice in form %}
-            <th class="text-center">
-              {% if child_choice.vars.multiple %}
-                <a href="#"
-                   class="js-multiple-choice-table-select-column"
-                   data-column-num="{{ loop.index + 1 }}"
-                   data-column-checked="false"
-                >
-                  {{ child_choice.vars.label }}
-                </a>
-              {% else %}
-                {{ child_choice.vars.label }}
-              {% endif %}
-            </th>
-          {% endfor %}
-        </tr>
-        </thead>
-        <tbody>
-        {% for choice_name, choice_value in choices %}
-          <tr>
-            <td>
-              {{ choice_name }}
-            </td>
-            {% for child_choice_name, child_choice in form %}
-              <td class="text-center">
-                {% if child_choice_entry_index_mapping[choice_value][child_choice_name] is defined %}
-                  {% set entry_index = child_choice_entry_index_mapping[choice_value][child_choice_name] %}
+    {% spaceless %}
+        <div class="choice-table table-responsive">
+            <table class="table">
+                <thead>
+                <tr>
+                    <th>{{ label }}</th>
+                    {% for child_choice in form %}
+                        <th class="text-center">
+                            {% if child_choice.vars.multiple %}
+                                <a href="#"
+                                   class="js-multiple-choice-table-select-column"
+                                   data-column-num="{{ loop.index + 1 }}"
+                                   data-column-checked="false"
+                                >
+                                    {{ child_choice.vars.label }}
+                                </a>
+                            {% else %}
+                                {{ child_choice.vars.label }}
+                            {% endif %}
+                        </th>
+                    {% endfor %}
+                </tr>
+                </thead>
+                <tbody>
+                {% for choice_name, choice_value in choices %}
+                    <tr>
+                        <td>
+                            {{ choice_name }}
+                        </td>
+                        {% for child_choice_name, child_choice in form %}
+                            <td class="text-center">
+                                {% if child_choice_entry_index_mapping[choice_value][child_choice_name] is defined %}
+                                    {% set entry_index = child_choice_entry_index_mapping[choice_value][child_choice_name] %}
 
-                  {% if child_choice.vars.multiple %}
-                    {{ form_widget(child_choice[entry_index], {'material_design': true}) }}
-                  {% else %}
-                    {{ form_widget(child_choice[entry_index]) }}
-                  {% endif %}
-                {% else %}
-                  --
-                {% endif %}
-              </td>
-            {% endfor %}
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% endspaceless %}
+                                    {% if child_choice.vars.multiple %}
+                                        {{ form_widget(child_choice[entry_index], {'material_design': true}) }}
+                                    {% else %}
+                                        {{ form_widget(child_choice[entry_index]) }}
+                                    {% endif %}
+                                {% else %}
+                                    --
+                                {% endif %}
+                            </td>
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endspaceless %}
 {% endblock material_multiple_choice_table_widget %}
 
 {% block translatable_widget -%}
-  {{ form_errors(form) }}
-  <div class="input-group locale-input-group js-locale-input-group d-flex">
-    {% for translateField in form %}
-      {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
-      {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
-      {% if default_locale.id_lang != translateField.vars.name %}
-        {% set classes = classes ~ ' d-none' %}
-      {% endif %}
-      <div class="{{ classes }}" style="flex-grow: 1;">
-        {{ form_widget(translateField) }}
-      </div>
-    {% endfor %}
-    {% if not hide_locales %}
-      <div class="dropdown">
-        <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
-                type="button"
-                data-toggle="dropdown"
-                aria-haspopup="true"
-                aria-expanded="false"
-                id="{{ form.vars.id }}"
-        >
-          {{ form.vars.default_locale.iso_code }}
-        </button>
-        <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
-          {% for locale in locales %}
-            <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
-          {% endfor %}
-        </div>
-      </div>
-    {% endif %}
-  </div>
+    {{ form_errors(form) }}
+    <div class="input-group locale-input-group js-locale-input-group d-flex">
+        {% for translateField in form %}
+            {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
+            {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
+            {% if default_locale.id_lang != translateField.vars.name %}
+                {% set classes = classes ~ ' d-none' %}
+            {% endif %}
+            <div class="{{ classes }}" style="flex-grow: 1;">
+                {{ form_widget(translateField) }}
+            </div>
+        {% endfor %}
+        {% if not hide_locales %}
+            <div class="dropdown">
+                <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
+                        type="button"
+                        data-toggle="dropdown"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        id="{{ form.vars.id }}"
+                >
+                    {{ form.vars.default_locale.iso_code }}
+                </button>
+                <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+                    {% for locale in locales %}
+                        <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
+                    {% endfor %}
+                </div>
+            </div>
+        {% endif %}
+    </div>
 {%- endblock translatable_widget %}
 
 {% block birthday_widget %}
-  {% if widget == 'single_text' %}
-    {{- block('form_widget_simple') -}}
-  {% else -%}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
-    {% if datetime is not defined or not datetime -%}
-      <div {{ block('widget_container_attributes') -}}>
-    {%- endif %}
+    {% if widget == 'single_text' %}
+        {{- block('form_widget_simple') -}}
+    {% else -%}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
+        {% if datetime is not defined or not datetime -%}
+            <div {{ block('widget_container_attributes') -}}>
+        {%- endif %}
 
-    {% set yearWidget = '<div class="col pl-0">' ~ form_widget(form.year) ~ '</div>'|raw %}
-    {% set monthWidget = '<div class="col">' ~ form_widget(form.month) ~ '</div>'|raw %}
-    {% set dayWidget = '<div class="col pr-0">' ~ form_widget(form.day) ~ '</div>'|raw %}
+        {% set yearWidget = '<div class="col pl-0">' ~ form_widget(form.year) ~ '</div>'|raw %}
+        {% set monthWidget = '<div class="col">' ~ form_widget(form.month) ~ '</div>'|raw %}
+        {% set dayWidget = '<div class="col pr-0">' ~ form_widget(form.day) ~ '</div>'|raw %}
 
-    {{- date_pattern|replace({
-      '{{ year }}': yearWidget,
-      '{{ month }}': monthWidget,
-      '{{ day }}': dayWidget,
-    })|raw -}}
+        {{- date_pattern|replace({
+            '{{ year }}': yearWidget,
+            '{{ month }}': monthWidget,
+            '{{ day }}': dayWidget,
+        })|raw -}}
 
-    {% if datetime is not defined or not datetime -%}
-      </div>
-    {%- endif -%}
-  {% endif %}
+        {% if datetime is not defined or not datetime -%}
+            </div>
+        {%- endif -%}
+    {% endif %}
 {% endblock birthday_widget %}
 
 {% block file_widget %}
-  <div class="custom-file">
-    {% set attr = attr|merge({
-      class: (attr.class|default('') ~ ' custom-file-input')|trim,
-      'data-multiple-files-text': '%count% files'|trans({}, 'Admin.Global'),
-      'data-locale': get_context_iso_code()
-    }) -%}
+    <div class="custom-file">
+        {% set attr = attr|merge({
+            class: (attr.class|default('') ~ ' custom-file-input')|trim,
+            'data-multiple-files-text': '%count% files'|trans({}, 'Admin.Global'),
+            'data-locale': get_context_iso_code()
+        }) -%}
 
-    {{ form_widget(form, {'attr': attr}) }}
+        {{ form_widget(form, {'attr': attr}) }}
 
-    <label class="custom-file-label" for="{{ form.vars.id }}">
-      {% set attributes = form.vars.attr %}
+        <label class="custom-file-label" for="{{ form.vars.id }}">
+            {% set attributes = form.vars.attr %}
 
-      {% if (attributes.placeholder is not defined) %}
+            {% if (attributes.placeholder is not defined) %}
 
-        {% if (attributes.multiple is not defined) %}
-          {{ 'Choose file'|trans({}, 'Shop.Theme.Actions') }}
-        {% else %}
-          {{ 'Choose files'|trans({}, 'Shop.Theme.Actions') }}
-        {% endif %}
+                {% if (attributes.multiple is not defined) %}
+                    {{ 'Choose file'|trans({}, 'Shop.Theme.Actions') }}
+                {% else %}
+                    {{ 'Choose files'|trans({}, 'Shop.Theme.Actions') }}
+                {% endif %}
 
-      {% else %}
-        {{ attributes.placeholder }}
-      {% endif %}
-    </label>
-  </div>
+            {% else %}
+                {{ attributes.placeholder }}
+            {% endif %}
+        </label>
+    </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -29,264 +29,264 @@
 {# Widgets #}
 
 {% block form_widget_simple -%}
-    {% if type is not defined or 'file' != type %}
-        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
-    {% endif %}
-    {{- parent() -}}
+  {% if type is not defined or 'file' != type %}
+    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
+  {% endif %}
+  {{- parent() -}}
 {%- endblock form_widget_simple %}
 
 {% block textarea_widget -%}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
-    {{- parent() -}}
+  {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
+  {{- parent() -}}
 {%- endblock textarea_widget %}
 
 {% block button_widget -%}
-    {% set attr = attr|merge({class: (attr.class|default('btn-default') ~ ' btn')|trim}) %}
-    {{- parent() -}}
+  {% set attr = attr|merge({class: (attr.class|default('btn-default') ~ ' btn')|trim}) %}
+  {{- parent() -}}
 {%- endblock %}
 
 {% block money_widget -%}
-    <div class="input-group money-type">
-        {% set prepend = '{{' == money_pattern[0:2] %}
-        {% if not prepend %}
-            <div class="input-group-prepend">
-                <span class="input-group-text">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
-            </div>
-        {% endif %}
-        {{- block('form_widget_simple') -}}
-        {% if prepend %}
-            <div class="input-group-append">
-                <span class="input-group-text">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
-            </div>
-        {% endif %}
-    </div>
+  <div class="input-group money-type">
+    {% set prepend = '{{' == money_pattern[0:2] %}
+    {% if not prepend %}
+      <div class="input-group-prepend">
+        <span class="input-group-text">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
+      </div>
+    {% endif %}
+    {{- block('form_widget_simple') -}}
+    {% if prepend %}
+      <div class="input-group-append">
+        <span class="input-group-text">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
+      </div>
+    {% endif %}
+  </div>
 {%- endblock money_widget %}
 
 {% block percent_widget -%}
-    <div class="input-group">
-        {{- block('form_widget_simple') -}}
-        <div class="input-group-append">
-            <span class="input-group-text">%</span>
-        </div>
+  <div class="input-group">
+    {{- block('form_widget_simple') -}}
+    <div class="input-group-append">
+      <span class="input-group-text">%</span>
     </div>
+  </div>
 {%- endblock percent_widget %}
 
 {% block datetime_widget -%}
-    {% if widget == 'single_text' %}
-        {{- block('form_widget_simple') -}}
-    {% else -%}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
-        <div {{ block('widget_container_attributes') }}>
-            {{- form_errors(form.date) -}}
-            {{- form_errors(form.time) -}}
-            {{- form_widget(form.date, { datetime: true } ) -}}
-            {{- form_widget(form.time, { datetime: true } ) -}}
-        </div>
-    {%- endif %}
+  {% if widget == 'single_text' %}
+    {{- block('form_widget_simple') -}}
+  {% else -%}
+    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
+    <div {{ block('widget_container_attributes') }}>
+      {{- form_errors(form.date) -}}
+      {{- form_errors(form.time) -}}
+      {{- form_widget(form.date, { datetime: true } ) -}}
+      {{- form_widget(form.time, { datetime: true } ) -}}
+    </div>
+  {%- endif %}
 {%- endblock datetime_widget %}
 
 {% block date_widget -%}
-    {% if widget == 'single_text' %}
-        {{- block('form_widget_simple') -}}
-    {% else -%}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
-        {% if datetime is not defined or not datetime -%}
-            <div {{ block('widget_container_attributes') -}}>
-        {%- endif %}
-        {{- date_pattern|replace({
-            '{{ year }}': form_widget(form.year),
-            '{{ month }}': form_widget(form.month),
-            '{{ day }}': form_widget(form.day),
-        })|raw -}}
-        {% if datetime is not defined or not datetime -%}
-            </div>
-        {%- endif -%}
-    {% endif %}
+  {% if widget == 'single_text' %}
+    {{- block('form_widget_simple') -}}
+  {% else -%}
+    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
+    {% if datetime is not defined or not datetime -%}
+      <div {{ block('widget_container_attributes') -}}>
+    {%- endif %}
+    {{- date_pattern|replace({
+      '{{ year }}': form_widget(form.year),
+      '{{ month }}': form_widget(form.month),
+      '{{ day }}': form_widget(form.day),
+    })|raw -}}
+    {% if datetime is not defined or not datetime -%}
+      </div>
+    {%- endif -%}
+  {% endif %}
 {%- endblock date_widget %}
 
 {% block time_widget -%}
-    {% if widget == 'single_text' %}
-        {{- block('form_widget_simple') -}}
-    {% else -%}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
-        {% if datetime is not defined or false == datetime -%}
-            <div {{ block('widget_container_attributes') -}}>
-        {%- endif -%}
-        {{- form_widget(form.hour) }}:{{ form_widget(form.minute) }}{% if with_seconds %}:{{ form_widget(form.second) }}{% endif %}
-        {% if datetime is not defined or false == datetime -%}
-            </div>
-        {%- endif -%}
-    {% endif %}
+  {% if widget == 'single_text' %}
+    {{- block('form_widget_simple') -}}
+  {% else -%}
+    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
+    {% if datetime is not defined or false == datetime -%}
+      <div {{ block('widget_container_attributes') -}}>
+    {%- endif -%}
+    {{- form_widget(form.hour) }}:{{ form_widget(form.minute) }}{% if with_seconds %}:{{ form_widget(form.second) }}{% endif %}
+    {% if datetime is not defined or false == datetime -%}
+      </div>
+    {%- endif -%}
+  {% endif %}
 {%- endblock time_widget %}
 
 {% block choice_widget_collapsed -%}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' custom-select')|trim}) %}
-    {{- parent() -}}
+  {% set attr = attr|merge({class: (attr.class|default('') ~ ' custom-select')|trim}) %}
+  {{- parent() -}}
 {%- endblock %}
 
 {% block choice_widget_expanded -%}
-    {% if '-inline' in label_attr.class|default('') -%}
-        <div class="control-group">
-            {%- for child in form %}
-                {{- form_widget(child, {
-                    parent_label_class: label_attr.class|default(''),
-                    translation_domain: choice_translation_domain,
-                }) -}}
-            {% endfor -%}
-        </div>
-    {%- else -%}
-        <div {{ block('widget_container_attributes') }}>
-            {%- for child in form %}
-                {{- form_widget(child, {
-                    parent_label_class: label_attr.class|default(''),
-                    translation_domain: choice_translation_domain,
-                }) -}}
-            {% endfor -%}
-        </div>
-    {%- endif %}
+  {% if '-inline' in label_attr.class|default('') -%}
+    <div class="control-group">
+      {%- for child in form %}
+        {{- form_widget(child, {
+          parent_label_class: label_attr.class|default(''),
+          translation_domain: choice_translation_domain,
+        }) -}}
+      {% endfor -%}
+    </div>
+  {%- else -%}
+    <div {{ block('widget_container_attributes') }}>
+      {%- for child in form %}
+        {{- form_widget(child, {
+          parent_label_class: label_attr.class|default(''),
+          translation_domain: choice_translation_domain,
+        }) -}}
+      {% endfor -%}
+    </div>
+  {%- endif %}
 {%- endblock choice_widget_expanded %}
 
 {% block checkbox_widget -%}
-    {% set parent_label_class = parent_label_class|default('') -%}
-    {% if 'checkbox-inline' in parent_label_class %}
-        {{- form_label(form, null, { widget: parent() }) -}}
-    {% else -%}
-        <div class="checkbox">
-            {{- form_label(form, null, { widget: parent() }) -}}
-        </div>
-    {%- endif %}
+  {% set parent_label_class = parent_label_class|default('') -%}
+  {% if 'checkbox-inline' in parent_label_class %}
+    {{- form_label(form, null, { widget: parent() }) -}}
+  {% else -%}
+    <div class="checkbox">
+      {{- form_label(form, null, { widget: parent() }) -}}
+    </div>
+  {%- endif %}
 {%- endblock checkbox_widget %}
 
 {% block radio_widget -%}
-    {%- set parent_label_class = parent_label_class|default('') -%}
-    {% if 'radio-inline' in parent_label_class %}
-        {{- form_label(form, null, { widget: parent() }) -}}
-    {% else -%}
-        <div class="radio">
-            {{- form_label(form, null, { widget: parent() }) -}}
-        </div>
-    {%- endif %}
+  {%- set parent_label_class = parent_label_class|default('') -%}
+  {% if 'radio-inline' in parent_label_class %}
+    {{- form_label(form, null, { widget: parent() }) -}}
+  {% else -%}
+    <div class="radio">
+      {{- form_label(form, null, { widget: parent() }) -}}
+    </div>
+  {%- endif %}
 {%- endblock radio_widget %}
 
 {% block choice_tree_widget -%}
-    <div {{ block('widget_container_attributes') }} class="category-tree-overflow">
-        <ul class="category-tree">
-            <li class="form-control-label text-right main-category">{{ "Main category"|trans({}, 'Admin.Catalog.Feature') }}</li>
-            {%- for child in choices %}
-            {{ block('choice_tree_item_widget') }}
-        {% endfor -%}
-        </ul>
-    </div>
+  <div {{ block('widget_container_attributes') }} class="category-tree-overflow">
+    <ul class="category-tree">
+      <li class="form-control-label text-right main-category">{{ "Main category"|trans({}, 'Admin.Catalog.Feature') }}</li>
+      {%- for child in choices %}
+        {{ block('choice_tree_item_widget') }}
+      {% endfor -%}
+    </ul>
+  </div>
 {%- endblock choice_tree_widget %}
 
 {% block choice_tree_item_widget -%}
-    <li>
-        {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
-        {% if multiple -%}
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
-                    {% if child.active is defined and child.active == 0 %}
-                        <i>{{ child.name }}</i>
-                    {%- else -%}
-                        {{ child.name }}
-                    {% endif %}
-                    {% if defaultCategory is defined %}
-                        <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />
-                    {% endif %}
-                </label>
-            </div>
-        {%- else -%}
-            <div class="radio">
-                <label>
-                    <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category">
-                    {{ child.name }}
-                    {% if defaultCategory is defined %}
-                        <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />
-                    {% endif %}
-                </label>
-            </div>
-        {%- endif %}
-        {% if child.children is defined %}
-            <ul>
-                {% for item in child.children %}
-                    {% set child = item %}
-                    {{ block('choice_tree_item_widget') }}
-                {% endfor -%}
-            </ul>
-        {% endif %}
-    </li>
+  <li>
+    {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
+    {% if multiple -%}
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
+          {% if child.active is defined and child.active == 0 %}
+            <i>{{ child.name }}</i>
+          {%- else -%}
+            {{ child.name }}
+          {% endif %}
+          {% if defaultCategory is defined %}
+            <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />
+          {% endif %}
+        </label>
+      </div>
+    {%- else -%}
+      <div class="radio">
+        <label>
+          <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category">
+          {{ child.name }}
+          {% if defaultCategory is defined %}
+            <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />
+          {% endif %}
+        </label>
+      </div>
+    {%- endif %}
+    {% if child.children is defined %}
+      <ul>
+        {% for item in child.children %}
+          {% set child = item %}
+          {{ block('choice_tree_item_widget') }}
+        {% endfor -%}
+      </ul>
+    {% endif %}
+  </li>
 {%- endblock choice_tree_item_widget %}
 
 {% block translatefields_widget %}
-    {{ form_errors(form) }}
-    <div class="translations tabbable" id="{{ form.vars.id }}">
-        {% if hideTabs == false and form|length > 1 %}
-        <ul class="translationsLocales nav nav-pills">
-            {% for translationsFields in form %}
-                <li class="nav-item">
-                    <a href="#" class="{% if defaultLocale.id_lang == translationsFields.vars.name %}active{% endif %} nav-link" data-toggle="tab" data-target=".translationsFields-{{ translationsFields.vars.id }}">
-                        {{ translationsFields.vars.label|capitalize }}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-        {% endif %}
+  {{ form_errors(form) }}
+  <div class="translations tabbable" id="{{ form.vars.id }}">
+    {% if hideTabs == false and form|length > 1 %}
+      <ul class="translationsLocales nav nav-pills">
+        {% for translationsFields in form %}
+          <li class="nav-item">
+            <a href="#" class="{% if defaultLocale.id_lang == translationsFields.vars.name %}active{% endif %} nav-link" data-toggle="tab" data-target=".translationsFields-{{ translationsFields.vars.id }}">
+              {{ translationsFields.vars.label|capitalize }}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
 
-        <div class="translationsFields tab-content">
-            {% for translationsFields in form %}
-                <div class="translationsFields-{{ translationsFields.vars.id }} tab-pane translation-field {% if hideTabs == false and form|length > 1 %}panel panel-default{% endif %} {% if defaultLocale.id_lang == translationsFields.vars.name %}show active{% endif %} {% if not form.vars.valid %}field-error{% endif %} translation-label-{{ translationsFields.vars.label }}">
-                    {{ form_errors(translationsFields) }}
-                    {{ form_widget(translationsFields) }}
-                </div>
-            {% endfor %}
+    <div class="translationsFields tab-content">
+      {% for translationsFields in form %}
+        <div class="translationsFields-{{ translationsFields.vars.id }} tab-pane translation-field {% if hideTabs == false and form|length > 1 %}panel panel-default{% endif %} {% if defaultLocale.id_lang == translationsFields.vars.name %}show active{% endif %} {% if not form.vars.valid %}field-error{% endif %} translation-label-{{ translationsFields.vars.label }}">
+          {{ form_errors(translationsFields) }}
+          {{ form_widget(translationsFields) }}
         </div>
+      {% endfor %}
     </div>
+  </div>
 {% endblock %}
 
 {% block translate_fields_widget -%}
-    {% if type is not defined or 'file' != type %}
-        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
-    {% endif %}
-    {{- parent() -}}
+  {% if type is not defined or 'file' != type %}
+    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
+  {% endif %}
+  {{- parent() -}}
 {%- endblock translate_fields_widget %}
 
 {% block translate_text_widget -%}
-    {{ form_errors(form) }}
-    <div class="input-group locale-input-group js-locale-input-group">
-        {% for translateField in form %}
-            {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
-            {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
+  {{ form_errors(form) }}
+  <div class="input-group locale-input-group js-locale-input-group">
+    {% for translateField in form %}
+      {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
+      {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
 
-            {% if default_locale.id_lang != translateField.vars.name %}
-                {% set classes = classes ~ ' d-none' %}
-            {% endif %}
+      {% if default_locale.id_lang != translateField.vars.name %}
+        {% set classes = classes ~ ' d-none' %}
+      {% endif %}
 
-            {% set attr = translateField.vars.attr %}
+      {% set attr = translateField.vars.attr %}
 
-            {{ form_widget(translateField, {attr: {'class': classes|trim}}) }}
-        {% endfor %}
+      {{ form_widget(translateField, {attr: {'class': classes|trim}}) }}
+    {% endfor %}
 
-        {% if not hide_locales %}
-        <div class="dropdown">
-            <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
-                    type="button"
-                    data-toggle="dropdown"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                    id="{{ form.vars.id }}"
-            >
-                {{ form.vars.default_locale.iso_code }}
-            </button>
+    {% if not hide_locales %}
+      <div class="dropdown">
+        <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
+                type="button"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+                id="{{ form.vars.id }}"
+        >
+          {{ form.vars.default_locale.iso_code }}
+        </button>
 
-            <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
-                {% for locale in locales %}
-                    <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
-                {% endfor %}
-            </div>
+        <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+          {% for locale in locales %}
+            <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
+          {% endfor %}
         </div>
-        {% endif %}
-    </div>
+      </div>
+    {% endif %}
+  </div>
 {%- endblock translate_text_widget %}
 
 {% block translate_textarea_widget -%}
@@ -332,17 +332,17 @@
 {%- endblock translate_textarea_widget %}
 
 {% block date_picker_widget %}
-    {% spaceless %}
-        {%  set attr = attr|merge({'class': ((attr.class|default('') ~ ' datepicker')|trim)}) %}
-        <div class="input-group datepicker">
-            <input type="text" class="form-control" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
-            <div class="input-group-append">
-                <div class="input-group-text">
-                    <i class="material-icons">date_range</i>
-                </div>
-            </div>
+  {% spaceless %}
+    {%  set attr = attr|merge({'class': ((attr.class|default('') ~ ' datepicker')|trim)}) %}
+    <div class="input-group datepicker">
+      <input type="text" class="form-control" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+      <div class="input-group-append">
+        <div class="input-group-text">
+          <i class="material-icons">date_range</i>
         </div>
-    {% endspaceless %}
+      </div>
+    </div>
+  {% endspaceless %}
 {% endblock date_picker_widget %}
 
 {% block date_range_widget %}
@@ -353,205 +353,205 @@
 {% endblock date_range_widget %}
 
 {% block search_and_reset_widget %}
-    {% spaceless %}
-        <button type="submit"
-                class="btn btn-primary grid-search-button d-block float-right"
-                title="{{ 'Search'|trans({}, 'Admin.Actions') }}"
-                name="{{ full_name }}[search]"
-        >
-          <i class="material-icons">search</i>
-          {{ 'Search'|trans({}, 'Admin.Actions') }}
-        </button>
+  {% spaceless %}
+    <button type="submit"
+            class="btn btn-primary grid-search-button d-block float-right"
+            title="{{ 'Search'|trans({}, 'Admin.Actions') }}"
+            name="{{ full_name }}[search]"
+    >
+      <i class="material-icons">search</i>
+      {{ 'Search'|trans({}, 'Admin.Actions') }}
+    </button>
 
-        {% if show_reset_button %}
-          <div class="clearfix"></div>
-            <button type="reset"
-                    name="{{ full_name }}[reset]"
-                    class="btn btn-link js-reset-search btn d-block grid-reset-button float-right"
-                    data-url="{{ reset_url }}"
-                    data-redirect="{{ redirect_url }}"
-            >
-              <i class="material-icons">clear</i>
-              {{ 'Reset'|trans({}, 'Admin.Actions') }}
-            </button>
-        {% endif %}
-    {% endspaceless %}
+    {% if show_reset_button %}
+      <div class="clearfix"></div>
+      <button type="reset"
+              name="{{ full_name }}[reset]"
+              class="btn btn-link js-reset-search btn d-block grid-reset-button float-right"
+              data-url="{{ reset_url }}"
+              data-redirect="{{ redirect_url }}"
+      >
+        <i class="material-icons">clear</i>
+        {{ 'Reset'|trans({}, 'Admin.Actions') }}
+      </button>
+    {% endif %}
+  {% endspaceless %}
 {% endblock search_and_reset_widget %}
 
 {% block switch_widget %}
-    {% spaceless %}
+  {% spaceless %}
     <span class="ps-switch">
         {% for choice in choices %}
-            {% set inputId = id ~'_' ~ choice.value %}
-            <input id="{{inputId}}" {{ block('attributes') }} name="{{ full_name }}" value="{{ choice.value }}" {%- if choice is selectedchoice(value) -%}checked="" {%- endif -%} {%- if disabled -%}disabled="" {%- endif -%} type="radio">
-            <label for="{{inputId}}">{{ choice.label|trans({}, choice_translation_domain) }}</label>
+          {% set inputId = id ~'_' ~ choice.value %}
+          <input id="{{inputId}}" {{ block('attributes') }} name="{{ full_name }}" value="{{ choice.value }}" {%- if choice is selectedchoice(value) -%}checked="" {%- endif -%} {%- if disabled -%}disabled="" {%- endif -%} type="radio">
+          <label for="{{inputId}}">{{ choice.label|trans({}, choice_translation_domain) }}</label>
         {% endfor %}
         <span class="slide-button"></span>
     </span>
-    {% endspaceless %}
+  {% endspaceless %}
 {% endblock switch_widget %}
 
 {% block _form_step6_attachments_widget %}
-    <div class="js-options-no-attachments {{ form|length > 0 ? 'hide' : '' }}">
-        <small>{{ 'There is no attachment yet.'|trans({}, 'Admin.Catalog.Notification') }}</small>
-    </div>
-    <div id="product-attachments" class="panel panel-default">
-      <div class="panel-body js-options-with-attachments {{ form|length == 0 ? 'hide' : '' }}">
-        <div>
-          <table id="product-attachment-file" class="table">
-            <thead class="thead-default">
-              <tr>
-                <th class="col-md-3"><input type="checkbox" id="product-attachment-files-check" /> {{ 'Title'|trans({}, 'Admin.Global') }}</th>
-                <th class="col-md-6">{{ 'File name'|trans({}, 'Admin.Global') }}</th>
-                <th class="col-md-2">{{ 'Type'|trans({}, 'Admin.Catalog.Feature') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-            {%- for child in form %}
-              <tr>
-                <td class="col-md-3">{{ form_widget(child) }}</td>
-                <td class="col-md-6 file-name"><span>{{ form.vars.attr.data[loop.index0]['file_name'] }}</span></td>
-                <td class="col-md-2">{{ form.vars.attr.data[loop.index0]['mime'] }}</td>
-              </tr>
-            {% endfor -%}
-            </tbody>
-          </table>
-        </div>
+  <div class="js-options-no-attachments {{ form|length > 0 ? 'hide' : '' }}">
+    <small>{{ 'There is no attachment yet.'|trans({}, 'Admin.Catalog.Notification') }}</small>
+  </div>
+  <div id="product-attachments" class="panel panel-default">
+    <div class="panel-body js-options-with-attachments {{ form|length == 0 ? 'hide' : '' }}">
+      <div>
+        <table id="product-attachment-file" class="table">
+          <thead class="thead-default">
+          <tr>
+            <th class="col-md-3"><input type="checkbox" id="product-attachment-files-check" /> {{ 'Title'|trans({}, 'Admin.Global') }}</th>
+            <th class="col-md-6">{{ 'File name'|trans({}, 'Admin.Global') }}</th>
+            <th class="col-md-2">{{ 'Type'|trans({}, 'Admin.Catalog.Feature') }}</th>
+          </tr>
+          </thead>
+          <tbody>
+          {%- for child in form %}
+            <tr>
+              <td class="col-md-3">{{ form_widget(child) }}</td>
+              <td class="col-md-6 file-name"><span>{{ form.vars.attr.data[loop.index0]['file_name'] }}</span></td>
+              <td class="col-md-2">{{ form.vars.attr.data[loop.index0]['mime'] }}</td>
+            </tr>
+          {% endfor -%}
+          </tbody>
+        </table>
       </div>
     </div>
+  </div>
 {% endblock %}
 
 {# Labels #}
 
 {% block form_label -%}
-    {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' control-label')|trim}) -%}
-    {{- parent() -}}
+  {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' control-label')|trim}) -%}
+  {{- parent() -}}
 {%- endblock form_label %}
 
 {% block choice_label -%}
-    {# remove the checkbox-inline and radio-inline class, it's only useful for embed labels #}
-    {%- set label_attr = label_attr|merge({class: label_attr.class|default('')|replace({'checkbox-inline': '', 'radio-inline': ''})|trim}) -%}
-    {{- block('form_label') -}}
+  {# remove the checkbox-inline and radio-inline class, it's only useful for embed labels #}
+  {%- set label_attr = label_attr|merge({class: label_attr.class|default('')|replace({'checkbox-inline': '', 'radio-inline': ''})|trim}) -%}
+  {{- block('form_label') -}}
 {% endblock %}
 
 {% block checkbox_label -%}
-    {{- block('checkbox_radio_label') -}}
+  {{- block('checkbox_radio_label') -}}
 {%- endblock checkbox_label %}
 
 {% block radio_label -%}
-    {{- block('checkbox_radio_label') -}}
+  {{- block('checkbox_radio_label') -}}
 {%- endblock radio_label %}
 
 {% block checkbox_radio_label %}
-    {# Do not display the label if widget is not defined in order to prevent double label rendering #}
-    {% if widget is defined %}
-      {% if required %}
-        {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
-      {% endif %}
-      {% if parent_label_class is defined %}
-          {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
-      {% endif %}
-      {% if label is not same as(false) and label is empty %}
-          {% set label = name|humanize %}
-      {% endif %}
-
-      {% if material_design is defined %}
-        <div class="md-checkbox md-checkbox-inline">
-          <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-          {{- widget|raw -}}
-          <i class="md-checkbox-control"></i>
-          {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
-          </label>
-        </div>
-      {% else %}
-      <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-        {{- widget|raw -}}
-        {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
-      </label>
-      {% endif %}
+  {# Do not display the label if widget is not defined in order to prevent double label rendering #}
+  {% if widget is defined %}
+    {% if required %}
+      {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
     {% endif %}
+    {% if parent_label_class is defined %}
+      {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
+    {% endif %}
+    {% if label is not same as(false) and label is empty %}
+      {% set label = name|humanize %}
+    {% endif %}
+
+    {% if material_design is defined %}
+      <div class="md-checkbox md-checkbox-inline">
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+        {{- widget|raw -}}
+        <i class="md-checkbox-control"></i>
+        {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
+        </label>
+      </div>
+    {% else %}
+      <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+      {{- widget|raw -}}
+      {{- label is not same as(false) ? (translation_domain is same as(false) ? label|raw : label|raw) -}}
+      </label>
+    {% endif %}
+  {% endif %}
 {% endblock checkbox_radio_label %}
 
 {# Rows #}
 
 {% block form_row -%}
-    <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
-        {{- form_label(form) -}}
-        {{- form_widget(form) -}}
-        {{- form_errors(form) -}}
-    </div>
+  <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
+    {{- form_label(form) -}}
+    {{- form_widget(form) -}}
+    {{- form_errors(form) -}}
+  </div>
 {%- endblock form_row %}
 
 {% block button_row -%}
-    <div class="form-group">
-        {{- form_widget(form) -}}
-    </div>
+  <div class="form-group">
+    {{- form_widget(form) -}}
+  </div>
 {%- endblock button_row %}
 
 {% block choice_row -%}
-    {% set force_error = true %}
-    {{- block('form_row') }}
+  {% set force_error = true %}
+  {{- block('form_row') }}
 {%- endblock choice_row %}
 
 {% block date_row -%}
-    {% set force_error = true %}
-    {{- block('form_row') }}
+  {% set force_error = true %}
+  {{- block('form_row') }}
 {%- endblock date_row %}
 
 {% block time_row -%}
-    {% set force_error = true %}
-    {{- block('form_row') }}
+  {% set force_error = true %}
+  {{- block('form_row') }}
 {%- endblock time_row %}
 
 {% block datetime_row -%}
-    {% set force_error = true %}
-    {{- block('form_row') }}
+  {% set force_error = true %}
+  {{- block('form_row') }}
 {%- endblock datetime_row %}
 
 {% block checkbox_row -%}
-    <div class="form-group{% if not valid %} has-error{% endif %}">
-        {{- form_widget(form) -}}
-        {{- form_errors(form) -}}
-    </div>
+  <div class="form-group{% if not valid %} has-error{% endif %}">
+    {{- form_widget(form) -}}
+    {{- form_errors(form) -}}
+  </div>
 {%- endblock checkbox_row %}
 
 {% block radio_row -%}
-    <div class="form-group{% if not valid %} has-error{% endif %}">
-        {{- form_widget(form) -}}
-        {{- form_errors(form) -}}
-    </div>
+  <div class="form-group{% if not valid %} has-error{% endif %}">
+    {{- form_widget(form) -}}
+    {{- form_errors(form) -}}
+  </div>
 {%- endblock radio_row %}
 
 {# Errors #}
 
 {% block form_errors -%}
-    {% if errors|length > 0 -%}
+  {% if errors|length > 0 -%}
     <div class="alert alert-danger">
-        {%- if errors|length > 1 -%}
-            <ul class="alert-text">
-                {%- for error in errors -%}
-                    <li> {{
-                        error.messagePluralization is null
-                        ? error.messageTemplate|trans(error.messageParameters, 'form_error')
-                        : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
-                        }}
-                    </li>
-                {%- endfor -%}
-            </ul>
-        {%- else -%}
-            <div class="alert-text">
-            {%- for error in errors -%}
-                <p> {{
-                    error.messagePluralization is null
-                    ? error.messageTemplate|trans(error.messageParameters, 'form_error')
-                    : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
-                    }}
-                </p>
-            {%- endfor -%}
-            </div>
-        {%- endif -%}
+      {%- if errors|length > 1 -%}
+        <ul class="alert-text">
+          {%- for error in errors -%}
+            <li> {{
+              error.messagePluralization is null
+              ? error.messageTemplate|trans(error.messageParameters, 'form_error')
+              : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
+              }}
+            </li>
+          {%- endfor -%}
+        </ul>
+      {%- else -%}
+        <div class="alert-text">
+          {%- for error in errors -%}
+            <p> {{
+              error.messagePluralization is null
+              ? error.messageTemplate|trans(error.messageParameters, 'form_error')
+              : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
+              }}
+            </p>
+          {%- endfor -%}
+        </div>
+      {%- endif -%}
     </div>
-    {%- endif %}
+  {%- endif %}
 {%- endblock form_errors %}
 
 
@@ -562,17 +562,17 @@
     <div class="choice-table">
       <table class="table table-bordered mb-0">
         <thead>
-          <tr>
-            <th class="checkbox">
-              <div class="md-checkbox">
-                <label>
-                  <input type="checkbox" class="js-choice-table-select-all">
-                  <i class="md-checkbox-control"></i>
-                  {{ 'Select all'|trans({}, 'Admin.Actions') }}
-                </label>
-              </div>
-            </th>
-          </tr>
+        <tr>
+          <th class="checkbox">
+            <div class="md-checkbox">
+              <label>
+                <input type="checkbox" class="js-choice-table-select-all">
+                <i class="md-checkbox-control"></i>
+                {{ 'Select all'|trans({}, 'Admin.Actions') }}
+              </label>
+            </div>
+          </th>
+        </tr>
         </thead>
         <tbody>
         {% for child in form %}
@@ -590,27 +590,27 @@
 
 {% block material_multiple_choice_table_widget %}
   {% spaceless %}
-    <div class="{% if scrollable %}choice-table{% endif %} table-responsive">
+    <div class="choice-table table-responsive">
       <table class="table">
         <thead>
-          <tr>
-            <th>{{ label }}</th>
-            {% for child_choice in form %}
-              <th class="text-center">
-                {% if child_choice.vars.multiple and child_choice.vars.name not in headers_to_disable %}
-                  <a href="#"
-                     class="js-multiple-choice-table-select-column"
-                     data-column-num="{{ loop.index + 1 }}"
-                     data-column-checked="false"
-                  >
-                    {{ child_choice.vars.label }}
-                  </a>
-                {% else %}
+        <tr>
+          <th>{{ label }}</th>
+          {% for child_choice in form %}
+            <th class="text-center">
+              {% if child_choice.vars.multiple %}
+                <a href="#"
+                   class="js-multiple-choice-table-select-column"
+                   data-column-num="{{ loop.index + 1 }}"
+                   data-column-checked="false"
+                >
                   {{ child_choice.vars.label }}
-                {% endif %}
-              </th>
-            {% endfor %}
-          </tr>
+                </a>
+              {% else %}
+                {{ child_choice.vars.label }}
+              {% endif %}
+            </th>
+          {% endfor %}
+        </tr>
         </thead>
         <tbody>
         {% for choice_name, choice_value in choices %}
@@ -642,16 +642,16 @@
 {% endblock material_multiple_choice_table_widget %}
 
 {% block translatable_widget -%}
+  {{ form_errors(form) }}
   <div class="input-group locale-input-group js-locale-input-group d-flex">
-    {% set classes = attr.class|default('') %}
     {% for translateField in form %}
-      {% set innerClasses = classes ~ translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
-      {% set innerClasses = innerClasses ~ ' js-locale-' ~ translateField.vars.label %}
+      {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
+      {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
       {% if default_locale.id_lang != translateField.vars.name %}
-        {% set innerClasses = innerClasses ~ ' d-none' %}
+        {% set classes = classes ~ ' d-none' %}
       {% endif %}
-      <div class="{{ innerClasses }}" style="flex-grow: 1;">
-        {{ form_widget(translateField, {attr: {'data-lang-id': translateField.vars.name }}) }}
+      <div class="{{ classes }}" style="flex-grow: 1;">
+        {{ form_widget(translateField) }}
       </div>
     {% endfor %}
     {% if not hide_locales %}
@@ -659,9 +659,6 @@
         <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
                 type="button"
                 data-toggle="dropdown"
-                {% if change_form_language_url is defined %}
-                  data-change-language-url="{{ form.vars.change_form_language_url }}"
-                {% endif %}
                 aria-haspopup="true"
                 aria-expanded="false"
                 id="{{ form.vars.id }}"
@@ -703,17 +700,13 @@
   {% endif %}
 {% endblock birthday_widget %}
 
-{% block generatable_text_widget %}
-  <div class="input-group">
-    {{- block('form_widget') -}}
-    <span class="input-group-btn ml-1">
-      <button class="btn btn-outline-secondary js-generator-btn"
-              type="button"
-              data-target-input-id="{{ id }}"
-              data-generated-value-length="{{ generated_value_length }}"
-      >
-        {{ 'Generate'|trans({}, 'Admin.Actions') }}
-      </button>
-   </span>
+{% block file_widget %}
+  <div class="custom-file">
+    {# todo: test multiple files upload after new PrestaShop Ui kit is updated #}
+    {# todo: check translations #}
+    {{ form_widget(form, {'attr': { 'data-multiple-files-text': 'files'|trans({}, 'Admin.Global') }}) }}
+    <label class="custom-file-label" for="{{ form.vars.id }}">
+      {{ form.vars.attr.placeholder is defined ? form.vars.attr.placeholder : 'Choose file'|trans({}, 'Shop.Theme.Actions') }}
+    </label>
   </div>
-{% endblock generatable_text_widget %}
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -712,18 +712,7 @@
 
     <label class="custom-file-label" for="{{ form.vars.id }}">
       {% set attributes = form.vars.attr %}
-
-      {% if (attributes.placeholder is not defined) %}
-
-        {% if (attributes.multiple is not defined) %}
-          {{ 'Choose file'|trans({}, 'Shop.Theme.Actions') }}
-        {% else %}
-          {{ 'Choose files'|trans({}, 'Shop.Theme.Actions') }}
-        {% endif %}
-
-      {% else %}
-        {{ attributes.placeholder }}
-      {% endif %}
+      {{ attributes.placeholder is defined ?  attributes.placeholder : 'Choose file(s)'|trans({}, 'Admin.Actions') }}
     </label>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -702,11 +702,28 @@
 
 {% block file_widget %}
   <div class="custom-file">
-    {# todo: test multiple files upload after new PrestaShop Ui kit is updated #}
-    {# todo: check translations #}
-    {{ form_widget(form, {'attr': { 'data-multiple-files-text': 'files'|trans({}, 'Admin.Global') }}) }}
+    {% set attr = attr|merge({
+      class: (attr.class|default('') ~ ' custom-file-input')|trim,
+      'data-multiple-files-text': '%count% files'|trans({}, 'Admin.Global'),
+      'data-locale': get_context_iso_code()
+    }) -%}
+
+    {{ form_widget(form, {'attr': attr}) }}
+
     <label class="custom-file-label" for="{{ form.vars.id }}">
-      {{ form.vars.attr.placeholder is defined ? form.vars.attr.placeholder : 'Choose file'|trans({}, 'Shop.Theme.Actions') }}
+      {% set attributes = form.vars.attr %}
+
+      {% if (attributes.placeholder is not defined) %}
+
+        {% if (attributes.multiple is not defined) %}
+          {{ 'Choose file'|trans({}, 'Shop.Theme.Actions') }}
+        {% else %}
+          {{ 'Choose files'|trans({}, 'Shop.Theme.Actions') }}
+        {% endif %}
+
+      {% else %}
+        {{ attributes.placeholder }}
+      {% endif %}
     </label>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Twig/ContextIsoCodeProviderExtension.php
+++ b/src/PrestaShopBundle/Twig/ContextIsoCodeProviderExtension.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Twig;
+
+/**
+ * Provides context language iso code
+ */
+class ContextIsoCodeProviderExtension extends \Twig_Extension
+{
+    /**
+     * @var string
+     */
+    private $isoCode;
+
+    /**
+     * @param $isoCode
+     */
+    public function __construct($isoCode)
+    {
+        $this->isoCode = $isoCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('get_context_iso_code', [$this, 'getIsoCode']),
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getIsoCode()
+    {
+        return $this->isoCode;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since on new Theme & logo page I needed new file input appearance I introduced it to every page where file upload  was used using default file upload input (Theme & logo, Import, products...). 
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | related with https://github.com/PrestaShop/PrestaShop/issues/10576
| How to test?  | Check pages (Theme & Logo, Import, Products edit and maybe there are more new pages to check where the file input was used :thinking: ) By default it takes full width of available space so in most cases i should look okey.

**TESTING NOTE**
There is a chance that you first need to hit **npm install** and then **npm run build** in order to see new file input

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

- [x] Merge https://github.com/PrestaShop/prestashop-ui-kit/pull/59

- [x] Use updated PrestaShop Ui kit (introduce it in current PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12436)
<!-- Reviewable:end -->
