### PR TITLE
Fix missing comma in sql upgrade file

### DIFF
--- a/install-dev/upgrade/sql/1.7.6.0.sql
+++ b/install-dev/upgrade/sql/1.7.6.0.sql
@@ -12,6 +12,6 @@ CREATE TABLE `PREFIX_currency_lang` (
     `name` varchar(255) NOT NULL,
     `symbol` varchar(255) NOT NULL,
     PRIMARY KEY (`id_currency`,`id_lang`)
-  ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+  ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
 
 /* PHP:ps_1760_copy_data_from_currency_to_currency_lang(); */;

--- a/install-dev/upgrade/sql/1.7.6.0.sql
+++ b/install-dev/upgrade/sql/1.7.6.0.sql
@@ -10,7 +10,7 @@ CREATE TABLE `PREFIX_currency_lang` (
     `id_currency` int(10) unsigned NOT NULL,
     `id_lang` int(10) unsigned NOT NULL,
     `name` varchar(255) NOT NULL,
-    `symbol` varchar(255) NOT NULL
+    `symbol` varchar(255) NOT NULL,
     PRIMARY KEY (`id_currency`,`id_lang`)
   ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | missing coma in sql upgrade
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | run upgrade to 1.7.6.0

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12696)
<!-- Reviewable:end -->
