### PR TITLE
[*] FIX : Tool's redirect method

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -191,9 +191,14 @@ class ToolsCore
             }
 
             $explode = explode('?', $url);
-            // don't use ssl if url is home page
-            // used when logout for example
-            $use_ssl = !empty($url);
+            if (Configuration::get('PS_SSL_ENABLED_EVERYWHERE')) {
+				$use_ssl = true;
+			} else {
+				// don't use ssl if url is home page
+				// used when logout for example
+				$use_ssl = !empty($url);
+			}
+            
             $url = $link->getPageLink($explode[0], $use_ssl);
             if (isset($explode[1])) {
                 $url .= '?' . $explode[1];


### PR DESCRIPTION
When SSL is activated. It's needed to check the configuration before redirect.
exemple : create an account, when the shop is HTTPS full activated, redirects to same page with account's creation form.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When SSL is activated. It's needed to check the configuration before redirect.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | create an account, when the shop is HTTPS full activated, redirects to same page with account's creation form.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13137)
<!-- Reviewable:end -->
