### PR TITLE
Add module main class parse error to log message

### DIFF
--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -228,7 +228,7 @@ class ModuleDataProvider
                     'Parse error detected in main class of module %module%! %parse_error%',
                     array(
                         '%module%' => $name,
-                        '%parse_error%' => $exception->getMessage()
+                        '%parse_error%' => $exception->getMessage(),
                     ),
                     'Admin.Modules.Notification'
                 )

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -225,12 +225,14 @@ class ModuleDataProvider
         } catch (PhpParser\Error $exception) {
             $this->logger->critical(
                 $this->translator->trans(
-                    'Parse error detected in main class of module %module%!',
-                    array('%module%' => $name),
+                    'Parse error detected in main class of module %module%! %parse_error%',
+                    array(
+                        '%module%' => $name,
+                        '%parse_error%' => $exception->getMessage()
+                    ),
                     'Admin.Modules.Notification'
                 )
             );
-
             return false;
         }
 

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -228,11 +228,12 @@ class ModuleDataProvider
                     'Parse error detected in main class of module %module%! %parse_error%',
                     array(
                         '%module%' => $name,
-                        '%parse_error%' => $exception->getMessage()
+                        '%parse_error%' => $exception->getMessage(),
                     ),
                     'Admin.Modules.Notification'
                 )
             );
+
             return false;
         }
 


### PR DESCRIPTION
During module installation the module main class is parsed to validated
its syntax. In case of a parse error an error message is logged. But the
log message does not include the actual parse error. The parse error is
entirely disregarded.

Adding the parse error to the log message helps to locate the exact
cause of why module installation failed.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | See above
| Type?         | improvement
| Category?     | BO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | none
| How to test?  | Install a module with a syntax error in its main class and see log message.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12784)
<!-- Reviewable:end -->
