### PR TITLE
Remove material icons on SQL manager page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/form.html.twig
@@ -54,11 +54,9 @@
       </div>
       <div class="card-footer">
         <a href="{{ path('admin_sql_requests_index') }}" class="btn btn-outline-secondary">
-          <i class="material-icons">cancel</i>
           {{ 'Cancel'|trans({}, 'Admin.Actions') }}
         </a>
         <button class="btn btn-primary float-right">
-          <i class="material-icons">save</i>
           {{ 'Save'|trans({}, 'Admin.Actions') }}
         </button>
       </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.6.x 
| Description?  | Remove material icons for save and cancel buttons on SQL manager page
| Type?         | bug fix 
| Category?     | BO 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13053
| How to test?  | Verify material icons on save and cancel are not here anymore
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13434)
<!-- Reviewable:end -->
