### PR TITLE
Update OrderHistory to manage {followup} & {shipping_number} vars in all email templates, not only in in_transit template

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -486,11 +486,14 @@ class OrderHistoryCore extends ObjectModel
             ShopUrl::cacheMainDomainForShop($order->id_shop);
 
             $topic = $result['osname'];
+            $carrier = new Carrier((int)$order->id_carrier, $order->id_lang);
             $data = array(
                 '{lastname}' => $result['lastname'],
                 '{firstname}' => $result['firstname'],
                 '{id_order}' => (int) $this->id_order,
                 '{order_name}' => $order->getUniqReference(),
+                '{followup}' => str_replace('@', $order->getWsShippingNumber(), $carrier->url),
+                '{shipping_number}' => $order->getWsShippingNumber(),
             );
 
             if ($result['module_name']) {

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -486,7 +486,7 @@ class OrderHistoryCore extends ObjectModel
             ShopUrl::cacheMainDomainForShop($order->id_shop);
 
             $topic = $result['osname'];
-            $carrier = new Carrier((int)$order->id_carrier, $order->id_lang);
+            $carrier = new Carrier((int) $order->id_carrier, $order->id_lang);
             $data = array(
                 '{lastname}' => $result['lastname'],
                 '{firstname}' => $result['firstname'],

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -486,13 +486,16 @@ class OrderHistoryCore extends ObjectModel
             ShopUrl::cacheMainDomainForShop($order->id_shop);
 
             $topic = $result['osname'];
-            $carrier = new Carrier((int) $order->id_carrier, $order->id_lang);
+            $carrierUrl = '';
+            if (Validate::isLoadedObject($carrier = new Carrier((int) $order->id_carrier, $order->id_lang))) {
+                $carrierUrl = $carrier->url;
+            }
             $data = array(
                 '{lastname}' => $result['lastname'],
                 '{firstname}' => $result['firstname'],
                 '{id_order}' => (int) $this->id_order,
                 '{order_name}' => $order->getUniqReference(),
-                '{followup}' => str_replace('@', $order->getWsShippingNumber(), $carrier->url),
+                '{followup}' => str_replace('@', $order->getWsShippingNumber(), $carrierUrl),
                 '{shipping_number}' => $order->getWsShippingNumber(),
             );
 


### PR DESCRIPTION
Fix prestashop issue https://github.com/PrestaShop/PrestaShop/issues/12592

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | delivery traking number {shipping_number} and url {followup} are not replaced outside in_transit order state.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12592
| How to test?  | Set in_transit email template to shipped order state or use  {shipping_number} or {followup} in another email template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12705)
<!-- Reviewable:end -->
