### PR TITLE
Forbid URLs to be inserted into Name fields

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -157,15 +157,33 @@ class ValidateCore
     }
 
     /**
-     * Check for name validity.
+     * Check whether given name is valid
      *
      * @param string $name Name to validate
      *
-     * @return bool Validity is ok or not
+     * @return int 1 if given input is a name, 0 else
      */
     public static function isName($name)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u'), stripslashes($name));
+        $cleanName = stripslashes($name);
+
+        // disallow content that looks like an url - slash character
+        if (false !== strpos($cleanName, '/')) {
+            return 0;
+        }
+
+        // disallow content that looks like an url - dots character
+        $dotCharacters = array('.', '。');
+        foreach ($dotCharacters as $dotCharacter) {
+            $dotPosition = strpos($cleanName, $dotCharacter);
+            if (false !== $dotPosition && isset($cleanName[$dotPosition + 1]) && ($cleanName[$dotPosition + 1] !== ' ')) {
+                return 0;
+            }
+        }
+
+        $validityPattern = Tools::cleanNonUnicodeSupport('/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u');
+
+        return preg_match($validityPattern, $cleanName);
     }
 
     /**

--- a/tests/Unit/Classes/ValidateCoreTest.php
+++ b/tests/Unit/Classes/ValidateCoreTest.php
@@ -91,6 +91,14 @@ class ValidateCoreTest extends TestCase
     }
 
     /**
+     * @dataProvider isNameDataProvider
+     */
+    public function testIsName($expected, $input)
+    {
+        $this->assertSame($expected, Validate::isName($input));
+    }
+
+    /**
      * @dataProvider isFloatDataProvider
      */
     public function testIsFloat($expected, $input)
@@ -107,7 +115,7 @@ class ValidateCoreTest extends TestCase
     }
 
     /**
-     * @depends testIsFloat
+     * @depends      testIsFloat
      * @dataProvider isOptFloatDataProvider
      */
     public function testIsOptFloat($expected, $input)
@@ -146,6 +154,26 @@ class ValidateCoreTest extends TestCase
             array(0, substr(sha1('AnotherRandomString'), 0, 39)),
             array(0, 123),
             array(0, false),
+        );
+    }
+
+    public function isNameDataProvider()
+    {
+        return array(
+            array(1, 'Mathieu'),
+            array(1, 'Dupont'),
+            array(1, 'Jaçinthé'),
+            array(1, 'John D.'),
+            array(1, 'John D. John'),
+            array(1, 'ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â'),
+            array(0, 'https://www.website.com'),
+            array(0, 'www.website.com'),
+            array(0, 'website。com'),
+            array(0, 'website%2Ecom'),
+            array(0, 'website/./com'),
+            array(0, '.rn'),
+            array(0, 'websitecom/a'),
+            array(0, 'websitecom%20a'),
         );
     }
 
@@ -213,7 +241,7 @@ class ValidateCoreTest extends TestCase
             $this->trueFloatDataProvider(),
             array(
                 array(false, -12.2151),
-                array(false, -12,2151),
+                array(false, -12, 2151),
                 array(false, '-12.2151'),
                 array(false, ''),
                 array(false, 'A'),
@@ -227,7 +255,7 @@ class ValidateCoreTest extends TestCase
         return array(
             array(true, 12),
             array(true, 12.2151),
-            array(true, 12,2151),
+            array(true, 12, 2151),
             array(true, '12.2151'),
         );
     }
@@ -238,7 +266,7 @@ class ValidateCoreTest extends TestCase
             $this->trueFloatDataProvider(),
             array(
                 array(true, -12.2151),
-                array(true, -12,2151),
+                array(true, -12, 2151),
                 array(true, '-12.2151'),
                 array(false, ''),
                 array(false, 'A'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Strengthen the isName validation to avoir URLs to be inserted in it
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | yes, if someone used such a field to store URLs
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13524
| How to test?  | Attempt, from front-office, to create a customer with an URL as first name or last name. Now it is not possible anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13549)
<!-- Reviewable:end -->
