### PR TITLE
Fixes incorrect hook names for identifiable object forms.

### DIFF
--- a/src/Core/Form/IdentifiableObject/Builder/FormBuilder.php
+++ b/src/Core/Form/IdentifiableObject/Builder/FormBuilder.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder;
 
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\FormDataProviderInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 
@@ -118,7 +119,7 @@ final class FormBuilder implements FormBuilderInterface
     {
         $formBuilder = $this->formFactory->createBuilder($formType, $data, $options);
 
-        $this->hookDispatcher->dispatchWithParameters('action' . $formBuilder->getName() . 'FormBuilderModifier', [
+        $this->hookDispatcher->dispatchWithParameters('action' . Container::camelize($formBuilder->getName()) . 'FormBuilderModifier', [
             'form_builder' => $formBuilder,
             'data' => &$data,
             'id' => $id,

--- a/src/Core/Form/IdentifiableObject/Handler/FormHandler.php
+++ b/src/Core/Form/IdentifiableObject/Handler/FormHandler.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler;
 
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\FormDataHandlerInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -134,14 +135,14 @@ final class FormHandler implements FormHandlerInterface
     {
         $data = $form->getData();
 
-        $this->hookDispatcher->dispatchWithParameters('actionBeforeUpdate' . $form->getName() . 'FormHandler', [
+        $this->hookDispatcher->dispatchWithParameters('actionBeforeUpdate' . Container::camelize($form->getName()) . 'FormHandler', [
             'form_data' => &$data,
             'id' => $id,
         ]);
 
         $this->dataHandler->update($id, $data);
 
-        $this->hookDispatcher->dispatchWithParameters('actionAfterUpdate' . $form->getName() . 'FormHandler', [
+        $this->hookDispatcher->dispatchWithParameters('actionAfterUpdate' . Container::camelize($form->getName()) . 'FormHandler', [
             'id' => $id,
         ]);
 
@@ -157,13 +158,13 @@ final class FormHandler implements FormHandlerInterface
     {
         $data = $form->getData();
 
-        $this->hookDispatcher->dispatchWithParameters('actionBeforeCreate' . $form->getName() . 'FormHandler', [
+        $this->hookDispatcher->dispatchWithParameters('actionBeforeCreate' . Container::camelize($form->getName()) . 'FormHandler', [
             'form_data' => &$data,
         ]);
 
         $id = $this->dataHandler->create($data);
 
-        $this->hookDispatcher->dispatchWithParameters('actionAfterCreate' . $form->getName() . 'FormHandler', [
+        $this->hookDispatcher->dispatchWithParameters('actionAfterCreate' . Container::camelize($form->getName()) . 'FormHandler', [
             'id' => $id,
         ]);
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | A lot of hooks were formatted using snake cases - this fix helps transform snake cases to the camelCase which leads to appropriate hook names
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13594
| How to test?  | Hooks like "actionAfterUpdatecms_page_categoryFormHandler" becomes "actionAfterUpdateCmsPageCategoryFormHandler"

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13643)
<!-- Reviewable:end -->
