### PR TITLE
Show free shipping indication only if appropriate

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -474,8 +474,8 @@ class CartPresenter implements PresenterInterface
         );
     }
     
-    private function getShippingDisplayValue($cart, $shippingCost) 
-    {        
+    private function getShippingDisplayValue($cart, $shippingCost)
+    {
         $hasFreeCarrier = 0;
         $default_country = null;
 
@@ -485,13 +485,13 @@ class CartPresenter implements PresenterInterface
 
         $delivery_option_list = $cart->getDeliveryOptionList($default_country);
 
-        if (isset($delivery_option_list) && count($delivery_option_list) > 0) {                
+        if (isset($delivery_option_list) && count($delivery_option_list) > 0) {
             foreach ($delivery_option_list as $option) {
-                foreach ($option as $currentCarrier) {                    
-                    if (isset($currentCarrier['is_free']) && $currentCarrier['is_free'] > 0) {                                                   
+                foreach ($option as $currentCarrier) {
+                    if (isset($currentCarrier['is_free']) && $currentCarrier['is_free'] > 0) {
                         $hasFreeCarrier = 1;
-                        break 2;                                                                        
-                    }                                                                  
+                        break 2;
+                    }
                 }
             }
         }
@@ -500,9 +500,7 @@ class CartPresenter implements PresenterInterface
 
         if ($shippingCost != 0) {
             $shippingDisplayValue = $this->priceFormatter->format($shippingCost);
-        } elseif ($hasFreeCarrier == 0) {
-            $shippingDisplayValue = $this->translator->trans('Not Calculated', array(), 'Shop.Theme.Checkout');
-        } else {
+        } elseif ($hasFreeCarrier == 1) {
             $shippingDisplayValue = $this->translator->trans('Free', array(), 'Shop.Theme.Checkout');
         }
 

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -475,10 +475,10 @@ class CartPresenter implements PresenterInterface
     }
 
     /**
-     * Accepts a cart object with the shipping cost amount and formats the shipping cost display value accordingly. 
+     * Accepts a cart object with the shipping cost amount and formats the shipping cost display value accordingly.
      * If the shipping cost is 0, then we must check if this is because of a free carrier and thus display 'Free' or
      * simply because the system was unable to determine shipping cost at this point and thus send an empty string to hide the shipping line.
-     * 
+     *
      * @param Cart $cart
      * @param float $shippingCost
      *
@@ -490,7 +490,7 @@ class CartPresenter implements PresenterInterface
 
         if ($shippingCost != 0) {
             $shippingDisplayValue = $this->priceFormatter->format($shippingCost);
-        } else {            
+        } else {
             $defaultCountry = null;
 
             if (isset(Context::getContext()->cookie->id_country)) {

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -476,22 +476,22 @@ class CartPresenter implements PresenterInterface
     
     private function getShippingDisplayValue($cart, $shippingCost) 
     {        
-        $hasFreeCarrierFirst = 0;
+        $hasFreeCarrier = 0;
         $default_country = null;
-        
+
         if (isset(Context::getContext()->cookie->id_country)) {
             $default_country = new Country(Context::getContext()->cookie->id_country);
         }
 
         $delivery_option_list = $cart->getDeliveryOptionList($default_country);
 
-        if (isset($delivery_option_list) && count($delivery_option_list) > 0) {
+        if (isset($delivery_option_list) && count($delivery_option_list) > 0) {                
             foreach ($delivery_option_list as $option) {
-                foreach ($option as $currentCarrier) {
-                    if ($currentCarrier['position'] == 0 && (isset($currentCarrier['is_free']) && $currentCarrier['is_free'] > 0)) {
-                        $hasFreeCarrierFirst = 1;
-                        break;
-                    }
+                foreach ($option as $currentCarrier) {                    
+                    if (isset($currentCarrier['is_free']) && $currentCarrier['is_free'] > 0) {                                                   
+                        $hasFreeCarrier = 1;
+                        break 2;                                                                        
+                    }                                                                  
                 }
             }
         }
@@ -500,12 +500,12 @@ class CartPresenter implements PresenterInterface
 
         if ($shippingCost != 0) {
             $shippingDisplayValue = $this->priceFormatter->format($shippingCost);
-        } else if ($hasFreeCarrierFirst == 0) {
+        } elseif ($hasFreeCarrier == 0) {
             $shippingDisplayValue = $this->translator->trans('Not Calculated', array(), 'Shop.Theme.Checkout');
         } else {
             $shippingDisplayValue = $this->translator->trans('Free', array(), 'Shop.Theme.Checkout');
         }
-        
+
         return $shippingDisplayValue;
     }
 

--- a/themes/classic/modules/ps_shoppingcart/modal.tpl
+++ b/themes/classic/modules/ps_shoppingcart/modal.tpl
@@ -57,7 +57,9 @@
                 <p class="cart-products-count">{l s='There is %product_count% item in your cart.' sprintf=['%product_count%' =>$cart.products_count] d='Shop.Theme.Checkout'}</p>
               {/if}
               <p><span class="label">{l s='Subtotal:' d='Shop.Theme.Checkout'}</span>&nbsp;<span class="value">{$cart.subtotals.products.value}</span></p>
-              <p><span>{l s='Shipping:' d='Shop.Theme.Checkout'}</span>&nbsp;<span class="value">{$cart.subtotals.shipping.value} {hook h='displayCheckoutSubtotalDetails' subtotal=$cart.subtotals.shipping}</span></p>
+              {if $cart.subtotals.shipping.value}
+                <p><span>{l s='Shipping:' d='Shop.Theme.Checkout'}</span>&nbsp;<span class="value">{$cart.subtotals.shipping.value} {hook h='displayCheckoutSubtotalDetails' subtotal=$cart.subtotals.shipping}</span></p>
+              {/if}
 
               {if !$configuration.display_prices_tax_incl && $configuration.taxes_enabled}
                 <p><span>{$cart.totals.total.label}&nbsp;{$cart.labels.tax_short}</span>&nbsp;<span>{$cart.totals.total.value}</span></p>

--- a/themes/classic/templates/checkout/_partials/cart-detailed-totals.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-totals.tpl
@@ -27,7 +27,7 @@
 
   <div class="card-block">
     {foreach from=$cart.subtotals item="subtotal"}
-      {if $subtotal.value && $subtotal.type !== 'tax'}
+      {if $subtotal && $subtotal.value|count_characters > 0 && $subtotal.type !== 'tax'}
         <div class="cart-summary-line" id="cart-subtotal-{$subtotal.type}">
           <span class="label{if 'products' === $subtotal.type} js-subtotal{/if}">
             {if 'products' == $subtotal.type}

--- a/themes/classic/templates/checkout/_partials/cart-summary-subtotals.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary-subtotals.tpl
@@ -26,7 +26,7 @@
 <div class="card-block cart-summary-subtotals-container">
 
   {foreach from=$cart.subtotals item="subtotal"}
-    {if $subtotal.value && $subtotal.type !== 'tax'}
+    {if $subtotal && $subtotal.value|count_characters > 0 && $subtotal.type !== 'tax'}
       <div class="cart-summary-line cart-summary-subtotals" id="cart-subtotal-{$subtotal.type}">
 
         <span class="label">


### PR DESCRIPTION
The problem is if you are not logged in or need postal codes to determine shipping, you always see shipping as "Free" in your cart, which really means "not calculated yet". It is bad for customer psychology to see "Free" and after they enter more information to get a price.

The result of this change is if there is shipping calculated then it will simply show it. If the system cannot determine shipping yet for any reason then you get "Not Calculated". Finally, if you really have free shipping then you get the indication "Free".


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?       | Instead of showing "Free", show an indication in cart like "Not Calculated" for shipping if shipping cost cannot yet be determined.
| Type?         |  improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10739 #15112

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13517)
<!-- Reviewable:end -->
