### PR TITLE
Forbid URLS to be added in customer names

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -173,8 +173,8 @@ class CustomerCore extends ObjectModel
         'primary' => 'id_customer',
         'fields' => array(
             'secure_key' => array('type' => self::TYPE_STRING, 'validate' => 'isMd5', 'copy_post' => false),
-            'lastname' => array('type' => self::TYPE_STRING, 'validate' => 'isName', 'required' => true, 'size' => 255),
-            'firstname' => array('type' => self::TYPE_STRING, 'validate' => 'isName', 'required' => true, 'size' => 255),
+            'lastname' => array('type' => self::TYPE_STRING, 'validate' => 'isCustomerName', 'required' => true, 'size' => 255),
+            'firstname' => array('type' => self::TYPE_STRING, 'validate' => 'isCustomerName', 'required' => true, 'size' => 255),
             'email' => array('type' => self::TYPE_STRING, 'validate' => 'isEmail', 'required' => true, 'size' => 255),
             'passwd' => array('type' => self::TYPE_STRING, 'validate' => 'isPasswd', 'required' => true, 'size' => 255),
             'last_passwd_gen' => array('type' => self::TYPE_STRING, 'copy_post' => false),

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -157,7 +157,23 @@ class ValidateCore
     }
 
     /**
-     * Check for name validity.
+     * Check whether given customer name is valid
+     *
+     * @param string $name Name to validate
+     *
+     * @return int 1 if given input is a name, 0 else
+     */
+    public static function isCustomerName($name)
+    {
+        $validityPattern = Tools::cleanNonUnicodeSupport(
+            '/^(?:[^0-9!<>,;?=+()\/\\@#"°*`{}_^$%:¤|\.。]|[\.。](?:\s|$))*$/u'
+        );
+
+        return preg_match($validityPattern, $name);
+    }
+
+    /**
+     * Check whether given name is valid
      *
      * @param string $name Name to validate
      *
@@ -165,7 +181,11 @@ class ValidateCore
      */
     public static function isName($name)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u'), stripslashes($name));
+        $validityPattern = Tools::cleanNonUnicodeSupport(
+            '/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u'
+        );
+
+        return preg_match($validityPattern, $name);
     }
 
     /**

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -166,7 +166,7 @@ class ValidateCore
     public static function isCustomerName($name)
     {
         $validityPattern = Tools::cleanNonUnicodeSupport(
-            '/^(?:[^0-9!<>,;?=+()\/\\@#"°*`{}_^$%:¤|\.。]|[\.。](?:\s|$))*$/u'
+            '/^(?:[^0-9!<>,;?=+()\/\\@#"°*`{}_^$%:¤\[\]|\.。]|[\.。](?:\s|$))*$/u'
         );
 
         return preg_match($validityPattern, $name);

--- a/classes/ValidateConstraintTranslator.php
+++ b/classes/ValidateConstraintTranslator.php
@@ -49,29 +49,33 @@ class ValidateConstraintTranslatorCore
      */
     public function translate($validator)
     {
-        if ($validator === 'isName') {
+        if ($validator === 'isName' || $validator === 'isCustomerName') {
             return $this->translator->trans(
                 'Invalid name',
-                array(),
+                [],
                 'Shop.Forms.Errors'
             );
-        } elseif ($validator === 'isBirthDate') {
+        }
+
+        if ($validator === 'isBirthDate') {
             return $this->translator->trans(
                 'Format should be %s.',
-                array(Tools::formatDateStr('31 May 1970')),
+                [Tools::formatDateStr('31 May 1970')],
                 'Shop.Forms.Errors'
             );
-        } elseif ($validator === 'required') {
+        }
+
+        if ($validator === 'required') {
             return $this->translator->trans(
                 'Required field',
-                array(),
+                [],
                 'Shop.Forms.Errors'
             );
         }
 
         return $this->translator->trans(
             'Invalid format.',
-            array(),
+            [],
             'Shop.Forms.Errors'
         );
     }

--- a/js/validate.js
+++ b/js/validate.js
@@ -1,11 +1,11 @@
 /* unicode_hack.js
-*    Copyright (C) 2010-2012  Marcelo Gibson de Castro GonÃ§alves. All rights reserved.
-*
-*    Copying and distribution of this file, with or without modification,
-*    are permitted in any medium without royalty provided the copyright
-*    notice and this notice are preserved.  This file is offered as-is,
-*    without any warranty.
-*/
+ *    Copyright (C) 2010-2012  Marcelo Gibson de Castro GonÃ§alves. All rights reserved.
+ *
+ *    Copying and distribution of this file, with or without modification,
+ *    are permitted in any medium without royalty provided the copyright
+ *    notice and this notice are preserved.  This file is offered as-is,
+ *    without any warranty.
+ */
 var unicode_hack = (function() {
     /* Regexps to match characters in the BMP according to their Unicode category.
        Extracted from Unicode specification, version 5.0.0, source:
@@ -99,9 +99,15 @@ var unicode_hack = (function() {
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+function validate_isCustomerName(s)
+{
+	var reg = /^(?:[^0-9!<>,;?=+()\/\\@#"°*`\{\}_^$%:¤|\.。]|[\.。](?:\s|$))*$/;
+	return reg.test(s);
+}
+
 function validate_isName(s)
 {
-	var reg = /^[^0-9!<>,;?=+()@#"°{}_$%:]+$/;
+	var reg = /^[^0-9!<>,;?=+()@#"°\{\}_$%:]+$/;
 	return reg.test(s);
 }
 

--- a/js/validate.js
+++ b/js/validate.js
@@ -101,7 +101,7 @@ var unicode_hack = (function() {
  */
 function validate_isCustomerName(s)
 {
-	var reg = /^(?:[^0-9!<>,;?=+()\/\\@#"°*`\{\}_^$%:¤|\.。]|[\.。](?:\s|$))*$/;
+	var reg = /^(?:[^0-9!<>,;?=+()\/\\@#"°*`\{\}_^$%:¤\[\]|\.。]|[\.。](?:\s|$))*$/;
 	return reg.test(s);
 }
 

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -195,6 +195,7 @@ class ValidateCoreTest extends TestCase
             array(1, 'websitecom/a'),
             array(0, 'websitecom%20a'),
             array(1, '`hello'),
+            array(1, 'hello[my friend]'),
         );
     }
 
@@ -227,6 +228,7 @@ class ValidateCoreTest extends TestCase
             array(0, 'websitecom/a'),
             array(0, 'websitecom%20a'),
             array(0, '`hello'),
+            array(0, 'hello[my friend]'),
         );
     }
 
@@ -255,7 +257,7 @@ class ValidateCoreTest extends TestCase
             array(false, '2020-03-19'),
             array(false, '1991-03-33'),
             array(false, '1991-15-19'),
-            array(true, date('Y-m-d', strtotime('now'))), 
+            array(true, date('Y-m-d', strtotime('now'))),
             array(true, date('Y-m-d', strtotime('-1 day'))),
             array(false, date('Y-m-d', strtotime('+1 day'))),
             array(true, date('Y-m-d', strtotime('-1 month'))),

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -91,6 +91,22 @@ class ValidateCoreTest extends TestCase
     }
 
     /**
+     * @dataProvider isNameDataProvider
+     */
+    public function testIsName($expected, $input)
+    {
+        $this->assertSame($expected, Validate::isName($input));
+    }
+
+    /**
+     * @dataProvider isCustomerNameDataProvider
+     */
+    public function testIsCustomerName($expected, $input)
+    {
+        $this->assertSame($expected, Validate::isCustomerName($input));
+    }
+
+    /**
      * @dataProvider isFloatDataProvider
      */
     public function testIsFloat($expected, $input)
@@ -146,6 +162,71 @@ class ValidateCoreTest extends TestCase
             array(0, substr(sha1('AnotherRandomString'), 0, 39)),
             array(0, 123),
             array(0, false),
+        );
+    }
+
+
+    public function isNameDataProvider()
+    {
+        return array(
+            array(1, 'Mathieu'),
+            array(1, 'Dupont'),
+            array(1, 'Jaçinthé'),
+            array(1, 'Jaçinthø'),
+            array(1, 'John D.'),
+            array(1, 'John D.John'),
+            array(1, 'John D. John'),
+            array(1, 'John D. John D.'),
+            array(1, 'Mario Bros.'),
+            array(1, 'ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â'),
+            array(0, 'https://www.website.com'),
+            array(1, 'www.website.com'),
+            array(1, 'www\.website\.com'),
+            array(1, 'www\\.website\\.com'),
+            array(1, 'www.website.com.'),
+            array(1, 'website。com'),
+            array(1, 'John D. www.some.site'),
+            array(1, 'www.website.com is cool'),
+            array(1, 'website。com。'),
+            array(1, 'website。com'),
+            array(0, 'website%2Ecom'),
+            array(1, 'website/./com'),
+            array(1, '.rn'),
+            array(1, 'websitecom/a'),
+            array(0, 'websitecom%20a'),
+            array(1, '`hello'),
+        );
+    }
+
+    public function isCustomerNameDataProvider()
+    {
+        return array(
+            array(1, 'Mathieu'),
+            array(1, 'Dupont'),
+            array(1, 'Jaçinthé'),
+            array(1, 'Jaçinthø'),
+            array(1, 'John D.'),
+            array(1, 'John D. John'),
+            array(1, 'John D. John D.'),
+            array(1, 'Mario Bros.'),
+            array(1, 'ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â'),
+            array(0, 'https://www.website.com'),
+            array(0, 'www.website.com'),
+            array(0, 'www\.website\.com'),
+            array(0, 'www\\.website\\.com'),
+            array(0, 'www.website.com.'),
+            array(0, 'website。com'),
+            array(0, 'John D.John'),
+            array(0, 'John D. www.some.site'),
+            array(0, 'www.website.com is cool'),
+            array(0, 'website。com。'),
+            array(0, 'website。com'),
+            array(0, 'website%2Ecom'),
+            array(0, 'website/./com'),
+            array(0, '.rn'),
+            array(0, 'websitecom/a'),
+            array(0, 'websitecom%20a'),
+            array(0, '`hello'),
         );
     }
 
@@ -240,7 +321,7 @@ class ValidateCoreTest extends TestCase
             $this->trueFloatDataProvider(),
             array(
                 array(false, -12.2151),
-                array(false, -12,2151),
+                array(false, -12, 2151),
                 array(false, '-12.2151'),
                 array(false, ''),
                 array(false, 'A'),
@@ -254,7 +335,7 @@ class ValidateCoreTest extends TestCase
         return array(
             array(true, 12),
             array(true, 12.2151),
-            array(true, 12,2151),
+            array(true, 12, 2151),
             array(true, '12.2151'),
         );
     }
@@ -265,7 +346,7 @@ class ValidateCoreTest extends TestCase
             $this->trueFloatDataProvider(),
             array(
                 array(true, -12.2151),
-                array(true, -12,2151),
+                array(true, -12, 2151),
                 array(true, '-12.2151'),
                 array(false, ''),
                 array(false, 'A'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Only forbid for customer name and not everywhere
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13524 
| How to test?  | Attempt, from front-office, to create a customer with an URL as first name or last name. Now it is not possible anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13604)
<!-- Reviewable:end -->
