### PR TITLE
Added the ability to manage and download Attachments via Webservice.

### DIFF
--- a/classes/Attachment.php
+++ b/classes/Attachment.php
@@ -56,6 +56,29 @@ class AttachmentCore extends ObjectModel
             'name' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 32),
             'description' => array('type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isCleanHtml'),
         ),
+        'associations' => array(
+            'products' => array('type' => self::HAS_MANY, 'field' => 'id_product', 'object' => 'Product', 'association' => 'product_attachment'),
+        ),
+    );
+
+    protected $webserviceParameters = array(
+        'objectNodeNames' => 'attachments',
+        'hidden_fields' => array(),
+        'fields' => array(
+            'file' => array(),
+            'file_name' => array(),
+            'file_size' => array(),
+            'mime' => array(),
+        ),
+        'associations' => array(
+            'products' => array(
+                'resource' => 'product',
+                'api' => 'products',
+                'fields' => array(
+                    'id' => array('required' => true),
+                ),
+            ),
+        ),
     );
 
     /**
@@ -148,6 +171,32 @@ class AttachmentCore extends ObjectModel
     }
 
     /**
+     * Unassociate all products from the current object
+     *
+     * @param bool $update_cache
+     *                           If set to true attachment cache will be updated
+     *
+     * @return bool Deletion result
+     */
+    public function deleteAttachments($update_attachment_cache = true)
+    {
+        $product_ids = Db::getInstance()->executeS('
+			SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product_attachment`
+			WHERE `id_attachment` = ' . (int) $this->id);
+        $res = Db::getInstance()->execute('
+			DELETE FROM `' . _DB_PREFIX_ . 'product_attachment`
+			WHERE `id_attachment` = ' . (int) $this->id);
+
+        if (isset($update_attachment_cache) && (bool) $update_attachment_cache === true) {
+            foreach ($product_ids as $product_id) {
+                Product::updateCacheAttachment((int) $product_id);
+            }
+        }
+
+        return $res;
+    }
+
+    /**
      * Delete Product attachments for the given Product ID.
      *
      * @param int $idProduct Product ID
@@ -237,7 +286,7 @@ class AttachmentCore extends ObjectModel
             $sql = 'SELECT * FROM `' . _DB_PREFIX_ . 'product_attachment` pa
 					LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (pa.`id_product` = pl.`id_product`' . Shop::addSqlRestrictionOnLang('pl') . ')
 					WHERE `id_attachment` IN (' . implode(',', array_map('intval', $idsAttachments)) . ')
-						AND pl.`id_lang` = ' . (int) $idLang;
+					AND pl.`id_lang` = ' . (int) $idLang;
             $tmp = Db::getInstance()->executeS($sql);
             $productAttachments = array();
             foreach ($tmp as $t) {
@@ -248,5 +297,37 @@ class AttachmentCore extends ObjectModel
         } else {
             return false;
         }
+    }
+
+    /**
+     * Get attachment products ids of current attachment for association.
+     *
+     * @return array
+     */
+    public function getWsProducts()
+    {
+        $result = Db::getInstance()->executeS('SELECT p.`id_product` AS id
+			FROM `' . _DB_PREFIX_ . 'product_attachment` pa
+			LEFT JOIN `' . _DB_PREFIX_ . 'product` p ON (p.id_product = pa.id_product)
+			' . Shop::addSqlAssociation('product', 'p') . '
+			WHERE pa.`id_attachment` = ' . (int) $this->id);
+
+        return $result;
+    }
+
+    /**
+     * Set products ids of current attachment for association.
+     *
+     * @param $products ids
+     */
+    public function setWsProducts($products)
+    {
+        $this->deleteAttachments(true);
+        foreach ($products as $product) {
+            Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'product_attachment` (`id_product`, `id_attachment`) VALUES (' . (int) $product['id'] . ', ' . (int) $this->id . ')');
+            Product::updateCacheAttachment((int) $product['id']);
+        }
+
+        return true;
     }
 }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -413,6 +413,7 @@ class ProductCore extends ObjectModel
             'tax_rules_group' => array('type' => self::HAS_ONE),
             'categories' => array('type' => self::HAS_MANY, 'field' => 'id_category', 'object' => 'Category', 'association' => 'category_product'),
             'stock_availables' => array('type' => self::HAS_MANY, 'field' => 'id_stock_available', 'object' => 'StockAvailable', 'association' => 'stock_availables'),
+            'attachments' => array('type' => self::HAS_MANY, 'field' => 'id_attachment', 'object' => 'Attachment', 'association' => 'product_attachment'),
         ),
     );
 
@@ -514,6 +515,13 @@ class ProductCore extends ObjectModel
                     'id_product_attribute' => array('required' => true),
                 ),
                 'setter' => false,
+            ),
+            'attachments' => array(
+                'resource' => 'attachment',
+                'api' => 'attachments',
+                'fields' => array(
+                    'id' => array('required' => true),
+                ),
             ),
             'accessories' => array(
                 'resource' => 'product',
@@ -6113,6 +6121,39 @@ class ProductCore extends ObjectModel
         return Db::getInstance()->executeS('SELECT `id_stock_available` id, `id_product_attribute`
             FROM `' . _DB_PREFIX_ . 'stock_available`
             WHERE `id_product`=' . (int) $this->id . StockAvailable::addSqlShopRestriction());
+    }
+
+    /**
+     * Webservice getter : get product attachments ids of current product for association
+     *
+     * @return array
+     */
+    public function getWsAttachments()
+    {
+        $result = Db::getInstance()->executeS('SELECT a.`id_attachment` AS id
+			FROM `' . _DB_PREFIX_ . 'product_attachment` pa
+			LEFT JOIN `' . _DB_PREFIX_ . 'attachment` a ON (pa.id_attachment = a.id_attachment)
+			' . Shop::addSqlAssociation('attachment', 'a') . '
+			WHERE pa.`id_product` = ' . (int) $this->id);
+
+        return $result;
+    }
+
+    /**
+     * Webservice setter : set product attachments ids of current product for association
+     *
+     * @param $attachments ids
+     */
+    public function setWsAttachments($attachments)
+    {
+        $this->deleteAttachments(true);
+        foreach ($attachments as $attachment) {
+            Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'product_attachment` 
+    				(`id_product`, `id_attachment`) VALUES (' . (int) $this->id . ', ' . (int) $attachment['id'] . ')');
+        }
+        Product::updateCacheAttachment((int) $this->id);
+
+        return true;
     }
 
     public function getWsTags()

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -49,7 +49,7 @@ class WebserviceRequestCore
      *
      * @var WebserviceSpecificManagementImages|WebserviceSpecificManagementSearch|WebserviceSpecificManagementAttachments|false
      */
-    protected $objectSpecificManagement = false;
+    public $objectSpecificManagement = false;
 
     /**
      * Base PrestaShop webservice URL.
@@ -239,19 +239,6 @@ class WebserviceRequestCore
         return self::$_instance;
     }
 
-    /*
-    protected function getOutputObject($type)
-    {
-        switch ($type)
-        {
-            case 'XML' :
-            default :
-                $obj_render = new WebserviceOutputXML();
-                break;
-        }
-        return $obj_render;
-    }
-    */
     protected function getOutputObject($type)
     {
         // set header param in header or as get param
@@ -1405,7 +1392,7 @@ class WebserviceRequestCore
      *
      * @return bool
      */
-    protected function executeEntityPost()
+    public function executeEntityPost()
     {
         return $this->saveEntityFromXml(201);
     }
@@ -1415,7 +1402,7 @@ class WebserviceRequestCore
      *
      * @return bool
      */
-    protected function executeEntityPut()
+    public function executeEntityPut()
     {
         return $this->saveEntityFromXml(200);
     }
@@ -1425,7 +1412,7 @@ class WebserviceRequestCore
      *
      * @return bool
      */
-    protected function executeEntityDelete()
+    public function executeEntityDelete()
     {
         $objects = array();
         $arr_avoid_id = array();

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -45,9 +45,9 @@ class WebserviceRequestCore
     protected $_outputEnabled = true;
 
     /**
-     * Set if the management is specific or if it is classic (entity management).
+     * Set if the management is specific or if it is classic (entity management)
      *
-     * @var WebserviceSpecificManagementImages|WebserviceSpecificManagementSearch|false
+     * @var WebserviceSpecificManagementImages|WebserviceSpecificManagementSearch|WebserviceSpecificManagementAttachments|false
      */
     protected $objectSpecificManagement = false;
 
@@ -286,6 +286,7 @@ class WebserviceRequestCore
     {
         $resources = array(
             'addresses' => array('description' => 'The Customer, Brand and Customer addresses', 'class' => 'Address'),
+            'attachments' => array('description' => 'The product Attachments', 'class' => 'Attachment', 'specific_management' => true),
             'carriers' => array('description' => 'The Carriers', 'class' => 'Carrier'),
             'carts' => array('description' => 'Customer\'s carts', 'class' => 'Cart'),
             'cart_rules' => array('description' => 'Cart rules management', 'class' => 'CartRule'),
@@ -1797,7 +1798,7 @@ class WebserviceRequestCore
      *
      * @return array with displaying informations (used in the dispatcher)
      */
-    protected function returnOutput()
+    public function returnOutput()
     {
         $return = array();
 

--- a/classes/webservice/WebserviceSpecificManagementAttachments.php
+++ b/classes/webservice/WebserviceSpecificManagementAttachments.php
@@ -1,0 +1,282 @@
+<?php
+
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author 	PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2016 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificManagementInterface
+{
+    /**
+     * @var WebserviceOutputBuilder
+     */
+    protected $objOutput;
+
+    protected $output;
+
+    /**
+     * @var WebserviceRequest
+     */
+    protected $wsObject;
+
+    /**
+     * The configuration parameters of the current resource
+     *
+     * @var array
+     */
+    public $resourceConfiguration;
+
+    protected $attachment_id;
+
+    protected $displayFile;
+
+    /*
+     * ------------------------------------------------
+     * GETTERS & SETTERS
+     * ------------------------------------------------
+     */
+
+    /**
+     * @param WebserviceOutputBuilderCore $obj
+     *
+     * @return WebserviceSpecificManagementInterface
+     */
+    public function setObjectOutput(WebserviceOutputBuilderCore $obj)
+    {
+        $this->objOutput = $obj;
+
+        return $this;
+    }
+
+    public function getObjectOutput()
+    {
+        return $this->objOutput;
+    }
+
+    public function setWsObject(WebserviceRequestCore $obj)
+    {
+        $this->wsObject = $obj;
+
+        return $this;
+    }
+
+    public function getWsObject()
+    {
+        return $this->wsObject;
+    }
+
+    public function getContent()
+    {
+        if ($this->displayFile) {
+            // if displayFile is set, present the file (download)
+            $this->objOutput->setHeaderParams('Content-Type', $this->displayFile['mime']);
+            $this->objOutput->setHeaderParams('Content-Length', $this->displayFile['file_size']);
+            $this->objOutput->setHeaderParams('Content-Disposition', 'attachment; filename="' . utf8_decode($this->displayFile['file_name']) . '"');
+
+            return file_get_contents($this->displayFile['file']);
+        } else {
+            // Emulate non-specific management
+            $this->wsObject->objectSpecificManagement = false;
+            $this->wsObject->returnOutput();
+        }
+    }
+
+    public function manage()
+    {
+        $this->manageAttachments();
+
+        return $this->wsObject->getOutputEnabled();
+    }
+
+    public function manageAttachments()
+    {
+        // Pre configuration...
+        if (isset($this->wsObject->urlSegment)) {
+            for ($i = 1; $i < 6; ++$i ) {
+                if (count($this->wsObject->urlSegment) == $i) {
+                    $this->wsObject->urlSegment[$i] = '';
+                }
+            }
+        }
+
+        if ($this->wsObject->urlSegment[0] != '') {
+            /**
+             * @var ObjectModel
+             */
+            $object = new Attachment();
+            $this->wsObject->resourceConfiguration = $object->getWebserviceParameters();
+        }
+
+        /*
+         * Available cases api/...:
+         *
+         * [Utilizes default webservice handling by emulating non-specific management]
+         *  attachments/ ("attachment_list")
+         *      GET     (xml/json) (list of attachments)
+         *      POST    (xml/json) (create/new) (not recommended, as no file will be automatically set (see attachments/file))
+         *  attachments/[1,+] ("attachment_description") (N-3)
+         *      GET     (xml/json)
+         *      PUT     (xml/json) (update)
+         *      DELETE
+         *
+         * [Specific management for file upload/download}
+         *  attachments/file/
+         *      POST    (bin) (create new attachment)
+         *  attachments/file/[1,+] (file management)
+         *      GET     (bin) (download file)
+         *      PUT     (bin) (upload/update file)
+         *      DELETE
+         */
+
+        if ($this->wsObject->urlSegment[1] == 'file') {
+            // File handling (upload/download)
+            switch ($this->wsObject->method) {
+                case 'GET':
+                case 'HEAD':
+                    $this->displayFile = $this->executeFileGetAndHead();
+                    break;
+                case 'POST':
+                case 'PUT':
+                    $this->executeFileAddAndEdit();
+
+                    // Emulate get/head to return output
+                    $this->wsObject->method = 'GET';
+                    $this->wsObject->urlSegment[1] = $this->attachment_id;
+                    $this->wsObject->urlSegment[2] = '';
+                    $this->wsObject->executeEntityGetAndHead();
+                    break;
+                case 'DELETE':
+                    $attachment = new Attachment((int) $this->wsObject->urlSegment[1]);
+                    $attachment->delete();
+                    break;
+            }
+        } else {
+            // Default handling via WebserviceRequest
+            switch ($this->wsObject->method) {
+                case 'GET':
+                case 'HEAD':
+                    $this->wsObject->executeEntityGetAndHead();
+                    break;
+                case 'POST':
+                    $this->wsObject->executeEntityPost();
+                    break;
+                case 'PUT':
+                    $this->wsObject->executeEntityPut();
+                    break;
+                case 'DELETE':
+                    $this->wsObject->executeEntityDelete();
+                    break;
+            }
+        }
+        // Need to set an object for the WebserviceOutputBuilder object in any case
+        // because schema need to get webserviceParameters of this object
+        if (isset($object)) {
+            $this->wsObject->objects['empty'] = $object;
+        }
+    }
+
+    /**
+     * Handles attachment file download
+     *
+     * @throws WebserviceException if attachment is not existing or file not available
+     *
+     * @return string[] file details
+     */
+    public function executeFileGetAndHead()
+    {
+        $a = new Attachment((int) $this->wsObject->urlSegment[2]);
+        if ($a) {
+            // Physical file location
+            $file = _PS_DOWNLOAD_DIR_ . $a->file;
+            // Check if file exists
+            if (file_exists($file)) {
+                // Return file details
+                return array(
+                    'file' => $file,
+                    'mime' => $a->mime,
+                    'file_name' => $a->file_name,
+                    'file_size' => $a->file_size,
+                );
+            } else {
+                throw new WebserviceException(sprintf('Unable to load the attachment file for attachment %d', $this->wsObject->urlSegment[2]), array(
+                    1,
+                    500,
+                ));
+            }
+        } else {
+            throw new WebserviceException(sprintf('Attachment %d not found', $this->wsObject->urlSegment[2]), array(
+                1,
+                500,
+            ));
+        }
+    }
+
+    /**
+     * Handles file upload
+     *
+     * Creates new attachment or replaces existing with a new file.
+     * [PUT] update existing attachment file
+     * [POST] create new attachment
+     */
+    public function executeFileAddAndEdit()
+    {
+        // Load attachment with or without id depending on method
+        $a = $this->wsObject->method == 'PUT' ? new Attachment((int) $this->wsObject->urlSegment[1]) : new Attachment();
+
+        // Check form data
+        if (isset($_FILES['file']) && is_uploaded_file($_FILES['file']['tmp_name'])) {
+            // Ensure file is within allowed size limit
+            if ($_FILES['file']['size'] > (Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024)) {
+                $this->wsObject->errors[] = sprintf($this->l('The file is too large. Maximum size allowed is: %1$d kB. The file you are trying to upload is %2$d kB.'), (Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024), number_format(($_FILES['file']['size'] / 1024), 2, '.', ''));
+            } else {
+                // Assign unique id
+                do {
+                    $uniqid = sha1(microtime());
+                } while (file_exists(_PS_DOWNLOAD_DIR_ . $uniqid));
+
+                $a->file_name = $_FILES['file']['name'];
+                $a->file = $uniqid;
+                $a->mime = $_FILES['file']['type'];
+                $a->name[Configuration::get('PS_LANG_DEFAULT')] = $_POST['name'];
+
+                // Move file to download dir
+                if (!move_uploaded_file($_FILES['file']['tmp_name'], _PS_DOWNLOAD_DIR_ . $uniqid)) {
+                    $this->wsObject->errors[] = $this->l('Failed to copy the file.');
+                    unlink(_PS_DOWNLOAD_DIR_ . $a->file);
+                    $a->delete();
+                } else {
+                    // Create/update attachment
+                    if ($a->id) {
+                        $a->update();
+                    } else {
+                        $a->add();
+                    }
+                    // Remember affected entity
+                    $this->attachment_id = $a->id;
+                }
+
+                // Delete temp file
+                @unlink($_FILES['file']['tmp_name']);
+            }
+        }
+    }
+}

--- a/classes/webservice/WebserviceSpecificManagementAttachments.php
+++ b/classes/webservice/WebserviceSpecificManagementAttachments.php
@@ -111,7 +111,7 @@ class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificM
     {
         // Pre configuration...
         if (isset($this->wsObject->urlSegment)) {
-            for ($i = 1; $i < 6; ++$i ) {
+            for ($i = 1; $i < 6; ++$i) {
                 if (count($this->wsObject->urlSegment) == $i) {
                     $this->wsObject->urlSegment[$i] = '';
                 }


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | develop |
| Description? | This pull request adds the ability to manage and download Attachments via Webservice. It also adds Attachments associations to Products and reverse (Product association for Attachments). |
| Type? | new feature |
| Category? | WS |
| BC breaks? | No, it's unlikely |
| Deprecations? | No |
| Fixed ticket? | No tickets, but multiple forum entries concerning this.<br>https://www.prestashop.com/forums/topic/322464-products-attachments-webservice/<br>https://www.prestashop.com/forums/topic/503882-webservice-for-downloading-product-attachments/<br>https://www.prestashop.com/forums/topic/430091-webservice-add-product-attachment/<br>https://www.prestashop.com/forums/topic/433842-products-attachments-via-web-service-possibile/<br>https://www.prestashop.com/forums/topic/275248-api-and-products-attachments/<br>https://www.prestashop.com/forums/topic/433666-file-upload-via-web-service/ <br><br>Probably missed some topics also. |
| How to test? | Use Webservice to add/update Attachments, check attachment associations for products via webservice. I should probably mention that not all of the functionality added has been thoroughly tested, however I've tested the binary upload and the fetching part of both endpoints. |
## Notes:

This is one of the essential parts which seem to be missing from PrestaShop in terms of Webservice.
Most other management can already be done through webservice, but Attachments are not handled yet.

In order to reuse functionality of WebserviceRequest for the handling of details; i.e. Attachment details handled via xml/json, some methods and variables of WebserviceRequest requires enhanced visibility in order to be used through the WebserviceSpecificManagementInterface. I can't see how this would not be backwards compatible, but perhaps someone else has more knowledge.

In order handle default request for presenting and updating Attachment details, I decided to emulate
such a request by unassigning the $objectSpecificManagement within the specific management and later calling the WebserviceRequest default operation.

Variables/Methods required to be **public** (WebserviceRequest.php):
_$objectSpecificManagement
returnOutput()
entityExecutePost()
entityExecutePut()
entityExecuteDelete()_

The binary handling of Attachment files has been more or less copied from the AdminAttachmentsController with the addition of some comments.

For the specific management part of the addition, I studied the specific management of images and tried to follow its structure for it to seemlessly integrate into the project.

Furthermore I hope that this could also work its way into the 1.6.1.x branch and releases as I see this as a critical feature that should have been implemented earlier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/5615)
<!-- Reviewable:end -->
