### PR TITLE
Add missing check in Manufacturer image uploader

### DIFF
--- a/src/Adapter/Image/Uploader/ManufacturerImageUploader.php
+++ b/src/Adapter/Image/Uploader/ManufacturerImageUploader.php
@@ -46,6 +46,7 @@ final class ManufacturerImageUploader extends AbstractImageUploader
      */
     public function upload($manufacturerId, UploadedFile $image)
     {
+        $this->checkImageIsAllowedForUpload($image);
         $temporaryImageName = tempnam(_PS_TMP_IMG_DIR_, 'PS');
 
         if (!$temporaryImageName) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -98,8 +98,8 @@ class ManufacturerController extends FrameworkBundleAdminController
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Manufacturer/index.html.twig', [
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
-            'manufacturer_grid' => $this->presentGrid($manufacturerGrid),
-            'manufacturer_address_grid' => $this->presentGrid($manufacturerAddressGrid),
+            'manufacturerGrid' => $this->presentGrid($manufacturerGrid),
+            'manufacturerAddressGrid' => $this->presentGrid($manufacturerAddressGrid),
         ]);
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/index.html.twig
@@ -43,7 +43,7 @@
   {% block manufacturers_listing %}
     <div class="row">
       <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturer_grid} %}
+        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerGrid} %}
       </div>
     </div>
   {% endblock %}
@@ -51,7 +51,7 @@
   {% block manufacturers_address_listing %}
     <div class="row">
       <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturer_address_grid} %}
+        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerAddressGrid} %}
       </div>
     </div>
   {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | src\Adapter\Image\Uploader\ManufacturerImageUploader was missing check if image is allowed for upload. Without this check, uploading wrong format file would throw an error. Plus minor fix controller to twig vars to be CamelCased instead of snake case.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Go to Sell > Catalog > Brands & Suppliers > open edit or create brand form. Try to upload non image file for example .pdf and save the form. You should get user friendly error message `Image format not recognized, allowed formats are: .gif, .jpg, .png`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13550)
<!-- Reviewable:end -->
