### PR TITLE
Validate theme zip file and show error messages

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -209,7 +209,7 @@ class ThemeController extends AbstractAdminController
         $importThemeForm = $this->createForm(ImportThemeType::class);
         $importThemeForm->handleRequest($request);
 
-        if ($importThemeForm->isSubmitted()) {
+        if ($importThemeForm->isSubmitted() && $importThemeForm->isValid()) {
             $data = $importThemeForm->getData();
             $importSource = null;
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ImportThemeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ImportThemeType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2019 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -16,27 +16,32 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to http://www.prestashop.com for more information.
+ * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2018 PrestaShop SA
+ * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
 
 namespace PrestaShopBundle\Form\Admin\Improve\Design\Theme;
 
+use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\File;
 
 /**
  * Class ImportThemeType
  */
 class ImportThemeType extends AbstractType
 {
+    use TranslatorAwareTrait;
+
     /**
      * @var array
      */
@@ -58,6 +63,10 @@ class ImportThemeType extends AbstractType
         $builder
             ->add('import_from_computer', FileType::class, [
                 'required' => false,
+                'constraints' => new File([
+                    'mimeTypes' => 'application/zip',
+                    'mimeTypesMessage' => $this->trans('Invalid file format.', [], 'Admin.Design.Notification'),
+                ]),
             ])
             ->add('import_from_web', UrlType::class, [
                 'required' => false,
@@ -69,5 +78,19 @@ class ImportThemeType extends AbstractType
                 'translation_domain' => false,
             ])
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'post_max_size_message' => $this->trans(
+                'The uploaded file is too large.',
+                [],
+                'Admin.Notifications.Error'
+            ),
+        ]);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -717,6 +717,8 @@ services:
         class: 'PrestaShopBundle\Form\Admin\Improve\Design\Theme\ImportThemeType'
         arguments:
             - '@=service("prestashop.core.form.choice_provider.theme_zip").getChoices()'
+        calls:
+            - { method: setTranslator, arguments: ['@translator'] }
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
@@ -1,29 +1,30 @@
 {#**
-  * 2007-2018 PrestaShop
-  *
-  * NOTICE OF LICENSE
-  *
-  * This source file is subject to the Open Software License (OSL 3.0)
-  * that is bundled with this package in the file LICENSE.txt.
-  * It is also available through the world-wide-web at this URL:
-  * https://opensource.org/licenses/OSL-3.0
-  * If you did not receive a copy of the license and are unable to
-  * obtain it through the world-wide-web, please send an email
-  * to license@prestashop.com so we can send you a copy immediately.
-  *
-  * DISCLAIMER
-  *
-  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-  * versions in the future. If you wish to customize PrestaShop for your
-  * needs please refer to http://www.prestashop.com for more information.
-  *
-  * @author    PrestaShop SA <contact@prestashop.com>
-  * @copyright 2007-2018 PrestaShop SA
-  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
-  * International Registered Trademark & Property of PrestaShop SA
-  *#}
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% set layoutTitle = 'Theme & Logo'|trans({}, 'Admin.Navigation.Menu') ~ ' > ' ~ 'Theme'|trans({}, 'Admin.Design.Feature') %}
 {% set layoutHeaderToolbarBtn = {
@@ -42,6 +43,7 @@
 {% block content %}
   <div class="row">
     <div class="col">
+      {{ form_errors(importThemeForm) }}
       {{ form_start(importThemeForm) }}
         <div class="row justify-content-center">
           <div class="col-xl-10">
@@ -52,15 +54,10 @@
               </h3>
               <div class="card-block row">
                 <div class="card-text">
-                  <div class="form-group row">
-                    <div class="form-control-label">
-                      {{ 'Zip file'|trans({}, 'Admin.Design.Feature') }}
-                    </div>
-                    <div class="col-sm">
-                      {{ form_widget(importThemeForm.import_from_computer) }}
-                      <small class="form-text">{{ 'Browse your computer files and select the Zip file for your new theme.'|trans({}, 'Admin.Design.Help') }}</small>
-                    </div>
-                  </div>
+                  {{ ps.form_group_row(importThemeForm.import_from_computer, {}, {
+                    label: 'Zip file'|trans({}, 'Admin.Design.Feature'),
+                    help: 'Browse your computer files and select the Zip file for your new theme.'|trans({}, 'Admin.Design.Help')
+                  }) }}
                 </div>
               </div>
               <div class="card-footer">
@@ -82,15 +79,10 @@
               </h3>
               <div class="card-block row">
                 <div class="card-text">
-                  <div class="form-group row">
-                    <div class="form-control-label">
-                      {{ 'Archive URL'|trans({}, 'Admin.Design.Feature') }}
-                    </div>
-                    <div class="col-sm">
-                      {{ form_widget(importThemeForm.import_from_web) }}
-                      <small class="form-text">{{ 'Indicate the complete URL to an online Zip file that contains your new theme. For instance, "http://example.com/files/theme.zip".'|trans({}, 'Admin.Design.Help') }}</small>
-                    </div>
-                  </div>
+                  {{ ps.form_group_row(importThemeForm.import_from_web, {}, {
+                    label: 'Archive URL'|trans({}, 'Admin.Design.Feature'),
+                    help: 'Indicate the complete URL to an online Zip file that contains your new theme. For instance, "http://example.com/files/theme.zip".'|trans({}, 'Admin.Design.Help')
+                  }) }}
                 </div>
               </div>
               <div class="card-footer">
@@ -112,15 +104,10 @@
               </h3>
               <div class="card-block row">
                 <div class="card-text">
-                  <div class="form-group row">
-                    <div class="form-control-label">
-                      {{ 'Select the archive'|trans({}, 'Admin.Design.Feature') }}
-                    </div>
-                    <div class="col-sm">
-                      {{ form_widget(importThemeForm.import_from_ftp) }}
-                      <small class="form-text">{{ 'This selector lists the Zip files that you uploaded in the \'/themes\' folder.'|trans({}, 'Admin.Design.Help') }}</small>
-                    </div>
-                  </div>
+                  {{ ps.form_group_row(importThemeForm.import_from_ftp, {}, {
+                    label: 'Select the archive'|trans({}, 'Admin.Design.Feature'),
+                    help: 'This selector lists the Zip files that you uploaded in the \'/themes\' folder.'|trans({}, 'Admin.Design.Help')
+                  }) }}
                 </div>
               </div>
               <div class="card-footer">


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes this error: https://github.com/PrestaShop/PrestaShop/pull/12331#issuecomment-477251435 . Implemented theme zip file validation before uploading it. Two new error messages are shown: when file is too large and when file is of invalid type.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Go to design > themes & logo, click _upload a theme_ in the top. **case 1)** Upload a theme zip file, which is too large for the server to handle and you should see a nice error message. https://prnt.sc/n4mh9f **case 2)** upload a different format file (not zip) and you should see another error message below the upload input. https://prnt.sc/n4mhkq

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13105)
<!-- Reviewable:end -->
