### PR TITLE
Remove translations from db when Language is deleted

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -521,9 +521,11 @@ class LanguageCore extends ObjectModel
 
             // Database translations deletion
             $result = Db::getInstance()->executeS('SHOW TABLES FROM `' . _DB_NAME_ . '`');
+            $tableNameKey = 'Tables_in_' . _DB_NAME_;
+
             foreach ($result as $row) {
-                if (isset($row['Tables_in_' . _DB_NAME_]) && !empty($row['Tables_in_' . _DB_NAME_]) && preg_match('/' . preg_quote(_DB_PREFIX_) . '_lang/', $row['Tables_in_' . _DB_NAME_])) {
-                    if (!Db::getInstance()->execute('DELETE FROM `' . $row['Tables_in_' . _DB_NAME_] . '` WHERE `id_lang` = ' . (int) $this->id)) {
+                if (isset($row[$tableNameKey]) && !empty($row[$tableNameKey]) && preg_match('/_lang$/', $row[$tableNameKey])) {
+                    if (!Db::getInstance()->execute('DELETE FROM `' . $row[$tableNameKey] . '` WHERE `id_lang` = ' . (int) $this->id)) {
                         return false;
                     }
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When language is being deleted from PrestaShop, all associated translations should be deleted from database as well. Before this PR, if you delete language from Back Office, translations in database would remain. Thanks to @zuk3975 for finding this issue!
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | See below.

### How to test

1. Add new Language to PrestaShop (i'll assume new language ID is 2).
2. Check that in database every `*_lang` table has translation with `id_lang` 2.
3. Delete language with ID 2 from Back Office.
4. Check that in database every `*_lang` table does not have translation with `id_lang` 2 anymore.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12559)
<!-- Reviewable:end -->
