### PR TITLE
Allow hookAdditionalCustomerFormFields and --AddressFormFields to modify fields positions

### DIFF
--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -153,7 +153,7 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
         }
 
         //To add the extra fields in address form
-        $additionalAddressFormFields = Hook::exec('additionalCustomerAddressFields', array(), null, true);
+        $additionalAddressFormFields = Hook::exec('additionalCustomerAddressFields', ['fields' => &$format], null, true);
         if (is_array($additionalAddressFormFields)) {
             foreach ($additionalAddressFormFields as $moduleName => $additionnalFormFields) {
                 if (!is_array($additionnalFormFields)) {

--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -227,7 +227,7 @@ class CustomerFormatterCore implements FormFormatterInterface
         }
 
         // ToDo, replace the hook exec with HookFinder when the associated PR will be merged
-        $additionalCustomerFormFields = Hook::exec('additionalCustomerFormFields', array(), null, true);
+        $additionalCustomerFormFields = Hook::exec('additionalCustomerFormFields', ['fields' => &$format], null, true);
 
         if (is_array($additionalCustomerFormFields)) {
             foreach ($additionalCustomerFormFields as $moduleName => $additionnalFormFields) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The hooks AdditionalCustomerFormFields and AdditionalAddressFormFields return an array of FormFields that you have to create, but doesn't receive it as parameter, so you can't insert fields in a specific position.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12755
| How to test?  | Creating a module?

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13119)
<!-- Reviewable:end -->
