### PR TITLE
Fix phpdoc on Module class

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -939,7 +939,7 @@ abstract class ModuleCore implements ModuleInterface
      * @param bool $return define the return way : false for a display, true for a return
      * @param bool $use_vars_instead_of_ids use an js vars instead of ids seperate by "¤"
      *
-     * @return bool|string
+     * @return false|string
      */
     public function displayFlags($languages, $default_language, $ids, $id, $return = false, $use_vars_instead_of_ids = false)
     {

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -591,7 +591,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param Module $module
      *
-     * @return bool
+     * @return bool|null Boolean if Module::$version != Module::$database_version, null instead
      */
     public static function needUpgrade($module)
     {
@@ -753,7 +753,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param array|string $name
      *
-     * @return true if succeed
+     * @return bool
      *
      * @since 1.4.1
      * @deprecated since 1.7
@@ -858,7 +858,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param array|string $name
      *
-     * @return true if succeed
+     * @return bool
      *
      * @since 1.7
      */
@@ -884,7 +884,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param array|string $name
      *
-     * @return true if succeed
+     * @return bool
      *
      * @since 1.4.1
      * @deprecated since 1.7
@@ -1115,7 +1115,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param string $module_name Module name
      *
-     * @return Module
+     * @return Module|false
      */
     public static function getInstanceByName($module_name)
     {
@@ -1164,7 +1164,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param int $id_module Module ID
      *
-     * @return Module instance
+     * @return Module|false
      */
     public static function getInstanceById($id_module)
     {
@@ -2443,7 +2443,7 @@ abstract class ModuleCore implements ModuleInterface
      * @param string|null $cache_id
      * @param string|null $compile_id
      *
-     * @return mixed
+     * @return string
      */
     public function fetch($templatePath, $cache_id = null, $compile_id = null)
     {
@@ -2505,7 +2505,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param string $template
      *
-     * @return string
+     * @return string|null
      */
     public function getTemplatePath($template)
     {
@@ -2901,6 +2901,8 @@ abstract class ModuleCore implements ModuleInterface
      * add a warning message to display at the top of the admin page.
      *
      * @param string $msg
+     *
+     * @return false|void
      */
     public function adminDisplayWarning($msg)
     {
@@ -2914,6 +2916,8 @@ abstract class ModuleCore implements ModuleInterface
      * add a info message to display at the top of the admin page.
      *
      * @param string $msg
+     *
+     * @return false|void
      */
     protected function adminDisplayInformation($msg)
     {

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2902,7 +2902,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param string $msg
      *
-     * @return false|void
+     * @return false|null
      */
     public function adminDisplayWarning($msg)
     {
@@ -2917,7 +2917,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param string $msg
      *
-     * @return false|void
+     * @return false|null
      */
     protected function adminDisplayInformation($msg)
     {

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -62,6 +62,11 @@ abstract class ModuleCore implements ModuleInterface
     /** @var string A little description of the module */
     public $description;
 
+    /**
+     * @var string Text to display when ask for confirmation on uninstall action
+     */
+    public $confirmUninstall;
+
     /** @var string author of the module */
     public $author;
 
@@ -70,6 +75,11 @@ abstract class ModuleCore implements ModuleInterface
 
     /** @var string Module key provided by addons.prestashop.com */
     public $module_key = '';
+
+    /**
+     * @var bool Set to true to enable bootstrap theme on configuration page
+     */
+    public $bootstrap = false;
 
     public $description_full;
 
@@ -446,7 +456,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Set errors, warning or success message of a module upgrade.
      *
-     * @param $upgrade_detail
+     * @param array $upgrade_detail
      */
     protected function setUpgradeMessage($upgrade_detail)
     {
@@ -475,7 +485,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Init the upgrade module.
      *
-     * @param $module
+     * @param Module $module
      *
      * @return bool
      */
@@ -562,8 +572,8 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Upgrade the registered version to a new one.
      *
-     * @param $name
-     * @param $version
+     * @param string $name
+     * @param string $version
      *
      * @return bool
      */
@@ -579,7 +589,7 @@ abstract class ModuleCore implements ModuleInterface
      * Check if a module need to be upgraded.
      * This method modify the module_cache adding an upgrade list file.
      *
-     * @param $module
+     * @param Module $module
      *
      * @return bool
      */
@@ -602,9 +612,9 @@ abstract class ModuleCore implements ModuleInterface
      * Load the available list of upgrade of a specified module
      * with an associated version.
      *
-     * @param $module_name
-     * @param $module_version
-     * @param $registered_version
+     * @param string $module_name
+     * @param string $module_version
+     * @param string $registered_version
      *
      * @return bool to know directly if any files have been found
      */
@@ -660,7 +670,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Return the status of the upgraded module.
      *
-     * @param $module_name
+     * @param string $module_name
      *
      * @return bool
      */
@@ -770,6 +780,8 @@ abstract class ModuleCore implements ModuleInterface
      * Activate current module.
      *
      * @param bool $force_all If true, enable module for all shop
+     *
+     * @return bool
      */
     public function enable($force_all = false)
     {
@@ -899,6 +911,8 @@ abstract class ModuleCore implements ModuleInterface
      * Desactivate current module.
      *
      * @param bool $force_all If true, disable module for all shop
+     *
+     * @return bool
      */
     public function disable($force_all = false)
     {
@@ -924,6 +938,8 @@ abstract class ModuleCore implements ModuleInterface
      * @param string $id Current div id]
      * @param bool $return define the return way : false for a display, true for a return
      * @param bool $use_vars_instead_of_ids use an js vars instead of ids seperate by "¤"
+     *
+     * @return bool|string
      */
     public function displayFlags($languages, $default_language, $ids, $id, $return = false, $use_vars_instead_of_ids = false)
     {
@@ -955,8 +971,8 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Connect module to a hook.
      *
-     * @param string $hook_name Hook name
-     * @param array $shop_list List of shop linked to the hook (if null, link hook to all shops)
+     * @param string|array $hook_name Hook name
+     * @param array|null $shop_list List of shop linked to the hook (if null, link hook to all shops)
      *
      * @return bool result
      */
@@ -968,8 +984,8 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Unregister module from hook.
      *
-     * @param mixed $id_hook Hook id (can be a hook name since 1.5.0)
-     * @param array $shop_list List of shop
+     * @param int|string $hook_id Hook id (can be a hook name since 1.5.0)
+     * @param array|null $shop_list List of shop
      *
      * @return bool result
      */
@@ -981,8 +997,8 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Unregister exceptions linked to module.
      *
-     * @param int $id_hook Hook id
-     * @param array $shop_list List of shop
+     * @param int $hook_id Hook id
+     * @param array|null $shop_list List of shop
      *
      * @return bool result
      */
@@ -1036,7 +1052,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Edit exceptions for module->Hook.
      *
-     * @param int $hookID Hook id
+     * @param int $id_hook Hook id
      * @param array $excepts List of shopID and file name
      *
      * @return bool result
@@ -1058,7 +1074,7 @@ abstract class ModuleCore implements ModuleInterface
      * of an AdminTab which belongs to a module, in order to keep translation
      * related to a module in its directory (instead of $_LANGADM).
      *
-     * @param mixed $current_class the
+     * @param string $current_class Name of Module class
      *
      * @return bool|string if the class belongs to a module, will return the module name. Otherwise, return false.
      */
@@ -1626,9 +1642,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Return non native module.
      *
-     * @param int $position Take only positionnables modules
-     *
-     * @return array Modules
+     * @return array|false Modules list or false if cannot read xml
      */
     public static function getNonNativeModuleList()
     {
@@ -1711,8 +1725,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Return if the module is provided by addons.prestashop.com or not.
      *
-     * @param string $name The module name (the folder name)
-     * @param string $key The key provided by addons
+     * @param string $module_name The module name (the folder name)
      *
      * @return int
      */
@@ -1878,7 +1891,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Create the Addons API call from the module name only.
      *
-     * @param string $name Module dir name
+     * @param string $module_name Module dir name
      *
      * @return bool Returns if the module is trusted by addons.prestashop.com
      */
@@ -1985,7 +1998,9 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param bool $id_hook Hook ID
      * @param bool $way Up (0) or Down (1)
-     * @param int $position
+     * @param int|null $position
+     *
+     * @return bool
      */
     public function updatePosition($id_hook, $way, $position = null)
     {
@@ -2062,7 +2077,9 @@ abstract class ModuleCore implements ModuleInterface
      * Reorder modules position
      *
      * @param bool $id_hook Hook ID
-     * @param array $shop_list List of shop
+     * @param array|null $shop_list List of shop
+     *
+     * @return bool
      */
     public function cleanPositions($id_hook, $shop_list = null)
     {
@@ -2206,6 +2223,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param int $id_module Module ID
      * @param int $id_hook Hook ID
+     * @param bool $dispatch
      *
      * @return array Exceptions
      */
@@ -2263,6 +2281,7 @@ abstract class ModuleCore implements ModuleInterface
      * Return exceptions for module in hook
      *
      * @param int $id_hook Hook ID
+     * @param bool $dispatch
      *
      * @return array Exceptions
      */
@@ -2421,8 +2440,8 @@ abstract class ModuleCore implements ModuleInterface
      * Use this method to return the result of a smarty template when assign data only locally with $this->smarty->assign().
      *
      * @param string $templatePath relative path the template file, from the module root dir
-     * @param null $cache_id
-     * @param null $compile_id
+     * @param string|null $cache_id
+     * @param string|null $compile_id
      *
      * @return mixed
      */
@@ -2525,8 +2544,8 @@ abstract class ModuleCore implements ModuleInterface
      * Clear template cache.
      *
      * @param string $template Template name
-     * @param int null $cache_id
-     * @param int null $compile_id
+     * @param string|null $cache_id
+     * @param string|null $compile_id
      *
      * @return int Number of template cleared
      */
@@ -2571,8 +2590,8 @@ abstract class ModuleCore implements ModuleInterface
      * Clear defered template cache.
      *
      * @param string $template_path Template path
-     * @param int null $cache_id
-     * @param int null $compile_id
+     * @param string|null $cache_id
+     * @param string|null $compile_id
      *
      * @return int Number of template cleared
      */
@@ -2715,7 +2734,7 @@ abstract class ModuleCore implements ModuleInterface
      * Check employee permission for module.
      *
      * @param array $variable (action)
-     * @param object $employee
+     * @param Employee $employee
      *
      * @return bool if module can be transplanted on hook
      */
@@ -2729,7 +2748,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param int $id_module
      * @param array $variable (action)
-     * @param object $employee
+     * @param Employee $employee
      *
      * @return bool if module can be transplanted on hook
      */
@@ -2756,6 +2775,7 @@ abstract class ModuleCore implements ModuleInterface
      * Get authorized modules for a client group.
      *
      * @param int $group_id
+     * @param array $shops
      *
      * @return array|null
      */
@@ -2842,7 +2862,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Return module position for a given hook
      *
-     * @param bool $id_hook Hook ID
+     * @param int $id_hook Hook ID
      *
      * @return int position
      */


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When working on MBO, my IDE give me some warning due to incomplete phpdoc on `Module::registerHook()` also with `Module::$bootstrap` and `Module::$confirmUninstall`
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Any
| How to test?  | It's just phpdoc so anythings should work as before :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13606)
<!-- Reviewable:end -->
