### PR TITLE
Remove deactivated currencies from new CLDR

### DIFF
--- a/src/Core/Form/ChoiceProvider/CurrencyNameByIsoCodeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CurrencyNameByIsoCodeChoiceProvider.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\CurrencyData;
 
 /**
  * Class CurrencyNameByIsoCodeChoiceProvider is responsible for retrieving currency names from cldr library.
@@ -34,12 +35,12 @@ use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 final class CurrencyNameByIsoCodeChoiceProvider implements FormChoiceProviderInterface
 {
     /**
-     * @var array
+     * @var CurrencyData[]
      */
     private $cldrAllCurrencies;
 
     /**
-     * @param array $cldrAllCurrencies
+     * @param CurrencyData[] $cldrAllCurrencies
      */
     public function __construct(array $cldrAllCurrencies)
     {
@@ -53,6 +54,11 @@ final class CurrencyNameByIsoCodeChoiceProvider implements FormChoiceProviderInt
     {
         $result = [];
         foreach ($this->cldrAllCurrencies as $cldrCurrency) {
+            // filter only on active currency
+            // we dont need here currencies which were deactivated in all territories
+            if (!$cldrCurrency->isActive()) {
+                continue;
+            }
             $currencyNames = $cldrCurrency->getDisplayNames();
             $isoCode = $cldrCurrency->getIsoCode();
             $displayName = sprintf('%s (%s)', $currencyNames['default'], $isoCode);

--- a/src/Core/Form/ChoiceProvider/CurrencyNameByIsoCodeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CurrencyNameByIsoCodeChoiceProvider.php
@@ -59,6 +59,7 @@ final class CurrencyNameByIsoCodeChoiceProvider implements FormChoiceProviderInt
 
             $result[$displayName] = $isoCode;
         }
+        ksort($result);
 
         return $result;
     }

--- a/src/Core/Localization/CLDR/CurrencyData.php
+++ b/src/Core/Localization/CLDR/CurrencyData.php
@@ -84,6 +84,13 @@ class CurrencyData
     protected $symbols;
 
     /**
+     * Is the currency used somewhere, or was it deactivated in all territories
+     *
+     * @var bool
+     */
+    protected $active;
+
+    /**
      * Override this object's data with another CurrencyData object.
      *
      * @param CurrencyData $currencyData
@@ -100,6 +107,10 @@ class CurrencyData
 
         if (null !== $currencyData->getNumericIsoCode()) {
             $this->setNumericIsoCode($currencyData->getNumericIsoCode());
+        }
+
+        if (null !== $currencyData->isActive()) {
+            $this->setActive($currencyData->isActive());
         }
 
         if (null !== $currencyData->getDecimalDigits()) {
@@ -221,5 +232,23 @@ class CurrencyData
         $this->symbols = $symbols;
 
         return $this;
+    }
+
+    /**
+     * is currency still active in some territory
+     *
+     * @return bool
+     */
+    public function isActive()
+    {
+        return $this->active;
+    }
+
+    /**
+     * @param bool $active
+     */
+    public function setActive($active)
+    {
+        $this->active = (bool) $active;
     }
 }

--- a/src/Core/Localization/CLDR/CurrencyData.php
+++ b/src/Core/Localization/CLDR/CurrencyData.php
@@ -86,7 +86,7 @@ class CurrencyData
     /**
      * Is the currency used somewhere, or was it deactivated in all territories
      *
-     * @var bool
+     * @var bool|null
      */
     protected $active;
 

--- a/src/Core/Localization/CLDR/CurrencyData.php
+++ b/src/Core/Localization/CLDR/CurrencyData.php
@@ -237,7 +237,7 @@ class CurrencyData
     /**
      * is currency still active in some territory
      *
-     * @return bool
+     * @return bool|null
      */
     public function isActive()
     {

--- a/src/Core/Localization/CLDR/Reader.php
+++ b/src/Core/Localization/CLDR/Reader.php
@@ -656,12 +656,12 @@ class Reader implements ReaderInterface
             if (empty($currencyDate->attributes()->to)) {
                 // no date "to": currency is active in some territory
                 return true;
-            } else {
-                // date "to" given: check if currency was active in near past to propose it
-                $dateTo = \DateTime::createFromFormat('Y-m-d', $currencyDate->attributes()->to);
-                if (false !== $dateTo && $dateTo->getTimestamp() > $currencyActiveDateThreshold) {
-                    return true;
-                }
+            }
+
+            // date "to" given: check if currency was active in near past to propose it
+            $dateTo = \DateTime::createFromFormat('Y-m-d', $currencyDate->attributes()->to);
+            if (false !== $dateTo && $dateTo->getTimestamp() > $currencyActiveDateThreshold) {
+                return true;
             }
         }
 

--- a/src/Core/Localization/CLDR/Reader.php
+++ b/src/Core/Localization/CLDR/Reader.php
@@ -628,12 +628,8 @@ class Reader implements ReaderInterface
             // no territory with dates means currency was never used
             return false;
         }
-        if (!$this->isCurrencyActiveSomewhere($currencyDates, $currencyActiveDateThreshold)) {
-            // currency is not active, dont store it
-            return false;
-        }
 
-        return true;
+        return $this->isCurrencyActiveSomewhere($currencyDates, $currencyActiveDateThreshold);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | some currencies do not need to be added if it is deactivated for a long time. Deprecate adding currencies BYR, LTL, STD which are deprecated
| Type?         | bug fix
| Category?     |  BO
| BC breaks?    | yes
| Deprecations? | yes
| Fixed ticket? | fixes #13270
| How to test?  | in BO go to currency add, the dropdown should show only active currency. CLDR uses file cache, so delete following directory if you try to test between several versions: /var/cache/dev

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13367)
<!-- Reviewable:end -->
