### PR TITLE
Bug when emails addresses are registered in uppercase.

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -151,6 +151,8 @@ class MailCore extends ObjectModel
             $idShop = Context::getContext()->shop->id;
         }
 
+        $to = Tools::strtolower($to);
+
         $keepGoing = array_reduce(
             Hook::exec(
                 'actionEmailSendBefore',


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a customer register his/her email address in uppercase, the confirmation email doesn't work as expected.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13386
| How to test?  | Register as customer entering your email in uppercase, check your inbox.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

I am not sure this is the best way to solve this issue, but it works for me. What do you think, PrestaShop Team?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13391)
<!-- Reviewable:end -->
