### PR TITLE
Fix delivery slips failure when upgrading

### DIFF
--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -242,4 +242,5 @@ INSERT INTO `PREFIX_configuration_lang` (`id_configuration`, `id_lang`, `value`)
         `value`
     FROM `PREFIX_configuration` c WHERE `name` = 'PS_DELIVERY_PREFIX'
     AND NOT EXISTS (SELECT 1 FROM `PREFIX_configuration_lang` WHERE `id_configuration` = c.`id_configuration`)
-)
+);
+

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -232,3 +232,14 @@ UPDATE `PREFIX_access_old` ao SET `id_tab` = (
 DROP TABLE IF EXISTS `PREFIX_access_old`;
 DROP TABLE IF EXISTS `PREFIX_module_access_old`;
 DROP TABLE IF EXISTS `PREFIX_tab_transit`;
+
+/* Inserts PS_DELIVERY_PREFIX in the languages config table when key is not already in table */
+INSERT INTO `PREFIX_configuration_lang` (`id_configuration`, `id_lang`, `value`) VALUES
+(
+    SELECT
+        `id_configuration`,
+        (SELECT `value` FROM `PREFIX_configuration` WHERE `name` = 'PS_LANG_DEFAULT'),
+        `value`
+    FROM `PREFIX_configuration` c WHERE `name` = 'PS_DELIVERY_PREFIX'
+    AND NOT EXISTS (SELECT 1 FROM `PREFIX_configuration_lang` WHERE `id_configuration` = c.`id_configuration`)
+)


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Delivery slips fails when upgrading to 1.7.5
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #12626 
| How to test?  | As it is difficult to determine what version generates the missing data in database, it is possible to simply delete the keys PS_DELIVERY_PREFIX from `ps_configuration_lang` before upgrade. It will crash "Delivery slips" before these changes, but not after.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12666)
<!-- Reviewable:end -->
