### PR TITLE
Fix saving shop association in migrated add/edit forms

### DIFF
--- a/src/Adapter/Domain/AbstractObjectModelHandler.php
+++ b/src/Adapter/Domain/AbstractObjectModelHandler.php
@@ -81,10 +81,13 @@ abstract class AbstractObjectModelHandler
 
         $insert = [];
         foreach ($shopAssociation as $shopId) {
-            $insert[] = [
-                $primaryKeyName => $primaryKeyValue,
-                'id_shop' => (int) $shopId,
-            ];
+            // Check if context employee has access to the shop before inserting shop association.
+            if (Context::getContext()->employee->hasAuthOnShop($shopId)) {
+                $insert[] = [
+                    $primaryKeyName => $primaryKeyValue,
+                    'id_shop' => (int) $shopId,
+                ];
+            }
         }
 
         Db::getInstance()->insert(

--- a/src/Adapter/Form/ChoiceProvider/ShopTreeChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ShopTreeChoiceProvider.php
@@ -58,6 +58,10 @@ final class ShopTreeChoiceProvider implements FormChoiceProviderInterface
             foreach ($shops as $shopId) {
                 $shop = Shop::getShop($shopId['id_shop']);
 
+                if (!$shop['id_shop']) {
+                    continue;
+                }
+
                 $shopGroupChoices['children'][] = [
                     'name' => $shop['name'],
                     'id_shop' => $shop['id_shop'],

--- a/src/Adapter/Form/ChoiceProvider/ShopTreeChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ShopTreeChoiceProvider.php
@@ -58,7 +58,8 @@ final class ShopTreeChoiceProvider implements FormChoiceProviderInterface
             foreach ($shops as $shopId) {
                 $shop = Shop::getShop($shopId['id_shop']);
 
-                if (!$shop['id_shop']) {
+                // If context employee doesn't have access to a shop, $shop will be false
+                if (false === $shop) {
                     continue;
                 }
 

--- a/src/Adapter/Language/CommandHandler/AbstractLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AbstractLanguageHandler.php
@@ -31,6 +31,7 @@ use Db;
 use ImageManager;
 use ImageType;
 use Language;
+use PrestaShop\PrestaShop\Adapter\Domain\AbstractObjectModelHandler;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\CopyingNoPictureException;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageImageUploadingException;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;
@@ -41,7 +42,7 @@ use Shop;
 /**
  * Encapsulates common legacy behavior for adding/editing language
  */
-abstract class AbstractLanguageHandler
+abstract class AbstractLanguageHandler extends AbstractObjectModelHandler
 {
     /**
      * Copies "No picture" image for specific language
@@ -152,57 +153,6 @@ abstract class AbstractLanguageHandler
         }
 
         unlink($temporaryImage);
-    }
-
-    /**
-     * @param int $languageId
-     * @param int[] $shopAssociation
-     */
-    protected function associateWithShops($languageId, array $shopAssociation)
-    {
-        if (!Shop::isFeatureActive()) {
-            return;
-        }
-
-        $languageTable = Language::$definition['table'];
-
-        if (!Shop::isTableAssociated($languageTable)) {
-            return;
-        }
-
-        // Get list of shop id we want to exclude from asso deletion
-        $excludeIds = $shopAssociation;
-        foreach (Db::getInstance()->executeS('SELECT id_shop FROM ' . _DB_PREFIX_ . 'shop') as $row) {
-            if (!Context::getContext()->employee->hasAuthOnShop($row['id_shop'])) {
-                $excludeIds[] = $row['id_shop'];
-            }
-        }
-
-        $excludeShopsCondtion = $excludeIds ?
-            ' AND id_shop NOT IN (' . implode(', ', array_map('intval', $excludeIds)) . ')' :
-            ''
-        ;
-
-        Db::getInstance()->delete(
-            $languageTable . '_shop',
-            '`id_lang` = ' . (int) $languageId . $excludeShopsCondtion
-        );
-
-        $insert = [];
-        foreach ($shopAssociation as $shopId) {
-            $insert[] = [
-                'id_lang' => (int) $languageId,
-                'id_shop' => (int) $shopId,
-            ];
-        }
-
-        Db::getInstance()->insert(
-            $languageTable . '_shop',
-            $insert,
-            false,
-            true,
-            Db::INSERT_IGNORE
-        );
     }
 
     /**

--- a/src/Adapter/Language/CommandHandler/AbstractLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AbstractLanguageHandler.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Language\CommandHandler;
 
 use Context;
-use Db;
 use ImageManager;
 use ImageType;
 use Language;
@@ -37,7 +36,6 @@ use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageImageUploadingE
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
-use Shop;
 
 /**
  * Encapsulates common legacy behavior for adding/editing language

--- a/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
@@ -85,7 +85,7 @@ final class AddLanguageHandler extends AbstractLanguageHandler implements AddLan
     private function addShopAssociation(Language $language, AddLanguageCommand $command)
     {
         $this->associateWithShops(
-            (int) $language->id,
+            $language,
             $command->getShopAssociation()
         );
     }

--- a/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
@@ -59,7 +59,7 @@ final class EditLanguageHandler extends AbstractLanguageHandler implements EditL
         $this->moveTranslationsIfIsoChanged($language, $command);
 
         $this->updateLanguageWithCommandData($language, $command);
-        $this->updateShopAssociationIfChanged($command);
+        $this->updateShopAssociationIfChanged($language, $command);
         $this->uploadFlagImageIfChanged($language, $command);
 
         return new LanguageId((int) $language->id);
@@ -185,16 +185,17 @@ final class EditLanguageHandler extends AbstractLanguageHandler implements EditL
     }
 
     /**
+     * @param Language $language
      * @param EditLanguageCommand $command
      */
-    private function updateShopAssociationIfChanged(EditLanguageCommand $command)
+    private function updateShopAssociationIfChanged(Language $language, EditLanguageCommand $command)
     {
         if (null === $command->getShopAssociation()) {
             return;
         }
 
         $this->associateWithShops(
-            $command->getLanguageId()->getValue(),
+            $language,
             $command->getShopAssociation()
         );
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR is aimed at migrated add/edit forms, that have shop association tree (e.g. edit Currency). Employee without access to specific shop, can still modify shop association for that shop. I'll explain more below the table for readability.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Below:

First problem that this PR fixes:
1. Have a multishop with 2 or more shops. 
2. Have an employee (non-superadmin) that has access only to shop 2. 
3. Have a currency that is **only** available on shop 2. In my case it looks like this from superadmin perspective: https://prnt.sc/mre82k
4. Login with the non-superadmin employee and go to edit the currency that's available only in shop 2.  
5. You should see something like this: https://prnt.sc/mrecke (you can see the empty checkbox in the screenshot, which is no longer there with this pull request).

Second problem that this PR fixes:
1. Follow steps 1-4 from the first problem description.
2. Open developer's console (F12 for Chrome) and paste this code there: 
`$('#currency_shop_association input[name=currency\\[shop_association\\]\\[\\]]:first').val(1).prop('checked', true)` 
and click enter. You should see something similar in the console: https://prnt.sc/mrefj0
3. Click "Save".
4. Log in to BO with a superadmin and go to edit same currency, you should see that shop access has changed: https://prnt.sc/mregdr
The problem is that as an employee without access to shop 1 I was able to give currency access to shop 1. Same works with any other add/edit form.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12751)
<!-- Reviewable:end -->
