### PR TITLE
[CO] Bugfix DuplicateProcessor.php for PHP 7.1 and 7.2

### DIFF
--- a/tools/parser_sql/processors/DuplicateProcessor.php
+++ b/tools/parser_sql/processors/DuplicateProcessor.php
@@ -41,8 +41,8 @@ require_once(dirname(__FILE__) . '/SetProcessor.php');
  */
 class DuplicateProcessor extends SetProcessor {
 
-    public function process($tokens) {
-        return parent::process($tokens, false);
+    public function process($tokens, $isUpdate = false) {
+        return parent::process($tokens, $isUpdate);
     }
 
 }


### PR DESCRIPTION
Adapted file for use under PHP 7.1 and 7.2 to avoid a blank page

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Bugfix for PHP 7.1 and 7.2 to make the SQL Manager work again. to make the SQL Manager work again. Must be applied together with #12642 
| Type?         | bug fix 
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12643)
<!-- Reviewable:end -->
