### PR TITLE
Use AdminSecurity annotation for ajax call for Sql Manager

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
@@ -388,6 +388,11 @@ class SqlManagerController extends FrameworkBundleAdminController
     /**
      * Get MySQL table columns data.
      *
+     * @AdminSecurity(
+     *     "is_granted(['read'], request.get('_legacy_controller'))",
+     *     redirectRoute="admin_sql_requests_index"
+     * )
+     *
      * @param string $mySqlTableName Database table name
      *
      * @return JsonResponse


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Before, you could access data provided by ajax route `/admin-dev/index.php/configure/advanced/sql-requests/tables/ps_badge/columns` without being granted READ rights for SQL Manager page. This PR fixes that.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | yes
| Fixed ticket? | 
| How to test?  | See below

## How to test

Try to access `/admin-dev/index.php/configure/advanced/sql-requests/tables/ps_badge/columns`.

Without the PR: you can access it with any BO account, even if you have no rights to see the Sql Manager page.
With the PR: it now requires READ Sql Manager rights for this page to get the data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12471)
<!-- Reviewable:end -->
