### PR TITLE
Fix shipping cost becoming free if more than a half or available quantity ordered

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2545,15 +2545,9 @@ class OrderCore extends ObjectModel
 
         // add real order products
         foreach ($this->getProducts() as $product) {
-            $new_cart->updateQty(
-                    $product['product_quantity'], 
+            $new_cart->updateQty( $product['product_quantity'], 
                     (int) $product['product_id'],
-                    null, //pass default values
-                    false, 
-                    'up', 
-                    0, 
-                    null, 
-                    true,
+                    null, false, 'up', 0, null, true,
                     true ); // - skipAvailabilityCheckOutOfStock
         }
 

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2545,7 +2545,16 @@ class OrderCore extends ObjectModel
 
         // add real order products
         foreach ($this->getProducts() as $product) {
-            $new_cart->updateQty($product['product_quantity'], (int) $product['product_id']);
+            $new_cart->updateQty(
+                    $product['product_quantity'], 
+                    (int) $product['product_id'],
+                    null, //pass default values
+                    false, 
+                    'up', 
+                    0, 
+                    null, 
+                    true,
+                    true ); // - skipAvailabilityCheckOutOfStock
         }
 
         // get new shipping cost

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2545,10 +2545,17 @@ class OrderCore extends ObjectModel
 
         // add real order products
         foreach ($this->getProducts() as $product) {
-            $new_cart->updateQty( $product['product_quantity'], 
-                    (int) $product['product_id'],
-                    null, false, 'up', 0, null, true,
-                    true ); // - skipAvailabilityCheckOutOfStock
+            $new_cart->updateQty(
+                $product['product_quantity'],
+                (int) $product['product_id'],
+                null,
+                false,
+                'up',
+                0,
+                null,
+                true,
+                true
+            ); // - skipAvailabilityCheckOutOfStock
         }
 
         // get new shipping cost


### PR DESCRIPTION
If more than a half specifiend in BO the shipping cost becomes free.

To fix that we should pass skipAvailabilityCheckOutOfStock  set to true to updateQty in class Cart
(classes/Cart.php)

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | If the order is beeing edited in BO and the quantity changed to more than a half of available qty the shipping cost gets free.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9694.
| How to test?  | Create an order in BO or FO with qty less than a half of availble. Correct qty in BO so the new qty would be more than a haft, it leads to shipping become free.

Issue link - https://github.com/PrestaShop/PrestaShop/issues/9694

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12711)
<!-- Reviewable:end -->
