### PR TITLE
Remove html escaping of errors

### DIFF
--- a/admin-dev/themes/default/template/layout.tpl
+++ b/admin-dev/themes/default/template/layout.tpl
@@ -35,7 +35,7 @@
   <div class="bootstrap">
     <div class="alert alert-danger">
       <button type="button" class="close" data-dismiss="alert">&times;</button>
-      {$error|escape:'html':'UTF-8'}
+      {$error}
     </div>
   </div>
 {/if}
@@ -45,13 +45,13 @@
 		<div class="alert alert-danger">
 			<button type="button" class="close" data-dismiss="alert">&times;</button>
 		{if count($errors) == 1}
-			{reset($errors)|escape:'html':'UTF-8'}
+			{reset($errors)}
 		{else }
 			{l s='%d errors' sprintf=[$errors|count]}
 			<br/>
 			<ol>
 				{foreach $errors as $error}
-					<li>{$error|escape:'html':'UTF-8'}</li>
+					<li>{$error}</li>
 				{/foreach}
 			</ol>
 		{/if}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | See below
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No
| How to test?  | Add a backend error with HTML and see that the HTML is now not escaped.

# Description
HTML escaping of errors were implemented in `PS 1.7.5.0-rc.1` [see commit](https://github.com/PrestaShop/PrestaShop/commit/8aa170e110b06c6ce6b8631eefa304f6206cfd7b). HTML escaping has not been implemented for any of the other message types `informations`, `confirmations` or `warnings`.

HTML escaping has the benefit of protecting against XSS injections but there is no protection in only adding this to one type of messages and this has a **major drawback** when plugins are trying to show HTML formatted error messages which a lot of plugins do. With the HTML escaping then it won't be able to implement lists, links or other helpful parts to a given error.

This PR removed the HTML escaping of errors to unify the behavior of all message types plus solving the issue that links cannot be included in error messages anymore.

# Error message without this commit
![image](https://user-images.githubusercontent.com/30228807/53740253-16cb1280-3e94-11e9-9b18-d27324ba57da.png)

# Error message with this commit
![image](https://user-images.githubusercontent.com/30228807/53740324-3e21df80-3e94-11e9-887e-48dcc196cd81.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12788)
<!-- Reviewable:end -->
