### PR TITLE
Add CMS page listing position update functionality

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/cms-page/index.js
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/index.js
@@ -83,4 +83,5 @@ $(() => {
   cmsGrid.addExtension(new BulkActionCheckboxExtension());
   cmsGrid.addExtension(new SubmitBulkExtension());
   cmsGrid.addExtension(new SubmitRowActionExtension());
+  cmsGrid.addExtension(new PositionExtension());
 });

--- a/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
@@ -209,7 +209,7 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
                             'update_method' => 'POST',
                             'update_route' => 'admin_cms_pages_update_position',
                             'record_route_params' => [
-                                'id_parent' => 'id_cms_category',
+                                'id_cms_category' => 'id_cms_category',
                             ],
                         ])
                 );

--- a/src/Core/Grid/Query/CmsPageQueryBuilder.php
+++ b/src/Core/Grid/Query/CmsPageQueryBuilder.php
@@ -166,7 +166,7 @@ final class CmsPageQueryBuilder extends AbstractDoctrineQueryBuilder
 
             if ('position' === $filterName) {
                 $modifiedPositionFilter = $this->getModifiedPositionFilter($value);
-                $qb->andWhere('cc.`' . $filterName . '` = :' . $filterName);
+                $qb->andWhere('c.`' . $filterName . '` = :' . $filterName);
                 $qb->setParameter($filterName, $modifiedPositionFilter);
                 continue;
             }

--- a/src/Core/Grid/Query/CmsPageQueryBuilder.php
+++ b/src/Core/Grid/Query/CmsPageQueryBuilder.php
@@ -157,10 +157,17 @@ final class CmsPageQueryBuilder extends AbstractDoctrineQueryBuilder
                 continue;
             }
 
-            if (in_array($filterName, ['id_cms', 'active', 'position'], true)) {
+            if (in_array($filterName, ['id_cms', 'active'], true)) {
                 $qb->andWhere('c.`' . $filterName . '` = :' . $filterName);
                 $qb->setParameter($filterName, $value);
 
+                continue;
+            }
+
+            if ('position' === $filterName) {
+                $modifiedPositionFilter = $this->getModifiedPositionFilter($value);
+                $qb->andWhere('cc.`' . $filterName . '` = :' . $filterName);
+                $qb->setParameter($filterName, $modifiedPositionFilter);
                 continue;
             }
 
@@ -169,5 +176,26 @@ final class CmsPageQueryBuilder extends AbstractDoctrineQueryBuilder
         }
 
         return $qb;
+    }
+
+    /**
+     * Gets modified position filter value. This is required due to in database position filter index starts from 0 and
+     * for the customer which wants to filter results the value starts from 1 instead.
+     *
+     * @param $positionFilterValue
+     *
+     * @return int|null - if null is returned then no results are found since position field does not hold null values
+     */
+    private function getModifiedPositionFilter($positionFilterValue)
+    {
+        if (!is_numeric($positionFilterValue)) {
+            return null;
+        }
+        $reducedByOneFilterValue = $positionFilterValue - 1;
+        if (0 > $reducedByOneFilterValue) {
+            return null;
+        }
+
+        return $reducedByOneFilterValue;
     }
 }

--- a/src/Core/Grid/Query/CmsPageQueryBuilder.php
+++ b/src/Core/Grid/Query/CmsPageQueryBuilder.php
@@ -79,6 +79,7 @@ final class CmsPageQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $qb
             ->select('c.`id_cms`, cl.`link_rewrite`, c.`active`, c.`position`, cl.`meta_title`, cl.`head_seo_title`')
+            ->addSelect('c.`id_cms_category`')
             ->groupBy('c.`id_cms`')
         ;
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -492,7 +492,6 @@ class CmsPageController extends FrameworkBundleAdminController
             'parentId' => $cmsCategoryParentId,
         ];
 
-
         $positionDefinition = $this->get('prestashop.core.grid.cms_page.position_definition');
         $positionUpdateFactory = $this->get('prestashop.core.grid.position.position_update_factory');
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -464,6 +464,63 @@ class CmsPageController extends FrameworkBundleAdminController
     }
 
     /**
+     * Updates cms page listing position.
+     *
+     * @AdminSecurity(
+     *     "is_granted('update', request.get('_legacy_controller'))",
+     *      redirectRoute="admin_cms_pages_index",
+     *      redirectQueryParamsToKeep={"id_cms_category"},
+     *      message="You do not have permission to edit this."
+     * )
+     * @DemoRestricted(
+     *     redirectRoute="admin_cms_pages_index",
+     *     redirectQueryParamsToKeep={"id_cms_category"}
+     * )
+     *
+     * @param int $cmsCategoryId
+     *
+     * @return RedirectResponse
+     *
+     * @throws CmsPageCategoryException
+     */
+    public function updateCmsPositionAction(Request $request)
+    {
+        $cmsCategoryParentId = $request->query->getInt('id_cms_category') ?:
+            CmsPageRootCategorySettings::ROOT_CMS_PAGE_CATEGORY_ID
+        ;
+
+        $positionsData = [
+            'positions' => $request->request->get('positions'),
+            'parentId' => $cmsCategoryParentId,
+        ];
+
+
+        $positionDefinition = $this->get('prestashop.core.grid.cms_page.position_definition');
+        $positionUpdateFactory = $this->get('prestashop.core.grid.position.position_update_factory');
+
+        try {
+            $positionUpdate = $positionUpdateFactory->buildPositionUpdate($positionsData, $positionDefinition);
+        } catch (PositionDataException $e) {
+            $errors = [$e->toArray()];
+            $this->flashErrors($errors);
+
+            return $this->redirectToParentIndexPage($cmsCategoryParentId);
+        }
+
+        $updater = $this->get('prestashop.core.grid.position.doctrine_grid_position_updater');
+
+        try {
+            $updater->update($positionUpdate);
+            $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+        } catch (PositionUpdateException $e) {
+            $errors = [$e->toArray()];
+            $this->flashErrors($errors);
+        }
+
+        return $this->redirectToIndexPageById($cmsCategoryParentId);
+    }
+
+    /**
      * Toggles cms page category status.
      *
      * @AdminSecurity(

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -477,8 +477,6 @@ class CmsPageController extends FrameworkBundleAdminController
      *     redirectQueryParamsToKeep={"id_cms_category"}
      * )
      *
-     * @param int $cmsCategoryId
-     *
      * @return RedirectResponse
      *
      * @throws CmsPageCategoryException

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -429,7 +429,7 @@ class CmsPageController extends FrameworkBundleAdminController
     public function updateCmsCategoryPositionAction(Request $request)
     {
         $cmsCategoryParentId = $request->query->getInt('id_cms_category') ?:
-            CmsPageRootCategorySettings::ROOT_CMS_PAGE_CATEGORY_ID
+            CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID
         ;
 
         $positionsData = [
@@ -484,7 +484,7 @@ class CmsPageController extends FrameworkBundleAdminController
     public function updateCmsPositionAction(Request $request)
     {
         $cmsCategoryParentId = $request->query->getInt('id_cms_category') ?:
-            CmsPageRootCategorySettings::ROOT_CMS_PAGE_CATEGORY_ID
+            CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID
         ;
 
         $positionsData = [

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -168,3 +168,10 @@ admin_cms_pages_category_update_position:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:updateCmsCategoryPosition'
     _legacy_controller: AdminCmsContent
     _legacy_link: AdminCmsContent:updatecms_category
+
+admin_cms_pages_update_position:
+  path: /update-position
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:updateCmsPosition'
+    _legacy_controller: AdminCmsContent

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -175,3 +175,4 @@ admin_cms_pages_update_position:
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\Design\CmsPage:updateCmsPosition'
     _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:updatecms

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -143,4 +143,6 @@ services:
         arguments:
           - '@prestashop.core.query_bus'
           - '@request_stack'
+          - '@prestashop.adapter.shop.context'
+          - '@=service("prestashop.adapter.multistore_feature").isUsed()'
         public: true

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_position_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_position_definition_factory.yml
@@ -10,3 +10,10 @@ services:
       $positionField: 'position'
       $parentIdField: 'id_parent'
 
+  prestashop.core.grid.cms_page.position_definition:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinition'
+    arguments:
+      $table: 'cms'
+      $idField: 'id_cms'
+      $positionField: 'position'
+      $parentIdField: 'id_cms_category'


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | adds usage of new PositionColumn functionality in the list. Also fixes filtering problem.
| Type?         |  improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | npm run dev or npm run build and start dragging the position column in the second list located in **admin-dev/index.php/improve/design/cms-pages/**

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13125)
<!-- Reviewable:end -->
