### PR TITLE
Fix fallback trans escape html

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -209,11 +209,22 @@ function smartyTranslate($params, $smarty)
                 return $params['s'];
             }
         }
-    }
 
-    if (($translation = Context::getContext()->getTranslator()->trans($params['s'], $params['sprintf'], $params['d'])) !== $params['s']
-        && $params['mod'] === false) {
-        return $translation;
+        if (isset($params['sprintf']) && !is_array($params['sprintf'])) {
+            $sprintf = array($params['sprintf']);
+        } elseif (isset($params['sprintf'])) {
+            $sprintf = $params['sprintf'];
+        }
+
+        if (isset($params['htmlspecialchars']) && $params['htmlspecialchars']) {
+            $sprintf['legacy'] = 'htmlspecialchars';
+        } elseif ($params['js']) {
+            $sprintf['legacy'] = 'addslashes';
+        }
+        $translation = Context::getContext()->getTranslator()->trans($params['s'], $sprintf, $params['d']);
+        if ($translation !== $params['s']) {
+            return $translation;
+        }
     }
 
     $string = str_replace('\'', '\\\'', $params['s']);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | When using legacy fallback on an unknown key the HTML tags were escaped because of `Translate::getModuleTranslation`. So we cancel this change by applying `htmlspecialchars_decode` afterwards. Furthermore the front smarty `{l s=""}` tag now only uses the Symfony translator when a domain was specified, and it transmits more parameters to the translator to deal with more advanced cases.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13358
| How to test?  | Perform a purchase using bank wire payment. The support link should be correctly displayed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13378)
<!-- Reviewable:end -->
