### PR TITLE
Improve the way VAT is managed for price calculation

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3298,12 +3298,17 @@ class ProductCore extends ObjectModel
         static $address = null;
         static $context = null;
 
-        if ($address === null) {
-            $address = new Address();
-        }
-
         if ($context == null) {
             $context = Context::getContext()->cloneContext();
+        }
+
+        if ($address === null) {
+            if (is_object($context->cart) && $context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')} != null) {
+                $id_address = $context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')};
+                $address = new Address($id_address);
+            } else {
+                $address = new Address();
+            }
         }
 
         if ($id_shop !== null && $context->shop->id != (int) $id_shop) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add some more checks for VAT calculation in EU
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9928 
| How to test?  | See below

In some conditions, we do not have the scenario related into https://github.com/PrestaShop/vatnumber/pull/7
Sometimes the first call to `VATNumberTaxManager::isAvailableForThisAddress()` does use `$cached_address` which is actually `NULL` (because this is the first call and not entering into the expected scenario `1 0 0 1 0 0` ...).

To fix this, we must edit Product class because the call is coming from there (a simple `Product::priceCalculation` from category page).
We can see here that the current cart address isn't retrieved but only country, state & postcode are set.

This is why we want to introduce a better address retrieving process and getting it directly from the cart context.
It will fix this weird scenario, and changes will probably be needed into vatnumber module?

The source of the issue is here, into `Product` class, not into vatnumber

cc @Quetzacoalt91

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12550)
<!-- Reviewable:end -->
