### PR TITLE
Ensure translations are always saved with the selected theme in back office

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -170,8 +170,8 @@ class TranslationController extends ApiController
             $translationService = $this->container->get('prestashop.service.translation');
             $response = [];
             foreach ($translations as $translation) {
-                if (!array_key_exists('theme', $translation)) {
-                    $translation['theme'] = null;
+                if (!array_key_exists('theme', $translation) || empty($translation['theme'])) {
+                    $translation['theme'] = $this->getSelectedTheme();
                 }
 
                 try {
@@ -315,7 +315,7 @@ class TranslationController extends ApiController
     private function getNormalTree($lang, $type, $selected, $search = null)
     {
         $treeBuilder = new TreeBuilder($this->translationService->langToLocale($lang), $this->getSelectedTheme());
-        $catalogue = $this->translationService->getTranslationsCatalogue($lang, $type, $selected, $search);
+        $catalogue = $this->translationService->getTranslationsCatalogue($lang, $type, $this->getSelectedTheme(), $search);
 
         return $this->getCleanTree($treeBuilder, $catalogue, $type, $selected, $search);
     }

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -170,7 +170,7 @@ class TranslationController extends ApiController
             $translationService = $this->container->get('prestashop.service.translation');
             $response = [];
             foreach ($translations as $translation) {
-                if (!array_key_exists('theme', $translation) || empty($translation['theme'])) {
+                if (empty($translation['theme'])) {
                     $translation['theme'] = $this->getSelectedTheme();
                 }
 


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In some cases, the theme was not selected when saving translations: now we have introduced back the concept of translation per theme, we couldn't manage to retrieve the translations.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #13084
| How to test?  | I summon the great @marionf here, she knows what she has to do :-) 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13088)
<!-- Reviewable:end -->
