### PR TITLE
[Need UI Kit update] Fixes switch input in Currency form to use toggle type

### DIFF
--- a/src/Adapter/Currency/QueryHandler/GetCurrencyForEditingHandler.php
+++ b/src/Adapter/Currency/QueryHandler/GetCurrencyForEditingHandler.php
@@ -76,7 +76,7 @@ final class GetCurrencyForEditingHandler implements GetCurrencyForEditingHandler
             $entity->id,
             $entity->iso_code,
             $entity->conversion_rate,
-            $entity->active,
+            (bool) $entity->active,
             $entity->getAssociatedShops()
         );
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -27,7 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Improve\International\Currencies;
 
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
-use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\ToggleType;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -102,7 +102,7 @@ class CurrencyType extends AbstractType
                     'Admin.Notifications.Error'
                 ),
             ])
-            ->add('active', SwitchType::class, [
+            ->add('active', ToggleType::class, [
                 'required' => false,
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Type/ToggleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ToggleType.php
@@ -31,7 +31,7 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Represents that can be toggled On/Off
+ * Represents field that can be toggled On/Off
  */
 class ToggleType extends AbstractType
 {

--- a/src/PrestaShopBundle/Form/Admin/Type/ToggleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ToggleType.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Represents that can be toggled On/Off
+ */
+class ToggleType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'attr' => [
+                    'data-toggle' => 'switch',
+                    'data-inverse' => true,
+                ],
+                'label' => false,
+            ])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return CheckboxType::class;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR introduces new toggle type which is being used in Currency form.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/10190#issuecomment-462843632
| How to test?  | With this PR input Currency "Status" input should look like this https://prnt.sc/nd71ne

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13458)
<!-- Reviewable:end -->
