### PR TITLE
Fix recurring technical error when saving modifications in a Carrier

### DIFF
--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -692,34 +692,11 @@ class AdminCarrierWizardControllerCore extends AdminController
                 if (!isset($range_sup[$key])) {
                     continue;
                 }
-                $add_range = true;
-                if ($range_type == Carrier::SHIPPING_METHOD_WEIGHT) {
-                    if (!RangeWeight::rangeExist(null, (float) $delimiter1, (float) $range_sup[$key], $carrier->id_reference)) {
-                        $range = new RangeWeight();
-                    } else {
-                        $range = new RangeWeight((int) $key);
-                        $range->id_carrier = (int) $carrier->id;
-                        $range->save();
-                        $add_range = false;
-                    }
-                }
-
-                if ($range_type == Carrier::SHIPPING_METHOD_PRICE) {
-                    if (!RangePrice::rangeExist(null, (float) $delimiter1, (float) $range_sup[$key], $carrier->id_reference)) {
-                        $range = new RangePrice();
-                    } else {
-                        $range = new RangePrice((int) $key);
-                        $range->id_carrier = (int) $carrier->id;
-                        $range->save();
-                        $add_range = false;
-                    }
-                }
-                if ($add_range) {
-                    $range->id_carrier = (int) $carrier->id;
-                    $range->delimiter1 = (float) $delimiter1;
-                    $range->delimiter2 = (float) $range_sup[$key];
-                    $range->save();
-                }
+                $range = $carrier->getRangeObject((int) $range_type);
+                $range->id_carrier = (int) $carrier->id;
+                $range->delimiter1 = (float) $delimiter1;
+                $range->delimiter2 = (float) $range_sup[$key];
+                $range->save();
 
                 if (!Validate::isLoadedObject($range)) {
                     return false;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix recurring problem when saving modifications in a Carrier. Famous popup `TECHNICAL ERROR` with a delicious message `Error thrown: [object Object] Text status: parsererror` due to a `PrestaShopException` thrown when trying to save Range. See issue for more details.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/12577
| How to test?  | See issue #12577

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12946)
<!-- Reviewable:end -->
