### PR TITLE
Changed the regex to force space and hyphen in postcode validation

### DIFF
--- a/classes/Country.php
+++ b/classes/Country.php
@@ -448,8 +448,6 @@ class CountryCore extends ObjectModel
         }
 
         $zipRegexp = '/^' . $this->zip_code_format . '$/ui';
-        $zipRegexp = str_replace(' ', '( |)', $zipRegexp);
-        $zipRegexp = str_replace('-', '(-|)', $zipRegexp);
         $zipRegexp = str_replace('N', '[0-9]', $zipRegexp);
         $zipRegexp = str_replace('L', '[a-zA-Z]', $zipRegexp);
         $zipRegexp = str_replace('C', $this->iso_code, $zipRegexp);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | previously the zipcode validation added an OR in the validation REGEX, this allowed zipcodes that need a hyphen or space to be written without one. With this change, the OR is deleted so the validation of the zipcode is more strict.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12689

## How to test? 

* Allow Zip code format validation in the BO
* Enter a validation code with a space or hyphen.
* Go to the checkout an enter the zipcode without the hyphen or space
* The validation doesn't pass anymore

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12733)
<!-- Reviewable:end -->
