### PR TITLE
Fix wrong cart calculation when using cart rule with virtual products

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
 use PrestaShop\PrestaShop\Adapter\AddressFactory;
 use PrestaShop\PrestaShop\Adapter\Cache\CacheAdapter;
 use PrestaShop\PrestaShop\Adapter\Customer\CustomerDataProvider;
@@ -181,7 +180,7 @@ class CartCore extends ObjectModel
     const ONLY_SHIPPING = 5;
     const ONLY_WRAPPING = 6;
 
-    /** @deprecated since 1.7 * */
+    /** @deprecated since 1.7 **/
     const ONLY_PRODUCTS_WITHOUT_SHIPPING = 7;
     const ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING = 8;
 
@@ -1289,8 +1288,7 @@ class CartCore extends ObjectModel
         Shop $shop = null,
         $auto_add_cart_rule = true,
         $skipAvailabilityCheckOutOfStock = false
-    )
-    {
+    ) {
         if (!$shop) {
             $shop = Context::getContext()->shop;
         }
@@ -1666,8 +1664,7 @@ class CartCore extends ObjectModel
         $id_product_attribute = 0,
         $id_customization = 0,
         $id_address_delivery = 0
-    )
-    {
+    ) {
         if (isset(self::$_nbProducts[$this->id])) {
             unset(self::$_nbProducts[$this->id]);
         }
@@ -1882,8 +1879,7 @@ class CartCore extends ObjectModel
         $products = null,
         $id_carrier = null,
         $use_cache = false
-    )
-    {
+    ) {
         if ((int) $id_carrier <= 0) {
             $id_carrier = null;
         }
@@ -4530,8 +4526,7 @@ class CartCore extends ObjectModel
         $new_id_address_delivery,
         $quantity = 1,
         $keep_quantity = false
-    )
-    {
+    ) {
         // Check address is linked with the customer
         if (!Customer::customerHasAddress(Context::getContext()->customer->id, $new_id_address_delivery)) {
             return false;

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
 use PrestaShop\PrestaShop\Adapter\AddressFactory;
 use PrestaShop\PrestaShop\Adapter\Cache\CacheAdapter;
 use PrestaShop\PrestaShop\Adapter\Customer\CustomerDataProvider;
@@ -180,7 +181,7 @@ class CartCore extends ObjectModel
     const ONLY_SHIPPING = 5;
     const ONLY_WRAPPING = 6;
 
-    /** @deprecated since 1.7 **/
+    /** @deprecated since 1.7 * */
     const ONLY_PRODUCTS_WITHOUT_SHIPPING = 7;
     const ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING = 8;
 
@@ -1288,7 +1289,8 @@ class CartCore extends ObjectModel
         Shop $shop = null,
         $auto_add_cart_rule = true,
         $skipAvailabilityCheckOutOfStock = false
-    ) {
+    )
+    {
         if (!$shop) {
             $shop = Context::getContext()->shop;
         }
@@ -1664,7 +1666,8 @@ class CartCore extends ObjectModel
         $id_product_attribute = 0,
         $id_customization = 0,
         $id_address_delivery = 0
-    ) {
+    )
+    {
         if (isset(self::$_nbProducts[$this->id])) {
             unset(self::$_nbProducts[$this->id]);
         }
@@ -1879,7 +1882,8 @@ class CartCore extends ObjectModel
         $products = null,
         $id_carrier = null,
         $use_cache = false
-    ) {
+    )
+    {
         if ((int) $id_carrier <= 0) {
             $id_carrier = null;
         }
@@ -1939,7 +1943,7 @@ class CartCore extends ObjectModel
 
         // CART CALCULATION
         $cartRules = array();
-        if (in_array($type, [Cart::BOTH, Cart::ONLY_DISCOUNTS])) {
+        if (in_array($type, [Cart::BOTH, Cart::BOTH_WITHOUT_SHIPPING, Cart::ONLY_DISCOUNTS])) {
             $cartRules = $this->getCartRules();
         }
         $calculator = $this->newCalculator($products, $cartRules, $id_carrier);
@@ -1963,6 +1967,10 @@ class CartCore extends ObjectModel
 
                 break;
             case Cart::BOTH_WITHOUT_SHIPPING:
+                $calculator->calculateRows();
+                $calculator->calculateCartRules();
+                $amount = $calculator->getTotal(true);
+                break;
             case Cart::ONLY_PRODUCTS:
                 $calculator->calculateRows();
                 $amount = $calculator->getRowTotal();
@@ -4294,7 +4302,7 @@ class CartCore extends ObjectModel
 
         // Backward compatibility: if true set customizations quantity to 0, they will be updated in Cart::_updateCustomizationQuantity
         $new_customization_method = (int) Db::getInstance()->getValue(
-            '
+                '
             SELECT COUNT(`id_customization`) FROM `' . _DB_PREFIX_ . 'cart_product`
             WHERE `id_cart` = ' . (int) $this->id .
                 ' AND `id_customization` != 0'
@@ -4522,7 +4530,8 @@ class CartCore extends ObjectModel
         $new_id_address_delivery,
         $quantity = 1,
         $keep_quantity = false
-    ) {
+    )
+    {
         // Check address is linked with the customer
         if (!Customer::customerHasAddress(Context::getContext()->customer->id, $new_id_address_delivery)) {
             return false;

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -136,15 +136,14 @@ class Calculator
     }
 
     /**
-     * @param bool $withTaxes
-     *
+     * @param bool $ignoreProcessedFlag force getting total even if calculation was not made internaly
      * @return AmountImmutable
      *
      * @throws \Exception
      */
-    public function getTotal()
+    public function getTotal($ignoreProcessedFlag = false)
     {
-        if (!$this->isProcessed) {
+        if (!$this->isProcessed && !$ignoreProcessedFlag) {
             throw new \Exception('Cart must be processed before getting its total');
         }
 
@@ -154,9 +153,13 @@ class Calculator
             $amount = $amount->add($rowPrice);
         }
         $shippingFees = $this->fees->getFinalShippingFees();
-        $amount = $amount->add($shippingFees);
+        if (null !== $shippingFees) {
+            $amount = $amount->add($shippingFees);
+        }
         $wrappingFees = $this->fees->getFinalWrappingFees();
-        $amount = $amount->add($wrappingFees);
+        if (null !== $wrappingFees) {
+            $amount = $amount->add($wrappingFees);
+        }
 
         return $amount;
     }

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -137,6 +137,7 @@ class Calculator
 
     /**
      * @param bool $ignoreProcessedFlag force getting total even if calculation was not made internaly
+     *
      * @return AmountImmutable
      *
      * @throws \Exception

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -575,4 +575,14 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
             );
         }
     }
+
+    /**
+     * @Given /^product "(.+)" is virtual$/
+     */
+    public function productWithNameProductisVirtual($productName)
+    {
+        $this->checkProductWithNameExists($productName);
+        $this->products[$productName]->is_virtual = 1;
+        $this->products[$productName]->save();
+    }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono_virtual.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono_virtual.feature
@@ -1,0 +1,37 @@
+@current
+@reset-database-before-feature
+Feature: Cart rule (amount) calculation with one cart rule
+  As a customer
+  I must be able to have correct cart total when adding cart rules
+
+  Scenario: 4 products in cart, one is virtual, several quantities, one 5€ global voucher
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
+    Given there is a product in the catalog named "product8" with a price of 12.345 and 1000 items in stock
+    Given product "product8" is virtual
+    Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule4" has a discount code "foo4"
+    When I add 3 items of product "product1" in my cart
+    When I add 2 items of product "product2" in my cart
+    When I add 1 items of product "product3" in my cart
+    When I add 2 items of product "product8" in my cart
+    Then cart rule "cartrule4" can be applied to my cart
+    When I use the discount "cartrule4"
+    Then my cart total should be 182.09 tax included
+    Then my cart total using previous calculation method should be 182.09 tax included
+
+  Scenario: Only virtual product in my cart, one 5€ global voucher
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product8" with a price of 12.345 and 1000 items in stock
+    Given product "product8" is virtual
+    Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule4" has a discount code "foo4"
+    When I add 2 items of product "product8" in my cart
+    Then cart rule "cartrule4" can be applied to my cart
+    When I use the discount "cartrule4"
+    Then my cart total should be 19.69 tax included
+    Then my cart total using previous calculation method should be 19.69 tax included


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When adding cart rule in a cart containing only virtual products, calculation was wrong
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | fixes #10264
| How to test?  | add only virtual products in cart. Try to apply a cart rule

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12965)
<!-- Reviewable:end -->
