### PR TITLE
Display shop path in Information page

### DIFF
--- a/src/Adapter/Shop/ShopInformation.php
+++ b/src/Adapter/Shop/ShopInformation.php
@@ -57,6 +57,7 @@ class ShopInformation
         return array(
             'version' => AppKernel::VERSION,
             'url' => $this->context->shop->getBaseURL(),
+            'path' => _PS_ROOT_DIR_,
             'theme' => $this->context->shop->theme->getName(),
         );
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -118,6 +118,9 @@
                         <strong>{{ 'Shop URL:'|trans }}</strong> {{ system.shop.url }}
                     </p>
                     <p>
+                        <strong>{{ 'Shop path:'|trans }}</strong> {{ system.shop.path }}
+                    </p>
+                    <p>
                         <strong>{{ 'Current theme in use:'|trans }}</strong> {{ system.shop.theme }}
                     </p>
                 </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Adds shop root path to shop information in the Information BO page, should be useful when you have ftp access but do not know where the relevant shop is installed
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Open the Information page, it should display the path under the shop URL

![image](https://user-images.githubusercontent.com/793712/55288479-3f213080-53b0-11e9-8e01-9b7651829aed.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13123)
<!-- Reviewable:end -->
