### PR TITLE
Migrate tax create/edit form

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -44,6 +44,8 @@ module.exports = {
     themes: './js/pages/themes',
     profiles: './js/pages/profiles',
     tax: './js/pages/tax',
+    manufacturer: './js/pages/catalog/manufacturer',
+    address: './js/pages/catalog/address',
     cms_page: './js/pages/cms-page',
     form_popover_error: './js/components/form/form-popover-error.js',
   },

--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -46,8 +46,6 @@ module.exports = {
     tax: './js/pages/tax',
     cms_page: './js/pages/cms-page',
     form_popover_error: './js/components/form/form-popover-error.js',
-    manufacturer: './js/pages/catalog/manufacturer',
-    address: './js/pages/catalog/address',
   },
   output: {
     path: path.resolve(__dirname, '../public'),

--- a/admin-dev/themes/new-theme/js/pages/tax/index.js
+++ b/admin-dev/themes/new-theme/js/pages/tax/index.js
@@ -23,7 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-import DisplayInCartOptionHandler from './display-in-cart-option-handler';
 import Grid from '../../components/grid/grid';
 import SortingExtension from '../../components/grid/extension/sorting-extension';
 import FiltersResetExtension from '../../components/grid/extension/filters-reset-extension';
@@ -33,13 +32,14 @@ import SubmitRowActionExtension from '../../components/grid/extension/action/row
 import SubmitBulkExtension from '../../components/grid/extension/submit-bulk-action-extension';
 import BulkActionCheckboxExtension from '../../components/grid/extension/bulk-action-checkbox-extension';
 import ExportToSqlManagerExtension from '../../components/grid/extension/export-to-sql-manager-extension';
+import DisplayInCartOptionHandler from './display-in-cart-option-handler';
+import TranslatableInput from '../../components/translatable-input';
 
 const $ = window.$;
 
 $(() => {
   const taxGrid = new Grid('tax');
 
-  new DisplayInCartOptionHandler();
   taxGrid.addExtension(new ExportToSqlManagerExtension());
   taxGrid.addExtension(new ReloadListActionExtension());
   taxGrid.addExtension(new SortingExtension());
@@ -48,4 +48,6 @@ $(() => {
   taxGrid.addExtension(new SubmitRowActionExtension());
   taxGrid.addExtension(new SubmitBulkExtension());
   taxGrid.addExtension(new BulkActionCheckboxExtension());
+  new DisplayInCartOptionHandler();
+  new TranslatableInput();
 });

--- a/src/Adapter/Tax/CommandHandler/AddTaxHandler.php
+++ b/src/Adapter/Tax/CommandHandler/AddTaxHandler.php
@@ -27,8 +27,8 @@
 namespace PrestaShop\PrestaShop\Adapter\Tax\CommandHandler;
 
 use PrestaShop\PrestaShop\Adapter\Tax\AbstractTaxHandler;
-use PrestaShop\PrestaShop\Core\Domain\Tax\Command\EditTaxCommand;
-use PrestaShop\PrestaShop\Core\Domain\Tax\CommandHandler\EditTaxHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Tax\Command\AddTaxCommand;
+use PrestaShop\PrestaShop\Core\Domain\Tax\CommandHandler\AddTaxHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Exception\TaxException;
 use PrestaShop\PrestaShop\Core\Domain\Tax\ValueObject\TaxId;
 use PrestaShopException;
@@ -37,31 +37,30 @@ use Tax;
 /**
  * Handles command which is responsible for tax editing
  */
-final class EditTaxHandler extends AbstractTaxHandler implements EditTaxHandlerInterface
+final class AddTaxHandler extends AbstractTaxHandler implements AddTaxHandlerInterface
 {
     /**
      * {@inheritdoc}
      *
      * @throws TaxException
      */
-    public function handle(EditTaxCommand $command)
+    public function handle(AddTaxCommand $command)
     {
-        $tax = new Tax($command->getTaxId()->getValue());
-        $this->assertTaxWasFound($command->getTaxId(), $tax);
+        $tax = new Tax();
 
         $tax->name = $command->getName();
         $tax->rate = $command->getRate();
         $tax->active = $command->isEnabled();
 
         try {
-            if (!$tax->update()) {
+            if (!$tax->save()) {
                 throw new TaxException(
-                    sprintf('Cannot update tax with id "%s"', $tax->id)
+                    sprintf('Cannot create tax with id "%s"', $tax->id)
                 );
             }
         } catch (PrestaShopException $e) {
             throw new TaxException(
-                sprintf('Cannot update tax with id "%s"', $tax->id)
+                sprintf('Cannot create tax with id "%s"', $tax->id)
             );
         }
 

--- a/src/Adapter/Tax/CommandHandler/AddTaxHandler.php
+++ b/src/Adapter/Tax/CommandHandler/AddTaxHandler.php
@@ -48,7 +48,7 @@ final class AddTaxHandler extends AbstractTaxHandler implements AddTaxHandlerInt
     {
         $tax = new Tax();
 
-        $tax->name = $command->getName();
+        $tax->name = $command->getLocalizedNames();
         $tax->rate = $command->getRate();
         $tax->active = $command->isEnabled();
 

--- a/src/Adapter/Tax/CommandHandler/EditTaxHandler.php
+++ b/src/Adapter/Tax/CommandHandler/EditTaxHandler.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Tax\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Tax\AbstractTaxHandler;
+use PrestaShop\PrestaShop\Core\Domain\Tax\Command\EditTaxCommand;
+use PrestaShop\PrestaShop\Core\Domain\Tax\CommandHandler\EditTaxHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Tax\Exception\TaxException;
+use PrestaShop\PrestaShop\Core\Domain\Tax\ValueObject\TaxId;
+use PrestaShopException;
+use Tax;
+
+/**
+ * Handles command which is responsible for tax editing
+ */
+final class EditTaxHandler extends AbstractTaxHandler implements EditTaxHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws TaxException
+     */
+    public function handle(EditTaxCommand $command)
+    {
+        $tax = new Tax($command->getTaxId()->getValue());
+        $this->assertTaxWasFound($command->getTaxId(), $tax);
+
+        if (null !== $command->getName()) {
+            $tax->name = $command->getName();
+        }
+        if (null !== $command->getRate()) {
+            $tax->rate = $command->getRate();
+        }
+        if (null !== $command->isEnabled()) {
+            $tax->active = $command->isEnabled();
+        }
+
+        try {
+            if (!$tax->update()) {
+                throw new TaxException(
+                    sprintf('Cannot update tax with id "%s"', $tax->id)
+                );
+            }
+        } catch (PrestaShopException $e) {
+            throw new TaxException(
+                sprintf('Cannot update tax with id "%s"', $tax->id)
+            );
+        }
+
+        return new TaxId((int) $tax->id);
+    }
+}

--- a/src/Adapter/Tax/CommandHandler/EditTaxHandler.php
+++ b/src/Adapter/Tax/CommandHandler/EditTaxHandler.php
@@ -49,9 +49,15 @@ final class EditTaxHandler extends AbstractTaxHandler implements EditTaxHandlerI
         $tax = new Tax($command->getTaxId()->getValue());
         $this->assertTaxWasFound($command->getTaxId(), $tax);
 
-        $tax->name = $command->getName();
-        $tax->rate = $command->getRate();
-        $tax->active = $command->isEnabled();
+        if (null !== $command->getLocalizedNames()) {
+            $tax->name = $command->getLocalizedNames();
+        }
+        if (null !== $command->getRate()) {
+            $tax->rate = $command->getRate();
+        }
+        if (null !== $command->isEnabled()) {
+            $tax->active = $command->isEnabled();
+        }
 
         try {
             if (!$tax->update()) {

--- a/src/Adapter/Tax/CommandHandler/EditTaxHandler.php
+++ b/src/Adapter/Tax/CommandHandler/EditTaxHandler.php
@@ -46,8 +46,7 @@ final class EditTaxHandler extends AbstractTaxHandler implements EditTaxHandlerI
      */
     public function handle(EditTaxCommand $command)
     {
-        $tax = new Tax($command->getTaxId()->getValue());
-        $this->assertTaxWasFound($command->getTaxId(), $tax);
+        $tax = $this->getTax($command->getTaxId());
 
         if (null !== $command->getLocalizedNames()) {
             $tax->name = $command->getLocalizedNames();

--- a/src/Core/Domain/Tax/Command/AddTaxCommand.php
+++ b/src/Core/Domain/Tax/Command/AddTaxCommand.php
@@ -26,19 +26,11 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Tax\Command;
 
-use PrestaShop\PrestaShop\Core\Domain\Tax\Exception\TaxException;
-use PrestaShop\PrestaShop\Core\Domain\Tax\ValueObject\TaxId;
-
 /**
- * Edits given tax with provided data
+ * Adds new tax
  */
-class EditTaxCommand
+class AddTaxCommand
 {
-    /**
-     * @var TaxId
-     */
-    private $taxId;
-
     /**
      * @var array
      */
@@ -55,31 +47,19 @@ class EditTaxCommand
     private $enabled;
 
     /**
-     * @param $taxId
      * @param array $name
      * @param float $rate
      * @param bool $enabled
-     *
-     * @throws TaxException
      */
-    public function __construct($taxId, array $name, $rate, $enabled)
+    public function __construct(array $name, $rate, $enabled)
     {
-        $this->taxId = new TaxId($taxId);
         $this->name = $name;
         $this->rate = $rate;
         $this->enabled = $enabled;
     }
 
     /**
-     * @return TaxId
-     */
-    public function getTaxId()
-    {
-        return $this->taxId;
-    }
-
-    /**
-     * @return array $name
+     * @return array
      */
     public function getName()
     {
@@ -87,7 +67,15 @@ class EditTaxCommand
     }
 
     /**
-     * @return float $rate
+     * @param array $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return float
      */
     public function getRate()
     {
@@ -95,10 +83,26 @@ class EditTaxCommand
     }
 
     /**
-     * @return bool $enabled
+     * @param float $rate
+     */
+    public function setRate($rate)
+    {
+        $this->rate = $rate;
+    }
+
+    /**
+     * @return bool
      */
     public function isEnabled()
     {
         return $this->enabled;
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = $enabled;
     }
 }

--- a/src/Core/Domain/Tax/Command/AddTaxCommand.php
+++ b/src/Core/Domain/Tax/Command/AddTaxCommand.php
@@ -34,7 +34,7 @@ class AddTaxCommand
     /**
      * @var array
      */
-    private $name;
+    private $localizedNames;
 
     /**
      * @var float
@@ -47,13 +47,13 @@ class AddTaxCommand
     private $enabled;
 
     /**
-     * @param array $name
+     * @param array $localizedNames
      * @param float $rate
      * @param bool $enabled
      */
-    public function __construct(array $name, $rate, $enabled)
+    public function __construct(array $localizedNames, $rate, $enabled)
     {
-        $this->name = $name;
+        $this->localizedNames = $localizedNames;
         $this->rate = $rate;
         $this->enabled = $enabled;
     }
@@ -61,17 +61,9 @@ class AddTaxCommand
     /**
      * @return array
      */
-    public function getName()
+    public function getLocalizedNames()
     {
-        return $this->name;
-    }
-
-    /**
-     * @param array $name
-     */
-    public function setName($name)
-    {
-        $this->name = $name;
+        return $this->localizedNames;
     }
 
     /**
@@ -80,14 +72,6 @@ class AddTaxCommand
     public function getRate()
     {
         return $this->rate;
-    }
-
-    /**
-     * @param float $rate
-     */
-    public function setRate($rate)
-    {
-        $this->rate = $rate;
     }
 
     /**

--- a/src/Core/Domain/Tax/Command/EditTaxCommand.php
+++ b/src/Core/Domain/Tax/Command/EditTaxCommand.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Tax\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Tax\Exception\TaxException;
+use PrestaShop\PrestaShop\Core\Domain\Tax\ValueObject\TaxId;
+
+/**
+ * Edits given tax with provided data
+ */
+class EditTaxCommand
+{
+    /**
+     * @var TaxId
+     */
+    private $taxId;
+
+    /**
+     * @var array|null
+     */
+    private $name;
+
+    /**
+     * @var float|null
+     */
+    private $rate;
+
+    /**
+     * @var bool|null
+     */
+    private $enabled;
+
+    /**
+     * @param $taxId
+     *
+     * @throws TaxException
+     */
+    public function __construct($taxId)
+    {
+        $this->taxId = new TaxId($taxId);
+    }
+
+    /**
+     * @return TaxId
+     */
+    public function getTaxId()
+    {
+        return $this->taxId;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param array|null $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getRate()
+    {
+        return $this->rate;
+    }
+
+    /**
+     * @param float|null $rate
+     */
+    public function setRate($rate)
+    {
+        $this->rate = $rate;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param bool|null $enabled
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = $enabled;
+    }
+}

--- a/src/Core/Domain/Tax/Command/EditTaxCommand.php
+++ b/src/Core/Domain/Tax/Command/EditTaxCommand.php
@@ -40,34 +40,28 @@ class EditTaxCommand
     private $taxId;
 
     /**
-     * @var array
+     * @var array|null
      */
-    private $name;
+    private $localizedNames;
 
     /**
-     * @var float
+     * @var float|null
      */
     private $rate;
 
     /**
-     * @var bool
+     * @var bool|null
      */
     private $enabled;
 
     /**
-     * @param $taxId
-     * @param array $name
-     * @param float $rate
-     * @param bool $enabled
+     * @param int $taxId
      *
      * @throws TaxException
      */
-    public function __construct($taxId, array $name, $rate, $enabled)
+    public function __construct($taxId)
     {
         $this->taxId = new TaxId($taxId);
-        $this->name = $name;
-        $this->rate = $rate;
-        $this->enabled = $enabled;
     }
 
     /**
@@ -79,15 +73,27 @@ class EditTaxCommand
     }
 
     /**
-     * @return array $name
+     * @return array|null
      */
-    public function getName()
+    public function getLocalizedNames()
     {
-        return $this->name;
+        return $this->localizedNames;
     }
 
     /**
-     * @return float $rate
+     * @param array|null $localizedNames
+     *
+     * @return self
+     */
+    public function setLocalizedNames($localizedNames)
+    {
+        $this->localizedNames = $localizedNames;
+
+        return $this;
+    }
+
+    /**
+     * @return float|null
      */
     public function getRate()
     {
@@ -95,10 +101,34 @@ class EditTaxCommand
     }
 
     /**
-     * @return bool $enabled
+     * @param float|null $rate
+     *
+     * @return self
+     */
+    public function setRate($rate)
+    {
+        $this->rate = $rate;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
      */
     public function isEnabled()
     {
         return $this->enabled;
+    }
+
+    /**
+     * @param bool|null $enabled
+     *
+     * @return self
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = $enabled;
+
+        return $this;
     }
 }

--- a/src/Core/Domain/Tax/CommandHandler/AddTaxHandlerInterface.php
+++ b/src/Core/Domain/Tax/CommandHandler/AddTaxHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Tax\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Tax\Command\AddTaxCommand;
+
+/**
+ * Defines contract for AddTaxHandler
+ */
+interface AddTaxHandlerInterface
+{
+    /**
+     * @param AddTaxCommand $command
+     */
+    public function handle(AddTaxCommand $command);
+}

--- a/src/Core/Domain/Tax/CommandHandler/EditTaxHandlerInterface.php
+++ b/src/Core/Domain/Tax/CommandHandler/EditTaxHandlerInterface.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * 2007-2019 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
@@ -21,14 +22,19 @@
  * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
- *#}
+ */
 
-  {% extends '@PrestaShop/Admin/layout.html.twig' %}
+namespace PrestaShop\PrestaShop\Core\Domain\Tax\CommandHandler;
 
-  {% block content %}
-    <div class="row justify-content-center">
-      <div class="col">
-        {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
-      </div>
-    </div>
-  {% endblock %}
+use PrestaShop\PrestaShop\Core\Domain\Tax\Command\EditTaxCommand;
+
+/**
+ * Defines contract for EditTaxHandler
+ */
+interface EditTaxHandlerInterface
+{
+    /**
+     * @param EditTaxCommand $command
+     */
+    public function handle(EditTaxCommand $command);
+}

--- a/src/Core/Domain/Tax/Query/GetTaxForEditing.php
+++ b/src/Core/Domain/Tax/Query/GetTaxForEditing.php
@@ -33,6 +33,9 @@ use PrestaShop\PrestaShop\Core\Domain\Tax\ValueObject\TaxId;
  */
 class GetTaxForEditing
 {
+    /**
+     * @var TaxId
+     */
     private $taxId;
 
     /**

--- a/src/Core/Domain/Tax/ValueObject/TaxId.php
+++ b/src/Core/Domain/Tax/ValueObject/TaxId.php
@@ -52,7 +52,7 @@ class TaxId
             );
         }
 
-        $this->taxId = (int) $taxId;
+        $this->taxId = $taxId;
     }
 
     /**

--- a/src/Core/Domain/Tax/ValueObject/TaxId.php
+++ b/src/Core/Domain/Tax/ValueObject/TaxId.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Domain\Tax\ValueObject;
 
 use PrestaShop\PrestaShop\Core\Domain\Tax\Exception\TaxConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Tax\Exception\TaxException;
 
 /**
  * Provides tax id data
@@ -42,7 +41,7 @@ class TaxId
     /**
      * @param int $taxId
      *
-     * @throws TaxException
+     * @throws TaxConstraintException
      */
     public function __construct($taxId)
     {

--- a/src/Core/Form/IdentifiableObject/DataHandler/TaxFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/TaxFormDataHandler.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Tax\Command\AddTaxCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Command\EditTaxCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Exception\TaxException;
 use PrestaShop\PrestaShop\Core\Domain\Tax\ValueObject\TaxId;
@@ -55,7 +56,16 @@ final class TaxFormDataHandler implements FormDataHandlerInterface
      */
     public function create(array $data)
     {
-        //@todo: implement create
+        $command = new AddTaxCommand(
+            $data['name'],
+            (float) $data['rate'],
+            (bool) $data['is_enabled']
+        );
+
+        /** @var TaxId $taxId */
+        $taxId = $this->commandBus->handle($command);
+
+        return $taxId->getValue();
     }
 
     /**
@@ -70,10 +80,12 @@ final class TaxFormDataHandler implements FormDataHandlerInterface
      */
     public function update($id, array $data)
     {
-        $command = new EditTaxCommand($id);
-        $command->setName($data['name']);
-        $command->setRate((float) $data['rate']);
-        $command->setEnabled((bool) $data['is_enabled']);
+        $command = new EditTaxCommand(
+            $id,
+            $data['name'],
+            (float) $data['rate'],
+            (bool) $data['is_enabled']
+        );
 
         /** @var TaxId $taxId */
         $taxId = $this->commandBus->handle($command);

--- a/src/Core/Form/IdentifiableObject/DataHandler/TaxFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/TaxFormDataHandler.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Tax\Command\EditTaxCommand;
+use PrestaShop\PrestaShop\Core\Domain\Tax\Exception\TaxException;
+use PrestaShop\PrestaShop\Core\Domain\Tax\ValueObject\TaxId;
+
+/**
+ * Handles submitted tax form data
+ */
+final class TaxFormDataHandler implements FormDataHandlerInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    public function __construct(CommandBusInterface $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    /**
+     * Create object from form data.
+     *
+     * @param array $data
+     *
+     * @return mixed
+     */
+    public function create(array $data)
+    {
+        //@todo: implement create
+    }
+
+    /**
+     * Update object with form data.
+     *
+     * @param int $id
+     * @param array $data
+     *
+     * @return int ID of identifiable object
+     *
+     * @throws TaxException
+     */
+    public function update($id, array $data)
+    {
+        $command = new EditTaxCommand($id);
+        $command->setName($data['name']);
+        $command->setRate((float) $data['rate']);
+        $command->setEnabled((bool) $data['is_enabled']);
+
+        /** @var TaxId $taxId */
+        $taxId = $this->commandBus->handle($command);
+
+        return $taxId->getValue();
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataHandler/TaxFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/TaxFormDataHandler.php
@@ -80,12 +80,11 @@ final class TaxFormDataHandler implements FormDataHandlerInterface
      */
     public function update($id, array $data)
     {
-        $command = new EditTaxCommand(
-            $id,
-            $data['name'],
-            (float) $data['rate'],
-            (bool) $data['is_enabled']
-        );
+        $command = (new EditTaxCommand($id))
+            ->setLocalizedNames($data['name'])
+            ->setRate((float) $data['rate'])
+            ->setEnabled((bool) $data['is_enabled'])
+        ;
 
         /** @var TaxId $taxId */
         $taxId = $this->commandBus->handle($command);

--- a/src/Core/Form/IdentifiableObject/DataProvider/TaxFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/TaxFormDataProvider.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Tax\Query\GetTaxForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Tax\QueryResult\EditableTax;
+
+/**
+ * Provides Data for tax add/edit form
+ */
+final class TaxFormDataProvider implements FormDataProviderInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $queryBus;
+
+    /**
+     * @param CommandBusInterface $queryBus
+     */
+    public function __construct(CommandBusInterface $queryBus)
+    {
+        $this->queryBus = $queryBus;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData($id)
+    {
+        /** @var EditableTax $editableTax */
+        $editableTax = $this->queryBus->handle(new GetTaxForEditing($id));
+
+        return [
+            'name' => $editableTax->getName(),
+            'rate' => $editableTax->getRate(),
+            'is_enabled' => $editableTax->isActive(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultData()
+    {
+        return [];
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataProvider/TaxFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/TaxFormDataProvider.php
@@ -68,6 +68,8 @@ final class TaxFormDataProvider implements FormDataProviderInterface
      */
     public function getDefaultData()
     {
-        return [];
+        return [
+            'is_enabled' => false,
+        ];
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/TaxFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/TaxFormDataProvider.php
@@ -51,13 +51,13 @@ final class TaxFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData($id)
+    public function getData($taxId)
     {
         /** @var EditableTax $editableTax */
-        $editableTax = $this->queryBus->handle(new GetTaxForEditing($id));
+        $editableTax = $this->queryBus->handle(new GetTaxForEditing($taxId));
 
         return [
-            'name' => $editableTax->getName(),
+            'name' => $editableTax->getLocalizedNames(),
             'rate' => $editableTax->getRate(),
             'is_enabled' => $editableTax->isActive(),
         ];

--- a/src/Core/Grid/Definition/Factory/TaxGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/TaxGridDefinitionFactory.php
@@ -117,8 +117,7 @@ final class TaxGridDefinitionFactory extends AbstractGridDefinitionFactory
                             ->setName($this->trans('Edit', [], 'Admin.Actions'))
                             ->setIcon('edit')
                             ->setOptions([
-                                //@todo: route admin_taxes_edit after implementation in another PR
-                                'route' => 'admin_taxes_index',
+                                'route' => 'admin_taxes_edit',
                                 'route_param_name' => 'taxId',
                                 'route_param_field' => 'id_tax',
                             ])

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -151,12 +151,21 @@ class TaxController extends FrameworkBundleAdminController
 
         $taxForm = $taxFormBuilder->getFormFor((int) $taxId);
         $taxForm->handleRequest($request);
-        $result = $taxFormHandler->handleFor((int) $taxId, $taxForm);
 
-        if (null !== $result->getIdentifiableObjectId()) {
-            $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+        try {
+            $result = $taxFormHandler->handleFor((int) $taxId, $taxForm);
 
-            return $this->redirectToRoute('admin_taxes_index');
+            if (null !== $result->getIdentifiableObjectId()) {
+                $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+
+                return $this->redirectToRoute('admin_taxes_index');
+            }
+        } catch (TaxException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            if ($e instanceof TaxNotFoundException) {
+                return $this->redirectToRoute('admin_taxes_index');
+            }
         }
 
         return $this->render('@PrestaShop/Admin/Improve/International/Tax/edit.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -137,7 +137,10 @@ class TaxController extends FrameworkBundleAdminController
     }
 
     /**
-     * Handles tax creation
+     * @AdminSecurity(
+     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_taxes_index",
+     * )
      *
      * @param Request $request
      *
@@ -148,9 +151,9 @@ class TaxController extends FrameworkBundleAdminController
         $taxFormHandler = $this->get('prestashop.core.form.identifiable_object.handler.tax_form_handler');
         $taxFormBuilder = $this->get('prestashop.core.form.identifiable_object.builder.tax_form_builder');
 
-        $taxForm = $taxFormBuilder->getForm();
-        $taxForm->handleRequest($request);
         try {
+            $taxForm = $taxFormBuilder->getForm();
+            $taxForm->handleRequest($request);
             $result = $taxFormHandler->handle($taxForm);
             if (null !== $result->getIdentifiableObjectId()) {
                 $this->addFlash('success', $this->trans('Successful creation.', 'Admin.Notifications.Success'));
@@ -164,11 +167,17 @@ class TaxController extends FrameworkBundleAdminController
         return $this->render('@PrestaShop/Admin/Improve/International/Tax/create.html.twig', [
             'taxForm' => $taxForm->createView(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'enableSidebar' => true,
         ]);
     }
 
     /**
      * Handles tax edit
+     *
+     * @AdminSecurity(
+     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_taxes_index",
+     * )
      *
      * @param Request $request
      * @param int $taxId
@@ -180,10 +189,9 @@ class TaxController extends FrameworkBundleAdminController
         $taxFormHandler = $this->get('prestashop.core.form.identifiable_object.handler.tax_form_handler');
         $taxFormBuilder = $this->get('prestashop.core.form.identifiable_object.builder.tax_form_builder');
 
-        $taxForm = $taxFormBuilder->getFormFor((int) $taxId);
-        $taxForm->handleRequest($request);
-
         try {
+            $taxForm = $taxFormBuilder->getFormFor((int) $taxId);
+            $taxForm->handleRequest($request);
             $result = $taxFormHandler->handleFor((int) $taxId, $taxForm);
 
             if (null !== $result->getIdentifiableObjectId()) {
@@ -206,6 +214,7 @@ class TaxController extends FrameworkBundleAdminController
             'taxForm' => $taxForm->createView(),
             'taxName' => $editableTax->getLocalizedNames()[$this->getContextLangId()],
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'enableSidebar' => true,
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -198,11 +198,13 @@ class TaxController extends FrameworkBundleAdminController
                 return $this->redirectToRoute('admin_taxes_index');
             }
         }
+
+        /** @var EditableTax $editableTax */
         $editableTax = $this->getQueryBus()->handle(new GetTaxForEditing((int) $taxId));
 
         return $this->render('@PrestaShop/Admin/Improve/International/Tax/edit.html.twig', [
             'taxForm' => $taxForm->createView(),
-            'taxName' => $editableTax->getName()[$this->getContextLangId()],
+            'taxName' => $editableTax->getLocalizedNames()[$this->getContextLangId()],
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
         ]);
     }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -137,6 +137,36 @@ class TaxController extends FrameworkBundleAdminController
     }
 
     /**
+     * Handles tax creation
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function createAction(Request $request)
+    {
+        $taxFormHandler = $this->get('prestashop.core.form.identifiable_object.handler.tax_form_handler');
+        $taxFormBuilder = $this->get('prestashop.core.form.identifiable_object.builder.tax_form_builder');
+
+        $taxForm = $taxFormBuilder->getForm();
+        $taxForm->handleRequest($request);
+        try {
+            $result = $taxFormHandler->handle($taxForm);
+            if (null !== $result->getIdentifiableObjectId()) {
+                $this->addFlash('success', $this->trans('Successful creation.', 'Admin.Notifications.Success'));
+
+                return $this->redirectToRoute('admin_taxes_index');
+            }
+        } catch (TaxException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        }
+
+        return $this->render('@PrestaShop/Admin/Improve/International/Tax/create.html.twig', [
+            'taxForm' => $taxForm->createView(),
+        ]);
+    }
+
+    /**
      * Handles tax edit
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -115,6 +115,8 @@ class TaxController extends FrameworkBundleAdminController
     /**
      * Provides filters functionality.
      *
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     *
      * @param Request $request
      *
      * @return RedirectResponse

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -46,7 +46,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Class TaxController is responsible for handling "Improve > International > Taxes" page.
+ * Responsible for handling "Improve > International > Taxes" page.
  */
 class TaxController extends FrameworkBundleAdminController
 {
@@ -134,6 +134,18 @@ class TaxController extends FrameworkBundleAdminController
         }
 
         return $this->redirectToRoute('admin_taxes_index', ['filters' => $filters]);
+    }
+
+    /**
+     * Handles tax edit
+     *
+     * @param $taxId
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function editAction($taxId)
+    {
+        return $this->render('@PrestaShop/Admin/Improve/International/Tax/edit.html.twig');
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -139,13 +139,29 @@ class TaxController extends FrameworkBundleAdminController
     /**
      * Handles tax edit
      *
+     * @param Request $request
      * @param $taxId
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
-    public function editAction($taxId)
+    public function editAction(Request $request, $taxId)
     {
-        return $this->render('@PrestaShop/Admin/Improve/International/Tax/edit.html.twig');
+        $taxFormHandler = $this->get('prestashop.core.form.identifiable_object.handler.tax_form_handler');
+        $taxFormBuilder = $this->get('prestashop.core.form.identifiable_object.builder.tax_form_builder');
+
+        $taxForm = $taxFormBuilder->getFormFor((int) $taxId);
+        $taxForm->handleRequest($request);
+        $result = $taxFormHandler->handleFor((int) $taxId, $taxForm);
+
+        if (null !== $result->getIdentifiableObjectId()) {
+            $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+
+            return $this->redirectToRoute('admin_taxes_index');
+        }
+
+        return $this->render('@PrestaShop/Admin/Improve/International/Tax/edit.html.twig', [
+            'taxForm' => $taxForm->createView(),
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -163,6 +163,7 @@ class TaxController extends FrameworkBundleAdminController
 
         return $this->render('@PrestaShop/Admin/Improve/International/Tax/create.html.twig', [
             'taxForm' => $taxForm->createView(),
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
         ]);
     }
 
@@ -202,6 +203,7 @@ class TaxController extends FrameworkBundleAdminController
         return $this->render('@PrestaShop/Admin/Improve/International/Tax/edit.html.twig', [
             'taxForm' => $taxForm->createView(),
             'taxName' => $editableTax->getName()[$this->getContextLangId()],
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -140,7 +140,7 @@ class TaxController extends FrameworkBundleAdminController
      * Handles tax edit
      *
      * @param Request $request
-     * @param $taxId
+     * @param int $taxId
      *
      * @return Response
      */
@@ -167,9 +167,11 @@ class TaxController extends FrameworkBundleAdminController
                 return $this->redirectToRoute('admin_taxes_index');
             }
         }
+        $editableTax = $this->getQueryBus()->handle(new GetTaxForEditing((int) $taxId));
 
         return $this->render('@PrestaShop/Admin/Improve/International/Tax/edit.html.twig', [
             'taxForm' => $taxForm->createView(),
+            'taxName' => $editableTax->getName()[$this->getContextLangId()],
         ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -59,8 +59,17 @@ class TaxType extends AbstractType
     {
         $builder
             ->add('name', TranslatableType::class, [
+                //@todo: DefaultLanguage constraint
                 'options' => [
                     'constraints' => [
+                        new Length([
+                            'max' => 32,
+                            'maxMessage' => $this->translator->trans(
+                                'This field cannot be longer than %limit% characters',
+                                ['%limit%' => 32],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
                         new Regex([
                             'pattern' => '/^[^<>={}]*$/u',
                             'message' => $this->translator->trans(
@@ -71,28 +80,22 @@ class TaxType extends AbstractType
                                 'Admin.Notifications.Error'
                             ),
                         ]),
-                        new NotBlank([
-                            'message' => $this->translator->trans(
-                                'The %s field is required.',
-                                [
-                                    sprintf('"%s"', $this->translator->trans('Name', [], 'Admin.Global')),
-                                ],
-                                'Admin.Notifications.Error'
-                            ),
-                        ]),
-                        new Length([
-                            'max' => 32,
-                            'maxMessage' => $this->translator->trans(
-                                'This field cannot be longer than %limit% characters',
-                                ['%limit%' => 32],
-                                'Admin.Notifications.Error'
-                            ),
-                        ]),
                     ],
                 ],
             ])
             ->add('rate', TextType::class, [
                 'constraints' => [
+                    new NotBlank([
+                        'message' => $this->translator->trans(
+                            'The %s field is required.',
+                            [
+                                sprintf('"%s"', $this->translator->trans(
+                                    'Rate', [], 'Admin.International.Feature'
+                                )),
+                            ],
+                            'Admin.Notifications.Error'
+                        ),
+                    ]),
                     new Length([
                         'max' => 6,
                         'maxMessage' => $this->translator->trans(
@@ -106,17 +109,6 @@ class TaxType extends AbstractType
                         'message' => $this->translator->trans(
                             'This field is invalid, it must contain numeric values',
                             [],
-                            'Admin.Notifications.Error'
-                        ),
-                    ]),
-                    new NotBlank([
-                        'message' => $this->translator->trans(
-                            'The %s field is required.',
-                            [
-                                sprintf('"%s"', $this->translator->trans(
-                                    'Rate', [], 'Admin.International.Feature'
-                                )),
-                            ],
                             'Admin.Notifications.Error'
                         ),
                     ]),

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Improve\International\Tax;
+
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Type;
+
+/**
+ * Form type for tax add/edit
+ */
+class TaxType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', TranslatableType::class, [
+                'options' => [
+                    'required' => true,
+                    'constraints' => [
+                        new Regex([
+                            'pattern' => '/^[^<>={}]*$/u',
+                        ]),
+                        new NotBlank(),
+                    ],
+                ],
+            ])
+            ->add('rate', TextType::class, [
+                'required' => true,
+                'constraints' => [
+                    new Length([
+                        'max' => 6,
+                    ]),
+                    new Type('numeric'),
+                    new NotBlank(),
+                ],
+            ])
+            ->add('is_enabled', SwitchType::class)
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -104,7 +104,9 @@ class TaxType extends AbstractType
                     new Type([
                         'type' => 'numeric',
                         'message' => $this->translator->trans(
-                            'This field must contain only numeric values', [], 'Admin.Notifications.Error'
+                            'This field is invalid, it must contain numeric values',
+                            [],
+                            'Admin.Notifications.Error'
                         ),
                     ]),
                     new NotBlank([

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -31,6 +31,7 @@ use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
@@ -42,6 +43,16 @@ use Symfony\Component\Validator\Constraints\Type;
 class TaxType extends AbstractType
 {
     /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -49,26 +60,69 @@ class TaxType extends AbstractType
         $builder
             ->add('name', TranslatableType::class, [
                 'options' => [
-                    'required' => true,
                     'constraints' => [
                         new Regex([
                             'pattern' => '/^[^<>={}]*$/u',
+                            'message' => $this->translator->trans(
+                                '%s is invalid.',
+                                [
+                                    sprintf('"%s"', $this->translator->trans('Name', [], 'Admin.Global')),
+                                ],
+                                'Admin.Notifications.Error'
+                            ),
                         ]),
-                        new NotBlank(),
+                        new NotBlank([
+                            'message' => $this->translator->trans(
+                                'The %s field is required.',
+                                [
+                                    sprintf('"%s"', $this->translator->trans('Name', [], 'Admin.Global')),
+                                ],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                        new Length([
+                            'max' => 32,
+                            'maxMessage' => $this->translator->trans(
+                                'This field cannot be longer than %limit% characters',
+                                ['%limit%' => 32],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
                     ],
                 ],
             ])
             ->add('rate', TextType::class, [
-                'required' => true,
                 'constraints' => [
                     new Length([
                         'max' => 6,
+                        'maxMessage' => $this->translator->trans(
+                            'This field cannot be longer than %limit% characters',
+                            ['%limit%' => 6],
+                            'Admin.Notifications.Error'
+                        ),
                     ]),
-                    new Type('numeric'),
-                    new NotBlank(),
+                    new Type([
+                        'type' => 'numeric',
+                        'message' => $this->translator->trans(
+                            'This field must contain only numeric values', [], 'Admin.Notifications.Error'
+                        ),
+                    ]),
+                    new NotBlank([
+                        'message' => $this->translator->trans(
+                            'The %s field is required.',
+                            [
+                                sprintf('"%s"', $this->translator->trans(
+                                    'Rate', [], 'Admin.International.Feature'
+                                )),
+                            ],
+                            'Admin.Notifications.Error'
+                        ),
+                    ]),
                 ],
             ])
-            ->add('is_enabled', SwitchType::class)
+            ->add('is_enabled', SwitchType::class, [
+                'required' => false,
+            ])
         ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\International\Tax;
 
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use Symfony\Component\Form\AbstractType;
@@ -59,9 +60,9 @@ class TaxType extends AbstractType
     {
         $builder
             ->add('name', TranslatableType::class, [
-                //@todo: DefaultLanguage constraint
                 'options' => [
                     'constraints' => [
+                        new DefaultLanguage(),
                         new Length([
                             'max' => 32,
                             'maxMessage' => $this->translator->trans(
@@ -71,6 +72,7 @@ class TaxType extends AbstractType
                             ),
                         ]),
                         new Regex([
+                            //@todo: isGenericName Constraint istead
                             'pattern' => '/^[^<>={}]*$/u',
                             'message' => $this->translator->trans(
                                 '%s is invalid.',

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -62,7 +62,6 @@ class TaxType extends AbstractType
             ->add('name', TranslatableType::class, [
                 'options' => [
                     'constraints' => [
-                        new DefaultLanguage(),
                         new Length([
                             'max' => 32,
                             'maxMessage' => $this->translator->trans(
@@ -72,7 +71,7 @@ class TaxType extends AbstractType
                             ),
                         ]),
                         new Regex([
-                            //@todo: isGenericName Constraint istead
+                            //@todo: specific Constraint instead (is in another PR)
                             'pattern' => '/^[^<>={}]*$/u',
                             'message' => $this->translator->trans(
                                 '%s is invalid.',
@@ -83,6 +82,9 @@ class TaxType extends AbstractType
                             ),
                         ]),
                     ],
+                ],
+                'constraints' => [
+                    new DefaultLanguage(),
                 ],
             ])
             ->add('rate', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -48,6 +48,9 @@ class TaxType extends AbstractType
      */
     private $translator;
 
+    /**
+     * @param TranslatorInterface $translator
+     */
     public function __construct(TranslatorInterface $translator)
     {
         $this->translator = $translator;
@@ -71,14 +74,10 @@ class TaxType extends AbstractType
                             ),
                         ]),
                         new Regex([
-                            //@todo: specific Constraint instead (is in another PR)
+                            //@todo: specific Constraint instead (is in another PR #12735)
                             'pattern' => '/^[^<>={}]*$/u',
                             'message' => $this->translator->trans(
-                                '%s is invalid.',
-                                [
-                                    sprintf('"%s"', $this->translator->trans('Name', [], 'Admin.Global')),
-                                ],
-                                'Admin.Notifications.Error'
+                                '%s is invalid.', [], 'Admin.Notifications.Error'
                             ),
                         ]),
                     ],

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/tax.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/tax.yml
@@ -57,3 +57,12 @@ admin_taxes_bulk_delete:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:bulkDelete'
     _legacy_controller: AdminTaxes
+
+admin_taxes_edit:
+  path: /{taxId}/edit
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:edit'
+    _legacy_controller: AdminTaxes
+  requirements:
+    taxId: \d+

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/tax.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/tax.yml
@@ -2,8 +2,7 @@ admin_taxes_index:
   path: /
   methods: [GET]
   defaults:
-    ##todo: implement index action
-    _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:create'
+    _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:index'
     _legacy_controller: AdminTaxes
 
 admin_taxes_save_options:

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/tax.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/tax.yml
@@ -4,6 +4,7 @@ admin_taxes_index:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:index'
     _legacy_controller: AdminTaxes
+    _legacy_link: AdminTaxes
 
 admin_taxes_save_options:
   path: /save-options
@@ -11,6 +12,7 @@ admin_taxes_save_options:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:saveOptions'
     _legacy_controller: AdminTaxes
+    _legacy_link: AdminTaxes:submitOptionstax
 
 admin_taxes_search:
   path: /
@@ -18,6 +20,7 @@ admin_taxes_search:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:search'
     _legacy_controller: AdminTaxes
+    _legacy_link: AdminTaxes:submitFiltertax
 
 admin_taxes_create:
   path: /new
@@ -25,6 +28,7 @@ admin_taxes_create:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:create'
     _legacy_controller: AdminTaxes
+    _legacy_link: AdminTaxes:addtax
 
 admin_taxes_edit:
   path: /{taxId}/edit
@@ -32,6 +36,9 @@ admin_taxes_edit:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:edit'
     _legacy_controller: AdminTaxes
+    _legacy_link: AdminTaxes:updatetax
+    _legacy_parameters:
+      id_tax: taxId
   requirements:
     taxId: \d+
 
@@ -41,6 +48,7 @@ admin_taxes_delete:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:delete'
     _legacy_controller: AdminTaxes
+    _legacy_link: AdminTaxes:deletetax
   requirements:
     taxId: \d+
 
@@ -49,9 +57,12 @@ admin_taxes_toggle_status:
   methods: POST
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:toggleStatus'
-    _legacy_controller: AdminCurrencies
+    _legacy_controller: AdminTaxes
+    _legacy_link: AdminTaxes:statustax
+    _legacy_parameters:
+      id_tax: taxId
   requirements:
-    currencyId: \d+
+    taxId: \d+
 
 admin_taxes_bulk_enable_status:
   path: /bulk-enable-status
@@ -59,6 +70,7 @@ admin_taxes_bulk_enable_status:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:bulkEnableStatus'
     _legacy_controller: AdminTaxes
+    _legacy_link: AdminTaxes:submitBulkenableSelectiontax
 
 admin_taxes_bulk_disable_status:
   path: /bulk-disable-status
@@ -66,6 +78,7 @@ admin_taxes_bulk_disable_status:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:bulkDisableStatus'
     _legacy_controller: AdminTaxes
+    _legacy_link: AdminTaxes:submitBulkdisableSelectiontax
 
 admin_taxes_bulk_delete:
   path: /bulk-delete
@@ -73,3 +86,4 @@ admin_taxes_bulk_delete:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:bulkDelete'
     _legacy_controller: AdminTaxes
+    _legacy_link: AdminTaxes:submitBulkdeletetax

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/tax.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/tax.yml
@@ -2,7 +2,8 @@ admin_taxes_index:
   path: /
   methods: [GET]
   defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:index'
+    ##todo: implement index action
+    _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:create'
     _legacy_controller: AdminTaxes
 
 admin_taxes_save_options:

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/tax.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/tax.yml
@@ -19,6 +19,22 @@ admin_taxes_search:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:search'
     _legacy_controller: AdminTaxes
 
+admin_taxes_create:
+  path: /new
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:create'
+    _legacy_controller: AdminTaxes
+
+admin_taxes_edit:
+  path: /{taxId}/edit
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:edit'
+    _legacy_controller: AdminTaxes
+  requirements:
+    taxId: \d+
+
 admin_taxes_delete:
   path: /{taxId}/delete
   methods: POST
@@ -57,12 +73,3 @@ admin_taxes_bulk_delete:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:bulkDelete'
     _legacy_controller: AdminTaxes
-
-admin_taxes_edit:
-  path: /{taxId}/edit
-  methods: [GET, POST]
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\International\Tax:edit'
-    _legacy_controller: AdminTaxes
-  requirements:
-    taxId: \d+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/tax.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/tax.yml
@@ -26,8 +26,14 @@ services:
     tags:
       - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Tax\Command\BulkDeleteTaxCommand' }
 
-  prestashop.adapter.language.query_handler.get_tax_for_editing:
+  prestashop.adapter.tax.query_handler.get_tax_for_editing_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Tax\QueryHandler\GetTaxForEditingHandler'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Tax\Query\GetTaxForEditing'
+
+  prestashop.adapter.tax.command_handler.edit_tax_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\Tax\CommandHandler\EditTaxHandler'
+    tags:
+      - name: tactician.handler
+        command: 'PrestaShop\PrestaShop\Core\Domain\Tax\Command\EditTaxCommand'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/tax.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/tax.yml
@@ -37,3 +37,9 @@ services:
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Tax\Command\EditTaxCommand'
+
+  prestashop.adapter.tax.command_handler.add_tax_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\Tax\CommandHandler\AddTaxHandler'
+    tags:
+      - name: tactician.handler
+        command: 'PrestaShop\PrestaShop\Core\Domain\Tax\Command\AddTaxCommand'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -164,8 +164,8 @@ services:
     prestashop.admin.currency.form_data_provider:
         class: 'PrestaShopBundle\Form\Admin\Improve\International\Currencies\CurrencyFormDataProvider'
         arguments:
-          - '@prestashop.core.command_bus'
-          - '@=service("prestashop.adapter.legacy.configuration").get("PS_ACTIVE_CRONJOB_EXCHANGE_RATE")'
+            - '@prestashop.core.command_bus'
+            - '@=service("prestashop.adapter.legacy.configuration").get("PS_ACTIVE_CRONJOB_EXCHANGE_RATE")'
 
     prestashop.admin.tax_options.form_data_provider:
         class: 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxOptionsFormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -739,7 +739,7 @@ services:
         tags:
             - { name: form.type }
 
-    form.type.international.tax:
+    form.type.international.tax_options:
       class: 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxOptionsType'
       arguments:
         - '@=service("prestashop.adapter.legacy.configuration").getBoolean("PS_USE_ECOTAX")'
@@ -765,5 +765,12 @@ services:
             - '@=service("prestashop.adapter.multistore_feature").isUsed()'
         calls:
             - { method: setTranslator, arguments: ['@translator'] }
+        tags:
+            - { name: form.type }
+
+    form.type.international.tax:
+        class: 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxType'
+        arguments:
+            - '@translator'
         tags:
             - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -77,3 +77,10 @@ services:
     arguments:
       - 'PrestaShopBundle\Form\Admin\Improve\Design\Pages\CmsPageCategoryType'
       - '@prestashop.core.form.identifiable_object.data_provider.cms_page_category_form_data_provider'
+
+  prestashop.core.form.identifiable_object.builder.tax_form_builder:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
+    factory: 'prestashop.core.form.builder.form_builder_factory:create'
+    arguments:
+      - 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxType'
+      - '@prestashop.core.form.identifiable_object.data_provider.tax_form_data_provider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -60,3 +60,8 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CmsPageCategoryFormDataHandler'
     arguments:
       - '@prestashop.core.command_bus'
+
+  prestashop.core.form.identifiable_object.data_handler.tax_form_data_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\TaxFormDataHandler'
+    arguments:
+      - '@prestashop.core.command_bus'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -60,3 +60,8 @@ services:
     arguments:
       - '@prestashop.core.query_bus'
       - '@=service("prestashop.adapter.shop.context").getContextListShopID()'
+
+  prestashop.core.form.identifiable_object.data_provider.tax_form_data_provider:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\TaxFormDataProvider'
+    arguments:
+      - '@prestashop.core.query_bus'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
@@ -69,3 +69,9 @@ services:
     factory: 'prestashop.core.form.identifiable_object.handler.form_handler_factory:create'
     arguments:
       - '@prestashop.core.form.identifiable_object.data_handler.cms_page_category_form_data_handler'
+
+  prestashop.core.form.identifiable_object.handler.tax_form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler'
+    factory: 'prestashop.core.form.identifiable_object.handler.form_handler_factory:create'
+    arguments:
+      - '@prestashop.core.form.identifiable_object.data_handler.tax_form_data_handler'

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
@@ -30,17 +30,26 @@
     <div class="card-header">
       {{ 'Taxes'|trans({}, 'Admin.Global') }}
     </div>
+
     <div class="card-block row">
       <div class="card-text">
+        {% set nameHint %}
+          {{ 'Tax name to display in carts and on invoices (e.g. "VAT").'|trans({}, 'Admin.International.Help') }}
+          {{ 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') }} {{ ' <>;=#{}' }}
+        {% endset %}
+
         {{ ps.form_group_row(taxForm.name, {}, {
-          'label': 'Name'|trans({}, 'Admin.Global')
+          'label': 'Name'|trans({}, 'Admin.Global'),
+          'help': nameHint,
         }) }}
+
+        {% set rateHint %}
+          {{ 'Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)'|trans({}, 'Admin.International.Help') }}
+        {% endset %}
 
         {{ ps.form_group_row(taxForm.rate, {}, {
           'label': 'Rate'|trans({}, 'Admin.International.Feature'),
-          'attr': {
-            'maxlength': 6
-          }
+          'help': rateHint,
         }) }}
 
         {{ ps.form_group_row(taxForm.is_enabled, {}, {

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
@@ -1,0 +1,64 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+
+  {{ form_start(taxForm) }}
+  <div class="card">
+    <div class="card-header">
+      {{ 'Taxes'|trans({}, 'Admin.Global') }}
+    </div>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ ps.form_group_row(taxForm.name, {}, {
+          'label': 'Name'|trans({}, 'Admin.Global')
+        }) }}
+
+        {{ ps.form_group_row(taxForm.rate, {}, {
+          'label': 'Rate'|trans({}, 'Admin.International.Feature'),
+          'attr': {
+            'maxlength': 6
+          }
+        }) }}
+
+        {{ ps.form_group_row(taxForm.is_enabled, {}, {
+          'label': 'Enable'|trans({}, 'Admin.Actions')
+        }) }}
+      </div>
+    </div>
+
+    <div class="card-footer">
+      <div class="d-inline-flex">
+        <a href="{{ path('admin_taxes_index') }}" class="btn btn-outline-secondary">
+          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+        </a>
+      </div>
+      <div class="d-inline-flex float-right">
+        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
+
+  </div>
+  {{ form_end(taxForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
@@ -25,49 +25,49 @@
 
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
-  {{ form_start(taxForm) }}
-  <div class="card">
-    <div class="card-header">
-      {{ 'Taxes'|trans({}, 'Admin.Global') }}
-    </div>
-
-    <div class="card-block row">
-      <div class="card-text">
-        {% set nameHint %}
-          {{ 'Tax name to display in carts and on invoices (e.g. "VAT").'|trans({}, 'Admin.International.Help') }}
-          {{ 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') }} {{ ' <>;=#{}' }}
-        {% endset %}
-
-        {{ ps.form_group_row(taxForm.name, {}, {
-          'label': 'Name'|trans({}, 'Admin.Global'),
-          'help': nameHint,
-        }) }}
-
-        {% set rateHint %}
-          {{ 'Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)'|trans({}, 'Admin.International.Help') }}
-        {% endset %}
-
-        {{ ps.form_group_row(taxForm.rate, {}, {
-          'label': 'Rate'|trans({}, 'Admin.International.Feature'),
-          'help': rateHint,
-        }) }}
-
-        {{ ps.form_group_row(taxForm.is_enabled, {}, {
-          'label': 'Enable'|trans({}, 'Admin.Actions')
-        }) }}
-      </div>
-    </div>
-
-    <div class="card-footer">
-      <div class="d-inline-flex">
-        <a href="{{ path('admin_taxes_index') }}" class="btn btn-outline-secondary">
-          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-        </a>
-      </div>
-      <div class="d-inline-flex float-right">
-        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-      </div>
-    </div>
-
+{{ form_start(taxForm) }}
+<div class="card">
+  <div class="card-header">
+    {{ 'Taxes'|trans({}, 'Admin.Global') }}
   </div>
-  {{ form_end(taxForm) }}
+
+  <div class="card-block row">
+    <div class="card-text">
+      {% set nameHint %}
+        {{ 'Tax name to display in carts and on invoices (e.g. "VAT").'|trans({}, 'Admin.International.Help') }}
+        {{ 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}
+      {% endset %}
+
+      {{ ps.form_group_row(taxForm.name, {}, {
+        'label': 'Name'|trans({}, 'Admin.Global'),
+        'help': nameHint,
+      }) }}
+
+      {% set rateHint %}
+        {{ 'Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)'|trans({}, 'Admin.International.Help') }}
+      {% endset %}
+
+      {{ ps.form_group_row(taxForm.rate, {}, {
+        'label': 'Rate'|trans({}, 'Admin.International.Feature'),
+        'help': rateHint,
+      }) }}
+
+      {{ ps.form_group_row(taxForm.is_enabled, {}, {
+        'label': 'Enable'|trans({}, 'Admin.Actions')
+      }) }}
+    </div>
+  </div>
+
+  <div class="card-footer">
+    <div class="d-inline-flex">
+      <a href="{{ path('admin_taxes_index') }}" class="btn btn-outline-secondary">
+        {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+      </a>
+    </div>
+    <div class="d-inline-flex float-right">
+      <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+    </div>
+  </div>
+
+</div>
+{{ form_end(taxForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
@@ -55,6 +55,10 @@
       {{ ps.form_group_row(taxForm.is_enabled, {}, {
         'label': 'Enable'|trans({}, 'Admin.Actions')
       }) }}
+
+      {% block tax_form_rest %}
+        {{ form_rest(taxForm) }}
+      {% endblock %}
     </div>
   </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/tax_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/tax_options.html.twig
@@ -23,76 +23,78 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% block tax_options %}
-  {{ form_start(taxOptionsForm, {'action': path('admin_taxes_save_options')}) }}
-  <div class="card">
-    <h3 class="card-header">
-      {{ 'Tax options'|trans({}, 'Admin.International.Feature') }}
-    </h3>
-    <div class="card-block row">
-      <div class="card-text">
-        <div class="form-group row">
-          <label class="form-control-label" for="{{ taxOptionsForm.options.enable_tax.vars.id }}">
-            {{ 'Enable tax'|trans({}, 'Admin.International.Feature') }}
-          </label>
-          <div class="col-sm">
-            {{ form_widget(taxOptionsForm.options.enable_tax, {'attr': {'class': 'js-enable-tax'}}) }}
-              <small class="form-text">
-                {{ 'Select whether or not to include tax on purchases.'|trans({}, 'Admin.International.Help') }}
-              </small>
-          </div>
-        </div>
-        <div class="form-group row">
-          <label class="form-control-label" for="{{ taxOptionsForm.options.display_tax_in_cart.vars.id }}">
-            {{ 'Display tax in the shopping cart'|trans({}, 'Admin.International.Feature') }}
-          </label>
-          <div class="col-sm">
-            {{ form_widget(taxOptionsForm.options.display_tax_in_cart, {'attr': {'class': 'js-display-in-cart'}}) }}
+{{ form_start(taxOptionsForm, {'action': path('admin_taxes_save_options')}) }}
+<div class="card">
+  <h3 class="card-header">
+    {{ 'Tax options'|trans({}, 'Admin.International.Feature') }}
+  </h3>
+  <div class="card-block row">
+    <div class="card-text">
+      <div class="form-group row">
+        <label class="form-control-label" for="{{ taxOptionsForm.options.enable_tax.vars.id }}">
+          {{ 'Enable tax'|trans({}, 'Admin.International.Feature') }}
+        </label>
+        <div class="col-sm">
+          {{ form_widget(taxOptionsForm.options.enable_tax, {'attr': {'class': 'js-enable-tax'}}) }}
             <small class="form-text">
-              {{ 'Select whether or not to display tax on a distinct line in the cart.'|trans({}, 'Admin.International.Help') }}
+              {{ 'Select whether or not to include tax on purchases.'|trans({}, 'Admin.International.Help') }}
             </small>
-          </div>
         </div>
+      </div>
+      <div class="form-group row">
+        <label class="form-control-label" for="{{ taxOptionsForm.options.display_tax_in_cart.vars.id }}">
+          {{ 'Display tax in the shopping cart'|trans({}, 'Admin.International.Feature') }}
+        </label>
+        <div class="col-sm">
+          {{ form_widget(taxOptionsForm.options.display_tax_in_cart, {'attr': {'class': 'js-display-in-cart'}}) }}
+          <small class="form-text">
+            {{ 'Select whether or not to display tax on a distinct line in the cart.'|trans({}, 'Admin.International.Help') }}
+          </small>
+        </div>
+      </div>
+      <div class="form-group row">
+        <label for="{{ taxOptionsForm.options.tax_address_type.vars.id }}" class="form-control-label">
+          {{ 'Based on'|trans({}, 'Admin.International.Feature') }}
+        </label>
+        <div class="col-sm">
+          {{ form_widget(taxOptionsForm.options.tax_address_type) }}
+        </div>
+      </div>
+      <div class="form-group row">
+        <label class="form-control-label" for="{{ taxOptionsForm.options.use_eco_tax.vars.id }}">
+          {{ 'Use ecotax'|trans({}, 'Admin.International.Feature') }}
+        </label>
+        <div class="col-sm">
+          {{ form_widget(taxOptionsForm.options.use_eco_tax) }}
+          {% if (taxOptionsForm.options.use_eco_tax.vars.value != 0) %}
+            <small class="form-text">
+              {{ 'If you disable the ecotax, the ecotax for all your products will be set to 0.'|trans({}, 'Admin.International.Help') }}
+            </small>
+          {% endif %}
+        </div>
+      </div>
+      {% if taxOptionsForm.options.eco_tax_rule_group is defined %}
         <div class="form-group row">
-          <label for="{{ taxOptionsForm.options.tax_address_type.vars.id }}" class="form-control-label">
-            {{ 'Based on'|trans({}, 'Admin.International.Feature') }}
+          <label class="form-control-label" for="{{ taxOptionsForm.options.eco_tax_rule_group.vars.id }}">
+            {{ 'Ecotax'|trans({}, 'Admin.International.Feature') }}
           </label>
           <div class="col-sm">
-            {{ form_widget(taxOptionsForm.options.tax_address_type) }}
+            {{ form_widget(taxOptionsForm.options.eco_tax_rule_group) }}
           </div>
         </div>
-        <div class="form-group row">
-          <label class="form-control-label" for="{{ taxOptionsForm.options.use_eco_tax.vars.id }}">
-            {{ 'Use ecotax'|trans({}, 'Admin.International.Feature') }}
-          </label>
-          <div class="col-sm">
-            {{ form_widget(taxOptionsForm.options.use_eco_tax) }}
-            {% if (taxOptionsForm.options.use_eco_tax.vars.value != 0) %}
-              <small class="form-text">
-                {{ 'If you disable the ecotax, the ecotax for all your products will be set to 0.'|trans({}, 'Admin.International.Help') }}
-              </small>
-            {% endif %}
-          </div>
-        </div>
-        {% if taxOptionsForm.options.eco_tax_rule_group is defined %}
-          <div class="form-group row">
-            <label class="form-control-label" for="{{ taxOptionsForm.options.eco_tax_rule_group.vars.id }}">
-              {{ 'Ecotax'|trans({}, 'Admin.International.Feature') }}
-            </label>
-            <div class="col-sm">
-              {{ form_widget(taxOptionsForm.options.eco_tax_rule_group) }}
-            </div>
-          </div>
-        {% endif %}
-      </div>
-    </div>
-    <div class="card-footer">
-      <div class="d-flex justify-content-end">
-        <button class="btn btn-primary">
-          {{ 'Save'|trans({}, 'Admin.Actions') }}
-        </button>
-      </div>
+      {% endif %}
+
+      {% block tax_options_rest %}
+        {{ form_rest(taxOptionsForm) }}
+      {% endblock %}
     </div>
   </div>
-  {{ form_end(taxOptionsForm) }}
-{% endblock %}
+  <div class="card-footer">
+    <div class="d-flex justify-content-end">
+      <button class="btn btn-primary">
+        {{ 'Save'|trans({}, 'Admin.Actions') }}
+      </button>
+    </div>
+  </div>
+</div>
+{{ form_end(taxOptionsForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/create.html.twig
@@ -23,18 +23,20 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-  {% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-  {% block content %}
-    <div class="row justify-content-center">
-      <div class="col">
-        {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
-      </div>
+{% set enableSidebar = true %}
+
+{% block content %}
+  <div class="row justify-content-center">
+    <div class="col">
+      {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
     </div>
-  {% endblock %}
+  </div>
+{% endblock %}
 
-  {% block javascripts %}
-    {{ parent() }}
+{% block javascripts %}
+  {{ parent() }}
 
-    <script src="{{ asset('themes/new-theme/public/tax.bundle.js') }}"></script>
-  {% endblock %}
+  <script src="{{ asset('themes/new-theme/public/tax.bundle.js') }}"></script>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/create.html.twig
@@ -1,0 +1,40 @@
+{#**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+  {% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+  {% block content %}
+    <div class="row justify-content-center">
+      <div class="col">
+        {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
+      </div>
+    </div>
+  {% endblock %}
+
+  {% block javascripts %}
+    {{ parent() }}
+
+    <script src="{{ asset('themes/new-theme/public/tax.bundle.js') }}"></script>
+  {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/create.html.twig
@@ -25,8 +25,6 @@
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% set enableSidebar = true %}
-
 {% block content %}
   <div class="row justify-content-center">
     <div class="col">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
@@ -25,7 +25,7 @@
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% set layoutTitle = 'Edit: %value%'|trans({'%value%': taxName}, 'Admin.Catalog.Feature') %}
+{% set layoutTitle = 'Edit: %value%'|trans({'%value%': taxName}, 'Admin.Actions') %}
 
 {% block content %}
   <div class="row justify-content-center">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
@@ -1,0 +1,35 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+  {% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+  {% block content %}
+    <div class="row justify-content-center">
+      <div class="col">
+        hello world
+        {#{{ include('@PrestaShop/Admin/Improve/International/Currency/Blocks/form.html.twig', {'currencyForm': currencyForm}) }}#}
+      </div>
+    </div>
+  {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
@@ -25,6 +25,7 @@
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
+{% set enableSidebar = true %}
 {% set layoutTitle = 'Edit: %value%'|trans({'%value%': taxName}, 'Admin.Actions') %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
@@ -23,12 +23,20 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-  {% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-  {% block content %}
-    <div class="row justify-content-center">
-      <div class="col">
-        {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
-      </div>
+{% set layoutTitle = 'Edit: %value%'|trans({'%value%': taxName}, 'Admin.Catalog.Feature') %}
+
+{% block content %}
+  <div class="row justify-content-center">
+    <div class="col">
+      {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
     </div>
-  {% endblock %}
+  </div>
+{% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+
+  <script src="{{ asset('themes/new-theme/public/tax.bundle.js') }}"></script>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
@@ -25,7 +25,6 @@
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% set enableSidebar = true %}
 {% set layoutTitle = 'Edit: %value%'|trans({'%value%': taxName}, 'Admin.Actions') %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/index.html.twig
@@ -23,12 +23,9 @@
 * International Registered Trademark & Property of PrestaShop SA
 *#}
 
-{#
-@todo: path admin_taxes_create after route implementation on another PR
-#}
 {% set layoutHeaderToolbarBtn = {
     'add' : {
-    'href': path('admin_taxes_index'),
+    'href': path('admin_taxes_create'),
     'desc': 'Add new tax'|trans({}, 'Admin.International.Feature'),
     'icon': 'add_circle_outline'
   }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Improve > International > Taxes edit tax form migration to symfony.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10612
| How to test?  | Tax edit and create form should keep same logic as in legacy page. Some minor changes: If edit/create form is submitted, but not valid then same page is re-rendered with error messages. (In legacy page it would redirect back to index page). Index route should be modified after creation of indexAction which is in another PR. :warning: Assets may have to be rebuilt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12641)
<!-- Reviewable:end -->
Waiting for #12735 merge to complete( to use TypedRegex constraint)