### PR TITLE
Improvements on LegacyUrlConverter, "tab" alias, insensitive and prevent infinite redirection loop

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer/customers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer/customers.yml
@@ -55,6 +55,10 @@ admin_customers_save_private_note:
     _controller: PrestaShopBundle:Admin/Sell/Customer/Customer:savePrivateNote
     _legacy_controller: AdminCustomers
     _legacy_link: AdminCustomers:updateCustomerNote
+    _legacy_parameters:
+      id_customer: customerId
+  requirements:
+    customerId: \d+
 
 admin_customers_toggle_status:
   path: /{customerId}/toggle-status

--- a/src/PrestaShopBundle/Routing/Converter/Exception/AlreadyConvertedException.php
+++ b/src/PrestaShopBundle/Routing/Converter/Exception/AlreadyConvertedException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Routing\Converter\Exception;
+
+/**
+ * Class AlreadyConvertedException is thrown when trying to converting
+ * an already converted url. Thus you can detect no redirection is needed
+ * and avoid an infinite loop.
+ */
+class AlreadyConvertedException extends RoutingException
+{
+}

--- a/src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php
+++ b/src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php
@@ -71,6 +71,12 @@ final class LegacyUrlConverter
      */
     public function convertByParameters(array $parameters)
     {
+        //Tab parameter can be used as an alias for controller
+        if (empty($parameters['controller']) && !empty($parameters['tab'])) {
+            $parameters['controller'] = $parameters['tab'];
+            unset($parameters['tab']);
+        }
+
         if (empty($parameters['controller'])) {
             throw new ArgumentException('Missing required controller argument');
         }

--- a/src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php
+++ b/src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php
@@ -238,8 +238,11 @@ final class LegacyUrlConverter
     private function checkAlreadyMatchingRoute($url)
     {
         try {
-            $this->router->match(parse_url($url, PHP_URL_PATH));
-            throw new AlreadyConvertedException(sprintf('%s is already a converted url', $url));
+            $urlPath = parse_url($url, PHP_URL_PATH);
+            if (!empty($urlPath)) {
+                $this->router->match($urlPath);
+                throw new AlreadyConvertedException(sprintf('%s is already a converted url', $url));
+            }
         } catch (ExceptionInterface $e) {
         }
     }

--- a/tests/TestCase/SymfonyIntegrationTestCase.php
+++ b/tests/TestCase/SymfonyIntegrationTestCase.php
@@ -26,12 +26,13 @@
 
 namespace Tests\TestCase;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use LegacyTests\Unit\ContextMocker;
 use LegacyTests\PrestaShopBundle\Utils\DatabaseCreator as Database;
 
-class SymfonyIntegrationTestCase extends KernelTestCase
+class SymfonyIntegrationTestCase extends WebTestCase
 {
     /**
      * @var ContextMocker
@@ -43,13 +44,21 @@ class SymfonyIntegrationTestCase extends KernelTestCase
      */
     protected $container;
 
+    /**
+     * @var Client
+     */
+    protected $client;
+
     protected function setUp()
     {
         parent::setUp();
         $this->contextMocker = new ContextMocker();
         $this->contextMocker->mockContext();
 
-        $this->bootKernel();
+        $this->client = self::createClient();
+
+        //createClient already creates the kernel
+        //$this->bootKernel();
         $this->container = self::$kernel->getContainer();
 
         // Global var for SymfonyContainer

--- a/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
@@ -74,7 +74,6 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
         ;
     }
 
-
     public function testItSucceedsForGenericNameTypeWhenValidCharactersGiven()
     {
         $value = 'good generic name /';
@@ -95,7 +94,6 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised()
         ;
     }
-
 
     public function testItSucceedsForCityNameTypeWhenValidCharactersGiven()
     {
@@ -261,7 +259,7 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidCharactersForCatalogNameType()
     {
         return [
-            ['<'], ['>'], [';'], ['='], ['#'], ['{'], ['}']
+            ['<'], ['>'], [';'], ['='], ['#'], ['{'], ['}'],
         ];
     }
 
@@ -271,7 +269,7 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidCharactersForGenericNameType()
     {
         return [
-            ['<'], ['>'], ['='], ['{'], ['}']
+            ['<'], ['>'], ['='], ['{'], ['}'],
         ];
     }
 
@@ -303,7 +301,7 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     {
         return [
             ['<'], ['>'], ['?'], ['#'], ['%'], [','], [';'], ['+'], ['¤'], [':'], ['!'], ['='], ['#'],
-            ['"'], ['$'], ['}'], ['{'], ['@'], ['|'], ['ž'], ['Š']
+            ['"'], ['$'], ['}'], ['{'], ['@'], ['|'], ['ž'], ['Š'],
         ];
     }
 
@@ -314,7 +312,7 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     {
         return [
             ['<'], ['>'], ['?'], ['#'], ['%'], [','], [';'], ['¤'], [':'], ['!'], ['='], ['#'],
-            ['"'], ['$'], ['}'], ['{'], ['@'], ['|'], ['ž'], ['Š'], ['r']
+            ['"'], ['$'], ['}'], ['{'], ['@'], ['|'], ['ž'], ['Š'], ['r'],
         ];
     }
 
@@ -328,14 +326,14 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidCharactersForLanguageIsoCodeType()
     {
         return [
-            ['a'], ['ž'], ['abcd'], ['2'], ['26'], ['ABCE']
+            ['a'], ['ž'], ['abcd'], ['2'], ['26'], ['ABCE'],
         ];
     }
 
     public function getInvalidCharactersForLanguageCodeType()
     {
         return [
-            ['az-acc'], ['1'], ['12-22'], ['ži-as']
+            ['az-acc'], ['1'], ['12-22'], ['ži-as'],
         ];
     }
 

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace LegacyTests\PrestaShopBundle\Routing\Converter;
+namespace Tests\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Routing\Converter\CacheKeyGeneratorInterface;
@@ -147,6 +147,7 @@ class CacheProviderTest extends TestCase
         $this->assertNotEmpty($legacyRoutes['admin_categories_create']);
         $this->assertNotEmpty($legacyRoutes['admin_categories_edit']);
 
+        //Second call is used to test cache is saved through mock expectations
         $legacyRoutes = $cacheProvider->getLegacyRoutes();
         $this->assertCount(4, $legacyRoutes);
     }
@@ -165,6 +166,7 @@ class CacheProviderTest extends TestCase
         $this->assertNotEmpty($legacyRoutes['admin_categories_create']);
         $this->assertNotEmpty($legacyRoutes['admin_categories_edit']);
 
+        //Second call is used to test cache is saved through mock expectations
         $legacyRoutes = $cacheProvider->getLegacyRoutes();
         $this->assertCount(4, $legacyRoutes);
     }
@@ -243,6 +245,84 @@ class CacheProviderTest extends TestCase
         $this->assertNotEmpty($controllerActions['AdminProducts']['new']);
         $this->assertNotEmpty($controllerActions['AdminCategories']);
         $this->assertNotEmpty($controllerActions['AdminCategories']['form']);
+    }
+
+    public function testGetActionsByControllerAndSaveCache()
+    {
+        $mockProvider = $this->buildMockRouterProvider($this->legacyRoutes);
+        $cacheProvider = new CacheProvider($mockProvider, $this->buildSavingCache(), $this->buildCacheKeyGenerator());
+
+        $controllerActions = $cacheProvider->getActionsByController('AdminProducts');
+        $this->assertCount(3, $controllerActions);
+        $this->assertSame(['index', 'create', 'new'], $controllerActions);
+
+        //Second call is used to test cache is saved through mock expectations
+        $controllerActions = $cacheProvider->getActionsByController('AdminProducts');
+        $this->assertCount(3, $controllerActions);
+        $this->assertSame(['index', 'create', 'new'], $controllerActions);
+    }
+
+    public function testGetActionsByControllerInsensitive()
+    {
+        $mockProvider = $this->buildMockRouterProvider($this->legacyRoutes);
+        $cacheProvider = new CacheProvider($mockProvider, $this->buildSavingCache(), $this->buildCacheKeyGenerator());
+
+        $controllerActions = $cacheProvider->getActionsByController('adminproducts');
+        $this->assertCount(3, $controllerActions);
+        $this->assertSame(['index', 'create', 'new'], $controllerActions);
+
+        //Second call is used to test cache is saved through mock expectations
+        $controllerActions = $cacheProvider->getActionsByController('AdMinProDucts');
+        $this->assertCount(3, $controllerActions);
+        $this->assertSame(['index', 'create', 'new'], $controllerActions);
+    }
+
+    public function testGetLegacyRouteByActionAndSaveCache()
+    {
+        $mockProvider = $this->buildMockRouterProvider($this->legacyRoutes);
+        $cacheProvider = new CacheProvider($mockProvider, $this->buildSavingCache(), $this->buildCacheKeyGenerator());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('AdminProducts', 'index');
+        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('AdminProducts', 'list');
+        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('AdminProducts', '');
+        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('AdminProducts', null);
+        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('AdminProducts', 'new');
+        $this->assertEquals('admin_products_create', $legacyRoute->getRouteName());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('AdminProducts', 'create');
+        $this->assertEquals('admin_products_create', $legacyRoute->getRouteName());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('AdminCategories', 'form');
+        $this->assertEquals('admin_categories_create', $legacyRoute->getRouteName());
+    }
+
+    public function testGetLegacyRouteByActionInsensitive()
+    {
+        $mockProvider = $this->buildMockRouterProvider($this->legacyRoutes);
+        $cacheProvider = new CacheProvider($mockProvider, $this->buildSavingCache(), $this->buildCacheKeyGenerator());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('adminproducts', 'index');
+        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('AdMinProdUcts', 'list');
+        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('ADMINPRODUCTS', 'new');
+        $this->assertEquals('admin_products_create', $legacyRoute->getRouteName());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('AdminProducts', 'CREATE');
+        $this->assertEquals('admin_products_create', $legacyRoute->getRouteName());
+
+        $legacyRoute = $cacheProvider->getLegacyRouteByAction('AdminCategories', 'Form');
+        $this->assertEquals('admin_categories_create', $legacyRoute->getRouteName());
     }
 
     /**

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
@@ -179,7 +179,7 @@ class CacheProviderTest extends TestCase
 
         $this->assertFalse($cache->hasItem(self::CACHE_KEY));
         //Just perform the test twice to be sure the result and the cache are correct
-        for ($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; ++$i) {
             $legacyRoutes = $cacheProvider->getLegacyRoutes();
             $this->assertCount(4, $legacyRoutes);
             $this->assertNotEmpty($legacyRoutes['admin_products']);
@@ -215,7 +215,7 @@ class CacheProviderTest extends TestCase
 
         $this->assertFalse($cache->hasItem(self::CACHE_KEY));
         //Just perform the test twice to be sure the result and the cache are correct
-        for ($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 2; ++$i) {
             $controllerActions = $cacheProvider->getControllersActions();
             $this->assertCount(2, $controllerActions);
             $this->assertNotEmpty($controllerActions['AdminProducts']);
@@ -413,6 +413,7 @@ class CacheProviderTest extends TestCase
 
     /**
      * @param array $legacyRoutes
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject|LegacyRouteProviderInterface
      */
     private function buildMockRouterProvider(array $legacyRoutes)

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyRouteTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyRouteTest.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace LegacyTests\PrestaShopBundle\Routing\Converter;
+namespace Tests\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Routing\Converter\LegacyRoute;

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace LegacyTests\PrestaShopBundle\Routing\Converter;
+namespace Tests\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Routing\Converter\Exception\ArgumentException;
@@ -53,6 +53,32 @@ class LegacyUrlConverterTest extends TestCase
         $this->assertEquals('/products', $url);
     }
 
+    public function testMinifiedController()
+    {
+        $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $url = $converter->convertByParameters([
+            'controller' => 'adminproducts',
+        ]);
+        $this->assertEquals('/products', $url);
+
+        $url = $converter->convertByUrl('?controller=adminproducts');
+        $this->assertEquals('/products', $url);
+    }
+
+    public function testBasicTab()
+    {
+        $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $url = $converter->convertByParameters([
+            'tab' => 'AdminProducts',
+        ]);
+        $this->assertEquals('/products', $url);
+
+        $url = $converter->convertByUrl('?tab=AdminProducts');
+        $this->assertEquals('/products', $url);
+    }
+
     public function testIndexAlias()
     {
         $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
@@ -64,6 +90,20 @@ class LegacyUrlConverterTest extends TestCase
         $this->assertEquals('/products', $url);
 
         $url = $converter->convertByUrl('?controller=AdminProducts&action=index');
+        $this->assertEquals('/products', $url);
+    }
+
+    public function testTabIndexAlias()
+    {
+        $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $url = $converter->convertByParameters([
+            'tab' => 'AdminProducts',
+            'action' => 'index',
+        ]);
+        $this->assertEquals('/products', $url);
+
+        $url = $converter->convertByUrl('?tab=AdminProducts&action=index');
         $this->assertEquals('/products', $url);
     }
 
@@ -92,6 +132,20 @@ class LegacyUrlConverterTest extends TestCase
         $this->assertEquals('/products/create', $url);
 
         $url = $converter->convertByUrl('?controller=AdminProducts&action=create');
+        $this->assertEquals('/products/create', $url);
+    }
+
+    public function testTabAction()
+    {
+        $router = $this->buildRouterMock('admin_products_create', '/products/create', 'AdminProducts:create');
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $url = $converter->convertByParameters([
+            'tab' => 'AdminProducts',
+            'action' => 'create',
+        ]);
+        $this->assertEquals('/products/create', $url);
+
+        $url = $converter->convertByUrl('?tab=AdminProducts&action=create');
         $this->assertEquals('/products/create', $url);
     }
 

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -277,6 +277,7 @@ class LegacyUrlConverterTest extends TestCase
     /**
      *  The parameter id_product|product_id must not be considered as a non migrated action
      *  (as would have been ?controller=AdminProducts&export_products_xml=1)
+     *
      * @throws ArgumentException
      * @throws RouteNotFoundException
      */
@@ -430,6 +431,7 @@ class LegacyUrlConverterTest extends TestCase
     /**
      * This tests is used to test the component with a list of routes and mainly to
      * check possible conflicts when action is
+     *
      * @throws ArgumentException
      * @throws RouteNotFoundException
      */
@@ -488,6 +490,7 @@ class LegacyUrlConverterTest extends TestCase
      * @param string|array $legacyLink
      * @param array|null $legacyParameters
      * @param array|null $expectedParameters
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject|RouterInterface
      */
     private function buildRouterMock($routeName, $routePath, $legacyLink, array $legacyParameters = null, array $expectedParameters = null)
@@ -537,6 +540,7 @@ class LegacyUrlConverterTest extends TestCase
 
     /**
      * @param array $routes
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject|RouterInterface
      */
     private function buildMultipleRouterMock(array $routes)
@@ -567,6 +571,7 @@ class LegacyUrlConverterTest extends TestCase
 
     /**
      * @param array $routes
+     *
      * @return RouteCollection
      */
     private function buildRouteCollection(array $routes)

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/RouterProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/RouterProviderTest.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace LegacyTests\PrestaShopBundle\Routing\Converter;
+namespace Tests\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Routing\Converter\Exception\RouteNotFoundException;
@@ -145,6 +145,41 @@ class RouterProviderTest extends TestCase
         $this->assertSame(['index', 'add', 'create'], $controllerActions);
     }
 
+    public function testGetActionsByControllerInsensitive()
+    {
+        $router = $this->buildMultipleRouterMock([
+            [
+                'route_name' => 'admin_products',
+                'path' => '/products',
+                '_legacy_link' => 'AdminProducts',
+            ],
+            [
+                'route_name' => 'admin_products_create',
+                'path' => '/products/create',
+                '_legacy_link' => [
+                    'AdminProducts:add',
+                    'AdminProducts:create',
+                ],
+            ],
+            [
+                'route_name' => 'admin_categories_create',
+                'path' => '/products/create',
+                '_legacy_link' => [
+                    'AdminCategories:add',
+                    'AdminCategories:create',
+                ],
+            ],
+        ]);
+        $routerProvider = new RouterProvider($router);
+        $controllerActions = $routerProvider->getActionsByController('adminproducts');
+        $this->assertCount(3, $controllerActions);
+        $this->assertSame(['index', 'add', 'create'], $controllerActions);
+
+        $controllerActions = $routerProvider->getActionsByController('adMinProDuctS');
+        $this->assertCount(3, $controllerActions);
+        $this->assertSame(['index', 'add', 'create'], $controllerActions);
+    }
+
     public function testGetLegacyRouteByAction()
     {
         $router = $this->buildMultipleRouterMock([
@@ -216,6 +251,64 @@ class RouterProviderTest extends TestCase
 
         $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminModules', 'add');
         $this->assertEquals('admin_modules_create', $legacyRoute->getRouteName());
+    }
+
+    public function testGetLegacyRouteByActionInsensitive()
+    {
+        $router = $this->buildMultipleRouterMock([
+            [
+                'route_name' => 'admin_products',
+                'path' => '/products',
+                '_legacy_link' => 'AdminProducts',
+            ],
+            [
+                'route_name' => 'admin_products_create',
+                'path' => '/products/create',
+                '_legacy_link' => [
+                    'AdminProducts:add',
+                    'AdminProducts:create',
+                ],
+            ],
+            [
+                'route_name' => 'admin_categories_create',
+                'path' => '/products/create',
+                '_legacy_link' => [
+                    'AdminCategories:add',
+                    'AdminCategories:create',
+                ],
+            ],
+            [
+                'route_name' => 'admin_modules_create',
+                'path' => '/modules/create',
+                '_legacy_link' => [
+                    'AdminModules:add',
+                    'AdminModules:create',
+                ],
+            ],
+            [
+                'route_name' => 'awesome_modules_create',
+                'path' => '/module/awesome/modules/create',
+                '_legacy_link' => [
+                    'AdminModules:add',
+                    'AdminModules:create',
+                ],
+            ],
+        ]);
+        $routerProvider = new RouterProvider($router);
+        $legacyRoute = $routerProvider->getLegacyRouteByAction('adminproducts', 'index');
+        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+
+        $legacyRoute = $routerProvider->getLegacyRouteByAction('AdMinProDucts', '');
+        $this->assertEquals('admin_products', $legacyRoute->getRouteName());
+
+        $legacyRoute = $routerProvider->getLegacyRouteByAction('ADMINPRODUCTS', 'add');
+        $this->assertEquals('admin_products_create', $legacyRoute->getRouteName());
+
+        $legacyRoute = $routerProvider->getLegacyRouteByAction('ADMINPRODUCTS', 'ADD');
+        $this->assertEquals('admin_products_create', $legacyRoute->getRouteName());
+
+        $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminProducts', 'Create');
+        $this->assertEquals('admin_products_create', $legacyRoute->getRouteName());
     }
 
     public function testControllerNotFound()

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/RouterProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/RouterProviderTest.php
@@ -353,6 +353,7 @@ class RouterProviderTest extends TestCase
 
     /**
      * @param array $routes
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject|RouterInterface
      */
     private function buildMultipleRouterMock(array $routes)
@@ -384,6 +385,7 @@ class RouterProviderTest extends TestCase
 
     /**
      * @param array $routes
+     *
      * @return RouteCollection
      */
     private function buildRouteCollection(array $routes)

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/RoutingCacheKeyGeneratorTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/RoutingCacheKeyGeneratorTest.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace LegacyTests\PrestaShopBundle\Routing\Converter;
+namespace Tests\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Routing\Converter\RoutingCacheKeyGenerator;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | This PR includes a few fix on `LegacyUrlConverter`: <ul><li>First some modules use tab argument instead of controller in `getAdminLink` so an alias was added to mange the conversion</li><li>Even without the alias some internal PrestaShop magic actually converts the tab argument into a controller argument but it's full lower case, so now `controller` and `action` matching is case insensitive in `LegacyUrlConverter`</li><li>Finally a bug was present when a converted url still had a `controller` argument it could lead to infinite redirection loop in `LegacyUrlListener` (combined with the mentioned magic), so now before converted a request a check is performed to see if the requests already matches a Symfony route</li></ul>
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13064
| How to test?  | See issue: go to stats module, click on customer online link you should redirected to new migrated customer view

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13439)
<!-- Reviewable:end -->
