### PR TITLE
Fix handling configuration in context of all stores / multi-store

### DIFF
--- a/src/Core/Domain/ShowcaseCard/CommandHandler/CloseShowcaseCardHandler.php
+++ b/src/Core/Domain/ShowcaseCard/CommandHandler/CloseShowcaseCardHandler.php
@@ -64,6 +64,6 @@ final class CloseShowcaseCardHandler implements CloseShowcaseCardHandlerInterfac
     public function handle(CloseShowcaseCardCommand $command)
     {
         $configurationName = $this->configurationMap->getConfigurationNameForClosedStatus($command->getShowcaseCard());
-        $this->configuration->set($configurationName, '1');
+        $this->configuration->setGlobalValue($configurationName, '1');
     }
 }

--- a/src/Core/Domain/ShowcaseCard/QueryHandler/GetShowcaseCardIsClosedHandler.php
+++ b/src/Core/Domain/ShowcaseCard/QueryHandler/GetShowcaseCardIsClosedHandler.php
@@ -67,6 +67,6 @@ final class GetShowcaseCardIsClosedHandler implements GetShowcaseCardIsClosedHan
     {
         $configurationName = $this->configurationMap->getConfigurationNameForClosedStatus($query->getShowcaseCard());
 
-        return (bool) $this->configuration->get($configurationName);
+        return (bool) $this->configuration->getGlobalValue($configurationName);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | at this moment we have no way to set globalValue in Configuration from migrated pages, this PR aims to fix this issue and resolve an issue with Showcards
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | Fixes #12390
| How to test?  | Follow steps in #12390 - problem should no longer exists

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12544)
<!-- Reviewable:end -->
