### PR TITLE
Add behat tests for free shipping

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1952,7 +1952,8 @@ class CartCore extends ObjectModel
         // CART CALCULATION
         $cartRules = array();
         if (in_array($type, [Cart::BOTH, Cart::BOTH_WITHOUT_SHIPPING, Cart::ONLY_DISCOUNTS])) {
-            $cartRules = $this->getCartRules();
+            $cartRules = $this->getTotalCalculationCartRules($type, $type == Cart::BOTH);
+            //$cartRules = $this->getCartRules();
         }
         $calculator = $this->newCalculator($products, $cartRules, $id_carrier);
         $computePrecision = $this->configuration->get('_PS_PRICE_COMPUTE_PRECISION_');

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1953,7 +1953,6 @@ class CartCore extends ObjectModel
         $cartRules = array();
         if (in_array($type, [Cart::BOTH, Cart::BOTH_WITHOUT_SHIPPING, Cart::ONLY_DISCOUNTS])) {
             $cartRules = $this->getTotalCalculationCartRules($type, $type == Cart::BOTH);
-            //$cartRules = $this->getCartRules();
         }
         $calculator = $this->newCalculator($products, $cartRules, $id_carrier);
         $computePrecision = $this->configuration->get('_PS_PRICE_COMPUTE_PRECISION_');

--- a/tests-legacy/Unit/Core/Cart/Calculation/CartOld.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/CartOld.php
@@ -341,4 +341,15 @@ class CartOld extends Cart
 
         return Tools::ps_round((float) $order_total, $compute_precision);
     }
+
+    public function getOrderTotal(
+        $with_taxes = true,
+        $type = Cart::BOTH,
+        $products = null,
+        $id_carrier = null,
+        $use_cache = true
+    ) {
+        return $this->getOrderTotalV1($with_taxes = true, $type , $products, $id_carrier, $use_cache);
+    }
+
 }

--- a/tests-legacy/Unit/Core/Cart/Calculation/CartOld.php
+++ b/tests-legacy/Unit/Core/Cart/Calculation/CartOld.php
@@ -341,15 +341,4 @@ class CartOld extends Cart
 
         return Tools::ps_round((float) $order_total, $compute_precision);
     }
-
-    public function getOrderTotal(
-        $with_taxes = true,
-        $type = Cart::BOTH,
-        $products = null,
-        $id_carrier = null,
-        $use_cache = true
-    ) {
-        return $this->getOrderTotalV1($with_taxes = true, $type , $products, $id_carrier, $use_cache);
-    }
-
 }

--- a/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
@@ -357,7 +357,7 @@ class CarrierFeatureContext extends AbstractPrestaShopFeatureContext
 
         $this->getCurrentCart()->update();
 
-        //CartRule::autoRemoveFromCart();
+        CartRule::autoRemoveFromCart();
         CartRule::autoAddToCart();
     }
 

--- a/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
@@ -284,8 +284,15 @@ class CarrierFeatureContext extends AbstractPrestaShopFeatureContext
         if (empty($this->carriers[$carrierName]->getZone((int) $this->zones[$zoneName]->id))) {
             $this->carriers[$carrierName]->addZone((int) $this->zones[$zoneName]->id);
         }
-        $rangeClass = $rangeType=='weight' ? RangeWeight::class : RangePrice::class;
-        $rangeId = $rangeClass::rangeExist($this->carriers[$carrierName]->id, $from, $to);
+        $rangeClass = $rangeType == 'weight' ? RangeWeight::class : RangePrice::class;
+        $primary = $rangeType == 'weight' ? 'id_range_weight' : 'id_range_price';
+        $rangeRows = $rangeClass::getRanges($this->carriers[$carrierName]->id);
+        $rangeId = false;
+        foreach ($rangeRows as $rangeRow) {
+            if ($rangeRow['delimiter1'] == $from) {
+                $rangeId = $rangeRow[$primary];
+            }
+        }
         if (!empty($rangeId)) {
             $range = new $rangeClass($rangeId);
         } else {

--- a/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
@@ -35,6 +35,7 @@ use Context;
 use Country;
 use Group;
 use RangePrice;
+use RangeWeight;
 use State;
 use Zone;
 
@@ -274,23 +275,24 @@ class CarrierFeatureContext extends AbstractPrestaShopFeatureContext
     /**
      * Be careful: this method REPLACES shipping fees for carrier
      *
-     * @Given /^carrier "(.+)" applies shipping fees of (\d+\.\d+) in zone "(.+)" for quantities between (\d+) and (\d+)$/
+     * @Given /^carrier "(.+)" applies shipping fees of (\d+\.\d+) in zone "(.+)" for (weight|price) between (\d+) and (\d+)$/
      */
-    public function setCarrierFees($carrierName, $shippingPrice, $zoneName, $fromQuantity, $toQuantity)
+    public function setCarrierFees($carrierName, $shippingPrice, $zoneName, $rangeType, $from, $to)
     {
         $this->checkCarrierWithNameExists($carrierName);
         $this->checkZoneWithNameExists($zoneName);
         if (empty($this->carriers[$carrierName]->getZone((int) $this->zones[$zoneName]->id))) {
             $this->carriers[$carrierName]->addZone((int) $this->zones[$zoneName]->id);
         }
-        $rangeId = RangePrice::rangeExist($this->carriers[$carrierName]->id, $fromQuantity, $toQuantity);
+        $rangeClass = $rangeType=='weight' ? RangeWeight::class : RangePrice::class;
+        $rangeId = $rangeClass::rangeExist($this->carriers[$carrierName]->id, $from, $to);
         if (!empty($rangeId)) {
-            $range = new RangePrice($rangeId);
+            $range = new $rangeClass($rangeId);
         } else {
-            $range = new RangePrice();
+            $range = new $rangeClass();
             $range->id_carrier = $this->carriers[$carrierName]->id;
-            $range->delimiter1 = $fromQuantity;
-            $range->delimiter2 = $toQuantity;
+            $range->delimiter1 = $from;
+            $range->delimiter2 = $to;
             $range->add();
             $this->priceRanges[] = $range;
         }
@@ -348,7 +350,7 @@ class CarrierFeatureContext extends AbstractPrestaShopFeatureContext
 
         $this->getCurrentCart()->update();
 
-        CartRule::autoRemoveFromCart();
+        //CartRule::autoRemoveFromCart();
         CartRule::autoAddToCart();
     }
 

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -166,6 +166,26 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^cart rule "(.+)" offers free shipping$/
+     */
+    public function cartRuleOffersFreeShipping($cartRuleName)
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->cartRules[$cartRuleName]->free_shipping = 1;
+        $this->cartRules[$cartRuleName]->save();
+    }
+
+    /**
+     * @Given /^cart rule "(.+)" applies discount only when cart total is above (\d+\.\d+)$/
+     */
+    public function cartRuleAppliesBetween($cartRuleName, $min)
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->cartRules[$cartRuleName]->minimum_amount = $min;
+        $this->cartRules[$cartRuleName]->save();
+    }
+
+    /**
      * @Then /^cart rule "(.+)" cannot be applied to my cart$/
      */
     public function cartRuleNamedCannotBeAppliedToMyCart($cartRuleName)

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -80,7 +80,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @When /^I add (\d+) items of product "(.+)" in my cart$/
+     * @When /^I add (\d+) items? of product "(.+)" in my cart$/
      */
     public function iAddProductNamedInMyCartWithQuantity($productQuantity, $productName)
     {

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/carrier.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/carrier.feature
@@ -14,11 +14,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
     Then cart shipping fees should be 0.0
@@ -37,11 +37,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     When I add 1 items of product "product1" in my cart
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
@@ -61,11 +61,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     When I add 3 items of product "product1" in my cart
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
@@ -87,11 +87,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     When I add 2 items of product "product2" in my cart
     When I add 3 items of product "product1" in my cart
     When I add 1 items of product "product3" in my cart
@@ -113,11 +113,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     When I select address "address1" in my cart
     When I select carrier "carrier2" in my cart
     Then cart shipping fees should be 0.0
@@ -136,11 +136,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     When I add 1 items of product "product1" in my cart
     When I select address "address1" in my cart
     When I select carrier "carrier2" in my cart
@@ -160,11 +160,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     When I add 3 items of product "product1" in my cart
     When I select address "address1" in my cart
     When I select carrier "carrier2" in my cart
@@ -186,11 +186,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     When I add 2 items of product "product2" in my cart
     When I add 3 items of product "product1" in my cart
     When I add 1 items of product "product3" in my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/carrier.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/carrier.feature
@@ -14,11 +14,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
     Then cart shipping fees should be 0.0
@@ -37,11 +37,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     When I add 1 items of product "product1" in my cart
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
@@ -61,11 +61,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     When I add 3 items of product "product1" in my cart
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
@@ -87,11 +87,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     When I add 2 items of product "product2" in my cart
     When I add 3 items of product "product1" in my cart
     When I add 1 items of product "product3" in my cart
@@ -113,11 +113,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     When I select address "address1" in my cart
     When I select carrier "carrier2" in my cart
     Then cart shipping fees should be 0.0
@@ -136,11 +136,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     When I add 1 items of product "product1" in my cart
     When I select address "address1" in my cart
     When I select carrier "carrier2" in my cart
@@ -160,11 +160,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     When I add 3 items of product "product1" in my cart
     When I select address "address1" in my cart
     When I select carrier "carrier2" in my cart
@@ -186,11 +186,11 @@ Feature: Cart calculation with carriers
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     When I add 2 items of product "product2" in my cart
     When I add 3 items of product "product1" in my cart
     When I add 1 items of product "product3" in my cart
@@ -199,3 +199,20 @@ Feature: Cart calculation with carriers
     Then cart shipping fees should be 7.7
     Then my cart total should be 163.1 tax included
     Then my cart total using previous calculation method should be 163.1 tax included
+
+  Scenario: free carrier in price range
+    Given I have an empty default cart
+    Given there is a product in the catalog named "product1" with a price of 151.0 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 150
+    Given carrier "carrier1" applies shipping fees of 0.0 in zone "zone1" for price between 150 and 1000
+    When I add 1 item of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    Then cart shipping fees should be 2.0
+    Then my cart total should be 153.0 tax included
+    Then my cart total using previous calculation method should be 153.0 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/cart_rule_carrier_specific.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/cart_rule_carrier_specific.feature
@@ -14,11 +14,11 @@ Feature: Cart calculation with carrier specific cart rules
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
     When I select address "address1" in my cart
@@ -39,11 +39,11 @@ Feature: Cart calculation with carrier specific cart rules
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
     When I add 1 items of product "product1" in my cart
@@ -64,11 +64,11 @@ Feature: Cart calculation with carrier specific cart rules
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
     When I select address "address1" in my cart
@@ -90,11 +90,11 @@ Feature: Cart calculation with carrier specific cart rules
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 55.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
     When I add 1 items of product "product1" in my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/cart_rule_carrier_specific.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/cart_rule_carrier_specific.feature
@@ -14,11 +14,11 @@ Feature: Cart calculation with carrier specific cart rules
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
     When I select address "address1" in my cart
@@ -39,11 +39,11 @@ Feature: Cart calculation with carrier specific cart rules
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
     When I add 1 items of product "product1" in my cart
@@ -64,11 +64,11 @@ Feature: Cart calculation with carrier specific cart rules
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
     When I select address "address1" in my cart
@@ -90,11 +90,11 @@ Feature: Cart calculation with carrier specific cart rules
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 55.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
     When I add 1 items of product "product1" in my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/change_carrier_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/change_carrier_cart_rule.feature
@@ -15,14 +15,14 @@ Feature: Cart calculation with carriers specific cart rules: carrier changes
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier3"
-    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo"
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
@@ -48,14 +48,14 @@ Feature: Cart calculation with carriers specific cart rules: carrier changes
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier3"
-    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo"
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
@@ -86,14 +86,14 @@ Feature: Cart calculation with carriers specific cart rules: carrier changes
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier3"
-    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo"
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
@@ -125,14 +125,14 @@ Feature: Cart calculation with carriers specific cart rules: carrier changes
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a carrier named "carrier3"
-    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
-    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for price between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for price between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo"
     Given cart rule "cartrule1" is restricted to carrier "carrier2"

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/change_carrier_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/change_carrier_cart_rule.feature
@@ -15,14 +15,14 @@ Feature: Cart calculation with carriers specific cart rules: carrier changes
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier3"
-    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo"
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
@@ -48,14 +48,14 @@ Feature: Cart calculation with carriers specific cart rules: carrier changes
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier3"
-    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo"
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
@@ -86,14 +86,14 @@ Feature: Cart calculation with carriers specific cart rules: carrier changes
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier3"
-    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo"
     Given cart rule "cartrule1" is restricted to carrier "carrier2"
@@ -125,14 +125,14 @@ Feature: Cart calculation with carriers specific cart rules: carrier changes
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is an address named "address2" with postcode "1" in state "state2"
     Given there is a carrier named "carrier1"
-    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 3.1 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 4.3 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier2"
-    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier2" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a carrier named "carrier3"
-    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for quantities between 0 and 10000
-    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for quantities between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 5.7 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier3" applies shipping fees of 6.2 in zone "zone2" for weight between 0 and 10000
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo"
     Given cart rule "cartrule1" is restricted to carrier "carrier2"

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono_virtual.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono_virtual.feature
@@ -1,4 +1,3 @@
-@current
 @reset-database-before-feature
 Feature: Cart rule (amount) calculation with one cart rule
   As a customer

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/carrier.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/carrier.feature
@@ -64,7 +64,6 @@ Feature: Cart calculation with cart rules giving gift
     Then my cart total should be 156.0 tax included
     Then my cart total using previous calculation method should be 156.0 tax included
 
-  @current
   Scenario: carrier fees not free, voucher with code set shipping fees free above amount, cart total is below
     Given I have an empty default cart
     Given there is a product in the catalog named "product1" with a price of 149.0 and 1000 items in stock
@@ -80,16 +79,16 @@ Feature: Cart calculation with cart rules giving gift
     Given cart rule "cartrule2" offers free shipping
     Given cart rule "cartrule2" applies discount only when cart total is above 150.0
     When I add 1 item of product "product1" in my cart
-    When I use the discount "cartrule2"
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
-    #Then cart shipping fees should be 7.0
-    #Then my cart total should be 156.0 tax included
+    Then cart rule "cartrule2" cannot be applied to my cart
+    Then cart shipping fees should be 7.0
+    Then my cart total should be 156.0 tax included
     Then my cart total using previous calculation method should be 156.0 tax included
 
   Scenario: carrier fees not free, voucher without code set shipping fees free above amount, cart total is below
     Given I have an empty default cart
-    Given there is a product in the catalog named "product1" with a price of 151.0 and 1000 items in stock
+    Given there is a product in the catalog named "product1" with a price of 149.0 and 1000 items in stock
     Given there is a zone named "zone1"
     Given there is a country named "country1" and iso code "FR" in zone "zone1"
     Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
@@ -102,11 +101,34 @@ Feature: Cart calculation with cart rules giving gift
     When I add 1 item of product "product1" in my cart
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
-    Then cart shipping fees should be 2.0
-    Then my cart total should be 153.0 tax included
-    Then my cart total using previous calculation method should be 153.0 tax included
+    Then cart shipping fees should be 7.0
+    Then my cart total should be 156.0 tax included
+    Then my cart total using previous calculation method should be 156.0 tax included
 
-  Scenario: carrier fees not free, voucher with code set shipping fees free above amount, cart total is below
+  Scenario: carrier fees not free, voucher with code set shipping fees free above amount, cart total is above
+    Given I have an empty default cart
+    Given there is a product in the catalog named "product1" with a price of 151.0 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 150
+    Given carrier "carrier1" applies shipping fees of 0.0 in zone "zone1" for price between 150 and 1000
+    Given there is a cart rule named "cartrule2" that applies an amount discount of 0.0 with priority 2, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule2" has a discount code "foo2"
+    Given cart rule "cartrule2" offers free shipping
+    Given cart rule "cartrule2" applies discount only when cart total is above 150.0
+    When I add 1 item of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    Then cart rule "cartrule2" can be applied to my cart
+    When I use the discount "cartrule2"
+    Then cart shipping fees should be 2.0
+    Then my cart total should be 151.0 tax included
+    Then my cart total using previous calculation method should be 151.0 tax included
+
+  Scenario: carrier fees not free, voucher without code set shipping fees free above amount, cart total is above
     Given I have an empty default cart
     Given there is a product in the catalog named "product1" with a price of 151.0 and 1000 items in stock
     Given there is a zone named "zone1"
@@ -125,5 +147,5 @@ Feature: Cart calculation with cart rules giving gift
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
     Then cart shipping fees should be 2.0
-    Then my cart total should be 153.0 tax included
-    Then my cart total using previous calculation method should be 153.0 tax included
+    Then my cart total should be 151.0 tax included
+    Then my cart total using previous calculation method should be 151.0 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/carrier.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/carrier.feature
@@ -1,0 +1,129 @@
+@reset-database-before-feature
+Feature: Cart calculation with cart rules giving gift
+  As a customer
+  I must be able to have correct cart total when adding products, and adding cart rule with gift
+
+  # Issue #9540 part one fixed by #12965
+  Scenario: free carrier in price range, voucher in percent set the price bellow range
+    Given I have an empty default cart
+    Given there is a product in the catalog named "product1" with a price of 151.0 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 150
+    Given carrier "carrier1" applies shipping fees of 0.0 in zone "zone1" for price between 150 and 1000
+    Given there is a cart rule named "cartrule2" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule2" has a discount code "foo2"
+    When I add 1 item of product "product1" in my cart
+    When I use the discount "cartrule2"
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    Then cart shipping fees should be 7.0
+    Then my cart total should be 82.5 tax included
+    Then my cart total using previous calculation method should be 82.5 tax included
+
+  Scenario: free carrier in price range, voucher in amount set the price bellow range
+    Given I have an empty default cart
+    Given there is a product in the catalog named "product1" with a price of 151.0 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 150
+    Given carrier "carrier1" applies shipping fees of 0.0 in zone "zone1" for price between 150 and 1000
+    Given there is a cart rule named "cartrule2" that applies an amount discount of 2.0 with priority 2, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule2" has a discount code "foo2"
+    When I add 1 item of product "product1" in my cart
+    When I use the discount "cartrule2"
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    Then cart shipping fees should be 7.0
+    Then my cart total should be 156.0 tax included
+    Then my cart total using previous calculation method should be 156.0 tax included
+
+  # Issue #12976 part two
+  Scenario: carrier fees not free, voucher without code set shipping fees free above amount, cart total is below
+    Given I have an empty default cart
+    Given there is a product in the catalog named "product1" with a price of 149.0 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    Given there is a cart rule named "cartrule2" that applies an amount discount of 0.0 with priority 2, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule2" offers free shipping
+    Given cart rule "cartrule2" applies discount only when cart total is above 150.0
+    When I add 1 item of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    Then cart shipping fees should be 7.0
+    Then my cart total should be 156.0 tax included
+    Then my cart total using previous calculation method should be 156.0 tax included
+
+  @current
+  Scenario: carrier fees not free, voucher with code set shipping fees free above amount, cart total is below
+    Given I have an empty default cart
+    Given there is a product in the catalog named "product1" with a price of 149.0 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 150
+    Given carrier "carrier1" applies shipping fees of 0.0 in zone "zone1" for price between 150 and 1000
+    Given there is a cart rule named "cartrule2" that applies an amount discount of 0.0 with priority 2, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule2" has a discount code "foo2"
+    Given cart rule "cartrule2" offers free shipping
+    Given cart rule "cartrule2" applies discount only when cart total is above 150.0
+    When I add 1 item of product "product1" in my cart
+    When I use the discount "cartrule2"
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    #Then cart shipping fees should be 7.0
+    #Then my cart total should be 156.0 tax included
+    Then my cart total using previous calculation method should be 156.0 tax included
+
+  Scenario: carrier fees not free, voucher without code set shipping fees free above amount, cart total is below
+    Given I have an empty default cart
+    Given there is a product in the catalog named "product1" with a price of 151.0 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    Given there is a cart rule named "cartrule2" that applies an amount discount of 0.0 with priority 2, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule2" offers free shipping
+    Given cart rule "cartrule2" applies discount only when cart total is above 150.0
+    When I add 1 item of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    Then cart shipping fees should be 2.0
+    Then my cart total should be 153.0 tax included
+    Then my cart total using previous calculation method should be 153.0 tax included
+
+  Scenario: carrier fees not free, voucher with code set shipping fees free above amount, cart total is below
+    Given I have an empty default cart
+    Given there is a product in the catalog named "product1" with a price of 151.0 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 150
+    Given carrier "carrier1" applies shipping fees of 0.0 in zone "zone1" for price between 150 and 1000
+    Given there is a cart rule named "cartrule2" that applies an amount discount of 0.0 with priority 2, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule2" has a discount code "foo2"
+    Given cart rule "cartrule2" offers free shipping
+    Given cart rule "cartrule2" applies discount only when cart total is above 150.0
+    When I add 1 item of product "product1" in my cart
+    When I use the discount "cartrule2"
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    Then cart shipping fees should be 2.0
+    Then my cart total should be 153.0 tax included
+    Then my cart total using previous calculation method should be 153.0 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
@@ -21,7 +21,7 @@ Feature: Check cart to order data copy
     Given address "address1" is associated to customer "customer1"
     Given there is a carrier named "carrier1"
     Given carrier "carrier1" ships to all groups
-    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for weight between 0 and 10000
     When I am logged in as "customer1"
     When I add 1 items of product "product1" in my cart
     When I use the discount "cartrule1"
@@ -57,7 +57,7 @@ Feature: Check cart to order data copy
     Given address "address1" is associated to customer "customer1"
     Given there is a carrier named "carrier1"
     Given carrier "carrier1" ships to all groups
-    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for weight between 0 and 10000
     When I am logged in as "customer1"
     When I add 1 items of product "product1" in my cart
     When I use the discount "cartrule1"
@@ -97,7 +97,7 @@ Feature: Check cart to order data copy
     Given address "address1" is associated to customer "customer1"
     Given there is a carrier named "carrier1"
     Given carrier "carrier1" ships to all groups
-    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for weight between 0 and 10000
     When I am logged in as "customer1"
     When I add 1 items of product "product2" in my cart
     When I add 1 items of product "product1" in my cart
@@ -139,7 +139,7 @@ Feature: Check cart to order data copy
     Given address "address1" is associated to customer "customer1"
     Given there is a carrier named "carrier1"
     Given carrier "carrier1" ships to all groups
-    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for weight between 0 and 10000
     When I am logged in as "customer1"
     When I add 1 items of product "product2" in my cart
     When I add 1 items of product "product1" in my cart
@@ -177,7 +177,7 @@ Feature: Check cart to order data copy
     Given address "address1" is associated to customer "customer1"
     Given there is a carrier named "carrier1"
     Given carrier "carrier1" ships to all groups
-    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for quantities between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for weight between 0 and 10000
     When I am logged in as "customer1"
     When I add 1 items of product "product1" in my cart
     When I use the discount "cartrule5"

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
@@ -21,7 +21,7 @@ Feature: Check cart to order data copy
     Given address "address1" is associated to customer "customer1"
     Given there is a carrier named "carrier1"
     Given carrier "carrier1" ships to all groups
-    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
     When I am logged in as "customer1"
     When I add 1 items of product "product1" in my cart
     When I use the discount "cartrule1"
@@ -57,7 +57,7 @@ Feature: Check cart to order data copy
     Given address "address1" is associated to customer "customer1"
     Given there is a carrier named "carrier1"
     Given carrier "carrier1" ships to all groups
-    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
     When I am logged in as "customer1"
     When I add 1 items of product "product1" in my cart
     When I use the discount "cartrule1"
@@ -97,7 +97,7 @@ Feature: Check cart to order data copy
     Given address "address1" is associated to customer "customer1"
     Given there is a carrier named "carrier1"
     Given carrier "carrier1" ships to all groups
-    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
     When I am logged in as "customer1"
     When I add 1 items of product "product2" in my cart
     When I add 1 items of product "product1" in my cart
@@ -139,7 +139,7 @@ Feature: Check cart to order data copy
     Given address "address1" is associated to customer "customer1"
     Given there is a carrier named "carrier1"
     Given carrier "carrier1" ships to all groups
-    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
     When I am logged in as "customer1"
     When I add 1 items of product "product2" in my cart
     When I add 1 items of product "product1" in my cart
@@ -177,7 +177,7 @@ Feature: Check cart to order data copy
     Given address "address1" is associated to customer "customer1"
     Given there is a carrier named "carrier1"
     Given carrier "carrier1" ships to all groups
-    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for weight between 0 and 10000
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
     When I am logged in as "customer1"
     When I add 1 items of product "product1" in my cart
     When I use the discount "cartrule5"


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | adds some free shipping behat tests, fix free shipping calculation bug
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | fixes #12976
| How to test?  | see issue #12976 Please test following use case too: a cart rule (with code) specific to a carrier #1. Select carrier #1 and apply cart rule. Select carrier #2 and verify cart rule is removed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13003)
<!-- Reviewable:end -->
