### PR TITLE
Update Search.php

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -669,24 +669,7 @@ class SearchCore
         }
 
         // Every fields are weighted according to the configuration in the backend
-        $weight_array = array(
-            'pname' => Configuration::get('PS_SEARCH_WEIGHT_PNAME'),
-            'reference' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'pa_reference' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'supplier_reference' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'pa_supplier_reference' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'ean13' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'pa_ean13' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'upc' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'pa_upc' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'description_short' => Configuration::get('PS_SEARCH_WEIGHT_SHORTDESC'),
-            'description' => Configuration::get('PS_SEARCH_WEIGHT_DESC'),
-            'cname' => Configuration::get('PS_SEARCH_WEIGHT_CNAME'),
-            'mname' => Configuration::get('PS_SEARCH_WEIGHT_MNAME'),
-            'tags' => Configuration::get('PS_SEARCH_WEIGHT_TAG'),
-            'attributes' => Configuration::get('PS_SEARCH_WEIGHT_ATTRIBUTE'),
-            'features' => Configuration::get('PS_SEARCH_WEIGHT_FEATURE'),
-        );
+        $weight_array = Search::getSearchIndexWeights();
 
         // Those are kind of global variables required to save the processed data in the database every X occurrences, in order to avoid overloading MySQL
         $count_words = 0;
@@ -791,6 +774,28 @@ class SearchCore
         }
 
         return true;
+    }
+    
+    protected static function getSearchIndexWeights()
+    {
+        return array(
+            'pname'                 => Configuration::get('PS_SEARCH_WEIGHT_PNAME'),
+            'reference'             => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'pa_reference'          => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'supplier_reference'    => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'pa_supplier_reference' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'ean13'                 => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'pa_ean13'              => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'upc'                   => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'pa_upc'                => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'description_short'     => Configuration::get('PS_SEARCH_WEIGHT_SHORTDESC'),
+            'description'           => Configuration::get('PS_SEARCH_WEIGHT_DESC'),
+            'cname'                 => Configuration::get('PS_SEARCH_WEIGHT_CNAME'),
+            'mname'                 => Configuration::get('PS_SEARCH_WEIGHT_MNAME'),
+            'tags'                  => Configuration::get('PS_SEARCH_WEIGHT_TAG'),
+            'attributes'            => Configuration::get('PS_SEARCH_WEIGHT_ATTRIBUTE'),
+            'features'              => Configuration::get('PS_SEARCH_WEIGHT_FEATURE'),
+        );
     }
 
     public static function removeProductsSearchIndex($products)

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -779,22 +779,22 @@ class SearchCore
     protected static function getSearchIndexWeights()
     {
         return array(
-            'pname'                 => Configuration::get('PS_SEARCH_WEIGHT_PNAME'),
-            'reference'             => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'pa_reference'          => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'supplier_reference'    => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'pname' => Configuration::get('PS_SEARCH_WEIGHT_PNAME'),
+            'reference' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'pa_reference' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'supplier_reference' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
             'pa_supplier_reference' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'ean13'                 => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'pa_ean13'              => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'upc'                   => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'pa_upc'                => Configuration::get('PS_SEARCH_WEIGHT_REF'),
-            'description_short'     => Configuration::get('PS_SEARCH_WEIGHT_SHORTDESC'),
-            'description'           => Configuration::get('PS_SEARCH_WEIGHT_DESC'),
-            'cname'                 => Configuration::get('PS_SEARCH_WEIGHT_CNAME'),
-            'mname'                 => Configuration::get('PS_SEARCH_WEIGHT_MNAME'),
-            'tags'                  => Configuration::get('PS_SEARCH_WEIGHT_TAG'),
-            'attributes'            => Configuration::get('PS_SEARCH_WEIGHT_ATTRIBUTE'),
-            'features'              => Configuration::get('PS_SEARCH_WEIGHT_FEATURE'),
+            'ean13' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'pa_ean13' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'upc' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'pa_upc' => Configuration::get('PS_SEARCH_WEIGHT_REF'),
+            'description_short' => Configuration::get('PS_SEARCH_WEIGHT_SHORTDESC'),
+            'description' => Configuration::get('PS_SEARCH_WEIGHT_DESC'),
+            'cname' => Configuration::get('PS_SEARCH_WEIGHT_CNAME'),
+            'mname' => Configuration::get('PS_SEARCH_WEIGHT_MNAME'),
+            'tags' => Configuration::get('PS_SEARCH_WEIGHT_TAG'),
+            'attributes' => Configuration::get('PS_SEARCH_WEIGHT_ATTRIBUTE'),
+            'features' => Configuration::get('PS_SEARCH_WEIGHT_FEATURE'),
         );
     }
 


### PR DESCRIPTION
I have the need to add another search index.
There is no problem to extends the adminController and add my parameter.
But to prevent the copy/paste of the whole function ``indexation()`` I would like to put the array creation into another protected function.
Like that, there is no need to copy/paste unwanted copied code, but just extends the concerned parts :)

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.4.x
| Description?  | Move code to another sub function
| Type?         | improvement
| Category?     |  FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | reindex products

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12939)
<!-- Reviewable:end -->
