### PR TITLE
Fix one case spelling in GetCmsPageForEditingHandler

### DIFF
--- a/src/Adapter/CMS/Page/QueryHandler/GetCmsPageForEditingHandler.php
+++ b/src/Adapter/CMS/Page/QueryHandler/GetCmsPageForEditingHandler.php
@@ -70,7 +70,7 @@ final class GetCmsPageForEditingHandler extends AbstractCmsPageHandler implement
      * @throws CmsPageCategoryException
      * @throws CmsPageNotFoundException
      */
-    public function handle(getCmsPageForEditing $query)
+    public function handle(GetCmsPageForEditing $query)
     {
         $cmsPageId = $query->getCmsPageId()->getValue();
         $cms = $this->getCmsPageIfExistsById($cmsPageId);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Bad case spelling that could create error on case-sensitive environments. I guess it's fine because php is case-insensitive but I dont want to bet on it. Thanks phpstan for finding this.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | I think we should be fine 🤔

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13357)
<!-- Reviewable:end -->
