### PR TITLE
Brands and addresses export action

### DIFF
--- a/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
+++ b/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
@@ -39,7 +39,7 @@ use Symfony\Component\Routing\Route;
 final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function configure()
     {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -399,11 +399,11 @@ class ManufacturerController extends FrameworkBundleAdminController
         $manufacturersGrid = $manufacturersGridFactory->getGrid($filters);
 
         $headers = [
-            'id_manufacturer' => $this->trans('id', 'Admin.Global'),
+            'id_manufacturer' => $this->trans('ID', 'Admin.Global'),
             'logo' => $this->trans('Logo', 'Admin.Global'),
             'name' => $this->trans('Name', 'Admin.Global'),
-            'addresses_count' => $this->trans('Addresses', 'Admin.Global'),
-            'products_count' => $this->trans('Products', 'Admin.Global'),
+            'addresses_count' => $this->trans('Addresses', 'Admin.Catalog.Feature'),
+            'products_count' => $this->trans('Products', 'Admin.Catalog.Feature'),
             'active' => $this->trans('Enabled', 'Admin.Global'),
         ];
 
@@ -411,12 +411,12 @@ class ManufacturerController extends FrameworkBundleAdminController
 
         foreach ($manufacturersGrid->getData()->getRecords()->all() as $record) {
             $data[] = [
-                'id' => $record['id_manufacturer'],
-                'Logo' => $record['logo'],
-                'Name' => $record['name'],
-                'Addresses' => $record['addresses_count'],
-                'Products' => $record['products_count'],
-                'Enabled' => $record['active'],
+                'id_manufacturer' => $record['id_manufacturer'],
+                'logo' => $record['logo'],
+                'name' => $record['name'],
+                'addresses_count' => $record['addresses_count'],
+                'products_count' => $record['products_count'],
+                'active' => $record['active'],
             ];
         }
 
@@ -452,10 +452,53 @@ class ManufacturerController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_manufacturers_index');
     }
 
-    public function exportAddressAction()
+    /**
+     * Export filtered manufacturer addresses.
+     *
+     * @AdminSecurity(
+     *     "is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller'))",
+     *     redirectRoute="admin_manufacturers_index"
+     * )
+     * @DemoRestricted(redirectRoute="admin_manufacturers_index")
+     *
+     * @param ManufacturerAddressFilters $filters
+     *
+     * @return Response
+     */
+    public function exportAddressAction(ManufacturerAddressFilters $filters)
     {
-        //todo: implement
-        return $this->redirectToRoute('admin_manufacturers_index');
+        $addressesGridFactory = $this->get('prestashop.core.grid.grid_factory.manufacturer_address');
+        $addressesGrid = $addressesGridFactory->getGrid($filters);
+
+        $headers = [
+            'id_address' => $this->trans('ID', 'Admin.Global'),
+            'name' => $this->trans('Brand', 'Admin.Global'),
+            'firstname' => $this->trans('First name', 'Admin.Global'),
+            'lastname' => $this->trans('Last name', 'Admin.Global'),
+            'postcode' => $this->trans('Zip/Postal code', 'Admin.Global'),
+            'city' => $this->trans('City', 'Admin.Global'),
+            'country' => $this->trans('Country', 'Admin.Global'),
+        ];
+
+        $data = [];
+
+        foreach ($addressesGrid->getData()->getRecords()->all() as $record) {
+            $data[] = [
+                'id_address' => $record['id_address'],
+                'name' => $record['name'],
+                'firstname' => $record['firstname'],
+                'lastname' => $record['lastname'],
+                'postcode' => $record['postcode'],
+                'city' => $record['city'],
+                'country' => $record['country'],
+            ];
+        }
+
+        return (new CsvResponse())
+            ->setData($data)
+            ->setHeadersData($headers)
+            ->setFileName('address_' . date('Y-m-d_His') . '.csv')
+            ;
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -402,8 +402,8 @@ class ManufacturerController extends FrameworkBundleAdminController
             'id_manufacturer' => $this->trans('ID', 'Admin.Global'),
             'logo' => $this->trans('Logo', 'Admin.Global'),
             'name' => $this->trans('Name', 'Admin.Global'),
-            'addresses_count' => $this->trans('Addresses', 'Admin.Catalog.Feature'),
-            'products_count' => $this->trans('Products', 'Admin.Catalog.Feature'),
+            'addresses_count' => $this->trans('Addresses', 'Admin.Global'),
+            'products_count' => $this->trans('Products', 'Admin.Global'),
             'active' => $this->trans('Enabled', 'Admin.Global'),
         ];
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Manufacturers (a.k.a brands) and addresses export list actions. Sell > Catalog > Brands & Suppliers.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  Fixes #13365 
| How to test?  | Go to Sell > Catalog > Brands & Suppliers.  Click on cog-wheel icon upper right corner of list and press Export. On successful export you will get `.csv` file with manufacturers or addresses list (depending on which list export you clicked). |

Some changes compared to legacy: 

- For both manufacturers and addresses in .csv file the header `id` field is changed to `ID` to fit translation in Admin.Global.
- when exporting manufacturers in legacy page fields: `logo, products, addresses` where always empty, now they contain correct values from grid.
- when exporting addresses in legacy page fields: `brand, country` where always empty, now they contain correct values from grid.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13446)
<!-- Reviewable:end -->
