### PR TITLE
Fix issue with the link Manage tax rules in the pricing tab

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig
@@ -83,7 +83,7 @@
               </div>
               <div class="col-md-8">
                 <label class="form-control-label">&nbsp;</label>
-                <a class="form-control-static external-link" href="{{ getAdminLink("AdminTaxes") }}">
+                <a class="form-control-static external-link" href="{{ getAdminLink("AdminTaxes") }}" target="_blank">
                   {{ 'Manage tax rules'|trans({}, 'Admin.Catalog.Feature') }}
                 </a>
               </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In product page, in the pricing tab, if you click on the link "Manage tax rules", we are redirected to the Taxes page, so all new modification in this product will disappear, it would be nice that link opens on a new window when clicking in it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12475
| How to test?  | *Go to BO => Catalog => Product page => Pricing Tab => Click on the link "Manage tax rules" => a new page is opened

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12497)
<!-- Reviewable:end -->
