### PR TITLE
Fix unknown customer_id error when creating order from BO when catalogue mode is ON…

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1133,7 +1133,8 @@ class AdminOrdersControllerCore extends AdminController
             }
         } elseif (Tools::isSubmit('submitAddOrder') && ($id_cart = Tools::getValue('id_cart')) &&
             ($module_name = Tools::getValue('payment_module_name')) &&
-            ($id_order_state = Tools::getValue('id_order_state')) && Validate::isModuleName($module_name)) {
+            ($id_order_state = Tools::getValue('id_order_state')) &&
+            (Validate::isModuleName($module_name) or Configuration::get('PS_CATALOG_MODE')) ) {
             if ($this->tabAccess['edit'] === '1') {
                 if (!Configuration::get('PS_CATALOG_MODE')) {
                     $payment_module = Module::getInstanceByName($module_name);


### PR DESCRIPTION
… (no payment module)

Adding OR condition Configuration::get('PS_CATALOG_MODE') for isSubmit('submitAddOrder')

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Fix unknown customer_id error when creating order from BO in catalogue mode by adding OR condition Configuration::get('PS_CATALOG_MODE') for isSubmit('submitAddOrder') into AdminOrdersController
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create an order from back-office when configured in CATALOG_MODE and selected payment method is BO order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13124)
<!-- Reviewable:end -->
