### PR TITLE
Bug fix position_identifier when strlen(primary_keyname) is less 3

### DIFF
--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -579,7 +579,7 @@ class HelperListCore extends Helper
         );
 
         if (!isset($this->table_id) && $this->position_identifier && (int)Tools::getValue($this->position_identifier, 1)) {
-            $this->table_id = substr($this->identifier, 3, strlen($this->identifier));
+            $this->table_id = (strlen($this->identifier) > 3)? substr($this->identifier, 3, strlen($this->identifier)) : substr($this->position_identifier, 3, strlen($this->position_identifier));
         }
 
         if ($this->position_identifier && ($this->orderBy == 'position' && $this->orderWay != 'DESC')) {


### PR DESCRIPTION
Fix the position_identifier bug when the size of the primary keyname(identifier) is less than 3

Ex. primary keyname => `id`

Due to this bug updating positions with DragDrop doesn't work ....

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13506)
<!-- Reviewable:end -->
