### PR TITLE
Fallback on default language when currency language is missing on constructor

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -179,14 +179,23 @@ class CurrencyCore extends ObjectModel
             if (null === $idLang) {
                 $idLang = Context::getContext()->language->id;
             }
+            $defaultIdLang = Configuration::get('PS_LANG_DEFAULT', null, null, $idShop);
             if (is_array($this->symbol)) {
-                $this->sign = $this->symbol = $this->symbol[$idLang];
+                if (isset($this->symbol[$idLang])) {
+                    $this->sign = $this->symbol = $this->symbol[$idLang];
+                } else {
+                    $this->sign = $this->symbol = $this->symbol[$defaultIdLang];
+                }
             } else {
                 $this->sign = $this->symbol;
             }
 
             if (is_array($this->name)) {
-                $this->name = ucfirst($this->name[$idLang]);
+                if (isset($this->name[$idLang])) {
+                    $this->name = ucfirst($this->name[$idLang]);
+                } else {
+                    $this->name = ucfirst($this->name[$defaultIdLang]);
+                }
             } else {
                 $this->name = ucfirst($this->name);
             }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fallback on default language when currency language is missing on constructor
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partial fix for #13247
| How to test?  | See issue's description, install shop with CLI and try to access the front office

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13250)
<!-- Reviewable:end -->
