### PR TITLE
Fix strpos arguments order

### DIFF
--- a/tools/build/Library/InstallUnpacker/classes/Download.php
+++ b/tools/build/Library/InstallUnpacker/classes/Download.php
@@ -72,7 +72,7 @@ class Download
     {
         $curl_timeout = 60;
 
-        if (!extension_loaded('openssl') && strpos('https://', $url) === true) {
+        if (!extension_loaded('openssl') && strpos($url, 'https://') === true) {
             $url = str_replace('https', 'http', $url);
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Wrong arguments order for strpos function.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13115)
<!-- Reviewable:end -->
