### PR TITLE
Remove unnecessary return on update

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataHandler/FormDataHandlerInterface.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/FormDataHandlerInterface.php
@@ -36,7 +36,7 @@ interface FormDataHandlerInterface
      *
      * @param array $data
      *
-     * @return mixed
+     * @return mixed ID of identifiable object
      */
     public function create(array $data);
 
@@ -45,8 +45,6 @@ interface FormDataHandlerInterface
      *
      * @param int $id
      * @param array $data
-     *
-     * @return int ID of identifiable object
      */
     public function update($id, array $data);
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The `update` method on `FormDataHandlerInterface` no longer is supposed to return an ID. 
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Nothing to test

Per the [CQS principle by Martin Fowler](https://martinfowler.com/bliki/CommandQuerySeparation.html), all methods should be either:
> - Queries: Return a result and do not change the observable state of the system (are free of side effects).
> - Commands: Change the state of a system but do not return a value.

We are already allowing ourselves to violate this in the `create` method because we don't use UUIDs, so we cannot know the ID in any other practical way.

I can see no reason that justifies this in the `update` method though, specially since that very same ID is a parameter to that method, and it's not supposed to be altered by the process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12941)
<!-- Reviewable:end -->
