### PR TITLE
Robots should not index search content

### DIFF
--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -61,6 +61,18 @@ class SearchControllerCore extends ProductListingFrontController
     }
 
     /**
+     * Ensure that no search results page is indexed by search engines.
+     */
+    public function getTemplateVarPage()
+    {
+        $page = parent::getTemplateVarPage();
+
+        $page['meta']['robots'] = 'noindex';
+
+        return $page;
+    }
+
+    /**
      * Performs the search.
      */
     public function initContent()


### PR DESCRIPTION
Google Search Console can complain of `Indexed, though blocked by robots.txt` for search results pages.  This PR adds `<meta name="robots" content="noindex">` to all search results pages so that they are not indexed as is standard practice.

Signed-off-by: John Cocula <john@cocula.com>

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Ensure that no search results pages will be indexed by search engines
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes #12754
| How to test?  | Please see comments in #12754 for test setup

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12817)
<!-- Reviewable:end -->
