### PR TITLE
Foward $locale to Translate::getModuleTranslation()

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1960,7 +1960,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param string $string String to translate
      * @param bool|string $specific filename to use in translation key
-     * @param string|null $locale Give a context for the translation
+     * @param string|null $locale Locale to translate to
      *
      * @return string Translation
      */
@@ -1970,7 +1970,14 @@ abstract class ModuleCore implements ModuleInterface
             return $string;
         }
 
-        return Translate::getModuleTranslation($this, $string, ($specific) ? $specific : $this->name);
+        return Translate::getModuleTranslation(
+            $this,
+            $string,
+            ($specific) ? $specific : $this->name,
+            null,
+            false,
+            $locale
+        );
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The `trans()` method allows setting the locale we want to translate to, but while the `l()` method has a parameter for that, it was never forwarded to the method that actually performs the translation. This change allows modules to translate to a different locale than one defined by the current context.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Read below

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12967)
<!-- Reviewable:end -->

## How to test

1. Pick up a non-native module that includes translations (for example [psgdpr](https://github.com/PrestaShop/psgdpr/)) and install it
2. In the module's PHP code, edit a call to `$this->l` (for example [this one](https://github.com/PrestaShop/psgdpr/blob/master/psgdpr.php#L115)) and change it so that the function receives three parameters: the orginal text, `false` and a locale already translated and different from your current one (eg. `it-IT`).
3. Verify that the wording you changed is being translated to the locale that you chose, instead of the current one