### PR TITLE
Fixes missing fields validation in Language command handlers

### DIFF
--- a/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
@@ -106,6 +106,10 @@ final class AddLanguageHandler extends AbstractLanguageHandler implements AddLan
         $language->is_rtl = $command->isRtl();
         $language->active = $command->isActive();
 
+        if (false === $language->validateFields(false)) {
+            throw new LanguageException('Cannot add language with invalid data');
+        }
+
         if (false === $language->add()) {
             throw new LanguageException(
                 sprintf('Failed to add new language "%s"', $command->getName())

--- a/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
@@ -101,6 +101,10 @@ final class EditLanguageHandler extends AbstractLanguageHandler implements EditL
             $language->active = $command->isActive();
         }
 
+        if (false === $language->validateFields(false)) {
+            throw new LanguageException('Cannot add language with invalid data');
+        }
+
         if (false === $language->update()) {
             throw new LanguageException(
                 sprintf('Cannot update language with id "%s"', $language->id)

--- a/src/Core/ConstraintValidator/TypedRegexConstraintValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexConstraintValidator.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\ConstraintValidator;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegexConstraint;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
@@ -84,6 +85,8 @@ class TypedRegexConstraintValidator extends ConstraintValidator
             'post_code' => '/^[a-zA-Z 0-9-]+$/',
             'phone_number' => '/^[+0-9. ()\/-]*$/',
             'message' => '/[<>{}]/i',
+            'language_iso_code' => IsoCode::PATTERN,
+            'language_code' => '/^[a-zA-Z]{2}(-[a-zA-Z]{2})?$/',
         ];
 
         if (isset($typePatterns[$type])) {

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\International\Language;
 
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegexConstraint;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -70,6 +71,9 @@ class LanguageType extends AbstractType
                     new NotBlank([
                         'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
                     ]),
+                    new TypedRegexConstraint([
+                        'type' => 'generic_name',
+                    ]),
                 ],
             ])
             ->add('iso_code', TextType::class, [
@@ -77,9 +81,8 @@ class LanguageType extends AbstractType
                     new NotBlank([
                         'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
                     ]),
-                    new Regex([
-                        'pattern' => IsoCode::PATTERN,
-                        'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                    new TypedRegexConstraint([
+                        'type' => 'language_iso_code',
                     ]),
                 ],
             ])
@@ -88,9 +91,8 @@ class LanguageType extends AbstractType
                     new NotBlank([
                         'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
                     ]),
-                    new Regex([
-                        'pattern' => '/^[a-zA-Z]{2}(-[a-zA-Z]{2})?$/',
-                        'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                    new TypedRegexConstraint([
+                        'type' => 'language_code',
                     ]),
                 ],
             ])
@@ -100,6 +102,9 @@ class LanguageType extends AbstractType
                         'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
                     ]),
                     new Regex([
+                        // We can't really check if this is valid or not,
+                        // because this is a string and you can write whatever you want in it.
+                        // That's why only < et > are forbidden (HTML).
                         'pattern' => '/^[^<>]+$/',
                         'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
                     ]),

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\Improve\International\Language;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegexConstraint;
-use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This fixes missing `validateFields()` validation on legacy object model.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Not sure if it can be validated by QA, because form validation already prevented user from attempting to create invalid Language.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13146)
<!-- Reviewable:end -->
