### PR TITLE
Fix lang on currency install

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -1,4 +1,7 @@
 <?php
+
+use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository;
+
 /**
  * 2007-2019 PrestaShop and Contributors
  *
@@ -758,4 +761,40 @@ class CurrencyCore extends ObjectModel
     {
         return Currency::countActiveCurrencies($idShop) > 1;
     }
+
+    /**
+     * This method aims to update localized data in currency from CLDR reference.
+     *
+     * @param array $languages
+     * @param LocaleRepository $localeRepoCLDR
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
+     */
+    public function refreshLocalizedCurrencyData(array $languages, LocaleRepository $localeRepoCLDR)
+    {
+        $symbolsByLang = $namesByLang = [];
+        foreach ($languages as $languageData) {
+            $language = new Language($languageData['id_lang']);
+            if ($language->locale === '') {
+                // Language doesn't have locale we can't install this language
+                continue;
+            }
+
+            $cldrLocale = $localeRepoCLDR->getLocale($language->locale);
+            $cldrCurrency = $cldrLocale->getCurrency($this->iso_code);
+
+            $symbol = (string) $cldrCurrency->getSymbol();
+            if (empty($symbol)) {
+                $symbol = $this->iso_code;
+            }
+            // symbol is localized
+            $namesByLang[$language->id] = $cldrCurrency->getDisplayName();
+            $symbolsByLang[$language->id] = $symbol;
+        }
+        $this->name = $namesByLang;
+        $this->symbol = $symbolsByLang;
+    }
+
 }

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -782,7 +782,9 @@ class CurrencyCore extends ObjectModel
                 continue;
             }
 
+            // CLDR locale give us the CLDR reference specification
             $cldrLocale = $localeRepoCLDR->getLocale($language->locale);
+            // CLDR currency gives data from CLDR reference, for the given language
             $cldrCurrency = $cldrLocale->getCurrency($this->iso_code);
 
             $symbol = (string) $cldrCurrency->getSymbol();

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -798,5 +798,4 @@ class CurrencyCore extends ObjectModel
         $this->name = $namesByLang;
         $this->symbol = $symbolsByLang;
     }
-
 }

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -487,7 +487,7 @@ class LocalizationPackCore
      */
     protected function refreshLocalizedCurrencyData(Currency $currency, array $languages, LocaleRepository $localeRepoCLDR)
     {
-        $symbolsByLang = [];
+        $symbolsByLang = $namesByLang = [];
         foreach ($languages as $languageData) {
             $language = new Language($languageData['id_lang']);
             if ($language->locale === '') {
@@ -503,8 +503,10 @@ class LocalizationPackCore
                 $symbol = $currency->iso_code;
             }
             // symbol is localized
+            $namesByLang[$language->id] = $cldrCurrency->getDisplayName();
             $symbolsByLang[$language->id] = $symbol;
         }
+        $currency->name = $namesByLang;
         $currency->symbol = $symbolsByLang;
     }
 

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -380,9 +380,11 @@ class LocalizationPackCore
 
     /**
      * @return LocaleRepository
+     *
      * @throws Exception
      */
-    protected function getCldrLocaleRepository(){
+    protected function getCldrLocaleRepository()
+    {
         $context = Context::getContext();
         $container = isset($context->controller) ? $context->controller->getContainer() : null;
         if (null === $container) {

--- a/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
+++ b/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
@@ -1,4 +1,8 @@
 <?php
+
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository;
+
 /**
  * 2007-2019 PrestaShop and Contributors
  *
@@ -36,5 +40,19 @@ function ps_1760_copy_data_from_currency_to_currency_lang()
             `name` = `" . _DB_PREFIX_ . "currency`.`name`,
             "
         );
+    }
+    /** @var Currency[] $currencies */
+    $currencies = Currency::getCurrencies(true, false);
+    $context = Context::getContext();
+    $container = isset($context->controller) ? $context->controller->getContainer() : null;
+    if (null === $container) {
+        $container = SymfonyContainer::getInstance();
+    }
+
+    /** @var LocaleRepository $localeRepoCLDR */
+    $localeRepoCLDR = $container->get('prestashop.core.localization.cldr.locale_repository');
+    foreach ($currencies as $currency) {
+        $currency->refreshLocalizedCurrencyData($languages, $localeRepoCLDR);
+        $currency->save();
     }
 }

--- a/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
@@ -44,7 +44,6 @@ use PrestaShopException;
  */
 final class AddCurrencyHandler extends AbstractCurrencyHandler implements AddCurrencyHandlerInterface
 {
-
     /**
      * @var LocaleRepository
      */

--- a/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
@@ -26,10 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Currency\CommandHandler;
 
-use Context;
 use Currency;
 use Language;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Command\AddCurrencyCommand;
 use PrestaShop\PrestaShop\Core\Domain\Currency\CommandHandler\AddCurrencyHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CannotCreateCurrencyException;

--- a/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
@@ -20,6 +20,8 @@ services:
 
     prestashop.adapter.currency.command_handler.create_currency:
         class: 'PrestaShop\PrestaShop\Adapter\Currency\CommandHandler\AddCurrencyHandler'
+        arguments:
+            - '@prestashop.core.localization.cldr.locale_repository'
         tags:
             - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Currency\Command\AddCurrencyCommand' }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | fix a bug on currency install, resulting in unexisting rows for currency_lang
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | fixes #13249 #13247 #13271
| How to test?  | install with lang=en, country=fr, both languages should work on frontoffice. Please check if it resolves the second issue @jolelievre is talking about in the comments of this issue #13249

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13261)
<!-- Reviewable:end -->
