### PR TITLE
FO : Display price with configured decimals

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4774,7 +4774,7 @@ class ProductCore extends ObjectModel
             (int) $row['id_product'],
             false,
             $id_product_attribute,
-            (self::$_taxCalculationMethod == PS_TAX_EXC ? 2 : 6),
+            6,
             null,
             false,
             true,

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4782,7 +4782,10 @@ class ProductCore extends ObjectModel
         );
 
         if (self::$_taxCalculationMethod == PS_TAX_EXC) {
-            $row['price_tax_exc'] = Tools::ps_round($row['price_tax_exc'], 2);
+            $row['price_tax_exc'] = Tools::ps_round(
+                $row['price_tax_exc'],
+                (int) Configuration::get('PS_PRICE_DISPLAY_PRECISION')
+            );
             $row['price'] = Product::getPriceStatic(
                 (int) $row['id_product'],
                 true,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Display the prices with the correct decimals when prices are displayed without tax
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Configure prices with 3 decimals. Configure price display without taxes. It always displays 2 decimals. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12938)
<!-- Reviewable:end -->
