### PR TITLE
Add breadcrumb to the prices drop page

### DIFF
--- a/controllers/front/listing/PricesDropController.php
+++ b/controllers/front/listing/PricesDropController.php
@@ -66,4 +66,16 @@ class PricesDropControllerCore extends ProductListingFrontController
             'Shop.Theme.Catalog'
         );
     }
+    
+    public function getBreadcrumbLinks()
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+
+        $breadcrumb['links'][] = [
+            'title' => $this->trans('On sale', array(), 'Shop.Theme.Catalog'),
+            'url' => $this->context->link->getPageLink('prices-drop', true),
+        ];
+
+        return $breadcrumb;
+    }
 }

--- a/controllers/front/listing/PricesDropController.php
+++ b/controllers/front/listing/PricesDropController.php
@@ -66,7 +66,7 @@ class PricesDropControllerCore extends ProductListingFrontController
             'Shop.Theme.Catalog'
         );
     }
-    
+
     public function getBreadcrumbLinks()
     {
         $breadcrumb = parent::getBreadcrumbLinks();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | add the missing breadcrumb function
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Just visit the prices drop page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12881)
<!-- Reviewable:end -->
