### PR TITLE
Fixes to Customer subdomain & controller

### DIFF
--- a/src/Core/Domain/Customer/Command/BulkDeleteCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/BulkDeleteCustomerCommand.php
@@ -46,12 +46,12 @@ class BulkDeleteCustomerCommand
 
     /**
      * @param int[] $customerIds
-     * @param CustomerDeleteMethod $deleteMethod
+     * @param string $deleteMethod
      */
-    public function __construct(array $customerIds, CustomerDeleteMethod $deleteMethod)
+    public function __construct(array $customerIds, $deleteMethod)
     {
         $this->setCustomerIds($customerIds);
-        $this->deleteMethod = $deleteMethod;
+        $this->deleteMethod = new CustomerDeleteMethod($deleteMethod);
     }
 
     /**

--- a/src/Core/Domain/Customer/Command/DeleteCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/DeleteCustomerCommand.php
@@ -45,13 +45,13 @@ class DeleteCustomerCommand
     private $deleteMethod;
 
     /**
-     * @param CustomerId $customerId
-     * @param CustomerDeleteMethod $deleteMethod
+     * @param int $customerId
+     * @param string $deleteMethod
      */
-    public function __construct(CustomerId $customerId, CustomerDeleteMethod $deleteMethod)
+    public function __construct($customerId, $deleteMethod)
     {
-        $this->customerId = $customerId;
-        $this->deleteMethod = $deleteMethod;
+        $this->customerId = new CustomerId($customerId);
+        $this->deleteMethod = new CustomerDeleteMethod($deleteMethod);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -44,11 +44,9 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetRequiredFieldsForCustome
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\ViewableCustomer;
-use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerDeleteMethod;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
-use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForViewing;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
@@ -611,7 +609,7 @@ class CustomerController extends AbstractAdminController
             try {
                 $command = new BulkDeleteCustomerCommand(
                     $customerIds,
-                    new CustomerDeleteMethod($data['delete_method'])
+                    $data['delete_method']
                 );
 
                 $this->getCommandBus()->handle($command);
@@ -653,8 +651,8 @@ class CustomerController extends AbstractAdminController
 
             try {
                 $command = new DeleteCustomerCommand(
-                    new CustomerId($customerId),
-                    new CustomerDeleteMethod($data['delete_method'])
+                    $customerId,
+                    $data['delete_method']
                 );
 
                 $this->getCommandBus()->handle($command);

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -375,108 +375,6 @@ class CustomerController extends AbstractAdminController
     }
 
     /**
-     * @return FormInterface
-     */
-    private function getRequiredFieldsForm()
-    {
-        $requiredFields = $this->getQueryBus()->handle(new GetRequiredFieldsForCustomer());
-
-        return $this->createForm(RequiredFieldsType::class, ['required_fields' => $requiredFields]);
-    }
-
-    /**
-     * If customer form is submitted and groups are not selected
-     * we add empty groups to request
-     *
-     * @param Request $request
-     */
-    private function addGroupSelectionToRequest(Request $request)
-    {
-        if (!$request->isMethod(Request::METHOD_POST)) {
-            return;
-        }
-
-        if (!$request->request->has('customer')
-            || isset($request->request->get('customer')['group_ids'])
-        ) {
-            return;
-        }
-
-        $customerData = $request->request->get('customer');
-        $customerData['group_ids'] = [];
-
-        $request->request->set('customer', $customerData);
-    }
-
-    /**
-     * Get errors that can be used to translate exceptions into user friendly messages
-     *
-     * @param CustomerException $e
-     *
-     * @return array
-     */
-    private function getErrorMessages(CustomerException $e)
-    {
-        return [
-            CustomerNotFoundException::class => $this->trans(
-                'This customer does not exist.',
-                'Admin.Orderscustomers.Notification'
-            ),
-            DuplicateCustomerEmailException::class => sprintf(
-                '%s %s',
-                $this->trans('An account already exists for this email address:', 'Admin.Orderscustomers.Notification'),
-                $e instanceof DuplicateCustomerEmailException ? $e->getEmail()->getValue() : ''
-            ),
-            CustomerDefaultGroupAccessException::class => $this->trans(
-                'A default customer group must be selected in group box.',
-                'Admin.Orderscustomers.Notification'
-            ),
-            CustomerConstraintException::class => [
-                CustomerConstraintException::INVALID_PASSWORD => $this->trans(
-                    'Password should be at least %length% characters long.',
-                    'Admin.Orderscustomers.Help',
-                    ['%length%' => Password::MIN_LENGTH]
-                ),
-                CustomerConstraintException::INVALID_FIRST_NAME => $this->trans(
-                    'The %s field is invalid.',
-                    'Admin.Notifications.Error',
-                    [sprintf('"%s"', $this->trans('First name', 'Admin.Global'))]
-                ),
-                CustomerConstraintException::INVALID_LAST_NAME => $this->trans(
-                    'The %s field is invalid.',
-                    'Admin.Notifications.Error',
-                    [sprintf('"%s"', $this->trans('Last name', 'Admin.Global'))]
-                ),
-                CustomerConstraintException::INVALID_EMAIL => $this->trans(
-                    'The %s field is invalid.',
-                    'Admin.Notifications.Error',
-                    [sprintf('"%s"', $this->trans('Email', 'Admin.Global'))]
-                ),
-                CustomerConstraintException::INVALID_BIRTHDAY => $this->trans(
-                    'The %s field is invalid.',
-                    'Admin.Notifications.Error',
-                    [sprintf('"%s"', $this->trans('Birthday', 'Admin.Orderscustomers.Feature'))]
-                ),
-                CustomerConstraintException::INVALID_APE_CODE => $this->trans(
-                    'The %s field is invalid.',
-                    'Admin.Notifications.Error',
-                    [sprintf('"%s"', $this->trans('APE', 'Admin.Orderscustomers.Feature'))]
-                ),
-            ],
-            CustomerTransformationException::class => [
-                CustomerTransformationException::CUSTOMER_IS_NOT_GUEST => $this->trans(
-                    'This customer already exists as a non-guest.',
-                    'Admin.Orderscustomers.Notification'
-                ),
-                CustomerTransformationException::TRANSFORMATION_FAILED => $this->trans(
-                    'An error occurred while updating customer information.',
-                    'Admin.Orderscustomers.Notification'
-                ),
-            ],
-        ];
-    }
-
-    /**
      * Toggle customer status.
      *
      * @AdminSecurity(
@@ -783,11 +681,113 @@ class CustomerController extends AbstractAdminController
     }
 
     /**
+     * @return FormInterface
+     */
+    private function getRequiredFieldsForm()
+    {
+        $requiredFields = $this->getQueryBus()->handle(new GetRequiredFieldsForCustomer());
+
+        return $this->createForm(RequiredFieldsType::class, ['required_fields' => $requiredFields]);
+    }
+
+    /**
+     * If customer form is submitted and groups are not selected
+     * we add empty groups to request
+     *
+     * @param Request $request
+     */
+    private function addGroupSelectionToRequest(Request $request)
+    {
+        if (!$request->isMethod(Request::METHOD_POST)) {
+            return;
+        }
+
+        if (!$request->request->has('customer')
+            || isset($request->request->get('customer')['group_ids'])
+        ) {
+            return;
+        }
+
+        $customerData = $request->request->get('customer');
+        $customerData['group_ids'] = [];
+
+        $request->request->set('customer', $customerData);
+    }
+
+    /**
+     * Get errors that can be used to translate exceptions into user friendly messages
+     *
+     * @param CustomerException $e
+     *
+     * @return array
+     */
+    private function getErrorMessages(CustomerException $e)
+    {
+        return [
+            CustomerNotFoundException::class => $this->trans(
+                'This customer does not exist.',
+                'Admin.Orderscustomers.Notification'
+            ),
+            DuplicateCustomerEmailException::class => sprintf(
+                '%s %s',
+                $this->trans('An account already exists for this email address:', 'Admin.Orderscustomers.Notification'),
+                $e instanceof DuplicateCustomerEmailException ? $e->getEmail()->getValue() : ''
+            ),
+            CustomerDefaultGroupAccessException::class => $this->trans(
+                'A default customer group must be selected in group box.',
+                'Admin.Orderscustomers.Notification'
+            ),
+            CustomerConstraintException::class => [
+                CustomerConstraintException::INVALID_PASSWORD => $this->trans(
+                    'Password should be at least %length% characters long.',
+                    'Admin.Orderscustomers.Help',
+                    ['%length%' => Password::MIN_LENGTH]
+                ),
+                CustomerConstraintException::INVALID_FIRST_NAME => $this->trans(
+                    'The %s field is invalid.',
+                    'Admin.Notifications.Error',
+                    [sprintf('"%s"', $this->trans('First name', 'Admin.Global'))]
+                ),
+                CustomerConstraintException::INVALID_LAST_NAME => $this->trans(
+                    'The %s field is invalid.',
+                    'Admin.Notifications.Error',
+                    [sprintf('"%s"', $this->trans('Last name', 'Admin.Global'))]
+                ),
+                CustomerConstraintException::INVALID_EMAIL => $this->trans(
+                    'The %s field is invalid.',
+                    'Admin.Notifications.Error',
+                    [sprintf('"%s"', $this->trans('Email', 'Admin.Global'))]
+                ),
+                CustomerConstraintException::INVALID_BIRTHDAY => $this->trans(
+                    'The %s field is invalid.',
+                    'Admin.Notifications.Error',
+                    [sprintf('"%s"', $this->trans('Birthday', 'Admin.Orderscustomers.Feature'))]
+                ),
+                CustomerConstraintException::INVALID_APE_CODE => $this->trans(
+                    'The %s field is invalid.',
+                    'Admin.Notifications.Error',
+                    [sprintf('"%s"', $this->trans('APE', 'Admin.Orderscustomers.Feature'))]
+                ),
+            ],
+            CustomerTransformationException::class => [
+                CustomerTransformationException::CUSTOMER_IS_NOT_GUEST => $this->trans(
+                    'This customer already exists as a non-guest.',
+                    'Admin.Orderscustomers.Notification'
+                ),
+                CustomerTransformationException::TRANSFORMATION_FAILED => $this->trans(
+                    'An error occurred while updating customer information.',
+                    'Admin.Orderscustomers.Notification'
+                ),
+            ],
+        ];
+    }
+
+    /**
      * @param CustomerException $e
      *
      * @return string
      */
-    protected function handleCustomerException(CustomerException $e)
+    private function handleCustomerException(CustomerException $e)
     {
         $type = get_class($e);
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -403,7 +403,7 @@ class CustomerController extends AbstractAdminController
                 $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
             );
         } catch (CustomerException $e) {
-            $this->addFlash('error', $this->handleCustomerException($e));
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
         return $this->redirectToRoute('admin_customers_index');
@@ -438,7 +438,7 @@ class CustomerController extends AbstractAdminController
                 $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
             );
         } catch (CustomerException $e) {
-            $this->handleCustomerException($e);
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
         return $this->redirectToRoute('admin_customers_index');
@@ -473,7 +473,7 @@ class CustomerController extends AbstractAdminController
                 $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
             );
         } catch (CustomerException $e) {
-            $this->addFlash('error', $this->handleCustomerException($e));
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
         return $this->redirectToRoute('admin_customers_index');
@@ -517,7 +517,7 @@ class CustomerController extends AbstractAdminController
                     $this->trans('The selection has been successfully deleted.', 'Admin.Notifications.Success')
                 );
             } catch (CustomerException $e) {
-                $this->addFlash('error', $this->handleCustomerException($e));
+                $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
             }
         }
 
@@ -557,7 +557,7 @@ class CustomerController extends AbstractAdminController
 
                 $this->addFlash('success', $this->trans('Successful deletion.', 'Admin.Notifications.Success'));
             } catch (CustomerException $e) {
-                $this->addFlash('error', $this->handleCustomerException($e));
+                $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
             }
         }
 
@@ -590,7 +590,7 @@ class CustomerController extends AbstractAdminController
 
             $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
         } catch (CustomerException $e) {
-            $this->addFlash('error', $this->handleCustomerException($e));
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
         return $this->redirectToRoute('admin_customers_index');
@@ -622,7 +622,7 @@ class CustomerController extends AbstractAdminController
 
             $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
         } catch (CustomerException $e) {
-            $this->addFlash('error', $this->handleCustomerException($e));
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
         return $this->redirectToRoute('admin_customers_index');
@@ -780,25 +780,5 @@ class CustomerController extends AbstractAdminController
                 ),
             ],
         ];
-    }
-
-    /**
-     * @param CustomerException $e
-     *
-     * @return string
-     */
-    private function handleCustomerException(CustomerException $e)
-    {
-        $type = get_class($e);
-
-        $errorMessages = [
-            CustomerNotFoundException::class => $this->trans('The object cannot be loaded (or found)', 'Admin.Notifications.Error'),
-        ];
-
-        if (isset($errorMessages[$type])) {
-            return $errorMessages[$type];
-        }
-
-        return $this->getFallbackErrorMessage($type, $e->getCode());
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | See below.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially https://github.com/PrestaShop/PrestaShop/issues/10560
| How to test?  | Please check that customer add, customer edit, customer delete and customer bulk delete work as before

### What does this PR do:
1. Some commands in `Customer` subdomain were accepting VOs, this PR fixes it to accept only scalar values.
2. Reorders `CustomerController` actions according to methods visibility.
3. Harmonizes error handling in `CustomerController`.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13256)
<!-- Reviewable:end -->
