### PR TITLE
Added a Theme Enabler command

### DIFF
--- a/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
+++ b/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Context;
+use Employee;
+
+final class ThemeEnablerCommand extends ContainerAwareCommand
+{
+    /**
+     * @var bool using CLI, the user must be allowed to enable themes
+     */
+    const USER_ALLOWED_TO_ENABLE = true;
+
+    /**
+     * @var int if the activation of the theme fails, return the right code
+     */
+    const RETURN_CODE_FAILED = 1;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function init(InputInterface $input, OutputInterface $output)
+    {
+        require $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
+
+        Context::getContext()->employee = new Employee();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('prestashop:theme:enable')
+            ->setDescription('Manage your themes via command line')
+            ->addArgument('theme', InputArgument::REQUIRED, 'Module on which the action will be executed')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $theme = $input->getArgument('theme');
+        $this->init($input, $output);
+
+        $activationSuccess = $this->getContainer()
+            ->get('prestashop.core.addon.theme.theme_manager')
+            ->enable(
+                $theme,
+                self::USER_ALLOWED_TO_ENABLE
+            )
+        ;
+
+        if (false === $activationSuccess) {
+            $io->error(sprintf('The selected theme "%s" is invalid', $theme));
+
+            return self::RETURN_CODE_FAILED;
+        }
+
+        $io->success(sprintf('Theme "%s" enabled with success.', $theme));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow developers to enable a different theme using CLI
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Yes, but not in the core :)
| How to test?  | put a theme in the themes folder and then execute the following command `php bin/console prestashop:theme:enable <theme-name>` where <theme-name> is replaced by the theme name.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12758)
<!-- Reviewable:end -->
