### PR TITLE
Set null values when trying to retrieve the non-existing default shop

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1078,7 +1078,7 @@ class LanguageCore extends ObjectModel
                 $lang_pack = self::getLangDetails($iso);
                 if (!empty($lang_pack['locale'])) {
                     self::installSfLanguagePack($lang_pack['locale'], $errors);
-                    self::generateEmailsLanguagePack($lang_pack, $errors);
+                    self::generateEmailsLanguagePack($lang_pack, $errors, false);
                 }
             }
         }
@@ -1143,8 +1143,9 @@ class LanguageCore extends ObjectModel
     /**
      * @param array $langPack
      * @param array $errors
+     * @param bool $overwriteTemplates
      */
-    private static function generateEmailsLanguagePack($langPack, &$errors = array())
+    private static function generateEmailsLanguagePack($langPack, &$errors = array(), $overwriteTemplates = false)
     {
         $locale = $langPack['locale'];
         $sfContainer = SymfonyContainer::getInstance();
@@ -1163,7 +1164,7 @@ class LanguageCore extends ObjectModel
         $generateCommand = new GenerateThemeMailTemplatesCommand(
             $mailTheme,
             $locale,
-            false
+            $overwriteTemplates
         );
         /** @var CommandBusInterface $commandBus */
         $commandBus = $sfContainer->get('prestashop.core.command_bus');
@@ -1191,7 +1192,7 @@ class LanguageCore extends ObjectModel
             E_USER_DEPRECATED
         );
 
-        self::generateEmailsLanguagePack($lang_pack, $errors);
+        self::generateEmailsLanguagePack($lang_pack, $errors, true);
     }
 
     public static function installLanguagePack($iso, $params, &$errors = array())
@@ -1208,7 +1209,7 @@ class LanguageCore extends ObjectModel
 
         $lang_pack = self::getLangDetails($iso);
         self::installSfLanguagePack(self::getLocaleByIso($iso), $errors);
-        self::generateEmailsLanguagePack($lang_pack, $errors);
+        self::generateEmailsLanguagePack($lang_pack, $errors, true);
 
         return count($errors) ? $errors : true;
     }

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -166,6 +166,15 @@ class ShopUrlCore extends ObjectModel
     public static function cacheMainDomainForShop($id_shop)
     {
         if (!isset(self::$main_domain_ssl[(int) $id_shop]) || !isset(self::$main_domain[(int) $id_shop])) {
+            // May be called while the context is not instanciated yet
+            // For instance in first step of the installer
+            if ($id_shop === null && !isset(Context::getContext()->shop)) {
+                self::$main_domain[(int) $id_shop] = null;
+                self::$main_domain_ssl[(int) $id_shop] = null;
+
+                return;
+            }
+
             $row = Db::getInstance()->getRow('
             SELECT domain, domain_ssl
             FROM ' . _DB_PREFIX_ . 'shop_url


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fixes an issue while switching on a new language not existing locally, during the installation process
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #13401
| How to test?  | When reaching the installer, switch on a language not yet installed on your filesystem (you may need to remove content in app/Resources/translations)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13471)
<!-- Reviewable:end -->
