### PR TITLE
Fix Symfony console crash because of DocumentationLinkProvider service definition

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -103,11 +103,6 @@ class LanguageCore extends ObjectModel
         'tabs' => 'tabs',
     );
 
-    public function __construct($id = null, $id_lang = null)
-    {
-        parent::__construct($id);
-    }
-
     public static function resetCache()
     {
         self::$_checkedLangs = null;

--- a/config/services/common.yml
+++ b/config/services/common.yml
@@ -1,3 +1,6 @@
+parameters:
+    mail_themes_uri: "/mails/themes"
+
 imports:
     - { resource: ../../src/PrestaShopBundle/Resources/config/services/core/cldr.yml }
     - { resource: ../../src/PrestaShopBundle/Resources/config/services/adapter/data_provider_common.yml }

--- a/config/services/front/services_prod.yml
+++ b/config/services/front/services_prod.yml
@@ -1,5 +1,5 @@
 imports:
-  - { resource: ../common.yml }
+    - { resource: ../common.yml }
 
 services:
     hashing:

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -101,6 +101,11 @@ class Configuration extends ParameterBag implements ConfigurationInterface
             return constant($key);
         }
 
+        //If configuration has never been accessed it is still empty and hasKey/isLangKey will always return false
+        if (!ConfigurationLegacy::configurationIsLoaded()) {
+            ConfigurationLegacy::loadConfiguration();
+        }
+
         // if the key is multi lang related, we return an array with the value per language.
         // getInt() meaning probably getInternational()
         if (ConfigurationLegacy::isLangKey($key)) {

--- a/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
@@ -7,3 +7,6 @@ services:
 
     prestashop.adapter.legacy.context:
         class: PrestaShop\PrestaShop\Adapter\LegacyContext
+        arguments:
+            - "%mail_themes_uri%"
+            - '@prestashop.adapter.tools'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
@@ -5,6 +5,9 @@ services:
     prestashop.adapter.legacy.configuration:
         class: PrestaShop\PrestaShop\Adapter\Configuration
 
+    prestashop.adapter.tools:
+      class: PrestaShop\PrestaShop\Adapter\Tools
+
     prestashop.adapter.legacy.context:
         class: PrestaShop\PrestaShop\Adapter\LegacyContext
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_provider.yml
@@ -1,3 +1,6 @@
+imports:
+  - { resource: ./data_provider_common.yml }
+
 services:
     _defaults:
         public: true

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -1,3 +1,6 @@
+imports:
+  - { resource: ./common.yml }
+
 services:
     _defaults:
         public: true
@@ -50,12 +53,6 @@ services:
 
     prestashop.adapter.legacy.kpi_configuration:
         class: PrestaShop\PrestaShop\Adapter\Configuration\KpiConfiguration
-
-    prestashop.adapter.legacy.context:
-        class: PrestaShop\PrestaShop\Adapter\LegacyContext
-        arguments:
-            - "%mail_themes_uri%"
-            - '@prestashop.adapter.tools'
 
     prestashop.adapter.legacy.logger:
         class: PrestaShop\PrestaShop\Adapter\LegacyLogger

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -88,9 +88,6 @@ services:
     prestashop.adapter.shop.context:
         class: PrestaShop\PrestaShop\Adapter\Shop\Context
 
-    prestashop.adapter.tools:
-        class: PrestaShop\PrestaShop\Adapter\Tools
-
     prestashop.adapter.image_manager:
         class: PrestaShop\PrestaShop\Adapter\ImageManager
         arguments: ["@prestashop.adapter.legacy.context"]

--- a/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
@@ -5,7 +5,7 @@ services:
   prestashop.core.util.helper_card.documentation_link_provider:
     class: 'PrestaShop\PrestaShop\Core\Util\HelperCard\DocumentationLinkProvider'
     arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'
+      - '@=service("prestashop.adapter.legacy.context").getContext().language ? service("prestashop.adapter.legacy.context").getContext().language.iso_code : "en-US"'
       -
         'team':
           'en': 'http://doc.prestashop.com/display/PS17/Team'


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix DocumentationLinkProvider service definition which crashed the symfony console, this required some updates on LegacyContext and Configuration services
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Clone this branch and launch `./bin/console` command or even `./bin/console debug:container` In back office check that the helper card documentation links still work correctly (including their translation).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12874)
<!-- Reviewable:end -->
