### PR TITLE
Do not look for translations if no locale

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -378,7 +378,7 @@ class ContextCore
 
         // In case we have at least 1 translated message, we return the current translator.
         // If some translations are missing, clear cache
-        if (count($translator->getCatalogue($locale)->all())) {
+        if ($locale === '' || count($translator->getCatalogue($locale)->all())) {
             $this->translator = $translator;
 
             return $translator;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | You can create new languages from the BO but they get created without a locale. This can create performance issues when the core looks for related translations. This avoids the performance issue.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Waiting for @jocel1 to explain it a bit 😉 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12940)
<!-- Reviewable:end -->
