### PR TITLE
Fix breadcrumb in search results page leads to 404 page

### DIFF
--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -110,7 +110,7 @@ class SearchControllerCore extends ProductListingFrontController
         $breadcrumb = parent::getBreadcrumbLinks();
         $breadcrumb['links'][] = array(
             'title' => $this->getTranslator()->trans('Search results', array(), 'Shop.Theme.Catalog'),
-            'url' => $this->context->link->getPageLink('search'),
+            'url' => $this->getCurrentUrl(),
         );
 
         return $breadcrumb;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Use the current url instead of generating a new search url with no search string.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12401
| How to test?  | Follow ticket instruction

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13218)
<!-- Reviewable:end -->
