### PR TITLE
Do not show price when catalog mode is enabled

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -172,6 +172,16 @@ class ProductLazyArray extends AbstractLazyArray
     /**
      * @arrayAccess
      *
+     * @return bool
+     */
+    public function getCatalogMode()
+    {
+        return Configuration::get('PS_CATALOG_MODE');
+    }
+
+    /**
+     * @arrayAccess
+     *
      * @return string
      */
     public function getUrl()
@@ -556,7 +566,7 @@ class ProductLazyArray extends AbstractLazyArray
         ProductPresentationSettings $settings,
         array $product
     ) {
-        return $settings->showPrices && (bool) $product['show_price'];
+        return $settings->showPrices && (bool) $product['show_price'] && !$this->getCatalogMode();
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes #9937 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9937 
| How to test?  | Enable catalog mode before this change, prices are shown, enable catalog mode after this change, prices are properly hidden

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12546)
<!-- Reviewable:end -->
