### PR TITLE
CO: Update unit_price_ratio only if unit_price is set

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -589,7 +589,7 @@ class ProductCore extends ObjectModel
     public function getFieldsShop()
     {
         $fields = parent::getFieldsShop();
-        if (isset($this->unit_price) && (null === $this->update_fields || (!empty($this->update_fields['price']) && !empty($this->update_fields['unit_price'])))) {
+        if (isset($this->unit_price) && null === $this->update_fields || (!empty($this->update_fields['price']) && !empty($this->update_fields['unit_price']))) {
             $fields['unit_price_ratio'] = (float) $this->unit_price > 0 ? $this->price / $this->unit_price : 0;
         }
         $fields['unity'] = pSQL($this->unity);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -589,7 +589,7 @@ class ProductCore extends ObjectModel
     public function getFieldsShop()
     {
         $fields = parent::getFieldsShop();
-        if (null === $this->update_fields || (!empty($this->update_fields['price']) && !empty($this->update_fields['unit_price']))) {
+        if (isset($this->unit_price) && (null === $this->update_fields || (!empty($this->update_fields['price']) && !empty($this->update_fields['unit_price'])))) {
             $fields['unit_price_ratio'] = (float) $this->unit_price > 0 ? $this->price / $this->unit_price : 0;
         }
         $fields['unity'] = pSQL($this->unity);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -588,7 +588,7 @@ class ProductCore extends ObjectModel
      */
     public function getFieldsShop()
     {
-        $fields = parent::getFieldsShop();        
+        $fields = parent::getFieldsShop();
         if (isset($this->unit_price) && (null === $this->update_fields || (!empty($this->update_fields['price']) && !empty($this->update_fields['unit_price'])))) {
             $fields['unit_price_ratio'] = (float) $this->unit_price > 0 ? $this->price / $this->unit_price : 0;
         }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -588,8 +588,8 @@ class ProductCore extends ObjectModel
      */
     public function getFieldsShop()
     {
-        $fields = parent::getFieldsShop();
-        if (isset($this->unit_price) && null === $this->update_fields || (!empty($this->update_fields['price']) && !empty($this->update_fields['unit_price']))) {
+        $fields = parent::getFieldsShop();        
+        if (isset($this->unit_price) && (null === $this->update_fields || (!empty($this->update_fields['price']) && !empty($this->update_fields['unit_price'])))) {
             $fields['unit_price_ratio'] = (float) $this->unit_price > 0 ? $this->price / $this->unit_price : 0;
         }
         $fields['unity'] = pSQL($this->unity);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If $product is instantiated as new Product($id), it is not FullyLoaded, and $product->unit_price is not defined, so 'unit_price_ratio' is reset in getFieldsShop(), and if $product is saved using $product->save(), then 'unit_price_ratio' is saved as 0. In order to avoid resetting 'unit_price_ratio', it should be (re)calculated only if 'unit_price' is available
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | 1) Set unit price for product X and save it natively by clicking "Save" button 2) Instantiate this product programmatically in any controller $product = new Product(X) 3) Save this product programmatically using $product->save() or $product->update()

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12769)
<!-- Reviewable:end -->
