### PR TITLE
fix currency install by getting some properties from CLDR reference

### DIFF
--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -23,8 +23,11 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Cldr\Update;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
+use PrestaShop\PrestaShop\Core\Localization\Specification\Factory as SpecificationFactory;
 
 class LocalizationPackCore
 {
@@ -338,25 +341,18 @@ class LocalizationPackCore
                     continue;
                 }
 
-                $defaultLang = (int) Configuration::get('PS_LANG_DEFAULT');
+                /** @var Language $defaultLang */
+                $defaultLang = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
 
-                $currency = new Currency(null, $defaultLang);
+                $currency = new Currency(null, $defaultLang->id);
                 $currency->name = (string) $attributes['name'];
                 $currency->iso_code = (string) $attributes['iso_code'];
                 $currency->iso_code_num = (int) $attributes['iso_code_num'];
                 $currency->numeric_iso_code = (string) $attributes['iso_code_num'];
-                // @todo retrieve sign/symbol from CLDR reference
-                $currency->sign = (string) $attributes['sign'];
-                $currency->symbol = (string) $attributes['sign'];
                 $currency->blank = (int) $attributes['blank'];
                 $currency->conversion_rate = 1; // This value will be updated if the store is online
                 $currency->format = (int) $attributes['format'];
                 $currency->decimals = (int) $attributes['decimals'];
-                // @todo retrieve precision from CLDR reference
-                // needs to be tested against installation process, currency adding, and automated tests
-                // following does not work properly since CLDR service is not initialized at install
-                // $currency->precision = (int) Tools::getContextLocale(Context::getContext())->getPriceSpecifications()->get($currency->iso_code)->getMaxFractionDigits();
-                $currency->precision = (int) $attributes['decimals'] > 0 ? 2 : 0;
                 $currency->active = true;
                 if (!$currency->validateFields()) {
                     $this->_errors[] = Context::getContext()->getTranslator()->trans('Invalid currency properties.', array(), 'Admin.International.Notification');
@@ -369,6 +365,9 @@ class LocalizationPackCore
 
                         return false;
                     }
+                    Cache::clear();
+                    $this->setCurrencyCldrData($currency, $defaultLang);
+                    $currency->save();
 
                     PaymentModule::addCurrencyPermissions($currency->id);
                 }
@@ -385,6 +384,37 @@ class LocalizationPackCore
         }
 
         return true;
+    }
+
+    protected function setCurrencyCldrData(Currency $currency, Language $lang){
+        $context = Context::getContext();
+        $container = isset($context->controller) ? $context->controller->getContainer() : null;
+        if (null === $container) {
+            $container = SymfonyContainer::getInstance();
+        }
+        /** @var \PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository $localeRepo */
+        $localeRepoCLDR = $container->get('prestashop.core.localization.cldr.locale_repository');
+        /** @var \PrestaShop\PrestaShop\Core\Localization\Locale\Repository $localeRepo */
+        $localeRepo = $container->get('prestashop.core.localization.locale.repository');
+        /** @var \PrestaShop\PrestaShop\Core\Localization\Currency\Repository $currencyRepo */
+        $currencyRepo = $container->get('prestashop.core.localization.currency.repository');
+
+        $cldrCurrency = $currencyRepo->getCurrency($currency->iso_code, $lang->locale);
+        $cldrLocale = $localeRepoCLDR->getLocale($lang->locale);
+        $priceSpecification = (new SpecificationFactory())->buildPriceSpecification(
+            $lang->locale,
+            $cldrLocale,
+            $cldrCurrency,
+            $localeRepo->isNumberGroupingUsed(),
+            $localeRepo->getCurrencyDisplayType()
+        );
+        $currency->precision = (int) $priceSpecification->getMaxFractionDigits();
+        $symbol = (string) $priceSpecification->getCurrencySymbol();
+        if (empty($symbol)) {
+            $symbol = $currency->iso_code;
+        }
+        $currency->sign = $symbol;
+        $currency->symbol = $symbol;
     }
 
     /**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -795,7 +795,7 @@ class ToolsCore
      *
      * @throws Exception
      */
-    protected static function getContextLocale(Context $context)
+    public static function getContextLocale(Context $context)
     {
         $locale = $context->currentLocale;
         if (null !== $locale) {

--- a/src/Core/Localization/Currency.php
+++ b/src/Core/Localization/Currency.php
@@ -166,7 +166,7 @@ class Currency implements CurrencyInterface
      */
     public function getSymbol($localeCode)
     {
-        if (!isset($this->symbols[$localeCode])) {
+        if (!array_key_exists($localeCode, $this->symbols)) {
             throw new LocalizationException('Unknown locale code: ' . $localeCode);
         }
 

--- a/src/Core/Localization/Locale.php
+++ b/src/Core/Localization/Locale.php
@@ -162,4 +162,11 @@ class Locale implements LocaleInterface
             $priceSpec
         );
     }
+
+    /**
+     * @return PriceSpecificationMap
+     */
+    public function getPriceSpecifications(){
+        return $this->priceSpecifications;
+    }
 }

--- a/src/Core/Localization/Locale/Repository.php
+++ b/src/Core/Localization/Locale/Repository.php
@@ -214,9 +214,9 @@ class Repository implements RepositoryInterface
                 $cldrLocale,
                 $currency,
                 $this->numberGroupingUsed,
-                $this->currencyDisplayType,
-                null // TODO : replace here with custom currency precision
+                $this->currencyDisplayType
             );
+            $thisPriceSpecification->setMaxFractionDigits((int) $currency->getDecimalPrecision());
 
             // Add the spec to the collection
             $priceSpecifications->add(
@@ -226,5 +226,21 @@ class Repository implements RepositoryInterface
         }
 
         return $priceSpecifications;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNumberGroupingUsed()
+    {
+        return $this->numberGroupingUsed;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrencyDisplayType()
+    {
+        return $this->currencyDisplayType;
     }
 }

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -98,22 +98,16 @@ class Factory
         CldrLocale $cldrLocale,
         Currency $currency,
         $numberGroupingUsed,
-        $currencyDisplayType,
-        $maxFractionDigits = null
+        $currencyDisplayType
     ) {
         $currencyPattern = $cldrLocale->getCurrencyPattern();
         $numbersSymbols = $cldrLocale->getAllNumberSymbols();
-
-        $precision = $maxFractionDigits;
-        if (null === $precision) {
-            $precision = (int) $currency->getDecimalPrecision();
-        }
 
         return new PriceSpecification(
             $this->getPositivePattern($currencyPattern),
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
-            $precision,
+            $this->getMaxFractionDigits($currencyPattern),
             $this->getMinFractionDigits($currencyPattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($currencyPattern) > 1,
             $this->getPrimaryGroupSize($currencyPattern),
@@ -221,6 +215,20 @@ class Factory
         $dotPos = (int) strpos($pattern, '.');
 
         return substr_count($pattern, '0', $dotPos);
+    }
+
+    /**
+     * Extract the max number of fraction digits from a number pattern (decimal, currency, percentage).
+     *
+     * @param string $pattern The formatting pattern to use for extraction (eg 0.00##)
+     *
+     * @return int The max number of fraction digits to display in the final number
+     */
+    protected function getMaxFractionDigits($pattern)
+    {
+        $dotPos = (int) strpos($pattern, '.');
+
+        return strlen(substr($pattern, $dotPos + 1));
     }
 
     /**

--- a/src/Core/Localization/Specification/Number.php
+++ b/src/Core/Localization/Specification/Number.php
@@ -323,4 +323,12 @@ class Number implements NumberInterface
             throw new LocalizationException('Invalid secondaryGroupSize');
         }
     }
+
+    /**
+     * @param int $maxFractionDigits
+     */
+    public function setMaxFractionDigits($maxFractionDigits)
+    {
+        $this->maxFractionDigits = $maxFractionDigits;
+    }
 }

--- a/tests-legacy/Integration/Core/Localization/LocaleUsageTest.php
+++ b/tests-legacy/Integration/Core/Localization/LocaleUsageTest.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepositor
 use PrestaShopBundle\Cache\LocalizationWarmer;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Tests\TestCase\SymfonyIntegrationTestCase;
+use AppKernel;
 
 class LocaleUsageTest extends SymfonyIntegrationTestCase
 {
@@ -54,13 +55,24 @@ class LocaleUsageTest extends SymfonyIntegrationTestCase
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
+
+        global $kernel;
+        if (null === $kernel && null !== self::$kernel) {
+            $kernel = self::$kernel;
+        } elseif (null !== $kernel && null === self::$kernel) {
+            self::$kernel = $kernel;
+        } else {
+            $kernel = new AppKernel('test', true);
+            $kernel->boot();
+            self::$kernel = $kernel;
+        }
+
         self::installTestedLanguagePacks();
     }
 
     protected function setUp()
     {
         parent::setUp();
-
         if (!self::$isCacheClear) {
             $this->clearCache();
             self::$isCacheClear = true;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | properly init currency at install
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | fixes #12659
| How to test?  | Install shop in some language. Check currency symbol/precision is correct. Install more localization packs, check symbol/precision

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13060)
<!-- Reviewable:end -->
