### PR TITLE
Filter themes without override in email generation form

### DIFF
--- a/src/Core/Form/ChoiceProvider/ThemeByNameWithEmailsChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ThemeByNameWithEmailsChoiceProvider.php
@@ -60,7 +60,7 @@ final class ThemeByNameWithEmailsChoiceProvider implements FormChoiceProviderInt
         foreach ($this->themeCollection as $theme) {
             $coreMailsFolder = $theme->getDirectory() . '/mails';
             $modulesMailFolder = $theme->getDirectory() . '/modules';
-            if (is_dir($coreMailsFolder) || is_dir($modulesMailFolder)) {
+            if (is_dir($coreMailsFolder) && is_dir($modulesMailFolder)) {
                 $themeChoices[$theme->getName()] = $theme->getName();
             }
         }

--- a/src/Core/Form/ChoiceProvider/ThemeByNameWithEmailsChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ThemeByNameWithEmailsChoiceProvider.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeCollection;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+
+/**
+ * Class ThemeByNameChoiceProvider provides theme choices with name values, but it
+ * filters themes which haven't overridden any email templates.
+ */
+final class ThemeByNameWithEmailsChoiceProvider implements FormChoiceProviderInterface
+{
+    /**
+     * @var ThemeCollection collection of themes
+     */
+    private $themeCollection;
+
+    /**
+     * @param ThemeCollection $themeCollection
+     */
+    public function __construct(ThemeCollection $themeCollection)
+    {
+        $this->themeCollection = $themeCollection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChoices()
+    {
+        $themeChoices = [];
+
+        /** @var Theme $theme */
+        foreach ($this->themeCollection as $theme) {
+            $coreMailsFolder = $theme->getDirectory() . '/mails';
+            $modulesMailFolder = $theme->getDirectory() . '/modules';
+            if (is_dir($coreMailsFolder) || is_dir($modulesMailFolder)) {
+                $themeChoices[$theme->getName()] = $theme->getName();
+            }
+        }
+
+        return $themeChoices;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/GenerateMailsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/GenerateMailsType.php
@@ -83,6 +83,7 @@ class GenerateMailsType extends TranslatorAwareType
                 'required' => false,
                 'empty_data' => '',
                 'data' => '',
+                'disabled' => count($this->themes) <= 0,
             ])
             ->add('overwrite', SwitchType::class, ['data' => false])
         ;

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -852,7 +852,7 @@ services:
         public: true
         arguments:
             - '@=service("prestashop.core.form.choice_provider.mail_themes").getChoices()'
-            - '@=service("prestashop.core.form.choice_provider.theme_by_name").getChoices()'
+            - '@=service("prestashop.core.form.choice_provider.theme_by_name_with_emails").getChoices()'
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -99,6 +99,11 @@ services:
     arguments:
       - '@=service("prestashop.core.addon.theme.repository").getListAsCollection()'
 
+  prestashop.core.form.choice_provider.theme_by_name_with_emails:
+    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameWithEmailsChoiceProvider'
+    arguments:
+      - '@=service("prestashop.core.addon.theme.repository").getListAsCollection()'
+
   prestashop.core.form.choice_provider.module_by_name:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleByNameChoiceProvider'
     arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig
@@ -65,6 +65,9 @@
             <div class="col-sm">
               {{ form_errors(generateMailsForm.theme) }}
               {{ form_widget(generateMailsForm.theme) }}
+              {% if generateMailsForm.theme.vars.disabled %}
+              <small class="form-text">{{ 'No emails were detected in any theme folder so this field is disabled.'|trans({}, 'Admin.Design.Help') }}</small>
+              {% endif %}
             </div>
           </div>
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | In email generation form, filter themes that don't contain any email templates override. Display a help message when the field is disabled (no themes to select).
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13586
| How to test?  | In a shop that does not contain any email overrides in its theme (for example a fresh install), go the "Design > Email theme", the theme selector is disabled and a help message is displayed under (you can still generate emails). Then go to "International > Translations" and start to modify translations for email body content for a selected theme (see screenshot). This will automatically copy all email templates in the selected theme, then go back to the generation form you should be able to select and overwrite the theme email templates.

![Capture d’écran 2019-05-09 à 09 42 37](https://user-images.githubusercontent.com/13801017/57435961-fd04cd80-723e-11e9-8999-25e86a5998d6.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13722)
<!-- Reviewable:end -->
