### PR TITLE
Add SecurityAnnotation linter

### DIFF
--- a/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
+++ b/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Routing\Route;
+
+final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
+{
+    public function configure()
+    {
+        $this
+            ->setName('prestashop:linter:security-annotation')
+            ->setDescription('Checks if Back Office route controllers has configured Security annotations.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $adminRouteProvider = $this->getContainer()->get('prestashop.bundle.routing.linter.admin_route_provider');
+        $securityAnnotationLinter = $this->getContainer()
+            ->get('prestashop.bundle.routing.linter.security_annotation_linter');
+
+        /** @var Route $route */
+        foreach ($adminRouteProvider->getRoutes() as $route) {
+            $securityAnnotationLinter->lint($route);
+        }
+
+        $output->writeln('Admin routes has AdminSecurity configured.');
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
@@ -40,10 +40,3 @@ admin_international_translations_copy_language:
     defaults:
         _controller: PrestaShopBundle:Admin/Translations:copyLanguage
         _legacy_controller: AdminTranslations
-
-admin_international_translations_export_language:
-    path: /export-language
-    methods: [POST]
-    defaults:
-        _controller: PrestaShopBundle:Admin/Translations:exportLanguage
-        _legacy_controller: AdminTranslations

--- a/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
@@ -39,6 +39,7 @@ services:
         class: 'PrestaShopBundle\Routing\Linter\SecurityAnnotationLinter'
         arguments:
           - '@annotation_reader'
+          - '@controller_name_converter'
 
     prestashop.bundle.routing.linter.admin_route_provider:
         class: 'PrestaShopBundle\Routing\Linter\AdminRouteProvider'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
@@ -38,5 +38,9 @@ services:
     prestashop.bundle.routing.linter.security_annotation_linter:
         class: 'PrestaShopBundle\Routing\Linter\SecurityAnnotationLinter'
         arguments:
-          - '@router'
           - '@annotation_reader'
+
+    prestashop.bundle.routing.linter.admin_route_provider:
+        class: 'PrestaShopBundle\Routing\Linter\AdminRouteProvider'
+        arguments:
+            - '@router'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
@@ -34,3 +34,9 @@ services:
             - ["%kernel.project_dir%/src/PrestaShopBundle/Resources/config/routing/admin"]
             - '@=service("prestashop.module_kernel.repository").getActiveModulesPaths()'
             - '%kernel.environment%'
+
+    prestashop.bundle.routing.linter.security_annotation_linter:
+        class: 'PrestaShopBundle\Routing\Linter\SecurityAnnotationLinter'
+        arguments:
+          - '@router'
+          - '@annotation_reader'

--- a/src/PrestaShopBundle/Routing/Linter/AdminRouteProvider.php
+++ b/src/PrestaShopBundle/Routing/Linter/AdminRouteProvider.php
@@ -45,8 +45,16 @@ final class AdminRouteProvider
 
     public function getRoutes()
     {
-        // @todo: implement admin routes filtering
+        $adminRoutes = [];
 
-        return $this->router->getRouteCollection();
+        foreach ($this->router->getRouteCollection() as $routeName => $route) {
+            if (strpos($routeName, 'admin_') !== 0) {
+                continue;
+            }
+
+            $adminRoutes[] = $route;
+        }
+
+        return $adminRoutes;
     }
 }

--- a/src/PrestaShopBundle/Routing/Linter/AdminRouteProvider.php
+++ b/src/PrestaShopBundle/Routing/Linter/AdminRouteProvider.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Routing\Linter;
+
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Get all configured routes for Back Office
+ */
+final class AdminRouteProvider
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    public function getRoutes()
+    {
+        // @todo: implement admin routes filtering
+
+        return $this->router->getRouteCollection();
+    }
+}

--- a/src/PrestaShopBundle/Routing/Linter/AdminRouteProvider.php
+++ b/src/PrestaShopBundle/Routing/Linter/AdminRouteProvider.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Routing\Linter;
 
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -38,11 +39,17 @@ final class AdminRouteProvider
      */
     private $router;
 
+    /**
+     * @param RouterInterface $router
+     */
     public function __construct(RouterInterface $router)
     {
         $this->router = $router;
     }
 
+    /**
+     * @return Route[] As routeName => route
+     */
     public function getRoutes()
     {
         $adminRoutes = [];
@@ -52,7 +59,7 @@ final class AdminRouteProvider
                 continue;
             }
 
-            $adminRoutes[] = $route;
+            $adminRoutes[$routeName] = $route;
         }
 
         return $adminRoutes;

--- a/src/PrestaShopBundle/Routing/Linter/LinterException.php
+++ b/src/PrestaShopBundle/Routing/Linter/LinterException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Routing\Linter;
+
+use RuntimeException;
+
+/**
+ * Is thrown when error occurs during linting.
+ */
+class LinterException extends RuntimeException
+{
+}

--- a/src/PrestaShopBundle/Routing/Linter/RouteLinterInterface.php
+++ b/src/PrestaShopBundle/Routing/Linter/RouteLinterInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Routing\Linter;
+
+use Symfony\Component\Routing\Route;
+
+/**
+ * Interface for service that performs linting on route
+ */
+interface RouteLinterInterface
+{
+    /**
+     * @param Route $route
+     *
+     * @return bool True if route passes linter or False otherwise
+     */
+    public function lint(Route $route);
+}

--- a/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
+++ b/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
@@ -63,7 +63,13 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
 
         $annotation = $this->annoationReader->getMethodAnnotation($reflection, AdminSecurity::class);
 
-        return null !== $annotation;
+        if (null === $annotation) {
+            throw new LinterException(sprintf(
+                '"%s:%s" does not have AdminSecurity annotation configured',
+                 $controllerAndMethod['controller'],
+                 $controllerAndMethod['method']
+            ));
+        }
     }
 
     /**
@@ -73,6 +79,8 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
      */
     private function extractControllerAndMethodNamesFromRoute(Route $route)
     {
+        // @todo: parsing needs to be improved & refactored into separate service
+
         list($controller, $method) = explode('::', $route->getDefault('_controller'));
 
         return [

--- a/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
+++ b/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
@@ -39,14 +39,14 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
     /**
      * @var Reader
      */
-    private $annoationReader;
+    private $annotationReader;
 
     /**
-     * @param Reader $annoationReader
+     * @param Reader $annotationReader
      */
-    public function __construct(Reader $annoationReader)
+    public function __construct(Reader $annotationReader)
     {
-        $this->annoationReader = $annoationReader;
+        $this->annotationReader = $annotationReader;
     }
 
     /**
@@ -61,7 +61,7 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
             $controllerAndMethod['method']
         );
 
-        $annotation = $this->annoationReader->getMethodAnnotation($reflection, AdminSecurity::class);
+        $annotation = $this->annotationReader->getMethodAnnotation($reflection, AdminSecurity::class);
 
         if (null === $annotation) {
             throw new LinterException(sprintf(

--- a/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
+++ b/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Routing\Linter;
+
+use Doctrine\Common\Annotations\Reader;
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use ReflectionMethod;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Checks if SecurityAnnotation is configured for route's controller action
+ */
+final class SecurityAnnotationLinter implements RouteLinterInterface
+{
+    /**
+     * @var Reader
+     */
+    private $annoationReader;
+
+    /**
+     * @param Reader $annoationReader
+     */
+    public function __construct(Reader $annoationReader)
+    {
+        $this->annoationReader = $annoationReader;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lint(Route $route)
+    {
+        $controllerAndMethod = $this->extractControllerAndMethodNamesFromRoute($route);
+
+        $reflection = new ReflectionMethod(
+            $controllerAndMethod['controller'],
+            $controllerAndMethod['method']
+        );
+
+        $annotation = $this->annoationReader->getMethodAnnotation($reflection, AdminSecurity::class);
+
+        return null !== $annotation;
+    }
+
+    /**
+     * @param Route $route
+     *
+     * @return array
+     */
+    private function extractControllerAndMethodNamesFromRoute(Route $route)
+    {
+        list($controller, $method) = explode('::', $route->getDefault('_controller'));
+
+        return [
+            'controller' => $controller,
+            'method' => $method,
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
+++ b/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
@@ -81,7 +81,7 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
     {
         // @todo: parsing needs to be improved & refactored into separate service
 
-        list($controller, $method) = explode('::', $route->getDefault('_controller'));
+        list($controller, $method) = explode(':', $route->getDefault('_controller'));
 
         return [
             'controller' => $controller,

--- a/tests/Integration/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinterTest.php
@@ -50,7 +50,7 @@ class SecurityAnnotationLinterTest extends KernelTestCase
     public function testLinterPassesWhenRouteControllerHasConfiguredAdminSecurityAnnotation()
     {
         $route = new Route('/', [
-            '_controller' => sprintf('%s:%s', TestController::class, 'indexAction'),
+            '_controller' => sprintf('%s::%s', TestController::class, 'indexAction'),
         ]);
 
         $this->securityAnnotationLinter->lint($route);
@@ -61,7 +61,7 @@ class SecurityAnnotationLinterTest extends KernelTestCase
     public function testLinterThrowsExceptionWhenRouteControllerDoesNotHaveConfiguredAdminSecutityAnnotation()
     {
         $route = new Route('/', [
-            '_controller' => sprintf('%s:%s', TestController::class, 'createAction'),
+            '_controller' => sprintf('%s::%s', TestController::class, 'createAction'),
         ]);
 
         $this->expectException(LinterException::class);

--- a/tests/Integration/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinterTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\PrestaShopBundle\Routing\Linter;
+
+use PrestaShopBundle\Routing\Linter\LinterException;
+use PrestaShopBundle\Routing\Linter\SecurityAnnotationLinter;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Routing\Route;
+use Tests\Resources\Controller\TestController;
+
+class SecurityAnnotationLinterTest extends KernelTestCase
+{
+    /**
+     * @var SecurityAnnotationLinter
+     */
+    private $securityAnnotationLinter;
+
+    protected function setUp()
+    {
+        self::bootKernel();
+
+        $container = self::$kernel->getContainer();
+        $this->securityAnnotationLinter = $container->get('prestashop.bundle.routing.linter.security_annotation_linter');
+    }
+
+    public function testLinterPassesWhenRouteControllerHasConfiguredAdminSecurityAnnotation()
+    {
+        $route = new Route('/', [
+            '_controller' => sprintf('%s:%s', TestController::class, 'indexAction'),
+        ]);
+
+        $this->securityAnnotationLinter->lint($route);
+
+        $this->assertTrue($exceptionWasNotThrown = true);
+    }
+
+    public function testLinterThrowsExceptionWhenRouteControllerDoesNotHaveConfiguredAdminSecutityAnnotation()
+    {
+        $route = new Route('/', [
+            '_controller' => sprintf('%s:%s', TestController::class, 'createAction'),
+        ]);
+
+        $this->expectException(LinterException::class);
+
+        $this->securityAnnotationLinter->lint($route);
+    }
+
+    protected function tearDown()
+    {
+        self::$kernel->shutdown();
+    }
+}

--- a/tests/Resources/Controller/TestController.php
+++ b/tests/Resources/Controller/TestController.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Resources\Controller;
+
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class is used to test @AdminSecurity annotation linter
+ */
+class TestController
+{
+    /**
+     * @AdminSecurity()
+     */
+    public function indexAction()
+    {
+        return new Response();
+    }
+
+    public function createAction()
+    {
+        return new Response();
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | It aims to add `AdminSecurity` linter for all Back Office routes.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Run `bin/console prestashop:linter:security-annotation`

### Example linter result
![linter](https://user-images.githubusercontent.com/15143151/55796990-fd8d3580-5ad3-11e9-8ea6-4a7d71e96a4f.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13200)
<!-- Reviewable:end -->
