### PR TITLE
Kpis list are now customizables using hooks

### DIFF
--- a/src/Core/Kpi/Exception/InvalidArgumentException.php
+++ b/src/Core/Kpi/Exception/InvalidArgumentException.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Kpi\Exception;
+
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+
+/**
+ * Will be thrown if Kpi factory arguments are invalid.
+ */
+final class InvalidArgumentException extends CoreException
+{
+    /**
+     * @param mixed $kpi
+     *
+     * @return InvalidArgumentException
+     */
+    public static function invalidKpi($kpi)
+    {
+        $exceptionMessage = sprintf(
+            'Kpi must be an instance of KpiInterface, got `%s`.',
+            gettype($kpi)
+        );
+
+        return new self($exceptionMessage);
+    }
+
+    /**
+     * @param mixed $identifier
+     *
+     * @return InvalidArgumentException
+     */
+    public static function invalidIdentifier($identifier)
+    {
+        $exceptionMessage = sprintf(
+            'Identifier must be a string, got `%s`.',
+            gettype($identifier)
+        );
+
+        return new self($exceptionMessage);
+    }
+}

--- a/src/Core/Kpi/Row/HookableKpiRowFactory.php
+++ b/src/Core/Kpi/Row/HookableKpiRowFactory.php
@@ -47,6 +47,7 @@ final class HookableKpiRowFactory implements KpiRowFactoryInterface
     /**
      * @var string used to make the hook selectable
      */
+    private $identifier;
 
     /**
      * @param KpiInterface[] $kpis

--- a/src/Core/Kpi/Row/HookableKpiRowFactory.php
+++ b/src/Core/Kpi/Row/HookableKpiRowFactory.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Kpi\Row;
+
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+
+/**
+ * Class KpiRowFactory builds a KPI row, able to dispatch a hook.
+ */
+final class HookableKpiRowFactory implements KpiRowFactoryInterface
+{
+    /**
+     * @var KpiInterface[] the list of KPIs to display
+     */
+    private $kpis;
+
+    /**
+     * @var HookDispatcherInterface the Hook Dispatcher
+     */
+    private $hookDispatcher;
+
+    /**
+     * @var string used to make the hook selectable
+     */
+
+    /**
+     * @param KpiInterface[] $kpis
+     */
+    public function __construct(
+        array $kpis,
+        HookDispatcherInterface $hookDispatcher,
+        $identifier
+    ) {
+        $this->kpis = $kpis;
+        $this->hookDispatcher = $hookDispatcher;
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build()
+    {
+        $kpiRow = new KpiRow();
+
+        $this->hookDispatcher->dispatchWithParameters($this->getHookName($this->identifier), $this->kpis);
+
+        foreach ($this->kpis as $kpi) {
+            $kpiRow->addKpi($kpi);
+        }
+
+        return $kpiRow;
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return string
+     */
+    private function getHookName($identifier)
+    {
+        return 'action' . ucfirst($identifier) . 'KpiRow';
+    }
+}

--- a/src/Core/Kpi/Row/HookableKpiRowFactory.php
+++ b/src/Core/Kpi/Row/HookableKpiRowFactory.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop and Contributors
+ * 2007-2019 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -16,7 +16,7 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://www.prestashop.com for more information.
+ * needs please refer to http://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright 2007-2019 PrestaShop SA and Contributors
@@ -51,6 +51,8 @@ final class HookableKpiRowFactory implements KpiRowFactoryInterface
 
     /**
      * @param KpiInterface[] $kpis
+     * @param HookDispatcherInterface $hookDispatcher
+     * @param string $identifier
      */
     public function __construct(
         array $kpis,
@@ -70,7 +72,7 @@ final class HookableKpiRowFactory implements KpiRowFactoryInterface
         $kpiRow = new KpiRow();
 
         $this->hookDispatcher->dispatchWithParameters($this->getHookName($this->identifier), [
-            'kpis' => &$this->kpis
+            'kpis' => &$this->kpis,
         ]);
 
         foreach ($this->kpis as $kpi) {

--- a/src/Core/Kpi/Row/HookableKpiRowFactory.php
+++ b/src/Core/Kpi/Row/HookableKpiRowFactory.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Kpi\Row;
 
+use PrestaShop\PrestaShop\Core\Kpi\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 
@@ -59,9 +60,11 @@ final class HookableKpiRowFactory implements KpiRowFactoryInterface
         HookDispatcherInterface $hookDispatcher,
         $identifier
     ) {
-        $this->kpis = $kpis;
-        $this->hookDispatcher = $hookDispatcher;
-        $this->identifier = $identifier;
+        if ($this->validateKpis($kpis) && $this->validateIdentifier($identifier)) {
+            $this->kpis = $kpis;
+            $this->hookDispatcher = $hookDispatcher;
+            $this->identifier = $identifier;
+        }
     }
 
     /**
@@ -75,11 +78,47 @@ final class HookableKpiRowFactory implements KpiRowFactoryInterface
             'kpis' => &$this->kpis,
         ]);
 
-        foreach ($this->kpis as $kpi) {
-            $kpiRow->addKpi($kpi);
+        if ($this->validateKpis($this->kpis)) {
+            foreach ($this->kpis as $kpi) {
+                $kpiRow->addKpi($kpi);
+            }
+
+            return $kpiRow;
+        }
+    }
+
+    /**
+     * @param array $kpis
+     *
+     * @return bool true if valid, else throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
+    private function validateKpis(array $kpis)
+    {
+        foreach ($kpis as $kpi) {
+            if (!$kpi instanceof KpiInterface) {
+                throw InvalidArgumentException::invalidKpi($kpi);
+            }
         }
 
-        return $kpiRow;
+        return true;
+    }
+
+    /**
+     * @param mixed $identifier
+     *
+     * @return bool true if valid, else throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
+    private function validateIdentifier($identifier)
+    {
+        if (!is_string($identifier)) {
+            throw InvalidArgumentException::invalidIdentifier($identifier);
+        }
+
+        return true;
     }
 
     /**

--- a/src/Core/Kpi/Row/HookableKpiRowFactory.php
+++ b/src/Core/Kpi/Row/HookableKpiRowFactory.php
@@ -69,7 +69,9 @@ final class HookableKpiRowFactory implements KpiRowFactoryInterface
     {
         $kpiRow = new KpiRow();
 
-        $this->hookDispatcher->dispatchWithParameters($this->getHookName($this->identifier), $this->kpis);
+        $this->hookDispatcher->dispatchWithParameters($this->getHookName($this->identifier), [
+            'kpis' => &$this->kpis
+        ]);
 
         foreach ($this->kpis as $kpi) {
             $kpiRow->addKpi($kpi);
@@ -85,6 +87,6 @@ final class HookableKpiRowFactory implements KpiRowFactoryInterface
      */
     private function getHookName($identifier)
     {
-        return 'action' . ucfirst($identifier) . 'KpiRow';
+        return 'action' . ucfirst($identifier) . 'KpiRowModifier';
     }
 }

--- a/src/Core/Kpi/Row/KpiRowFactory.php
+++ b/src/Core/Kpi/Row/KpiRowFactory.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
 /**
  * Class KpiRowFactory builds a KPI row.
  *
- * @deprecated since 1.7.6, will be removed in the next major version.
+ * @deprecated since 1.7.6, will be removed in the next major version, use HookableKpiRowFactory instead.
  */
 final class KpiRowFactory implements KpiRowFactoryInterface
 {
@@ -46,7 +46,8 @@ final class KpiRowFactory implements KpiRowFactoryInterface
     public function __construct(KpiInterface ...$kpis)
     {
         @trigger_error(
-            'Using `KpiRowFactory` class is deprecated and will be removed in the next major',
+            'Using `KpiRowFactory` class is deprecated and will be removed in the next major,' .
+            'use HookableKpiRowFactory instead',
             E_USER_DEPRECATED
         );
 

--- a/src/Core/Kpi/Row/KpiRowFactory.php
+++ b/src/Core/Kpi/Row/KpiRowFactory.php
@@ -30,6 +30,8 @@ use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
 
 /**
  * Class KpiRowFactory builds a KPI row.
+ *
+ * @deprecated since 1.7.6, will be removed in the next major version.
  */
 final class KpiRowFactory implements KpiRowFactoryInterface
 {
@@ -43,6 +45,11 @@ final class KpiRowFactory implements KpiRowFactoryInterface
      */
     public function __construct(KpiInterface ...$kpis)
     {
+        @trigger_error(
+            'Using `KpiRowFactory` class is deprecated and will be removed in the next major',
+            E_USER_DEPRECATED
+        );
+
         $this->kpis = $kpis;
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/kpi.yml
@@ -8,24 +8,33 @@ services:
 
     # KPI Row factories
     prestashop.core.kpi_row.factory.translations_page:
-        class: PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactory
+        class: PrestaShop\PrestaShop\Core\Kpi\Row\HookableKpiRowFactory
         arguments:
-            - '@prestashop.adapter.kpi.enabled_languages'
-            - '@prestashop.adapter.kpi.main_country'
-            - '@prestashop.adapter.kpi.translations'
+            -
+                - '@prestashop.adapter.kpi.enabled_languages'
+                - '@prestashop.adapter.kpi.main_country'
+                - '@prestashop.adapter.kpi.translations'
+            - '@prestashop.core.hook.dispatcher'
+            - 'translations'
 
     prestashop.core.kpi_row.factory.categories:
-        class: PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactory
+        class: PrestaShop\PrestaShop\Core\Kpi\Row\HookableKpiRowFactory
         arguments:
-          - '@prestashop.adapter.kpi.disabled_categories'
-          - '@prestashop.adapter.kpi.empty_categories'
-          - '@prestashop.adapter.kpi.top_category'
-          - '@prestashop.adapter.kpi.average_products_in_category'
+          -
+              - '@prestashop.adapter.kpi.disabled_categories'
+              - '@prestashop.adapter.kpi.empty_categories'
+              - '@prestashop.adapter.kpi.top_category'
+              - '@prestashop.adapter.kpi.average_products_in_category'
+          - '@prestashop.core.hook.dispatcher'
+          - 'categories'
 
     prestashop.core.kpi_row.factory.customers:
-        class: PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactory
+        class: PrestaShop\PrestaShop\Core\Kpi\Row\HookableKpiRowFactory
         arguments:
-            - '@prestashop.adapter.kpi.most_common_customers_gender'
-            - '@prestashop.adapter.kpi.average_customer_age'
-            - '@prestashop.adapter.kpi.order_per_customer'
-            - '@prestashop.adapter.kpi.newsletter_registrations'
+            -
+                - '@prestashop.adapter.kpi.most_common_customers_gender'
+                - '@prestashop.adapter.kpi.average_customer_age'
+                - '@prestashop.adapter.kpi.order_per_customer'
+                - '@prestashop.adapter.kpi.newsletter_registrations'
+            - '@prestashop.core.hook.dispatcher'
+            - 'customers'

--- a/tests/Unit/Core/Kpi/HookableKpiRowFactoryTest.php
+++ b/tests/Unit/Core/Kpi/HookableKpiRowFactoryTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * 2007-2019 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Core\Kpi;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+use PrestaShop\PrestaShop\Core\Kpi\Row\HookableKpiRowFactory;
+use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactoryInterface;
+use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowInterface;
+
+/**
+ * @doc ./vendor/bin/phpunit
+ */
+class HookableKpiRowFactoryTest extends TestCase
+{
+    public function testCanBeConstructedWithValidKpis()
+    {
+        $kpiMock1 = $this->createMock(KpiInterface::class);
+        $kpiMock2 = $this->createMock(KpiInterface::class);
+        $kpiMock3 = $this->createMock(KpiInterface::class);
+
+        $factory = new HookableKpiRowFactory(
+            [
+                $kpiMock1,
+                $kpiMock2,
+                $kpiMock3,
+            ],
+            $this->createMock(HookDispatcherInterface::class),
+            'fooBar'
+        );
+
+        $this->assertInstanceOf(KpiRowFactoryInterface::class, $factory);
+    }
+
+    public function testBuild()
+    {
+        $kpiMock1 = $this->createMock(KpiInterface::class);
+        $kpiMock2 = $this->createMock(KpiInterface::class);
+        $kpiMock3 = $this->createMock(KpiInterface::class);
+
+        $factory = new HookableKpiRowFactory(
+            [
+                $kpiMock1,
+                $kpiMock2,
+                $kpiMock3,
+            ],
+            $this->createMock(HookDispatcherInterface::class),
+            'fooBar'
+        );
+
+        /** @var KpiRowInterface $result */
+        $result = $factory->build();
+
+        $this->assertInstanceOf(KpiRowInterface::class, $result);
+
+        $kpis = $result->getKpis();
+
+        $this->assertEquals($kpis[0], $kpiMock1);
+        $this->assertEquals($kpis[1], $kpiMock2);
+        $this->assertEquals($kpis[2], $kpiMock3);
+    }
+}

--- a/tests/Unit/Core/Kpi/HookableKpiRowFactoryTest.php
+++ b/tests/Unit/Core/Kpi/HookableKpiRowFactoryTest.php
@@ -28,6 +28,7 @@ namespace Tests\Unit\Core\Kpi;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShop\PrestaShop\Core\Kpi\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\HookableKpiRowFactory;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactoryInterface;
@@ -52,6 +53,47 @@ class HookableKpiRowFactoryTest extends TestCase
             ],
             $this->createMock(HookDispatcherInterface::class),
             'fooBar'
+        );
+
+        $this->assertInstanceOf(KpiRowFactoryInterface::class, $factory);
+    }
+
+    public function testCantBeConstructedWithInvalidKpis()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Kpi must be an instance of KpiInterface, got `string`.');
+
+        $kpiMock1 = $this->createMock(KpiInterface::class);
+        $kpiMock2 = $this->createMock(KpiInterface::class);
+
+        $factory = new HookableKpiRowFactory(
+            [
+                $kpiMock1,
+                $kpiMock2,
+                'kpiMock3',
+            ],
+            $this->createMock(HookDispatcherInterface::class),
+            'fooBar'
+        );
+
+        $this->assertInstanceOf(KpiRowFactoryInterface::class, $factory);
+    }
+
+    public function testCantBeConstructedWithInvalidIdentifier()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Identifier must be a string, got `boolean`.');
+
+        $kpiMock1 = $this->createMock(KpiInterface::class);
+        $kpiMock2 = $this->createMock(KpiInterface::class);
+
+        $factory = new HookableKpiRowFactory(
+            [
+                $kpiMock1,
+                $kpiMock2,
+            ],
+            $this->createMock(HookDispatcherInterface::class),
+            false
         );
 
         $this->assertInstanceOf(KpiRowFactoryInterface::class, $factory);

--- a/tests/Unit/Core/Kpi/HookableKpiRowFactoryTest.php
+++ b/tests/Unit/Core/Kpi/HookableKpiRowFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop
+ * 2007-2019 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to http://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA
+ * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
@@ -34,7 +34,7 @@ use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactoryInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowInterface;
 
 /**
- * @doc ./vendor/bin/phpunit
+ * @doc ./vendor/bin/phpunit -c tests/Unit/phpunit.xml --filter="HookableKpiRowFactoryTest"
  */
 class HookableKpiRowFactoryTest extends TestCase
 {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Until now, it wasn't possible to alter the list of KPIs blocks in Back Office pages. This contribution introduces a new factory able to dispatch a hook.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | yes, we shouldn't use the old `KpiRowFactory` class anymore. Still, my contribution is compatible with the old usage (but you won't be able to dispatch a hook).
| Fixed ticket? | not yet (I guess)
| How to test?  | In `develop` branch, access to `/admin-dev/sell/customers` page: you should see 4 kpis on the top of the page. Then use my branch and download (and install) the following [module](https://github.com/PrestaShop/PrestaShop/files/2901202/customers.zip): you should see only 3 kpis. WOW!

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12706)
<!-- Reviewable:end -->