### PR TITLE
Fix syntax error in tpl

### DIFF
--- a/admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl
@@ -82,7 +82,7 @@
 											<div class="form-group">
 												<span class="col-lg-3 control-label"><strong>{l s='Attachment'}</strong></span>
 												<div class="col-lg-9">
-													<a href="{$link->getAdminLink('AdminCarts', true, [], ['ajax' => 1, 'action' => 'customizationImage', 'img' => $data['value'], 'name' => $returnedCustomization['id_order_detail']|intval|cat:'-file'|cat:$smarty.foreach.data.iteration.iteration]])}" class="_blank"><img class="img-thumbnail" src="{$picture_folder}{$data['value']}_small" alt="" /></a>
+													<a href="{$link->getAdminLink('AdminCarts', true, [], ['ajax' => 1, 'action' => 'customizationImage', 'img' => $data['value'], 'name' => $returnedCustomization['id_order_detail']|intval|cat:'-file'|cat:$smarty.foreach.data.iteration.iteration])}" class="_blank"><img class="img-thumbnail" src="{$picture_folder}{$data['value']}_small" alt="" /></a>
 												</div>
 											</div>
 										{/foreach}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fix syntax error in tpl following endpoint deprecation
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #13361
| How to test?  | Reproduce the given scenario and check the syntax error disapeared

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13363)
<!-- Reviewable:end -->
