### PR TITLE
Add duplicated product id parameters to the hook

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -1060,6 +1060,7 @@ class ProductController extends FrameworkBundleAdminController
                     );
                     // Hooks: managed in ProductUpdater
                     $duplicateProductId = $productUpdater->duplicateProduct($id);
+                    $hookEventParameters['duplicate_product_id'] = $duplicateProductId;
                     $this->addFlash(
                         'success',
                         $this->trans('Product successfully duplicated.', 'Admin.Catalog.Notification')


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add duplicated product id parameters to the hook
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | write a small module hooked on actionAdminDuplicateAfter or actionAdminProductsControllerDuplicateAfter and look at the parameters

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13415)
<!-- Reviewable:end -->
