### PR TITLE
Fix wrong cart calculation using rules with free Gift

### DIFF
--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -91,8 +91,8 @@ class CartRuleCalculator
                     && ($product['id_product_attribute'] == $cartRule->gift_product_attribute
                         || !(int) $cartRule->gift_product_attribute)
                 ) {
-                    $cartRow->applyFlatDiscount($cartRow->getFinalUnitPrice());
                     $cartRuleData->addDiscountApplied($cartRow->getFinalUnitPrice());
+                    $cartRow->applyFlatDiscount($cartRow->getFinalUnitPrice());
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Wrong calculation of "cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS", using rules whith free Gift
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | please see below


- the discount is applied before sending his amount to the calculator, so the amount discounted of a free gift is always 0 whereas it souhld be gift'price
- to test, create a Cart Rule, offering a free gift, on your front shop create an order, and watch on BO the "reduction total" for the created order
- side effect : `PaymentModule::validateOrder(` does not correctly register , `$order->total_discount` On : https://github.com/PrestaShop/PrestaShop/blob/develop/classes/PaymentModule.php#L980

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13232)
<!-- Reviewable:end -->
