### PR TITLE
Move lint checks in GitHub action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,12 +8,12 @@ workflow "Code Quality" {
 
 action "PHP 5.6 Syntax check" {
   uses = "docker://prestashop/github-action-php-lint:5.6"
-  args = "-name \"*.php\" ! -path \"./vendor/*\" ! -path \"./tools/*\" ! -path \"./modules/*\""
+  args = "! -path \"./vendor/*\" ! -path \"./tools/*\" ! -path \"./modules/*\""
 }
 
 action "PHP 7.2 Syntax check" {
   uses = "docker://prestashop/github-action-php-lint:7.2"
-  args = "-name \"*.php\" ! -path \"./vendor/*\" ! -path \"./tools/*\" ! -path \"./modules/*\""
+  args = "! -path \"./vendor/*\" ! -path \"./tools/*\" ! -path \"./modules/*\""
 }
 
 action "PHP-CS-Fixer" {

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,11 @@
+workflow "Code Quality" {
+  on = "push"
+  resolves = [
+    "PHP-CS-Fixer",
+  ]
+}
+
+action "PHP-CS-Fixer" {
+  uses = "docker://oskarstark/php-cs-fixer-ga"
+  args = "--config=.php_cs.dist --diff --diff-format=udiff --dry-run"
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -2,10 +2,22 @@ workflow "Code Quality" {
   on = "push"
   resolves = [
     "PHP-CS-Fixer",
+    "PHP 5.6 Syntax check",
   ]
 }
 
+action "PHP 5.6 Syntax check" {
+  uses = "docker://prestashop/github-action-php-lint:5.6"
+  args = "-name \"*.php\" ! -path \"./vendor/*\" ! -path \"./tools/*\" ! -path \"./modules/*\""
+}
+
+action "PHP 7.2 Syntax check" {
+  uses = "docker://prestashop/github-action-php-lint:7.2"
+  args = "-name \"*.php\" ! -path \"./vendor/*\" ! -path \"./tools/*\" ! -path \"./modules/*\""
+}
+
 action "PHP-CS-Fixer" {
+  needs = ["PHP 7.2 Syntax check"]
   uses = "docker://oskarstark/php-cs-fixer-ga"
   args = "--config=.php_cs.dist --diff --diff-format=udiff --dry-run"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
   global:
     - SYMFONY_DEPRECATIONS_HELPER=disabled
   matrix:
-    - PRESTASHOP_TEST_TYPE=lint
     - PRESTASHOP_TEST_TYPE=unit
     - PRESTASHOP_TEST_TYPE=integration
     - PRESTASHOP_TEST_TYPE=e2e
@@ -73,10 +72,6 @@ before_install:
   # PrestaShop configuration
   - cp tests-legacy/parameters.yml.travis app/config/parameters.yml
 
-
-notifications:
-  hipchat: ec4e21c5eb82066ba8be5fd1afefde@1184657
-
 before_script:
   - if [ "$EXTRA_DEPS" = "phpHigh" ]; then
         composer update --ignore-platform-reqs --no-suggest --ansi --no-interaction --no-progress --quiet;
@@ -84,16 +79,11 @@ before_script:
         composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --quiet;
     fi
 
-  - if [ "$PRESTASHOP_TEST_TYPE" != "lint" ]; then
-        bash travis-scripts/install-prestashop;
-    fi
+  - bash travis-scripts/install-prestashop;
 
 script:
-  - if [ "$PRESTASHOP_TEST_TYPE" = "lint" ]; then
-        bash tests-legacy/check_file_syntax.sh;
-    fi
-
   - if [ "$PRESTASHOP_TEST_TYPE" = "unit" ]; then
+        bash tests-legacy/check_file_syntax.sh;
         bash tests-legacy/check_phpunit.sh;
     fi
 

--- a/tests-legacy/check_file_syntax.sh
+++ b/tests-legacy/check_file_syntax.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-! (find . -name "*.php" ! -path "./vendor/*" ! -path "./tools/*" ! -path "./modules/*" -print0 | xargs -0 -n1 -P4 php -l | grep -q "Parse error")
-php=$?
-
 # Yml tests
 php bin/console lint:yaml src
 yaml_src=$?
@@ -16,7 +13,7 @@ yaml_themes=$?
 php bin/console lint:yaml .t9n.yml
 yaml_trad=$?
 
-if [[ "$php" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad" == "0" ]]; then
+if [[ "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad" == "0" ]]; then
   echo -e "\e[92mSYNTAX TESTS OK"
   exit 0;
 else

--- a/tests-legacy/check_file_syntax.sh
+++ b/tests-legacy/check_file_syntax.sh
@@ -16,19 +16,10 @@ yaml_themes=$?
 php bin/console lint:yaml .t9n.yml
 yaml_trad=$?
 
-# Check our current PHP Coding Style rules
-php ./vendor/bin/php-cs-fixer fix --dry-run --diff --diff-format=udiff
-coding_styles=$?
-
-if [[ "$php" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad" == "0" && "$coding_styles" == "0" ]]; then
+if [[ "$php" == "0" && "$yaml_src" == "0" && "$yaml_app" == "0" && "$yaml_themes" == "0" && "$yaml_trad" == "0" ]]; then
   echo -e "\e[92mSYNTAX TESTS OK"
   exit 0;
 else
   echo -e "\e[91mSYNTAX TESTS FAILED"
-  if [[ "$coding_styles" -ne "0" ]]; then
-   echo -e "\e[39mRun PHP CS Fixer from your PrestaShop folder to fix the lint issues:";
-   echo -e '- Linux: "php ./vendor/bin/php-cs-fixer fix"';
-   echo -e '- Windows: "vendor\\bin\\php-cs-fixer fix"';
-  fi
   exit 255;
 fi


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Travis has too many things to check and we want to reduce its work. We remove two jobs and make them available via Github Actions
| Type?         | new feature
| Category?     | TE
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Cannot be tested here. See here for the expected result: https://github.com/PrestaShop/PrestaShop-pv-changes/pull/11/checks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13167)
<!-- Reviewable:end -->
