### PR TITLE
DoctrineBuilderExtension uses YamlParser for its config

### DIFF
--- a/src/Adapter/Container/DoctrineBuilderExtension.php
+++ b/src/Adapter/Container/DoctrineBuilderExtension.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Container;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use PrestaShop\PrestaShop\Core\Util\File\YamlParser;
 use PrestaShopBundle\DependencyInjection\Compiler\ModulesDoctrineCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -39,18 +40,25 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class DoctrineBuilderExtension implements ContainerBuilderExtensionInterface
 {
+    /** @var string */
+    private $cacheDir;
+
+    /**
+     * @param string $cacheDir
+     */
+    public function __construct($cacheDir)
+    {
+        $this->cacheDir = $cacheDir;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function build(ContainerBuilder $container)
     {
-        //Config is mandatory to init doctrine, during install process it might no be available so we skip the build
-        $configFile = _PS_ROOT_DIR_ . '/app/config/config.php';
-        if (!file_exists($configFile)) {
-            return;
-        }
-        $config = require $configFile;
+        $yamlParser = new YamlParser($this->cacheDir);
 
+        $config = $yamlParser->parse(_PS_ROOT_DIR_ . '/app/config/config.yml');
         $container->registerExtension(new DoctrineExtension());
         $container->loadFromExtension('doctrine', $config['doctrine']);
         $container->addCompilerPass(new ModulesDoctrineCompilerPass());

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -161,7 +161,7 @@ class ContainerBuilder
         //Build extensions
         $builderExtensions = [
             new ContainerParametersExtension($this->environment),
-            new DoctrineBuilderExtension(),
+            new DoctrineBuilderExtension($this->environment->getCacheDir()),
         ];
         /** @var ContainerBuilderExtensionInterface $builderExtension */
         foreach ($builderExtensions as $builderExtension) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | DoctrineBuilderExtension now get its config thanks to the `config.yml` file and `YamlParser` class
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12960)
<!-- Reviewable:end -->
