### PR TITLE
The same message for any images restrictions

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -451,7 +451,7 @@ class ImageManagerCore
             return Context::getContext()->getTranslator()->trans('Image is too large (%1$d kB). Maximum allowed: %2$d kB', array($file['size'] / 1024, $maxFileSize / 1024), 'Admin.Notifications.Error');
         }
         if (!ImageManager::isRealImage($file['tmp_name'], $file['type']) || !ImageManager::isCorrectImageFileExt($file['name'], $types) || preg_match('/\%00/', $file['name'])) {
-            return Context::getContext()->getTranslator()->trans('Image format not recognized, allowed formats are: .gif, .jpg, .png', array(), 'Admin.Notifications.Error');
+            return Context::getContext()->getTranslator()->trans('Image format not recognized, allowed format(s) is(are): .%s', array(implode(', .', $types)), 'Admin.Notifications.Error');
         }
         if ($file['error']) {
             return Context::getContext()->getTranslator()->trans('Error while uploading image; please change your server\'s settings. (Error code: %s)', array($file['error']), 'Admin.Notifications.Error');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We have the same message independently of restrictions for images types. So if we have allowed only .jpg when a user tries to load a .png image he gets an error which says that "Image format not recognized, allowed formats are: .gif, .jpg, .png" and it's confusing.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Just use method `ImageManager::validateUpload($file, Tools::getMaxUploadSize(), array('jpg'))` from anywhere and try to load images with different type

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13253)
<!-- Reviewable:end -->
