### PR TITLE
Remove 'Constraint' suffix from TypedRegex constraint and validator

### DIFF
--- a/src/Core/ConstraintValidator/Constraints/TypedRegex.php
+++ b/src/Core/ConstraintValidator/Constraints/TypedRegex.php
@@ -26,13 +26,13 @@
 
 namespace PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints;
 
-use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexConstraintValidator;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use Symfony\Component\Validator\Constraint;
 
 /**
  * Provides regex validation by type
  */
-class TypedRegexConstraint extends Constraint
+class TypedRegex extends Constraint
 {
     /**
      * @var string
@@ -57,6 +57,6 @@ class TypedRegexConstraint extends Constraint
      */
     public function validatedBy()
     {
-        return TypedRegexConstraintValidator::class;
+        return TypedRegexValidator::class;
     }
 }

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Core\ConstraintValidator;
 
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegexConstraint;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
@@ -36,15 +36,15 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 /**
  * Validates specific regex pattern for provided type
  */
-class TypedRegexConstraintValidator extends ConstraintValidator
+class TypedRegexValidator extends ConstraintValidator
 {
     /**
      * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
     {
-        if (!$constraint instanceof TypedRegexConstraint) {
-            throw new UnexpectedTypeException($constraint, TypedRegexConstraint::class);
+        if (!$constraint instanceof TypedRegex) {
+            throw new UnexpectedTypeException($constraint, TypedRegex::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -27,7 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegexConstraint;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -52,7 +52,7 @@ class ProfileType extends AbstractType
                 ],
                 'options' => [
                     'constraints' => [
-                        new TypedRegexConstraint([
+                        new TypedRegex([
                             'type' => 'generic_name',
                         ]),
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -29,7 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Improve\Design\Pages;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\IsUrlRewrite;
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegexConstraint;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -106,7 +106,7 @@ class CmsPageType extends AbstractType
                         'class' => 'js-copier-source-title',
                     ],
                     'constraints' => [
-                        new TypedRegexConstraint([
+                        new TypedRegex([
                             'type' => 'generic_name',
                         ]),
                         new Length([
@@ -124,7 +124,7 @@ class CmsPageType extends AbstractType
                 'required' => false,
                 'options' => [
                     'constraints' => [
-                        new TypedRegexConstraint([
+                        new TypedRegex([
                             'type' => 'generic_name',
                         ]),
                         new Length([
@@ -142,7 +142,7 @@ class CmsPageType extends AbstractType
                 'required' => false,
                 'options' => [
                     'constraints' => [
-                        new TypedRegexConstraint([
+                        new TypedRegex([
                             'type' => 'generic_name',
                         ]),
                     ],
@@ -157,7 +157,7 @@ class CmsPageType extends AbstractType
                         'placeholder' => $this->translator->trans('Add tag', [], 'Admin.Actions'),
                     ],
                     'constraints' => [
-                        new TypedRegexConstraint([
+                        new TypedRegex([
                             'type' => 'generic_name',
                         ]),
                         new Length([

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\International\Language;
 
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegexConstraint;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
@@ -70,7 +70,7 @@ class LanguageType extends AbstractType
                     new NotBlank([
                         'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
                     ]),
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'generic_name',
                     ]),
                 ],
@@ -80,7 +80,7 @@ class LanguageType extends AbstractType
                     new NotBlank([
                         'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
                     ]),
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'language_iso_code',
                     ]),
                 ],
@@ -90,7 +90,7 @@ class LanguageType extends AbstractType
                     new NotBlank([
                         'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
                     ]),
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'language_code',
                     ]),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Sell\Address;
 
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegexConstraint;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -113,7 +113,7 @@ class ManufacturerAddressType extends AbstractType
                             'This field cannot be empty', [], 'Admin.Notifications.Error'
                         ),
                     ]),
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'name',
                     ]),
                     new Length([
@@ -133,7 +133,7 @@ class ManufacturerAddressType extends AbstractType
                             'This field cannot be empty', [], 'Admin.Notifications.Error'
                         ),
                     ]),
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'name',
                     ]),
                     new Length([
@@ -148,7 +148,7 @@ class ManufacturerAddressType extends AbstractType
             ])
             ->add('address', TextType::class, [
                 'constraints' => [
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'address',
                     ]),
                     new Length([
@@ -164,7 +164,7 @@ class ManufacturerAddressType extends AbstractType
             ->add('address2', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'address',
                     ]),
                     new Length([
@@ -180,7 +180,7 @@ class ManufacturerAddressType extends AbstractType
             ->add('post_code', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'post_code',
                     ]),
                     new Length([
@@ -200,7 +200,7 @@ class ManufacturerAddressType extends AbstractType
                             'This field cannot be empty', [], 'Admin.Notifications.Error'
                         ),
                     ]),
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'city_name',
                     ]),
                     new Length([
@@ -235,7 +235,7 @@ class ManufacturerAddressType extends AbstractType
             ->add('home_phone', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'phone_number',
                     ]),
                     new Length([
@@ -251,7 +251,7 @@ class ManufacturerAddressType extends AbstractType
             ->add('mobile_phone', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'phone_number',
                     ]),
                     new Length([
@@ -267,7 +267,7 @@ class ManufacturerAddressType extends AbstractType
             ->add('other', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'message',
                     ]),
                     new Length([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Manufacturer/ManufacturerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Manufacturer/ManufacturerType.php
@@ -27,7 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Manufacturer;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegexConstraint;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
@@ -88,7 +88,7 @@ class ManufacturerType extends AbstractType
                             'Admin.Notifications.Error'
                         ),
                     ]),
-                    new TypedRegexConstraint([
+                    new TypedRegex([
                         'type' => 'catalog_name',
                     ]),
                 ],
@@ -131,7 +131,7 @@ class ManufacturerType extends AbstractType
                 'required' => false,
                 'options' => [
                     'constraints' => [
-                        new TypedRegexConstraint([
+                        new TypedRegex([
                             'type' => 'generic_name',
                         ]),
                         new Length([
@@ -150,7 +150,7 @@ class ManufacturerType extends AbstractType
                 'required' => false,
                 'options' => [
                     'constraints' => [
-                        new TypedRegexConstraint([
+                        new TypedRegex([
                             'type' => 'generic_name',
                         ]),
                         new Length([
@@ -173,7 +173,7 @@ class ManufacturerType extends AbstractType
                         'placeholder' => $this->translator->trans('Add tag', [], 'Admin.Actions'),
                     ],
                     'constraints' => [
-                        new TypedRegexConstraint([
+                        new TypedRegex([
                             'type' => 'generic_name',
                         ]),
                     ],


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Rename `TypedRegexConstraint to TypedRegex` and `TypedRegexConstraintValidator to TypedRegexValidator`
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No issue with validation on "Add/edit CMS page", "Add/edit brand" and "Add/edit brand address"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13159)
<!-- Reviewable:end -->
