### PR TITLE
Allow Travis phpHigh build to fail as it is an informative check, not not a mandatory check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,9 @@ matrix:
   exclude:
     - php: 7.2 # Replaced with additional tests
       env: PRESTASHOP_TEST_TYPE=e2e
+  allow_failures:
+    - php: 7.2
+      env: EXTRA_DEPS=phpHigh  PRESTASHOP_TEST_TYPE=unit
 
 before_install:
   # Avoid Composer authentication issues


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow Travis phpHigh build to fail as it is an informative check, not a mandatory check
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Travis should be green

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12793)
<!-- Reviewable:end -->
