### PR TITLE
Allow to use date as parameter for nightly builds

### DIFF
--- a/tests/E2E/scripts/run-nightly-reports.sh
+++ b/tests/E2E/scripts/run-nightly-reports.sh
@@ -10,6 +10,7 @@ set -x
 
 BRANCH=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/TRAVIS_BRANCH -H "Metadata-Flavor: Google")
 CURRENT_DATE=$([ -z "$1" ] && date +%Y-%m-%d || echo $1)
+NO_SHUTDOWN=$([ -z "$2" ] && "" || echo "yes")
 DIR_PATH="/var/ps-reports/${CURRENT_DATE}"
 REPORT_NAME="${CURRENT_DATE}-${BRANCH}"
 REPORT_PATH="${DIR_PATH}/campaigns"
@@ -30,6 +31,8 @@ if [ -n "$(ls ${REPORT_PATH})" ]; then
 
   # Send file, remove directory, and shutdown if everything is ok
   gsutil cp -r "${DIR_PATH}/reports" gs://prestashop-core-nightly && \
-  rm -rf $DIR_PATH && \
-  shutdown -h now
+  rm -rf $DIR_PATH
+  if [ -z "${NO_SHUTDOWN}" ]; then
+    shutdown -h now
+  fi
 fi

--- a/tests/E2E/scripts/run-nightly-reports.sh
+++ b/tests/E2E/scripts/run-nightly-reports.sh
@@ -9,7 +9,7 @@
 set -x
 
 BRANCH=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/TRAVIS_BRANCH -H "Metadata-Flavor: Google")
-CURRENT_DATE="$(date +%Y-%m-%d)"
+CURRENT_DATE=$([ -z "$1" ] && date +%Y-%m-%d || echo $1)
 DIR_PATH="/var/ps-reports/${CURRENT_DATE}"
 REPORT_NAME="${CURRENT_DATE}-${BRANCH}"
 REPORT_PATH="${DIR_PATH}/campaigns"

--- a/tests/E2E/scripts/run-nightly-tests.sh
+++ b/tests/E2E/scripts/run-nightly-tests.sh
@@ -3,7 +3,7 @@
 set -x
 
 BRANCH=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/TRAVIS_BRANCH -H "Metadata-Flavor: Google")
-CURRENT_DATE="$(date +%Y-%m-%d)"
+CURRENT_DATE=$([ -z "$1" ] && date +%Y-%m-%d || echo $1)
 DIR_PATH="/var/ps-reports/${CURRENT_DATE}"
 REPORT_NAME="${CURRENT_DATE}-${BRANCH}"
 REPORT_PATH="${DIR_PATH}/campaigns"


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since travis had a bad day and run the cron on the afternoob (sometimes) we need to be able to set date, at least to execute manually the scripts if it's needed.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Travis must be green.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13176)
<!-- Reviewable:end -->
