### PR TITLE
Fixes #11887 - Error 500 when disabling or duplicating a product with a too long short description

### DIFF
--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -73,7 +73,9 @@ class AdminProductDataUpdater implements ProductInterface
         $failedIdList = array();
         foreach ($productListId as $productId) {
             $product = new Product($productId);
-            if (!Validate::isLoadedObject($product)) {
+            if (!Validate::isLoadedObject($product)
+                || (($product->validateFields(false, true)) !== true)
+                || (($product->validateFieldsLang(false, true)) !== true)) {
                 $failedIdList[] = $productId;
                 continue;
             }
@@ -165,6 +167,10 @@ class AdminProductDataUpdater implements ProductInterface
         $product = new Product($productId);
         if (!Validate::isLoadedObject($product)) {
             throw new \Exception('AdminProductDataUpdater->duplicateProduct() received an unknown ID.', 5005);
+        }
+        if ((($product->validateFields(false, true)) !== true)
+            || (($product->validateFieldsLang(false, true)) !== true)) {
+            throw new UpdateProductException('Cannot duplicate many requested products', 5004);
         }
 
         $id_product_old = $product->id;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Error 500 - Disable or duplicate product with a too long short description
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | Fixes #11887
| How to test?  | Follow the steps to reproduce the behavior described in the Issue #11887

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12662)
<!-- Reviewable:end -->
