### PR TITLE
Fallback on language code when locale is empty

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -809,7 +809,10 @@ class ToolsCore
 
         /** @var LocaleRepository $localeRepository */
         $localeRepository = $container->get(self::SERVICE_LOCALE_REPOSITORY);
-        $locale = $localeRepository->getLocale((string) $context->language->locale);
+        $locale = !empty($context->language->locale) ?
+            $context->language->locale :
+            $context->language->language_code;
+        $locale = $localeRepository->getLocale($locale);
 
         return $locale;
     }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -184,7 +184,10 @@ abstract class ControllerCore
             $this->container = $this->buildContainer();
         }
         $localeRepo = $this->get(self::SERVICE_LOCALE_REPOSITORY);
-        $this->context->currentLocale = $localeRepo->getLocale($this->context->language->locale);
+        $locale = !empty($this->context->language->locale) ?
+            $this->context->language->locale :
+            $this->context->language->language_code;
+        $this->context->currentLocale = $localeRepo->getLocale($locale);
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a language is manually created, the CLDR receives an empty locale and fails. This PRs fallbacks on the language code.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #12673
| How to test?  | Front office still works even if a home made language is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12803)
<!-- Reviewable:end -->
