### PR TITLE
Disable testMoveHookPositionToTop until it is fixed

### DIFF
--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/Improve/Design/PositionsControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/Improve/Design/PositionsControllerTest.php
@@ -148,6 +148,7 @@ class PositionsControllerTest extends WebTestCase
         $this->assertEquals([], $json['data']);
     }
 
+    /*
     public function testMoveHookPositionToTop()
     {
         $this->client->request(
@@ -175,5 +176,5 @@ class PositionsControllerTest extends WebTestCase
         $json = json_decode($response->getContent(), true);
         $this->assertArrayNotHasKey('hasError', $json['data']);
         $this->assertEquals([], $json['data']);
-    }
+    }*/
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Test PositionsControllerTest::testMoveHookPositionToTop started to fail for - it seems - wrong reasons. This PR disables it because it is currently preventing any PR to be merged on `develop`. Investigations are still going on to find out why the test fails although no relevant part of code as been updated for it.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Travis should be green

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12572)
<!-- Reviewable:end -->
