### PR TITLE
Deprecate Cart::addExtraCarriers()

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4868,10 +4868,18 @@ class CartCore extends ObjectModel
     /**
      * Execute hook displayCarrierList (extraCarrier) and merge them into the $array.
      *
+     * @deprecated since 1.7.6.0.
+     * @see https://github.com/PrestaShop/PrestaShop/issues/10979
+     *
      * @param array $array
      */
     public static function addExtraCarriers(&$array)
     {
+        @trigger_error(
+            __FUNCTION__ . 'is deprecated since version 1.7.6.0 and will be removed in the next major version.',
+            E_USER_DEPRECATED
+        );
+
         $first = true;
         $hook_extracarrier_addr = array();
         foreach (Context::getContext()->cart->getAddressCollection() as $address) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Adds a deprecation notice to Cart::addExtraCarriers() which is no longer used.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | Fixes #10979
| How to test?  | Nothing to test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12808)
<!-- Reviewable:end -->
