### PR TITLE
Fixes option for MaterialMultipleChoiceTableType

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -597,7 +597,7 @@
             <th>{{ label }}</th>
             {% for child_choice in form %}
               <th class="text-center">
-                {% if child_choice.vars.multiple %}
+                {% if child_choice.vars.multiple and child_choice.vars.name not in headers_to_disable %}
                   <a href="#"
                      class="js-multiple-choice-table-select-column"
                      data-column-num="{{ loop.index + 1 }}"


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | For some reason this option was removed from template. I guess it could have happened when someone did a rebase.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Check Webservice Key form. Before this fix https://prnt.sc/ncrc3t and after this fix https://prnt.sc/ncrbkh

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13435)
<!-- Reviewable:end -->
