### PR TITLE
Update AdminImagesController.php

### DIFF
--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -433,9 +433,10 @@ class AdminImagesControllerCore extends AdminController
 
         foreach ($toDel as $d) {
             foreach ($type as $imageType) {
-                if (preg_match('/^[0-9]+\-' . ($product ? '[0-9]+\-' : '') . $imageType['name'] . '\.jpg$/', $d)
+                if ((preg_match('/^[0-9]+\-' . ($product ? '[0-9]+\-' : '') . $imageType['name'] . '\.jpg$/', $d)
                     || (count($type) > 1 && preg_match('/^[0-9]+\-[_a-zA-Z0-9-]*\.jpg$/', $d))
-                    || preg_match('/^([[:lower:]]{2})\-default\-' . $imageType['name'] . '\.jpg$/', $d)) {
+                    || preg_match('/^([[:lower:]]{2})\-default\-' . $imageType['name'] . '\.jpg$/', $d))
+                    && !preg_match('/^(.)*_thumb.jpg$/', $d)) {
                     if (file_exists($dir . $d)) {
                         unlink($dir . $d);
                     }


### PR DESCRIPTION
When the category thumbnails are regenerated by selecting "Delete previous images", the system also deletes the "menu thumbnails" which are the images with the suffix "_thumb.jpg" losing them definitively.

Thanks!

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.5.x
| Description?  | When the category thumbnails are regenerated by selecting **Delete previous images**, the system also deletes the **menu thumbnails** which are the images with the suffix **_thumb.jpg** losing them definitively.
| Type?         | bug fix 
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Add a **Menu Thumbnail** image to a category, Go to Admin> Design> Image Settings, in  **Regenerate thumbnails** select **Categories** for the **Select an image** field and then click **Regenerate Thumbnails**. Before it would delete menu thumbnails too. Now menu thumbnails are not deleted.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13758)
<!-- Reviewable:end -->
