### PR TITLE
Update layout-both-columns.tpl

### DIFF
--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -90,6 +90,7 @@
               </div>
             {/block}
           </div>
+          
         </div>
         {hook h="displayWrapperBottom"}
       </section>

--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -58,36 +58,38 @@
           {block name='breadcrumb'}
             {include file='_partials/breadcrumb.tpl'}
           {/block}
+          
+          <div class="row">
+            {block name="left_column"}
+              <div id="left-column" class="col-xs-12 col-sm-4 col-md-3">
+                {if $page.page_name == 'product'}
+                  {hook h='displayLeftColumnProduct'}
+                {else}
+                  {hook h="displayLeftColumn"}
+                {/if}
+              </div>
+            {/block}
 
-          {block name="left_column"}
-            <div id="left-column" class="col-xs-12 col-sm-4 col-md-3">
-              {if $page.page_name == 'product'}
-                {hook h='displayLeftColumnProduct'}
-              {else}
-                {hook h="displayLeftColumn"}
-              {/if}
-            </div>
-          {/block}
+            {block name="content_wrapper"}
+              <div id="content-wrapper" class="left-column right-column col-sm-4 col-md-6">
+                {hook h="displayContentWrapperTop"}
+                {block name="content"}
+                  <p>Hello world! This is HTML5 Boilerplate.</p>
+                {/block}
+                {hook h="displayContentWrapperBottom"}
+              </div>
+            {/block}
 
-          {block name="content_wrapper"}
-            <div id="content-wrapper" class="left-column right-column col-sm-4 col-md-6">
-              {hook h="displayContentWrapperTop"}
-              {block name="content"}
-                <p>Hello world! This is HTML5 Boilerplate.</p>
-              {/block}
-              {hook h="displayContentWrapperBottom"}
-            </div>
-          {/block}
-
-          {block name="right_column"}
-            <div id="right-column" class="col-xs-12 col-sm-4 col-md-3">
-              {if $page.page_name == 'product'}
-                {hook h='displayRightColumnProduct'}
-              {else}
-                {hook h="displayRightColumn"}
-              {/if}
-            </div>
-          {/block}
+            {block name="right_column"}
+              <div id="right-column" class="col-xs-12 col-sm-4 col-md-3">
+                {if $page.page_name == 'product'}
+                  {hook h='displayRightColumnProduct'}
+                {else}
+                  {hook h="displayRightColumn"}
+                {/if}
+              </div>
+            {/block}
+          </div>
         </div>
         {hook h="displayWrapperBottom"}
       </section>

--- a/themes/classic/templates/layouts/layout-full-width.tpl
+++ b/themes/classic/templates/layouts/layout-full-width.tpl
@@ -28,7 +28,7 @@
 {block name='right_column'}{/block}
 
 {block name='content_wrapper'}
-  <div id="content-wrapper">
+  <div id="content-wrapper" class="col-xs-12 clearfix">
     {hook h="displayContentWrapperTop"}
     {block name='content'}
       <p>Hello world! This is HTML5 Boilerplate.</p>


### PR DESCRIPTION
The div `<div class="row">`  has been added to the file
since the bootstrap structure includes the following div sequence:
`<div class="container">`
`<div class="row">`
`<div class="col-***">`
as shown in the Bootstrap documentation https://getbootstrap.com/docs/4.3/layout/grid/ where you can read: "In a grid layout, content must be placed within columns and only columns may be immediate children of rows."

Thanks.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.5.x
| Description?  | A "row" div is missing in the file "Update layout-both-columns.tpl"
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13724)
<!-- Reviewable:end -->
