### PR TITLE
Do not go to the latest step when you change a previous step state in checkout

### DIFF
--- a/classes/checkout/AbstractCheckoutStep.php
+++ b/classes/checkout/AbstractCheckoutStep.php
@@ -176,4 +176,23 @@ abstract class AbstractCheckoutStepCore implements CheckoutStepInterface
     {
         return $this;
     }
+
+    /**
+     * Find next step and mark it as current
+     */
+    public function setNextStepAsCurrent()
+    {
+        $steps = $this->getCheckoutProcess()->getSteps();
+        $next = false;
+        foreach ($steps as $step) {
+            if ($next === true) {
+                $step->step_is_current = true;
+                break;
+            }
+
+            if ($step === $this) {
+                $next = true;
+            }
+        }
+    }
 }

--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -67,7 +67,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
         if (array_key_exists('use_same_address', $requestParams)) {
             $this->use_same_address = (bool) $requestParams['use_same_address'];
             if (!$this->use_same_address) {
-                $this->step_is_current = true;
+                $this->setCurrent(true);
             }
         }
 
@@ -96,7 +96,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
                     $this->use_same_address = true;
                 }
             }
-            $this->step_is_current = true;
+            $this->setCurrent(true);
         }
 
         // Can't really hurt to set the firstname and lastname.
@@ -108,7 +108,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
         if (isset($requestParams['saveAddress'])) {
             $saved = $this->addressForm->fillWith($requestParams)->submit();
             if (!$saved) {
-                $this->step_is_current = true;
+                $this->setCurrent(true);
                 $this->getCheckoutProcess()->setHasErrors(true);
                 if ($requestParams['saveAddress'] === 'delivery') {
                     $this->show_delivery_address_form = true;
@@ -131,7 +131,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             }
         } elseif (isset($requestParams['newAddress'])) {
             // while a form is open, do not go to next step
-            $this->step_is_current = true;
+            $this->setCurrent(true);
             if ($requestParams['newAddress'] === 'delivery') {
                 $this->show_delivery_address_form = true;
             } else {
@@ -141,7 +141,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             $this->form_has_continue_button = $this->use_same_address;
         } elseif (isset($requestParams['editAddress'])) {
             // while a form is open, do not go to next step
-            $this->step_is_current = true;
+            $this->setCurrent(true);
             if ($requestParams['editAddress'] === 'delivery') {
                 $this->show_delivery_address_form = true;
             } else {
@@ -178,10 +178,12 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             }
         }
 
-        if (!$this->step_is_complete) {
-            $this->step_is_complete = isset($requestParams['confirm-addresses']) &&
+        if (isset($requestParams['confirm-addresses'])) {
+            $this->setNextStepAsCurrent();
+            $this->setComplete(
                 $this->getCheckoutSession()->getIdAddressInvoice() &&
-                $this->getCheckoutSession()->getIdAddressDelivery();
+                $this->getCheckoutSession()->getIdAddressDelivery()
+            );
         }
 
         $addresses_count = $this->getCheckoutSession()->getCustomerAddressesCount();
@@ -190,7 +192,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             $this->show_delivery_address_form = true;
         } elseif ($addresses_count < 2 && !$this->use_same_address) {
             $this->show_invoice_address_form = true;
-            $this->step_is_complete = false;
+            $this->setComplete(false);
         }
 
         if ($this->show_invoice_address_form) {

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -123,6 +123,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
     public function handleRequest(array $requestParams = array())
     {
         if (isset($requestParams['delivery_option'])) {
+            $this->setComplete(false);
             $this->getCheckoutSession()->setDeliveryOption(
                 $requestParams['delivery_option']
             );
@@ -139,7 +140,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
             $this->getCheckoutSession()->setMessage($requestParams['delivery_message']);
         }
 
-        if ($this->step_is_reachable && isset($requestParams['confirmDeliveryOption'])) {
+        if ($this->isReachable() && isset($requestParams['confirmDeliveryOption'])) {
             // we're done if
             // - the step was reached (= all previous steps complete)
             // - user has clicked on "continue"
@@ -147,8 +148,12 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
             // - the is a selected delivery option
             // - the module associated to the delivery option confirms
             $deliveryOptions = $this->getCheckoutSession()->getDeliveryOptions();
-            $this->step_is_complete =
-                !empty($deliveryOptions) && $this->getCheckoutSession()->getSelectedDeliveryOption() && $this->isModuleComplete($requestParams);
+            $this->setNextStepAsCurrent();
+            $this->setComplete(
+                !empty($deliveryOptions)
+                && $this->getCheckoutSession()->getSelectedDeliveryOption()
+                && $this->isModuleComplete($requestParams)
+            );
         }
 
         $this->setTitle($this->getTranslator()->trans('Shipping Method', array(), 'Shop.Theme.Checkout'));

--- a/classes/checkout/CheckoutPersonalInformationStep.php
+++ b/classes/checkout/CheckoutPersonalInformationStep.php
@@ -47,7 +47,7 @@ class CheckoutPersonalInformationStepCore extends AbstractCheckoutStep
     public function handleRequest(array $requestParameters = array())
     {
         // personal info step is always reachable
-        $this->step_is_reachable = true;
+        $this->setReachable(true);
 
         $this->registerForm
             ->fillFromCustomer(
@@ -60,23 +60,25 @@ class CheckoutPersonalInformationStepCore extends AbstractCheckoutStep
         if (isset($requestParameters['submitCreate'])) {
             $this->registerForm->fillWith($requestParameters);
             if ($this->registerForm->submit()) {
-                $this->step_is_complete = true;
+                $this->setNextStepAsCurrent();
+                $this->setComplete(true);
             } else {
-                $this->step_is_complete = false;
+                $this->setComplete(false);
                 $this->setCurrent(true);
                 $this->getCheckoutProcess()->setHasErrors(true)->setNextStepReachable();
             }
         } elseif (isset($requestParameters['submitLogin'])) {
             $this->loginForm->fillWith($requestParameters);
             if ($this->loginForm->submit()) {
-                $this->step_is_complete = true;
+                $this->setNextStepAsCurrent();
+                $this->setComplete(true);
             } else {
                 $this->getCheckoutProcess()->setHasErrors(true);
                 $this->show_login_form = true;
             }
         } elseif (array_key_exists('login', $requestParameters)) {
             $this->show_login_form = true;
-            $this->step_is_current = true;
+            $this->setCurrent(true);
         }
 
         $this->logged_in = $this
@@ -85,7 +87,7 @@ class CheckoutPersonalInformationStepCore extends AbstractCheckoutStep
             ->customerHasLoggedIn();
 
         if ($this->logged_in && !$this->getCheckoutSession()->getCustomer()->is_guest) {
-            $this->step_is_complete = true;
+            $this->setComplete(true);
         }
 
         $this->setTitle(

--- a/classes/checkout/CheckoutProcess.php
+++ b/classes/checkout/CheckoutProcess.php
@@ -126,7 +126,7 @@ class CheckoutProcessCore implements RenderableInterface
 
     public function getDataToPersist()
     {
-        $data = array();
+        $data = [];
         foreach ($this->getSteps() as $step) {
             $defaultStepData = array(
                 'step_is_reachable' => $step->isReachable(),
@@ -165,6 +165,7 @@ class CheckoutProcessCore implements RenderableInterface
 
                 break;
             }
+
             if (!$step->isComplete()) {
                 break;
             }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -433,10 +433,10 @@ class CartControllerCore extends FrontController
         if (!$this->id_product_attribute) {
             if ($qty_to_check < $product->minimal_quantity) {
                 $this->errors[] = $this->trans(
-                     'The minimum purchase order quantity for the product %product% is %quantity%.',
-                     array('%product%' => $product->name, '%quantity%' => $product->minimal_quantity),
-                     'Shop.Notifications.Error'
-                 );
+                    'The minimum purchase order quantity for the product %product% is %quantity%.',
+                    array('%product%' => $product->name, '%quantity%' => $product->minimal_quantity),
+                    'Shop.Notifications.Error'
+                );
 
                 return;
             }
@@ -444,10 +444,10 @@ class CartControllerCore extends FrontController
             $combination = new Combination($this->id_product_attribute);
             if ($qty_to_check < $combination->minimal_quantity) {
                 $this->errors[] = $this->trans(
-                     'The minimum purchase order quantity for the product %product% is %quantity%.',
-                     array('%product%' => $product->name, '%quantity%' => $combination->minimal_quantity),
-                     'Shop.Notifications.Error'
-                 );
+                    'The minimum purchase order quantity for the product %product% is %quantity%.',
+                    array('%product%' => $product->name, '%quantity%' => $combination->minimal_quantity),
+                    'Shop.Notifications.Error'
+                );
 
                 return;
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Do not go to the latest step when you change a previous step state. <br>Use accessors instead of method properties.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12456 #9620 
| How to test?  | You must be able to switch between step without loosing data, but you always need to click to continue to go to the next order step.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13106)
<!-- Reviewable:end -->
