### PR TITLE
Add deprecation notice for hook actionAjaxDieBefore

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -101,6 +101,9 @@ class HookCore extends ObjectModel
         // Product page
         'displayProductTabContent' => array('from' => '1.7.0.0'),
         'displayProductTab' => array('from' => '1.7.0.0'),
+
+        // Controller
+        'actionAjaxDieBefore' => array('from' => '1.6.1.1'),
     );
 
     const MODULE_LIST_BY_HOOK_KEY = 'hook_module_exec_list_';


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The hook actionAjaxDieBefore [is deprecated since 1.6.1.1](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/controller/Controller.php#L741) but no deprecation notice was issued when using it.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | n/a
| How to test?  | Nothing to test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12841)
<!-- Reviewable:end -->
