### PR TITLE
Introduce behat context modifiers to execute scenarios variations

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/Modifier/ProductFeatureContextModifier.php
+++ b/tests/Integration/Behaviour/Features/Context/Modifier/ProductFeatureContextModifier.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * 2007-2019 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context\Modifier;
+
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Tests\Integration\Behaviour\Features\Context\ProductFeatureContext;
+use Behat\Behat\Context\Context as BehatContext;
+
+/**
+ * This Modifier enables the use of tag '@test-with-modifier-virtual-products'.
+ * Scenarios marked with this tag will be run with virtual products instead of standard products.
+ */
+class ProductFeatureContextModifier implements BehatContext
+{
+    const PROFILE_VIRTUAL_PRODUCTS = 'virtual_products';
+
+    /** @BeforeScenario */
+    public function before(BeforeScenarioScope $scope)
+    {
+        $parameters = $scope->getEnvironment()->getSuite()->getSetting('parameters');
+
+        if (false === array_key_exists('profile', $parameters)) {
+            return;
+        }
+
+        $profile = $parameters['profile'];
+
+        if ($profile !== self::PROFILE_VIRTUAL_PRODUCTS) {
+            return;
+        }
+
+        $productFeatureContext = $scope->getEnvironment()->getContext(ProductFeatureContext::class);
+        $productFeatureContext->activateCreateVirtualProductsModifier();
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Modifier/ProductFeatureContextModifier.php
+++ b/tests/Integration/Behaviour/Features/Context/Modifier/ProductFeatureContextModifier.php
@@ -43,17 +43,9 @@ class ProductFeatureContextModifier implements BehatContext
     {
         $parameters = $scope->getEnvironment()->getSuite()->getSetting('parameters');
 
-        if (false === array_key_exists('profile', $parameters)) {
-            return;
+        if (!empty($parameters['profile']) && $parameters['profile'] === self::PROFILE_VIRTUAL_PRODUCTS) {
+            $productFeatureContext = $scope->getEnvironment()->getContext(ProductFeatureContext::class);
+            $productFeatureContext->toggleCreateVirtualProductsFlagModifier(true);
         }
-
-        $profile = $parameters['profile'];
-
-        if ($profile !== self::PROFILE_VIRTUAL_PRODUCTS) {
-            return;
-        }
-
-        $productFeatureContext = $scope->getEnvironment()->getContext(ProductFeatureContext::class);
-        $productFeatureContext->activateCreateVirtualProductsModifier();
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -59,6 +59,8 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
      */
     protected $customizationFields = [];
 
+    protected $flagModifierCreateVirtualProducts = false;
+
     /* PRODUCTS */
 
     /**
@@ -69,6 +71,11 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function getProductWithName($productName)
     {
         return $this->products[$productName];
+    }
+
+    public function activateCreateVirtualProductsModifier()
+    {
+        $this->flagModifierCreateVirtualProducts = true;
     }
 
     /**
@@ -188,6 +195,11 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
         $product->price = $price;
         $product->name = $productName;
         $product->quantity = $productQuantity;
+
+        if ($this->flagModifierCreateVirtualProducts) {
+            $product->is_virtual = 1;
+        }
+
         $product->add();
         StockAvailable::setQuantity((int) $product->id, 0, $product->quantity);
 

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -73,9 +73,18 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
         return $this->products[$productName];
     }
 
-    public function activateCreateVirtualProductsModifier()
+    /**
+     * @param bool $newValue
+     *
+     * @throws \Exception
+     */
+    public function toggleCreateVirtualProductsFlagModifier($newValue)
     {
-        $this->flagModifierCreateVirtualProducts = true;
+        if (!is_bool($newValue)) {
+            throw new \Exception('Expected boolean');
+        }
+
+        $this->flagModifierCreateVirtualProducts = $newValue;
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
@@ -5,7 +5,6 @@ Feature: Cart calculation with currencies
 
   # USD / USD
 
-  @test-with-modifier-virtual-products
   Scenario: Empty cart (default USD/ current USD)
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -17,6 +16,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 0.0 tax included
     Then my cart total using previous calculation method should be 0.0 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: one product in cart, quantity 1
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -29,6 +29,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 26.812 tax included
     Then my cart total using previous calculation method should be 26.812 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: one product in cart, quantity 3
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -41,6 +42,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 66.44 tax included
     Then my cart total using previous calculation method should be 66.44 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: 3 products in cart, several quantities
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -70,6 +72,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 0.0 tax included
     Then my cart total using previous calculation method should be 0.0 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: one product in cart, quantity 1
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -82,6 +85,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 33.515 tax included
     Then my cart total using previous calculation method should be 33.515 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: one product in cart, quantity 3
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -94,6 +98,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 83.05 tax included
     Then my cart total using previous calculation method should be 83.05 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: 3 products in cart, several quantities
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -123,6 +128,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 0.0 tax included
     Then my cart total using previous calculation method should be 0.0 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: one product in cart, quantity 1
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -135,6 +141,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 24.66704 tax included
     Then my cart total using previous calculation method should be 24.66704 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: one product in cart, quantity 3
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -147,6 +154,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 61.12 tax included
     Then my cart total using previous calculation method should be 61.12 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: 3 products in cart, several quantities
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -176,6 +184,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 0.0 tax included
     Then my cart total using previous calculation method should be 0.0 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: one product in cart, quantity 1
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -188,6 +197,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 16.89156 tax included
     Then my cart total using previous calculation method should be 16.89156 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: one product in cart, quantity 3
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -200,6 +210,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 41.85 tax included
     Then my cart total using previous calculation method should be 41.85 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: 3 products in cart, several quantities
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -229,6 +240,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 0.0 tax included
     Then my cart total using previous calculation method should be 0.0 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: one product in cart, quantity 1
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -241,6 +253,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 24.66704 tax included
     Then my cart total using previous calculation method should be 24.66704 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: one product in cart, quantity 3
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
@@ -253,6 +266,7 @@ Feature: Cart calculation with currencies
     Then my cart total should be 61.12 tax included
     Then my cart total using previous calculation method should be 61.12 tax included
 
+  @test-with-modifier-virtual-products
   Scenario: 3 products in cart, several quantities
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
@@ -5,6 +5,7 @@ Feature: Cart calculation with currencies
 
   # USD / USD
 
+  @test-with-modifier-virtual-products
   Scenario: Empty cart (default USD/ current USD)
     Given I have an empty default cart
     Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -7,6 +7,8 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\SqlManagerFeatureContext
         cart:
+            parameters:
+                profile: 'default'
             paths:
                 features: Features/Scenario/Cart
             contexts:
@@ -27,9 +29,18 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CarrierFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\OrderFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Modifier\ProductFeatureContextModifier
         translation:
             paths:
                 features: Features/Scenario/Translation
             contexts:
                 - Tests\Integration\Behaviour\Features\Context\TranslationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\ModuleFeatureContext
+
+virtual_products:
+    suites:
+        cart:
+            parameters:
+                profile: 'virtual_products'
+            filters:
+                tags: '@test-with-modifier-virtual-products'

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -39,8 +39,14 @@ default:
 
 virtual_products:
     suites:
+        database:
+            filters:
+                tags: '@test-with-modifier-virtual-products'
         cart:
             parameters:
                 profile: 'virtual_products'
+            filters:
+                tags: '@test-with-modifier-virtual-products'
+        translation:
             filters:
                 tags: '@test-with-modifier-virtual-products'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This setup that aims to provide a simple mechanism that would allow us to run our behat tests in multiple configurations: different languages, currencies, settings ...
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  |  php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml --profile virtual_products

## Background

We have now a nice behat test suite that covers lot of scenarios, including cart prices computations. However this suite is run for one currency, one language. We would like to run it for a lot of different configurations: differenr currencies (EUR, USD ...), with virtual or not products ...

Of course we want to do this without having to copy-paste ou scenarios, in order to keep them maintenable.

## Solution

This PR introduces into key FeatureConcepts some flags that control settings, and have Modifiers that can switch these flags on and off. These feature flags are controlled by the behat [profile](http://behat.org/en/latest/user_guide/configuration.html#overriding-default-params) you use.

If you run tests using `default` profile, it will work with all modifier flags set to off. It runs all tests.

However, if you run the behat tests using the `virtual_products` profile, it will:
- turn the virtual_product modifier flag to yes, which will modify how the "I create a product" step behaves, now it will create virtual products instead of standard products
- only target the tests marked with the `@test-with-modifier-virtual-products` flag

## Want to test ?

Pull this branch, and run
```
php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml --profile virtual_products
```

## CI setup

We need to make Travis run
```
php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml
```
then
```
php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml --profile virtual_products
```

Basically, Travis will need to run the behat tests *as many times as there are profiles*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13596)
<!-- Reviewable:end -->
