### PR TITLE
Fix dispatched hook on the Grid presenter: action<GridDefinitionId>GridFilterFormModifier

### DIFF
--- a/src/Core/Grid/Presenter/GridPresenter.php
+++ b/src/Core/Grid/Presenter/GridPresenter.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\PositionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterInterface;
+use Symfony\Component\DependencyInjection\Container;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters;
@@ -93,7 +94,7 @@ final class GridPresenter implements GridPresenterInterface
             $presentedGrid['form_prefix'] = $searchCriteria->getFilterId();
         }
 
-        $this->hookDispatcher->dispatchWithParameters('action' . $definition->getId() . 'GridPresenterModifier', [
+        $this->hookDispatcher->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridPresenterModifier', [
             'presented_grid' => &$presentedGrid,
         ]);
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The dispatched hook doesn't fit what is documented and specified
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no (the hook is not available right now)
| Deprecations? | no
| Fixed ticket? | Fixes #13579
| How to test?  | No need, but you can create a module that hooks to the Logs Grid presenter

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13609)
<!-- Reviewable:end -->
