### PR TITLE
Order Creation: fix out of stock status

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -554,7 +554,7 @@ abstract class PaymentModuleCore extends Module
                             $order_detail->product_quantity_in_stock < 0)) {
                         $history = new OrderHistory();
                         $history->id_order = (int) $order->id;
-                        $history->changeIdOrderState(Configuration::get($order->valid ? 'PS_OS_OUTOFSTOCK_PAID' : 'PS_OS_OUTOFSTOCK_UNPAID'), $order, true);
+                        $history->changeIdOrderState(Configuration::get($order->hasBeenPaid() ? 'PS_OS_OUTOFSTOCK_PAID' : 'PS_OS_OUTOFSTOCK_UNPAID'), $order, true);
                         $history->addWithemail();
                     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | if a product is out of stock, the order status is changed. However, it is currently changed to a paid orderstate even if the original orderstate is not considered as paid
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12473)
<!-- Reviewable:end -->
