### PR TITLE
Forbid mix of URL and names in Name fields

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -173,11 +173,14 @@ class ValidateCore
         }
 
         // disallow content that looks like an url - dots character
-        $dotCharacters = array('.', '。');
+        $dotCharacters = array('\.', '。');
         foreach ($dotCharacters as $dotCharacter) {
-            $dotPosition = strpos($cleanName, $dotCharacter);
-            if (false !== $dotPosition && isset($cleanName[$dotPosition + 1]) && ($cleanName[$dotPosition + 1] !== ' ')) {
-                return 0;
+            $dotPositions = self::findAllDotOffsets($cleanName, $dotCharacter);
+
+            foreach ($dotPositions as $dotPosition) {
+                if (isset($cleanName[$dotPosition + 1]) && ($cleanName[$dotPosition + 1] !== ' ')) {
+                    return 0;
+                }
             }
         }
 
@@ -1257,5 +1260,28 @@ class ValidateCore
         }
 
         return true;
+    }
+
+    /**
+     * Search for dot positions in given string
+     *
+     * @param string $string
+     * @param string $dotCharacter
+     *
+     * @return array offsets of dots in given string
+     */
+    protected static function findAllDotOffsets($string, $dotCharacter)
+    {
+        $matches = array();
+
+        preg_match_all('#' . $dotCharacter . '#', $string, $matches, PREG_OFFSET_CAPTURE);
+
+        $result = current($matches);
+
+        if (empty($result)) {
+            return array();
+        }
+
+        return array_map(function ($dotPart) { return $dotPart[1];}, $result);
     }
 }

--- a/tests/Unit/Classes/ValidateCoreTest.php
+++ b/tests/Unit/Classes/ValidateCoreTest.php
@@ -174,6 +174,10 @@ class ValidateCoreTest extends TestCase
             array(0, '.rn'),
             array(0, 'websitecom/a'),
             array(0, 'websitecom%20a'),
+            array(0, '/a'),
+            array(0, 'John F. www.website.com'),
+            array(0, 'John F. www.website.com www.website.com'),
+            array(0, 'website._com'),
         );
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Strengthen the isName validation to avoid mix of URLs and names to be inserted in it
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13524
| How to test?  | Attempt, from front-office, to create a customer with "John F. www.spam.com" as first name or last name. Now it is not possible anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13566)
<!-- Reviewable:end -->
