### PR TITLE
Improve error handling in migrated controllers

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfilesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfilesController.php
@@ -62,7 +62,7 @@ class ProfilesController extends FrameworkBundleAdminController
             '@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/index.html.twig',
             [
                 'layoutHeaderToolbarBtn' => [
-                    'add'=> [
+                    'add' => [
                         'href' => $this->generateUrl('admin_profiles_create'),
                         'desc' => $this->trans('Add new profile', 'Admin.Advparameters.Feature'),
                         'icon' => 'add_circle_outline',

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfilesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfilesController.php
@@ -61,7 +61,16 @@ class ProfilesController extends FrameworkBundleAdminController
         return $this->render(
             '@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/index.html.twig',
             [
+                'layoutHeaderToolbarBtn' => [
+                    'add'=> [
+                        'href' => $this->generateUrl('admin_profiles_create'),
+                        'desc' => $this->trans('Add new profile', 'Admin.Advparameters.Feature'),
+                        'icon' => 'add_circle_outline',
+                  ],
+                ],
                 'help_link' => $this->generateSidebarLink('AdminProfiles'),
+                'enableSidebar' => true,
+                'layoutTitle' => $this->trans('Profiles', 'Admin.Navigation.Menu'),
                 'grid' => $this->presentGrid($profilesGridFactory->getGrid($filters)),
             ]
         );

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfilesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfilesController.php
@@ -57,20 +57,14 @@ class ProfilesController extends FrameworkBundleAdminController
     public function indexAction(ProfilesFilters $filters)
     {
         $profilesGridFactory = $this->get('prestashop.core.grid.factory.profiles');
-        $gridPresenter = $this->get('prestashop.core.grid.presenter.grid_presenter');
 
-        return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/profiles.html.twig', [
-            'layoutHeaderToolbarBtn' => [
-                'add' => [
-                    'href' => $this->getAdminLink('AdminProfiles', ['addprofile' => '']),
-                    'desc' => $this->trans('Add new profile', 'Admin.Advparameters.Feature'),
-                    'icon' => 'add_circle_outline',
-                ],
-            ],
-            'enableSidebar' => true,
-            'help_link' => $this->generateSidebarLink('AdminProfiles'),
-            'grid' => $gridPresenter->present($profilesGridFactory->getGrid($filters)),
-        ]);
+        return $this->render(
+            '@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/index.html.twig',
+            [
+                'help_link' => $this->generateSidebarLink('AdminProfiles'),
+                'grid' => $this->presentGrid($profilesGridFactory->getGrid($filters)),
+            ]
+        );
     }
 
     /**
@@ -96,6 +90,20 @@ class ProfilesController extends FrameworkBundleAdminController
         }
 
         return $this->redirectToRoute('admin_profiles_index', ['filters' => $filters]);
+    }
+
+    /**
+     * Show profile's create page
+     *
+     * @return Response
+     */
+    public function createAction()
+    {
+        $legacyLink = $this->getAdminLink('AdminProfiles', [
+            'addprofile' => 1,
+        ]);
+
+        return $this->redirect($legacyLink);
     }
 
     /**
@@ -142,7 +150,7 @@ class ProfilesController extends FrameworkBundleAdminController
 
             $this->addFlash('success', $this->trans('Successful deletion', 'Admin.Notifications.Success'));
         } catch (ProfileException $e) {
-            $this->addFlash('error', $this->handleDeleteException($e));
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
         return $this->redirectToRoute('admin_profiles_index');
@@ -172,7 +180,7 @@ class ProfilesController extends FrameworkBundleAdminController
 
             $this->addFlash('success', $this->trans('Successful deletion', 'Admin.Notifications.Success'));
         } catch (ProfileException $e) {
-            $this->addFlash('error', $this->handleDeleteException($e));
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
         return $this->redirectToRoute('admin_profiles_index');
@@ -181,24 +189,23 @@ class ProfilesController extends FrameworkBundleAdminController
     /**
      * Get human readable error for exception.
      *
-     * @param ProfileException $e
-     *
-     * @return string Error message
+     * @return array
      */
-    protected function handleDeleteException(ProfileException $e)
+    protected function getErrorMessages()
     {
-        $type = get_class($e);
-
-        $exceptionMessages = [
-            ProfileNotFoundException::class => $this->trans('The object cannot be loaded (or found)', 'Admin.Notifications.Error'),
-            CannotDeleteSuperAdminProfileException::class => $this->trans('For security reasons, you cannot delete the Administrator\'s profile.', 'Admin.Advparameters.Notification'),
-            ProfileException::class => $this->trans('An error occurred while deleting the object.', 'Admin.Notifications.Error'),
+        return [
+            ProfileNotFoundException::class => $this->trans(
+                'The object cannot be loaded (or found)',
+                'Admin.Notifications.Error'
+            ),
+            CannotDeleteSuperAdminProfileException::class => $this->trans(
+                'For security reasons, you cannot delete the Administrator\'s profile.',
+                'Admin.Advparameters.Notification'
+            ),
+            ProfileException::class => $this->trans(
+                'An error occurred while deleting the object.',
+                'Admin.Notifications.Error'
+            ),
         ];
-
-        if (isset($exceptionMessages[$type])) {
-            return $exceptionMessages[$type];
-        }
-
-        return $this->trans('An error occurred while deleting the object.', 'Admin.Notifications.Error');
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
@@ -33,6 +33,7 @@ use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * ContactsController is responsible for actions and rendering
@@ -45,34 +46,23 @@ class ContactsController extends FrameworkBundleAdminController
      *
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
-     * @Template("@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/index.html.twig")
-     *
      * @param Request $request
      * @param ContactFilters $filters
      *
-     * @return array
+     * @return Response
      */
     public function indexAction(Request $request, ContactFilters $filters)
     {
-        $contactsGridFactory = $this->get('prestashop.core.grid.factory.contacts');
-        $gridPresenter = $this->get('prestashop.core.grid.presenter.grid_presenter');
+        $contactGridFactory = $this->get('prestashop.core.grid.factory.contacts');
+        $contactGrid = $contactGridFactory->getGrid($filters);
 
-        $contactsGrid = $contactsGridFactory->getGrid($filters);
-
-        return [
-            'layoutTitle' => $this->trans('Contacts', 'Admin.Navigation.Menu'),
-            'layoutHeaderToolbarBtn' => [
-                'add' => [
-                    'href' => $this->generateUrl('admin_contacts_create'),
-                    'desc' => $this->trans('Add new contact', 'Admin.Shopparameters.Feature'),
-                    'icon' => 'add_circle_outline',
-                ],
-            ],
-            'requireAddonsSearch' => true,
-            'enableSidebar' => true,
-            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
-            'grid' => $gridPresenter->present($contactsGrid),
-        ];
+        return $this->render(
+            '@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/index.html.twig',
+            [
+                'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+                'contactGrid' => $this->presentGrid($contactGrid),
+            ]
+        );
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
@@ -59,6 +59,16 @@ class ContactsController extends FrameworkBundleAdminController
             '@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/index.html.twig',
             [
                 'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+                'enableSidebar' => true,
+                'layoutTitle' => $this->trans('Contacts', 'Admin.Navigation.Menu'),
+                'requireAddonsSearch' => true,
+                'layoutHeaderToolbarBtn' => [
+                    'add' => [
+                        'desc' => $this->trans('Add new contact', 'Admin.Shopparameters.Feature'),
+                        'icon' => 'add_circle_outline',
+                        'href' => $this->generateUrl('admin_contacts_create'),
+                    ],
+                ],
                 'contactGrid' => $this->presentGrid($contactGrid),
             ]
         );

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
@@ -30,7 +30,6 @@ use PrestaShop\PrestaShop\Core\Search\Filters\ContactFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -395,25 +395,20 @@ class CurrencyController extends FrameworkBundleAdminController
                 ),
             ],
             DefaultCurrencyInMultiShopException::class => [
-                DefaultCurrencyInMultiShopException::CANNOT_REMOVE_CURRENCY =>
-                    $this->trans(
+                DefaultCurrencyInMultiShopException::CANNOT_REMOVE_CURRENCY => $this->trans(
                         '%currency% is the default currency for shop %shop_name%, and therefore cannot be removed from shop association',
                         'Admin.International.Notification',
                         [
-                            '%currency%' =>
-                                $e instanceof DefaultCurrencyInMultiShopException ? $e->getCurrencyName() : '',
-                            '%shop_name%' =>
-                                $e instanceof DefaultCurrencyInMultiShopException ? $e->getShopName() : '',
+                            '%currency%' => $e instanceof DefaultCurrencyInMultiShopException ? $e->getCurrencyName() : '',
+                            '%shop_name%' => $e instanceof DefaultCurrencyInMultiShopException ? $e->getShopName() : '',
                         ]
                     ),
                 DefaultCurrencyInMultiShopException::CANNOT_DISABLE_CURRENCY => $this->trans(
                     '%currency% is the default currency for shop %shop_name%, and therefore cannot be disabled',
                     'Admin.International.Notification',
                     [
-                        '%currency%' =>
-                            $e instanceof DefaultCurrencyInMultiShopException ? $e->getCurrencyName() : '',
-                        '%shop_name%' =>
-                            $e instanceof DefaultCurrencyInMultiShopException ? $e->getShopName() : '',
+                        '%currency%' => $e instanceof DefaultCurrencyInMultiShopException ? $e->getCurrencyName() : '',
+                        '%shop_name%' => $e instanceof DefaultCurrencyInMultiShopException ? $e->getShopName() : '',
                     ]
                 ),
             ],

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/profiles.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/profiles.yml
@@ -12,6 +12,13 @@ admin_profiles_search:
         _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Profiles:search'
         _legacy_controller: AdminProfiles
 
+admin_profiles_create:
+    path: /new
+    methods: [GET, POST]
+    defaults:
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Profiles:create'
+        _legacy_controller: AdminProfiles
+
 admin_profiles_edit:
     path: /{profileId}/edit
     methods: GET

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/index.html.twig
@@ -25,16 +25,6 @@
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% set layoutTitle = 'Profiles'|trans({}, 'Admin.Navigation.Menu') %}
-{% set enableSidebar = true %}
-{% set layoutHeaderToolbarBtn = {
-  'add': {
-    'href': path('admin_profiles_create'),
-    'desc': 'Add new profile'|trans({}, 'Admin.Advparameters.Feature'),
-    'icon': 'add_circle_outline'
-  }
-} %}
-
 {% block content %}
   {% block profiles_list_panel %}
     <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/index.html.twig
@@ -25,6 +25,16 @@
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
+{% set layoutTitle = 'Profiles'|trans({}, 'Admin.Navigation.Menu') %}
+{% set enableSidebar = true %}
+{% set layoutHeaderToolbarBtn = {
+  'add': {
+    'href': path('admin_profiles_create'),
+    'desc': 'Add new profile'|trans({}, 'Admin.Advparameters.Feature'),
+    'icon': 'add_circle_outline'
+  }
+} %}
+
 {% block content %}
   {% block profiles_list_panel %}
     <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Contact/Contacts/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Contact/Contacts/index.html.twig
@@ -25,17 +25,6 @@
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% set layoutTitle = 'Contacts'|trans({}, 'Admin.Navigation.Menu') %}
-{% set enableSidebar = true %}
-{% set requireAddonsSearch = true %}
-{% set layoutHeaderToolbarBtn = {
-  'add': {
-    'desc': 'Add new contact'|trans({}, 'Admin.Shopparameters.Feature'),
-    'icon': 'add_circle_outline',
-    'href': path('admin_contacts_create')
-  }
-} %}
-
 {% block content %}
   {% block contacts_list_panel %}
     <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Contact/Contacts/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Contact/Contacts/index.html.twig
@@ -25,11 +25,22 @@
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
+{% set layoutTitle = 'Contacts'|trans({}, 'Admin.Navigation.Menu') %}
+{% set enableSidebar = true %}
+{% set requireAddonsSearch = true %}
+{% set layoutHeaderToolbarBtn = {
+  'add': {
+    'desc': 'Add new contact'|trans({}, 'Admin.Shopparameters.Feature'),
+    'icon': 'add_circle_outline',
+    'href': path('admin_contacts_create')
+  }
+} %}
+
 {% block content %}
   {% block contacts_list_panel %}
     <div class="row">
       <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': grid} %}
+        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': contactGrid} %}
       </div>
     </div>
   {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR aims making error handling the same across all migrated controllers.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Part of https://github.com/PrestaShop/PrestaShop/issues/12438
| How to test?  | Nothing should change for migrated pages "Profiles", "Contacts" and "Currencies"

### Controllers that error handling were updated:
* ProfileController
* CurrencyController

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12505)
<!-- Reviewable:end -->
