### PR TITLE
Forbid URLs to be inserted into Name fields

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -159,8 +159,8 @@ class CustomerCore extends ObjectModel
         'primary' => 'id_customer',
         'fields' => array(
             'secure_key' =>                array('type' => self::TYPE_STRING, 'validate' => 'isMd5', 'copy_post' => false),
-            'lastname' =>                    array('type' => self::TYPE_STRING, 'validate' => 'isName', 'required' => true, 'size' => 32),
-            'firstname' =>                    array('type' => self::TYPE_STRING, 'validate' => 'isName', 'required' => true, 'size' => 32),
+            'lastname' =>                    array('type' => self::TYPE_STRING, 'validate' => 'isCustomerName', 'required' => true, 'size' => 32),
+            'firstname' =>                    array('type' => self::TYPE_STRING, 'validate' => 'isCustomerName', 'required' => true, 'size' => 32),
             'email' =>                        array('type' => self::TYPE_STRING, 'validate' => 'isEmail', 'required' => true, 'size' => 128),
             'passwd' =>                    array('type' => self::TYPE_STRING, 'validate' => 'isPasswd', 'required' => true, 'size' => 32),
             'last_passwd_gen' =>            array('type' => self::TYPE_STRING, 'copy_post' => false),

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -149,6 +149,22 @@ class ValidateCore
     }
 
     /**
+     * Check whether given customer name is valid
+     *
+     * @param string $name Name to validate
+     *
+     * @return int 1 if given input is a name, 0 else
+     */
+    public static function isCustomerName($name)
+    {
+        $validityPattern = Tools::cleanNonUnicodeSupport(
+            '/^(?:[^0-9!<>,;?=+()\/\\@#"°*`{}_^$%:¤|\.。]|[\.。](?:\s|$))*$/u'
+        );
+
+        return preg_match($validityPattern, $name);
+    }
+
+    /**
      * Check whether given name is valid
      *
      * @param string $name Name to validate
@@ -158,7 +174,7 @@ class ValidateCore
     public static function isName($name)
     {
         $validityPattern = Tools::cleanNonUnicodeSupport(
-            '/^(?:[^0-9!<>,;?=+()\/\\@#"°*`{}_^$%:¤|\.。]|[\.。](?:\s|$))*$/u'
+            '/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u'
         );
 
         return preg_match($validityPattern, $name);

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -158,7 +158,7 @@ class ValidateCore
     public static function isCustomerName($name)
     {
         $validityPattern = Tools::cleanNonUnicodeSupport(
-            '/^(?:[^0-9!<>,;?=+()\/\\@#"°*`{}_^$%:¤|\.。]|[\.。](?:\s|$))*$/u'
+            '/^(?:[^0-9!<>,;?=+()\/\\@#"°*`{}_^$%:¤\[\]|\.。]|[\.。](?:\s|$))*$/u'
         );
 
         return preg_match($validityPattern, $name);

--- a/js/validate.js
+++ b/js/validate.js
@@ -1,11 +1,11 @@
 /* unicode_hack.js
-*    Copyright (C) 2010-2012  Marcelo Gibson de Castro GonÃ§alves. All rights reserved.
-*
-*    Copying and distribution of this file, with or without modification,
-*    are permitted in any medium without royalty provided the copyright
-*    notice and this notice are preserved.  This file is offered as-is,
-*    without any warranty.
-*/
+ *    Copyright (C) 2010-2012  Marcelo Gibson de Castro GonÃ§alves. All rights reserved.
+ *
+ *    Copying and distribution of this file, with or without modification,
+ *    are permitted in any medium without royalty provided the copyright
+ *    notice and this notice are preserved.  This file is offered as-is,
+ *    without any warranty.
+ */
 var unicode_hack = (function() {
     /* Regexps to match characters in the BMP according to their Unicode category.
        Extracted from Unicode specification, version 5.0.0, source:
@@ -75,33 +75,39 @@ var unicode_hack = (function() {
 	};
 
 })();
-/*
-* 2007-2017 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Open Software License (OSL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/osl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author PrestaShop SA <contact@prestashop.com>
-*  @copyright  2007-2017 PrestaShop SA
-*  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+/**
+ * 2007-2017 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2017 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+function validate_isCustomerName(s)
+{
+	var reg = /^(?:[^0-9!<>,;?=+()\/\\@#"°*`\{\}_^$%:¤|\.。]|[\.。](?:\s|$))*$/;
+	return reg.test(s);
+}
+
 function validate_isName(s)
 {
-	var reg = /^[^0-9!<>,;?=+()@#"°{}_$%:]+$/;
+	var reg = /^[^0-9!<>,;?=+()@#"°\{\}_$%:]+$/;
 	return reg.test(s);
 }
 

--- a/js/validate.js
+++ b/js/validate.js
@@ -101,7 +101,7 @@ var unicode_hack = (function() {
  */
 function validate_isCustomerName(s)
 {
-	var reg = /^(?:[^0-9!<>,;?=+()\/\\@#"°*`\{\}_^$%:¤|\.。]|[\.。](?:\s|$))*$/;
+	var reg = /^(?:[^0-9!<>,;?=+()\/\\@#"°*`\{\}_^$%:¤\[\]|\.。]|[\.。](?:\s|$))*$/;
 	return reg.test(s);
 }
 

--- a/tests/Unit/classes/ValidateCoreTest.php
+++ b/tests/Unit/classes/ValidateCoreTest.php
@@ -83,6 +83,14 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider isCustomerNameDataProvider
+     */
+    public function testIsCustomerName($expected, $input)
+    {
+        $this->assertSame($expected, Validate::isCustomerName($input));
+    }
+
+    /**
      * @dataProvider isFloatDataProvider
      */
     public function testIsFloat($expected, $input)
@@ -115,15 +123,15 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
         $this->assertSame($expected, Validate::isInt($input));
     }
 
-        // --- providers ---
+    // --- providers ---
 
-        public function isIp2LongDataProvider()
-        {
-            return array(
+    public function isIp2LongDataProvider()
+    {
+        return array(
             array(false, 'toto'),
             array(true, '123')
         );
-        }
+    }
 
     public function isMd5DataProvider()
     {
@@ -149,7 +157,41 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
         );
     }
 
+
     public function isNameDataProvider()
+    {
+        return array(
+            array(1, 'Mathieu'),
+            array(1, 'Dupont'),
+            array(1, 'Jaçinthé'),
+            array(1, 'Jaçinthø'),
+            array(1, 'John D.'),
+            array(1, 'John D.John'),
+            array(1, 'John D. John'),
+            array(1, 'John D. John D.'),
+            array(1, 'Mario Bros.'),
+            array(1, 'ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â'),
+            array(0, 'https://www.website.com'),
+            array(1, 'www.website.com'),
+            array(1, 'www\.website\.com'),
+            array(1, 'www\\.website\\.com'),
+            array(1, 'www.website.com.'),
+            array(1, 'website。com'),
+            array(1, 'John D. www.some.site'),
+            array(1, 'www.website.com is cool'),
+            array(1, 'website。com。'),
+            array(1, 'website。com'),
+            array(0, 'website%2Ecom'),
+            array(1, 'website/./com'),
+            array(1, '.rn'),
+            array(1, 'websitecom/a'),
+            array(0, 'websitecom%20a'),
+            array(1, '`hello'),
+            array(1, 'hello[my friend]'),
+        );
+    }
+
+    public function isCustomerNameDataProvider()
     {
         return array(
             array(1, 'Mathieu'),
@@ -167,6 +209,7 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
             array(0, 'www\\.website\\.com'),
             array(0, 'www.website.com.'),
             array(0, 'website。com'),
+            array(0, 'John D.John'),
             array(0, 'John D. www.some.site'),
             array(0, 'www.website.com is cool'),
             array(0, 'website。com。'),
@@ -176,6 +219,8 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
             array(0, '.rn'),
             array(0, 'websitecom/a'),
             array(0, 'websitecom%20a'),
+            array(0, '`hello'),
+            array(0, 'hello[my friend]'),
         );
     }
 
@@ -213,7 +258,7 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
             $this->trueFloatDataProvider(),
             array(
                 array(false, -12.2151),
-                array(false, -12,2151),
+                array(false, -12, 2151),
                 array(false, '-12.2151'),
                 array(false, ''),
                 array(false, 'A'),
@@ -227,7 +272,7 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
         return array(
             array(true, 12),
             array(true, 12.2151),
-            array(true, 12,2151),
+            array(true, 12, 2151),
             array(true, '12.2151'),
         );
     }
@@ -238,7 +283,7 @@ class ValidateCoreTest extends PHPUnit_Framework_TestCase
             $this->trueFloatDataProvider(),
             array(
                 array(true, -12.2151),
-                array(true, -12,2151),
+                array(true, -12, 2151),
                 array(true, '-12.2151'),
                 array(false, ''),
                 array(false, 'A'),

--- a/themes/default-bootstrap/authentication.tpl
+++ b/themes/default-bootstrap/authentication.tpl
@@ -123,11 +123,11 @@
 					</div>
 					<div class="required form-group">
 						<label for="firstname">{l s='First name'} <sup>*</sup></label>
-						<input type="text" class="is_required validate form-control" data-validate="isName" id="firstname" name="firstname" value="{if isset($smarty.post.firstname)}{$smarty.post.firstname}{/if}" />
+						<input type="text" class="is_required validate form-control" data-validate="isCustomerName" id="firstname" name="firstname" value="{if isset($smarty.post.firstname)}{$smarty.post.firstname}{/if}" />
 					</div>
 					<div class="required form-group">
 						<label for="lastname">{l s='Last name'} <sup>*</sup></label>
-						<input type="text" class="is_required validate form-control" data-validate="isName" id="lastname" name="lastname" value="{if isset($smarty.post.lastname)}{$smarty.post.lastname}{/if}" />
+						<input type="text" class="is_required validate form-control" data-validate="isCustomerName" id="lastname" name="lastname" value="{if isset($smarty.post.lastname)}{$smarty.post.lastname}{/if}" />
 					</div>
 					<div class="form-group date-select">
 						<label>{l s='Date of Birth'}</label>
@@ -444,11 +444,11 @@
 			</div>
 			<div class="required form-group">
 				<label for="customer_firstname">{l s='First name'} <sup>*</sup></label>
-				<input onkeyup="$('#firstname').val(this.value);" type="text" class="is_required validate form-control" data-validate="isName" id="customer_firstname" name="customer_firstname" value="{if isset($smarty.post.customer_firstname)}{$smarty.post.customer_firstname}{/if}" />
+				<input onkeyup="$('#firstname').val(this.value);" type="text" class="is_required validate form-control" data-validate="isCustomerName" id="customer_firstname" name="customer_firstname" value="{if isset($smarty.post.customer_firstname)}{$smarty.post.customer_firstname}{/if}" />
 			</div>
 			<div class="required form-group">
 				<label for="customer_lastname">{l s='Last name'} <sup>*</sup></label>
-				<input onkeyup="$('#lastname').val(this.value);" type="text" class="is_required validate form-control" data-validate="isName" id="customer_lastname" name="customer_lastname" value="{if isset($smarty.post.customer_lastname)}{$smarty.post.customer_lastname}{/if}" />
+				<input onkeyup="$('#lastname').val(this.value);" type="text" class="is_required validate form-control" data-validate="isCustomerName" id="customer_lastname" name="customer_lastname" value="{if isset($smarty.post.customer_lastname)}{$smarty.post.customer_lastname}{/if}" />
 			</div>
 			<div class="required form-group">
 				<label for="email">{l s='Email'} <sup>*</sup></label>

--- a/themes/default-bootstrap/identity.tpl
+++ b/themes/default-bootstrap/identity.tpl
@@ -70,13 +70,13 @@
                     <label for="firstname" class="required">
                         {l s='First name'}
                     </label>
-                    <input class="is_required validate form-control" data-validate="isName" type="text" id="firstname" name="firstname" value="{$smarty.post.firstname}" />
+                    <input class="is_required validate form-control" data-validate="isCustomerName" type="text" id="firstname" name="firstname" value="{$smarty.post.firstname}" />
                 </div>
                 <div class="required form-group">
                     <label for="lastname" class="required">
                         {l s='Last name'}
                     </label>
-                    <input class="is_required validate form-control" data-validate="isName" type="text" name="lastname" id="lastname" value="{$smarty.post.lastname}" />
+                    <input class="is_required validate form-control" data-validate="isCustomerName" type="text" name="lastname" id="lastname" value="{$smarty.post.lastname}" />
                 </div>
                 <div class="required form-group">
                     <label for="email" class="required">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Only forbid for customer name and not everywhere
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13524 
| How to test?  | Attempt, from front-office, to create a customer with an URL as first name or last name. Now it is not possible anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13607)
<!-- Reviewable:end -->
