### PR TITLE
Fix wrong price display in BO when using a specific price in a different currency

### DIFF
--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -473,7 +473,7 @@ class AdminProductWrapper
                     }
 
                     $price = Tools::ps_round($specific_price['price'], 2);
-                    $fixed_price = ($price == Tools::ps_round($product->price, 2) || $specific_price['price'] == -1) ? '--' : Tools::displayPrice($price, $current_specific_currency);
+                    $fixed_price = (($price == Tools::ps_round($product->price, 2) && $current_specific_currency['id_currency'] == $defaultCurrency->id) || $specific_price['price'] == -1) ? '--' : Tools::displayPrice($price, $current_specific_currency);
 
                     $content[] = [
                         'id_specific_price' => $specific_price['id_specific_price'],


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The comparaison $price == Tools::ps_round($product->price, 2) is Only valid When currencies are the same, so i'ts better to always show real product selling price
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  
| How to test?  | Use more than one currency , set a specific price for a currency , equal to "normal" product price , but in other currency



When displaying informations about specific product Price, "--" was displayed 
on my samples picture : default Currency is € and i set a specific price on USD) , please find below the Specific price configured :
![image](https://user-images.githubusercontent.com/3170104/57454605-84ffcd00-7269-11e9-9abc-89b326d32b75.png)


Before, this patch , admin Product page ( Pricing Tab ) is :

![image](https://user-images.githubusercontent.com/3170104/57454510-51bd3e00-7269-11e9-8501-19e7b38fbb32.png)

Whereas it should be , as $40 is not Equals to 40 €
![image](https://user-images.githubusercontent.com/3170104/57454476-394d2380-7269-11e9-8f16-1b2a65dcb917.png)




<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13730)
<!-- Reviewable:end -->
