### PR TITLE
Fix duplicate HTML id

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 {% if form.suppliers|length > 0 %}
-  <div id="custom_fields">
+  <div id="form_step6_suppliers_custom_fields">
     <h2>{{ form.suppliers.vars.label }}</h2>
     <div class="row mb-1">
       <div class="col-md-12">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig
@@ -52,7 +52,7 @@
             <thead class="thead-default">
             <tr>
               <th width="70%">{{ 'Choose the suppliers associated with this product'|trans({}, 'Admin.Catalog.Feature') }}</th>
-              <th width=30%">{{ 'Default supplier'|trans({}, 'Admin.Catalog.Feature') }}</th>
+              <th width="30%">{{ 'Default supplier'|trans({}, 'Admin.Catalog.Feature') }}</th>
             </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | duplicated HTML ids are invalid
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | In Supplier section of Product Page in back office, you should see only one "custom_fields" when doing something like $('#custom_fields') in your developer web toolbar

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12465)
<!-- Reviewable:end -->
