### PR TITLE
Install ps_faviconnotificationbo automatically

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -902,6 +902,7 @@ class Install extends AbstractInstall
                 'ps_customtext',
                 'ps_emailsubscription',
                 'ps_facetedsearch',
+                'ps_faviconnotificationbo',
                 'ps_featuredproducts',
                 'ps_imageslider',
                 'ps_languageselector',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The module was included in the zip in 1.7.5.0 but not installed automatically with PS. This PR makes it so that the module is installed automatically alongside the rest of the native modules.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12701
| How to test?  | Install PS, the module is installed automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12810)
<!-- Reviewable:end -->
