### PR TITLE
Do not get data from null currency

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -787,6 +787,11 @@ class CurrencyCore extends ObjectModel
             // CLDR currency gives data from CLDR reference, for the given language
             $cldrCurrency = $cldrLocale->getCurrency($this->iso_code);
 
+            if (empty($cldrCurrency)) {
+                // The currency may not be declared in the locale, eg with custom iso code
+                continue;
+            }
+
             $symbol = (string) $cldrCurrency->getSymbol();
             if (empty($symbol)) {
                 $symbol = $this->iso_code;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | In some case (for instance no-NO lang), currency details are not provided by CLDR. When it occurs, do not try to get details from it and go on the next one.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13463
| How to test?  | Import Norwegian lang pack, then check you have "no-NO" in the installed language. Once done, try to import another lang pack, which should crash until you get this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13563)
<!-- Reviewable:end -->
