### PR TITLE
Make Hook::unregisterHook able to unregistered many hooks at once

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -587,7 +587,7 @@ class HookCore extends ObjectModel
 
             // Unregister module on hook by id
             $result &= Db::getInstance()->delete(
-                'hook_module', 
+                'hook_module',
                 '`id_module` = ' . (int) $module_instance->id . ' AND `id_hook` = ' . (int) $hook_id . $idShops
             );
 

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -565,7 +565,7 @@ class HookCore extends ObjectModel
         if (is_array($hook_name)) {
             $hook_names = $hook_name;
         } else {
-            $hook_names = array($hook_name);
+            $hook_names = [$hook_name];
         }
 
         $idShops = ($shop_list) ? ' AND `id_shop` IN(' . implode(', ', array_map('intval', $shop_list)) . ')' : '';
@@ -594,7 +594,7 @@ class HookCore extends ObjectModel
             // Clean modules position
             $module_instance->cleanPositions($hook_id, $shop_list);
 
-            Hook::exec('actionModuleUnRegisterHookAfter', array('object' => $module_instance, 'hook_name' => $hook_name));
+            Hook::exec('actionModuleUnRegisterHookAfter', ['object' => $module_instance, 'hook_name' => $hook_name]);
         }
 
         return $result;

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -561,30 +561,39 @@ class HookCore extends ObjectModel
 
     public static function unregisterHook($module_instance, $hook_name, $shop_list = null)
     {
-        if (is_numeric($hook_name)) {
-            // $hook_name passed it the id_hook
-            $hook_id = $hook_name;
-            $hook_name = Hook::getNameById((int) $hook_id);
+        $result = true;
+        if (is_array($hook_name)) {
+            $hook_names = $hook_name;
         } else {
-            $hook_id = Hook::getIdByName($hook_name);
+            $hook_names = array($hook_name);
         }
 
-        if (!$hook_id) {
-            return false;
-        }
+        foreach ($hook_names as $hook_name) {
+            if (is_numeric($hook_name)) {
+                // $hook_name passed it the id_hook
+                $hook_id = $hook_name;
+                $hook_name = Hook::getNameById((int) $hook_id);
+            } else {
+                $hook_id = Hook::getIdByName($hook_name);
+            }
 
-        Hook::exec('actionModuleUnRegisterHookBefore', ['object' => $module_instance, 'hook_name' => $hook_name]);
+            if (!$hook_id) {
+                return false;
+            }
 
-        // Unregister module on hook by id
-        $sql = 'DELETE FROM `' . _DB_PREFIX_ . 'hook_module`
+            Hook::exec('actionModuleUnRegisterHookBefore', ['object' => $module_instance, 'hook_name' => $hook_name]);
+
+            // Unregister module on hook by id
+            $sql = 'DELETE FROM `' . _DB_PREFIX_ . 'hook_module`
             WHERE `id_module` = ' . (int) $module_instance->id . ' AND `id_hook` = ' . (int) $hook_id
             . (($shop_list) ? ' AND `id_shop` IN(' . implode(', ', array_map('intval', $shop_list)) . ')' : '');
-        $result = Db::getInstance()->execute($sql);
+            $result &= Db::getInstance()->execute($sql);
 
-        // Clean modules position
-        $module_instance->cleanPositions($hook_id, $shop_list);
+            // Clean modules position
+            $module_instance->cleanPositions($hook_id, $shop_list);
 
-        Hook::exec('actionModuleUnRegisterHookAfter', ['object' => $module_instance, 'hook_name' => $hook_name]);
+            Hook::exec('actionModuleUnRegisterHookAfter', array('object' => $module_instance, 'hook_name' => $hook_name));
+        }
 
         return $result;
     }

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -568,6 +568,8 @@ class HookCore extends ObjectModel
             $hook_names = array($hook_name);
         }
 
+        $idShops = ($shop_list) ? ' AND `id_shop` IN(' . implode(', ', array_map('intval', $shop_list)) . ')' : '';
+
         foreach ($hook_names as $hook_name) {
             if (is_numeric($hook_name)) {
                 // $hook_name passed it the id_hook
@@ -584,10 +586,10 @@ class HookCore extends ObjectModel
             Hook::exec('actionModuleUnRegisterHookBefore', ['object' => $module_instance, 'hook_name' => $hook_name]);
 
             // Unregister module on hook by id
-            $sql = 'DELETE FROM `' . _DB_PREFIX_ . 'hook_module`
-            WHERE `id_module` = ' . (int) $module_instance->id . ' AND `id_hook` = ' . (int) $hook_id
-            . (($shop_list) ? ' AND `id_shop` IN(' . implode(', ', array_map('intval', $shop_list)) . ')' : '');
-            $result &= Db::getInstance()->execute($sql);
+            $result &= Db::getInstance()->delete(
+                'hook_module', 
+                '`id_module` = ' . (int) $module_instance->id . ' AND `id_hook` = ' . (int) $hook_id . $idShops
+            );
 
             // Clean modules position
             $module_instance->cleanPositions($hook_id, $shop_list);


### PR DESCRIPTION
Apply the same behavior as on Hook::registerHook

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Ability to pass an array in the Hook function unregisterHook as in the Hook method registerHook
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Put an array of hook name and hook id and/of only a hook name or id<br>$this->unregisterHook(array('header',12',validateOrder')); or $this->unregisterHook('header');

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13587)
<!-- Reviewable:end -->
