### PR TITLE
Fix bad file path in IE CSS spliter (ccc) when shop has base URI

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -640,7 +640,7 @@ class MediaCore
         foreach ($compiled_css as $css => $media) {
             $file_info = parse_url($css);
             $file_basename = basename($file_info['path']);
-            $css_content = file_get_contents(_PS_ROOT_DIR_.$file_info['path']);
+            $css_content = file_get_contents(_PS_ROOT_DIR_.Tools::str_replace_once(__PS_BASE_URI__, '/', $file_info['path']));
             $count = $splitter->countSelectors($css_content) - $css_rule_limit;
             if (($count / $css_rule_limit) > 0) {
                 $part = 2;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | When client is IE <= 9, the css splitter splits the CSS in various files. If a shop has a base URI, the paths that need to opened are non-existent.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a.
| How to test?  | Enable multishop with one shop that is located in a virtual URI (for example, `/fr/`; Enable CCC; Change your browser's User Agent to IE <= 9 (see screenshot below); Open any front office page of that shop; Check logs.

Example log before this fix:
```
PHP Warning:  file_get_contents([...]/httpdocs/fr/themes/default-bootstrap/cache/v_438_d3bbfb3930f1a35f47191d3e8008c14a_all.css): failed to open stream: No such file or directory in [...]/httpdocs/classes/Media.php on line 643
```

How to change your browser User Agent (Google Chrome):

![screenshot 2019-02-13 at 13 05 20](https://user-images.githubusercontent.com/898057/52710868-c0536e00-2f90-11e9-894a-4e1fba0d2a6d.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12554)
<!-- Reviewable:end -->
