### PR TITLE
[FO] Fix warning in ProductController

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -251,7 +251,7 @@ class ProductControllerCore extends FrontController
             }
 
             $accessories = $this->product->getAccessories($this->context->language->id);
-            if ($this->product->cache_is_pack || count($accessories)) {
+            if ($this->product->cache_is_pack || !empty($accessories)) {
                 $this->context->controller->addCSS(_THEME_CSS_DIR_.'product_list.css');
             }
             if ($this->product->customizable) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | product->getAccessories may return false if no accessories associated with product. This cause warning message in product controller:
"PHP Warning:  count(): Parameter must be an array or an object that implements Countable" in PHP 7.2. We need only check for non-empty value in $accessories and it will be right way
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12690)
<!-- Reviewable:end -->
