### PR TITLE
Add missing security annotations

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowInterface;
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\DataProvider\Admin\RecommendedModules;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -329,6 +330,8 @@ class CommonController extends FrameworkBundleAdminController
      * @param string $gridDefinitionFactoryServiceId
      * @param string $redirectRoute
      * @param array $redirectQueryParamsToKeep
+     *
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
      *
      * @return RedirectResponse
      */

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -206,6 +206,8 @@ class ImportController extends FrameworkBundleAdminController
     /**
      * Download import sample file.
      *
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))", redirectRoute="admin_import")
+     *
      * @param $sampleName
      *
      * @return Response

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -230,6 +230,11 @@ class ImportController extends FrameworkBundleAdminController
     /**
      * Get available entity fields.
      *
+     * @AdminSecurity(
+     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_import"
+     * )
+     *
      * @param Request $request
      *
      * @return JsonResponse

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportDataConfigurationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportDataConfigurationController.php
@@ -152,6 +152,11 @@ class ImportDataConfigurationController extends FrameworkBundleAdminController
     /**
      * Get import data match configuration.
      *
+     * @AdminSecurity(
+     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_import"
+     * )
+     *
      * @param Request $request
      *
      * @return JsonResponse

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -82,6 +82,8 @@ class ProfileController extends FrameworkBundleAdminController
     /**
      * Used for applying filtering actions.
      *
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     *
      * @param Request $request
      *
      * @return RedirectResponse

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -367,8 +367,6 @@ class ThemeController extends AbstractAdminController
     /**
      * Show Front Office theme's pages layout customization.
      *
-     * @DemoRestricted(redirectRoute="admin_themes_index")
-     *
      * @param Request $request
      *
      * @return Response

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -85,6 +85,8 @@ class CurrencyController extends FrameworkBundleAdminController
     /**
      * Provides filters functionality.
      *
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     *
      * @param Request $request
      *
      * @return RedirectResponse

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -79,6 +79,8 @@ class LanguageController extends FrameworkBundleAdminController
     /**
      * Process Grid search.
      *
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     *
      * @param Request $request
      *
      * @return RedirectResponse

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -83,6 +83,8 @@ class SupplierController extends FrameworkBundleAdminController
     /**
      * Filters list results.
      *
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     *
      * @param Request $request
      *
      * @return RedirectResponse
@@ -351,6 +353,8 @@ class SupplierController extends FrameworkBundleAdminController
 
     /**
      * Exports to csv visible suppliers list data.
+     *
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
      *
      * @param SupplierFilters $filters
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -111,6 +111,8 @@ class CustomerController extends AbstractAdminController
     /**
      * Show customer create form & handle processing of it.
      *
+     * @AdminSecurity("is_granted(['create'], request.get('_legacy_controller'))")
+     *
      * @param Request $request
      *
      * @return Response
@@ -160,6 +162,8 @@ class CustomerController extends AbstractAdminController
 
     /**
      * Show customer edit form & handle processing of it.
+     *
+     * @AdminSecurity("is_granted(['update'], request.get('_legacy_controller'))")
      *
      * @param int $customerId
      * @param Request $request
@@ -627,6 +631,8 @@ class CustomerController extends AbstractAdminController
 
     /**
      * Export filtered customers
+     *
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
      *
      * @param CustomerFilters $filters
      *

--- a/src/PrestaShopBundle/Controller/Admin/StockController.php
+++ b/src/PrestaShopBundle/Controller/Admin/StockController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin;
 
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
 /**
@@ -36,6 +37,8 @@ class StockController extends FrameworkBundleAdminController
     protected $layoutTitle = 'Stock';
 
     /**
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     *
      * @Template("@PrestaShop/Admin/Stock/overview.html.twig")
      */
     public function overviewAction()

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -49,6 +49,8 @@ class TranslationsController extends FrameworkBundleAdminController
     const controller_name = self::CONTROLLER_NAME;
 
     /**
+     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     *
      * @Template("@PrestaShop/Admin/Translations/overview.html.twig")
      */
     public function overviewAction()

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -49,8 +49,6 @@ class TranslationsController extends FrameworkBundleAdminController
     const controller_name = self::CONTROLLER_NAME;
 
     /**
-     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
-     *
      * @Template("@PrestaShop/Admin/Translations/overview.html.twig")
      */
     public function overviewAction()

--- a/src/PrestaShopBundle/Controller/Api/ApiController.php
+++ b/src/PrestaShopBundle/Controller/Api/ApiController.php
@@ -190,4 +190,20 @@ abstract class ApiController
 
         return new JsonResponse($response, $status, $headers);
     }
+
+    /**
+     * Checks if access is granted.
+     *
+     * @param string $controller name of the controller
+     * @param array $accessLevel
+     *
+     * @return bool
+     */
+    protected function isGranted(array $accessLevel, $controller)
+    {
+        return $this->container->get('security.authorization_checker')->isGranted(
+            $accessLevel,
+            $controller.'_'
+        );
+    }
 }

--- a/src/PrestaShopBundle/Controller/Api/ApiController.php
+++ b/src/PrestaShopBundle/Controller/Api/ApiController.php
@@ -203,7 +203,7 @@ abstract class ApiController
     {
         return $this->container->get('security.authorization_checker')->isGranted(
             $accessLevel,
-            $controller.'_'
+            $controller . '_'
         );
     }
 }

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -34,8 +34,11 @@ use PrestaShopBundle\Entity\ProductIdentity;
 use PrestaShopBundle\Entity\Repository\StockRepository;
 use PrestaShopBundle\Exception\InvalidPaginationParamsException;
 use PrestaShopBundle\Exception\ProductNotFoundException;
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class StockController extends ApiController
@@ -86,6 +89,10 @@ class StockController extends ApiController
      */
     public function editProductAction(Request $request)
     {
+        if (!$this->isGranted([PageVoter::UPDATE], $request->get('_legacy_controller'))) {
+            return new JsonResponse(null, Response::HTTP_FORBIDDEN);
+        }
+
         try {
             $this->guardAgainstMissingDeltaParameter($request);
             $delta = $request->request->getInt('delta');
@@ -111,10 +118,16 @@ class StockController extends ApiController
     /**
      * @param Request $request
      *
+     * @AdminSecurity("is_granted(['update'], request.get('_legacy_controller'))")
+     *
      * @return JsonResponse
      */
     public function bulkEditProductsAction(Request $request)
     {
+        if (!$this->isGranted([PageVoter::UPDATE], $request->get('_legacy_controller'))) {
+            return new JsonResponse(null, Response::HTTP_FORBIDDEN);
+        }
+
         try {
             $this->guardAgainstInvalidBulkEditionRequest($request);
             $stockMovementsParams = json_decode($request->getContent(), true);

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -34,7 +34,6 @@ use PrestaShopBundle\Entity\ProductIdentity;
 use PrestaShopBundle\Entity\Repository\StockRepository;
 use PrestaShopBundle\Exception\InvalidPaginationParamsException;
 use PrestaShopBundle\Exception\ProductNotFoundException;
-use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -118,8 +118,6 @@ class StockController extends ApiController
     /**
      * @param Request $request
      *
-     * @AdminSecurity("is_granted(['update'], request.get('_legacy_controller'))")
-     *
      * @return JsonResponse
      */
     public function bulkEditProductsAction(Request $request)

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
@@ -11,6 +11,7 @@ admin_employees_search:
   methods: [POST]
   defaults:
     _controller: 'PrestaShopBundle:Admin\Common:searchGrid'
+    _legacy_controller: AdminEmployees
     gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.employee
     redirectRoute: admin_employees_index
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
@@ -3,6 +3,7 @@ admin_international_translation_overview:
     methods:  [GET]
     defaults:
         _controller: PrestaShopBundle:Admin/Translations:overview
+        _legacy_controller: AdminTranslations
         _legacy_link: AdminTranslationSf
 
 admin_international_translations_export_theme:

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/stocks.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/stocks.yml
@@ -3,6 +3,7 @@ admin_stock_overview:
     methods:  [GET]
     defaults:
         _controller: PrestaShopBundle:Admin/Stock:overview
+        _legacy_controller: AdminStockManagement
         _legacy_link: AdminStockManagement
 
 admin_stock_movements_overview:
@@ -10,3 +11,4 @@ admin_stock_movements_overview:
     methods: [GET]
     defaults:
         _controller: PrestaShopBundle:Admin/Stock:overview
+        _legacy_controller: AdminStockManagement

--- a/src/PrestaShopBundle/Resources/config/routing/api/stocks.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/stocks.yml
@@ -23,6 +23,7 @@ api_stock_edit_product:
     methods: [POST]
     defaults:
         _controller: prestashop.core.api.stock.controller:editProductAction
+        _legacy_controller: AdminStockManagement
     requirements:
         productId: \d+
 
@@ -31,6 +32,7 @@ api_stock_edit_product_combination:
     methods: [POST]
     defaults:
         _controller: prestashop.core.api.stock.controller:editProductAction
+        _legacy_controller: AdminStockManagement
     requirements:
         productId: \d+
         combinationId: \d+
@@ -40,3 +42,4 @@ api_stock_bulk_edit_products:
     methods: [POST]
     defaults:
         _controller: prestashop.core.api.stock.controller:bulkEditProductsAction
+        _legacy_controller: AdminStockManagement


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Adding missing security annotations that will check if employee has sufficient permissions before allowing to access the actions.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Check if specified actions are working with given permissions and showing an error message with insufficient permissions. The actions are listed below.

Actions that are secured with this PR:
* admin_suppliers_search - **search action in suppliers grid**
* admin_suppliers_export - **export action in suppliers grid**
* admin_customers_filter - **search action in customers grid**
* admin_customers_create - **customer creation form page and submit action**
* admin_customers_edit - **customer edit form page and submit action**
* admin_customers_export - **export action in customers grid**
* admin_stock_overview - **stock page `/admin-dev/index.php/sell/stocks/`**
* admin_stock_movements_overview - **stock movements page `/admin-dev/index.php/sell/stocks/movements`**
* admin_import_file_upload - **import file upload action**
* admin_import_sample_download - **import sample file download action**
* admin_employees_search - **search action in employees grid**
* admin_profiles_search - **search action in profiles grid**
* admin_international_translation_overview - **translations app (accessed by clicking "modify" in International>Translations) e.g. `/admin-dev/index.php/improve/international/translations/?lang=en&type=back&locale=en-US`**
* admin_languages_search - **search action in languages grid**
* admin_currencies_search - **search action in currencies grid**
* admin_cms_pages_search_cms_category - **search action in CMS category grid**
* admin_import_data_configuration_get - **functionality from import step 2, which is hidden and still WIP**
* admin_import_get_available_fields - **action to retrieve import available fields, which are displayed in import step 1 (https://prnt.sc/nc4nr4)**

---

Actions for which security is **not** fixed in this PR:
* many actions from product page - @matks informed me that product page will be reworked soon.
* admin_common_recommended_modules - couldn't find where this action is used at all. https://github.com/PrestaShop/PrestaShop/blob/5eaef1459a8d3ceb35ffa0a312a1632877947e9e/src/PrestaShopBundle/Controller/Admin/CommonController.php#L157
* Category page actions - they are fixed in https://github.com/PrestaShop/PrestaShop/pull/13236
* Actions that have specific security rules which are defined in action's code instead of annotations.
* JSON actions - we need to improve security annotations to support JSON responses. It is done in https://github.com/PrestaShop/PrestaShop/pull/13236

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13372)
<!-- Reviewable:end -->
