### PR TITLE
Remove deprecated customization constants & fix undefined index notice

### DIFF
--- a/pdf/invoice.product-tab.tpl
+++ b/pdf/invoice.product-tab.tpl
@@ -105,9 +105,9 @@
 					<td class="center"> &nbsp;</td>
 
 					<td>
-						{if isset($customization.datas[$smarty.const._CUSTOMIZE_TEXTFIELD_]) && count($customization.datas[$smarty.const._CUSTOMIZE_TEXTFIELD_]) > 0}
+						{if isset($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) && count($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) > 0}
 							<table style="width: 100%;">
-								{foreach $customization.datas[$smarty.const._CUSTOMIZE_TEXTFIELD_] as $customization_infos}
+								{foreach $customization.datas[Product::CUSTOMIZE_TEXTFIELD] as $customization_infos}
 									<tr>
 										<td style="width: 30%;">
 											{$customization_infos.name|string_format:{l s='%s:' d='Shop.Pdf' pdf='true'}}
@@ -118,11 +118,11 @@
 							</table>
 						{/if}
 
-						{if isset($customization.datas[$smarty.const._CUSTOMIZE_FILE_]) && count($customization.datas[$smarty.const._CUSTOMIZE_FILE_]) > 0}
+						{if isset($customization.datas[Product::CUSTOMIZE_FILE]) && count($customization.datas[Product::CUSTOMIZE_FILE]) > 0}
 							<table style="width: 100%;">
 								<tr>
 									<td style="width: 70%;">{l s='image(s):' d='Shop.Pdf' pdf='true'}</td>
-									<td>{count($customization.datas[$smarty.const._CUSTOMIZE_FILE_])}</td>
+									<td>{count($customization.datas[Product::CUSTOMIZE_FILE])}</td>
 								</tr>
 							</table>
 						{/if}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This removes deprecated customization constants (_CUSTOMIZE_TEXTFIELD_ and _CUSTOMIZE_FILE_) from invoice template. It also fixes a smarty undefined index notice.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Enable PS_MODE_DEV, create an order with a customized files, generate invoice, display invoice.<br><br>This also fixes a notice caused by a weird smarty behavior that strips `isset` when using `$smarty.constant._MY_CONSTANT_` as array index.<br>Here is a smarty statement:<br>```{if isset($customization.datas[$smarty.const._CUSTOMIZE_TEXTFIELD_]) && count($customization.datas[$smarty.const._CUSTOMIZE_TEXTFIELD_]) > 0}```<br>And here is the compiled output:<br>```<?php if ((($_smarty_tpl->tpl_vars['customization']->value['datas'][@constant('_CUSTOMIZE_TEXTFIELD_')] !== null )) && count($_smarty_tpl->tpl_vars['customization']->value['datas'][@constant('_CUSTOMIZE_TEXTFIELD_')]) > 0) {?>```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13022)
<!-- Reviewable:end -->
