### PR TITLE
Allow ipv6 to be used in htaccess redirects

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2540,6 +2540,9 @@ class ToolsCore
         }
 
         foreach ($domains as $domain => $list_uri) {
+            // As we use regex in the htaccess, ipv6 surrounded by brackets must be escaped
+            $domain = str_replace(['[', ']'], ['\[', '\]'], $domain);
+
             foreach ($list_uri as $uri) {
                 fwrite($write_fd, PHP_EOL . PHP_EOL . '#Domain: ' . $domain . PHP_EOL);
                 if (Shop::isFeatureActive()) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a shop is linked to an IPv6, the current htaccess does not properly, and the (product) images are not displayed. This PR escapes the brackets needed in a ipv6 url used as regex in the .htaccess.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Update your local shop domain with `[::1]`, which means localhost via ipv6. The images must be displayed on the front office.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12753)
<!-- Reviewable:end -->
