### PR TITLE
fix old bug PSCSX-8515 (group for not logged in user)

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1201,7 +1201,7 @@ class FrontControllerCore extends Controller
 
         $context = Context::getContext();
         if (!isset($context->customer) || !$context->customer->id) {
-            return array();
+            return array((int)Group::getCurrent()->id);
         }
 
         if (!is_array(self::$currentCustomerGroups)) {


### PR DESCRIPTION
in getCurrentCustomerGroups function, if user is not logged in (no customer present), return default value instead of empty list. fixes search if shop has non-default 'visitor' group and categories that are only accessible for the non-default visitor group.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | version 1.6.1.23
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | PSCSX-8515 http://forge.prestashop.com/browse/PSCSX-8515?jql=labels%20%3D%20search
| How to test?  | set visitor group to different group than the default (id 1) and configure one ore more categories so that the default visitor group (id 1) does not have access to this category, but the configured non-default visitor group has. before this bug fix, products of this category can not be found by the search. after this PR is applied, those products do correctly appear in search results.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13073)
<!-- Reviewable:end -->
