### PR TITLE
Bug set lang conf after same name set simple conf

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -478,7 +478,6 @@ class ConfigurationCore extends ObjectModel
                 }
             } else {
                 self::clearLangValues($key);
-
                 // If key does not exists, create it
                 if (!$configID = Configuration::getIdByName($key, $idShopGroup, $idShop)) {
                     $now = date('Y-m-d H:i:s');
@@ -543,14 +542,15 @@ class ConfigurationCore extends ObjectModel
 
         return $result;
     }
-    
+
     /**
      * @param $key
+     *
      * @return int
      */
     protected static function checkExistsLangValues($key)
     {
-        return (int)Db::getInstance()->getValue(
+        return (int) Db::getInstance()->getValue(
             'SELECT cl.`id_configuration` FROM ' . _DB_PREFIX_ . 'configuration_lang cl
             LEFT JOIN ' . _DB_PREFIX_ . 'configuration c ON cl.`id_configuration` = c.`id_configuration`
             WHERE c.`name` = "' . pSQL($key) . '"'
@@ -565,11 +565,11 @@ class ConfigurationCore extends ObjectModel
         if ($id_configuration = (int) self::checkExistsLangValues($key)) {
             Db::getInstance()->delete(
                 'configuration',
-                'id_configuration = ' . (int)$id_configuration
+                'id_configuration = ' . (int) $id_configuration
             );
             Db::getInstance()->delete(
                 'configuration_lang',
-                'id_configuration = ' . (int)$id_configuration
+                'id_configuration = ' . (int) $id_configuration
             );
         }
     }

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -477,6 +477,8 @@ class ConfigurationCore extends ObjectModel
                     $result &= Db::getInstance()->execute($sql);
                 }
             } else {
+                self::clearLangValues($key);
+                
                 // If key does not exists, create it
                 if (!$configID = Configuration::getIdByName($key, $idShopGroup, $idShop)) {
                     $now = date('Y-m-d H:i:s');
@@ -540,6 +542,36 @@ class ConfigurationCore extends ObjectModel
         Configuration::set($key, $values, $idShopGroup, $idShop);
 
         return $result;
+    }
+    
+    /**
+     * @param $key
+     * @return int
+     */
+    protected static function checkExistsLangValues($key)
+    {
+        return (int)Db::getInstance()->getValue(
+            'SELECT cl.`id_configuration` FROM '._DB_PREFIX_.'configuration_lang cl
+            LEFT JOIN '._DB_PREFIX_.'configuration c ON cl.`id_configuration` = c.`id_configuration`
+            WHERE c.`name` = "'.pSQL($key).'"'
+        );
+    }
+
+    /**
+     * @param $key
+     */
+    protected static function clearLangValues($key)
+    {
+        if ($id_configuration = (int)self::checkExistsLangValues($key)) {
+            Db::getInstance()->delete(
+                'configuration',
+                'id_configuration = '.(int)$id_configuration
+            );
+            Db::getInstance()->delete(
+                'configuration_lang',
+                'id_configuration = '.(int)$id_configuration
+            );
+        }
     }
 
     /**

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -478,7 +478,7 @@ class ConfigurationCore extends ObjectModel
                 }
             } else {
                 self::clearLangValues($key);
-                
+
                 // If key does not exists, create it
                 if (!$configID = Configuration::getIdByName($key, $idShopGroup, $idShop)) {
                     $now = date('Y-m-d H:i:s');
@@ -551,9 +551,9 @@ class ConfigurationCore extends ObjectModel
     protected static function checkExistsLangValues($key)
     {
         return (int)Db::getInstance()->getValue(
-            'SELECT cl.`id_configuration` FROM '._DB_PREFIX_.'configuration_lang cl
-            LEFT JOIN '._DB_PREFIX_.'configuration c ON cl.`id_configuration` = c.`id_configuration`
-            WHERE c.`name` = "'.pSQL($key).'"'
+            'SELECT cl.`id_configuration` FROM ' . _DB_PREFIX_ . 'configuration_lang cl
+            LEFT JOIN ' . _DB_PREFIX_ . 'configuration c ON cl.`id_configuration` = c.`id_configuration`
+            WHERE c.`name` = "' . pSQL($key) . '"'
         );
     }
 
@@ -562,14 +562,14 @@ class ConfigurationCore extends ObjectModel
      */
     protected static function clearLangValues($key)
     {
-        if ($id_configuration = (int)self::checkExistsLangValues($key)) {
+        if ($id_configuration = (int) self::checkExistsLangValues($key)) {
             Db::getInstance()->delete(
                 'configuration',
-                'id_configuration = '.(int)$id_configuration
+                'id_configuration = ' . (int)$id_configuration
             );
             Db::getInstance()->delete(
                 'configuration_lang',
-                'id_configuration = '.(int)$id_configuration
+                'id_configuration = ' . (int)$id_configuration
             );
         }
     }


### PR DESCRIPTION
The problem is that when you set a language
the value of the configuration variable, and then the normal value, then the normal value not set in configuration variable

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The problem is that when you set a language the value of the configuration variable, and then the normal value, then the normal value not set in configuration variable
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Configuration::updateValue('PS_SAME_NAME', array('First', 'Second')); Configuration::updateValue('PS_SAME_NAME', 'First'); //Reload page and comment two lines in up //Returned false var_dump(Configuration::get('PS_SAME_NAME'));

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13548)
<!-- Reviewable:end -->
