### PR TITLE
Escape strings in installation assistant plus remove unwanted javascript

### DIFF
--- a/install-dev/controllers/http/configure.php
+++ b/install-dev/controllers/http/configure.php
@@ -318,6 +318,6 @@ class InstallControllerHttpConfigure extends InstallControllerHttp implements Ht
             return;
         }
 
-        return '<span class="result aligned errorTxt">'.$this->errors[$field].'</span>';
+        return '<span class="result aligned errorTxt">' . Tools::htmlentitiesUTF8($this->errors[$field]) . '</span>';
     }
 }

--- a/install-dev/theme/views/configure.php
+++ b/install-dev/theme/views/configure.php
@@ -25,12 +25,6 @@
  */
  $this->displayTemplate('header') ?>
 
-<script type="text/javascript">
-<!--
-var default_iso = '<?php echo $this->session->shop_country ?>';
--->
-</script>
-
 <!-- Configuration form -->
 <div id="infosShopBlock">
 	<h2><?php echo $this->translator->trans('Information about your Store', array(), 'Install'); ?></h2>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Escape strings in installation assistant plus remove unwanted javascript. Thanks Alexander Drabek
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Installation must work as before.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13738)
<!-- Reviewable:end -->
