### PR TITLE
Remove id_attribute parameter from product link when it is equal to 0

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -132,7 +132,7 @@ class LinkCore
         $ean13 = null,
         $idLang = null,
         $idShop = null,
-        $ipa = 0,
+        $ipa = null,
         $force_routes = false,
         $relativeProtocol = false,
         $addAnchor = false,
@@ -161,6 +161,10 @@ class LinkCore
             $params['id'] = $product->id;
         }
 
+        //Attribute equal to 0 or empty is useless, so we force it to null so that it won't be inserted in query parameters
+        if (empty($ipa)) {
+            $ipa = null;
+        }
         $params['id_product_attribute'] = $ipa;
         if (!$alias) {
             $product = $this->getProductObject($product, $idLang, $idShop);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -57,7 +57,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         if (Validate::isLoadedObject($this->product)) {
             if (!$this->product->hasCombinations() ||
                 !$this->isValidCombination(Tools::getValue('id_product_attribute'), $this->product->id)) {
-                //Invalid combination we redirect to the canonical url (with attribute id)
+                //Invalid combination we redirect to the canonical url (without attribute id)
                 unset($_GET['id_product_attribute']);
             } else {
                 //Only redirect to canonical (parent product without combination) when the requested combination is not valid


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Keeping `id_attribute = 0` cause extra useless query parameter, so we force it to null to ensure urls are always clean (and match the canonical for product without combinations)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13662
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13664)
<!-- Reviewable:end -->
