### PR TITLE
Fix currency display on not existing language

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -179,7 +179,7 @@ class CurrencyCore extends ObjectModel
         if ($this->iso_code) {
             // As the CLDR used to return a string even if in multi shop / lang,
             // We force only one string to be returned
-            if (null === $idLang) {
+            if (empty($idLang)) {
                 $idLang = Context::getContext()->language->id;
             }
             if (is_array($this->symbol)) {

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -169,7 +169,7 @@ class CurrencyCore extends ObjectModel
      * CurrencyCore constructor.
      *
      * @param null $id
-     * @param null $idLang
+     * @param false|null $idLang if null or false, default language will be used
      * @param null $idShop
      */
     public function __construct($id = null, $idLang = null, $idShop = null)

--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -80,7 +80,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
      *
      * @param string $isoCode
      *                        An ISO 4217 currency code
-     * @param int|null $idLang
+     * @param int|null|false $idLang
      *                         Set this parameter if you want the currency in a specific language.
      *                         If null, default language will be used
      *

--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -80,9 +80,9 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
      *
      * @param string $isoCode
      *                        An ISO 4217 currency code
-     * @param int|null|false $idLang
-     *                         Set this parameter if you want the currency in a specific language.
-     *                         If null, default language will be used
+     * @param int|false|null $idLang
+     *                               Set this parameter if you want the currency in a specific language.
+     *                               If null, default language will be used
      *
      * @return currency|null
      *                       The asked Currency object, or null if not found

--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -82,7 +82,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
      *                        An ISO 4217 currency code
      * @param int|false|null $idLang
      *                               Set this parameter if you want the currency in a specific language.
-     *                               If null, default language will be used
+     *                               If null or false, default language will be used
      *
      * @return currency|null
      *                       The asked Currency object, or null if not found

--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -94,7 +94,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
             return null;
         }
 
-        if (null === $idLang) {
+        if (empty($idLang)) {
             $idLang = $this->configuration->get('PS_LANG_DEFAULT');
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | fix an issue displaying currency on FO after installing new language
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | fixes https://github.com/PrestaShop/PrestaShop/issues/13483
| How to test?  | on BO > localization > international > languages > add new language. On FO select this just added language. You should not have a php error anymore
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13525)
<!-- Reviewable:end -->
