### PR TITLE
Add missing hook description for additionalCustomerAddressFields

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -576,6 +576,11 @@
       <title>Add fields to the Customer form</title>
       <description>This hook returns an array of FormFields to add them to the customer registration form</description>
     </hook>
+    <hook id="additionalCustomerAddressFields">
+      <name>additionalCustomerAddressFields</name>
+      <title>Add fields to the Customer address form</title>
+      <description>This hook returns an array of FormFields to add them to the customer address registration form</description>
+    </hook>
     <hook id="addWebserviceResources">
       <name>addWebserviceResources</name>
       <title>Add extra webservice resource</title>


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The hook `additionalCustomerAddressFields` added in #9132 was missing its description
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Nothing to test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13242)
<!-- Reviewable:end -->
