### PR TITLE
[POC] Allow trans() to fall back on the legacy translation system when used with modules

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -161,11 +161,21 @@ class TranslateCore
      * @param null $sprintf
      * @param bool $js
      * @param string|null $locale
+     * @param bool $fallback [default=true] If true, this method falls back to the new translation system if no translation is found
      *
      * @return mixed|string
+     *
+     * @throws Exception
      */
-    public static function getModuleTranslation($module, $originalString, $source, $sprintf = null, $js = false, $locale = null)
-    {
+    public static function getModuleTranslation(
+        $module,
+        $originalString,
+        $source,
+        $sprintf = null,
+        $js = false,
+        $locale = null,
+        $fallback = true
+    ) {
         global $_MODULES, $_MODULE, $_LANGADM;
 
         static $langCache = array();
@@ -276,7 +286,7 @@ class TranslateCore
          * Native modules working on both 1.6 & 1.7 are translated in messages.xlf
          * So we need to check in the Symfony catalog for translations
          */
-        if ($ret === $originalString) {
+        if ($ret === $originalString && $fallback) {
             $ret = Context::getContext()->getTranslator()->trans($originalString, $sprintf_for_trans, null, $locale);
         }
 

--- a/src/Adapter/Localization/LegacyTranslator.php
+++ b/src/Adapter/Localization/LegacyTranslator.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Localization;
+
+use Translate;
+
+/**
+ * Wraps the Legacy translation system
+ *
+ * @deprecated The legacy translation system will be removed in the next major version
+ */
+class LegacyTranslator
+{
+    /**
+     * @param string $moduleName Module name
+     * @param string $originalString String to translate
+     * @param string|false $source
+     * @param null $sprintf
+     * @param bool $js
+     * @param null $locale
+     * @param bool $fallback
+     *
+     * @return mixed|string
+     *
+     * @throws \Exception
+     */
+    public function translate(
+        $moduleName,
+        $originalString,
+        $source,
+        $sprintf = null,
+        $js = false,
+        $locale = null,
+        $fallback = true
+    ) {
+        return Translate::getModuleTranslation($moduleName, $originalString, $source, $sprintf, $js, $locale, $fallback);
+    }
+}

--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -27,26 +27,44 @@
 
 namespace PrestaShopBundle\Translation;
 
+use PrestaShop\PrestaShop\Adapter\Localization\LegacyTranslator;
+use Symfony\Component\Translation\Exception\InvalidArgumentException;
+
 trait PrestaShopTranslatorTrait
 {
     public static $regexSprintfParams = '#(?:%%|%(?:[0-9]+\$)?[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFosxX])#';
     public static $regexClassicParams = '/%\w+%/';
 
     /**
-     * @todo: add the right PHPDoc
+     * Translates the given message.
+     *
+     * @param string $id The message id (may also be an object that can be cast to string)
+     * @param array $parameters An array of parameters for the message
+     * @param string|null $domain The domain for the message or null to use the default
+     * @param string|null $locale The locale or null to use the default
+     *
+     * @return string The translated string
+     *
+     * @throws InvalidArgumentException If the locale contains invalid characters
      */
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
-        if (null !== $domain) {
-            $domain = str_replace('.', '', $domain);
-        }
+        $normalizedDomain = (null !== $domain) ?
+            str_replace('.', '', $domain)
+            : null;
 
         if (isset($parameters['legacy'])) {
             $legacy = $parameters['legacy'];
             unset($parameters['legacy']);
         }
 
-        $translated = parent::trans($id, array(), $domain, $locale);
+        $translated = parent::trans($id, array(), $normalizedDomain, $locale);
+
+        // @todo to remove after the legacy translation system has ben phased out
+        if ($this->shouldFallbackToLegacyModuleTranslation($id, $normalizedDomain, $translated)) {
+            return $this->translateUsingLegacySystem($id, $parameters, $domain, $locale);
+        }
+
         if (isset($legacy) && 'htmlspecialchars' === $legacy) {
             $translated = call_user_func($legacy, $translated, ENT_NOQUOTES);
         } elseif (isset($legacy)) {
@@ -63,9 +81,16 @@ trait PrestaShopTranslatorTrait
     }
 
     /**
-     * @todo: remove this function at it relies on a function not
-     * available in the trait.
-     * Also $locale is unused.
+     * Performs a reverse search in the catalogue and returns the translation key if found.
+     * AVOID USING THIS, IT PROVIDES APPROXIMATE RESULTS.
+     *
+     * @param string $translated Translated string
+     * @param string $domain Translation domain
+     * @param string|null $locale Unused
+     *
+     * @return string The translation
+     *
+     * @deprecated This method should not be used and will be removed
      */
     public function getSourceString($translated, $domain, $locale = null)
     {
@@ -84,7 +109,17 @@ trait PrestaShopTranslatorTrait
     }
 
     /**
-     * @todo: add the right PHPDoc
+     * Translates the given choice message by choosing a translation according to a number.
+     *
+     * @param string $id The message id (may also be an object that can be cast to string)
+     * @param int $number The number to use to find the index of the message
+     * @param array $parameters An array of parameters for the message
+     * @param string|null $domain The domain for the message or null to use the default
+     * @param string|null $locale The locale or null to use the default
+     *
+     * @return string The translated string
+     *
+     * @throws InvalidArgumentException If the locale contains invalid characters
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
@@ -108,5 +143,50 @@ trait PrestaShopTranslatorTrait
     {
         return (bool) preg_match_all(static::$regexSprintfParams, $string)
             && !(bool) preg_match_all(static::$regexClassicParams, $string);
+    }
+
+    /**
+     * Tries to translate the provided message using the legacy system
+     *
+     * @param string $message
+     * @param array $parameters
+     * @param string $domain
+     * @param string|null $locale
+     *
+     * @return mixed|string
+     *
+     * @throws \Exception
+     */
+    private function translateUsingLegacySystem($message, array $parameters, $domain, $locale = null)
+    {
+        $domainParts = explode('.', $domain);
+        if (count($domainParts) < 2) {
+            throw new InvalidArgumentException(sprintf('Invalid domain: "%s"', $domain));
+        }
+        $moduleName = strtolower($domainParts[1]);
+        $sourceFile = (!empty($domainParts[2])) ? strtolower($domainParts[2]) : false;
+
+        return (new LegacyTranslator())->translate($moduleName, $message, $sourceFile, $parameters, false, $locale, false);
+    }
+
+    /**
+     * Indicates if we should try and translate the provided wording using the legacy system
+     *
+     * @param string $message Message to translate
+     * @param string $domain Translation domain
+     * @param string $translated Message after first translation attempt
+     *
+     * @return bool
+     */
+    private function shouldFallbackToLegacyModuleTranslation($message, $domain, $translated)
+    {
+        return
+            $message === $translated
+            && 'Modules' === substr($domain, 0, 7)
+            && (
+                !method_exists($this, 'getCatalogue')
+                || !$this->getCatalogue()->has($message, $domain)
+            )
+        ;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This change allows to use `trans()` in Modern modules by falling back to the legacy translation system.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | Fixes #13039 
| How to test?  | Create a module, translate it using the legacy system, then use `trans()` in an AdminController or in a twig template.

This PR allows the translation system to fall back on the legacy system on the following conditions:

1. The translated wording looks the same as the translation key
2. The translation key is not found in the translation catalogue
3. The translation domain starts with "Modules"
4. The translation domain looks like "Modules.SomeModuleName"

If all of those are true, then the translation system will try to find the module named "somemodule" (in lower case) and use its translations.

Extra: If the translation domain has a third part, it will also be used in the legacy system (also in lowercase).

---

This PR needs to be tested with an actual module to make sure it works as intended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13138)
<!-- Reviewable:end -->
