### PR TITLE
Fixes fatal error when trying to get the images of a product with no images 

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -607,6 +607,8 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 } else {
                     $this->objOutput->setStatus(404);
                     $this->wsObject->setOutputEnabled(false);
+
+                    return true;
                 }
             }
         } else {


### PR DESCRIPTION
Related with #12357 

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you try to get the product images from a product with no images (from the ws), it throws a http 500 error.
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| How to test?  | Create a product with no images, through admin panel or webservice, and then, THROUGH WEBSERVICE get all its images (for example calling ```api/images/products/{id}?display=full```)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12836)
<!-- Reviewable:end -->
