### PR TITLE
Fix fatal error in product catalog when short description is too long

### DIFF
--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -74,7 +74,7 @@ class AdminProductDataUpdater implements ProductInterface
         foreach ($productListId as $productId) {
             $product = new Product($productId);
             if (!Validate::isLoadedObject($product)
-                || (($product->validateFields(false, true)) !== true)
+                || $product->validateFields(false, true) !== true
                 || $product->validateFieldsLang(false, true) !== true) {
                 $failedIdList[] = $productId;
 

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -40,6 +40,7 @@ use Search;
 use Shop;
 use ShopGroup;
 use Validate;
+use Language;
 
 /**
  * This class will update/insert/delete data from DB / ORM about Product, for both Front and Admin interfaces.
@@ -171,9 +172,15 @@ class AdminProductDataUpdater implements ProductInterface
             throw new \Exception('AdminProductDataUpdater->duplicateProduct() received an unknown ID.', 5005);
         }
 
-        if ($product->validateFields(false, true) !== true
-            || $product->validateFieldsLang(false, true) !== true) {
-            throw new UpdateProductException('Cannot duplicate many requested products', 5004);
+        foreach (Language::getIDs(false) as $id_lang) {
+            if ($product->validateField('description_short', $product->description_short[$id_lang], $id_lang) !== true) {
+                throw new UpdateProductException(
+                    sprintf(
+                        'Cannot duplicate this product because the "Summary" field for the language "%s" is too long',
+                        Language::getIsoById($id_lang)
+                    )
+                );                                        
+            }
         }
 
         $id_product_old = $product->id;

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -75,7 +75,7 @@ class AdminProductDataUpdater implements ProductInterface
             $product = new Product($productId);
             if (!Validate::isLoadedObject($product)
                 || (($product->validateFields(false, true)) !== true)
-                || (($product->validateFieldsLang(false, true)) !== true)) {
+                || $product->validateFieldsLang(false, true) !== true) {
                 $failedIdList[] = $productId;
 
                 continue;

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -172,7 +172,7 @@ class AdminProductDataUpdater implements ProductInterface
         }
 
         if ($product->validateFields(false, true) !== true
-            || (($product->validateFieldsLang(false, true)) !== true)) {
+            || $product->validateFieldsLang(false, true) !== true) {
             throw new UpdateProductException('Cannot duplicate many requested products', 5004);
         }
 

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -73,7 +73,9 @@ class AdminProductDataUpdater implements ProductInterface
         $failedIdList = array();
         foreach ($productListId as $productId) {
             $product = new Product($productId);
-            if (!Validate::isLoadedObject($product)) {
+            if (!Validate::isLoadedObject($product)
+                || (($product->validateFields(false, true)) !== true)
+                || (($product->validateFieldsLang(false, true)) !== true)) {
                 $failedIdList[] = $productId;
 
                 continue;
@@ -167,6 +169,11 @@ class AdminProductDataUpdater implements ProductInterface
         $product = new Product($productId);
         if (!Validate::isLoadedObject($product)) {
             throw new \Exception('AdminProductDataUpdater->duplicateProduct() received an unknown ID.', 5005);
+        }
+
+        if ((($product->validateFields(false, true)) !== true)
+            || (($product->validateFieldsLang(false, true)) !== true)) {
+            throw new UpdateProductException('Cannot duplicate many requested products', 5004);
         }
 
         $id_product_old = $product->id;

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -179,7 +179,7 @@ class AdminProductDataUpdater implements ProductInterface
                         'Cannot duplicate this product because the "Summary" field for the language "%s" is too long',
                         Language::getIsoById($id_lang)
                     )
-                );                                        
+                );
             }
         }
 

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -171,7 +171,7 @@ class AdminProductDataUpdater implements ProductInterface
             throw new \Exception('AdminProductDataUpdater->duplicateProduct() received an unknown ID.', 5005);
         }
 
-        if ((($product->validateFields(false, true)) !== true)
+        if ($product->validateFields(false, true) !== true
             || (($product->validateFieldsLang(false, true)) !== true)) {
             throw new UpdateProductException('Cannot duplicate many requested products', 5004);
         }

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -40,7 +40,6 @@ use Search;
 use Shop;
 use ShopGroup;
 use Validate;
-use Language;
 
 /**
  * This class will update/insert/delete data from DB / ORM about Product, for both Front and Admin interfaces.
@@ -172,15 +171,9 @@ class AdminProductDataUpdater implements ProductInterface
             throw new \Exception('AdminProductDataUpdater->duplicateProduct() received an unknown ID.', 5005);
         }
 
-        foreach (Language::getIDs(false) as $id_lang) {
-            if ($product->validateField('description_short', $product->description_short[$id_lang], $id_lang) !== true) {
-                throw new UpdateProductException(
-                    sprintf(
-                        'Cannot duplicate this product because the "Summary" field for the language "%s" is too long',
-                        Language::getIsoById($id_lang)
-                    )
-                );
-            }
+        if (($error = $product->validateFields(false, true)) !== true
+            || ($error = $product->validateFieldsLang(false, true)) !== true) {
+            throw new UpdateProductException(sprintf('Cannot duplicate this product: %s', $error));
         }
 
         $id_product_old = $product->id;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Error 500 - Disable or duplicate product with a too long short description
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | Fixes #11887
| How to test?  | Follow the steps to reproduce the behavior described in the Issue #11887

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12662)
<!-- Reviewable:end -->
