### PR TITLE
Fix not null voucher with free shipping producing php error

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1977,7 +1977,7 @@ class CartCore extends ObjectModel
             case Cart::BOTH_WITHOUT_SHIPPING:
                 $calculator->calculateRows();
                 // dont process free shipping to avoid calculation loop (and maximum nested functions !)
-                $calculator->calculateCartRules(false);
+                $calculator->calculateCartRulesWithoutFreeShipping();
                 $amount = $calculator->getTotal(true);
                 break;
             case Cart::ONLY_PRODUCTS:

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1976,6 +1976,7 @@ class CartCore extends ObjectModel
                 break;
             case Cart::BOTH_WITHOUT_SHIPPING:
                 $calculator->calculateRows();
+                // dont process free shipping to avoid calculation loop (and maximum nested functions !)
                 $calculator->calculateCartRules(false);
                 $amount = $calculator->getTotal(true);
                 break;

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1976,7 +1976,7 @@ class CartCore extends ObjectModel
                 break;
             case Cart::BOTH_WITHOUT_SHIPPING:
                 $calculator->calculateRows();
-                $calculator->calculateCartRules();
+                $calculator->calculateCartRules(false);
                 $amount = $calculator->getTotal(true);
                 break;
             case Cart::ONLY_PRODUCTS:

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -263,13 +263,14 @@ class Calculator
 
     /**
      * calculate only cart rules (rows and fees have to be calculated first).
+     * @param bool $withFreeShipping used to calculate free shipping discount (avoid loop on shipping calculation)
      */
-    public function calculateCartRules()
+    public function calculateCartRules($withFreeShipping = true)
     {
         $this->cartRuleCalculator->setCartRules($this->cartRules)
             ->setCartRows($this->cartRows)
             ->setCalculator($this)
-            ->applyCartRules();
+            ->applyCartRules($withFreeShipping);
     }
 
     /**
@@ -288,5 +289,13 @@ class Calculator
     public function getCartRulesData()
     {
         return $this->cartRuleCalculator->getCartRulesData();
+    }
+
+    /**
+     * @return int
+     */
+    public function getCarrierId()
+    {
+        return $this->id_carrier;
     }
 }

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -263,16 +263,25 @@ class Calculator
 
     /**
      * calculate only cart rules (rows and fees have to be calculated first).
-     *
-     * @param bool $withFreeShipping used to calculate free shipping discount (avoid loop on shipping calculation)
      */
-    public function calculateCartRules($withFreeShipping = true)
+    public function calculateCartRules()
     {
         $this->cartRuleCalculator->setCartRules($this->cartRules)
             ->setCartRows($this->cartRows)
             ->setCalculator($this)
-            ->useFreeShipping($withFreeShipping)
             ->applyCartRules();
+    }
+
+    /**
+     * calculate only cart rules (rows and fees have to be calculated first), but don't process free-shipping discount
+     * (avoid loop on shipping calculation)
+     */
+    public function calculateCartRulesWithoutFreeShipping()
+    {
+        $this->cartRuleCalculator->setCartRules($this->cartRules)
+            ->setCartRows($this->cartRows)
+            ->setCalculator($this)
+            ->applyCartRulesWithoutFreeShipping();
     }
 
     /**

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -292,12 +292,4 @@ class Calculator
     {
         return $this->cartRuleCalculator->getCartRulesData();
     }
-
-    /**
-     * @return int
-     */
-    public function getCarrierId()
-    {
-        return $this->id_carrier;
-    }
 }

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -263,6 +263,7 @@ class Calculator
 
     /**
      * calculate only cart rules (rows and fees have to be calculated first).
+     *
      * @param bool $withFreeShipping used to calculate free shipping discount (avoid loop on shipping calculation)
      */
     public function calculateCartRules($withFreeShipping = true)

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -271,7 +271,8 @@ class Calculator
         $this->cartRuleCalculator->setCartRules($this->cartRules)
             ->setCartRows($this->cartRows)
             ->setCalculator($this)
-            ->applyCartRules($withFreeShipping);
+            ->useFreeShipping($withFreeShipping)
+            ->applyCartRules();
     }
 
     /**

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Cart;
 
 use Cart;
-use CartRule;
 
 class CartRuleCalculator
 {
@@ -76,6 +75,7 @@ class CartRuleCalculator
     /**
      * @param CartRuleData $cartRuleData
      * @param bool $withFreeShipping used to calculate free shipping discount (avoid loop on shipping calculation)
+     *
      * @throws \PrestaShopDatabaseException
      */
     protected function applyCartRule(CartRuleData $cartRuleData, $withFreeShipping = true)

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -51,12 +51,14 @@ class CartRuleCalculator
     protected $fees;
 
     /**
-     * @param bool $withFreeShipping used to calculate free shipping discount (avoid loop on shipping calculation)
+     * @var bool
      */
-    public function applyCartRules($withFreeShipping = true)
+    protected $useFreeShipping;
+
+    public function applyCartRules()
     {
         foreach ($this->cartRules as $cartRule) {
-            $this->applyCartRule($cartRule, $withFreeShipping);
+            $this->applyCartRule($cartRule);
         }
     }
 
@@ -74,11 +76,10 @@ class CartRuleCalculator
 
     /**
      * @param CartRuleData $cartRuleData
-     * @param bool $withFreeShipping used to calculate free shipping discount (avoid loop on shipping calculation)
      *
      * @throws \PrestaShopDatabaseException
      */
-    protected function applyCartRule(CartRuleData $cartRuleData, $withFreeShipping = true)
+    protected function applyCartRule(CartRuleData $cartRuleData)
     {
         $cartRule = $cartRuleData->getCartRule();
         $cart = $this->calculator->getCart();
@@ -88,7 +89,7 @@ class CartRuleCalculator
         }
 
         // Free shipping on selected carriers
-        if ($cartRule->free_shipping && $withFreeShipping) {
+        if ($cartRule->free_shipping && $this->useFreeShipping) {
             $initialShippingFees = new AmountImmutable(
                 $cart->getOrderTotal(true, Cart::ONLY_SHIPPING),
                 $cart->getOrderTotal(false, Cart::ONLY_SHIPPING)
@@ -252,6 +253,18 @@ class CartRuleCalculator
     public function setCalculator($calculator)
     {
         $this->calculator = $calculator;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $useFreeShipping used to calculate free shipping discount (avoid loop on shipping calculation)
+     *
+     * @return CartRuleCalculator
+     */
+    public function useFreeShipping($useFreeShipping)
+    {
+        $this->useFreeShipping = $useFreeShipping;
 
         return $this;
     }

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -53,7 +53,7 @@ class CartRuleCalculator
     /**
      * @var bool
      */
-    protected $useFreeShipping;
+    protected $useFreeShipping = true;
 
     public function applyCartRules()
     {

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -51,14 +51,22 @@ class CartRuleCalculator
     protected $fees;
 
     /**
-     * @var bool
+     * process cartrules calculation
      */
-    protected $useFreeShipping = true;
-
     public function applyCartRules()
     {
         foreach ($this->cartRules as $cartRule) {
             $this->applyCartRule($cartRule);
+        }
+    }
+
+    /**
+     * process cartrules calculation, excluding free-shipping processing
+     */
+    public function applyCartRulesWithoutFreeShipping()
+    {
+        foreach ($this->cartRules as $cartRule) {
+            $this->applyCartRule($cartRule, false);
         }
     }
 
@@ -76,10 +84,11 @@ class CartRuleCalculator
 
     /**
      * @param CartRuleData $cartRuleData
+     * @param bool $withFreeShipping used to calculate free shipping discount (avoid loop on shipping calculation)
      *
      * @throws \PrestaShopDatabaseException
      */
-    protected function applyCartRule(CartRuleData $cartRuleData)
+    protected function applyCartRule(CartRuleData $cartRuleData, $withFreeShipping = true)
     {
         $cartRule = $cartRuleData->getCartRule();
         $cart = $this->calculator->getCart();
@@ -89,7 +98,7 @@ class CartRuleCalculator
         }
 
         // Free shipping on selected carriers
-        if ($cartRule->free_shipping && $this->useFreeShipping) {
+        if ($cartRule->free_shipping && $withFreeShipping) {
             $initialShippingFees = new AmountImmutable(
                 $cart->getOrderTotal(true, Cart::ONLY_SHIPPING),
                 $cart->getOrderTotal(false, Cart::ONLY_SHIPPING)
@@ -253,18 +262,6 @@ class CartRuleCalculator
     public function setCalculator($calculator)
     {
         $this->calculator = $calculator;
-
-        return $this;
-    }
-
-    /**
-     * @param bool $useFreeShipping used to calculate free shipping discount (avoid loop on shipping calculation)
-     *
-     * @return CartRuleCalculator
-     */
-    public function useFreeShipping($useFreeShipping)
-    {
-        $this->useFreeShipping = $useFreeShipping;
 
         return $this;
     }

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -88,6 +88,14 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^there is a cart rule named "(.+)" that applies no discount with priority (\d+), quantity of (.*) and quantity per user (.*)$/
+     */
+    public function thereIsACartRuleWithNameAndNoDiscountAndPriorityOfAndQuantityOfAndQuantityPerUserOf($cartRuleName, $priority, $cartRuleQuantity, $cartRuleQuantityPerUser)
+    {
+        $this->createCartRule($cartRuleName, 0, 0, $priority, $cartRuleQuantity, $cartRuleQuantityPerUser);
+    }
+
+    /**
      * @Given /^there is a cart rule named "(.+)" that applies an amount discount of (\d+\.\d+) with priority (\d+), quantity of (.*) and quantity per user (.*)$/
      */
     public function thereIsACartRuleWithNameAndAmountDiscountOfAndPriorityOfAndQuantityOfAndQuantityPerUserOf($cartRuleName, $amount, $priority, $cartRuleQuantity, $cartRuleQuantityPerUser)

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -80,7 +80,7 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @Given /^there is a cart rule named "(.+)" that applies a percent discount of (\d+\.\d+)% with priority (\d+), quantity of (.*) and quantity per user (.*)$/
+     * @Given /^there is a cart rule named "(.+)" that applies a percent discount of (\d+\.\d+)% with priority (\d+), quantity of (\d+) and quantity per user (\d+)$/
      */
     public function thereIsACartRuleWithNameAndPercentDiscountOf50AndPriorityOfAndQuantityOfAndQuantityPerUserOf($cartRuleName, $percent, $priority, $cartRuleQuantity, $cartRuleQuantityPerUser)
     {
@@ -88,7 +88,7 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @Given /^there is a cart rule named "(.+)" that applies no discount with priority (\d+), quantity of (.*) and quantity per user (.*)$/
+     * @Given /^there is a cart rule named "(.+)" that applies no discount with priority (\d+), quantity of (\d+) and quantity per user (\d+)$/
      */
     public function thereIsACartRuleWithNameAndNoDiscountAndPriorityOfAndQuantityOfAndQuantityPerUserOf($cartRuleName, $priority, $cartRuleQuantity, $cartRuleQuantityPerUser)
     {
@@ -96,7 +96,7 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @Given /^there is a cart rule named "(.+)" that applies an amount discount of (\d+\.\d+) with priority (\d+), quantity of (.*) and quantity per user (.*)$/
+     * @Given /^there is a cart rule named "(.+)" that applies an amount discount of (\d+\.\d+) with priority (\d+), quantity of (\d+) and quantity per user (\d+)$/
      */
     public function thereIsACartRuleWithNameAndAmountDiscountOfAndPriorityOfAndQuantityOfAndQuantityPerUserOf($cartRuleName, $amount, $priority, $cartRuleQuantity, $cartRuleQuantityPerUser)
     {

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
@@ -1,0 +1,29 @@
+@reset-database-before-feature
+Feature: Cart rule (amount) calculation with one cart rule offering free shipping
+  As a customer
+  I must be able to have correct cart total when adding cart rules
+
+  Scenario: One product in cart, one cartRule offering only free shipping
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a cart rule named "cartrule4" that applies no discount with priority 4, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule4" offers free shipping
+    Given cart rule "cartrule4" has a discount code "foo4"
+    When I add 1 items of product "product1" in my cart
+    When I use the discount "cartrule4"
+    Then my cart total should be 19.812 tax included
+    Then my cart total using previous calculation method should be 19.812 tax included
+
+  @current
+  Scenario: One product in cart, one cartRule offering free shipping AND 5€ discount
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule4" offers free shipping
+    Given cart rule "cartrule4" has a discount code "foo4"
+    When I add 1 items of product "product1" in my cart
+    When I use the discount "cartrule4"
+    Then my cart total using previous calculation method should be 14.812 tax included
+    Then my cart total should be 14.812 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
@@ -15,7 +15,6 @@ Feature: Cart rule (amount) calculation with one cart rule offering free shippin
     Then my cart total should be 19.812 tax included
     Then my cart total using previous calculation method should be 19.812 tax included
 
-  @current
   Scenario: One product in cart, one cartRule offering free shipping AND 5€ discount
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -25,5 +24,5 @@ Feature: Cart rule (amount) calculation with one cart rule offering free shippin
     Given cart rule "cartrule4" has a discount code "foo4"
     When I add 1 items of product "product1" in my cart
     When I use the discount "cartrule4"
-    Then my cart total using previous calculation method should be 14.812 tax included
     Then my cart total should be 14.812 tax included
+    Then my cart total using previous calculation method should be 14.812 tax included


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fix regression introduced in 1.7.6.x on vouchers: not null (percent or amount) voucher with free shipping was producing php error (maximum nested function)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | fixes #13543 
| How to test?  | On BO create voucher with not null amount AND free shipping. Apply it on FO. It should not result in php error when refreshing page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13617)
<!-- Reviewable:end -->
