### PR TITLE
Customization - improve phpdoc and constants usage

### DIFF
--- a/classes/Customization.php
+++ b/classes/Customization.php
@@ -345,7 +345,7 @@ class CustomizationCore extends ObjectModel
 			LEFT JOIN `' . _DB_PREFIX_ . 'customized_data` cd ON (cf.id_customization_field = cd.index)
 			WHERE `id_product` = ' . (int) $this->id_product . '
 			AND id_customization = ' . (int) $this->id . '
-			AND cf.type = 1')) {
+			AND cf.type = ' . (int) Product::CUSTOMIZE_TEXTFIELD)) {
             return array();
         }
 
@@ -366,7 +366,7 @@ class CustomizationCore extends ObjectModel
 			LEFT JOIN `' . _DB_PREFIX_ . 'customized_data` cd ON (cf.id_customization_field = cd.index)
 			WHERE `id_product` = ' . (int) $this->id_product . '
 			AND id_customization = ' . (int) $this->id . '
-			AND cf.type = 0')) {
+			AND cf.type = ' . (int) Product::CUSTOMIZE_FILE)) {
             return array();
         }
 
@@ -392,10 +392,10 @@ class CustomizationCore extends ObjectModel
         Db::getInstance()->execute('
 		DELETE FROM `' . _DB_PREFIX_ . 'customized_data`
 		WHERE id_customization = ' . (int) $this->id . '
-		AND type = 1');
+		AND type = ' . (int) Product::CUSTOMIZE_TEXTFIELD);
         foreach ($values as $value) {
             $query = 'INSERT INTO `' . _DB_PREFIX_ . 'customized_data` (`id_customization`, `type`, `index`, `value`)
-				VALUES (' . (int) $this->id . ', 1, ' . (int) $value['id_customization_field'] . ', \'' . pSQL($value['value']) . '\')';
+				VALUES (' . (int) $this->id . ', ' . (int) Product::CUSTOMIZE_TEXTFIELD . ', ' . (int) $value['id_customization_field'] . ', \'' . pSQL($value['value']) . '\')';
 
             if (!Db::getInstance()->execute($query)) {
                 return false;

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1056,7 +1056,7 @@ class AdminProductsControllerCore extends AdminController
         $text_count = 0;
         if (is_array($current_customization)) {
             foreach ($current_customization as $field) {
-                if ($field['type'] == 1) {
+                if ($field['type'] == Product::CUSTOMIZE_TEXTFIELD) {
                     ++$text_count;
                 } else {
                     ++$files_count;

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -276,9 +276,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             $customization_fields = $this->product->customizable ? $this->product->getCustomizationFields($this->context->language->id) : false;
             if (is_array($customization_fields)) {
                 foreach ($customization_fields as &$customization_field) {
-                    if ($customization_field['type'] == 0) {
+                    if ($customization_field['type'] == Product::CUSTOMIZE_FILE) {
                         $customization_field['key'] = 'pictures_' . $this->product->id . '_' . $customization_field['id_customization_field'];
-                    } elseif ($customization_field['type'] == 1) {
+                    } elseif ($customization_field['type'] == Product::CUSTOMIZE_TEXTFIELD) {
                         $customization_field['key'] = 'textFields_' . $this->product->id . '_' . $customization_field['id_customization_field'];
                     }
                 }

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -675,7 +675,7 @@ class AdminProductWrapper
                     )
                 );
 
-                if ($customization['type'] == 0) {
+                if ($customization['type'] == Product::CUSTOMIZE_FILE) {
                     ++$countFieldFile;
                 } else {
                     ++$countFieldText;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Make debug of a module for customization, have to understand what are `index` in `customized_data` table and see some todo in phpdoc. So I share my fresh knowledge
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | None
| How to test?  | Nothing it's just phpdoc and constants

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12956)
<!-- Reviewable:end -->
