### PR TITLE
Performance: avoid useless attributes queries

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6234,6 +6234,10 @@ class ProductCore extends ObjectModel
      */
     public static function getAttributesParams($id_product, $id_product_attribute)
     {
+        if ($id_product_attribute == 0) {
+            return array();
+        }
+        
         $id_lang = (int) Context::getContext()->language->id;
         $cache_id = 'Product::getAttributesParams_' . (int) $id_product . '-' . (int) $id_product_attribute . '-' . (int) $id_lang;
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6235,7 +6235,7 @@ class ProductCore extends ObjectModel
     public static function getAttributesParams($id_product, $id_product_attribute)
     {
         if ($id_product_attribute == 0) {
-            return array();
+            return [];
         }
         $id_lang = (int) Context::getContext()->language->id;
         $cache_id = 'Product::getAttributesParams_' . (int) $id_product . '-' . (int) $id_product_attribute . '-' . (int) $id_lang;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6237,7 +6237,6 @@ class ProductCore extends ObjectModel
         if ($id_product_attribute == 0) {
             return array();
         }
-        
         $id_lang = (int) Context::getContext()->language->id;
         $cache_id = 'Product::getAttributesParams_' . (int) $id_product . '-' . (int) $id_product_attribute . '-' . (int) $id_lang;
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Performance : avoid useless attributes queries
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | apply the patch , activate debug Profling and compare queries count<br><br>this pull can avoid several queries, as `Product::getAttributesParams($id_product, $id_product_attribute)` is called at each `public static function getProductProperties($id_lang, $row, Context $context = null)` itself called by each product "Assembled" by the product assembler. (`classes/ProductAssembler.php`)<br>regards

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13141)
<!-- Reviewable:end -->
