### PR TITLE
Compare strictly value of hook name when getting modules registered on it

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -594,7 +594,7 @@ class HookCore extends ObjectModel
      *
      * @since 1.5.0
      *
-     * @param string $hook_name Get list of modules for this hook if given
+     * @param string|null $hook_name Get list of modules for this hook if given
      *
      * @return array
      */
@@ -691,7 +691,7 @@ class HookCore extends ObjectModel
         }
 
         // If hook_name is given, just get list of modules for this hook
-        if ($hook_name) {
+        if (null !== $hook_name) {
             $retro_hook_name = strtolower(Hook::getRetroHookName($hook_name));
             $hook_name = strtolower($hook_name);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Compare types of variable to avoid side effects on callers when sending empty string as param of `Hook::getHookModuleExecList()`. Follows up https://github.com/PrestaShop/PrestaShop/pull/8463
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/pull/8463
| How to test?  | Add an empty hook in your database with `insert into ps_hook (name, title, position) values ("", "Temp", 0);`, then go to a back office controller with Symfony.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13711)
<!-- Reviewable:end -->
