### PR TITLE
Solved problem with texture upload when attribute has hex color

### DIFF
--- a/admin-dev/themes/default/template/controllers/attributes/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/attributes/helpers/form/form.tpl
@@ -46,6 +46,13 @@
 			{else}
 				<p class="form-control-static">{l s='None' d='Admin.Global'}</p>
 			{/if}
+			{if isset($imageTextureUrl) && $imageTextureUrl && isset($imageTextureExists) && $imageTextureExists}
+			<p>
+				<a class="btn btn-default" href="{$imageTextureUrl}">
+					<i class="icon-trash"></i> {l s='Delete' d='Admin.Actions'}
+				</a>
+			</p>
+			{/if}
 		</div>
 	{else}
 		{$smarty.block.parent}

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -81,6 +81,8 @@ class AdminAttributesGroupsControllerCore extends AdminController
             ),
         );
         $this->fieldImageSettings = array('name' => 'texture', 'dir' => 'co');
+
+        $this->image_dir = 'co';
     }
 
     /**
@@ -794,12 +796,6 @@ class AdminAttributesGroupsControllerCore extends AdminController
                 }
                 $_POST['id_parent'] = 0;
                 $this->processSave($this->token);
-            }
-
-            if (Tools::getValue('id_attribute') && Tools::isSubmit('submitAddattribute') && Tools::getValue('color') && !Tools::getValue('filename')) {
-                if (file_exists(_PS_IMG_DIR_ . $this->fieldImageSettings['dir'] . '/' . (int) Tools::getValue('id_attribute') . '.jpg')) {
-                    unlink(_PS_IMG_DIR_ . $this->fieldImageSettings['dir'] . '/' . (int) Tools::getValue('id_attribute') . '.jpg');
-                }
             }
         } else {
             if (Tools::isSubmit('submitBulkdelete' . $this->table)) {

--- a/themes/classic/templates/catalog/_partials/product-variants.tpl
+++ b/themes/classic/templates/catalog/_partials/product-variants.tpl
@@ -44,7 +44,7 @@
               <label>
                 <input class="input-color" type="radio" data-product-attribute="{$id_attribute_group}" name="group[{$id_attribute_group}]" value="{$id_attribute}"{if $group_attribute.selected} checked="checked"{/if}>
                 <span
-                  {if $group_attribute.html_color_code}class="color" style="background-color: {$group_attribute.html_color_code}" {/if}
+                  {if $group_attribute.html_color_code && !$group_attribute.texture}class="color" style="background-color: {$group_attribute.html_color_code}" {/if}
                   {if $group_attribute.texture}class="color texture" style="background-image: url({$group_attribute.texture})" {/if}
                 ><span class="sr-only">{$group_attribute.name}</span></span>
               </label>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | solved issue from #10596 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10596 
| How to test?  | try to upload texture when attribute has hex color, you can't, which is regression from 1.6, try to do that after change, you can
| Sponsor company  | impSolutions

also, i've added possibility to delete texture...

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12523)
<!-- Reviewable:end -->
