### PR TITLE
Fix wrong use of alias when registering new hook

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -255,6 +255,22 @@ class HookCore extends ObjectModel
     }
 
     /**
+     * Indicates whether the provided hook is an alias of another one
+     *
+     * @param string $hookName Hook name to test
+     *
+     * @return bool TRUE if the hook is an alias, false otherwise
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    public static function isAlias(string $hookName): bool
+    {
+        $aliases = self::getCanonicalHookNames();
+
+        return isset($aliases[strtolower($hookName)]);
+    }
+
+    /**
      * Get the list of hook aliases, indexed by hook name
      *
      * @since 1.7.1.0

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -211,6 +211,8 @@ class HookCore extends ObjectModel
 
     /**
      * Return hook ID from name.
+     *
+     * @throws PrestaShopObjectNotFoundException
      */
     public static function getNameById($hook_id)
     {
@@ -220,6 +222,11 @@ class HookCore extends ObjectModel
 							SELECT `name`
 							FROM `' . _DB_PREFIX_ . 'hook`
 							WHERE `id_hook` = ' . (int) $hook_id);
+
+            if (false === $result) {
+                throw new PrestaShopObjectNotFoundException('The hook id #%s does not exist in database', $hook_id);
+            }
+
             Cache::store($cache_id, $result);
 
             return $result;

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -281,7 +281,7 @@ class HookCore extends ObjectModel
     {
         $cacheId = 'hook_aliases';
         if (!Cache::isStored($cacheId)) {
-            $hookAliasList = Db::getInstance()->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'hook_alias`');
+            $hookAliasList = Db::getInstance()->executeS('SELECT `name`, `alias` FROM `' . _DB_PREFIX_ . 'hook_alias`');
             $hookAliases = [];
             if ($hookAliasList) {
                 foreach ($hookAliasList as $ha) {
@@ -373,7 +373,6 @@ class HookCore extends ObjectModel
      * @return bool
      *
      * @since 1.7.1.0
-     *
      */
     public static function isHookCallableOn(Module $module, string $hookName, $testAliases = true): bool
     {
@@ -457,15 +456,15 @@ class HookCore extends ObjectModel
      * @since 1.5.0
      *
      * @return array<int, array<int, array{
-     *      id_hook: string|int,
-     *      title: string,
-     *      description: string,
-     *      hm.position: string|int,
-     *      m.position: string|int,
-     *      id_module: string,
-     *      name: string,
-     *      active: string|int
-     * }>>
+     *                    id_hook: string|int,
+     *                    title: string,
+     *                    description: string,
+     *                    hm.position: string|int,
+     *                    m.position: string|int,
+     *                    id_module: string,
+     *                    name: string,
+     *                    active: string|int
+     *                    CS }>>
      */
     public static function getHookModuleList()
     {

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -137,7 +137,7 @@ class HookCore extends ObjectModel
             return 'displayHeader';
         }
 
-        $hookNamesByAlias = Hook::getHookAliasDictionary();
+        $hookNamesByAlias = Hook::getCanonicalHookNames();
         if (isset($hookNamesByAlias[$loweredName])) {
             return $hookNamesByAlias[$loweredName];
         }
@@ -236,7 +236,7 @@ class HookCore extends ObjectModel
     }
 
     /**
-     * Returns a list of hook names, indexed by alias.
+     * Returns a list of hook names, indexed by lower case alias.
      *
      * @since 1.5.0
      *
@@ -251,7 +251,7 @@ class HookCore extends ObjectModel
             E_USER_DEPRECATED
         );
 
-        return self::getHookAliasDictionary();
+        return self::getCanonicalHookNames();
     }
 
     /**
@@ -321,13 +321,13 @@ class HookCore extends ObjectModel
     }
 
     /**
-     * Returns a list of hook names, indexed by alias.
+     * Returns a list of hook names, indexed by lower case alias.
      *
      * @return array Array of hook names, indexed by lower case alias
      *
      * @throws PrestaShopDatabaseException
      */
-    private static function getHookAliasDictionary(): array
+    private static function getCanonicalHookNames(): array
     {
         $cacheId = 'hook_alias';
 
@@ -415,7 +415,7 @@ class HookCore extends ObjectModel
      */
     public static function getRetroHookName($hookName)
     {
-        $hookNamesByAlias = static::getHookAliasDictionary();
+        $hookNamesByAlias = static::getCanonicalHookNames();
         if (isset($hookNamesByAlias[strtolower($hookName)])) {
             // return the canonical name (?)
             return $hookNamesByAlias[strtolower($hookName)];

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -521,11 +521,7 @@ class HookCore extends ObjectModel
     public static function registerHook($module_instance, $hook_name, $shop_list = null)
     {
         $return = true;
-        if (is_array($hook_name)) {
-            $hook_names = $hook_name;
-        } else {
-            $hook_names = [$hook_name];
-        }
+        $hook_names = (is_array($hook_name)) ? $hook_name : [$hook_name];
 
         foreach ($hook_names as $hook_name) {
             // Check hook name validation and if module is installed
@@ -536,13 +532,16 @@ class HookCore extends ObjectModel
                 return false;
             }
 
-            // Retrocompatibility
-            $hook_name_bak = $hook_name;
-            if ($alias = Hook::getRetroHookName($hook_name)) {
-                $hook_name = $alias;
-            }
+            $hook_name = static::normalizeHookName($hook_name);
 
-            Hook::exec('actionModuleRegisterHookBefore', ['object' => $module_instance, 'hook_name' => $hook_name]);
+            Hook::exec(
+                'actionModuleRegisterHookBefore',
+                array(
+                    'object' => $module_instance,
+                    'hook_name' => $hook_name,
+                )
+            );
+
             // Get hook id
             $id_hook = Hook::getIdByName($hook_name);
 

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -259,9 +259,9 @@ class HookCore extends ObjectModel
      *
      * @since 1.7.1.0
      *
-     * @return array Array of hookName => hookAliases[]
+     * @return string[][] Array of hookName => hookAliases[]
      */
-    private static function getHookAliasesList()
+    private static function getHookAliasesList(): array
     {
         $cacheId = 'hook_aliases';
         if (!Cache::isStored($cacheId)) {
@@ -328,7 +328,7 @@ class HookCore extends ObjectModel
      *
      * @throws PrestaShopDatabaseException
      */
-    private static function getHookAliasDictionary()
+    private static function getHookAliasDictionary(): array
     {
         $cacheId = 'hook_alias';
 
@@ -353,12 +353,12 @@ class HookCore extends ObjectModel
      *
      * @since 1.7.1.0
      *
-     * @param static $module
+     * @param Module $module
      * @param string $hookName
      *
      * @return bool
      */
-    private static function isHookCallableOn($module, $hookName)
+    private static function isHookCallableOn(Module $module, string $hookName): bool
     {
         $aliases = array_merge(
             [$hookName],
@@ -379,13 +379,13 @@ class HookCore extends ObjectModel
      *
      * @since 1.7.1.0
      *
-     * @param static $module
+     * @param Module $module
      * @param string $hookName
      * @param array $hookArgs
      *
-     * @return string
+     * @return mixed
      */
-    private static function callHookOn($module, $hookName, $hookArgs)
+    private static function callHookOn(Module $module, string $hookName, array $hookArgs)
     {
         if (is_callable([$module, 'hook' . $hookName])) {
             return Hook::coreCallHook($module, 'hook' . $hookName, $hookArgs);

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -363,12 +363,18 @@ class HookCore extends ObjectModel
      */
     private static function isHookCallableOn($module, $hookName)
     {
-        $aliases = Hook::getHookAliasesFor($hookName);
-        $aliases[] = $hookName;
+        $aliases = array_merge(
+            [$hookName],
+            Hook::getHookAliasesFor($hookName)
+        );
 
-        return array_reduce($aliases, function ($prev, $curr) use ($module) {
-            return $prev || is_callable([$module, 'hook' . $curr]);
-        }, false);
+        foreach ($aliases as $currentHookName) {
+            if (is_callable(array($module, 'hook' . $currentHookName))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -288,7 +288,6 @@ class HookCore extends ObjectModel
      * @return string[] List of aliases
      *
      * @since 1.7.1.0
-     *
      */
     private static function getHookAliasesFor(string $canonicalHookName): array
     {
@@ -334,7 +333,7 @@ class HookCore extends ObjectModel
 
         if (!Cache::isStored($cacheId)) {
             $databaseResults = Db::getInstance()->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'hook_alias`');
-            $hooksByAlias = array();
+            $hooksByAlias = [];
             if ($databaseResults) {
                 foreach ($databaseResults as $record) {
                     $hooksByAlias[strtolower($record['alias'])] = $record['name'];
@@ -366,7 +365,7 @@ class HookCore extends ObjectModel
         );
 
         foreach ($aliases as $currentHookName) {
-            if (is_callable(array($module, 'hook' . $currentHookName))) {
+            if (is_callable([$module, 'hook' . $currentHookName])) {
                 return true;
             }
         }
@@ -523,6 +522,7 @@ class HookCore extends ObjectModel
      * @param int[]|null $shop_list List of shop ids
      *
      * @return bool
+     *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
@@ -666,12 +666,11 @@ class HookCore extends ObjectModel
      *
      * @param string|null $hookName Hook name (null to return all hooks)
      *
-     * @return array[]|false Returns an array of hook registrations, or false if the provided hook name is not registered.
+     * @return array[]|false returns an array of hook registrations, or false if the provided hook name is not registered
      *
      * @throws PrestaShopDatabaseException
      *
      * @since 1.5.0
-     *
      */
     public static function getHookModuleExecList($hookName = null)
     {
@@ -690,7 +689,6 @@ class HookCore extends ObjectModel
         if (!empty($aliases)) {
             $alreadyIncludedModuleIds = array_column($modulesToInvoke, 'id_module');
             foreach ($aliases as $alias) {
-
                 $hookAlias = strtolower($alias);
                 if (isset($allHookRegistrations[$hookAlias])) {
                     foreach ($allHookRegistrations[$hookAlias] as $registeredAlias) {
@@ -764,6 +762,7 @@ class HookCore extends ObjectModel
             if ($isRegistryEnabled) {
                 $hookRegistry->collect();
             }
+
             return ($array_return) ? [] : '';
         }
 
@@ -772,6 +771,7 @@ class HookCore extends ObjectModel
             if ($isRegistryEnabled) {
                 $hookRegistry->collect();
             }
+
             return ($array_return) ? [] : false;
         }
 
@@ -988,6 +988,7 @@ class HookCore extends ObjectModel
      * @param string|null $hookName Hook name (to be used when the hook registration is dynamic and context sensitive)
      *
      * @return array[][]
+     *
      * @throws PrestaShopDatabaseException
      */
     private static function getAllHookRegistrations(Context $context, ?string $hookName): array
@@ -1147,7 +1148,7 @@ class HookCore extends ObjectModel
     /**
      * Returns all hook IDs, indexed by hook name.
      *
-     * @param bool $withAliases [default=false] If true, includes hook aliases along their canonical hook id.
+     * @param bool $withAliases [default=false] If true, includes hook aliases along their canonical hook id
      * @param bool $refreshCache [default=false] Force cache refresh
      *
      * @return int[]

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -131,12 +131,15 @@ class HookCore extends ObjectModel
      */
     public static function normalizeHookName($hookName)
     {
-        if (strtolower($hookName) == 'displayheader') {
+        $loweredName = strtolower($hookName);
+
+        if ($loweredName == 'displayheader') {
             return 'displayHeader';
         }
-        $hookAliasList = Hook::getHookAliasList();
-        if (isset($hookAliasList[strtolower($hookName)])) {
-            return $hookAliasList[strtolower($hookName)];
+
+        $hookNamesByAlias = Hook::getHookAliasDictionary();
+        if (isset($hookNamesByAlias[$loweredName])) {
+            return $hookNamesByAlias[$loweredName];
         }
 
         return $hookName;
@@ -247,21 +250,12 @@ class HookCore extends ObjectModel
      */
     public static function getHookAliasList()
     {
-        $cache_id = 'hook_alias';
-        if (!Cache::isStored($cache_id)) {
-            $hook_alias_list = Db::getInstance()->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'hook_alias`');
-            $hook_alias = [];
-            if ($hook_alias_list) {
-                foreach ($hook_alias_list as $ha) {
-                    $hook_alias[strtolower($ha['alias'])] = $ha['name'];
-                }
-            }
-            Cache::store($cache_id, $hook_alias);
+        @trigger_error(
+            __FUNCTION__ . ' is deprecated since version 1.7.1.0.',
+            E_USER_DEPRECATED
+        );
 
-            return $hook_alias;
-        }
-
-        return Cache::retrieve($cache_id);
+        return self::getHookAliasDictionary();
     }
 
     /**
@@ -325,6 +319,33 @@ class HookCore extends ObjectModel
             Cache::store($cacheId, $retroName);
 
             return $retroName;
+        }
+
+        return Cache::retrieve($cacheId);
+    }
+
+    /**
+     * Returns a list of hook names, indexed by alias.
+     *
+     * @return array Array of hook names, indexed by lower case alias
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    private static function getHookAliasDictionary()
+    {
+        $cacheId = 'hook_alias';
+
+        if (!Cache::isStored($cacheId)) {
+            $databaseResults = Db::getInstance()->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'hook_alias`');
+            $hooksByAlias = array();
+            if ($databaseResults) {
+                foreach ($databaseResults as $record) {
+                    $hooksByAlias[strtolower($record['alias'])] = $record['name'];
+                }
+            }
+            Cache::store($cacheId, $hooksByAlias);
+
+            return $hooksByAlias;
         }
 
         return Cache::retrieve($cacheId);

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -345,10 +345,10 @@ class HookCore extends ObjectModel
      */
     private static function getCanonicalHookNames(): array
     {
-        $cacheId = 'hook_alias';
+        $cacheId = 'hook_canonical_names';
 
         if (!Cache::isStored($cacheId)) {
-            $databaseResults = Db::getInstance()->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'hook_alias`');
+            $databaseResults = Db::getInstance()->executeS('SELECT name, alias FROM `' . _DB_PREFIX_ . 'hook_alias`');
             $hooksByAlias = [];
             if ($databaseResults) {
                 foreach ($databaseResults as $record) {

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -274,29 +274,30 @@ class HookCore extends ObjectModel
     }
 
     /**
-     * Return backward compatibility hook names.
+     * Returns all backward compatibility hook names for a given canonical hook name.
+     *
+     * @param string $canonicalHookName Canonical hook name
+     *
+     * @return string[] List of aliases
      *
      * @since 1.7.1.0
      *
-     * @param $hookName
-     *
-     * @return array
      */
-    private static function getHookAliasesFor($hookName)
+    private static function getHookAliasesFor(string $canonicalHookName): array
     {
-        $cacheId = 'hook_aliases_' . $hookName;
+        $cacheId = 'hook_aliases_' . $canonicalHookName;
         if (!Cache::isStored($cacheId)) {
             $aliasesList = Hook::getHookAliasesList();
 
-            if (isset($aliasesList[$hookName])) {
-                Cache::store($cacheId, $aliasesList[$hookName]);
+            if (isset($aliasesList[$canonicalHookName])) {
+                Cache::store($cacheId, $aliasesList[$canonicalHookName]);
 
-                return $aliasesList[$hookName];
+                return $aliasesList[$canonicalHookName];
             }
 
             // look up if this hook is an alias of another one
-            $retroName = array_keys(array_filter($aliasesList, function ($elem) use ($hookName) {
-                return in_array($hookName, $elem);
+            $retroName = array_keys(array_filter($aliasesList, function ($elem) use ($canonicalHookName) {
+                return in_array($canonicalHookName, $elem);
             }));
 
             if (empty($retroName)) {

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1,12 +1,11 @@
 <?php
 /**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ * 2007-2019 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
+ * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/OSL-3.0
  * If you did not receive a copy of the license and are unable to
@@ -17,10 +16,10 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
+ * needs please refer to https://www.prestashop.com for more information.
  *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
@@ -123,6 +122,13 @@ class HookCore extends ObjectModel
         return parent::add($autodate, $null_values);
     }
 
+    /**
+     * Returns the canonical name for a given hook.
+     *
+     * @param string $hookName
+     *
+     * @return string
+     */
     public static function normalizeHookName($hookName)
     {
         if (strtolower($hookName) == 'displayheader') {
@@ -231,13 +237,13 @@ class HookCore extends ObjectModel
     }
 
     /**
-     * Get list of hook alias.
+     * Returns a list of hook names, indexed by alias.
      *
      * @since 1.5.0
      *
-     * @return array
+     * @return array Array of hookAlias => hookName
      *
-     * @deprecated 1.7.1.0
+     * @deprecated Since 1.7.1.0
      */
     public static function getHookAliasList()
     {
@@ -259,11 +265,11 @@ class HookCore extends ObjectModel
     }
 
     /**
-     * Get the list of hook aliases.
+     * Get the list of hook aliases, indexed by hook name
      *
      * @since 1.7.1.0
      *
-     * @return array
+     * @return array Array of hookName => hookAliases[]
      */
     private static function getHookAliasesList()
     {
@@ -273,9 +279,6 @@ class HookCore extends ObjectModel
             $hookAliases = [];
             if ($hookAliasList) {
                 foreach ($hookAliasList as $ha) {
-                    if (!isset($hookAliases[$ha['name']])) {
-                        $hookAliases[$ha['name']] = [];
-                    }
                     $hookAliases[$ha['name']][] = $ha['alias'];
                 }
             }
@@ -308,6 +311,7 @@ class HookCore extends ObjectModel
                 return $aliasesList[$hookName];
             }
 
+            // look up if this hook is an alias of another one
             $retroName = array_keys(array_filter($aliasesList, function ($elem) use ($hookName) {
                 return in_array($hookName, $elem);
             }));
@@ -331,8 +335,8 @@ class HookCore extends ObjectModel
      *
      * @since 1.7.1.0
      *
-     * @param $module
-     * @param $hookName
+     * @param static $module
+     * @param string $hookName
      *
      * @return bool
      */
@@ -351,9 +355,9 @@ class HookCore extends ObjectModel
      *
      * @since 1.7.1.0
      *
-     * @param $module
-     * @param $hookName
-     * @param $hookArgs
+     * @param static $module
+     * @param string $hookName
+     * @param array $hookArgs
      *
      * @return string
      */
@@ -372,29 +376,35 @@ class HookCore extends ObjectModel
     }
 
     /**
-     * Return backward compatibility hook name.
+     * This function exists for retro compatibility only. Do not use!
+     *
+     * - If the provided hook name is an alias, it returns the canonical name of the aliased hook.
+     * - If the hook name is not an alias, but it has a know alias, then it will return that.
+     * - If the hook does not have an alias, it will return an empty string.
      *
      * @since 1.5.0
      *
-     * @param string $hook_name Hook name
+     * @param string $hookName Hook name
      *
      * @return int Hook ID
      *
      * @deprecated 1.7.1.0
      */
-    public static function getRetroHookName($hook_name)
+    public static function getRetroHookName($hookName)
     {
-        $alias_list = Hook::getHookAliasList();
-        if (isset($alias_list[strtolower($hook_name)])) {
-            return $alias_list[strtolower($hook_name)];
+        $hookNamesByAlias = static::getHookAliasDictionary();
+        if (isset($hookNamesByAlias[strtolower($hookName)])) {
+            // return the canonical name (?)
+            return $hookNamesByAlias[strtolower($hookName)];
         }
 
-        $retro_hook_name = array_search($hook_name, $alias_list);
-        if ($retro_hook_name === false) {
+        $alias = array_search($hookName, $hookNamesByAlias);
+        if ($alias === false) {
             return '';
         }
 
-        return $retro_hook_name;
+        // return the alias
+        return $alias;
     }
 
     /**
@@ -530,7 +540,7 @@ class HookCore extends ObjectModel
             $shop_list_employee = Shop::getShops(true, null, true);
 
             foreach ($shop_list as $shop_id) {
-                // Check if already register
+                // Check if already registered
                 $sql = 'SELECT hm.`id_module`
                     FROM `' . _DB_PREFIX_ . 'hook_module` hm, `' . _DB_PREFIX_ . 'hook` h
                     WHERE hm.`id_module` = ' . (int) $module_instance->id . ' AND h.`id_hook` = ' . $id_hook . '

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -309,7 +309,9 @@ class HookCore extends ObjectModel
             return Cache::retrieve($cacheId);
         }
 
-        $aliases = Hook::getAllHookAliases()[$canonicalHookName] ?? [];
+        $allAliases = Hook::getAllHookAliases();
+
+        $aliases = $allAliases[$canonicalHookName] ?? [];
 
         Cache::store($cacheId, $aliases);
 

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -623,131 +623,57 @@ class HookCore extends ObjectModel
     }
 
     /**
-     * Get list of modules we can execute per hook.
+     * Returns a list of modules that are registered for a given hook, each following this schema:
+     *
+     * ```
+     *     [
+     *         'id_hook' => $hookId,
+     *         'module' => $moduleName,
+     *         'id_module' => $moduleId
+     *     ]
+     * ```
+     *
+     * If no hook name is given, it returns all the hook registrations, indexed by lower cased hook name.
+     *
+     * @param string|null $hookName Hook name (null to return all hooks)
+     *
+     * @return array[]|false Returns an array of hook registrations, or false if the provided hook name is not registered.
+     *
+     * @throws PrestaShopDatabaseException
      *
      * @since 1.5.0
      *
-     * @param string|null $hook_name Get list of modules for this hook if given
-     *
-     * @return array
      */
-    public static function getHookModuleExecList($hook_name = null)
+    public static function getHookModuleExecList($hookName = null)
     {
-        $context = Context::getContext();
-        $cache_id = self::MODULE_LIST_BY_HOOK_KEY . (isset($context->shop->id) ? '_' . $context->shop->id : '') . ((isset($context->customer)) ? '_' . $context->customer->id : '');
-        if (!Cache::isStored($cache_id) || $hook_name == 'displayPayment' || $hook_name == 'displayPaymentEU' || $hook_name == 'paymentOptions' || $hook_name == 'displayBackOfficeHeader' || $hook_name == 'displayAdminLogin') {
-            $frontend = true;
-            $groups = [];
-            $use_groups = Group::isFeatureActive();
-            if (isset($context->employee)) {
-                $frontend = false;
-            } else {
-                // Get groups list
-                if ($use_groups) {
-                    if (isset($context->customer) && $context->customer->isLogged()) {
-                        $groups = $context->customer->getGroups();
-                    } elseif (isset($context->customer) && $context->customer->isLogged(true)) {
-                        $groups = [(int) Configuration::get('PS_GUEST_GROUP')];
-                    } else {
-                        $groups = [(int) Configuration::get('PS_UNIDENTIFIED_GROUP')];
-                    }
-                }
-            }
+        $allHookRegistrations = self::getAllHookRegistrations(Context::getContext(), $hookName);
 
-            // SQL Request
-            $sql = new DbQuery();
-            $sql->select('h.`name` as hook, m.`id_module`, h.`id_hook`, m.`name` as module');
-            $sql->from('module', 'm');
-            if ($hook_name != 'displayBackOfficeHeader' && $hook_name != 'displayAdminLogin') {
-                $sql->join(Shop::addSqlAssociation('module', 'm', true, 'module_shop.enable_device & ' . (int) Context::getContext()->getDevice()));
-                $sql->innerJoin('module_shop', 'ms', 'ms.`id_module` = m.`id_module`');
-            }
-            $sql->innerJoin('hook_module', 'hm', 'hm.`id_module` = m.`id_module`');
-            $sql->innerJoin('hook', 'h', 'hm.`id_hook` = h.`id_hook`');
-            if ($hook_name != 'paymentOptions') {
-                $sql->where('h.`name` != "paymentOptions"');
-            } elseif ($frontend) {
-                // For payment modules, we check that they are available in the contextual country
-                if (Validate::isLoadedObject($context->country)) {
-                    $sql->where('((h.`name` = "displayPayment" OR h.`name` = "displayPaymentEU" OR h.`name` = "paymentOptions")AND (SELECT `id_country` FROM `' . _DB_PREFIX_ . 'module_country` mc WHERE mc.`id_module` = m.`id_module` AND `id_country` = ' . (int) $context->country->id . ' AND `id_shop` = ' . (int) $context->shop->id . ' LIMIT 1) = ' . (int) $context->country->id . ')');
-                }
-                if (Validate::isLoadedObject($context->currency)) {
-                    $sql->where('((h.`name` = "displayPayment" OR h.`name` = "displayPaymentEU" OR h.`name` = "paymentOptions") AND (SELECT `id_currency` FROM `' . _DB_PREFIX_ . 'module_currency` mcr WHERE mcr.`id_module` = m.`id_module` AND `id_currency` IN (' . (int) $context->currency->id . ', -1, -2) LIMIT 1) IN (' . (int) $context->currency->id . ', -1, -2))');
-                }
-                if (Validate::isLoadedObject($context->cart)) {
-                    $carrier = new Carrier($context->cart->id_carrier);
-                    if (Validate::isLoadedObject($carrier)) {
-                        $sql->where('((h.`name` = "displayPayment" OR h.`name` = "displayPaymentEU" OR h.`name` = "paymentOptions") AND (SELECT `id_reference` FROM `' . _DB_PREFIX_ . 'module_carrier` mcar WHERE mcar.`id_module` = m.`id_module` AND `id_reference` = ' . (int) $carrier->id_reference . ' AND `id_shop` = ' . (int) $context->shop->id . ' LIMIT 1) = ' . (int) $carrier->id_reference . ')');
-                    }
-                }
-            }
-            if (Validate::isLoadedObject($context->shop) && $hook_name != 'displayAdminLogin') {
-                $sql->where('hm.`id_shop` = ' . (int) $context->shop->id);
-            }
-
-            if ($frontend) {
-                if ($use_groups) {
-                    $sql->leftJoin('module_group', 'mg', 'mg.`id_module` = m.`id_module`');
-                    if (Validate::isLoadedObject($context->shop)) {
-                        $sql->where('mg.id_shop = ' . ((int) $context->shop->id) . (count($groups) ? ' AND  mg.`id_group` IN (' . implode(', ', $groups) . ')' : ''));
-                    } elseif (count($groups)) {
-                        $sql->where('mg.`id_group` IN (' . implode(', ', $groups) . ')');
-                    }
-                }
-            }
-
-            $sql->groupBy('hm.id_hook, hm.id_module');
-            $sql->orderBy('hm.`position`');
-
-            $list = [];
-            if ($result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql)) {
-                foreach ($result as $row) {
-                    $row['hook'] = strtolower($row['hook']);
-                    if (!isset($list[$row['hook']])) {
-                        $list[$row['hook']] = [];
-                    }
-
-                    $list[$row['hook']][] = [
-                        'id_hook' => $row['id_hook'],
-                        'module' => $row['module'],
-                        'id_module' => $row['id_module'],
-                    ];
-                }
-            }
-            if ($hook_name != 'displayPayment' && $hook_name != 'displayPaymentEU' && $hook_name != 'paymentOptions' && $hook_name != 'displayBackOfficeHeader' && $hook_name != 'displayAdminLogin') {
-                Cache::store($cache_id, $list);
-                // @todo remove this in 1.6, we keep it in 1.5 for backward compatibility
-                self::$_hook_modules_cache_exec = $list;
-            }
-        } else {
-            $list = Cache::retrieve($cache_id);
+        // If no hook_name is given, return all registered hooks
+        if (null === $hookName) {
+            return $allHookRegistrations;
         }
 
-        // If hook_name is given, just get list of modules for this hook
-        if (null !== $hook_name) {
-            $retro_hook_name = strtolower(Hook::getRetroHookName($hook_name));
-            $hook_name = strtolower($hook_name);
+        $normalizedHookName = strtolower($hookName);
+        $modulesToInvoke = (isset($allHookRegistrations[$normalizedHookName])) ? $allHookRegistrations[$normalizedHookName] : [];
 
-            $return = [];
-            $inserted_modules = [];
-            if (isset($list[$hook_name])) {
-                $return = $list[$hook_name];
-            }
-            foreach ($return as $module) {
-                $inserted_modules[] = $module['id_module'];
-            }
-            if (isset($list[$retro_hook_name])) {
-                foreach ($list[$retro_hook_name] as $retro_module_call) {
-                    if (!in_array($retro_module_call['id_module'], $inserted_modules)) {
-                        $return[] = $retro_module_call;
+        // add modules that are registered to aliases of this hook
+        $aliases = Hook::getHookAliasesFor($hookName);
+        if (!empty($aliases)) {
+            $alreadyIncludedModuleIds = array_column($modulesToInvoke, 'id_module');
+            foreach ($aliases as $alias) {
+
+                $hookAlias = strtolower($alias);
+                if (isset($allHookRegistrations[$hookAlias])) {
+                    foreach ($allHookRegistrations[$hookAlias] as $registeredAlias) {
+                        if (!in_array($registeredAlias['id_module'], $alreadyIncludedModuleIds)) {
+                            $modulesToInvoke[] = $registeredAlias;
+                        }
                     }
                 }
             }
-
-            return count($return) > 0 ? $return : false;
-        } else {
-            return $list;
         }
+
+        return !empty($modulesToInvoke) ? $modulesToInvoke : false;
     }
 
     /**
@@ -1019,6 +945,179 @@ class HookCore extends ObjectModel
         }
 
         return null;
+    }
+
+    /**
+     * Retrieves all modules registered to any hook, indexed by hok name.
+     *
+     * Each registration looks like this:
+     *
+     * ```
+     *     [
+     *         'id_hook' => $hookId,
+     *         'module' => $moduleName,
+     *         'id_module' => $moduleId
+     *     ]
+     * ```
+     *
+     * @param Context $context
+     * @param string|null $hookName Hook name (to be used when the hook registration is dynamic and context sensitive)
+     *
+     * @return array[][]
+     * @throws PrestaShopDatabaseException
+     */
+    private static function getAllHookRegistrations(Context $context, ?string $hookName): array
+    {
+        $shop = $context->shop;
+        $customer = $context->customer;
+
+        $cache_id = self::MODULE_LIST_BY_HOOK_KEY
+            . ($shop instanceof Shop && isset($shop->id) ? '_' . $shop->id : '')
+            . ($customer instanceof Customer ? '_' . $customer->id : '');
+
+        $useCache = (
+            !in_array(
+                $hookName,
+                [
+                    'displayPayment',
+                    'displayPaymentEU',
+                    'paymentOptions',
+                    'displayBackOfficeHeader',
+                    'displayAdminLogin',
+                ]
+            )
+        );
+
+        if ($useCache && Cache::isStored($cache_id)) {
+            return Cache::retrieve($cache_id);
+        }
+
+        $groups = [];
+        $use_groups = Group::isFeatureActive();
+        $frontend = !$context->employee instanceof Employee;
+        if ($frontend) {
+            // Get groups list
+            if ($use_groups) {
+                if ($customer instanceof Customer && $customer->isLogged()) {
+                    $groups = $customer->getGroups();
+                } elseif ($customer instanceof Customer && $customer->isLogged(true)) {
+                    $groups = [(int) Configuration::get('PS_GUEST_GROUP')];
+                } else {
+                    $groups = [(int) Configuration::get('PS_UNIDENTIFIED_GROUP')];
+                }
+            }
+        }
+
+        // SQL Request
+        $sql = new DbQuery();
+        $sql->select('h.`name` as hook, m.`id_module`, h.`id_hook`, m.`name` as module');
+        $sql->from('module', 'm');
+        if (!in_array($hookName, ['displayBackOfficeHeader', 'displayAdminLogin'])) {
+            $sql->join(
+                Shop::addSqlAssociation(
+                    'module',
+                    'm',
+                    true,
+                    'module_shop.enable_device & ' . (int) Context::getContext()->getDevice()
+                )
+            );
+            $sql->innerJoin('module_shop', 'ms', 'ms.`id_module` = m.`id_module`');
+        }
+        $sql->innerJoin('hook_module', 'hm', 'hm.`id_module` = m.`id_module`');
+        $sql->innerJoin('hook', 'h', 'hm.`id_hook` = h.`id_hook`');
+        if ($hookName !== 'paymentOptions') {
+            $sql->where('h.`name` != "paymentOptions"');
+        } elseif ($frontend) {
+            // For payment modules, we check that they are available in the contextual country
+            if (Validate::isLoadedObject($context->country)) {
+                $sql->where(
+                    '(
+                        h.`name` IN ("displayPayment", "displayPaymentEU", "paymentOptions")
+                        AND (
+                            SELECT `id_country`
+                            FROM `' . _DB_PREFIX_ . 'module_country` mc
+                            WHERE mc.`id_module` = m.`id_module`
+                            AND `id_country` = ' . (int) $context->country->id . '
+                            AND `id_shop` = ' . (int) $shop->id . '
+                            LIMIT 1
+                        ) = ' . (int) $context->country->id . ')'
+                );
+            }
+            if (Validate::isLoadedObject($context->currency)) {
+                $sql->where(
+                    '(
+                        h.`name` IN ("displayPayment", "displayPaymentEU", "paymentOptions")
+                        AND (
+                            SELECT `id_currency`
+                            FROM `' . _DB_PREFIX_ . 'module_currency` mcr
+                            WHERE mcr.`id_module` = m.`id_module`
+                            AND `id_currency` IN (' . (int) $context->currency->id . ', -1, -2)
+                            LIMIT 1
+                        ) IN (' . (int) $context->currency->id . ', -1, -2))'
+                );
+            }
+            if (Validate::isLoadedObject($context->cart)) {
+                $carrier = new Carrier($context->cart->id_carrier);
+                if (Validate::isLoadedObject($carrier)) {
+                    $sql->where(
+                        '(
+                            h.`name` IN ("displayPayment", "displayPaymentEU", "paymentOptions")
+                            AND (
+                                SELECT `id_reference`
+                                FROM `' . _DB_PREFIX_ . 'module_carrier` mcar
+                                WHERE mcar.`id_module` = m.`id_module`
+                                AND `id_reference` = ' . (int) $carrier->id_reference . '
+                                AND `id_shop` = ' . (int) $shop->id . '
+                                LIMIT 1
+                            ) = ' . (int) $carrier->id_reference . ')'
+                    );
+                }
+            }
+        }
+        if (Validate::isLoadedObject($shop) && $hookName !== 'displayAdminLogin') {
+            $sql->where('hm.`id_shop` = ' . (int) $shop->id);
+        }
+
+        if ($frontend) {
+            if ($use_groups) {
+                $sql->leftJoin('module_group', 'mg', 'mg.`id_module` = m.`id_module`');
+                if (Validate::isLoadedObject($shop)) {
+                    $sql->where(
+                        'mg.id_shop = ' . ((int) $shop->id)
+                        . (count($groups) ? ' AND  mg.`id_group` IN (' . implode(', ', $groups) . ')' : '')
+                    );
+                } elseif (count($groups)) {
+                    $sql->where('mg.`id_group` IN (' . implode(', ', $groups) . ')');
+                }
+            }
+        }
+
+        $sql->groupBy('hm.id_hook, hm.id_module');
+        $sql->orderBy('hm.`position`');
+
+        $allHookRegistrations = [];
+        if ($result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql)) {
+            foreach ($result as $row) {
+                $row['hook'] = strtolower($row['hook']);
+                if (!isset($allHookRegistrations[$row['hook']])) {
+                    $allHookRegistrations[$row['hook']] = [];
+                }
+
+                $allHookRegistrations[$row['hook']][] = [
+                    'id_hook' => $row['id_hook'],
+                    'module' => $row['module'],
+                    'id_module' => $row['id_module'],
+                ];
+            }
+        }
+
+        if ($useCache) {
+            Cache::store($cache_id, $allHookRegistrations);
+            // @todo remove this in 1.6, we keep it in 1.5 for backward compatibility
+            self::$_hook_modules_cache_exec = $allHookRegistrations;
+        }
+
+        return $allHookRegistrations;
     }
 
     /**

--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -656,7 +656,7 @@ abstract class CacheCore
 
     /**
      * @param string $key
-     * @param string $value
+     * @param mixed $value
      */
     public static function store($key, $value)
     {

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3343,11 +3343,10 @@ abstract class ModuleCore implements ModuleInterface
         $hooks_list = Hook::getHooks();
         $possible_hooks_list = [];
         $registeredHookList = Hook::getHookModuleList();
-        foreach ($hooks_list as &$current_hook) {
+        foreach ($hooks_list as $current_hook) {
             $hook_name = $current_hook['name'];
-            $retro_hook_name = Hook::getRetroHookName($hook_name);
 
-            if (is_callable([$this, 'hook' . ucfirst($hook_name)]) || is_callable([$this, 'hook' . ucfirst($retro_hook_name)])) {
+            if (!Hook::isAlias($hook_name) && Hook::isHookCallableOn($this, $hook_name)) {
                 $possible_hooks_list[] = [
                     'id_hook' => $current_hook['id_hook'],
                     'name' => $hook_name,

--- a/install-dev/data/xml/hook_alias.xml
+++ b/install-dev/data/xml/hook_alias.xml
@@ -34,8 +34,8 @@
       <name>displayHome</name>
     </hook_alias>
     <hook_alias id="header">
-      <alias>displayHeader</alias>
-      <name>Header</name>
+      <alias>Header</alias>
+      <name>displayHeader</name>
     </hook_alias>
     <hook_alias id="cart">
       <alias>cart</alias>

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -861,3 +861,6 @@ INNER JOIN `PREFIX_hook` AS hfrom ON hm.id_hook = hfrom.id_hook AND hfrom.name =
 INNER JOIN `PREFIX_hook` AS hto ON hto.name = 'actionPerformancePageSave'
 SET hm.id_hook = hto.id_hook;
 DELETE FROM `PREFIX_hook` WHERE name = 'actionPerformancePageFormSave';
+
+/* Update wrong hook alias */
+UPDATE `PREFIX_hook_alias` SET name = 'displayHeader', alias = 'Header' WHERE name = 'Header' AND alias = 'displayHeader';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Hooking a module to hook `actionAuthenticationBefore` doesn't work on a clean install.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no... i think
| Deprecations? | no
| Fixed ticket? | Fixes #18945
| How to test?  | Read below

When installing a module that tried to hook to `actionAuthenticationBefore`, it didn't work.

After some investigation, we found out that said module wasn't previously registered in `ps_hooks` on a clean install (which is not an issue in itself because PrestaShop automatically adds them as needed). However, even if it's not registered in `ps_hooks`, it does have an alias in `ps_hook_alias`: `actionBeforeAuthentication`.

Whenever a hook doesn't exist in `ps_hooks`, it is automatically added. But if the hook has an alias, we found that the _lowercased_ alias was being inserted instead. Why? No clue. I think it was a bug. Maybe?

As far as I can tell, the bug goes way back to 2011, probably beyond...

---
**Update on 2020-08-05:** With this change, the alias behavior is now as follows:

**Context:**
- `someNewHook` is a given hook
- `someHook` is an alias for `someNewHook`

**Scenario 1:** Nominal case – a module registers to `someNewHook`, the hook `someNewHook` is dispatched
- table ps_hook contains “someNewHook”
- table ps_hook_module refers to “someNewHook”
- when `someNewHook` is dispatched, the module’s `hooksomeNewHook()` method is called

**Scenario 2:** Old code dispatches a renamed hook – a module registers to `someNewHook`, the hook `someHook` is dispatched
- table ps_hook contains “someNewHook”
- table ps_hook_module refers to “someNewHook”
- when `someHook` is dispatched, the module’s `hooksomeNewHook()` method is called

**Scenario 3:** Modules get backwards compatibility with renamed hooks – a module registers to `someHook`, the hook `someNewHook` is dispatched
- table ps_hook contains “someHook”
- table ps_hook_module contains “someHook”
- when `someNewHook` is dispatched, the module’s `hooksomeHook()` method is called

**Scenario 4:** Old code calls old hook and old module still works – a module registers to `someHook`, the hook `someHook` is dispatched
- table ps_hook contains “someHook”
- table ps_hook_module contains “someHook”
- when `someHook` is dispatched, the module’s `hooksomeHook()` method is called

---
**Update on 2020-08-06:** This change allowed me to realize that the the hook `displayHeader` was used as an alias of `Header` instead of the other way around. This was making `Header` be treated as the canonical hook name instead of an alias, which broke ps_shoppingcart.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12578)
<!-- Reviewable:end -->
