### PR TITLE
Fix notice when iso code does not exist in array

### DIFF
--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -564,6 +564,6 @@ class AdminDashboardControllerCore extends AdminController
             'pl' => 'https://www.prestashop.com/pl/kontakt?utm_source=back-office&utm_medium=links&utm_campaign=help-center-pl&utm_content=download17',
         ];
 
-        return $links[$languageCode] ?: $links['en'];
+        return isset($links[$languageCode]) ? $links[$languageCode] : $links['en'];
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Following #13095, this PR fixes a notice when the iso code does not exist
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #13117
| How to test?  | Go to the dashboard with the japan language enabled for the current employee

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13122)
<!-- Reviewable:end -->
