### PR TITLE
Refacto addons store controller and handle addons failure

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AddonsStoreController.php
@@ -44,8 +44,19 @@ class AddonsStoreController extends FrameworkBundleAdminController
      */
     public function indexAction(Request $request)
     {
+        $pageContent = @file_get_contents($this->getAddonsUrl($request));
+
+        if (!$pageContent) {
+            $this->addFlash('error', $this->trans(
+                'It looks like we have trouble connecting to Addons. Please refresh the page or check your firewall configuration.',
+                'Admin.Notifications.Error'
+            ));
+
+            return $this->redirectToRoute('admin_module_catalog');
+        }
+
         return $this->render('@PrestaShop/Admin/Improve/Module/addons_store.html.twig', array(
-            'pageContent' => file_get_contents($this->getAddonsUrl($request)),
+            'pageContent' => $pageContent,
             'layoutHeaderToolbarBtn' => array(),
             'layoutTitle' => $this->trans('Module selection', 'Admin.Navigation.Menu'),
             'requireAddonsSearch' => true,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Handle possible Addons failure with error message
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |  Make sure your computer cannot reach `https://addons.prestashop.com` and check the behavior of the page "Module > Modules Catalog > Modules Selection".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12699)
<!-- Reviewable:end -->
