### PR TITLE
[POC] Add a hook to form_rest for custom field rendering

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
@@ -320,7 +320,7 @@
 
 {%- block form_end -%}
   {%- if not render_rest is defined or render_rest -%}
-    {{ form_rest(form) }}
+    {{ form_rest(form, { render_hook: false }) }}
   {%- endif -%}
   </form>
 {%- endblock form_end -%}
@@ -340,6 +340,10 @@
 {%- endblock form_errors -%}
 
 {%- block form_rest -%}
+  {% if render_hook is not defined or render_hook %}
+    {{ renderhook('display' ~ name ~ 'FormRest', { form: form }) }}
+  {% endif %}
+
   {% for child in form -%}
     {% if not child.rendered %}
       {{- form_row(child) -}}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Adds a hook that allows to customize form fields rendering from a module
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | This was discussed in https://github.com/PrestaShop/PrestaShop/issues/12585
| How to test?  | Explained below.

To test:

Install this module: [module](https://github.com/rokaszygmantas/formextensiontest)
The module will add two new fields in the bottom of language edit form.

Without this PR the fields are unaligned as we cannot control the rendering: https://prnt.sc/nc96pk
With this PR it should look much better, since we can customize the rendering: https://prnt.sc/nc9zjy 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13412)
<!-- Reviewable:end -->
