### PR TITLE
Make all grids responsive

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/table.html.twig
@@ -23,8 +23,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{{ form_start(grid.filter_form, {'attr': {'id': grid.id ~ '_filter_form'}}) }}
-<table class="grid-table js-grid-table table table-responsive-lg {% if is_ordering_column(grid) %}grid-ordering-column{% endif %} {% if grid.attributes.is_empty_state %}border-0{% endif %}"
+{{ form_start(grid.filter_form, {'attr': {'id': grid.id ~ '_filter_form', 'class': 'table-responsive'}}) }}
+<table class="grid-table js-grid-table table {% if is_ordering_column(grid) %}grid-ordering-column{% endif %} {% if grid.attributes.is_empty_state %}border-0{% endif %}"
        id="{{ grid.id }}_grid_table"
        data-query="{{ grid.data.query }}"
 >


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | This change makes all grids scroll horizontally when there's not enough space
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Go to a page that displays a grid (eg: Customers listing), then reduce the browser window width. If the grid does not fit the page, then the grid alone will scroll horizontally instead of the whole page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13349)
<!-- Reviewable:end -->
