### PR TITLE
Restores deleted generatable_text_widget from template

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -738,3 +738,18 @@
     </div>
   {% endif %}
 {% endblock %}
+
+{% block generatable_text_widget %}
+  <div class="input-group">
+    {{- block('form_widget') -}}
+    <span class="input-group-btn ml-1">
+      <button class="btn btn-outline-secondary js-generator-btn"
+              type="button"
+              data-target-input-id="{{ id }}"
+              data-generated-value-length="{{ generated_value_length }}"
+      >
+        {{ 'Generate'|trans({}, 'Admin.Actions') }}
+      </button>
+   </span>
+  </div>
+{% endblock generatable_text_widget %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | For some reason template was removed in https://github.com/PrestaShop/PrestaShop/pull/12436/files#diff-23dce51da0cb1ed536621b396c47954eL706 This PR fixes described issue.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13263
| How to test?  | "Generate" button should be available again.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13264)
<!-- Reviewable:end -->
