### PR TITLE
Fix reduction_exclude_special when $cartRule->reduction_product == 0

### DIFF
--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -100,8 +100,12 @@ class CartRuleCalculator
         // Discount (%) on the whole order
         if ($cartRule->reduction_percent && $cartRule->reduction_product == 0) {
             foreach ($this->cartRows as $cartRow) {
-                $amount = $cartRow->applyPercentageDiscount($cartRule->reduction_percent);
-                $cartRuleData->addDiscountApplied($amount);
+                $product = $cartRow->getRowData();
+                if ((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
+                        || !$cartRule->reduction_exclude_special)) {
+                    $amount = $cartRow->applyPercentageDiscount($cartRule->reduction_percent);
+                    $cartRuleData->addDiscountApplied($amount);
+                }
             }
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.6.x
| Description?  | CartRules exclude specials from discounts doesn't work when no specific products are selected.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |CartRules exclude specials from discounts doesn't work when no specific products are selected.
This is very wrong behaviour.

If you have none selected (reduction_product==0) you also want to exclude special prices for this discount when you switch on : reduction_exclude_special

The current code only exclude products with special prices when reduction_product==-2 (selected products) which is obviously wrong

Reproduction steps:
Add a cartrule ( not a catalog rule!) 
Add discount in percentage
Apply this discount to: Order (excluding carriercosts)

1)Now add a product with a special price to an empty cart. --> It' s impossible to add the cart rule code. Which is correct behaviour
2)Now add a product WITHOUT a special price to the cart --> Now add the cart rule code to the cart, succes. Which is also correct behaviour.
3)Now look at your discount price. It's incorrect because the discount is also on the product which has an special price even though is switched on : reduction_exclude_special to ON

Using this code will let the rule behave correctly, it's aware of reduction_exclude_special

UPDATE: 
-------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/14218917/55948034-f3904180-5c4f-11e9-88a4-87149fa2a20b.png)
Here is proof of what is wrong. The discount 28.13 (labeled 1 in the picture) is correct, however the caluculated and applied discount for this order because of the bug is 46.63 ( labeled 2 in the picture), 
This PR fixes that

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13267)
<!-- Reviewable:end -->
