### PR TITLE
Fix manufacturers namespace typos and wrong typecasts in commands

### DIFF
--- a/src/Adapter/Manufacturer/CommandHandler/BulkDeleteManufacturerHandler.php
+++ b/src/Adapter/Manufacturer/CommandHandler/BulkDeleteManufacturerHandler.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Manufacturer\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\BulkDeleteManufacturerCommand;
-use PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHanlder\BulkDeleteManufacturerHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHandler\BulkDeleteManufacturerHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\DeleteManufacturerException;
 
 /**

--- a/src/Adapter/Manufacturer/CommandHandler/BulkToggleManufacturerStatusHandler.php
+++ b/src/Adapter/Manufacturer/CommandHandler/BulkToggleManufacturerStatusHandler.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Manufacturer\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\BulkToggleManufacturerStatusCommand;
-use PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHanlder\BulkToggleManufacturerStatusHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHandler\BulkToggleManufacturerStatusHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\UpdateManufacturerException;
 
 /**

--- a/src/Adapter/Manufacturer/CommandHandler/DeleteManufacturerHandler.php
+++ b/src/Adapter/Manufacturer/CommandHandler/DeleteManufacturerHandler.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Manufacturer\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerCommand;
-use PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHanlder\DeleteManufacturerHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHandler\DeleteManufacturerHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\DeleteManufacturerException;
 
 /**

--- a/src/Adapter/Manufacturer/CommandHandler/ToggleManufacturerStatusHandler.php
+++ b/src/Adapter/Manufacturer/CommandHandler/ToggleManufacturerStatusHandler.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Manufacturer\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\ToggleManufacturerStatusCommand;
-use PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHanlder\ToggleManufacturerStatusHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHandler\ToggleManufacturerStatusHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\UpdateManufacturerException;
 
 /**

--- a/src/Core/Domain/Manufacturer/Command/AddManufacturerCommand.php
+++ b/src/Core/Domain/Manufacturer/Command/AddManufacturerCommand.php
@@ -73,31 +73,31 @@ class AddManufacturerCommand
 
     /**
      * @param string $name
-     * @param string[]|null $localizedShortDescriptions
-     * @param string[]|null $localizedDescriptions
-     * @param string[]|null $localizedMetaTitles
-     * @param string[]|null $localizedMetaDescriptions
-     * @param string[]|null $localizedMetaKeywords
      * @param bool $enabled
+     * @param string[] $localizedShortDescriptions
+     * @param string[] $localizedDescriptions
+     * @param string[] $localizedMetaTitles
+     * @param string[] $localizedMetaDescriptions
+     * @param string[] $localizedMetaKeywords
      * @param array $shopAssociation
      */
     public function __construct(
         $name,
-        $enabled = false,
-        array $localizedShortDescriptions = null,
-        array $localizedDescriptions = null,
-        array $localizedMetaTitles = null,
-        array $localizedMetaDescriptions = null,
-        array $localizedMetaKeywords = null,
-        array $shopAssociation = []
+        $enabled,
+        array $localizedShortDescriptions,
+        array $localizedDescriptions,
+        array $localizedMetaTitles,
+        array $localizedMetaDescriptions,
+        array $localizedMetaKeywords,
+        array $shopAssociation
     ) {
         $this->name = $name;
+        $this->enabled = $enabled;
         $this->localizedShortDescriptions = $localizedShortDescriptions;
         $this->localizedDescriptions = $localizedDescriptions;
         $this->localizedMetaTitles = $localizedMetaTitles;
         $this->localizedMetaDescriptions = $localizedMetaDescriptions;
         $this->localizedMetaKeywords = $localizedMetaKeywords;
-        $this->enabled = $enabled;
         $this->shopAssociation = $shopAssociation;
     }
 
@@ -110,7 +110,7 @@ class AddManufacturerCommand
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
     public function getLocalizedShortDescriptions()
     {
@@ -118,7 +118,7 @@ class AddManufacturerCommand
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
     public function getLocalizedDescriptions()
     {
@@ -126,7 +126,7 @@ class AddManufacturerCommand
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
     public function getLocalizedMetaTitles()
     {
@@ -134,7 +134,7 @@ class AddManufacturerCommand
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
     public function getLocalizedMetaDescriptions()
     {
@@ -142,7 +142,7 @@ class AddManufacturerCommand
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
     public function getLocalizedMetaKeywords()
     {

--- a/src/Core/Domain/Manufacturer/CommandHandler/BulkDeleteManufacturerHandlerInterface.php
+++ b/src/Core/Domain/Manufacturer/CommandHandler/BulkDeleteManufacturerHandlerInterface.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHanlder;
+namespace PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\BulkDeleteManufacturerCommand;
 

--- a/src/Core/Domain/Manufacturer/CommandHandler/BulkToggleManufacturerStatusHandlerInterface.php
+++ b/src/Core/Domain/Manufacturer/CommandHandler/BulkToggleManufacturerStatusHandlerInterface.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHanlder;
+namespace PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\BulkToggleManufacturerStatusCommand;
 

--- a/src/Core/Domain/Manufacturer/CommandHandler/DeleteManufacturerHandlerInterface.php
+++ b/src/Core/Domain/Manufacturer/CommandHandler/DeleteManufacturerHandlerInterface.php
@@ -24,17 +24,17 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHanlder;
+namespace PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHandler;
 
-use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\ToggleManufacturerStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerCommand;
 
 /**
- * Defines contract for ToggleManufacturerStatusHandler
+ * Defines contract for DeleteManufacturerHandler
  */
-interface ToggleManufacturerStatusHandlerInterface
+interface DeleteManufacturerHandlerInterface
 {
     /**
-     * @param ToggleManufacturerStatusCommand $command
+     * @param DeleteManufacturerCommand $command
      */
-    public function handle(ToggleManufacturerStatusCommand $command);
+    public function handle(DeleteManufacturerCommand $command);
 }

--- a/src/Core/Domain/Manufacturer/CommandHandler/ToggleManufacturerStatusHandlerInterface.php
+++ b/src/Core/Domain/Manufacturer/CommandHandler/ToggleManufacturerStatusHandlerInterface.php
@@ -24,17 +24,17 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHanlder;
+namespace PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHandler;
 
-use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\ToggleManufacturerStatusCommand;
 
 /**
- * Defines contract for DeleteManufacturerHandler
+ * Defines contract for ToggleManufacturerStatusHandler
  */
-interface DeleteManufacturerHandlerInterface
+interface ToggleManufacturerStatusHandlerInterface
 {
     /**
-     * @param DeleteManufacturerCommand $command
+     * @param ToggleManufacturerStatusCommand $command
      */
-    public function handle(DeleteManufacturerCommand $command);
+    public function handle(ToggleManufacturerStatusCommand $command);
 }

--- a/src/Core/Domain/Manufacturer/QueryHandler/GetManufacturerForEditingHandlerInterface.php
+++ b/src/Core/Domain/Manufacturer/QueryHandler/GetManufacturerForEditingHandlerInterface.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Domain\Manufacturer\QueryResult\EditableManufactu
 
 /**
  * Defines contract for GetManufacturerForEditingHandler
->>>>>>> 324c887cde... Implemented data provider for manufacturerForm and enabled javascript in manufacturer edit page
  */
 interface GetManufacturerForEditingHandlerInterface
 {

--- a/src/Core/Domain/Manufacturer/QueryResult/EditableManufacturer.php
+++ b/src/Core/Domain/Manufacturer/QueryResult/EditableManufacturer.php
@@ -44,32 +44,32 @@ class EditableManufacturer
     private $name;
 
     /**
-     * @var string[]|null
+     * @var string[]
      */
     private $localizedShortDescriptions;
 
     /**
-     * @var string[]|null
+     * @var string[]
      */
     private $localizedDescriptions;
 
     /**
-     * @var array|null
+     * @var array
      */
     private $logoImage;
 
     /**
-     * @var string[]|null
+     * @var string[]
      */
     private $localizedMetaTitles;
 
     /**
-     * @var string[]|null
+     * @var string[]
      */
     private $localizedMetaDescriptions;
 
     /**
-     * @var string[]|null
+     * @var string[]
      */
     private $localizedMetaKeywords;
 
@@ -87,25 +87,25 @@ class EditableManufacturer
      * @param ManufacturerId $manufacturerId
      * @param string $name
      * @param bool $enabled
-     * @param array|null $localizedShortDescriptions
-     * @param array|null $localizedDescriptions
-     * @param array|null $logoImage
-     * @param array|null $localizedMetaTitles
-     * @param array|null $localizedMetaDescriptions
-     * @param array|null $localizedMetaKeywords
+     * @param array $localizedShortDescriptions
+     * @param array $localizedDescriptions
+     * @param array $logoImage
+     * @param array $localizedMetaTitles
+     * @param array $localizedMetaDescriptions
+     * @param array $localizedMetaKeywords
      * @param array $associatedShops
      */
     public function __construct(
         ManufacturerId $manufacturerId,
         $name,
-        $enabled = false,
-        array $localizedShortDescriptions = null,
-        array $localizedDescriptions = null,
-        array $localizedMetaTitles = null,
-        array $localizedMetaDescriptions = null,
-        array $localizedMetaKeywords = null,
-        array $logoImage = null,
-        array $associatedShops = []
+        $enabled,
+        array $localizedShortDescriptions,
+        array $localizedDescriptions,
+        array $localizedMetaTitles,
+        array $localizedMetaDescriptions,
+        array $localizedMetaKeywords,
+        array $logoImage,
+        array $associatedShops
     ) {
         $this->manufacturerId = $manufacturerId;
         $this->name = $name;
@@ -136,7 +136,7 @@ class EditableManufacturer
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
     public function getLocalizedShortDescriptions()
     {
@@ -144,7 +144,7 @@ class EditableManufacturer
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
     public function getLocalizedDescriptions()
     {
@@ -152,7 +152,7 @@ class EditableManufacturer
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     public function getLogoImage()
     {
@@ -160,7 +160,7 @@ class EditableManufacturer
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
     public function getLocalizedMetaTitles()
     {
@@ -168,7 +168,7 @@ class EditableManufacturer
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
     public function getLocalizedMetaDescriptions()
     {
@@ -176,7 +176,7 @@ class EditableManufacturer
     }
 
     /**
-     * @return string[]|null
+     * @return string[]
      */
     public function getLocalizedMetaKeywords()
     {

--- a/src/Core/Domain/Manufacturer/QueryResult/EditableManufacturer.php
+++ b/src/Core/Domain/Manufacturer/QueryResult/EditableManufacturer.php
@@ -89,10 +89,10 @@ class EditableManufacturer
      * @param bool $enabled
      * @param array $localizedShortDescriptions
      * @param array $localizedDescriptions
-     * @param array $logoImage
      * @param array $localizedMetaTitles
      * @param array $localizedMetaDescriptions
      * @param array $localizedMetaKeywords
+     * @param array|null $logoImage
      * @param array $associatedShops
      */
     public function __construct(
@@ -104,7 +104,7 @@ class EditableManufacturer
         array $localizedMetaTitles,
         array $localizedMetaDescriptions,
         array $localizedMetaKeywords,
-        array $logoImage,
+        $logoImage,
         array $associatedShops
     ) {
         $this->manufacturerId = $manufacturerId;

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
@@ -38,8 +38,6 @@ admin_manufacturers_edit:
   defaults:
     _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Manufacturer:edit'
     _legacy_controller: AdminManufacturers
-    _legacy_parameters:
-      id_manufacturer: manufacturerId
   requirements:
     manufacturerId: \d+
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
@@ -38,7 +38,6 @@ admin_manufacturers_edit:
   defaults:
     _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Manufacturer:edit'
     _legacy_controller: AdminManufacturers
-    _legacy_link: AdminManufacturers:updatemanufacturer
     _legacy_parameters:
       id_manufacturer: manufacturerId
   requirements:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Manufacturers contained two command handlers directories of which one had misspelled name 'CommandHanlder'; EditableManufacturer and AddManufacturer commands had fields in constructor with some wrong type casting/optional fields
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Brands page should work same as before. Use this link to test brand page: `admin-dev/index.php/sell/catalog/brands`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13067)
<!-- Reviewable:end -->
