### PR TITLE
Wrong discount subtotal when customergroup is set to use ex taxes

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2062,12 +2062,12 @@ class CartCore extends ObjectModel
     /**
      * @return float
      */
-    public function getDiscountSubtotalWithoutGifts()
+    public function getDiscountSubtotalWithoutGifts($withTaxes = true)
     {
         $discountSubtotal = $this->excludeGiftsDiscountFromTotal()
-            ->getOrderTotal(true, self::ONLY_DISCOUNTS);
+            ->getOrderTotal($withTaxes, self::ONLY_DISCOUNTS);
         $this->includeGiftsDiscountInTotal();
-
+        
         return $discountSubtotal;
     }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2067,7 +2067,7 @@ class CartCore extends ObjectModel
         $discountSubtotal = $this->excludeGiftsDiscountFromTotal()
             ->getOrderTotal($withTaxes, self::ONLY_DISCOUNTS);
         $this->includeGiftsDiscountInTotal();
-        
+
         return $discountSubtotal;
     }
 

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -326,7 +326,7 @@ class CartPresenter implements PresenterInterface
         $productsTotalExcludingTax = $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
         $total_excluding_tax = $cart->getOrderTotal(false);
         $total_including_tax = $cart->getOrderTotal(true);
-        $total_discount = $cart->getDiscountSubtotalWithoutGifts();
+        $total_discount = $cart->getDiscountSubtotalWithoutGifts($this->includeTaxes());
         $totalCartAmount = $cart->getOrderTotal($this->includeTaxes(), Cart::ONLY_PRODUCTS);
 
         $subtotals['products'] = array(


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | from https://github.com/PrestaShop/PrestaShop/pull/13632 : Wrong discount subtotal when customergroup is exc taxes
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13658 #11360 #9856
| How to test?  | Set in customergroup price without taxes the discount subtotal in the cart is always displayed including taxes as seen in the previous code. Now the variable inc or ex taxes is passed to getDiscountSubtotalWithoutGifts resulting in correctly displaying the discount subtotal in the shopping cart

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13684)
<!-- Reviewable:end -->
