### PR TITLE
#11379 Prepend carrier ID, otherwise carrier would be overwritten

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -68,7 +68,7 @@ class ProductShipping extends CommonAbstractType
         );
         $this->carriersChoices = [];
         foreach ($carriers as $carrier) {
-            $this->carriersChoices[$carrier['id_carrier'].' - '.$carrier['name'] . ' (' . $carrier['delay'] . ')'] = $carrier['id_reference'];
+            $this->carriersChoices[$carrier['id_carrier'] . ' - ' . $carrier['name'] . ' (' . $carrier['delay'] . ')'] = $carrier['id_reference'];
         }
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -68,7 +68,7 @@ class ProductShipping extends CommonAbstractType
         );
         $this->carriersChoices = [];
         foreach ($carriers as $carrier) {
-            $this->carriersChoices[$carrier['name'] . ' (' . $carrier['delay'] . ')'] = $carrier['id_reference'];
+            $this->carriersChoices[$carrier['id_carrier'].' - '.$carrier['name'] . ' (' . $carrier['delay'] . ')'] = $carrier['id_reference'];
         }
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | When more carriers have the same name and delay, disappear on the carrier list on the product details' shipping tab carrier's list - because of elements of the associative array ($carriers) are rewritten. There're no other clean ways at the moment to solve this issue. But this is a valid fix, moreover it helps the user to identify easily the carrier, if the same name/delay is assigned.
| Type?         | bug fix 
| Category?     |  BO 
| BC breaks?    |no
| Deprecations? | no
| Fixed ticket? | Fixes #11379
| How to test?  | Follow issue instructions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13077)
<!-- Reviewable:end -->
