### PR TITLE
Move PHP-CS-Fixer in GitHub Actions

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,11 @@
+workflow "Code Quality" {
+  on = "push"
+  resolves = [
+    "PHP-CS-Fixer",
+  ]
+}
+
+action "PHP-CS-Fixer" {
+  uses = "docker://oskarstark/php-cs-fixer-ga"
+  args = "--config=.php_cs.dist --diff --diff-format=udiff --dry-run"
+}

--- a/tests-legacy/check_file_syntax.sh
+++ b/tests-legacy/check_file_syntax.sh
@@ -16,19 +16,10 @@ yaml_themes=$?
 php bin/console lint:yaml .t9n.yml
 yaml_trad=$?
 
-# Check our current PHP Coding Style rules
-php ./vendor/bin/php-cs-fixer fix --dry-run --diff --diff-format=udiff
-coding_styles=$?
-
-if [[ "$php" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad" == "0" && "$coding_styles" == "0" ]]; then
+if [[ "$php" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad" == "0" ]]; then
   echo -e "\e[92mSYNTAX TESTS OK"
   exit 0;
 else
   echo -e "\e[91mSYNTAX TESTS FAILED"
-  if [[ "$coding_styles" -ne "0" ]]; then
-   echo -e "\e[39mRun PHP CS Fixer from your PrestaShop folder to fix the lint issues:";
-   echo -e '- Linux: "php ./vendor/bin/php-cs-fixer fix"';
-   echo -e '- Windows: "vendor\\bin\\php-cs-fixer fix"';
-  fi
   exit 255;
 fi


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Create first GitHub actions workflow and add PHP Cs fixer in it as example.
| Type?         | new feature
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/pull/12710#issuecomment-470957610
| How to test?  | PHP-CS-fixer runs properly on "Checks" tab

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12890)
<!-- Reviewable:end -->
