### PR TITLE
Fix instance module overrides in grider.php

### DIFF
--- a/admin-dev/grider.php
+++ b/admin-dev/grider.php
@@ -98,7 +98,7 @@ if (!$shop_id) {
     
 require_once($module_path);
 
-$grid = new $module();
+$grid = Module::getInstanceByName($module);
 $grid->setEmployee($id_employee);
 $grid->setLang($id_lang);
 if ($option) {


### PR DESCRIPTION
I detected this problem because previous code didn't run overrided getData() method in a ModuleGrid module override. 

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.6.1.x
| Description?  | grider.php instanced parent module instead of overrided module so some methods were unable to be overrided.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create an override for any ModuleGrid, for example  statsbestcustomers.php, and override getData() method. Check that override getData() method is executed after code change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13648)
<!-- Reviewable:end -->
