### PR TITLE
Fix incorrect processing of _select_payment.tpl when Catalogue mode is ON.

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2854,6 +2854,7 @@ class AdminOrdersControllerCore extends AdminController
 
         $this->context->smarty->assign(array(
             'payment_modules' => $payment_modules,
+	    'PS_CATALOG_MODE' => Configuration::get('PS_CATALOG_MODE')
         ));
 
         die(Tools::jsonEncode(array(


### PR DESCRIPTION
Missing PS_CATALOG_MODE in function ajaxProcessChangePaymentMethod() for correct _select_payment.tpl processing when Catalogue mode is ON.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Missing PS_CATALOG_MODE variable into function ajaxProcessChangePaymentMethod() of AdminOrdersController for correct _select_payment.tpl processing when Catalogue mode is ON.
| Type?         | bug fix
| Category?     |  BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create an order from the Back-Office with Catalogue mode ON. The Payment method should be "Back-Office order" as coded into _select_payment.tpl .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13116)
<!-- Reviewable:end -->
