### PR TITLE
The lang parameter in the url is now shop dependent

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -640,7 +640,7 @@ class ToolsCore
         ) {
             $context->cookie->id_lang = $newLanguageId;
             $language = new Language($newLanguageId);
-            if (Validate::isLoadedObject($language) && $language->active) {
+            if (Validate::isLoadedObject($language) && $language->active && $language->isAssociatedToShop()) {
                 $context->language = $language;
             }
         }


### PR DESCRIPTION


<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The lang parameter in the url is now shop dependant. Even if a language was not selected on a website (for example de), if this language was active we could use the url http://domain/de/xxxx but the language was not in the languages list.<br>Now, we can activate a language and unselect it on a particular website (in the previous case, we can no more access to http://domain/de/*)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | On the localisation>languages tab, choose an active language in the list and unselect the website to test.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12597)
<!-- Reviewable:end -->
