### PR TITLE
WIP: load doctrine entity mappings from modules

### DIFF
--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use PrestaShopBundle\DependencyInjection\Compiler\DynamicRolePass;
 use PrestaShopBundle\DependencyInjection\Compiler\LoadServicesFromModulesPass;
 use PrestaShopBundle\DependencyInjection\Compiler\OverrideTranslatorServiceCompilerPass;
@@ -36,7 +37,9 @@ use PrestaShopBundle\DependencyInjection\Compiler\RouterPass;
 use PrestaShopBundle\DependencyInjection\PrestaShopExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\Yaml\Yaml;
 
 class PrestaShopBundle extends Bundle
 {
@@ -60,5 +63,61 @@ class PrestaShopBundle extends Bundle
         $container->addCompilerPass(new RouterPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new OverrideTranslatorServiceCompilerPass());
         $container->addCompilerPass(new OverrideTwigServiceCompilerPass());
+        $this->addModuleEntityMappingsPass($container);
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    private function addModuleEntityMappingsPass(ContainerBuilder $container)
+    {
+        $installedModules  = $container->getParameter('kernel.active_modules');
+
+        foreach ($this->getModulesPaths() as $modulePath) {
+            if (in_array($modulePath->getFilename(), $installedModules)
+                && file_exists($modulePath . '/config/doctrine.yml')
+            ) {
+                $config = Yaml::parse(file_get_contents($modulePath . '/config/doctrine.yml'));
+
+                foreach ($config['doctrine']['orm']['mappings'] as $key => $mapping) {
+                    $container->addCompilerPass($this->buildDoctrineOrmMappingPass($modulePath, $mapping));
+                }
+            }
+        }
+    }
+
+    /**
+     * @return \Iterator
+     */
+    private function getModulesPaths()
+    {
+        return Finder::create()->directories()->in(__DIR__ . '/../../modules')->depth(0);
+    }
+
+    /**
+     * @param array $mapping
+     *
+     * @return DoctrineOrmMappingsPass
+     */
+    private function buildDoctrineOrmMappingPass($path, $mapping)
+    {
+        [$namespaces, $managerParameters, $enabledParameter, $aliasMap] = [
+            [$path.'/'.$mapping['dir'] => $mapping['prefix']],
+            [],
+            false,
+            [$mapping['alias'] => $mapping['prefix']]
+        ];
+
+        if ($mapping['type'] === 'xml') {
+            return DoctrineOrmMappingsPass::createXmlMappingDriver(
+                $namespaces, $managerParameters, $enabledParameter, $aliasMap
+            );
+        } elseif ($mapping['type'] === 'yml') {
+            return DoctrineOrmMappingsPass::createYamlMappingDriver(
+                $namespaces, $managerParameters, $enabledParameter, $aliasMap
+            );
+        }
+
+        throw new \Exception(sprintf('mapping of type %s not supported for modules', $type));
     }
 }


### PR DESCRIPTION
This is a quick attempt at loading doctrine entity mappings from module configuration files. Mainly for discussion (context: I'm not familiar with PS and I've just begun a module. I'd rather use doctrine entities and wait for ps 1.7.6 to use it, instead of doing it another way)

Some remarks

 * is adding `DoctrineOrmMappingsPass` the correct approach ? (maybe there would be a more generic way to merge configuration from modules in the main configuration)

* table prefix needs some work. It can be handled with a doctrine listener from the module but there's probably better to do

* this code supposes the existence of a `config/doctrine.yml` file, following the same format as doctrine's mapping configuration in DoctrineBundle.

* so far, only used on a 1.7.5 installation

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Adds compiler passes to load doctrine entitiy mappings from modules
| Type?         | new feature
| Category?     | CO
| BC breaks?    | 
| Deprecations? | No
| Fixed ticket? | "Fixes #11596".
| How to test?  | not yet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12549)
<!-- Reviewable:end -->
