### PR TITLE
Fix PhpDoc for AttributeGroupCore::getAttributes()

### DIFF
--- a/classes/AttributeGroup.php
+++ b/classes/AttributeGroup.php
@@ -219,7 +219,7 @@ class AttributeGroupCore extends ObjectModel
      * Get all attributes for a given language / group.
      *
      * @param int $idLang Language ID
-     * @param bool $idAttributeGroup AttributeGroup ID
+     * @param int $idAttributeGroup AttributeGroup ID
      *
      * @return array Attributes
      */


### PR DESCRIPTION
Require bool but uses int


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix PhpDoc for AttributeGroupCore::getAttributes()
| Type?  | refacto
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/1
| How to test?  | Reported by PhpStan v0.11.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12747)
<!-- Reviewable:end -->
