### PR TITLE
Fix bug with incorrect error display within the forms

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -642,7 +642,6 @@
 {% endblock material_multiple_choice_table_widget %}
 
 {% block translatable_widget -%}
-  {{ form_errors(form) }}
   <div class="input-group locale-input-group js-locale-input-group d-flex">
     {% for translateField in form %}
       {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -103,9 +103,34 @@
   appears with the errors combined by language.
 #}
 {% macro form_widget_with_error(form, vars, extraVars) %}
+  {% import '@PrestaShop/Admin/macros.html.twig' as self %}
+
   {% set vars = vars|default({}) %}
   {% set extraVars = extraVars|default({}) %}
   {% set attr = vars.attr|default({}) %}
+  {% set attr = attr|merge({'class': (attr.class is defined ? attr.class : '')} ) %}
+  {% set vars = vars|merge({'attr': attr}) %}
+
+  {{ form_widget(form, vars) }}
+
+  {% if extraVars.help is defined %}
+    <small class="form-text">{{ extraVars.help }}</small>
+  {% endif %}
+
+  {{ self.form_error_with_popover(form) }}
+
+{% endmacro %}
+
+{#
+  It displays all nested errors for any form type.
+  If form type has error_by_locale parameter set then the error is being displayed with the specific locale assigned to it.
+  If form type has errors_by_locale parameter set then the errors are being assigned to the locales and are displayed
+  in the popover template.
+  If there are more then one error it also assigns all errors in the pop-up to appear.
+  On page load, user sees only the errors count but then user hovers over the element the popover
+  appears with the errors combined by language.
+#}
+{% macro form_error_with_popover(form) %}
   {% set errors = [] %}
 
   {% if form.vars.valid is defined and not form.vars.valid  %}
@@ -121,15 +146,6 @@
     {% endfor %}
   {% endif %}
 
-  {% set attr = attr|merge({'class': (attr.class is defined ? attr.class : '')} ) %}
-  {% set vars = vars|merge({'attr': attr}) %}
-
-  {{ form_widget(form, vars) }}
-
-  {% if extraVars.help is defined %}
-    <small class="form-text">{{ extraVars.help }}</small>
-  {% endif %}
-
   {% if errors|length > 0 %}
     {# for form types which has locales and there are more then 1 error , additional errors are displaying inside popover #}
     {% set errorPopover = null %}
@@ -138,35 +154,49 @@
       {% set popoverContainer = 'popover-error-container-'~form.vars.id %}
       <div class="{{ popoverContainer }}"></div>
 
+
       {% if form.vars.errors_by_locale is defined %}
           {% set popoverErrors = form.vars.errors_by_locale %}
 
-          {% set popoverErrorContent %}
-            <div class="popover-error-list">
-              <ul>
-                {% for popoverError in popoverErrors %}
-                  <li class="text-danger">
-                    {{ '%error_message% - Language: %language_name%'|trans({'%error_message%': popoverError.error_message, '%language_name%': popoverError.locale_name}, 'Admin.Notifications.Error') }}
-                  </li>
-                {% endfor %}
-              </ul>
-            </div>
-          {% endset %}
+          {# collecting translatable errors - the ones which has locale name attached #}
+          {% set translatableErrors = [] %}
+          {% for translatableError in popoverErrors %}
+            {% set translatableErrors = translatableErrors|merge([translatableError.error_message]) %}
+          {% endfor %}
+
+          {# if an error found which does not exist in translatable errors array - it adds it to the popover error container #}
+          {% for error in errors %}
+            {% if error not in translatableErrors %}
+              {% set popoverErrors = popoverErrors|merge([error]) %}
+            {% endif %}
+          {% endfor %}
+
         {% else %}
           {% set popoverErrors = errors %}
-
-          {% set popoverErrorContent %}
-            <div class="popover-error-list">
-              <ul>
-                {% for popoverError in popoverErrors %}
-                  <li class="text-danger">
-                    {{ popoverError }}
-                  </li>
-                {% endfor %}
-              </ul>
-            </div>
-          {% endset %}
       {% endif %}
+
+      {% set errorMessages = [] %}
+      {% for popoverError in popoverErrors %}
+        {% set errorMessage = popoverError %}
+
+        {% if popoverError.error_message is defined and popoverError.locale_name is defined %}
+          {% set errorMessage = '%error_message% - Language: %language_name%'|trans({'%error_message%': popoverError.error_message, '%language_name%': popoverError.locale_name}, 'Admin.Notifications.Error') %}
+        {% endif %}
+
+        {% set errorMessages = errorMessages|merge([errorMessage]) %}
+      {% endfor %}
+
+      {% set popoverErrorContent %}
+        <div class="popover-error-list">
+          <ul>
+            {% for popoverError in errorMessages %}
+              <li class="text-danger">
+                {{ popoverError }}
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endset %}
 
       <template class="js-popover-error-content" data-id="{{ form.vars.id }}">
         {{ popoverErrorContent }}
@@ -185,27 +215,27 @@
         </span>
       {% endset %}
 
-      {% elseif form.vars.error_by_locale is defined %}
-        {% set errorByLocale = '%error_message% - Language: %language_name%'|trans({'%error_message%': form.vars.error_by_locale.error_message, '%language_name%': form.vars.error_by_locale.locale_name}, 'Admin.Notifications.Error') %}
-        {% set errors = [errorByLocale] %}
+    {% elseif form.vars.error_by_locale is defined %}
+      {% set errorByLocale = '%error_message% - Language: %language_name%'|trans({'%error_message%': form.vars.error_by_locale.error_message, '%language_name%': form.vars.error_by_locale.locale_name}, 'Admin.Notifications.Error') %}
+      {% set errors = [errorByLocale] %}
     {% endif %}
 
     <div class="invalid-feedback-container">
       {% if errorPopover is not null %}
-          <div class="text-danger">
-            {{ errorPopover }}
-          </div>
-        {% else %}
-          <div class="d-inline-block text-danger align-top">
-            <i class="material-icons form-error-icon">error_outline</i>
-          </div>
-          <div class="d-inline-block">
-            {% for error in errors %}
-              <div class="text-danger">
-                {{ error }}
-              </div>
-            {% endfor %}
-          </div>
+        <div class="text-danger">
+          {{ errorPopover }}
+        </div>
+      {% else %}
+        <div class="d-inline-block text-danger align-top">
+          <i class="material-icons form-error-icon">error_outline</i>
+        </div>
+        <div class="d-inline-block">
+          {% for error in errors %}
+            <div class="text-danger">
+              {{ error }}
+            </div>
+          {% endfor %}
+        </div>
       {% endif %}
     </div>
   {% endif %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | for translatable type inputs different type errors such as DefaultLanguage constraint and IsUrlRewrite contraint together generated message: see image below :arrow_down_small: and after the fix the message looks like this: see second image below :arrow_down_small: 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Check several migrated controllers - check how errors area appearing for multilanguage fields and for regular fields. E.g test Seo & urls meta form and leave a default language empty and for another language make a mistake intentionaly and check how it looks like.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

first image with the problem:

![Screenshot(11)](https://user-images.githubusercontent.com/17051250/55409808-62dca600-556b-11e9-90f6-487032e1d379.png)

second image with the problem fix:

![Screenshot from 2019-04-02 17-20-05](https://user-images.githubusercontent.com/17051250/55409939-a33c2400-556b-11e9-9c75-25038c9178cf.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13145)
<!-- Reviewable:end -->
