### PR TITLE
Add a missing space that could trigger an SQL error

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -490,8 +490,8 @@ class CategoryCore extends ObjectModel
             $chunks = array_chunk($queries, 5000);
             foreach ($chunks as $chunk) {
                 $sqlChunk = array_map(function ($value) { return '(' . rtrim(implode(',', $value)) . ')'; }, $chunk);
-                Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'category` (id_category, nleft, nright) 
-                VALUES ' . rtrim(implode(',', $sqlChunk), ',') . ' 
+                Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'category` (id_category, nleft, nright)
+                VALUES ' . rtrim(implode(',', $sqlChunk), ',') . '
                 ON DUPLICATE KEY UPDATE nleft=VALUES(nleft), nright=VALUES(nright)');
             }
         }
@@ -858,12 +858,12 @@ class CategoryCore extends ObjectModel
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 		SELECT c.`id_category`, cl.`name`, c.id_parent
 		FROM `' . _DB_PREFIX_ . 'category` c
-		LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl 
+		LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl
 		ON (c.`id_category` = cl.`id_category`' . Shop::addSqlRestrictionOnLang('cl') . ')
 		' . Shop::addSqlAssociation('category', 'c') . '
 		WHERE cl.`id_lang` = ' . (int) $idLang . '
         AND c.`nleft` >= ' . (int) $rootTreeInfo['nleft'] . '
-        AND c.`nright` <= ' . (int) $rootTreeInfo['nright'] . '		
+        AND c.`nright` <= ' . (int) $rootTreeInfo['nright'] . '
 		GROUP BY c.id_category
 		ORDER BY c.`id_category`, category_shop.`position`');
     }
@@ -971,7 +971,7 @@ class CategoryCore extends ObjectModel
 					WHERE cp.`id_category` = ' . (int) $this->id .
                 ($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '') .
                 ($active ? ' AND product_shop.`active` = 1' : '') .
-                ($idSupplier ? 'AND p.id_supplier = ' . (int) $idSupplier : '');
+                ($idSupplier ? ' AND p.id_supplier = ' . (int) $idSupplier : '');
 
             return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
         }
@@ -1563,7 +1563,7 @@ class CategoryCore extends ObjectModel
 
         if (!empty($treeInfo)) {
             $rootTreeInfo = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow(
-                'SELECT c.`nleft`, c.`nright` FROM `' . _DB_PREFIX_ . 'category` c 
+                'SELECT c.`nleft`, c.`nright` FROM `' . _DB_PREFIX_ . 'category` c
             WHERE c.`id_category` = ' . (int) $context->shop->id_category
             );
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The missing space would trigger an SQL syntax error if `$idSupplier` was true
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | It happened on my FO on the /supplier/{id}-{rewrite} (Supplier page should be activated)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13150)
<!-- Reviewable:end -->
