### PR TITLE
Change product canonical url to parent, no more redirection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ script:
     fi
 
   - if [ $PRESTASHOP_TEST_TYPE = "e2e" ]; then
-        bash tests-legacy/check_e2e.sh;
+        bash tests/check_e2e.sh;
     fi
 
 after_script:

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -55,16 +55,27 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function canonicalRedirection($canonical_url = '')
     {
         if (Validate::isLoadedObject($this->product)) {
-            if (!$this->product->hasCombinations()) {
+            if (!$this->product->hasCombinations() ||
+                !$this->isValidCombination(Tools::getValue('id_product_attribute'), $this->product->id)) {
+                //Invalid combination we redirect to the canonical url (with attribute id)
                 unset($_GET['id_product_attribute']);
-            } elseif (!$this->isValidCombination(Tools::getValue('id_product_attribute'), $this->product->id)) {
-                $_GET['id_product_attribute'] = Product::getDefaultAttribute($this->product->id);
             } else {
                 //Only redirect to canonical (parent product without combination) when the requested combination is not valid
+                //In this case we are in a valid combination url and we must display it with redirection for SEO purpose
                 return;
             }
 
-            parent::canonicalRedirection($this->context->link->getProductLink($this->product));
+            //Note: we NEED these 6 arguments to have $ipa=null or else a parameter will be added
+            //id_product_attribute=0 and force the redirection
+            parent::canonicalRedirection($this->context->link->getProductLink(
+                $this->product,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+            ));
         }
     }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -59,8 +59,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 unset($_GET['id_product_attribute']);
             } elseif (!$this->isValidCombination(Tools::getValue('id_product_attribute'), $this->product->id)) {
                 $_GET['id_product_attribute'] = Product::getDefaultAttribute($this->product->id);
+            } else {
+                //Only redirect to canonical (parent product without combination) when the requested combination is not valid
+                return;
             }
-            $idProductAttribute = $this->getIdProductAttributeByRequest();
+
             parent::canonicalRedirection($this->context->link->getProductLink(
                 $this->product,
                 null,
@@ -68,7 +71,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 null,
                 null,
                 null,
-                $idProductAttribute
+                null
             ));
         }
     }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -64,15 +64,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 return;
             }
 
-            parent::canonicalRedirection($this->context->link->getProductLink(
-                $this->product,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            ));
+            parent::canonicalRedirection($this->context->link->getProductLink($this->product));
         }
     }
 

--- a/tests/E2E/README.md
+++ b/tests/E2E/README.md
@@ -50,7 +50,7 @@ npm install
 This command line does it for you but you need a mysql server available with the right to create a database:
 
 ```bash
-php install/index_cli.php --language=en \
+php install-dev/index_cli.php --language=en \
                           --country=fr \
                           --domain=localhost \
                           --db_server=localhostr \

--- a/tests/check_e2e.sh
+++ b/tests/check_e2e.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ "x$TRAVIS_BUILD_DIR" == "x" ]; then
+  export TRAVIS_BUILD_DIR=$(cd $(dirname "$0")/../ && pwd);
+fi
+
 bash travis-scripts/run-selenium-tests;
 SELENIUM=$?
 

--- a/tests/check_e2e.sh
+++ b/tests/check_e2e.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-if [ "x$TRAVIS_BUILD_DIR" == "x" ]; then
-  export TRAVIS_BUILD_DIR=$(cd $(dirname "$0")/../ && pwd);
-fi
-
 bash travis-scripts/run-selenium-tests;
 SELENIUM=$?
 

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -27,7 +27,7 @@
     <div class="thumbnail-container">
       {block name='product_thumbnail'}
         {if $product.cover}
-          <a href="{$product.url}" class="thumbnail product-thumbnail">
+          <a href="{$product.canonical_url}" class="thumbnail product-thumbnail">
             <img
               src="{$product.cover.bySize.home_default.url}"
               alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
@@ -35,7 +35,7 @@
             />
           </a>
         {else}
-          <a href="{$product.url}" class="thumbnail product-thumbnail">
+          <a href="{$product.canonical_url}" class="thumbnail product-thumbnail">
             <img src="{$urls.no_picture_image.bySize.home_default.url}" />
           </a>
         {/if}
@@ -44,9 +44,9 @@
       <div class="product-description">
         {block name='product_name'}
           {if $page.page_name == 'index'}
-            <h3 class="h3 product-title" itemprop="name"><a href="{$product.url}">{$product.name|truncate:30:'...'}</a></h3>
+            <h3 class="h3 product-title" itemprop="name"><a href="{$product.canonical_url}">{$product.name|truncate:30:'...'}</a></h3>
           {else}
-            <h2 class="h3 product-title" itemprop="name"><a href="{$product.url}">{$product.name|truncate:30:'...'}</a></h2>
+            <h2 class="h3 product-title" itemprop="name"><a href="{$product.canonical_url}">{$product.name|truncate:30:'...'}</a></h2>
           {/if}
         {/block}
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Change product canonical url to parent, no more redirection
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12548
| How to test?  | Go to catalog pages, check that product with combinations have their link to the parent url (no attribute id in the url). Then go to the product page, check that you are not redirected (the url does not contain an attribute id) but the default combination is displayed. Check that combination urls are still accessible but their canonical all point to the parent one.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13009)
<!-- Reviewable:end -->
