### PR TITLE
Do not call removed cldr lib

### DIFF
--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -38,7 +38,6 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
         $this->className = 'SpecificPriceRule';
         $this->lang = false;
         $this->multishop_context = Shop::CONTEXT_ALL;
-        $this->cldr = Tools::getCldr(Context::getContext());
 
         parent::__construct();
 
@@ -155,8 +154,8 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
 
         foreach ($this->_list as $k => $list) {
             if (null !== $this->_list[$k]['currency_iso_code']) {
-                $currency = $this->cldr->getCurrency($this->_list[$k]['currency_iso_code']);
-                $this->_list[$k]['currency_name'] = ucfirst($currency['name']);
+                $currency = new Currency(Currency::getIdByIsoCode($this->_list[$k]['currency_iso_code']));
+                $this->_list[$k]['currency_name'] = $currency->name;
             }
 
             if ($list['reduction_type'] == 'amount') {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Remove call to deleted CLDR
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #13406
| How to test?  | Cart rule controller must work again, with localized data from the database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13409)
<!-- Reviewable:end -->
