### PR TITLE
Fix issue on order with free gift

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3347,7 +3347,7 @@ class CartCore extends ObjectModel
         }
 
         if (null === $product_list) {
-            $products = $this->getProducts(false, false, null, false);
+            $products = $this->getProducts(false, false, null, true);
         } else {
             $products = $product_list;
         }

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono_virtual.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono_virtual.feature
@@ -1,4 +1,3 @@
-@current
 @reset-database-before-feature
 Feature: Cart rule (amount) calculation with one cart rule
   As a customer


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | fix notice displayed on BO when opening an order with free gift
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | fixes #13244
| How to test?  | see #13244

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13477)
<!-- Reviewable:end -->
