### PR TITLE
Empty filter should not be shown

### DIFF
--- a/themes/classic/templates/catalog/_partials/facets.tpl
+++ b/themes/classic/templates/catalog/_partials/facets.tpl
@@ -1,162 +1,168 @@
 {**
- * 2007-2019 PrestaShop and Contributors
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/AFL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://www.prestashop.com for more information.
- *
- * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
- * International Registered Trademark & Property of PrestaShop SA
- *}
+  * 2007-2019 PrestaShop and Contributors
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+  * that is bundled with this package in the file LICENSE.txt.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/AFL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to https://www.prestashop.com for more information.
+  *
+  * @author    PrestaShop SA <contact@prestashop.com>
+  * @copyright 2007-2019 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+  * International Registered Trademark & Property of PrestaShop SA
+  *}
+{if $facets|count}
   <div id="search_filters">
-
     {block name='facets_title'}
       <p class="text-uppercase h6 hidden-sm-down">{l s='Filter By' d='Shop.Theme.Actions'}</p>
     {/block}
 
     {block name='facets_clearall_button'}
-      <div id="_desktop_search_filters_clear_all" class="hidden-sm-down clear-all-wrapper">
-        <button data-search-url="{$clear_all_link}" class="btn btn-tertiary js-search-filters-clear-all">
-          <i class="material-icons">&#xE14C;</i>
-          {l s='Clear all' d='Shop.Theme.Actions'}
-        </button>
-      </div>
+      {if $activeFilters|count}
+        <div id="_desktop_search_filters_clear_all" class="hidden-sm-down clear-all-wrapper">
+          <button data-search-url="{$clear_all_link}" class="btn btn-tertiary js-search-filters-clear-all">
+            <i class="material-icons">&#xE14C;</i>
+            {l s='Clear all' d='Shop.Theme.Actions'}
+          </button>
+        </div>
+      {/if}
     {/block}
 
     {foreach from=$facets item="facet"}
-      {if $facet.displayed}
-        <section class="facet clearfix">
-          <p class="h6 facet-title hidden-sm-down">{$facet.label}</p>
-          {assign var=_expand_id value=10|mt_rand:100000}
-          {assign var=_collapse value=true}
-          {foreach from=$facet.filters item="filter"}
-            {if $filter.active}{assign var=_collapse value=false}{/if}
-          {/foreach}
-          <div class="title hidden-md-up" data-target="#facet_{$_expand_id}" data-toggle="collapse"{if !$_collapse} aria-expanded="true"{/if}>
-            <p class="h6 facet-title">{$facet.label}</p>
-            <span class="float-xs-right">
-              <span class="navbar-toggler collapse-icons">
-                <i class="material-icons add">&#xE313;</i>
-                <i class="material-icons remove">&#xE316;</i>
-              </span>
+      {if !$facet.displayed}
+        {continue}
+      {/if}
+
+      <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">{$facet.label}</p>
+        {assign var=_expand_id value=10|mt_rand:100000}
+        {assign var=_collapse value=true}
+        {foreach from=$facet.filters item="filter"}
+          {if $filter.active}{assign var=_collapse value=false}{/if}
+        {/foreach}
+
+        <div class="title hidden-md-up" data-target="#facet_{$_expand_id}" data-toggle="collapse"{if !$_collapse} aria-expanded="true"{/if}>
+          <p class="h6 facet-title">{$facet.label}</p>
+          <span class="float-xs-right">
+            <span class="navbar-toggler collapse-icons">
+              <i class="material-icons add">&#xE313;</i>
+              <i class="material-icons remove">&#xE316;</i>
             </span>
-          </div>
+          </span>
+        </div>
 
-          {if $facet.widgetType !== 'dropdown'}
+        {if $facet.widgetType !== 'dropdown'}
+          {block name='facet_item_other'}
+            <ul id="facet_{$_expand_id}" class="collapse{if !$_collapse} in{/if}">
+              {foreach from=$facet.filters key=filter_key item="filter"}
+                {if !$filter.displayed}
+                  {continue}
+                {/if}
 
-            {block name='facet_item_other'}
-              <ul id="facet_{$_expand_id}" class="collapse{if !$_collapse} in{/if}">
-                {foreach from=$facet.filters key=filter_key item="filter"}
-                  {if $filter.displayed}
-                    <li>
-                      <label class="facet-label{if $filter.active} active {/if}" for="facet_input_{$_expand_id}_{$filter_key}">
-                        {if $facet.multipleSelectionAllowed}
-                          <span class="custom-checkbox">
-                            <input
-                              id="facet_input_{$_expand_id}_{$filter_key}"
-                              data-search-url="{$filter.nextEncodedFacetsURL}"
-                              type="checkbox"
-                              {if $filter.active } checked {/if}
-                            >
-                            {if isset($filter.properties.color)}
-                              <span class="color" style="background-color:{$filter.properties.color}"></span>
-                              {elseif isset($filter.properties.texture)}
-                                <span class="color texture" style="background-image:url({$filter.properties.texture})"></span>
-                              {else}
-                              <span {if !$js_enabled} class="ps-shown-by-js" {/if}><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
-                            {/if}
-                          </span>
+                <li>
+                  <label class="facet-label{if $filter.active} active {/if}" for="facet_input_{$_expand_id}_{$filter_key}">
+                    {if $facet.multipleSelectionAllowed}
+                      <span class="custom-checkbox">
+                        <input
+                          id="facet_input_{$_expand_id}_{$filter_key}"
+                          data-search-url="{$filter.nextEncodedFacetsURL}"
+                          type="checkbox"
+                          {if $filter.active }checked{/if}
+                        >
+                        {if isset($filter.properties.color)}
+                          <span class="color" style="background-color:{$filter.properties.color}"></span>
+                        {elseif isset($filter.properties.texture)}
+                          <span class="color texture" style="background-image:url({$filter.properties.texture})"></span>
                         {else}
-                          <span class="custom-radio">
-                            <input
-                              id="facet_input_{$_expand_id}_{$filter_key}"
-                              data-search-url="{$filter.nextEncodedFacetsURL}"
-                              type="radio"
-                              name="filter {$facet.label}"
-                              {if $filter.active } checked {/if}
-                            >
-                            <span {if !$js_enabled} class="ps-shown-by-js" {/if}></span>
-                          </span>
+                          <span {if !$js_enabled} class="ps-shown-by-js" {/if}><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
                         {/if}
+                      </span>
+                    {else}
+                      <span class="custom-radio">
+                        <input
+                          id="facet_input_{$_expand_id}_{$filter_key}"
+                          data-search-url="{$filter.nextEncodedFacetsURL}"
+                          type="radio"
+                          name="filter {$facet.label}"
+                          {if $filter.active }checked{/if}
+                        >
+                        <span {if !$js_enabled} class="ps-shown-by-js" {/if}></span>
+                      </span>
+                    {/if}
 
+                    <a
+                      href="{$filter.nextEncodedFacetsURL}"
+                      class="_gray-darker search-link js-search-link"
+                      rel="nofollow"
+                    >
+                      {$filter.label}
+                      {if $filter.magnitude}
+                        <span class="magnitude">({$filter.magnitude})</span>
+                      {/if}
+                    </a>
+                  </label>
+                </li>
+              {/foreach}
+            </ul>
+          {/block}
+
+        {else}
+
+          {block name='facet_item_dropdown'}
+            <ul id="facet_{$_expand_id}" class="collapse{if !$_collapse} in{/if}">
+              <li>
+                <div class="col-sm-12 col-xs-12 col-md-12 facet-dropdown dropdown">
+                  <a class="select-title" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    {$active_found = false}
+                    <span>
+                      {foreach from=$facet.filters item="filter"}
+                        {if $filter.active}
+                          {$filter.label}
+                          {if $filter.magnitude}
+                            ({$filter.magnitude})
+                          {/if}
+                          {$active_found = true}
+                        {/if}
+                      {/foreach}
+                      {if !$active_found}
+                        {l s='(no filter)' d='Shop.Theme.Global'}
+                      {/if}
+                    </span>
+                    <i class="material-icons float-xs-right">&#xE5C5;</i>
+                  </a>
+                  <div class="dropdown-menu">
+                    {foreach from=$facet.filters item="filter"}
+                      {if !$filter.active}
                         <a
-                          href="{$filter.nextEncodedFacetsURL}"
-                          class="_gray-darker search-link js-search-link"
                           rel="nofollow"
+                          href="{$filter.nextEncodedFacetsURL}"
+                          class="select-list"
                         >
                           {$filter.label}
                           {if $filter.magnitude}
-                            <span class="magnitude">({$filter.magnitude})</span>
+                            ({$filter.magnitude})
                           {/if}
                         </a>
-                      </label>
-                    </li>
-                  {/if}
-                {/foreach}
-              </ul>
-            {/block}
-
-          {else}
-
-            {block name='facet_item_dropdown'}
-              <ul id="facet_{$_expand_id}" class="collapse{if !$_collapse} in{/if}">
-                <li>
-                  <div class="col-sm-12 col-xs-12 col-md-12 facet-dropdown dropdown">
-                    <a class="select-title" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                      {$active_found = false}
-                      <span>
-                        {foreach from=$facet.filters item="filter"}
-                          {if $filter.active}
-                            {$filter.label}
-                            {if $filter.magnitude}
-                              ({$filter.magnitude})
-                            {/if}
-                            {$active_found = true}
-                          {/if}
-                        {/foreach}
-                        {if !$active_found}
-                          {l s='(no filter)' d='Shop.Theme.Global'}
-                        {/if}
-                      </span>
-                      <i class="material-icons float-xs-right">&#xE5C5;</i>
-                    </a>
-                    <div class="dropdown-menu">
-                      {foreach from=$facet.filters item="filter"}
-                        {if !$filter.active}
-                          <a
-                            rel="nofollow"
-                            href="{$filter.nextEncodedFacetsURL}"
-                            class="select-list"
-                          >
-                            {$filter.label}
-                            {if $filter.magnitude}
-                              ({$filter.magnitude})
-                            {/if}
-                          </a>
-                        {/if}
-                      {/foreach}
-                    </div>
+                      {/if}
+                    {/foreach}
                   </div>
-                </li>
-              </ul>
-            {/block}
-
-          {/if}
-        </section>
-      {/if}
+                </div>
+              </li>
+            </ul>
+          {/block}
+        {/if}
+      </section>
     {/foreach}
   </div>
+{/if}

--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -1,27 +1,27 @@
 {**
- * 2007-2019 PrestaShop and Contributors
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/AFL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://www.prestashop.com for more information.
- *
- * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
- * International Registered Trademark & Property of PrestaShop SA
- *}
+  * 2007-2019 PrestaShop and Contributors
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+  * that is bundled with this package in the file LICENSE.txt.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/AFL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to https://www.prestashop.com for more information.
+  *
+  * @author    PrestaShop SA <contact@prestashop.com>
+  * @copyright 2007-2019 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+  * International Registered Trademark & Property of PrestaShop SA
+  *}
 {extends file=$layout}
 
 {block name='content'}
@@ -34,7 +34,7 @@
     <section id="products">
       {if $listing.products|count}
 
-        <div id="">
+        <div>
           {block name='product_list_top'}
             {include file='catalog/_partials/products-top.tpl' listing=$listing}
           {/block}
@@ -46,7 +46,7 @@
           </div>
         {/block}
 
-        <div id="">
+        <div>
           {block name='product_list'}
             {include file='catalog/_partials/products.tpl' listing=$listing}
           {/block}
@@ -59,9 +59,13 @@
         </div>
 
       {else}
+        <div id="js-product-list-top"></div>
 
-        {include file='errors/not-found.tpl'}
+        <div id="js-product-list">
+          {include file='errors/not-found.tpl'}
+        </div>
 
+        <div id="js-product-list-bottom"></div>
       {/if}
     </section>
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Apply a patch to not display empty filters. Also, we need to always be able to target js-product-list id in case we have no products but still have filters available.<br>These changes have already been applied on the facetedsearch module.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9736 
| How to test?  | Follow ticket instruction.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13081)
<!-- Reviewable:end -->
