### PR TITLE
Set 'order_discounts' available in WebService

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -306,6 +306,7 @@ class WebserviceRequestCore
             'messages' => array('description' => 'The Messages', 'class' => 'Message'),
             'order_carriers' => array('description' => 'The Order carriers', 'class' => 'OrderCarrier'),
             'order_details' => array('description' => 'Details of an order', 'class' => 'OrderDetail'),
+            'order_discounts' => array('description' => 'Discounts of an order', 'class' => 'OrderDiscount'),
             'order_histories' => array('description' => 'The Order histories', 'class' => 'OrderHistory'),
             'order_invoices' => array('description' => 'The Order invoices', 'class' => 'OrderInvoice'),
             'orders' => array('description' => 'The Customers orders', 'class' => 'Order'),


### PR DESCRIPTION
In 1.7.x versions of PrestaShop, the `order_discounts` class is not accesible from API.
This modification breaks my Odoo <-> PrestaShop connector as I need to synchronize order discounts between the two systems.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.x
| Description?  | `order_discounts` object is not accessible via WebSeiivces. It was accessible in 1.6.x versions.
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? yes
| Fixed ticket? | Fixes #13394
| How to test?  | Enable WebServices and check if the `order_discounts` ojbect is available.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13393)
<!-- Reviewable:end -->
