### PR TITLE
Fix selectors in E2E tests in addons catalog page and in the autoupgrade test

### DIFF
--- a/tests/E2E/test/campaigns/install_upgrade/02_autoupgrade.js
+++ b/tests/E2E/test/campaigns/install_upgrade/02_autoupgrade.js
@@ -2,7 +2,6 @@ const {Installation} = require('../../selectors/BO/installation');
 const {AccessPageBO} = require('../../selectors/BO/access_page');
 const {ModulePage} = require('../../selectors/BO/module_page');
 const {AddProductPage} = require('../../selectors/BO/add_product_page');
-const {OnBoarding} = require('../../selectors/BO/onboarding.js');
 const {AccessPageFO} = require('../../selectors/FO/access_page');
 const {ShopParameters} = require('../../selectors/BO/shopParameters/shop_parameters');
 
@@ -48,10 +47,6 @@ scenario('The shop installation', () => {
 
   welcomeScenarios.findAndCloseWelcomeModal('installation');
 
-  scenario('paaaaaaaaaaaause', client => {
-    test('paaaaaaaaaaaause', () => client.pause(25000));
-  }, 'installation');
-
   scenario('Install "Top-sellers block" and "New products block" modules From Cross selling', client => {
     moduleCommonScenarios.installModule(client, ModulePage, AddProductPage, "ps_bestsellers");
     moduleCommonScenarios.installModule(client, ModulePage, AddProductPage, "ps_newproducts");
@@ -59,7 +54,7 @@ scenario('The shop installation', () => {
 
   scenario('Install " 1-Click Upgrade " From Cross selling and configure it', client => {
     moduleCommonScenarios.installModule(client, ModulePage, AddProductPage, "autoupgrade");
-    test('should click on "configure" button', () => client.waitForExistAndClick(ModulePage.configure_module_button.split('%moduleTechName').join("autoupgrade")));
+    test('should click on "configure" button', () => client.waitForExistAndClick(ModulePage.configure_module_theme_button.split('%moduleTechName').join("autoupgrade")));
     test('should deactivate the shop', () => {
       return promise
         .then(() => client.waitForVisibleElement(ModulePage.confirm_maintenance_shop_icon))

--- a/tests/E2E/test/selectors/BO/addons_catalog_page.js
+++ b/tests/E2E/test/selectors/BO/addons_catalog_page.js
@@ -6,7 +6,7 @@ module.exports = {
     module_name: '//*[@id="product_content"]//h1',
     discover_payment_modules_link: '//*[@id="main-div"]//div[contains(@class, "addons-module-selection-ps")]//a[contains(text(), "Discover the payment modules")]',
     view_all_modules_button: '//*[@id="main-div"]//div[contains(@class, "addons-all-modules")]//a[contains(text(), "View all modules")]',
-    prestashop_addons_logo: '//*[@id="logo"]',
+    prestashop_addons_logo: '//*[@id="ps_link_logo"]',
     search_addons_input: '//*[@id="addons-search-box"]',
     search_name: '//*[@id="search_name"]/b'
   }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | Fix selector in addons catalog page and another one in the autoupgrage test
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | /
| How to test?  | TEST_PATH=full/suiteName/* npm run specific-test -- --URL=shopURL

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13583)
<!-- Reviewable:end -->
