### PR TITLE
Adding close welcome module in tests product

### DIFF
--- a/tests/E2E/test/campaigns/full/02_product/07_next_and_previous_page.js
+++ b/tests/E2E/test/campaigns/full/02_product/07_next_and_previous_page.js
@@ -7,18 +7,13 @@ const {AccessPageBO} = require('../../../selectors/BO/access_page');
 const {productPage} = require('../../../selectors/FO/product_page');
 const commonProductScenarios = require('../../common_scenarios/product');
 const {TrafficAndSeo} = require('../../../selectors/BO/shopParameters/shop_parameters');
-const {OnBoarding} = require('../../../selectors/BO/onboarding.js');
-let promise = Promise.resolve();
+const welcomeScenarios = require('../../common_scenarios/welcome');
 scenario('Go to next & previous page', () => {
   scenario('Login in the Back Office', client => {
     test('should open the browser', () => client.open());
     test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
-    test('should check and click on "Stop the OnBoarding" button', () => {
-      return promise
-        .then(() => client.isVisible(OnBoarding.stop_button))
-        .then(() => client.stopOnBoarding(OnBoarding.stop_button));
-    });
-  }, 'onboarding');
+  }, 'common_client');
+  welcomeScenarios.findAndCloseWelcomeModal();
 
   scenario('Check product pagination in the Front Office', client => {
     commonProductScenarios.checkProductPaginationFO(client, productPage, 'enable', 1);

--- a/tests/E2E/test/campaigns/full/02_product/08_filters_in_catalog_page.js
+++ b/tests/E2E/test/campaigns/full/02_product/08_filters_in_catalog_page.js
@@ -7,12 +7,16 @@ const {AddProductPage} = require('../../../selectors/BO/add_product_page');
 const {Menu} = require('../../../selectors/BO/menu.js');
 const commonProduct = require('../../common_scenarios/product');
 const promise = Promise.resolve();
+const welcomeScenarios = require('../../common_scenarios/welcome');
 
 scenario('Check the sort of products in the Back Office', client => {
-  test('should open browser', () => client.open());
-  test('should log in successfully in BO', () => client.signInBO(AccessPageBO));
-  test('should go to "Catalog" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.products_submenu));
+  scenario('Login in the Back Office', client => {
+    test('should open the browser', () => client.open());
+    test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
+  }, 'common_client');
+  welcomeScenarios.findAndCloseWelcomeModal();
   scenario('Close symfony toolbar then change items per page number', client => {
+    test('should go to "Catalog" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.products_submenu));
     test('should close symfony toolbar', () => {
       return promise
         .then(() => client.waitForSymfonyToolbar(AddProductPage, 2000))

--- a/tests/E2E/test/campaigns/full/02_product/10_buttons_in_footer_product_page.js
+++ b/tests/E2E/test/campaigns/full/02_product/10_buttons_in_footer_product_page.js
@@ -11,6 +11,7 @@ const {productPage} = require('../../../selectors/FO/product_page');
 const {Menu} = require('../../../selectors/BO/menu.js');
 const common_scenarios = require('../../common_scenarios/product');
 let promise = Promise.resolve();
+const welcomeScenarios = require('../../common_scenarios/welcome');
 
 let firstProductData = {
   name: 'TEST PRODUCT',
@@ -26,7 +27,7 @@ scenario('Check product page buttons', () => {
     test('should open the browser', () => client.open());
     test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
   }, 'product/product');
-
+  welcomeScenarios.findAndCloseWelcomeModal();
   common_scenarios.createProduct(AddProductPage, firstProductData);
 
   scenario('Testing "Preview" button', client => {
@@ -122,6 +123,7 @@ scenario('Check product page buttons', () => {
     test('should check that the success alert message is well displayed', () => client.waitForExistAndClick(AddProductPage.close_validation_button));
     test('should click on "Preview" button', () => client.waitForExistAndClick(AddProductPage.preview_buttons));
     test('should switch to the Preview page in the Front Office', () => client.switchWindow(2));
+    common_scenarios.clickOnPreviewLink(client, AddProductPage.preview_link, productPage.product_name);
     test('should check the offline warning message', () => client.checkTextValue(productPage.offline_warning_message, "This product is not visible to your customers.", "contain"));
     test('should go back to the Back Office', () => client.switchWindow(0));
     test('should set the product "Online"', () => client.waitForExistAndClick(AddProductPage.product_online_toggle));

--- a/tests/E2E/test/campaigns/full/02_product/11_delete_product.js
+++ b/tests/E2E/test/campaigns/full/02_product/11_delete_product.js
@@ -4,7 +4,7 @@ const {AddProductPage} = require('../../../selectors/BO/add_product_page');
 const {Menu} = require('../../../selectors/BO/menu.js');
 const {CatalogPage} = require('../../../selectors/BO/catalogpage/index');
 const {SearchProductPage} = require('../../../selectors/FO/search_product_page');
-
+const welcomeScenarios = require('../../common_scenarios/welcome');
 const common_scenarios = require('../../common_scenarios/product');
 
 let productData = {
@@ -20,7 +20,7 @@ scenario('Delete product', () => {
     test('should open the browser', () => client.open());
     test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
   }, 'product/product');
-
+  welcomeScenarios.findAndCloseWelcomeModal();
   common_scenarios.createProduct(AddProductPage, productData);
 
   scenario('Delete product "DP' + date_time + '"', client => {

--- a/tests/E2E/test/campaigns/full/02_product/12_edit_check_demo_product_in_BO.js
+++ b/tests/E2E/test/campaigns/full/02_product/12_edit_check_demo_product_in_BO.js
@@ -6,6 +6,7 @@
 const {AddProductPage} = require('../../../selectors/BO/add_product_page');
 const {AccessPageBO} = require('../../../selectors/BO/access_page');
 const commonScenarios = require('../../common_scenarios/product');
+const welcomeScenarios = require('../../common_scenarios/welcome');
 
 let productData = [
   {
@@ -91,7 +92,7 @@ scenario('Check the basic information of demo product in the Back Office', () =>
     test('should open the browser', () => client.open());
     test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
   }, 'product/product');
-
+  welcomeScenarios.findAndCloseWelcomeModal();
   for(let i = 0; i < productData.length; i++) {
     commonScenarios.checkDemoProductBO(AddProductPage, productData[i]);
   }

--- a/tests/E2E/test/campaigns/full/02_product/13_navigate_between_catalog_pages.js
+++ b/tests/E2E/test/campaigns/full/02_product/13_navigate_between_catalog_pages.js
@@ -6,6 +6,7 @@
 const {AccessPageBO} = require('../../../selectors/BO/access_page');
 const {Menu} = require('../../../selectors/BO/menu.js');
 const commonProduct = require('../../common_scenarios/product');
+const welcomeScenarios = require('../../common_scenarios/welcome');
 let productData = {
   name: 'Product test',
   quantity: "50",
@@ -19,7 +20,7 @@ scenario('Navigate between the catalog pages in the back office', () => {
     test('should open the browser', () => client.open());
     test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
   }, 'common_client');
-
+  welcomeScenarios.findAndCloseWelcomeModal();
   scenario('Create products to have more than 20 product in the catalog', client => {
     test('should go to "Catalog" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.products_submenu));
     test('should create products if there\'s less than 20 product in the list', () => commonProduct.checkPaginationThenCreateProduct(client, productData));

--- a/tests/E2E/test/campaigns/full/02_product/14_options_in_catalog_page.js
+++ b/tests/E2E/test/campaigns/full/02_product/14_options_in_catalog_page.js
@@ -10,6 +10,7 @@ const {ProductList} = require('../../../selectors/BO/add_product_page');
 const {productPage} = require('../../../selectors/FO/product_page');
 const {AddProductPage} = require('../../../selectors/BO/add_product_page');
 const common_scenarios = require('../../common_scenarios/product');
+const welcomeScenarios = require('../../common_scenarios/welcome');
 
 let promise = Promise.resolve();
 
@@ -18,6 +19,7 @@ scenario('Check the options in the catalog page', () => {
     test('should open the browser', () => client.open());
     test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
   }, 'common_client');
+  welcomeScenarios.findAndCloseWelcomeModal();
   scenario('Disable the first product from the list in the Back Office', client => {
     test('should go to "Catalog" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.products_submenu));
     test('should disable the first product', () => client.waitForExistAndClick(ProductList.product_status.replace('%I', 1).replace('%ACTION', 'enabled')));

--- a/tests/E2E/test/campaigns/full/02_product/15_buttons_in_header_product_page.js
+++ b/tests/E2E/test/campaigns/full/02_product/15_buttons_in_header_product_page.js
@@ -11,6 +11,7 @@ const {productPage} = require('../../../selectors/FO/product_page');
 const {Menu} = require('../../../selectors/BO/menu.js');
 const commonScenarios = require('../../common_scenarios/product');
 let promise = Promise.resolve();
+const welcomeScenarios = require('../../common_scenarios/welcome');
 
 let productData = {
   name: 'PH',
@@ -33,7 +34,7 @@ scenario('Check that the buttons in header product page works successfully', () 
     test('should open the browser', () => client.open());
     test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
   }, 'product/product');
-
+  welcomeScenarios.findAndCloseWelcomeModal();
   commonScenarios.createProduct(AddProductPage, productData);
 
   scenario('Check that "Type of product" select works successfully', client => {
@@ -74,6 +75,7 @@ scenario('Check that the buttons in header product page works successfully', () 
     test('should go to the product page', () => client.waitForExistAndClick(SearchProductPage.product_result_name));
     test('should check that the "Product name" is in french language', () => client.checkTextValue(productPage.product_name, ('produit' + date_time).toUpperCase()));
     test('should switch the front office language to English', () => client.changeLanguage());
+    commonScenarios.clickOnPreviewLink(client, AddProductPage.preview_link, productPage.product_name);
     test('should check that the "Product name" is in English language', () => client.checkTextValue(productPage.product_name, productData.name + date_time));
     test('should go back to the Back Office', () => client.switchWindow(0));
     test('should select the "English" language from the list', () => client.waitAndSelectByValue(AddProductPage.product_language, 'en'));

--- a/tests/E2E/test/campaigns/full/02_product/16_filter_by_categories_in_catalog_page.js
+++ b/tests/E2E/test/campaigns/full/02_product/16_filter_by_categories_in_catalog_page.js
@@ -7,12 +7,14 @@ const {AccessPageBO} = require('../../../selectors/BO/access_page');
 const {Menu} = require('../../../selectors/BO/menu.js');
 const {ProductList} = require('../../../selectors/BO/add_product_page');
 const commonProduct = require('../../common_scenarios/product');
+const welcomeScenarios = require('../../common_scenarios/welcome');
 
 scenario('Filters by categories in catalog page', () => {
   scenario('Login in the Back Office', client => {
     test('should open the browser', () => client.open());
     test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
   }, 'common_client');
+  welcomeScenarios.findAndCloseWelcomeModal();
   scenario('Check the filtering operation of the categories in the product page', client => {
     test('should go to "Catalog > Categories" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.category_submenu));
     test('should get categories number', () => client.getCategoriesPageNumber('category_grid_table'));

--- a/tests/E2E/test/campaigns/full/02_product/17_display_all_product.js
+++ b/tests/E2E/test/campaigns/full/02_product/17_display_all_product.js
@@ -9,7 +9,7 @@ const {ProductList} = require('../../../selectors/BO/add_product_page');
 const {ProductSettings} = require('../../../selectors/BO/shopParameters/product_settings');
 const {productPage} = require('../../../selectors/FO/product_page');
 const {Menu} = require('../../../selectors/BO/menu.js');
-
+const welcomeScenarios = require('../../common_scenarios/welcome');
 const commonScenarios = require('../../common_scenarios/product');
 
 let promise = Promise.resolve();
@@ -21,7 +21,7 @@ scenario('Display all product', () => {
     test('should open the browser', () => client.open());
     test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
   }, 'product/product');
-
+  welcomeScenarios.findAndCloseWelcomeModal();
   scenario('Check the product pagination in the Back Office', client => {
     test('should go to "Products" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.products_submenu));
     test('should select "active product"', () => client.waitAndSelectByValue(ProductList.status_filter, "1"));

--- a/tests/E2E/test/campaigns/high/02_product/02_create_pack_of_product.js
+++ b/tests/E2E/test/campaigns/high/02_product/02_create_pack_of_product.js
@@ -6,14 +6,17 @@ const {productPage} = require('../../../selectors/FO/product_page');
 const {Menu} = require('../../../selectors/BO/menu.js');
 let data = require('./../../../datas/product-data');
 let promise = Promise.resolve();
+const welcomeScenarios = require('../../common_scenarios/welcome');
 
-scenario('Create a pack of products in the Back Office', client => {
-  test('should open browser', () => client.open());
-  test('should log in successfully in BO', () => client.signInBO(AccessPageBO));
-  test('should go to "Catalog" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.products_submenu));
-  test('should click on "NEW PRODUCT"', () => client.waitForExistAndClick(AddProductPage.new_product_button));
-
+scenario('Create a pack of products in the Back Office', () => {
+  scenario('Login in the Back Office', client => {
+    test('should open browser', () => client.open());
+    test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
+  }, 'product/product');
+  welcomeScenarios.findAndCloseWelcomeModal();
   scenario('Edit the Basic settings', client => {
+    test('should go to "Catalog" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.products_submenu));
+    test('should click on "NEW PRODUCT"', () => client.waitForExistAndClick(AddProductPage.new_product_button));
     test('should set the "product name"', () => client.waitAndSetValue(AddProductPage.product_name_input, data.pack.name + date_time));
     test('should set the "Summary" text', () => client.setEditorText(AddProductPage.summary_textarea, data.common.summary));
     test('should click on "Description" tab', () => client.waitForExistAndClick(AddProductPage.tab_description));

--- a/tests/E2E/test/campaigns/high/02_product/05_check_default_product_sort.js
+++ b/tests/E2E/test/campaigns/high/02_product/05_check_default_product_sort.js
@@ -1,9 +1,15 @@
 const {AccessPageBO} = require('../../../selectors/BO/access_page');
 const {Menu} = require('../../../selectors/BO/menu.js');
+const welcomeScenarios = require('../../common_scenarios/welcome');
 
-scenario('Check default product sort in the Back Office', client => {
-  test('should open browser', () => client.open());
-  test('should log in successfully in BO', () => client.signInBO(AccessPageBO));
-  test('should go to "Catalog" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.products_submenu));
-  test('should check the default product sort', () => client.getElementID())
-}, 'product/product', true);
+scenario('Check default product sort in the Back Office', () => {
+  scenario('Open the browser then log in the Back Office', client => {
+    test('should open browser', () => client.open());
+    test('should log in successfully in the Back Office', () => client.signInBO(AccessPageBO));
+  }, 'common_client');
+  welcomeScenarios.findAndCloseWelcomeModal();
+  scenario('Check default product sort in the Back Office', client => {
+    test('should go to "Catalog" page', () => client.goToSubtabMenuPage(Menu.Sell.Catalog.catalog_menu, Menu.Sell.Catalog.products_submenu));
+    test('should check the default product sort', () => client.getElementID());
+  }, 'product/product');
+}, 'product/product',true);

--- a/tests/E2E/test/campaigns/high/02_product/06_pack_stock.js
+++ b/tests/E2E/test/campaigns/high/02_product/06_pack_stock.js
@@ -7,6 +7,7 @@ const {SearchProductPage} = require('../../../selectors/FO/search_product_page')
 const {AddProductPage} = require('../../../selectors/BO/add_product_page');
 const common_scenarios = require('../../common_scenarios/product');
 const {Menu} = require('../../../selectors/BO/menu.js');
+const welcomeScenarios = require('../../common_scenarios/welcome');
 
 let productData = [{
   name: 'A',
@@ -32,6 +33,7 @@ scenario('Create standard product "A" and pack product "B" in the Back Office', 
     test('should open the browser', () => client.open());
     test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
   }, 'product/product');
+  welcomeScenarios.findAndCloseWelcomeModal();
   scenario('Change configuration of "Default pack stock management" and "Allow ordering of out-of-stock products"', client => {
     test('Should go to "Product settings" page', () => client.goToSubtabMenuPage(Menu.Configure.ShopParameters.shop_parameters_menu, Menu.Configure.ShopParameters.product_settings_submenu));
     test('Should click on "NO" button to disable ordering of out-of-stock products', () => client.scrollWaitForExistAndClick(ProductSettings.disableOrderOutOfStock_button));

--- a/tests/E2E/test/campaigns/high/02_product/08_check_shopping_cart.js
+++ b/tests/E2E/test/campaigns/high/02_product/08_check_shopping_cart.js
@@ -7,6 +7,7 @@ const {CheckoutOrderPage} = require('../../../selectors/FO/order_page');
 const {Menu} = require('../../../selectors/BO/menu.js');
 const common_scenarios = require('../../common_scenarios/product');
 let promise = Promise.resolve();
+const welcomeScenarios = require('../../common_scenarios/welcome');
 
 let productData = {
   name: 'CSC',
@@ -21,9 +22,12 @@ let productData = {
  * http://forge.prestashop.com/browse/BOOM-3268
  **/
 
-scenario('Check that the shopping cart dosen\'t allow checkout of zero quantity and inactive products', client => {
-  test('should open the browser', () => client.open());
-  test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
+scenario('Check that the shopping cart dosen\'t allow checkout of zero quantity and inactive products', () => {
+  scenario('Login in the Back Office', client => {
+    test('should open the browser', () => client.open());
+    test('should login successfully in the Back Office', () => client.signInBO(AccessPageBO));
+  }, 'common_client');
+  welcomeScenarios.findAndCloseWelcomeModal();
   common_scenarios.createProduct(AddProductPage, productData);
 
   scenario('Test case n°1 : Check that the shopping cart dosen\'t allow checkout of inactive products', client => {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Closing welcome module in each test, so they can be run independently after a fresh install of prestashop 
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH=full/02_product/* run specific-test -- --URL=Shop_URL

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13651)
<!-- Reviewable:end -->
