### PR TITLE
Update OrderReturn.php

### DIFF
--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -102,6 +102,9 @@ class OrderReturnCore extends ObjectModel
         /* Quantity check */
         if ($order_detail_list) {
             foreach (array_keys($order_detail_list) as $key) {
+                if (!isset($product_qty_list[$key])){
+                    return false;
+                }                
                 if ($qty = (int) $product_qty_list[$key]) {
                     if ($products[$key]['product_quantity'] - $qty < 0) {
                         return false;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Type?         | bug fix
| Category?     | FO
| Deprecations? | no
| Description?  | If you try to create a return of an order for an item that has already been returned, the following error appears: 
```
Notice: Undefined offset: 4
in OrderReturn.php line 105
at OrderReturnCore-> checkEnoughProduct (array ('4'), array ('1'), false, false) in OrderFollowController.php line 77
at OrderFollowControllerCore-> postProcess () in Controller.php line 270
at ControllerCore-> run () in Dispatcher.php line 511
at DispatcherCore-> dispatch () in index.php line 28
```


Tanks


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13668)
<!-- Reviewable:end -->
