### PR TITLE
Refactor AddonsStoreController to use annotations and some improvements

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php
@@ -36,7 +36,6 @@ use Symfony\Component\HttpFoundation\Request;
 class AddonsStoreController extends FrameworkBundleAdminController
 {
     /**
-     *
      * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Improve\Modules;
 
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -35,11 +36,9 @@ use Symfony\Component\HttpFoundation\Request;
 class AddonsStoreController extends FrameworkBundleAdminController
 {
     /**
-     * @var string the controller name for routing
-     */
-    const CONTROLLER_NAME = 'AdminAddonsCatalog';
-
-    /**
+     *
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     *
      * @param Request $request
      *
      * @return \Symfony\Component\HttpFoundation\Response
@@ -54,9 +53,9 @@ class AddonsStoreController extends FrameworkBundleAdminController
             'requireBulkActions' => false,
             'showContentHeader' => true,
             'enableSidebar' => true,
-            'help_link' => $this->generateSidebarLink('AdminAddonsCatalog'),
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'requireFilterStatus' => false,
-            'level' => $this->authorizationLevel($this::CONTROLLER_NAME),
+            'level' => $this->authorizationLevel($request->attributes->get('_legacy_controller')),
         ));
     }
 
@@ -75,6 +74,7 @@ class AddonsStoreController extends FrameworkBundleAdminController
         $countryCode = $context->country->iso_code;
         $activity = (int) $this->get('prestashop.adapter.legacy.configuration')->get('PS_SHOP_ACTIVITY');
 
+        // GET parameters are concatenated this way in order to ensure they are not encoded
         return "https://addons.prestashop.com/iframe/search-1.7.php?psVersion=$psVersion&isoLang=$languageCode&isoCurrency=$currencyCode&isoCountry=$countryCode&activity=$activity&parentUrl=$parent_domain";
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Refactor Controller to use latest conventions about annotations and some improvements
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |  Previously you could access "Improve > Module Catalog > Module selection" if you were logged in the backoffice, even if you were not granted the READ access. Try it with direct link `/admin-dev/index.php/improve/modules/addons-store`. With this PR, you now need the READ access to access the page. I also refactored a bit the code but the page behavior should not be changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12622)
<!-- Reviewable:end -->
