### PR TITLE
Bug Fix: Multiple options with a couple in stock

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -958,12 +958,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
 
         if (!Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
-            $productAttributes = array_filter(
-                $this->product->getAttributeCombinations(),
-                function ($elem) {
-                    return $elem['quantity'] > 0;
-                }
-            );
+            $productAttributes = $this->product->getAttributeCombinations();
             $productAttribute = array_filter(
                 $productAttributes,
                 function ($elem) use ($requestedIdProductAttribute) {


### PR DESCRIPTION
The proposed change will fix a bug where a product has multiple options, with one or more having stock, you can't select an option that does not have stock when you have set the preference to allow out of stock product options to be purchased.

The bug is you have a product with 5 options (S / M / L / XL / XXL) XL is in stock, the others are not in stock.  You have chosen to allow out of stock product to be purchased, because you have one product in stock, when selecting one of the out of stock options the page will reload and go back to the in-stock option as default.  

The bug is the filter that is used for quantity > 0 when the config option of PS_DISP_UNAVAILABLE_ATTR is set.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.4.X
| Description?  | The proposed change will fix a bug where a product has multiple options, with one or more having stock, you can't select an option that does not have stock when you have set the preference to allow out of stock product options to be purchased.

The bug is you have a product with 5 options (S / M / L / XL / XXL) XL is in stock, the others are not in stock.  You have chosen to allow out of stock product to be purchased, because you have one product in stock, when selecting one of the out of stock options the page will reload and go back to the in-stock option as default.  
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | This bug seems to be in various versions, the site I am working on is in the 1.7.4.x 
Here is a closed ticket: http://forge.prestashop.com/browse/BOOM-3120
| How to test?  | Run the code without the patch with a product with 5 options, one with stock with the configuration set as above and you will see the incorrect behavior

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13670)
<!-- Reviewable:end -->
