### PR TITLE
Replace hardcoded currency sign in specific price form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -254,7 +254,7 @@ class ProductSpecificPrice extends CommonAbstractType
                 [
                     'label' => $this->translator->trans('Reduction type', [], 'Admin.Catalog.Feature'),
                     'choices' => [
-                        '€' => 'amount',
+                        $this->currency->getSign() => 'amount',
                         $this->translator->trans('%', [], 'Admin.Global') => 'percentage',
                     ],
                     'required' => true,


### PR DESCRIPTION
Incorrect sp_reduction_type hardcoded currency sign fix

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | develop
| Description  | this fix replace hard coded currency symbol
| Type?         | improvement
| Category?     | BO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | i don't no
| How to test?  | See back office product edit page > add custom price > select#form_step2_specific_price_sp_reduction_type option amount label

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12838)
<!-- Reviewable:end -->
