### PR TITLE
Hide tax label in front when tax display is disabled in the shop

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1549,7 +1549,10 @@ class FrontControllerCore extends Controller
 
     protected function getDisplayTaxesLabel()
     {
-        return (Module::isEnabled('ps_legalcompliance') && (bool) Configuration::get('AEUC_LABEL_TAX_INC_EXC')) || $this->context->country->display_tax_label;
+        return
+            (Module::isEnabled('ps_legalcompliance') && (bool) Configuration::get('AEUC_LABEL_TAX_INC_EXC'))
+            || (Configuration::get('PS_TAX_DISPLAY') && $this->context->country->display_tax_label)
+        ;
     }
 
     public function getTemplateVarCurrency()

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1549,10 +1549,7 @@ class FrontControllerCore extends Controller
 
     protected function getDisplayTaxesLabel()
     {
-        return
-            (Module::isEnabled('ps_legalcompliance') && (bool) Configuration::get('AEUC_LABEL_TAX_INC_EXC'))
-            || (Configuration::get('PS_TAX') && $this->context->country->display_tax_label)
-        ;
+        return (Module::isEnabled('ps_legalcompliance') && (bool) Configuration::get('AEUC_LABEL_TAX_INC_EXC')) || $this->context->country->display_tax_label;
     }
 
     public function getTemplateVarCurrency()

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1551,7 +1551,7 @@ class FrontControllerCore extends Controller
     {
         return
             (Module::isEnabled('ps_legalcompliance') && (bool) Configuration::get('AEUC_LABEL_TAX_INC_EXC'))
-            || (Configuration::get('PS_TAX_DISPLAY') && $this->context->country->display_tax_label)
+            || (Configuration::get('PS_TAX') && $this->context->country->display_tax_label)
         ;
     }
 

--- a/themes/classic/templates/catalog/_partials/product-prices.tpl
+++ b/themes/classic/templates/catalog/_partials/product-prices.tpl
@@ -90,7 +90,9 @@
     {hook h='displayProductPriceBlock' product=$product type="weight" hook_origin='product_sheet'}
 
     <div class="tax-shipping-delivery-label">
-      {if $configuration.display_taxes_label}
+      {if !$configuration.taxes_enabled}
+        {l s='No tax' d='Shop.Theme.Catalog'}
+      {elseif $configuration.display_taxes_label}
         {$product.labels.tax_long}
       {/if}
       {hook h='displayProductPriceBlock' product=$product type="price"}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Hide tax label when Tax display is disabled in back office
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13240
| How to test?  | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13411)
<!-- Reviewable:end -->
