### PR TITLE
Improves in Customer form Birthday Input to use date input type.

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -77,7 +77,7 @@ class CustomerFormCore extends AbstractForm
     {
         $params = get_object_vars($customer);
         $params['id_customer'] = $customer->id;
-        $params['birthday'] = $customer->birthday === '0000-00-00' ? null : Tools::displayDate($customer->birthday);
+        $params['birthday'] = $customer->birthday === '0000-00-00' ? null : $customer->birthday;
 
         return $this->fillWith($params);
     }

--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -197,7 +197,7 @@ class CustomerFormatterCore implements FormFormatterInterface
         if ($this->ask_for_birthdate) {
             $format['birthday'] = (new FormField())
                 ->setName('birthday')
-                ->setType('text')
+                ->setType('date')
                 ->setLabel(
                     $this->translator->trans(
                         'Birthdate',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This fix improves a usability problem in register form, concretely in Birthday Date Input. <br> As a default, the input date uses text type but exists the date format for inputs, that improve the facility to insert, edit and change the date. Also, this fix improves the behaviour on mobile-friendly devices.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15253
| How to test?  | After applying this fix accessing into Register Customer form in the front office or changing the date in Identity area in My Account the input for birthday use the type Dato with all benefits that it brings.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13036)
<!-- Reviewable:end -->
