### PR TITLE
Fixes default Customer group overriding

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -218,8 +218,8 @@ class CustomerCore extends ObjectModel
      */
     public function __construct($id = null)
     {
-        parent::__construct($id);
         $this->id_default_group = (int) Configuration::get('PS_CUSTOMER_GROUP');
+        parent::__construct($id);
     }
 
     /**

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -218,6 +218,7 @@ class CustomerCore extends ObjectModel
      */
     public function __construct($id = null)
     {
+        // It sets default value for customer group even when customer does not exist
         $this->id_default_group = (int) Configuration::get('PS_CUSTOMER_GROUP');
         parent::__construct($id);
     }

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -81,7 +81,9 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
             throw new CustomerException('Customer contains invalid field values');
         }
 
-        $customer->update();
+        if (false === $customer->update()) {
+            throw new CustomerException('Failed to update customer');
+        }
     }
 
     /**

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForEditingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForEditingHandler.php
@@ -74,7 +74,7 @@ final class GetCustomerForEditingHandler implements GetCustomerForEditingHandler
             (bool) $customer->optin,
             (bool) $customer->newsletter,
             $customer->getGroups(),
-            $customer->id_default_group,
+            (int) $customer->id_default_group,
             (string) $customer->company,
             (string) $customer->siret,
             (string) $customer->ape,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fixes `id_default_group` overriding in Customer.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13274
| How to test?  | In Customer form Default group should be displayed correctly.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13353)
<!-- Reviewable:end -->
