### PR TITLE
Match multiline translation expressions in modules

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1275,7 +1275,7 @@ class AdminTranslationsControllerCore extends AdminController
             case 'modules':
                 // Parsing modules file
                 if ($type_file == 'php') {
-                    $regex = '/->l\(\s*(\')' . _PS_TRANS_PATTERN_ . '\'(\s*,\s*?\'(.+)\')?(\s*,\s*?(.+))?\s*\)/U';
+                    $regex = '/->l\(\s*(\')' . _PS_TRANS_PATTERN_ . '\'(\s*,\s*?\'(.+)\')?(\s*,\s*?(.+))?\s*\)/Ums';
                 } else {
                     // In tpl file look for something that should contain mod='module_name' according to the documentation
                     $regex = '/\{l\s*s=([\'\"])' . _PS_TRANS_PATTERN_ . '\1.*\s+mod=\'' . $module_name . '\'.*\}/U';

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1275,7 +1275,7 @@ class AdminTranslationsControllerCore extends AdminController
             case 'modules':
                 // Parsing modules file
                 if ($type_file == 'php') {
-                    $regex = '/->l\((\')' . _PS_TRANS_PATTERN_ . '\'(, ?\'(.+)\')?(, ?(.+))?\)/U';
+                    $regex = '/->l\(\s*(\')' . _PS_TRANS_PATTERN_ . '\'(\s*,\s*?\'(.+)\')?(\s*,\s*?(.+))?\s*\)/U';
                 } else {
                     // In tpl file look for something that should contain mod='module_name' according to the documentation
                     $regex = '/\{l\s*s=([\'\"])' . _PS_TRANS_PATTERN_ . '\1.*\s+mod=\'' . $module_name . '\'.*\}/U';


### PR DESCRIPTION
When a module developers write a multiline translation expression, it's not displayed in the backoffice translation page.
This modification matches white spaces (if any) to allow for more flexible detection.
Example:
```
$this->l(
  'Are you sure you want to delete this customization?',
  $source
);
```

Or

```
$this->l(
  'Are you sure you want to delete this customization?'
);
```

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | match multiline translation expressions
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12903)
<!-- Reviewable:end -->
