### PR TITLE
Prevent including jQuery in the new theme

### DIFF
--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -128,4 +128,13 @@ class AdminLegacyLayoutControllerCore extends AdminController
 
         $this->outPutHtml;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addJquery($version = null, $folder = null, $minifier = true)
+    {
+        // jQuery is already included, so do nothing
+        @trigger_error(__FUNCTION__ . 'is deprecated and has no effect in the New Theme since version 1.7.6.0.', E_USER_DEPRECATED);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | It shouldn't be possible to add jQuery to the new theme, because it's already included in the UI kit. This PR works better with this modification in gamification: https://github.com/PrestaShop/gamification/pull/62
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | maybe? - It's no longer possible to include jQuery twice
| Deprecations? | yes
| Fixed ticket? | n/a
| How to test?  | Using current gamification, it shouldn't work. Using the provided change it should. In any case, you should no longer have jQuery 1.x loaded in the new theme.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12716)
<!-- Reviewable:end -->
