### PR TITLE
Use string value for CSRF token in DeliveryControllerTest

### DIFF
--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
@@ -65,7 +65,7 @@ class DeliveryControllerTest extends WebTestCase
                     'options' => [
                         'number' => 'foo',
                     ],
-                    '_token' => $token,
+                    '_token' => $token->getValue(),
                 ],
             ]
         );
@@ -90,7 +90,7 @@ class DeliveryControllerTest extends WebTestCase
                     'options' => [
                         'number' => '100',
                     ],
-                    '_token' => $token,
+                    '_token' => $token->getValue(),
                 ],
             ]
         );
@@ -119,7 +119,7 @@ class DeliveryControllerTest extends WebTestCase
                     'pdf' => [
                         'date_from' => 'foo',
                     ],
-                    '_token' => $token,
+                    '_token' => $token->getValue(),
                 ],
             ]
         );
@@ -146,7 +146,7 @@ class DeliveryControllerTest extends WebTestCase
             [
                 'slip_pdf_form' => [
                     'pdf' => [],
-                    '_token' => $token,
+                    '_token' => $token->getValue(),
                 ],
             ]
         );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Use string value for CSRF token in DeliveryControllerTest to comply with Symfony v3.4.23. Else our unit tests break with this Symfony version because of https://github.com/symfony/symfony/pull/29884
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | All Travis builds should be green, including HIGH_DEPS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12804)
<!-- Reviewable:end -->
