### PR TITLE
[Backport from develop] Allow Travis phpHigh build to fail as it is an informative check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,9 @@ matrix:
   exclude:
     - php: 7.2 # Replaced with additional tests
       env: PRESTASHOP_TEST_TYPE=e2e
+  allow_failures:
+    - php: 7.2
+      env: EXTRA_DEPS=phpHigh  PRESTASHOP_TEST_TYPE=unit
 
 before_install:
   # Avoid Composer authentication issues


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Allow Travis phpHigh build to fail as it is an informative check, not a mandatory check. This will enable nightly builds for 1.7.5.x .
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Travis should be green on github although the build HIGH_DEPS fails for known reasons that are not an issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12902)
<!-- Reviewable:end -->
