### PR TITLE
Add hookDispatcher in GridFactory constructor, HookDispatcherAwareTrait has a safer getter

### DIFF
--- a/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
@@ -66,11 +66,12 @@ abstract class AbstractGridDefinitionFactory implements GridDefinitionFactoryInt
      * Set hook dispatcher.
      *
      * @param HookDispatcherInterface $hookDispatcher
+     *
      * @deprecated
      */
     final public function setHookDispatcher(HookDispatcherInterface $hookDispatcher)
     {
-        @trigger_error('The AbstractGridDefinitionFactory::setHookDispatcher method is deprecated as of 1.7.6. Please use the constructor instead', E_USER_DEPRECATED);
+        @trigger_error('The AbstractGridDefinitionFactory::setHookDispatcher method is deprecated as of 1.7.5.1 Please use the constructor instead', E_USER_DEPRECATED);
 
         $this->hookDispatcher = $hookDispatcher;
     }

--- a/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
@@ -34,7 +34,8 @@ use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinition;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollectionInterface;
-use PrestaShop\PrestaShop\Core\Hook\HookDispatcherAwareTrait;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\DependencyInjection\Container;
 
@@ -43,7 +44,36 @@ use Symfony\Component\DependencyInjection\Container;
  */
 abstract class AbstractGridDefinitionFactory implements GridDefinitionFactoryInterface
 {
-    use TranslatorAwareTrait, HookDispatcherAwareTrait;
+    use TranslatorAwareTrait;
+
+    /**
+     * @var HookDispatcherInterface
+     */
+    protected $hookDispatcher;
+
+    /**
+     * @param HookDispatcherInterface|null $hookDispatcher
+     */
+    public function __construct(HookDispatcherInterface $hookDispatcher = null)
+    {
+        if (null === $hookDispatcher) {
+            @trigger_error('The $hookDispatcher parameter should not be null, inject your main HookDispatcherInterface service, or NullDispatcher if you don\'t need hooks.', E_USER_DEPRECATED);
+        }
+        $this->hookDispatcher = $hookDispatcher ? $hookDispatcher : new NullDispatcher();
+    }
+
+    /**
+     * Set hook dispatcher.
+     *
+     * @param HookDispatcherInterface $hookDispatcher
+     * @deprecated
+     */
+    final public function setHookDispatcher(HookDispatcherInterface $hookDispatcher)
+    {
+        @trigger_error('The AbstractGridDefinitionFactory::setHookDispatcher method is deprecated as of 1.7.6. Please use the constructor instead', E_USER_DEPRECATED);
+
+        $this->hookDispatcher = $hookDispatcher;
+    }
 
     /**
      * {@inheritdoc}
@@ -59,7 +89,7 @@ abstract class AbstractGridDefinitionFactory implements GridDefinitionFactoryInt
             $this->getBulkActions()
         );
 
-        $this->getHookDispatcher()->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridDefinitionModifier', [
+        $this->hookDispatcher->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridDefinitionModifier', [
             'definition' => $definition,
         ]);
 

--- a/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
@@ -59,7 +59,7 @@ abstract class AbstractGridDefinitionFactory implements GridDefinitionFactoryInt
             $this->getBulkActions()
         );
 
-        $this->hookDispatcher->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridDefinitionModifier', [
+        $this->getHookDispatcher()->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridDefinitionModifier', [
             'definition' => $definition,
         ]);
 

--- a/src/Core/Grid/Filter/GridFilterFormFactory.php
+++ b/src/Core/Grid/Filter/GridFilterFormFactory.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Filter;
 
 use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
-use PrestaShop\PrestaShop\Core\Hook\HookDispatcherAwareTrait;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\DependencyInjection\Container;
@@ -37,19 +37,30 @@ use Symfony\Component\DependencyInjection\Container;
  */
 final class GridFilterFormFactory implements GridFilterFormFactoryInterface
 {
-    use HookDispatcherAwareTrait;
-
     /**
      * @var FormFactoryInterface
      */
     private $formFactory;
 
     /**
-     * @param FormFactoryInterface $formFactory
+     * @var HookDispatcherInterface
      */
-    public function __construct(FormFactoryInterface $formFactory)
-    {
+    private $hookDispatcher;
+
+    /**
+     * @param FormFactoryInterface $formFactory
+     * @param HookDispatcherInterface|null $hookDispatcher
+     */
+    public function __construct(
+        FormFactoryInterface $formFactory,
+        HookDispatcherInterface $hookDispatcher = null
+    ) {
         $this->formFactory = $formFactory;
+
+        if (null === $hookDispatcher) {
+            @trigger_error('The $hookDispatcher parameter should not be null, inject your main HookDispatcherInterface service, or NullDispatcher if you don\'t need hooks.', E_USER_DEPRECATED);
+        }
+        $this->hookDispatcher = $hookDispatcher ? $hookDispatcher : new NullDispatcher();
     }
 
     /**
@@ -71,7 +82,7 @@ final class GridFilterFormFactory implements GridFilterFormFactoryInterface
             );
         }
 
-        $this->getHookDispatcher()->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridFilterFormModifier', [
+        $this->hookDispatcher->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridFilterFormModifier', [
             'filter_form_builder' => $formBuilder,
         ]);
 

--- a/src/Core/Grid/Filter/GridFilterFormFactory.php
+++ b/src/Core/Grid/Filter/GridFilterFormFactory.php
@@ -71,7 +71,7 @@ final class GridFilterFormFactory implements GridFilterFormFactoryInterface
             );
         }
 
-        $this->hookDispatcher->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridFilterFormModifier', [
+        $this->getHookDispatcher()->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridFilterFormModifier', [
             'filter_form_builder' => $formBuilder,
         ]);
 

--- a/src/Core/Grid/GridFactory.php
+++ b/src/Core/Grid/GridFactory.php
@@ -31,6 +31,8 @@ use PrestaShop\PrestaShop\Core\Grid\Data\Factory\GridDataFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\Filter\GridFilterFormFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherAwareTrait;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
@@ -59,15 +61,18 @@ final class GridFactory implements GridFactoryInterface
      * @param GridDefinitionFactoryInterface $definitionFactory
      * @param GridDataFactoryInterface $dataFactory
      * @param GridFilterFormFactoryInterface $filterFormFactory
+     * @param HookDispatcherInterface $hookDispatcher
      */
     public function __construct(
         GridDefinitionFactoryInterface $definitionFactory,
         GridDataFactoryInterface $dataFactory,
-        GridFilterFormFactoryInterface $filterFormFactory
+        GridFilterFormFactoryInterface $filterFormFactory,
+        HookDispatcherInterface $hookDispatcher = null
     ) {
         $this->definitionFactory = $definitionFactory;
         $this->dataFactory = $dataFactory;
         $this->filterFormFactory = $filterFormFactory;
+        $this->setHookDispatcher(null !== $hookDispatcher ? $hookDispatcher : new NullDispatcher());
     }
 
     /**
@@ -78,7 +83,7 @@ final class GridFactory implements GridFactoryInterface
         $definition = $this->definitionFactory->getDefinition();
         $data = $this->dataFactory->getData($searchCriteria);
 
-        $this->hookDispatcher->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridDataModifier', [
+        $this->getHookDispatcher()->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridDataModifier', [
             'data' => &$data,
         ]);
 

--- a/src/Core/Hook/HookDispatcherAwareTrait.php
+++ b/src/Core/Hook/HookDispatcherAwareTrait.php
@@ -30,6 +30,7 @@ use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 
 /**
  * Trait EventDispatcherAwareTrait.
+ * @deprecated
  */
 trait HookDispatcherAwareTrait
 {
@@ -39,24 +40,14 @@ trait HookDispatcherAwareTrait
     protected $hookDispatcher;
 
     /**
-     * @return HookDispatcherInterface|NullDispatcher
-     */
-    public function getHookDispatcher()
-    {
-        if (!$this->hookDispatcher) {
-            $this->hookDispatcher = new NullDispatcher();
-        }
-
-        return $this->hookDispatcher;
-    }
-
-    /**
      * Set hook dispatcher.
      *
      * @param HookDispatcherInterface $hookDispatcher
      */
     public function setHookDispatcher(HookDispatcherInterface $hookDispatcher)
     {
+        @trigger_error('HookDispatcherAwareTrait is deprecated as of 1.7.5 and will be removed in the next major version. If you need to inject HookDispatcherInterface use the constructor not setter injection.', E_USER_DEPRECATED);
+
         $this->hookDispatcher = $hookDispatcher;
     }
 }

--- a/src/Core/Hook/HookDispatcherAwareTrait.php
+++ b/src/Core/Hook/HookDispatcherAwareTrait.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Hook;
 
+use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
+
 /**
  * Trait EventDispatcherAwareTrait.
  */
@@ -35,6 +37,18 @@ trait HookDispatcherAwareTrait
      * @var HookDispatcherInterface
      */
     protected $hookDispatcher;
+
+    /**
+     * @return HookDispatcherInterface|NullDispatcher
+     */
+    public function getHookDispatcher()
+    {
+        if (!$this->hookDispatcher) {
+            $this->hookDispatcher = new NullDispatcher();
+        }
+
+        return $this->hookDispatcher;
+    }
 
     /**
      * Set hook dispatcher.

--- a/src/Core/Hook/HookDispatcherAwareTrait.php
+++ b/src/Core/Hook/HookDispatcherAwareTrait.php
@@ -26,10 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Core\Hook;
 
-use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
-
 /**
  * Trait EventDispatcherAwareTrait.
+ *
  * @deprecated
  */
 trait HookDispatcherAwareTrait
@@ -46,7 +45,7 @@ trait HookDispatcherAwareTrait
      */
     public function setHookDispatcher(HookDispatcherInterface $hookDispatcher)
     {
-        @trigger_error('HookDispatcherAwareTrait is deprecated as of 1.7.5 and will be removed in the next major version. If you need to inject HookDispatcherInterface use the constructor not setter injection.', E_USER_DEPRECATED);
+        @trigger_error('HookDispatcherAwareTrait is deprecated as of 1.7.5.1 and will be removed in the next major version. If you need to inject HookDispatcherInterface use the constructor not setter injection.', E_USER_DEPRECATED);
 
         $this->hookDispatcher = $hookDispatcher;
     }

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -114,8 +114,7 @@ services:
             - '@prestashop.core.grid.definition.factory.logs'
             - '@prestashop.core.grid.data_provider.log'
             - '@prestashop.core.grid.filter.form_factory'
-        calls:
-        - [setHookDispatcher, ['@prestashop.core.hook.dispatcher']]
+            - '@prestashop.core.hook.dispatcher'
 
     prestashop.core.grid.factory.email_logs:
         class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
@@ -123,8 +122,7 @@ services:
             - '@prestashop.core.grid.definition.factory.email_logs'
             - '@prestashop.core.grid.data_provider.email_logs'
             - '@prestashop.core.grid.filter.form_factory'
-        calls:
-        - [setHookDispatcher, ['@prestashop.core.hook.dispatcher']]
+            - '@prestashop.core.hook.dispatcher'
 
     prestashop.core.grid.factory.request_sql:
         class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
@@ -132,8 +130,7 @@ services:
             - '@prestashop.core.grid.definition.factory.request_sql'
             - '@prestashop.core.grid.data_provider.request_sql'
             - '@prestashop.core.grid.filter.form_factory'
-        calls:
-        - [setHookDispatcher, ['@prestashop.core.hook.dispatcher']]
+            - '@prestashop.core.hook.dispatcher'
 
     prestashop.core.grid.factory.backup:
         class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
@@ -141,8 +138,7 @@ services:
             - '@prestashop.core.grid.definition.factory.backup'
             - '@prestashop.core.backup.listing.grid_data_factory'
             - '@prestashop.core.grid.filter.form_factory'
-        calls:
-        - [setHookDispatcher, ['@prestashop.core.hook.dispatcher']]
+            - '@prestashop.core.hook.dispatcher'
 
     prestashop.core.grid.factory.webservice_key:
         class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
@@ -150,8 +146,7 @@ services:
             - '@prestashop.core.grid.definition.factory.webservice_key'
             - '@prestashop.core.grid.data_provider.webservice_key'
             - '@prestashop.core.grid.filter.form_factory'
-        calls:
-        - [setHookDispatcher, ['@prestashop.core.hook.dispatcher']]
+            - '@prestashop.core.hook.dispatcher'
 
     prestashop.core.grid.factory.meta:
         class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
@@ -159,8 +154,7 @@ services:
             - '@prestashop.core.grid.definition.factory.meta'
             - '@prestashop.core.grid.data_provider.meta'
             - '@prestashop.core.grid.filter.form_factory'
-        calls:
-        - [setHookDispatcher, ['@prestashop.core.hook.dispatcher']]
+            - '@prestashop.core.hook.dispatcher'
 
     # Grid presenter
     prestashop.core.grid.presenter.grid_presenter:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -8,8 +8,7 @@ services:
         class: 'PrestaShop\PrestaShop\Core\Grid\Filter\GridFilterFormFactory'
         arguments:
             - '@form.factory'
-        calls:
-            - [setHookDispatcher, ['@prestashop.core.hook.dispatcher']]
+            - '@prestashop.core.hook.dispatcher'
 
     # Grid data providers
     prestashop.core.grid.data_provider.log:
@@ -164,7 +163,7 @@ services:
 
     # Grid Query builder
     prestashop.core.grid.abstract_query_builder:
-        class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory'
+        class: 'PrestaShop\PrestaShop\Core\Grid\Query\AbstractDoctrineQueryBuilder'
         abstract: true
         arguments:
             - '@doctrine.dbal.default_connection'


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | GridFactory now has a constructor parameter for hookDispatcher, and HookDispatcherAwareTrait has a fallback to return a NullDispatcher
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12506
| How to test?  | See issue #12506

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12507)
<!-- Reviewable:end -->
