### PR TITLE
Fix to handle fancybox customer creation in Add an Order page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -150,6 +150,7 @@ class CustomerController extends AbstractAdminController
             'customerForm' => $customerForm->createView(),
             'isB2bFeatureActive' => $this->get('prestashop.core.b2b.b2b_feature')->isActive(),
             'minPasswordLength' => Password::MIN_LENGTH,
+            'displayInIframe' => $request->query->has('submitFormAjax'),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -130,6 +130,16 @@ class CustomerController extends AbstractAdminController
             if ($customerId = $result->getIdentifiableObjectId()) {
                 $this->addFlash('success', $this->trans('Successful creation.', 'Admin.Notifications.Success'));
 
+                if ($request->query->has('submitFormAjax')) {
+                    /** @var ViewableCustomer $customerInformation */
+                    $customerInformation = $this->getQueryBus()->handle(new GetCustomerForViewing((int) $customerId));
+
+                    return $this->render('@PrestaShop/Admin/Sell/Customer/modal_create_success.html.twig', [
+                        'customerId' => $customerId,
+                        'customerEmail' => $customerInformation->getPersonalInformation()->getEmail(),
+                    ]);
+                }
+
                 return $this->redirectToRoute('admin_customers_index');
             }
         } catch (CustomerException $e) {
@@ -163,8 +173,7 @@ class CustomerController extends AbstractAdminController
                 'is_password_required' => false,
             ];
             $customerForm = $this->get('prestashop.core.form.identifiable_object.builder.customer_form_builder')
-                ->getFormFor((int) $customerId, [], $customerFormOptions)
-            ;
+                ->getFormFor((int) $customerId, [], $customerFormOptions);
             $customerForm->handleRequest($request);
 
             $customerFormHandler = $this->get('prestashop.core.form.identifiable_object.handler.customer_form_handler');
@@ -771,8 +780,7 @@ class CustomerController extends AbstractAdminController
         return (new CsvResponse())
             ->setData($data)
             ->setHeadersData($headers)
-            ->setFileName('customer_' . date('Y-m-d_His') . '.csv')
-        ;
+            ->setFileName('customer_' . date('Y-m-d_His') . '.csv');
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
@@ -123,7 +123,11 @@
         </div>
       </div>
       <div class="card-footer">
-        <a href="{{ path('admin_customers_index') }}" class="btn btn-outline-secondary">
+        {% if displayInIframe == true %}
+          <a href="javascript:window.history.back();" class="btn btn-outline-secondary">
+        {% else %}
+          <a href="{{ path('admin_customers_index') }}" class="btn btn-outline-secondary">
+        {% endif %}
           <i class="material-icons">cancel</i>
           {{ 'Cancel'|trans({}, 'Admin.Actions') }}
         </a>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/modal_create_success.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/modal_create_success.html.twig
@@ -1,0 +1,38 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
+
+{% block content %}
+{% endblock %}
+
+{% block javascripts %}
+  <script type="text/javascript">
+    {# Script dedicated to close "Create a customer" fancybox used in Add an Order #}
+    $('#customer', window.parent.document).val('{{ customerEmail }}');
+    parent.setupCustomer({{ customerId }});
+    parent.$.fancybox.close();
+  </script>
+{% endblock %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix to handle fancybox customer creation in Add an Order page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13013
| How to test?  | See fixed ticket behavior

This is a port of legacy behavior in https://github.com/PrestaShop/PrestaShop/issues/13013#issuecomment-476002724 . I considered modifying the system but, as explained in comment below, this would have a great impact. It's better to wait for Add an order page to be migrated to fully fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13043)
<!-- Reviewable:end -->
