### PR TITLE
Fix exclude discounted products on CartRule

### DIFF
--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -121,7 +121,7 @@ class CartRuleCalculator
             $cartRowCheapest = null;
             foreach ($this->cartRows as $cartRow) {
                 $product = $cartRow->getRowData();
-                    if ((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
+                if ((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
                     || !$cartRule->reduction_exclude_special)) {
                     if ($cartRowCheapest === null
                         || $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded() > $cartRow->getInitialUnitPrice()

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -121,14 +121,12 @@ class CartRuleCalculator
             $cartRowCheapest = null;
             foreach ($this->cartRows as $cartRow) {
                 $product = $cartRow->getRowData();
-                if ((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
-                    || !$cartRule->reduction_exclude_special)) {
-                    if ($cartRowCheapest === null
+                if (((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
+                        || !$cartRule->reduction_exclude_special)) && ($cartRowCheapest === null
                         || $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded() > $cartRow->getInitialUnitPrice()
-                            ->getTaxIncluded()
-                    ) {
-                        $cartRowCheapest = $cartRow;
-                    }
+                            ->getTaxIncluded())
+                ) {
+                    $cartRowCheapest = $cartRow;
                 }
             }
             if ($cartRowCheapest !== null) {

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -100,8 +100,12 @@ class CartRuleCalculator
         // Discount (%) on the whole order
         if ($cartRule->reduction_percent && $cartRule->reduction_product == 0) {
             foreach ($this->cartRows as $cartRow) {
-                $amount = $cartRow->applyPercentageDiscount($cartRule->reduction_percent);
-                $cartRuleData->addDiscountApplied($amount);
+                $product = $cartRow->getRowData();
+                if ((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
+                        || !$cartRule->reduction_exclude_special)) {
+                    $amount = $cartRow->applyPercentageDiscount($cartRule->reduction_percent);
+                    $cartRuleData->addDiscountApplied($amount);
+                }
             }
         }
 

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -120,18 +120,22 @@ class CartRuleCalculator
             /** @var CartRow|null $cartRowCheapest */
             $cartRowCheapest = null;
             foreach ($this->cartRows as $cartRow) {
-                if ($cartRowCheapest === null
-                    || $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded() > $cartRow->getInitialUnitPrice()
-                                                                                           ->getTaxIncluded()
-                ) {
-                    $cartRowCheapest = $cartRow;
+                $product = $cartRow->getRowData();
+                    if ((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
+                    || !$cartRule->reduction_exclude_special)) {
+                    if ($cartRowCheapest === null
+                        || $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded() > $cartRow->getInitialUnitPrice()
+                            ->getTaxIncluded()
+                    ) {
+                        $cartRowCheapest = $cartRow;
+                    }
                 }
             }
             if ($cartRowCheapest !== null) {
                 // apply only on one product of the cheapest row
                 $discountTaxIncluded = $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded()
                                        * $cartRule->reduction_percent / 100;
-                $discountTaxExcluded = $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded()
+                $discountTaxExcluded = $cartRowCheapest->getInitialUnitPrice()->getTaxExcluded()
                                        * $cartRule->reduction_percent / 100;
                 $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
                 $cartRowCheapest->applyFlatDiscount($amount);

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -155,6 +155,27 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^cart rule "(.+)" is restricted to cheapest product$/
+     */
+    public function cartRuleIsRestrictedToCheapestProduct($cartRuleName)
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->cartRules[$cartRuleName]->product_restriction = 1;
+        $this->cartRules[$cartRuleName]->reduction_product = -1;
+        $this->cartRules[$cartRuleName]->save();
+    }
+
+    /**
+     * @Given /^cart rule "(.+)" does not apply to already discounted products$/
+     */
+    public function cartRuleDoesNotApplyToDiscountedProduct($cartRuleName)
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->cartRules[$cartRuleName]->reduction_exclude_special = 1;
+        $this->cartRules[$cartRuleName]->save();
+    }
+
+    /**
      * @Given /^cart rule "(.+)" offers a gift product "(.+)"$/
      */
     public function cartRuleNamedHasAGiftProductNamed($cartRuleName, $productName)

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -28,6 +28,8 @@ namespace Tests\Integration\Behaviour\Features\Context;
 
 use Cart;
 use Combination;
+use Context;
+use SpecificPrice;
 use Configuration;
 use Customization;
 use CustomizationField;
@@ -48,6 +50,11 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
      * @var Combination[][]
      */
     protected $combinations = [];
+
+    /**
+     * @var SpecificPrice[][]
+     */
+    protected $specificPrices = [];
 
     /**
      * @var Customization[]
@@ -241,6 +248,58 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
         $this->checkProductWithNameExists($productName);
         $this->products[$productName]->id_tax_rules_group = $taxRuleGroupId;
         $this->products[$productName]->save();
+    }
+
+    /* SPECIFIC PRICE */
+
+    /**
+     * @Given /^product "(.+)" has a specific price named "(.+)" with an amount discount of (\d+\.\d+)$/
+     */
+    public function productWithNameHasASpecificPriceWithAmountDiscount($productName, $specificPriceName, $specificPriceDiscount)
+    {
+        if (isset($this->specificPrices[$productName][$specificPriceName])) {
+            throw new \Exception('Product named "' . $productName . '" has already a specific price named "' . $specificPriceName . '"');
+        }
+        $specificPrice = new SpecificPrice();
+        $specificPrice->id_product = $this->products[$productName]->id;
+        $specificPrice->price = -1;
+        $specificPrice->reduction = $specificPriceDiscount;
+        $specificPrice->reduction_type = 'amount';
+        $specificPrice->from_quantity = 1;
+        $specificPrice->from = '0000-00-00 00:00:00';
+        $specificPrice->to = '0000-00-00 00:00:00';
+        // set required values from default
+        $specificPrice->id_shop = (int) Context::getContext()->shop->id;
+        $specificPrice->id_currency = (int) Context::getContext()->currency->id;
+        $specificPrice->id_country = (int) Context::getContext()->country->id;
+        $specificPrice->id_group = (int) Context::getContext()->customer->id_shop_group;
+        $specificPrice->id_customer = (int) Context::getContext()->customer->id;
+        $specificPrice->add();
+        $this->specificPrices[$productName][$specificPriceName] = $specificPrice;
+    }
+
+    /**
+     * This hook can be used to perform a database cleaning of added objects
+     *
+     * @AfterScenario
+     */
+    public function cleanSpecificPriceFixtures()
+    {
+        foreach ($this->specificPrices as $productName => $specificPrices) {
+            foreach ($specificPrices as $specificPriceName => $specificPrice) {
+                $specificPrice->delete();
+            }
+        }
+        $this->specificPrices = [];
+    }
+
+    /**
+     * @param $productName
+     * @param $specificPriceName
+     */
+    public function checkSpecificPriceWithNameExists($productName, $specificPriceName)
+    {
+        $this->checkFixtureExists($this->specificPrices[$productName], 'SpecificPrice', $specificPriceName);
     }
 
     /* COMBINATION */

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/cheapest_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/cheapest_product.feature
@@ -1,0 +1,79 @@
+@reset-database-before-feature
+Feature: Cart rule (percent) calculation with one cart rule restricted to cheapest product
+  As a customer
+  I must be able to have correct cart total when adding cart rules
+
+  Scenario: Empty cart, one 50% cartRule on cheapest product
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule10" is restricted to cheapest product
+    Given cart rule "cartrule10" has a discount code "foo10"
+    Then I should have 0 different products in my cart
+    When I use the discount "cartrule10"
+    Then my cart total should be 0.0 tax included
+    Then my cart total using previous calculation method should be 0.0 tax included
+
+  Scenario: one product in cart, quantity 1, one specific 50% cartRule on cheapest product
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule10" is restricted to cheapest product
+    Given cart rule "cartrule10" has a discount code "foo10"
+    When I add 1 items of product "product1" in my cart
+    When I use the discount "cartrule10"
+    Then my cart total should be 16.906 tax included
+    Then my cart total using previous calculation method should be 16.906 tax included
+
+  Scenario: multiple products in cart, several quantities, one 50% cartRule on cheapest product
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
+    Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule10" is restricted to cheapest product
+    Given cart rule "cartrule10" has a discount code "foo10"
+    When I add 2 items of product "product2" in my cart
+    When I add 3 items of product "product1" in my cart
+    When I add 1 items of product "product3" in my cart
+    When I use the discount "cartrule10"
+    Then my cart total should be 152.494 tax included
+    Then my cart total using previous calculation method should be 152.494 tax included
+
+  Scenario: multiple products in cart, several quantities, one 50% cartRule on cheapest product excluding already discounted
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
+    Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule10" is restricted to cheapest product
+    Given cart rule "cartrule10" does not apply to already discounted products
+    Given cart rule "cartrule10" has a discount code "foo10"
+    When I add 2 items of product "product2" in my cart
+    When I add 3 items of product "product1" in my cart
+    When I add 1 items of product "product3" in my cart
+    When I use the discount "cartrule10"
+    Then my cart total should be 152.494 tax included
+    Then my cart total using previous calculation method should be 152.494 tax included
+
+  Scenario: multiple products in cart, several quantities, one 50% cartRule on cheapest product excluding already discounted, cheapest product is already discounted
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given product "product1" has a specific price named "specificPrice1" with an amount discount of 3.0
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
+    Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule10" is restricted to cheapest product
+    Given cart rule "cartrule10" does not apply to already discounted products
+    Given cart rule "cartrule10" has a discount code "foo10"
+    When I add 2 items of product "product2" in my cart
+    When I add 3 items of product "product1" in my cart
+    When I add 1 items of product "product3" in my cart
+    When I use the discount "cartrule10"
+    Then my cart total should be 137.806 tax included
+    Then my cart total using previous calculation method should be 137.806 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/cheapest_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/cheapest_product.feature
@@ -15,7 +15,7 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to cheape
     Then my cart total should be 0.0 tax included
     Then my cart total using previous calculation method should be 0.0 tax included
 
-  Scenario: one product in cart, quantity 1, one specific 50% cartRule on cheapest product
+  Scenario: one product in cart, quantity 1, one 50% cartRule on cheapest product
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/exclude_discounted_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/exclude_discounted_product.feature
@@ -1,0 +1,21 @@
+@reset-database-before-feature
+Feature: Cart rule (percent) calculation with one cart rule restricted to not already discounted product
+  As a customer
+  I must be able to have correct cart total when adding cart rules
+
+  Scenario: multiple products in cart, several quantities, one 50% cartRule on cheapest product excluding already discounted, cheapest product is already discounted
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given product "product1" has a specific price named "specificPrice1" with an amount discount of 3.0
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
+    Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule10" does not apply to already discounted products
+    Given cart rule "cartrule10" has a discount code "foo10"
+    When I add 2 items of product "product2" in my cart
+    When I add 3 items of product "product1" in my cart
+    When I add 1 items of product "product3" in my cart
+    When I use the discount "cartrule10"
+    Then my cart total should be 105.418 tax included
+    Then my cart total using previous calculation method should be 105.418 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Product/specific_price.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Product/specific_price.feature
@@ -1,0 +1,16 @@
+@reset-database-before-feature
+Feature: Cart calculation with only products with specific prices
+  As a customer
+  I must be able to have correct cart total when adding products
+
+  Scenario: multiple products in cart, several quantities, one product with specific prices
+    Given I have an empty default cart
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given product "product1" has a specific price named "specificPrice1" with an amount discount of 3.0
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
+    When I add 2 items of product "product2" in my cart
+    When I add 3 items of product "product1" in my cart
+    When I add 1 items of product "product3" in my cart
+    Then my cart total should be 153.4 tax included
+    Then my cart total using previous calculation method should be 153.4 tax included


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | CartRules exclude specials from discounts doesn't work when no specific products are selected. Thank you @venditdevs 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | fixes https://github.com/PrestaShop/PrestaShop/issues/10300
| How to test?  | on BO create cartRule with "exclude discounted product" checked. On a product add a specific price. On FO add the product and the cart rule. Cart calculation should be good. Behat tests added
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13704)
<!-- Reviewable:end -->
