### PR TITLE
Fix notice when trying to create a return for an order item that has already been returned

### DIFF
--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -104,7 +104,7 @@ class OrderReturnCore extends ObjectModel
             foreach (array_keys($order_detail_list) as $key) {
                 if (!isset($product_qty_list[$key])) {
                     return false;
-                }                 
+                }
                 if ($qty = (int) $product_qty_list[$key]) {
                     if ($products[$key]['product_quantity'] - $qty < 0) {
                         return false;

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -102,6 +102,9 @@ class OrderReturnCore extends ObjectModel
         /* Quantity check */
         if ($order_detail_list) {
             foreach (array_keys($order_detail_list) as $key) {
+                if (!isset($product_qty_list[$key])){
+                    return false;
+                }                 
                 if ($qty = (int) $product_qty_list[$key]) {
                     if ($products[$key]['product_quantity'] - $qty < 0) {
                         return false;

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -102,7 +102,7 @@ class OrderReturnCore extends ObjectModel
         /* Quantity check */
         if ($order_detail_list) {
             foreach (array_keys($order_detail_list) as $key) {
-                if (!isset($product_qty_list[$key])){
+                if (!isset($product_qty_list[$key])) {
                     return false;
                 }                 
                 if ($qty = (int) $product_qty_list[$key]) {


### PR DESCRIPTION
If you try to create a return of an order for an item that has already been returned, the following error appears:

Notice: Undefined offset: 4
in OrderReturn.php line 105
at OrderReturnCore-> checkEnoughProduct (array ('4'), array ('1'), false, false) in OrderFollowController.php line 77
at OrderFollowControllerCore-> postProcess () in Controller.php line 270
at ControllerCore-> run () in Dispatcher.php line 511
at DispatcherCore-> dispatch () in index.php line 28

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | wher you try to create a return of an order for an item that has already been returned, error appears.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | try to create a return of an order for an item that has already been returned
|Sponsor company   | Codencode snc


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13687)
<!-- Reviewable:end -->
