### PR TITLE
Fix display for RTL languages for Helper cards

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/helper_card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/helper_card.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 <div class="helper-card card">
-  <div class="helper-card__left helper-card__team shape-one">
+  <div class="helper-card__left helper-card__team shape-one img-rtl">
     <img src="{{ asset('themes/new-theme/scss/img/helper-card/team@3x.png') }}" class="img-fluid">
   </div>
   <div class="helper-card__right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig
@@ -28,7 +28,7 @@
 {% block meta_showcase_card %}
   {% if not showcaseCardIsClosed %}
   <div id="seo-urls-showcase-card" class="showcase-card card">
-    <div class="showcase-card__left shape-one helper-card__meta-background">
+    <div class="showcase-card__left shape-one helper-card__meta-background img-rtl">
       <img src="{{ asset('themes/new-theme/scss/img/helper-card/seo@3x.png') }}" class="img-fluid">
     </div>
     <div class="showcase-card__right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/helper_card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/helper_card.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 <div class="helper-card card">
-  <div class="helper-card__left helper-card__customer shape-one">
+  <div class="helper-card__left helper-card__customer shape-one img-rtl">
     <img src="{{ asset('themes/new-theme/scss/img/helper-card/customer@3x.png') }}" class="img-fluid">
   </div>
   <div class="helper-card__right">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix display for RTL languages for Helper cards
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/12715
| How to test?  | Use a RTL language for your backoffice (example: if your BO is in english, set the English language to RTL from the Languages > edit page). Check the 3 URLs stated in https://github.com/PrestaShop/PrestaShop/issues/12715: the helper cards should be correctly displayed (from right to left).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12809)
<!-- Reviewable:end -->
