### PR TITLE
Remove duplicate CLDR service

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/currency.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/currency.yml
@@ -6,4 +6,4 @@ services:
         class: 'PrestaShop\PrestaShop\Core\Currency\CurrencyGridDataFactory'
         arguments:
             - '@prestashop.core.grid.data_provider.currency'
-            - '@prestashop.core.localization.cldr.repository'
+            - '@prestashop.core.cldr.repository'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -153,7 +153,7 @@ services:
   prestashop.core.form.choice_provider.currency_name_by_iso_code:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyNameByIsoCodeChoiceProvider'
     arguments:
-      - '@=service("prestashop.core.localization.cldr.repository").getAllCurrencies()'
+      - '@=service("prestashop.core.cldr.repository").getAllCurrencies()'
 
   prestashop.core.form.choice_provider.permissions_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PermissionsChoiceProvider'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -83,7 +83,7 @@ services:
         class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerGridDataFactoryDecorator'
         arguments:
             - '@prestashop.core.grid.data_provider.customer'
-            - '@prestashop.core.localization.cldr.repository'
+            - '@prestashop.core.cldr.repository'
             - "@=service('prestashop.adapter.legacy.context').getContext().currency.iso_code"
 
     prestashop.core.grid.data.factory.language:

--- a/src/PrestaShopBundle/Resources/config/services/core/localization.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/localization.yml
@@ -1,6 +1,3 @@
-imports:
-    - { resource: localization/*.yml }
-
 services:
     _defaults:
         public: true

--- a/src/PrestaShopBundle/Resources/config/services/core/localization/cldr.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/localization/cldr.yml
@@ -1,8 +1,0 @@
-services:
-  _defaults:
-    public: true
-
-  prestashop.core.localization.cldr.repository:
-    class: 'PrestaShop\PrestaShop\Core\Cldr\Repository'
-    arguments:
-      - "@=service('prestashop.adapter.legacy.context').getContext().language.iso_code"


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove duplicated CLDR service
| Type?         | refacto
| Category?     | CO
| BC breaks?    | no, because both services have been added for 1.7.6 so removing one is not a BC
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/12118
| How to test?  | International > Localization > Currencies page (listing + add/edit) should work as before, no regressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12766)
<!-- Reviewable:end -->
