### PR TITLE
Add naming convention linter

### DIFF
--- a/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
+++ b/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Command;
 
-use PrestaShopBundle\Routing\Linter\LinterException;
+use PrestaShopBundle\Routing\Linter\Exception\LinterException;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
+++ b/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
@@ -78,9 +78,11 @@ final class NamingConventionLinterCommand extends ContainerAwareCommand
             ));
             $io->listing($invalidRoutes);
 
-            return;
+            return 1;
         }
 
         $io->success('Admin routes and controllers follow naming conventions.');
+
+        return 0;
     }
 }

--- a/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
+++ b/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
@@ -33,6 +33,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Routing\Route;
 
+/**
+ * Runs naming conventions linter in the CLI
+ */
 final class NamingConventionLinterCommand extends ContainerAwareCommand
 {
     /**
@@ -55,25 +58,25 @@ final class NamingConventionLinterCommand extends ContainerAwareCommand
         $namingConventionLinter = $this->getContainer()
             ->get('prestashop.bundle.routing.linter.naming_convention_linter');
 
-        $notConfiguredRoutes = [];
+        $invalidRoutes = [];
 
         /** @var Route $route */
         foreach ($adminRouteProvider->getRoutes() as $routeName => $route) {
             try {
                 $namingConventionLinter->lint($routeName, $route);
             } catch (LinterException $e) {
-                $notConfiguredRoutes[] = $routeName;
+                $invalidRoutes[] = $routeName;
             }
         }
 
         $io = new SymfonyStyle($input, $output);
 
-        if (!empty($notConfiguredRoutes)) {
+        if (!empty($invalidRoutes)) {
             $io->warning(sprintf(
                 '%s routes are not following naming conventions:',
-                count($notConfiguredRoutes)
+                count($invalidRoutes)
             ));
-            $io->listing($notConfiguredRoutes);
+            $io->listing($invalidRoutes);
 
             return;
         }

--- a/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
+++ b/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
@@ -33,10 +33,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Routing\Route;
 
-/**
- * Checks if all admin routes have @AdminSecurity configured
- */
-final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
+final class NamingConventionLinterCommand extends ContainerAwareCommand
 {
     /**
      * {@inheritdoc}
@@ -44,8 +41,8 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
     public function configure()
     {
         $this
-            ->setName('prestashop:linter:security-annotation')
-            ->setDescription('Checks if Back Office route controllers has configured Security annotations.')
+            ->setName('prestashop:linter:naming-convention')
+            ->setDescription('Checks if Back Office routes and controllers follow naming convention.')
         ;
     }
 
@@ -55,15 +52,15 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $adminRouteProvider = $this->getContainer()->get('prestashop.bundle.routing.linter.admin_route_provider');
-        $securityAnnotationLinter = $this->getContainer()
-            ->get('prestashop.bundle.routing.linter.security_annotation_linter');
+        $namingConventionLinter = $this->getContainer()
+            ->get('prestashop.bundle.routing.linter.naming_convention_linter');
 
         $notConfiguredRoutes = [];
 
         /** @var Route $route */
         foreach ($adminRouteProvider->getRoutes() as $routeName => $route) {
             try {
-                $securityAnnotationLinter->lint($routeName, $route);
+                $namingConventionLinter->lint($routeName, $route);
             } catch (LinterException $e) {
                 $notConfiguredRoutes[] = $routeName;
             }
@@ -73,7 +70,7 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
 
         if (!empty($notConfiguredRoutes)) {
             $io->warning(sprintf(
-                '%s routes are not configured with @AdminSecurity annotation:',
+                '%s routes are not following naming conventions:',
                 count($notConfiguredRoutes)
             ));
             $io->listing($notConfiguredRoutes);
@@ -81,6 +78,6 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
             return;
         }
 
-        $io->success('Admin routes has @AdminSecurity configured.');
+        $io->success('Admin routes and controllers follow naming conventions.');
     }
 }

--- a/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
+++ b/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Command;
 
-use PrestaShopBundle\Routing\Linter\LinterException;
+use PrestaShopBundle\Routing\Linter\Exception\LinterException;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
@@ -41,6 +41,11 @@ services:
           - '@annotation_reader'
           - '@controller_name_converter'
 
+    prestashop.bundle.routing.linter.naming_convention_linter:
+        class: 'PrestaShopBundle\Routing\Linter\NamingConventionLinter'
+        arguments:
+            - '@controller_name_converter'
+
     prestashop.bundle.routing.linter.admin_route_provider:
         class: 'PrestaShopBundle\Routing\Linter\AdminRouteProvider'
         arguments:

--- a/src/PrestaShopBundle/Routing/Linter/Exception/LinterException.php
+++ b/src/PrestaShopBundle/Routing/Linter/Exception/LinterException.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShopBundle\Routing\Linter;
+namespace PrestaShopBundle\Routing\Linter\Exception;
 
 use RuntimeException;
 

--- a/src/PrestaShopBundle/Routing/Linter/Exception/NamingConventionException.php
+++ b/src/PrestaShopBundle/Routing/Linter/Exception/NamingConventionException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Routing\Linter\Exception;
+
+/**
+ * Thrown when naming convention is not followed
+ */
+class NamingConventionException extends LinterException
+{
+}

--- a/src/PrestaShopBundle/Routing/Linter/NamingConventionLinter.php
+++ b/src/PrestaShopBundle/Routing/Linter/NamingConventionLinter.php
@@ -26,34 +26,25 @@
 
 namespace PrestaShopBundle\Routing\Linter;
 
-use Doctrine\Common\Annotations\Reader;
-use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use ReflectionMethod;
+use Doctrine\Common\Inflector\Inflector;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\Routing\Route;
 
 /**
- * Checks if SecurityAnnotation is configured for route's controller action
+ * Checks that route and contoller follows naming conventions
  */
-final class SecurityAnnotationLinter implements RouteLinterInterface
+final class NamingConventionLinter implements RouteLinterInterface
 {
-    /**
-     * @var Reader
-     */
-    private $annotationReader;
-
     /**
      * @var ControllerNameParser
      */
     private $controllerNameParser;
 
     /**
-     * @param Reader $annotationReader
      * @param ControllerNameParser $controllerNameParser
      */
-    public function __construct(Reader $annotationReader, ControllerNameParser $controllerNameParser)
+    public function __construct(ControllerNameParser $controllerNameParser)
     {
-        $this->annotationReader = $annotationReader;
         $this->controllerNameParser = $controllerNameParser;
     }
 
@@ -62,21 +53,19 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
      */
     public function lint($routeName, Route $route)
     {
-        $controllerAndMethod = $this->extractControllerAndMethodNamesFromRoute($route);
+        $controllerAndMethodName = $this->getControllerAndMethodName($route);
 
-        $reflection = new ReflectionMethod(
-            $controllerAndMethod['controller'],
-            $controllerAndMethod['method']
+        $pluralizedController = Inflector::tableize(
+            Inflector::pluralize($controllerAndMethodName['controller'])
         );
 
-        $annotation = $this->annotationReader->getMethodAnnotation($reflection, AdminSecurity::class);
+        $expectedRouteName = strtr('admin_{resources}_{action}', [
+            '{resources}' => $pluralizedController,
+            '{action}' => Inflector::tableize($controllerAndMethodName['method']),
+        ]);
 
-        if (null === $annotation) {
-            throw new LinterException(sprintf(
-                '"%s:%s" does not have AdminSecurity annotation configured',
-                 $controllerAndMethod['controller'],
-                 $controllerAndMethod['method']
-            ));
+        if ($routeName !== $expectedRouteName) {
+            throw new LinterException(sprintf('Route "%s" does not follow naming convention.', $routeName));
         }
     }
 
@@ -85,16 +74,20 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
      *
      * @return array
      */
-    private function extractControllerAndMethodNamesFromRoute(Route $route)
+    private function getControllerAndMethodName(Route $route)
     {
         $controller = $route->getDefault('_controller');
 
         if (strpos($controller, '::') === false) {
-            // we need to support controllers defined as services & defined using short notation
             $controller = $this->controllerNameParser->parse($controller);
         }
 
         list($controller, $method) = explode('::', $controller, 2);
+
+        $controllerParts = explode('\\', $controller);
+        $controller = preg_replace('/Controller$/', '', end($controllerParts));
+
+        $method = preg_replace('/Action$/', '', $method);
 
         return [
             'controller' => $controller,

--- a/src/PrestaShopBundle/Routing/Linter/NamingConventionLinter.php
+++ b/src/PrestaShopBundle/Routing/Linter/NamingConventionLinter.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Routing\Linter;
 
 use Doctrine\Common\Inflector\Inflector;
+use PrestaShopBundle\Routing\Linter\Exception\NamingConventionException;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\Routing\Route;
 
@@ -65,7 +66,7 @@ final class NamingConventionLinter implements RouteLinterInterface
         ]);
 
         if ($routeName !== $expectedRouteName) {
-            throw new LinterException(sprintf('Route "%s" does not follow naming convention.', $routeName));
+            throw new NamingConventionException(sprintf('Route "%s" does not follow naming convention.', $routeName));
         }
     }
 

--- a/src/PrestaShopBundle/Routing/Linter/RouteLinterInterface.php
+++ b/src/PrestaShopBundle/Routing/Linter/RouteLinterInterface.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Routing\Linter;
 
+use PrestaShopBundle\Routing\Linter\Exception\LinterException;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -36,7 +37,7 @@ interface RouteLinterInterface
     /**
      * @param Route $route
      *
-     * @return bool True if route passes linter or False otherwise
+     * @throws LinterException when linting error occurs
      */
     public function lint($routeName, Route $route);
 }

--- a/src/PrestaShopBundle/Routing/Linter/RouteLinterInterface.php
+++ b/src/PrestaShopBundle/Routing/Linter/RouteLinterInterface.php
@@ -38,5 +38,5 @@ interface RouteLinterInterface
      *
      * @return bool True if route passes linter or False otherwise
      */
-    public function lint(Route $route);
+    public function lint($routeName, Route $route);
 }

--- a/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
+++ b/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Routing\Linter;
 
 use Doctrine\Common\Annotations\Reader;
+use PrestaShopBundle\Routing\Linter\Exception\LinterException;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use ReflectionMethod;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;

--- a/tests/Integration/PrestaShopBundle/Routing/Linter/NamingConventionLinterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Linter/NamingConventionLinterTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\PrestaShopBundle\Routing\Linter;
+
+use PrestaShopBundle\Routing\Linter\Exception\NamingConventionException;
+use PrestaShopBundle\Routing\Linter\NamingConventionLinter;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Routing\Route;
+use Tests\Resources\Controller\TestController;
+
+class NamingConventionLinterTest extends KernelTestCase
+{
+    /**
+     * @var NamingConventionLinter
+     */
+    private $namingConventionLinter;
+
+    protected function setUp()
+    {
+        self::bootKernel();
+
+        $this->namingConventionLinter = self::$kernel->getContainer()
+            ->get('prestashop.bundle.routing.linter.naming_convention_linter');
+    }
+
+    /**
+     * @dataProvider getRoutesThatFollowNamingConventions
+     */
+    public function testLinterPassesWhenRouteAndControllerFollowNamingConventions($routeName, Route $route)
+    {
+        $this->namingConventionLinter->lint($routeName, $route);
+
+        $this->assertTrue($exceptionWasNotThrown = true);
+    }
+
+    /**
+     * @dataProvider getRoutesThatDoNotFollowNamingConventions
+     */
+    public function testLinterThrowsExceptionWhenRouteAndControllerDoesNotFollowNamingConventions($routeName, Route $route)
+    {
+        $this->expectException(NamingConventionException::class);
+
+        $this->namingConventionLinter->lint($routeName, $route);
+    }
+
+    public function getRoutesThatFollowNamingConventions()
+    {
+        yield [
+            'admin_tests_index',
+            new Route('/', [
+                '_controller' => sprintf('%s::%s', TestController::class, 'indexAction'),
+            ]),
+        ];
+
+        yield [
+            'admin_tests_do_something_complex',
+            new Route('/', [
+                '_controller' => sprintf('%s::%s', TestController::class, 'doSomethingComplexAction'),
+            ]),
+        ];
+    }
+
+    public function getRoutesThatDoNotFollowNamingConventions()
+    {
+        yield [
+            'admin_test_index',
+            new Route('/', [
+                '_controller' => sprintf('%s::%s', TestController::class, 'createAction'),
+            ]),
+        ];
+
+        yield [
+            'admin_tests_do_something',
+            new Route('/', [
+                '_controller' => sprintf('%s::%s', TestController::class, 'doSomethingComplexAction'),
+            ]),
+        ];
+    }
+
+    protected function tearDown()
+    {
+        self::$kernel->shutdown();
+    }
+}

--- a/tests/Integration/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinterTest.php
@@ -26,7 +26,7 @@
 
 namespace Tests\Integration\PrestaShopBundle\Routing\Linter;
 
-use PrestaShopBundle\Routing\Linter\LinterException;
+use PrestaShopBundle\Routing\Linter\Exception\LinterException;
 use PrestaShopBundle\Routing\Linter\SecurityAnnotationLinter;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Routing\Route;

--- a/tests/Integration/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinterTest.php
@@ -53,7 +53,7 @@ class SecurityAnnotationLinterTest extends KernelTestCase
             '_controller' => sprintf('%s::%s', TestController::class, 'indexAction'),
         ]);
 
-        $this->securityAnnotationLinter->lint($route);
+        $this->securityAnnotationLinter->lint('route_name', $route);
 
         $this->assertTrue($exceptionWasNotThrown = true);
     }
@@ -66,7 +66,7 @@ class SecurityAnnotationLinterTest extends KernelTestCase
 
         $this->expectException(LinterException::class);
 
-        $this->securityAnnotationLinter->lint($route);
+        $this->securityAnnotationLinter->lint('route_name', $route);
     }
 
     protected function tearDown()

--- a/tests/Resources/Controller/TestController.php
+++ b/tests/Resources/Controller/TestController.php
@@ -47,7 +47,7 @@ class TestController
         return new Response();
     }
 
-    public function doSomethingComplextAction()
+    public function doSomethingComplexAction()
     {
         return new Response();
     }

--- a/tests/Resources/Controller/TestController.php
+++ b/tests/Resources/Controller/TestController.php
@@ -46,4 +46,9 @@ class TestController
     {
         return new Response();
     }
+
+    public function doSomethingComplextAction()
+    {
+        return new Response();
+    }
 }

--- a/tests/Unit/PrestaShopBundle/Routing/Linter/NamingConventionLinterTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Linter/NamingConventionLinterTest.php
@@ -24,27 +24,27 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace Tests\Integration\PrestaShopBundle\Routing\Linter;
+namespace Tests\Unit\PrestaShopBundle\Routing\Linter;
 
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\PrestaShopBundle;
 use PrestaShopBundle\Routing\Linter\Exception\NamingConventionException;
 use PrestaShopBundle\Routing\Linter\NamingConventionLinter;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Route;
 use Tests\Resources\Controller\TestController;
 
-class NamingConventionLinterTest extends KernelTestCase
+class NamingConventionLinterTest extends TestCase
 {
     /**
      * @var NamingConventionLinter
      */
     private $namingConventionLinter;
 
-    protected function setUp()
+    public function setUp()
     {
-        self::bootKernel();
-
-        $this->namingConventionLinter = self::$kernel->getContainer()
-            ->get('prestashop.bundle.routing.linter.naming_convention_linter');
+        $this->namingConventionLinter = new NamingConventionLinter($this->createControllerNameParser());
     }
 
     /**
@@ -101,8 +101,13 @@ class NamingConventionLinterTest extends KernelTestCase
         ];
     }
 
-    protected function tearDown()
+    public function createControllerNameParser()
     {
-        self::$kernel->shutdown();
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getBundles')->willReturn([
+            'prestashop' => $this->createMock(PrestaShopBundle::class),
+        ]);
+
+        return new ControllerNameParser($kernel);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR introduces naming convention linter that checks if controller and route names are following PrestaShop conventions.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Run `bin/console prestashop:linter:naming-convention`

Example result:
![Screenshot from 2019-04-12 15-02-54](https://user-images.githubusercontent.com/15143151/56035926-2449a700-5d34-11e9-9360-07120379fb75.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13384)
<!-- Reviewable:end -->
