### PR TITLE
Migrate Cms page create/edit actions

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -48,6 +48,7 @@ module.exports = {
     manufacturer: './js/pages/manufacturer',
     manufacturer_address: './js/pages/manufacturer/address',
     cms_page: './js/pages/cms-page',
+    cms_page_form: './js/pages/cms-page/form',
     form_popover_error: './js/components/form/form-popover-error',
   },
   output: {

--- a/admin-dev/themes/new-theme/js/pages/cms-page/form/index.js
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/form/index.js
@@ -1,0 +1,40 @@
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+const $ = window.$;
+import ChoiceTree from '../../../components/form/choice-tree';
+import TaggableField from '../../../components/taggable-field';
+import TranslatableInput from '../../../components/translatable-input';
+
+$(() => {
+  new ChoiceTree('#cms_page_page_category');
+  new TranslatableInput();
+  new TaggableField({
+    tokenFieldSelector: 'input.js-taggable-field',
+    options: {
+      createTokensOnBlur: true,
+    },
+  });
+});

--- a/admin-dev/themes/new-theme/js/pages/cms-page/form/index.js
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/form/index.js
@@ -27,14 +27,20 @@ const $ = window.$;
 import ChoiceTree from '../../../components/form/choice-tree';
 import TaggableField from '../../../components/taggable-field';
 import TranslatableInput from '../../../components/translatable-input';
+import textToLinkRewriteCopier from '../../../components/text-to-link-rewrite-copier';
 
 $(() => {
-  new ChoiceTree('#cms_page_page_category');
+  new ChoiceTree('#cms_page_page_category_id');
   new TranslatableInput();
   new TaggableField({
     tokenFieldSelector: 'input.js-taggable-field',
     options: {
       createTokensOnBlur: true,
     },
+  });
+
+  textToLinkRewriteCopier({
+    sourceElementSelector: 'input.js-copier-source-title',
+    destinationElementSelector: 'input.js-copier-destination-friendly-url',
   });
 });

--- a/admin-dev/themes/new-theme/public/cms_page_form.bundle.js
+++ b/admin-dev/themes/new-theme/public/cms_page_form.bundle.js
@@ -1,0 +1,49 @@
+!function(e){function n(a){if(t[a])return t[a].exports;var o=t[a]={i:a,l:!1,exports:{}};return e[a].call(o.exports,o,o.exports,n),o.l=!0,o.exports}var t={};n.m=e,n.c=t,n.i=function(e){return e},n.d=function(e,t,a){n.o(e,t)||Object.defineProperty(e,t,{configurable:!1,enumerable:!0,get:a})},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,"a",t),t},n.o=function(e,n){return Object.prototype.hasOwnProperty.call(e,n)},n.p="",n(n.s=291)}({14:function(e,n,t){"use strict";function a(e,n){if(!(e instanceof n))throw new TypeError("Cannot call a class as a function")}var o=function(){function e(e,n){for(var t=0;t<n.length;t++){var a=n[t];a.enumerable=a.enumerable||!1,a.configurable=!0,"value"in a&&(a.writable=!0),Object.defineProperty(e,a.key,a)}}return function(n,t,a){return t&&e(n.prototype,t),a&&e(n,a),n}}(),l=window.$,r=function(){function e(n){a(this,e),n=n||{},this.localeItemSelector=n.localeItemSelector||".js-locale-item",this.localeButtonSelector=n.localeButtonSelector||".js-locale-btn",this.localeInputSelector=n.localeInputSelector||".js-locale-input",l("body").on("click",this.localeItemSelector,this.toggleInputs.bind(this))}return o(e,[{key:"toggleInputs",value:function(e){var n=l(e.target),t=n.closest("form"),a=n.data("locale"),o=t.find(this.localeButtonSelector),r=o.data("change-language-url");o.text(a),t.find(this.localeInputSelector).addClass("d-none"),t.find(this.localeInputSelector+".js-locale-"+a).removeClass("d-none"),r&&this._saveSelectedLanguage(r,a)}},{key:"_saveSelectedLanguage",value:function(e,n){l.post({url:e,data:{language_iso_code:n}})}}]),e}();n.a=r},17:function(e,n,t){"use strict";function a(e,n){if(!(e instanceof n))throw new TypeError("Cannot call a class as a function")}var o=function(){function e(e,n){for(var t=0;t<n.length;t++){var a=n[t];a.enumerable=a.enumerable||!1,a.configurable=!0,"value"in a&&(a.writable=!0),Object.defineProperty(e,a.key,a)}}return function(n,t,a){return t&&e(n.prototype,t),a&&e(n,a),n}}(),l=window.$,r=function(){function e(n){var t=this;return a(this,e),this.$container=l(n),this.$container.on("click",".js-input-wrapper",function(e){var n=l(e.currentTarget);t._toggleChildTree(n)}),this.$container.on("click",".js-toggle-choice-tree-action",function(e){var n=l(e.currentTarget);t._toggleTree(n)}),{enableAutoCheckChildren:function(){return t.enableAutoCheckChildren()},enableAllInputs:function(){return t.enableAllInputs()},disableAllInputs:function(){return t.disableAllInputs()}}}return o(e,[{key:"enableAutoCheckChildren",value:function(){this.$container.on("change",'input[type="checkbox"]',function(e){var n=l(e.currentTarget);n.closest("li").find('ul input[type="checkbox"]').prop("checked",n.is(":checked"))})}},{key:"enableAllInputs",value:function(){this.$container.find("input").removeAttr("disabled")}},{key:"disableAllInputs",value:function(){this.$container.find("input").attr("disabled","disabled")}},{key:"_toggleChildTree",value:function(e){var n=e.closest("li");if(n.hasClass("expanded"))return void n.removeClass("expanded").addClass("collapsed");n.hasClass("collapsed")&&n.removeClass("collapsed").addClass("expanded")}},{key:"_toggleTree",value:function(e){var n=e.closest(".js-choice-tree-container"),t=e.data("action"),a={addClass:{expand:"expanded",collapse:"collapsed"},removeClass:{expand:"collapsed",collapse:"expanded"},nextAction:{expand:"collapse",collapse:"expand"},text:{expand:"collapsed-text",collapse:"expanded-text"},icon:{expand:"collapsed-icon",collapse:"expanded-icon"}};n.find("li").each(function(e,n){var o=l(n);o.hasClass(a.removeClass[t])&&o.removeClass(a.removeClass[t]).addClass(a.addClass[t])}),e.data("action",a.nextAction[t]),e.find(".material-icons").text(e.data(a.icon[t])),e.find(".js-toggle-text").text(e.data(a.text[t]))}}]),e}();n.a=r},24:function(e,n,t){"use strict";function a(e,n){if(!(e instanceof n))throw new TypeError("Cannot call a class as a function")}/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+var o=window.$,l=function e(n){var t=n.tokenFieldSelector,l=n.options,r=void 0===l?{}:l;a(this,e),o(t).tokenfield(r)};n.a=l},28:function(e,n,t){"use strict";/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+var a=window.$,o=function(e){var n=e.attr("data-lang-id");return void 0===n?null:parseInt(n)},l=function(e){var n=e.sourceElementSelector,t=e.destinationElementSelector,l=e.options,r=void 0===l?{eventName:"input"}:l;a(document).on(r.eventName,""+n,function(e){var n=a(e.currentTarget),l=o(n);a(null!==l?t+'[data-lang-id="'+l+'"]':t).val(str2url(n.val(),"UTF-8"))})};n.a=l},291:function(e,n,t){"use strict";Object.defineProperty(n,"__esModule",{value:!0});var a=t(17),o=t(24),l=t(14),r=t(28);(0,window.$)(function(){new a.a("#cms_page_page_category_id"),new l.a,new o.a({tokenFieldSelector:"input.js-taggable-field",options:{createTokensOnBlur:!0}}),t.i(r.a)({sourceElementSelector:"input.js-copier-source-title",destinationElementSelector:"input.js-copier-destination-friendly-url"})})}});

--- a/src/Adapter/CMS/Page/CommandHandler/AbstractCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/AbstractCmsPageHandler.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\CMS\Page\CommandHandler;
 
 use CMS;
+use PrestaShop\PrestaShop\Adapter\Domain\AbstractObjectModelHandler;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
 use PrestaShopException;
@@ -36,7 +37,7 @@ use PrestaShopException;
  *
  * @internal
  */
-abstract class AbstractCmsPageHandler
+abstract class AbstractCmsPageHandler extends AbstractObjectModelHandler
 {
     /**
      * Gets cms object if it exists. If it does not exist it throws exceptions.

--- a/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
@@ -48,6 +48,11 @@ final class AddCmsPageHandler extends AbstractCmsPageHandler implements AddCmsPa
     public function handle(AddCmsPageCommand $command)
     {
         $cms = $this->createCmsFromCommand($command);
+
+        if (false === $cms->validateFields(false)) {
+            throw new CmsPageException('Cms page contains invalid field values');
+        }
+
         try {
             if (false === $cms->add()) {
                 throw new CannotAddCmsPageException(

--- a/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\CMS\Page\CommandHandler;
+
+use CMS;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\AddCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\CommandHandler\AddCmsPageHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotAddCmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+use PrestaShopException;
+
+/**
+ * Handles AddCmsPageCommand using legacy object model
+ */
+final class AddCmsPageHandler extends AbstractCmsPageHandler implements AddCmsPageHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws CmsPageException
+     * @throws PrestaShopException
+     */
+    public function handle(AddCmsPageCommand $command)
+    {
+        $cms = $this->createCmsFromCommand($command);
+        try {
+            if (false === $cms->add()) {
+                throw new CannotAddCmsPageException(
+                    'Failed to add cms page'
+                );
+            }
+            $this->associateWithShops($cms, $command->getShopAssociation());
+        } catch (PrestaShopException $e) {
+            throw new CmsPageException(
+                'An unexpected error occurred when adding cms page category',
+                0,
+                $e
+            );
+        }
+
+        return new CmsPageId((int) $cms->id);
+    }
+
+    /**
+     * @param AddCmsPageCommand $command
+     *
+     * @return CMS
+     *
+     * @throws PrestaShopException
+     */
+    protected function createCmsFromCommand(AddCmsPageCommand $command)
+    {
+        $cms = new CMS();
+        $cms->meta_title = $command->getLocalizedTitle();
+        $cms->head_seo_title = $command->getLocalizedMetaTitle();
+        $cms->id_cms_category = $command->getCmsPageCategory()->getValue();
+        $cms->meta_description = $command->getLocalizedMetaDescription();
+        $cms->meta_keywords = $command->getLocalizedMetaKeyword();
+        $cms->link_rewrite = $command->getLocalizedFriendlyUrl();
+        $cms->content = $command->getLocalizedContent();
+        $cms->indexation = $command->isIndexedForSearch();
+        $cms->active = $command->isDisplayed();
+
+        return $cms;
+    }
+}

--- a/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
@@ -49,11 +49,11 @@ final class AddCmsPageHandler extends AbstractCmsPageHandler implements AddCmsPa
     {
         $cms = $this->createCmsFromCommand($command);
 
-        if (false === $cms->validateFields(false)) {
-            throw new CmsPageException('Cms page contains invalid field values');
-        }
-
         try {
+            if (false === $cms->validateFields(false) || false === $cms->validateFieldsLang(false)) {
+                throw new CmsPageException('Cms page contains invalid field values');
+            }
+
             if (false === $cms->add()) {
                 throw new CannotAddCmsPageException(
                     'Failed to add cms page'

--- a/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
@@ -62,7 +62,7 @@ final class AddCmsPageHandler extends AbstractCmsPageHandler implements AddCmsPa
             $this->associateWithShops($cms, $command->getShopAssociation());
         } catch (PrestaShopException $e) {
             throw new CmsPageException(
-                'An unexpected error occurred when adding cms page category',
+                'An unexpected error occurred when adding cms page',
                 0,
                 $e
             );

--- a/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
@@ -50,7 +50,7 @@ final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCms
         $cms = $this->createCmsFromCommand($command);
 
         try {
-            if (false === $cms->validateFields(false)) {
+            if (false === $cms->validateFields(false) || false === $cms->validateFieldsLang(false)) {
                 throw new CmsPageException('Cms page contains invalid field values');
             }
             if (false === $cms->update()) {

--- a/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\CMS\Page\CommandHandler;
+
+use CMS;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\EditCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\CommandHandler\EditCmsPageHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotEditCmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+use PrestaShopException;
+
+/**
+ * Edits cms page
+ */
+final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCmsPageHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws CmsPageException
+     */
+    public function handle(EditCmsPageCommand $command)
+    {
+        $cms = $this->createCmsFromCommand($command);
+
+        if (false === $cms->validateFields(false)) {
+            throw new CmsPageException('Cms page contains invalid field values');
+        }
+
+        try {
+            if (false === $cms->update()) {
+                throw new CannotEditCmsPageException(
+                    sprintf('Failed to update cms page with id %s', $command->getCmsPageId()->getValue())
+                );
+            }
+            $this->associateWithShops($cms, $command->getShopAssociation());
+        } catch (PrestaShopException $e) {
+            throw new CmsPageException(
+                sprintf(
+                    'An unexpected error occurred when editing cms page with id %s',
+                    $command->getCmsPageId()->getValue()
+                ),
+                0,
+                $e
+            );
+        }
+
+        return new CmsPageId((int) $cms->id);
+    }
+
+    /**
+     * @param EditCmsPageCommand $command
+     *
+     * @return CMS
+     *
+     * @throws CmsPageException
+     * @throws CmsPageNotFoundException
+     */
+    private function createCmsFromCommand(EditCmsPageCommand $command)
+    {
+        $cms = $this->getCmsPageIfExistsById($command->getCmsPageId()->getValue());
+
+        if (null !== $command->getLocalizedTitle()) {
+            $cms->meta_title = $command->getLocalizedTitle();
+        }
+
+        if (null !== $command->getLocalizedMetaTitle()) {
+            $cms->head_seo_title = $command->getLocalizedMetaTitle();
+        }
+
+        if (null !== $command->getCmsPageCategory()) {
+            $cms->id_cms_category = $command->getCmsPageCategory()->getValue();
+        }
+
+        if (null !== $command->getLocalizedMetaDescription()) {
+            $cms->meta_description = $command->getLocalizedMetaDescription();
+        }
+
+        if (null !== $command->getLocalizedMetaKeyword()) {
+            $cms->meta_keywords = $command->getLocalizedMetaKeyword();
+        }
+
+        if (null !== $command->getLocalizedFriendlyUrl()) {
+            $cms->link_rewrite = $command->getLocalizedFriendlyUrl();
+        }
+
+        if (null !== $command->getLocalizedContent()) {
+            $cms->content = $command->getLocalizedContent();
+        }
+
+        if (null !== $command->isIndexedForSearch()) {
+            $cms->indexation = $command->isIndexedForSearch();
+        }
+
+        if (null !== $command->isDisplayed()) {
+            $cms->active = $command->isDisplayed();
+        }
+
+        return $cms;
+    }
+}

--- a/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
@@ -49,11 +49,10 @@ final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCms
     {
         $cms = $this->createCmsFromCommand($command);
 
-        if (false === $cms->validateFields(false)) {
-            throw new CmsPageException('Cms page contains invalid field values');
-        }
-
         try {
+            if (false === $cms->validateFields(false)) {
+                throw new CmsPageException('Cms page contains invalid field values');
+            }
             if (false === $cms->update()) {
                 throw new CannotEditCmsPageException(
                     sprintf('Failed to update cms page with id %s', $command->getCmsPageId()->getValue())
@@ -94,8 +93,8 @@ final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCms
             $cms->head_seo_title = $command->getLocalizedMetaTitle();
         }
 
-        if (null !== $command->getCmsPageCategory()) {
-            $cms->id_cms_category = $command->getCmsPageCategory()->getValue();
+        if (null !== $command->getCmsPageCategoryId()) {
+            $cms->id_cms_category = $command->getCmsPageCategoryId()->getValue();
         }
 
         if (null !== $command->getLocalizedMetaDescription()) {

--- a/src/Adapter/CMS/Page/QueryHandler/GetCmsPageForEditingHandler.php
+++ b/src/Adapter/CMS/Page/QueryHandler/GetCmsPageForEditingHandler.php
@@ -27,37 +27,51 @@
 namespace PrestaShop\PrestaShop\Adapter\CMS\Page\QueryHandler;
 
 use PrestaShop\PrestaShop\Adapter\CMS\Page\CommandHandler\AbstractCmsPageHandler;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Query\getCmsPageForEditing;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\QueryHandler\GetCmsPageForEditingHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\QueryResult\EditableCmsPage;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
+use PrestaShopException;
 
 /**
  * Gets cms page for editing
  */
 final class GetCmsPageForEditingHandler extends AbstractCmsPageHandler implements GetCmsPageForEditingHandlerInterface
 {
-
     /**
      * @param GetCmsPageForEditing $query
      *
      * @return EditableCmsPage
+     *
+     * @throws CmsPageException
+     * @throws CmsPageCategoryException
+     * @throws CmsPageNotFoundException
      */
     public function handle(getCmsPageForEditing $query)
     {
-        $cms = $this->getCmsPageIfExistsById($query->getCmsPageId()->getValue());
+        $cmsPageId = $query->getCmsPageId()->getValue();
+        $cms = $this->getCmsPageIfExistsById($cmsPageId);
 
-        return new EditableCmsPage(
-            (int) $cms->id_cms_category,
-            $cms->meta_title,
-            $cms->head_seo_title,
-            $cms->meta_description,
-            $cms->meta_keywords,
-            $cms->link_rewrite,
-            $cms->content,
-            $cms->indexation,
-            $cms->active,
-            $cms->getAssociatedShops()
-        );
-
+        try {
+            return new EditableCmsPage(
+                (int) $cms->id,
+                (int) $cms->id_cms_category,
+                $cms->meta_title,
+                $cms->head_seo_title,
+                $cms->meta_description,
+                $cms->meta_keywords,
+                $cms->link_rewrite,
+                $cms->content,
+                $cms->indexation,
+                $cms->active,
+                $cms->getAssociatedShops()
+            );
+        } catch (PrestaShopException $e) {
+            throw new CmsPageException(
+                sprintf('An error occurred when getting cms page for editing with id "%s"', $cmsPageId)
+            );
+        }
     }
 }

--- a/src/Adapter/CMS/Page/QueryHandler/GetCmsPageForEditingHandler.php
+++ b/src/Adapter/CMS/Page/QueryHandler/GetCmsPageForEditingHandler.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\CMS\Page\QueryHandler;
+
+use PrestaShop\PrestaShop\Adapter\CMS\Page\CommandHandler\AbstractCmsPageHandler;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Query\getCmsPageForEditing;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\QueryHandler\GetCmsPageForEditingHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\QueryResult\EditableCmsPage;
+
+/**
+ * Gets cms page for editing
+ */
+final class GetCmsPageForEditingHandler extends AbstractCmsPageHandler implements GetCmsPageForEditingHandlerInterface
+{
+
+    /**
+     * @param GetCmsPageForEditing $query
+     *
+     * @return EditableCmsPage
+     */
+    public function handle(getCmsPageForEditing $query)
+    {
+        $cms = $this->getCmsPageIfExistsById($query->getCmsPageId()->getValue());
+
+        return new EditableCmsPage(
+            (int) $cms->id_cms_category,
+            $cms->meta_title,
+            $cms->head_seo_title,
+            $cms->meta_description,
+            $cms->meta_keywords,
+            $cms->link_rewrite,
+            $cms->content,
+            $cms->indexation,
+            $cms->active,
+            $cms->getAssociatedShops()
+        );
+
+    }
+}

--- a/src/Core/Domain/CmsPage/Command/AddCmsPageCommand.php
+++ b/src/Core/Domain/CmsPage/Command/AddCmsPageCommand.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
+
+/**
+ * Adds new cms page
+ */
+class AddCmsPageCommand
+{
+    /**
+     * @var CmsPageCategoryId
+     */
+    private $cmsPageCategoryId;
+
+    /**
+     * @var string[]
+     */
+    private $localizedTitle;
+
+    /**
+     * @var string[]
+     */
+    private $localizedMetaTitle;
+
+    /**
+     * @var string[]
+     */
+    private $localizedMetaDescription;
+
+    /**
+     * @var string[]
+     */
+    private $LocalizedMetaKeyword;
+
+    /**
+     * @var string[]
+     */
+    private $localizedFriendlyUrl;
+
+    /**
+     * @var string[]
+     */
+    private $localizedContent;
+
+    /**
+     * @var bool
+     */
+    private $indexedForSearch;
+
+    /**
+     * @var bool
+     */
+    private $displayed;
+
+    /**
+     * @var array
+     */
+    private $shopAssociation;
+
+    /**
+     * @param int $cmsPageCategoryId
+     * @param string[] $localizedTitle
+     * @param string[] $localizedMetaTitle
+     * @param string[] $localizedMetaDescription
+     * @param string[] $LocalizedMetaKeyword
+     * @param string[] $localizedFriendlyUrl
+     * @param string[] $localizedContent
+     * @param bool $indexedForSearch
+     * @param bool $displayed
+     * @param array $shopAssociation
+     *
+     * @throws CmsPageCategoryException
+     */
+    public function __construct(
+        $cmsPageCategoryId,
+        array $localizedTitle,
+        array $localizedMetaTitle,
+        array $localizedMetaDescription,
+        array $LocalizedMetaKeyword,
+        array $localizedFriendlyUrl,
+        array $localizedContent,
+        $indexedForSearch,
+        $displayed,
+        array $shopAssociation
+    ) {
+        $this->cmsPageCategoryId = new CmsPageCategoryId($cmsPageCategoryId);
+        $this->localizedTitle = $localizedTitle;
+        $this->localizedMetaTitle = $localizedMetaTitle;
+        $this->localizedMetaDescription = $localizedMetaDescription;
+        $this->LocalizedMetaKeyword = $LocalizedMetaKeyword;
+        $this->localizedFriendlyUrl = $localizedFriendlyUrl;
+        $this->localizedContent = $localizedContent;
+        $this->indexedForSearch = $indexedForSearch;
+        $this->displayed = $displayed;
+        $this->shopAssociation = $shopAssociation;
+    }
+
+    /**
+     * @return CmsPageCategoryId
+     */
+    public function getCmsPageCategory()
+    {
+        return $this->cmsPageCategoryId;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedTitle()
+    {
+        return $this->localizedTitle;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedMetaTitle()
+    {
+        return $this->localizedMetaTitle;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedMetaDescription()
+    {
+        return $this->localizedMetaDescription;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedMetaKeyword()
+    {
+        return $this->LocalizedMetaKeyword;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedFriendlyUrl()
+    {
+        return $this->localizedFriendlyUrl;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedContent()
+    {
+        return $this->localizedContent;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIndexedForSearch()
+    {
+        return $this->indexedForSearch;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDisplayed()
+    {
+        return $this->displayed;
+    }
+
+    /**
+     * @return array
+     */
+    public function getShopAssociation()
+    {
+        return $this->shopAssociation;
+    }
+}

--- a/src/Core/Domain/CmsPage/Command/EditCmsPageCommand.php
+++ b/src/Core/Domain/CmsPage/Command/EditCmsPageCommand.php
@@ -78,12 +78,12 @@ class EditCmsPageCommand
     /**
      * @var bool|null
      */
-    private $indexedForSearch;
+    private $isIndexedForSearch;
 
     /**
      * @var bool|null
      */
-    private $displayed;
+    private $isDisplayed;
 
     /**
      * @var array|null
@@ -97,5 +97,225 @@ class EditCmsPageCommand
     public function __construct($cmsPageId)
     {
         $this->cmsPageId = new CmsPageId($cmsPageId);
+    }
+
+    /**
+     * @return CmsPageId
+     */
+    public function getCmsPageId()
+    {
+        return $this->cmsPageId;
+    }
+
+    /**
+     * @param CmsPageId $cmsPageId
+     *
+     * @return self
+     */
+    public function setCmsPageId($cmsPageId)
+    {
+        $this->cmsPageId = $cmsPageId;
+
+        return $this;
+    }
+
+    /**
+     * @return CmsPageCategoryId|null
+     */
+    public function getCmsPageCategoryId()
+    {
+        return $this->cmsPageCategoryId;
+    }
+
+    /**
+     * @param CmsPageCategoryId|null $cmsPageCategoryId
+     *
+     * @return self
+     */
+    public function setCmsPageCategoryId($cmsPageCategoryId)
+    {
+        $this->cmsPageCategoryId = $cmsPageCategoryId;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedTitle()
+    {
+        return $this->localizedTitle;
+    }
+
+    /**
+     * @param string[]|null $localizedTitle
+     *
+     * @return self
+     */
+    public function setLocalizedTitle(array $localizedTitle)
+    {
+        $this->localizedTitle = $localizedTitle;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedMetaTitle()
+    {
+        return $this->localizedMetaTitle;
+    }
+
+    /**
+     * @param string[]|null $localizedMetaTitle
+     *
+     * @return self
+     */
+    public function setLocalizedMetaTitle(array $localizedMetaTitle)
+    {
+        $this->localizedMetaTitle = $localizedMetaTitle;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedMetaDescription()
+    {
+        return $this->localizedMetaDescription;
+    }
+
+    /**
+     * @param string[]|null $localizedMetaDescription
+     *
+     * @return self
+     */
+    public function setLocalizedMetaDescription(array $localizedMetaDescription)
+    {
+        $this->localizedMetaDescription = $localizedMetaDescription;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedMetaKeyword()
+    {
+        return $this->LocalizedMetaKeyword;
+    }
+
+    /**
+     * @param string[]|null $LocalizedMetaKeyword
+     *
+     * @return self
+     */
+    public function setLocalizedMetaKeyword(array $LocalizedMetaKeyword)
+    {
+        $this->LocalizedMetaKeyword = $LocalizedMetaKeyword;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedFriendlyUrl()
+    {
+        return $this->localizedFriendlyUrl;
+    }
+
+    /**
+     * @param string[]|null $localizedFriendlyUrl
+     *
+     * @return self
+     */
+    public function setLocalizedFriendlyUrl(array $localizedFriendlyUrl)
+    {
+        $this->localizedFriendlyUrl = $localizedFriendlyUrl;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedContent()
+    {
+        return $this->localizedContent;
+    }
+
+    /**
+     * @param string[]|null $localizedContent
+     *
+     * @return self
+     */
+    public function setLocalizedContent(array $localizedContent)
+    {
+        $this->localizedContent = $localizedContent;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function isIndexedForSearch()
+    {
+        return $this->isIndexedForSearch;
+    }
+
+    /**
+     * @param bool|null $isIndexedForSearch
+     *
+     * @return self
+     */
+    public function setIsIndexedForSearch($isIndexedForSearch)
+    {
+        $this->isIndexedForSearch = $isIndexedForSearch;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function isDisplayed()
+    {
+        return $this->isDisplayed;
+    }
+
+    /**
+     * @param bool|null $isDisplayed
+     *
+     * @return self
+     */
+    public function setIsDisplayed($isDisplayed)
+    {
+        $this->isDisplayed = $isDisplayed;
+
+        return $this;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getShopAssociation()
+    {
+        return $this->shopAssociation;
+    }
+
+    /**
+     * @param array|null $shopAssociation
+     *
+     * @return self
+     */
+    public function setShopAssociation(array $shopAssociation)
+    {
+        $this->shopAssociation = $shopAssociation;
+
+        return $this;
     }
 }

--- a/src/Core/Domain/CmsPage/Command/EditCmsPageCommand.php
+++ b/src/Core/Domain/CmsPage/Command/EditCmsPageCommand.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
+
+/**
+ * Edits cms page
+ */
+class EditCmsPageCommand
+{
+    /**
+     * @var CmsPageId
+     */
+    private $cmsPageId;
+
+    /**
+     * @var CmsPageCategoryId|null
+     */
+    private $cmsPageCategoryId;
+
+    /**
+     * @var string[]|null
+     */
+    private $localizedTitle;
+
+    /**
+     * @var string[]|null
+     */
+    private $localizedMetaTitle;
+
+    /**
+     * @var string[]|null
+     */
+    private $localizedMetaDescription;
+
+    /**
+     * @var string[]|null
+     */
+    private $LocalizedMetaKeyword;
+
+    /**
+     * @var string[]|null
+     */
+    private $localizedFriendlyUrl;
+
+    /**
+     * @var string[]|null
+     */
+    private $localizedContent;
+
+    /**
+     * @var bool|null
+     */
+    private $indexedForSearch;
+
+    /**
+     * @var bool|null
+     */
+    private $displayed;
+
+    /**
+     * @var array|null
+     */
+    private $shopAssociation;
+
+    /**
+     * @param int $cmsPageId
+     * @throws CmsPageException
+     */
+    public function __construct($cmsPageId)
+    {
+        $this->cmsPageId = new CmsPageId($cmsPageId);
+    }
+}

--- a/src/Core/Domain/CmsPage/Command/EditCmsPageCommand.php
+++ b/src/Core/Domain/CmsPage/Command/EditCmsPageCommand.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
 
 /**
@@ -92,6 +93,7 @@ class EditCmsPageCommand
 
     /**
      * @param int $cmsPageId
+     *
      * @throws CmsPageException
      */
     public function __construct($cmsPageId)
@@ -108,18 +110,6 @@ class EditCmsPageCommand
     }
 
     /**
-     * @param CmsPageId $cmsPageId
-     *
-     * @return self
-     */
-    public function setCmsPageId($cmsPageId)
-    {
-        $this->cmsPageId = $cmsPageId;
-
-        return $this;
-    }
-
-    /**
      * @return CmsPageCategoryId|null
      */
     public function getCmsPageCategoryId()
@@ -128,13 +118,15 @@ class EditCmsPageCommand
     }
 
     /**
-     * @param CmsPageCategoryId|null $cmsPageCategoryId
+     * @param int|null $cmsPageCategoryId
      *
      * @return self
+     *
+     * @throws CmsPageCategoryException
      */
     public function setCmsPageCategoryId($cmsPageCategoryId)
     {
-        $this->cmsPageCategoryId = $cmsPageCategoryId;
+        $this->cmsPageCategoryId = new CmsPageCategoryId($cmsPageCategoryId);
 
         return $this;
     }

--- a/src/Core/Domain/CmsPage/CommandHandler/AddCmsPageHandlerInterface.php
+++ b/src/Core/Domain/CmsPage/CommandHandler/AddCmsPageHandlerInterface.php
@@ -24,49 +24,20 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\CommandHandler;
 
-use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\CmsPageRootCategorySettings;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\AddCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
 
-class CmsPageFormDataProvider implements FormDataProviderInterface
+/**
+ * Interface for services that handles AddCmsPageCommand
+ */
+interface AddCmsPageHandlerInterface
 {
     /**
-     * @var array
-     */
-    private $contextShopIds;
-
-    /**
-     * @param array $contextShopIds
-     */
-    public function __construct(array $contextShopIds)
-    {
-        $this->contextShopIds = $contextShopIds;
-    }
-
-    /**
-     * Get form data for given object with given id.
+     * @param AddCmsPageCommand $command
      *
-     * @param int $id
-     *
-     * @return mixed
+     * @return CmsPageId
      */
-    public function getData($id)
-    {
-        // TODO: Implement getData() method.
-    }
-
-    /**
-     * Get default form data.
-     *
-     * @return mixed
-     */
-    public function getDefaultData()
-    {
-        return [
-            'page_category' => CmsPageRootCategorySettings::ROOT_CMS_PAGE_CATEGORY_ID,
-            'shop_association' => $this->contextShopIds,
-            'is_indexed_for_search' => false,
-            'is_displayed' => false,
-        ];
-    }
+    public function handle(AddCmsPageCommand $command);
 }

--- a/src/Core/Domain/CmsPage/CommandHandler/EditCmsPageHandlerInterface.php
+++ b/src/Core/Domain/CmsPage/CommandHandler/EditCmsPageHandlerInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\EditCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+
+/**
+ * Defines contract for EditCmsPageHandler.
+ */
+interface EditCmsPageHandlerInterface
+{
+    /**
+     * @param EditCmsPageCommand $command
+     *
+     * @return CmsPageId
+     */
+    public function handle(EditCmsPageCommand $command);
+}

--- a/src/Core/Domain/CmsPage/Exception/CannotAddCmsPageException.php
+++ b/src/Core/Domain/CmsPage/Exception/CannotAddCmsPageException.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop SA and Contributors
+ * 2007-2019 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -16,7 +16,7 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to http://www.prestashop.com for more information.
+ * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright 2007-2019 PrestaShop SA and Contributors
@@ -26,11 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception;
 
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
-
 /**
- * Base exception for cms page sub-domain
+ * Thrown on failure when adding new cms page
  */
-class CmsPageException extends DomainException
+class CannotAddCmsPageException extends CmsPageException
 {
 }

--- a/src/Core/Domain/CmsPage/Exception/CannotEditCmsPageException.php
+++ b/src/Core/Domain/CmsPage/Exception/CannotEditCmsPageException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception;
+
+class CannotEditCmsPageException extends CmsPageException
+{
+}

--- a/src/Core/Domain/CmsPage/Query/GetCmsPageForEditing.php
+++ b/src/Core/Domain/CmsPage/Query/GetCmsPageForEditing.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\Query;
+
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+
+/**
+ * Gets object which transfers cms page data for editing
+ */
+class GetCmsPageForEditing
+{
+    /**
+     * @var CmsPageId
+     */
+    private $cmsPageId;
+
+    /**
+     * @param int $cmsPageId
+     *
+     * @throws CmsPageException
+     */
+    public function __construct($cmsPageId)
+    {
+        $this->cmsPageId = new CmsPageId($cmsPageId);
+    }
+
+    /**
+     * @return CmsPageId
+     */
+    public function getCmsPageId()
+    {
+        return $this->cmsPageId;
+    }
+}

--- a/src/Core/Domain/CmsPage/QueryHandler/GetCmsPageForEditingHandlerInterface.php
+++ b/src/Core/Domain/CmsPage/QueryHandler/GetCmsPageForEditingHandlerInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Query\getCmsPageForEditing;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\QueryResult\EditableCmsPage;
+
+/**
+ * Interface for service that handles getCmsPageForEditing query
+ */
+interface GetCmsPageForEditingHandlerInterface
+{
+    /**
+     * @param GetCmsPageForEditing $query
+     *
+     * @return EditableCmsPage
+     */
+    public function handle(GetCmsPageForEditing $query);
+}

--- a/src/Core/Domain/CmsPage/QueryResult/EditableCmsPage.php
+++ b/src/Core/Domain/CmsPage/QueryResult/EditableCmsPage.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\QueryResult;
+
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
+
+/**
+ * Transfers cms page data for editing
+ */
+class EditableCmsPage
+{
+    /**
+     * @var CmsPageCategoryId
+     */
+    private $cmsPageCategoryId;
+
+    /**
+     * @var string[]
+     */
+    private $localizedTitle;
+
+    /**
+     * @var string[]
+     */
+    private $localizedMetaTitle;
+
+    /**
+     * @var string[]
+     */
+    private $localizedMetaDescription;
+
+    /**
+     * @var string[]
+     */
+    private $LocalizedMetaKeyword;
+
+    /**
+     * @var string[]
+     */
+    private $localizedFriendlyUrl;
+
+    /**
+     * @var string[]
+     */
+    private $localizedContent;
+
+    /**
+     * @var bool
+     */
+    private $indexedForSearch;
+
+    /**
+     * @var bool
+     */
+    private $displayed;
+
+    /**
+     * @var array
+     */
+    private $shopAssociation;
+
+    /**
+     * @param int $cmsPageCategoryId
+     * @param string[] $localizedTitle
+     * @param string[] $localizedMetaTitle
+     * @param string[] $localizedMetaDescription
+     * @param string[] $LocalizedMetaKeyword
+     * @param string[] $localizedFriendlyUrl
+     * @param string[] $localizedContent
+     * @param bool $indexedForSearch
+     * @param bool $displayed
+     * @param array $shopAssociation
+     *
+     * @throws CmsPageCategoryException
+     */
+    public function __construct(
+        $cmsPageCategoryId,
+        array $localizedTitle,
+        array $localizedMetaTitle,
+        array $localizedMetaDescription,
+        array $LocalizedMetaKeyword,
+        array $localizedFriendlyUrl,
+        array $localizedContent,
+        $indexedForSearch,
+        $displayed,
+        array $shopAssociation
+    ) {
+        $this->cmsPageCategoryId = new CmsPageCategoryId($cmsPageCategoryId);
+        $this->localizedTitle = $localizedTitle;
+        $this->localizedMetaTitle = $localizedMetaTitle;
+        $this->localizedMetaDescription = $localizedMetaDescription;
+        $this->LocalizedMetaKeyword = $LocalizedMetaKeyword;
+        $this->localizedFriendlyUrl = $localizedFriendlyUrl;
+        $this->localizedContent = $localizedContent;
+        $this->indexedForSearch = $indexedForSearch;
+        $this->displayed = $displayed;
+        $this->shopAssociation = $shopAssociation;
+    }
+
+    /**
+     * @return CmsPageCategoryId
+     */
+    public function getCmsPageCategory()
+    {
+        return $this->cmsPageCategoryId;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedTitle()
+    {
+        return $this->localizedTitle;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedMetaTitle()
+    {
+        return $this->localizedMetaTitle;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedMetaDescription()
+    {
+        return $this->localizedMetaDescription;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedMetaKeyword()
+    {
+        return $this->LocalizedMetaKeyword;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedFriendlyUrl()
+    {
+        return $this->localizedFriendlyUrl;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedContent()
+    {
+        return $this->localizedContent;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIndexedForSearch()
+    {
+        return $this->indexedForSearch;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDisplayed()
+    {
+        return $this->displayed;
+    }
+
+    /**
+     * @return array
+     */
+    public function getShopAssociation()
+    {
+        return $this->shopAssociation;
+    }
+}

--- a/src/Core/Domain/CmsPage/QueryResult/EditableCmsPage.php
+++ b/src/Core/Domain/CmsPage/QueryResult/EditableCmsPage.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\QueryResult;
 
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
 
@@ -34,6 +36,11 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategor
  */
 class EditableCmsPage
 {
+    /**
+     * @var CmsPageId
+     */
+    private $cmsPageId;
+
     /**
      * @var CmsPageCategoryId
      */
@@ -85,6 +92,7 @@ class EditableCmsPage
     private $shopAssociation;
 
     /**
+     * @param int $cmsPageId
      * @param int $cmsPageCategoryId
      * @param string[] $localizedTitle
      * @param string[] $localizedMetaTitle
@@ -97,8 +105,10 @@ class EditableCmsPage
      * @param array $shopAssociation
      *
      * @throws CmsPageCategoryException
+     * @throws CmsPageException
      */
     public function __construct(
+        $cmsPageId,
         $cmsPageCategoryId,
         array $localizedTitle,
         array $localizedMetaTitle,
@@ -110,6 +120,7 @@ class EditableCmsPage
         $displayed,
         array $shopAssociation
     ) {
+        $this->cmsPageId = new CmsPageId($cmsPageId);
         $this->cmsPageCategoryId = new CmsPageCategoryId($cmsPageCategoryId);
         $this->localizedTitle = $localizedTitle;
         $this->localizedMetaTitle = $localizedMetaTitle;
@@ -120,6 +131,14 @@ class EditableCmsPage
         $this->indexedForSearch = $indexedForSearch;
         $this->displayed = $displayed;
         $this->shopAssociation = $shopAssociation;
+    }
+
+    /**
+     * @return CmsPageId
+     */
+    public function getCmsPageId()
+    {
+        return $this->cmsPageId;
     }
 
     /**

--- a/src/Core/Domain/CmsPage/QueryResult/EditableCmsPage.php
+++ b/src/Core/Domain/CmsPage/QueryResult/EditableCmsPage.php
@@ -144,7 +144,7 @@ class EditableCmsPage
     /**
      * @return CmsPageCategoryId
      */
-    public function getCmsPageCategory()
+    public function getCmsPageCategoryId()
     {
         return $this->cmsPageCategoryId;
     }

--- a/src/Core/Domain/CmsPageCategory/ValueObject/CmsPageCategoryId.php
+++ b/src/Core/Domain/CmsPageCategory/ValueObject/CmsPageCategoryId.php
@@ -46,7 +46,6 @@ class CmsPageCategoryId
     public function __construct($cmsPageCategoryId)
     {
         $this->assertIsIntegerGreaterThanZero($cmsPageCategoryId);
-        $this->cmsPageCategoryId = (int) $cmsPageCategoryId;
     }
 
     /**

--- a/src/Core/Domain/CmsPageCategory/ValueObject/CmsPageCategoryId.php
+++ b/src/Core/Domain/CmsPageCategory/ValueObject/CmsPageCategoryId.php
@@ -46,6 +46,7 @@ class CmsPageCategoryId
     public function __construct($cmsPageCategoryId)
     {
         $this->assertIsIntegerGreaterThanZero($cmsPageCategoryId);
+        $this->cmsPageCategoryId = $cmsPageCategoryId;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataHandler/CmsPageFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CmsPageFormDataHandler.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+
+class CmsPageFormDataHandler implements FormDataHandlerInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    /**
+     * @param CommandBusInterface $commandBus
+     */
+    public function __construct(CommandBusInterface $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    /**
+     * Create object from form data.
+     *
+     * @param array $data
+     *
+     * @return mixed
+     */
+    public function create(array $data)
+    {
+        // TODO: Implement create() method.
+    }
+
+    /**
+     * Update object with form data.
+     *
+     * @param int $id
+     * @param array $data
+     *
+     * @return int ID of identifiable object
+     */
+    public function update($id, array $data)
+    {
+        // TODO: Implement update() method.
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataHandler/CmsPageFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CmsPageFormDataHandler.php
@@ -58,7 +58,7 @@ class CmsPageFormDataHandler implements FormDataHandlerInterface
     public function create(array $data)
     {
         /**
-         * @var CmsPageId
+         * @var CmsPageId $cmsPageId
          */
         $cmsPageId = $this->commandBus->handle(new AddCmsPageCommand(
             (int) $data['page_category'],

--- a/src/Core/Form/IdentifiableObject/DataHandler/CmsPageFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CmsPageFormDataHandler.php
@@ -27,6 +27,9 @@
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\AddCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
 
 class CmsPageFormDataHandler implements FormDataHandlerInterface
 {
@@ -48,11 +51,29 @@ class CmsPageFormDataHandler implements FormDataHandlerInterface
      *
      * @param array $data
      *
-     * @return mixed
+     * @return int
+     *
+     * @throws CmsPageCategoryException
      */
     public function create(array $data)
     {
-        // TODO: Implement create() method.
+        /**
+         * @var CmsPageId
+         */
+        $cmsPageId = $this->commandBus->handle(new AddCmsPageCommand(
+            (int) $data['page_category'],
+            $data['title'],
+            $data['meta_title'],
+            $data['meta_description'],
+            $data['meta_keyword'],
+            $data['friendly_url'],
+            $data['content'],
+            $data['is_indexed_for_search'],
+            $data['is_displayed'],
+            is_array($data['shop_association']) ? $data['shop_association'] : []
+        ));
+
+        return $cmsPageId->getValue();
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataProvider/CmsPageFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CmsPageFormDataProvider.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
+
+class CmsPageFormDataProvider implements FormDataProviderInterface
+{
+    /**
+     * Get form data for given object with given id.
+     *
+     * @param int $id
+     *
+     * @return mixed
+     */
+    public function getData($id)
+    {
+        // TODO: Implement getData() method.
+    }
+
+    /**
+     * Get default form data.
+     *
+     * @return mixed
+     */
+    public function getDefaultData()
+    {
+        // TODO: Implement getDefaultData() method.
+    }
+}

--- a/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
@@ -164,7 +164,7 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
                             ->setIcon('edit')
                             ->setOptions([
                                 'route' => 'admin_cms_pages_edit',
-                                'route_param_name' => 'cmsId',
+                                'route_param_name' => 'cmsPageId',
                                 'route_param_field' => 'id_cms',
                             ])
                         )

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop.
+ * 2007-2019 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -16,10 +16,10 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to http://www.prestashop.com for more information.
+ * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2018 PrestaShop SA
+ * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -146,6 +146,11 @@ class CmsPageController extends FrameworkBundleAdminController
     /**
      * Creates cms page
      *
+     * @AdminSecurity(
+     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_cms_pages_index"
+     * )
+     *
      * @param Request $request
      *
      * @return Response
@@ -154,6 +159,22 @@ class CmsPageController extends FrameworkBundleAdminController
     {
         $formBuilder = $this->getCmsPageFormBuilder();
         $form = $formBuilder->getForm();
+        $form->handleRequest($request);
+
+        try {
+            $result = $this->getCmsPageFormHandler()->handle($form);
+
+            if (null !== $result->getIdentifiableObjectId()) {
+                $this->addFlash(
+                    'success',
+                    $this->trans('Successful creation.', 'Admin.Notifications.Success')
+                );
+
+                return $this->redirectToRoute('admin_cms_pages_index');
+            }
+        } catch (DomainException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        }
 
         return $this->render('PrestaShopBundle:Admin/Improve/Design/Cms:add.html.twig', [
             'cmsPageForm' => $form->createView(),
@@ -1013,6 +1034,7 @@ class CmsPageController extends FrameworkBundleAdminController
     }
 
     /**
+<<<<<<< HEAD
      * Gets user friendly error message by exception.
      *
      * @param CmsPageException $exception
@@ -1053,5 +1075,15 @@ class CmsPageController extends FrameworkBundleAdminController
         }
 
         return $this->getFallbackErrorMessage($exceptionType, $exception->getCode());
+    }
+
+    /**
+     * Gets user friendly error messages
+     *
+     * @return array
+     */
+    private function getErrorMessages()
+    {
+        return [];
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -144,6 +144,25 @@ class CmsPageController extends FrameworkBundleAdminController
     }
 
     /**
+     * Creates cms page
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function createAction(Request $request)
+    {
+        $formBuilder = $this->getCmsPageFormBuilder();
+        $form = $formBuilder->getForm();
+
+        return $this->render('PrestaShopBundle:Admin/Improve/Design/Cms:add.html.twig', [
+            'cmsPageForm' => $form->createView(),
+            'enableSidebar' => true,
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+        ]);
+    }
+
+    /**
      * Displays cms category page form and handles create new cms page category logic.
      *
      * @AdminSecurity(
@@ -809,6 +828,22 @@ class CmsPageController extends FrameworkBundleAdminController
         );
 
         return $cmsPageCategoryParentId;
+    }
+
+    /**
+     * @return FormBuilderInterface
+     */
+    private function getCmsPageFormBuilder()
+    {
+        return $this->get('prestashop.core.form.identifiable_object.builder.cms_page_form_builder');
+    }
+
+    /**
+     * @return FormHandlerInterface
+     */
+    private function getCmsPageFormHandler()
+    {
+        return $this->get('prestashop.core.form.identifiable_object.handler.cms_page_form_handler');
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -117,6 +117,8 @@ class CmsPageController extends FrameworkBundleAdminController
     }
 
     /**
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     *
      * @param Request $request
      *
      * @return RedirectResponse
@@ -149,7 +151,9 @@ class CmsPageController extends FrameworkBundleAdminController
      *
      * @AdminSecurity(
      *     "is_granted('create', request.get('_legacy_controller'))",
-     *     redirectRoute="admin_cms_pages_index"
+     *     redirectRoute="admin_cms_pages_index",
+     *     redirectQueryParamsToKeep={"id_cms_category"},
+     *     message="You do not have permission to add this."
      * )
      *
      * @param Request $request
@@ -186,6 +190,13 @@ class CmsPageController extends FrameworkBundleAdminController
     }
 
     /**
+     *  @AdminSecurity(
+     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_cms_pages_index",
+     *     redirectQueryParamsToKeep={"id_cms_category"},
+     *     message="You do not have permission to edit this."
+     * )
+     *
      * @param Request $request
      * @param $cmsPageId
      *

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -179,6 +179,7 @@ class CmsPageController extends FrameworkBundleAdminController
 
         return $this->render('PrestaShopBundle:Admin/Improve/Design/Cms:add.html.twig', [
             'cmsPageForm' => $form->createView(),
+            'cmsCategoryParentId' => $request->get('id_cms_category'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
         ]);
@@ -218,6 +219,7 @@ class CmsPageController extends FrameworkBundleAdminController
 
         return $this->render('@PrestaShop/Admin/Improve/Design/Cms/edit.html.twig', [
             'cmsPageForm' => $form->createView(),
+            'cmsCategoryParentId' => $request->get('id_cms_category'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
         ]);

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -174,7 +174,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 return $this->redirectToRoute('admin_cms_pages_index');
             }
         } catch (DomainException $e) {
-            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+            $this->addFlash('error', $this->getCmsPageErrorByExceptionType($e));
         }
 
         return $this->render('PrestaShopBundle:Admin/Improve/Design/Cms:add.html.twig', [
@@ -209,7 +209,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 return $this->redirectToRoute('admin_cms_pages_index');
             }
         } catch (DomainException $e) {
-            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+            $this->addFlash('error', $this->getCmsPageErrorByExceptionType($e));
 
             if ($e instanceof CmsPageNotFoundException) {
                 return $this->redirectToRoute('admin_cms_pages_index');
@@ -762,11 +762,6 @@ class CmsPageController extends FrameworkBundleAdminController
         return $redirectResponse;
     }
 
-    public function editCmsAction()
-    {
-        //todo: implement
-    }
-
     /**
      * Gets cms page category form builder.
      *
@@ -1076,11 +1071,11 @@ class CmsPageController extends FrameworkBundleAdminController
     /**
      * Gets user friendly error message by exception.
      *
-     * @param CmsPageException $exception
+     * @param DomainException $exception
      *
      * @return string
      */
-    private function getCmsPageErrorByExceptionType(CmsPageException $exception)
+    private function getCmsPageErrorByExceptionType(DomainException $exception)
     {
         $exceptionTypeDictionary = [
             CannotToggleCmsPageException::class => $this->trans(
@@ -1114,15 +1109,5 @@ class CmsPageController extends FrameworkBundleAdminController
         }
 
         return $this->getFallbackErrorMessage($exceptionType, $exception->getCode());
-    }
-
-    /**
-     * Gets user friendly error messages
-     *
-     * @return array
-     */
-    private function getErrorMessages()
-    {
-        return [];
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -173,7 +173,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 //todo: wait for second list to be merged and
                 return $this->redirectToRoute('admin_cms_pages_index');
             }
-        } catch (CmsPageException $e) {
+        } catch (DomainException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -208,7 +208,7 @@ class CmsPageController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_cms_pages_index');
             }
-        } catch (CmsPageException $e) {
+        } catch (DomainException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             if ($e instanceof CmsPageNotFoundException) {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotEnableCmsPageExcep
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotToggleCmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Query\GetCmsCategoryIdForRedirection;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\CmsPageRootCategorySettings;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\BulkDeleteCmsPageCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\BulkDisableCmsPageCategoryCommand;
@@ -172,11 +173,50 @@ class CmsPageController extends FrameworkBundleAdminController
                 //todo: wait for second list to be merged and
                 return $this->redirectToRoute('admin_cms_pages_index');
             }
-        } catch (DomainException $e) {
+        } catch (CmsPageException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
         return $this->render('PrestaShopBundle:Admin/Improve/Design/Cms:add.html.twig', [
+            'cmsPageForm' => $form->createView(),
+            'enableSidebar' => true,
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+        ]);
+    }
+
+    /**
+     * @param Request $request
+     * @param $cmsPageId
+     *
+     * @return Response
+     */
+    public function editAction(Request $request, $cmsPageId)
+    {
+        $cmsPageId = (int) $cmsPageId;
+
+        $form = $this->getCmsPageFormBuilder()->getFormFor($cmsPageId);
+        $form->handleRequest($request);
+
+        try {
+            $result = $this->getCmsPageFormHandler()->handleFor($cmsPageId, $form);
+
+            if (null !== $result->getIdentifiableObjectId()) {
+                $this->addFlash(
+                    'success',
+                    $this->trans('Successful update.', 'Admin.Notifications.Success')
+                );
+
+                return $this->redirectToRoute('admin_cms_pages_index');
+            }
+        } catch (CmsPageException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            if ($e instanceof CmsPageNotFoundException) {
+                return $this->redirectToRoute('admin_cms_pages_index');
+            }
+        }
+
+        return $this->render('@PrestaShop/Admin/Improve/Design/Cms/edit.html.twig', [
             'cmsPageForm' => $form->createView(),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
@@ -1034,7 +1074,6 @@ class CmsPageController extends FrameworkBundleAdminController
     }
 
     /**
-<<<<<<< HEAD
      * Gets user friendly error message by exception.
      *
      * @param CmsPageException $exception

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -169,7 +169,7 @@ class CmsPageController extends FrameworkBundleAdminController
                     'success',
                     $this->trans('Successful creation.', 'Admin.Notifications.Success')
                 );
-
+                //todo: wait for second list to be merged and
                 return $this->redirectToRoute('admin_cms_pages_index');
             }
         } catch (DomainException $e) {

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -102,6 +102,9 @@ class CmsPageType extends AbstractType
                     ]),
                 ],
                 'options' => [
+                    'attr' => [
+                        'class' => 'js-copier-source-title',
+                    ],
                     'constraints' => [
                         //@todo: typedRegexConstraint generic_name PR #12735
                         new Regex([
@@ -209,6 +212,9 @@ class CmsPageType extends AbstractType
                     ]),
                 ],
                 'options' => [
+                    'attr' => [
+                        'class' => 'js-copier-destination-friendly-url',
+                    ],
                     'constraints' => [
                         new IsUrlRewrite(),
                         new Length([

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Improve\Design\Pages;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\IsUrlRewrite;
+use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Regex;
+
+/**
+ * Defines Improve > Design > Pages cms page form
+ */
+class CmsPageType  extends AbstractType
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var array
+     */
+    private $allCmsCategories;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $allCmsCategories
+     */
+    public function __construct(TranslatorInterface $translator, array $allCmsCategories)
+    {
+        $this->translator = $translator;
+        $this->allCmsCategories = $allCmsCategories;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('page_category', MaterialChoiceTreeType::class, [
+                'required' => false,
+                'choices_tree' => $this->allCmsCategories,
+            ])
+            ->add('title', TranslatableType::class, [
+                'options' => [
+                    'constraints' => [
+                        //@todo: typedRegexConstraint generic_name PR #12735
+                        new Regex([
+                            'pattern' => '/^[^<>={}]*$/u',
+                            'message' => $this->translator->trans(
+                                '%s is invalid.',
+                                [],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                        new Length([
+                            'max' => 255,
+                            'maxMessage' => $this->translator->trans(
+                                'This field cannot be longer than %limit% characters',
+                                ['%limit%' => 255],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                    ],
+                ],
+            ])
+            ->add('meta_title', TranslatableType::class, [
+                'required' => false,
+                'options' => [
+                    'constraints' => [
+                        //@todo: typedRegexConstraint generic_name PR #12735
+                        new Regex([
+                            'pattern' => '/^[^<>={}]*$/u',
+                            'message' => $this->translator->trans(
+                                '%s is invalid.',
+                                [],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                        new Length([
+                            'max' => 255,
+                            'maxMessage' => $this->translator->trans(
+                                'This field cannot be longer than %limit% characters',
+                                ['%limit%' => 255],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                    ],
+                ],
+            ])
+            ->add('meta_description', TranslatableType::class, [
+                'required' => false,
+                'options' => [
+                    'constraints' => [
+                        //@todo: typedRegexConstraint generic_name PR #12735
+                        new Regex([
+                            'pattern' => '/^[^<>={}]*$/u',
+                            'message' => $this->translator->trans(
+                                '%s is invalid.',
+                                [],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                    ],
+                ],
+            ])
+            ->add('meta_description', TranslatableType::class, [
+                'required' => false,
+                'options' => [
+                    'constraints' => [
+                        //@todo: typedRegexConstraint generic_name PR #12735
+                        new Regex([
+                            'pattern' => '/^[^<>={}]*$/u',
+                            'message' => $this->translator->trans(
+                                '%s is invalid.',
+                                [],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                        new Length([
+                            'max' => 512,
+                            'maxMessage' => $this->translator->trans(
+                                'This field cannot be longer than %limit% characters',
+                                ['%limit%' => 512],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                    ],
+                ],
+            ])
+            ->add('friendly_url', TranslatableType::class, [
+                'error_bubbling' => false,
+                'constraints' => [
+                    new DefaultLanguage(),
+                ],
+                'options' => [
+                    'constraints' => [
+                        new IsUrlRewrite(),
+                    ],
+                ],
+                new Length([
+                    'max' => 128,
+                    'maxMessage' => $this->translator->trans(
+                        'This field cannot be longer than %limit% characters',
+                        ['%limit%' => 128],
+                        'Admin.Notifications.Error'
+                    ),
+                ]),
+            ])
+            ->add('content', TranslatableType::class, [
+                'type' => TextareaType::class,
+                'required' => false,
+                'options' => [
+                    'constraints' => [
+                        new CleanHtml([
+                            'message' => $this->translator->trans(
+                                '%s is invalid.',
+                                [],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                        new Length([
+                            //@todo: according to legacy. Is there a reason for this???
+                            'max' => 3999999999999,
+                            'maxMessage' => $this->translator->trans(
+                                'This field cannot be longer than %limit% characters',
+                                ['%limit%' => 3999999999999],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                    ],
+                ],
+            ])
+            ->add('is_indexed_for_search', SwitchType::class, [
+                'required' => false,
+            ])
+            ->add('is_enabled', SwitchType::class, [
+                'required' => false,
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Improve\Design\Pages;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\IsUrlRewrite;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegexConstraint;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -40,7 +41,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Regex;
 
 /**
  * Defines Improve > Design > Pages cms page form
@@ -106,14 +106,8 @@ class CmsPageType extends AbstractType
                         'class' => 'js-copier-source-title',
                     ],
                     'constraints' => [
-                        //@todo: typedRegexConstraint generic_name PR #12735
-                        new Regex([
-                            'pattern' => '/^[^<>={}]*$/u',
-                            'message' => $this->translator->trans(
-                                '%s is invalid.',
-                                [],
-                                'Admin.Notifications.Error'
-                            ),
+                        new TypedRegexConstraint([
+                            'type' => 'generic_name',
                         ]),
                         new Length([
                             'max' => 255,
@@ -130,14 +124,8 @@ class CmsPageType extends AbstractType
                 'required' => false,
                 'options' => [
                     'constraints' => [
-                        //@todo: typedRegexConstraint generic_name PR #12735
-                        new Regex([
-                            'pattern' => '/^[^<>={}]*$/u',
-                            'message' => $this->translator->trans(
-                                '%s is invalid.',
-                                [],
-                                'Admin.Notifications.Error'
-                            ),
+                        new TypedRegexConstraint([
+                            'type' => 'generic_name',
                         ]),
                         new Length([
                             'max' => 255,
@@ -154,14 +142,8 @@ class CmsPageType extends AbstractType
                 'required' => false,
                 'options' => [
                     'constraints' => [
-                        //@todo: typedRegexConstraint generic_name PR #12735
-                        new Regex([
-                            'pattern' => '/^[^<>={}]*$/u',
-                            'message' => $this->translator->trans(
-                                '%s is invalid.',
-                                [],
-                                'Admin.Notifications.Error'
-                            ),
+                        new TypedRegexConstraint([
+                            'type' => 'generic_name',
                         ]),
                     ],
                 ],
@@ -175,14 +157,8 @@ class CmsPageType extends AbstractType
                         'placeholder' => $this->translator->trans('Add tag', [], 'Admin.Actions'),
                     ],
                     'constraints' => [
-                        //@todo: typedRegexConstraint generic_name PR #12735
-                        new Regex([
-                            'pattern' => '/^[^<>={}]*$/u',
-                            'message' => $this->translator->trans(
-                                '%s is invalid.',
-                                [],
-                                'Admin.Notifications.Error'
-                            ),
+                        new TypedRegexConstraint([
+                            'type' => 'generic_name',
                         ]),
                         new Length([
                             'max' => 512,
@@ -237,15 +213,6 @@ class CmsPageType extends AbstractType
                             'message' => $this->translator->trans(
                                 '%s is invalid.',
                                 [],
-                                'Admin.Notifications.Error'
-                            ),
-                        ]),
-                        new Length([
-                            //@todo: according to legacy. Is there a reason for this???
-                            'max' => 3999999999999,
-                            'maxMessage' => $this->translator->trans(
-                                'This field cannot be longer than %limit% characters',
-                                ['%limit%' => 3999999999999],
                                 'Admin.Notifications.Error'
                             ),
                         ]),

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -86,6 +86,21 @@ class CmsPageType extends AbstractType
                 'choice_value' => 'id_cms_category',
             ])
             ->add('title', TranslatableType::class, [
+                'error_bubbling' => false,
+                'constraints' => [
+                    new DefaultLanguage([
+                        'message' => $this->translator->trans(
+                            'The field %field_name% is required at least in your default language.',
+                            [
+                                '%field_name%' => sprintf(
+                                    '"%s"',
+                                    $this->translator->trans('Title', [], 'Admin.Global')
+                                ),
+                            ],
+                            'Admin.Notifications.Error'
+                        ),
+                    ]),
+                ],
                 'options' => [
                     'constraints' => [
                         //@todo: typedRegexConstraint generic_name PR #12735
@@ -152,6 +167,10 @@ class CmsPageType extends AbstractType
                 'type' => TextType::class,
                 'required' => false,
                 'options' => [
+                    'attr' => [
+                        'class' => 'js-taggable-field',
+                        'placeholder' => $this->translator->trans('Add tag', [], 'Admin.Actions'),
+                    ],
                     'constraints' => [
                         //@todo: typedRegexConstraint generic_name PR #12735
                         new Regex([
@@ -176,7 +195,18 @@ class CmsPageType extends AbstractType
             ->add('friendly_url', TranslatableType::class, [
                 'error_bubbling' => false,
                 'constraints' => [
-                    new DefaultLanguage(),
+                    new DefaultLanguage([
+                        'message' => $this->translator->trans(
+                            'The field %field_name% is required at least in your default language.',
+                            [
+                                '%field_name%' => sprintf(
+                                    '"%s"',
+                                    $this->translator->trans('Friendly URL', [], 'Admin.Global')
+                                ),
+                            ],
+                            'Admin.Notifications.Error'
+                        ),
+                    ]),
                 ],
                 'options' => [
                     'constraints' => [
@@ -219,7 +249,7 @@ class CmsPageType extends AbstractType
             ->add('is_indexed_for_search', SwitchType::class, [
                 'required' => false,
             ])
-            ->add('is_enabled', SwitchType::class, [
+            ->add('is_displayed', SwitchType::class, [
                 'required' => false,
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -80,7 +80,7 @@ class CmsPageType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('page_category', MaterialChoiceTreeType::class, [
+            ->add('page_category_id', MaterialChoiceTreeType::class, [
                 'required' => false,
                 'choices_tree' => $this->allCmsCategories,
                 'choice_value' => 'id_cms_category',

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -12,6 +12,23 @@ admin_cms_pages_search:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:search'
     _legacy_controller: AdminCmsContent
 
+admin_cms_pages_create:
+    path: /new
+    methods: [GET, POST]
+    defaults:
+        _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:create'
+        _legacy_controller: AdminCmsContent
+
+admin_cms_pages_search_cms_category:
+    path: /category/search
+    methods: POST
+    defaults:
+        _controller: PrestaShopBundle:Admin\Common:searchGrid
+        gridDefinitionFactoryService: prestashop.core.grid.definition.factory.cms_page_category
+        redirectRoute: admin_cms_pages_index
+        redirectQueryParamsToKeep:
+          - 'id_cms_category'
+
 admin_cms_pages_category_create:
   path: /category/new
   methods: [GET, POST]

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -13,30 +13,30 @@ admin_cms_pages_search:
     _legacy_controller: AdminCmsContent
 
 admin_cms_pages_create:
-    path: /new
-    methods: [GET, POST]
-    defaults:
-        _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:create'
-        _legacy_controller: AdminCmsContent
+  path: /new
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:create'
+    _legacy_controller: AdminCmsContent
 
 admin_cms_pages_edit:
-    path: /{cmsPageId}/edit
-    methods: [GET, POST]
-    defaults:
-        _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:edit'
-        _legacy_controller: AdminCmsContent
-    requirements:
-        cmsPageId: \d+
+  path: /{cmsPageId}/edit
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:edit'
+    _legacy_controller: AdminCmsContent
+  requirements:
+    cmsPageId: \d+
 
 admin_cms_pages_search_cms_category:
-    path: /category/search
-    methods: POST
-    defaults:
-        _controller: PrestaShopBundle:Admin\Common:searchGrid
-        gridDefinitionFactoryService: prestashop.core.grid.definition.factory.cms_page_category
-        redirectRoute: admin_cms_pages_index
-        redirectQueryParamsToKeep:
-          - 'id_cms_category'
+  path: /category/search
+  methods: POST
+  defaults:
+    _controller: PrestaShopBundle:Admin\Common:searchGrid
+    gridDefinitionFactoryService: prestashop.core.grid.definition.factory.cms_page_category
+    redirectRoute: admin_cms_pages_index
+    redirectQueryParamsToKeep:
+      - 'id_cms_category'
 
 admin_cms_pages_category_create:
   path: /category/new

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -4,13 +4,15 @@ admin_cms_pages_index:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:index'
     _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent
 
 admin_cms_pages_search:
   path: /search
-  methods: POST
+  methods: GET
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:search'
     _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:submitFiltercms
 
 admin_cms_pages_create:
   path: /new
@@ -18,6 +20,7 @@ admin_cms_pages_create:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:create'
     _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:addcms
 
 admin_cms_pages_edit:
   path: /{cmsPageId}/edit
@@ -25,80 +28,11 @@ admin_cms_pages_edit:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:edit'
     _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:updatecms
+    _legacy_parameters:
+      id_cms: cmsPageId
   requirements:
     cmsPageId: \d+
-
-admin_cms_pages_search_cms_category:
-  path: /category/search
-  methods: POST
-  defaults:
-    _controller: PrestaShopBundle:Admin\Common:searchGrid
-    gridDefinitionFactoryService: prestashop.core.grid.definition.factory.cms_page_category
-    redirectRoute: admin_cms_pages_index
-    redirectQueryParamsToKeep:
-      - 'id_cms_category'
-
-admin_cms_pages_category_create:
-  path: /category/new
-  methods: [GET, POST]
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:createCmsCategory'
-    _legacy_controller: AdminCmsContent
-
-admin_cms_pages_category_edit:
-  path: /category/{cmsCategoryId}/edit
-  methods: [GET, POST]
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:editCmsCategory'
-    _legacy_controller: AdminCmsContent
-  requirements:
-    cmsCategoryId: \d+
-
-admin_cms_pages_category_delete:
-  path: /category/{cmsCategoryId}/delete
-  methods: DELETE
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:deleteCmsCategory'
-    _legacy_controller: AdminCmsContent
-  requirements:
-    cmsCategoryId: \d+
-
-admin_cms_pages_category_delete_bulk:
-  path: /category/delete-bulk
-  methods: POST
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:deleteBulkCmsCategory'
-    _legacy_controller: AdminCmsContent
-
-admin_cms_pages_category_toggle:
-  path: /category/{cmsCategoryId}/toggle-status
-  methods: POST
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:toggleCmsCategory'
-    _legacy_controller: AdminCmsContent
-  requirements:
-    cmsCategoryId: \d+
-
-admin_cms_pages_category_bulk_status_enable:
-  path: /category/bulk-enable-status
-  methods: POST
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:bulkCmsPageCategoryStatusEnable'
-    _legacy_controller: AdminCmsContent
-
-admin_cms_pages_category_bulk_status_disable:
-  path: /category/bulk-disable-status
-  methods: POST
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:bulkCmsPageCategoryStatusDisable'
-    _legacy_controller: AdminCmsContent
-
-admin_cms_pages_category_update_position:
-  path: /category/update-position
-  methods: POST
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:updateCmsCategoryPosition'
-    _legacy_controller: AdminCmsContent
 
 admin_cms_pages_toggle:
   path: /{cmsId}/toggle-status
@@ -106,6 +40,9 @@ admin_cms_pages_toggle:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:toggleCms'
     _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:statuscms
+    _legacy_parameters:
+      id_cms: cmsId
   requirements:
     cmsId: \d+
 
@@ -115,6 +52,9 @@ admin_cms_pages_delete:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:deleteCms'
     _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:deletecms
+    _legacy_parameters:
+      id_cms: cmsId
   requirements:
     cmsId: \d+
 
@@ -124,6 +64,7 @@ admin_cms_pages_bulk_enable_status:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:bulkEnableCmsPageStatus'
     _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:submitBulkenableSelectioncms
 
 admin_cms_pages_bulk_disable_status:
   path: /bulk-disable-status
@@ -131,6 +72,7 @@ admin_cms_pages_bulk_disable_status:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:bulkDisableCmsPageStatus'
     _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:submitBulkdisableSelectioncms
 
 admin_cms_pages_bulk_delete:
   path: /bulk-delete
@@ -138,3 +80,91 @@ admin_cms_pages_bulk_delete:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:bulkDeleteCmsPage'
     _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:submitBulkdeletecms
+
+admin_cms_pages_search_cms_category:
+  path: /category/search
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Common:searchGrid'
+    gridDefinitionFactoryService: prestashop.core.grid.definition.factory.cms_page_category
+    redirectRoute: admin_cms_pages_index
+    redirectQueryParamsToKeep:
+      - 'id_cms_category'
+    _legacy_link: AdminCmsContent:submitFiltercms_category
+
+admin_cms_pages_category_create:
+  path: /category/new
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:createCmsCategory'
+    _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:addcms_category
+
+admin_cms_pages_category_edit:
+  path: /category/{cmsCategoryId}/edit
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:editCmsCategory'
+    _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:updatecms_category
+    _legacy_parameters:
+      id_cms_category: cmsCategoryId
+  requirements:
+    cmsCategoryId: \d+
+
+admin_cms_pages_category_delete:
+  path: /category/{cmsCategoryId}/delete
+  methods: DELETE
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:deleteCmsCategory'
+    _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:deletecms_category
+    _legacy_parameters:
+      id_cms_category: cmsCategoryId
+  requirements:
+    cmsCategoryId: \d+
+
+admin_cms_pages_category_delete_bulk:
+  path: /category/delete-bulk
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:deleteBulkCmsCategory'
+    _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:submitBulkdeletecms_category
+
+admin_cms_pages_category_toggle:
+  path: /category/{cmsCategoryId}/toggle-status
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:toggleCmsCategory'
+    _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:statuscms_category
+    _legacy_parameters:
+      id_cms_category: cmsCategoryId
+  requirements:
+    cmsCategoryId: \d+
+
+admin_cms_pages_category_bulk_status_enable:
+  path: /category/bulk-enable-status
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:bulkCmsPageCategoryStatusEnable'
+    _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:submitBulkenableSelectioncms_category
+
+admin_cms_pages_category_bulk_status_disable:
+  path: /category/bulk-disable-status
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:bulkCmsPageCategoryStatusDisable'
+    _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:submitBulkdisableSelectioncms_category
+
+admin_cms_pages_category_update_position:
+  path: /category/update-position
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:updateCmsCategoryPosition'
+    _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:updatecms_category

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -8,7 +8,7 @@ admin_cms_pages_index:
 
 admin_cms_pages_search:
   path: /search
-  methods: GET
+  methods: POST
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:search'
     _legacy_controller: AdminCmsContent

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -19,6 +19,13 @@ admin_cms_pages_create:
         _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:create'
         _legacy_controller: AdminCmsContent
 
+admin_cms_pages_edit:
+  path: /new
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:edit'
+    _legacy_controller: AdminCmsContent
+
 admin_cms_pages_search_cms_category:
     path: /category/search
     methods: POST

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -20,11 +20,13 @@ admin_cms_pages_create:
         _legacy_controller: AdminCmsContent
 
 admin_cms_pages_edit:
-  path: /{cmsPageId}/edit
-  methods: [GET, POST]
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:edit'
-    _legacy_controller: AdminCmsContent
+    path: /{cmsPageId}/edit
+    methods: [GET, POST]
+    defaults:
+        _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:edit'
+        _legacy_controller: AdminCmsContent
+    requirements:
+        cmsPageId: \d+
 
 admin_cms_pages_search_cms_category:
     path: /category/search
@@ -103,15 +105,6 @@ admin_cms_pages_toggle:
   methods: POST
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:toggleCms'
-    _legacy_controller: AdminCmsContent
-  requirements:
-    cmsId: \d+
-
-admin_cms_pages_edit:
-  path: /{cmsId}/edit
-  methods: [GET,POST]
-  defaults:
-    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:editCms'
     _legacy_controller: AdminCmsContent
   requirements:
     cmsId: \d+

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -20,7 +20,7 @@ admin_cms_pages_create:
         _legacy_controller: AdminCmsContent
 
 admin_cms_pages_edit:
-  path: /new
+  path: /{cmsPageId}/edit
   methods: [GET, POST]
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:edit'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cms_page.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cms_page.yml
@@ -37,3 +37,9 @@ services:
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkDeleteCmsPageCommand
+
+  prestashop.adapter.cms_page.command_handler.add_cms_page_handler:
+    class: PrestaShop\PrestaShop\Adapter\CMS\Page\CommandHandler\AddCmsPageHandler
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\AddCmsPageCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cms_page.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cms_page.yml
@@ -49,3 +49,9 @@ services:
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\EditCmsPageCommand
+
+  prestashop.adapter.cms_page.query_handler.get_cms_page_for_editing_handler:
+    class: PrestaShop\PrestaShop\Adapter\CMS\Page\QueryHandler\GetCmsPageForEditingHandler
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\CmsPage\Query\GetCmsPageForEditing

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cms_page.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cms_page.yml
@@ -43,3 +43,9 @@ services:
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\AddCmsPageCommand
+
+  prestashop.adapter.cms_page.command_handler.edit_cms_page_handler:
+    class: PrestaShop\PrestaShop\Adapter\CMS\Page\CommandHandler\EditCmsPageHandler
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\EditCmsPageCommand

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -772,7 +772,6 @@ services:
         tags:
             - { name: form.type }
 
-<<<<<<< HEAD
     form.type.international.tax:
         class: 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxType'
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -772,6 +772,7 @@ services:
         tags:
             - { name: form.type }
 
+<<<<<<< HEAD
     form.type.international.tax:
         class: 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxType'
         arguments:
@@ -814,3 +815,12 @@ services:
             - '@=service("prestashop.adapter.admin.data_provider.addons").getAddonsEmail()["username_addons"]'
         tags:
             - { name: form.type }
+
+    form.type.cms_page:
+      class: 'PrestaShopBundle\Form\Admin\Improve\Design\Pages\CmsPageType'
+      arguments:
+        - '@translator'
+        - '@=service("prestashop.core.form.choice_provider.cms_categories").getChoices()'
+        - '@=service("prestashop.adapter.multistore_feature").isUsed()'
+      tags:
+        - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -105,3 +105,10 @@ services:
     arguments:
       - 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile\ProfileType'
       - '@prestashop.core.form.identifiable_object.data_provider.profile_form_data_provider'
+
+  prestashop.core.form.identifiable_object.builder.cms_page_form_builder:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
+    factory: 'prestashop.core.form.builder.form_builder_factory:create'
+    arguments:
+      - 'PrestaShopBundle\Form\Admin\Improve\Design\Pages\CmsPageType'
+      - '@prestashop.core.form.identifiable_object.data_provider.cms_page_form_data_provider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -86,3 +86,8 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\ProfileFormDataHandler'
     arguments:
       - '@prestashop.core.command_bus'
+      -
+  prestashop.core.form.identifiable_object.data_handler.cms_page_form_data_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CmsPageFormDataHandler'
+    arguments:
+      - '@prestashop.core.command_bus'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -88,4 +88,5 @@ services:
   prestashop.core.form.identifiable_object.data_provider.cms_page_form_data_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CmsPageFormDataProvider'
     arguments:
+      - '@prestashop.core.query_bus'
       - '@=service("prestashop.adapter.shop.context").getContextListShopID()'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -84,3 +84,6 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\ProfileFormDataProvider'
     arguments:
       - '@prestashop.core.query_bus'
+
+  prestashop.core.form.identifiable_object.data_provider.cms_page_form_data_provider:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CmsPageFormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -87,3 +87,5 @@ services:
 
   prestashop.core.form.identifiable_object.data_provider.cms_page_form_data_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CmsPageFormDataProvider'
+    arguments:
+      - '@=service("prestashop.adapter.shop.context").getContextListShopID()'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
@@ -93,3 +93,9 @@ services:
     factory: 'prestashop.core.form.identifiable_object.handler.form_handler_factory:create'
     arguments:
       - '@prestashop.core.form.identifiable_object.data_handler.profile_form_data_handler'
+
+  prestashop.core.form.identifiable_object.handler.cms_page_form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler'
+    factory: 'prestashop.core.form.identifiable_object.handler.form_handler_factory:create'
+    arguments:
+      - '@prestashop.core.form.identifiable_object.data_handler.cms_page_form_data_handler'

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -1,0 +1,107 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+
+{{ form_start(cmsPageForm) }}
+<div class="card">
+  <div class="card-header">
+    {{ 'CMS Category'|trans({}, 'Admin.Design.Feature') }}
+  </div>
+  <div class="card-block row">
+    <div class="card-text">
+
+      {% set invalidCharactersForCatalogLabel = 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ '<>;=#{}' %}
+      {% set invalidCharactersForNameLabel = 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ '<>={}' %}
+
+      {{ ps.form_group_row(cmsPageForm.page_category, {}, {
+        'label': 'Page category'|trans({}, 'Admin.Design.Feature'),
+      }) }}
+
+      {{ ps.form_group_row(cmsPageForm.title, {}, {
+        'label': 'Title'|trans({}, 'Admin.Global'),
+        'help': invalidCharactersForCatalogLabel
+      }) }}
+
+      {{ ps.form_group_row(cmsPageForm.meta_title, {}, {
+        'label': 'Meta title'|trans({}, 'Admin.Global'),
+        'help': invalidCharactersForCatalogLabel
+      }) }}
+
+      {{ ps.form_group_row(cmsPageForm.meta_description, {}, {
+        'label': 'Meta description'|trans({}, 'Admin.Global'),
+        'help': invalidCharactersForCatalogLabel
+      }) }}
+
+      {{ ps.form_group_row(cmsPageForm.meta_keyword, {}, {
+        'label': 'Meta keywords'|trans({}, 'Admin.Global'),
+        'help': invalidCharactersForCatalogLabel
+      }) }}
+
+      {{ ps.form_group_row(cmsPageForm.friendly_url, {}, {
+        'label': 'Friendly URL'|trans({}, 'Admin.Global'),
+        'help': invalidCharactersForCatalogLabel
+      }) }}
+
+      {{ ps.form_group_row(cmsPageForm.content, {}, {
+        'label': 'Page content'|trans({}, 'Admin.Design.Feature'),
+        'help': invalidCharactersForCatalogLabel
+      }) }}
+
+      {{ ps.form_group_row(cmsPageForm.is_indexed_for_search, {}, {
+        'label': 'Indexation by search engines'|trans({}, 'Admin.Design.Feature'),
+        'help': invalidCharactersForCatalogLabel
+      }) }}
+
+      {{ ps.form_group_row(cmsPageForm.is_enabled, {}, {
+        'label': 'Displayed'|trans({}, 'Admin.Global'),
+        'help': invalidCharactersForCatalogLabel
+      }) }}
+
+      {% if cmsPageForm.shop_association is defined %}
+        {{ ps.form_group_row(cmsPageForm.shop_association, {}, {
+          'label': 'Shop association'|trans({}, 'Admin.Global')
+        }) }}
+      {% endif %}
+
+      {% block cms_page_form_rest %}
+        {{ form_rest(cmsPageForm) }}
+      {% endblock %}
+    </div>
+  </div>
+
+  <div class="card-footer">
+    <div class="d-inline-flex">
+      <a href="{{ path('admin_cms_pages_index') }}" class="btn btn-outline-secondary">
+        {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+      </a>
+    </div>
+    <div class="d-inline-flex float-right">
+      <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+    </div>
+  </div>
+
+</div>
+{{ form_end(cmsPageForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -33,7 +33,7 @@
   <div class="card-block row">
     <div class="card-text">
 
-      {% set invalidCharsHint = 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ '<>={}' %}
+      {% set invalidCharsHint = 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>={}' %}
 
       {{ ps.form_group_row(cmsPageForm.page_category_id, {}, {
         'label': 'Page category'|trans({}, 'Admin.Design.Feature'),
@@ -41,12 +41,14 @@
 
       {{ ps.form_group_row(cmsPageForm.title, {}, {
         'label': 'Title'|trans({}, 'Admin.Global'),
-        'help': invalidCharsHint
+        'help': 'Used in the h1 page tag, and as the default title tag value.'|trans({}, 'Admin.Design.Help')
+         ~ ' ' ~ invalidCharsHint
       }) }}
 
       {{ ps.form_group_row(cmsPageForm.meta_title, {}, {
         'label': 'Meta title'|trans({}, 'Admin.Global'),
-        'help': invalidCharsHint
+        'help': 'Used to override the title tag value. If left blank, the default title value is used.'|trans({}, 'Admin.Design.Help')
+        ~ ' ' ~ invalidCharsHint
       }) }}
 
       {{ ps.form_group_row(cmsPageForm.meta_description, {}, {
@@ -56,11 +58,13 @@
 
       {{ ps.form_group_row(cmsPageForm.meta_keyword, {}, {
         'label': 'Meta keywords'|trans({}, 'Admin.Global'),
-        'help': invalidCharsHint
+        'help': 'To add "tags" click in the field, write something, and then press "Enter."'|trans({}, 'Admin.Design.Help')
+        ~ ' ' ~ invalidCharsHint
       }) }}
 
       {{ ps.form_group_row(cmsPageForm.friendly_url, {}, {
         'label': 'Friendly URL'|trans({}, 'Admin.Global'),
+        'help': 'Only letters and the hyphen (-) character are allowed.'|trans({}, 'Admin.Design.Feature')
       }) }}
 
       {{ ps.form_group_row(cmsPageForm.content, {}, {

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -33,8 +33,7 @@
   <div class="card-block row">
     <div class="card-text">
 
-      {% set invalidCharactersForCatalogLabel = 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ '<>;=#{}' %}
-      {% set invalidCharactersForNameLabel = 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ '<>={}' %}
+      {% set invalidCharsHint = 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ '<>={}' %}
 
       {{ ps.form_group_row(cmsPageForm.page_category, {}, {
         'label': 'Page category'|trans({}, 'Admin.Design.Feature'),
@@ -42,42 +41,38 @@
 
       {{ ps.form_group_row(cmsPageForm.title, {}, {
         'label': 'Title'|trans({}, 'Admin.Global'),
-        'help': invalidCharactersForCatalogLabel
+        'help': invalidCharsHint
       }) }}
 
       {{ ps.form_group_row(cmsPageForm.meta_title, {}, {
         'label': 'Meta title'|trans({}, 'Admin.Global'),
-        'help': invalidCharactersForCatalogLabel
+        'help': invalidCharsHint
       }) }}
 
       {{ ps.form_group_row(cmsPageForm.meta_description, {}, {
         'label': 'Meta description'|trans({}, 'Admin.Global'),
-        'help': invalidCharactersForCatalogLabel
+        'help': invalidCharsHint
       }) }}
 
       {{ ps.form_group_row(cmsPageForm.meta_keyword, {}, {
         'label': 'Meta keywords'|trans({}, 'Admin.Global'),
-        'help': invalidCharactersForCatalogLabel
+        'help': invalidCharsHint
       }) }}
 
       {{ ps.form_group_row(cmsPageForm.friendly_url, {}, {
         'label': 'Friendly URL'|trans({}, 'Admin.Global'),
-        'help': invalidCharactersForCatalogLabel
       }) }}
 
       {{ ps.form_group_row(cmsPageForm.content, {}, {
         'label': 'Page content'|trans({}, 'Admin.Design.Feature'),
-        'help': invalidCharactersForCatalogLabel
       }) }}
 
       {{ ps.form_group_row(cmsPageForm.is_indexed_for_search, {}, {
         'label': 'Indexation by search engines'|trans({}, 'Admin.Design.Feature'),
-        'help': invalidCharactersForCatalogLabel
       }) }}
 
-      {{ ps.form_group_row(cmsPageForm.is_enabled, {}, {
+      {{ ps.form_group_row(cmsPageForm.is_displayed, {}, {
         'label': 'Displayed'|trans({}, 'Admin.Global'),
-        'help': invalidCharactersForCatalogLabel
       }) }}
 
       {% if cmsPageForm.shop_association is defined %}
@@ -105,3 +100,8 @@
 
 </div>
 {{ form_end(cmsPageForm) }}
+
+{% block javascripts %}
+
+  <script src="{{ asset('themes/new-theme/public/cms_page_form.bundle.js') }}"></script>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -35,7 +35,7 @@
 
       {% set invalidCharsHint = 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ '<>={}' %}
 
-      {{ ps.form_group_row(cmsPageForm.page_category, {}, {
+      {{ ps.form_group_row(cmsPageForm.page_category_id, {}, {
         'label': 'Page category'|trans({}, 'Admin.Design.Feature'),
       }) }}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -28,7 +28,7 @@
 {{ form_start(cmsPageForm) }}
 <div class="card">
   <div class="card-header">
-    {{ 'CMS Category'|trans({}, 'Admin.Design.Feature') }}
+    {{ 'Page'|trans({}, 'Admin.Global') }}
   </div>
   <div class="card-block row">
     <div class="card-text">
@@ -89,7 +89,7 @@
 
   <div class="card-footer">
     <div class="d-inline-flex">
-      <a href="{{ path('admin_cms_pages_index') }}" class="btn btn-outline-secondary">
+      <a href="{{ path('admin_cms_pages_index', {'id_cms_category' : cmsCategoryParentId}) }}" class="btn btn-outline-secondary">
         {{ 'Cancel'|trans({}, 'Admin.Actions') }}
       </a>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/add.html.twig
@@ -28,9 +28,7 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {
-        'cmsCategoryParentId': app.request.query.get('id_cms_category'),
-      }) }}
+      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {}) }}
     </div>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/add.html.twig
@@ -1,0 +1,34 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  <div class="row justify-content-center">
+    <div class="col">
+      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig') }}
+    </div>
+  </div>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/add.html.twig
@@ -28,7 +28,9 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig') }}
+      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {
+        'cmsCategoryParentId': app.request.query.get('id_cms_category'),
+      }) }}
     </div>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/edit.html.twig
@@ -28,9 +28,7 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {
-        'cmsCategoryParentId': app.request.query.get('id_cms_category'),
-      }) }}
+      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {}) }}
     </div>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/edit.html.twig
@@ -1,0 +1,36 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  <div class="row justify-content-center">
+    <div class="col">
+      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {
+        'cmsCategoryParentId': app.request.query.get('id_cms_category'),
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/index.html.twig
@@ -26,6 +26,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% set layoutHeaderToolbarBtn = {
+  add_cms_category: {
+    href: path('admin_cms_pages_category_create', {'id_cms_category' : app.request.query.get('id_cms_category')}),
+    desc: 'Add new page category'|trans({}, 'Admin.Design.Help'),
+    icon: 'add_circle_outline',
+  },
   add_cms_page: {
     href: path('admin_cms_pages_create', {'id_cms_category' : app.request.query.get('id_cms_category')}),
     desc: 'Add new page'|trans({}, 'Admin.Design.Help'),

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/index.html.twig
@@ -26,9 +26,9 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% set layoutHeaderToolbarBtn = {
-  add: {
-    href: path('admin_cms_pages_category_create', {'id_cms_category' : app.request.query.get('id_cms_category')}),
-    desc: 'Add new page category'|trans({}, 'Admin.Design.Help'),
+  add_cms_page: {
+    href: path('admin_cms_pages_create', {'id_cms_category' : app.request.query.get('id_cms_category')}),
+    desc: 'Add new page'|trans({}, 'Admin.Design.Help'),
     icon: 'add_circle_outline',
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Migration of Improve > Design > Pages page create/edit form. `Save and preview` button in forms should be implemented in separate PR
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Forms should work as in legacy page. Test using routes `/admin-dev/index.php/improve/design/cms-pages/new` and `/admin-dev/index.php/improve/design/cms-pages/{page_id}/edit`. :warning: Assets may need to be rebuilt.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12995)
<!-- Reviewable:end -->
