### PR TITLE
Fix notice undefined index: icon on Design -> Positions

### DIFF
--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -44,7 +44,7 @@
                   data-toggle="pstooltip"
                   data-placement="bottom"{/if}
                 >
-                  <i class="material-icons">{$btn.icon}</i>
+                  {if !empty($btn.icon)}<i class="material-icons">{$btn.icon}</i>{/if}
                   {$btn.desc|escape}
                 </a>
               {/if}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix a PHP Notice on Design -> Posit﻿ion﻿s, in toolbar, button `Transplant a module`
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://www.prestashop.com/forums/topic/963504-php-notice-warning/
| How to test?  | Check html code of button `Transplant a module` on Design -> Posit﻿ion﻿s, before `<i class="material-icons"></i> Transplant a module` After `Transplant a module`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13177)
<!-- Reviewable:end -->
