### PR TITLE
Fix error bubbling inside the translatable type

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
@@ -83,7 +83,6 @@ abstract class AbstractCategoryType extends TranslatorAwareType
     {
         $builder
             ->add('name', TranslatableType::class, [
-                'error_bubbling' => false,
                 'type' => TextType::class,
                 'constraints' => [
                     new DefaultLanguage(),
@@ -167,7 +166,6 @@ abstract class AbstractCategoryType extends TranslatorAwareType
             ])
             ->add('link_rewrite', TranslatableType::class, [
                 'type' => TextType::class,
-                'error_bubbling' => false,
                 'constraints' => [
                     new DefaultLanguage(),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -46,7 +46,6 @@ class ProfileType extends AbstractType
         $builder
             ->add('name', TranslatableType::class, [
                 'type' => TextType::class,
-                'error_bubbling' => false,
                 'constraints' => [
                     new DefaultLanguage(),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
@@ -77,7 +77,6 @@ class ContactType extends AbstractType
     {
         $builder
             ->add('title', TranslatableType::class, [
-                'error_bubbling' => false,
                 'constraints' => [
                     new DefaultLanguage(),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
@@ -167,7 +167,6 @@ class MetaType extends AbstractType
             if (isset($formData['page_name']) && 'index' !== $formData['page_name']) {
                 $form = $event->getForm();
                 $form->add('url_rewrite', TranslatableType::class, [
-                    'error_bubbling' => false,
                     'constraints' => [
                         new DefaultLanguage(),
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -74,7 +74,6 @@ class CmsPageCategoryType extends AbstractType
 
         $builder
             ->add('name', TranslatableType::class, [
-                'error_bubbling' => false,
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
@@ -157,7 +156,6 @@ class CmsPageCategoryType extends AbstractType
                 ],
             ])
             ->add('friendly_url', TranslatableType::class, [
-                'error_bubbling' => false,
                 'constraints' => [
                     new DefaultLanguage(),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -86,7 +86,6 @@ class CmsPageType extends AbstractType
                 'choice_value' => 'id_cms_category',
             ])
             ->add('title', TranslatableType::class, [
-                'error_bubbling' => false,
                 'constraints' => [
                     new DefaultLanguage([
                         'message' => $this->translator->trans(
@@ -172,7 +171,6 @@ class CmsPageType extends AbstractType
                 ],
             ])
             ->add('friendly_url', TranslatableType::class, [
-                'error_bubbling' => false,
                 'constraints' => [
                     new DefaultLanguage([
                         'message' => $this->translator->trans(

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -130,6 +130,7 @@ class TranslatableType extends AbstractType
             'type' => TextType::class,
             'options' => [],
             'locales' => $this->locales,
+            'error_bubbling' => false,
         ]);
 
         $resolver->setAllowedTypes('locales', 'array');


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | For developers its easy to forget that for translatable type when constraint is applied for whole type, such as 'DefaultLanguage' error bubbling must be set to false in order to see the errors near the input. 
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13107
| How to test?  | for example check the Seo & cms page form and dont enter anything in Rewritten URL  field for default language - the beautiful error should be displayed below the input

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13158)
<!-- Reviewable:end -->
