### PR TITLE
Deprecate unused parameter

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1960,12 +1960,19 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param string $string String to translate
      * @param bool|string $specific filename to use in translation key
-     * @param string|null $locale Give a context for the translation
+     * @param string|null $locale [deprecated] Unused
      *
      * @return string Translation
      */
     public function l($string, $specific = false, $locale = null)
     {
+        if ($locale !== null) {
+            @trigger_error(
+                'Use of $locale in ' . __FUNCTION__ . ' has no effect and is deprecated since version 1.7.6.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
         if (self::$_generate_config_xml_mode) {
             return $string;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add deprecation message for unused parameter
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | n/a
| How to test?  | Nothing to test

This parameter was added during development of 1.7.3.0 in #8252, but the code that used it was removed before release in #8265.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12966)
<!-- Reviewable:end -->
