### PR TITLE
Add id for orders view page to ease E2E testing

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
@@ -41,7 +41,8 @@
             <div class="col">
               {{ 'Valid orders:'|trans({}, 'Admin.Orderscustomers.Feature') }}
               <span class="badge badge-success rounded">{{ validOrdersCount }}</span>
-              {{ 'for a total amount of %s'|trans({}, 'Admin.Orderscustomers.Feature')|format(customerInformation.ordersInformation.totalSpent) }}
+              {% set totalAmount = '<span id="total-order-amount">'~customerInformation.ordersInformation.totalSpent~'</span>' %}
+              {{ 'for a total amount of %s'|trans({}, 'Admin.Orderscustomers.Feature')|format(totalAmount)|raw }}
             </div>
             <div class="col">
               {{ 'Invalid orders:'|trans({}, 'Admin.Orderscustomers.Feature') }}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Add a span with an ID in Order View page to allow its targeting in E2E tests
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13598
| How to test?  | See ticket

I'm wondering if I should introduce a `rawonlyspan` twig function to be used here. This would prevent the vulnerabilities that come with `raw` usage. Is it over-engineering or is it a good thing ?
@PierreRambaud

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13603)
<!-- Reviewable:end -->
