### PR TITLE
Add variable to tell if prices are tax included or not

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1526,6 +1526,7 @@ class FrontControllerCore extends Controller
 
         return array(
             'display_taxes_label' => $this->getDisplayTaxesLabel(),
+            'display_prices_tax_incl' => (bool) (new TaxConfiguration())->includeTaxes(),
             'low_quantity_threshold' => (int) Configuration::get('PS_LAST_QTIES'),
             'is_b2b' => (bool) Configuration::get('PS_B2B_ENABLE'),
             'is_catalog' => (bool) Configuration::isCatalogMode(),

--- a/src/Core/Filter/FrontEndObject/ConfigurationFilter.php
+++ b/src/Core/Filter/FrontEndObject/ConfigurationFilter.php
@@ -38,6 +38,7 @@ class ConfigurationFilter extends HashMapWhitelistFilter
     {
         $whitelist = array(
             'display_taxes_label',
+            'display_prices_tax_incl',
             'is_catalog',
             'opt_in',
             'quantity_discount',


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Adds a variable (available in smarty and `prestashop` JS object) which allows people to tell if the configuration is set to display prices including tax or not.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Nothing to test really

This PR will help in making #13047 cleaner

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13135)
<!-- Reviewable:end -->
