### PR TITLE
Fixes customer view url in notifications bar

### DIFF
--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -137,6 +137,10 @@ class NotificationCore
                 'status' => ((!empty($value['status'])) ? Tools::safeOutput($value['status']) : ''),
                 'customer_name' => $customerName,
                 'date_add' => isset($value['date_add']) ? Tools::displayDate($value['date_add']) : 0,
+                'customer_view_url' => Context::getContext()->link->getAdminLink('AdminCustomers', true, [
+                    'customerId' => $value['id_customer'],
+                    'viewcustomer' => 1,
+                ])
             );
         }
 

--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -137,10 +137,14 @@ class NotificationCore
                 'status' => ((!empty($value['status'])) ? Tools::safeOutput($value['status']) : ''),
                 'customer_name' => $customerName,
                 'date_add' => isset($value['date_add']) ? Tools::displayDate($value['date_add']) : 0,
-                'customer_view_url' => Context::getContext()->link->getAdminLink('AdminCustomers', true, [
-                    'customerId' => $value['id_customer'],
-                    'viewcustomer' => true,
-                ])
+                'customer_view_url' => Context::getContext()->link->getAdminLink(
+                    'AdminCustomers',
+                    true,
+                    [
+                        'customerId' => $value['id_customer'],
+                        'viewcustomer' => true,
+                    ]
+                )
             );
         }
 

--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -144,7 +144,7 @@ class NotificationCore
                         'customerId' => $value['id_customer'],
                         'viewcustomer' => true,
                     ]
-                )
+                ),
             );
         }
 

--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -139,7 +139,7 @@ class NotificationCore
                 'date_add' => isset($value['date_add']) ? Tools::displayDate($value['date_add']) : 0,
                 'customer_view_url' => Context::getContext()->link->getAdminLink('AdminCustomers', true, [
                     'customerId' => $value['id_customer'],
-                    'viewcustomer' => 1,
+                    'viewcustomer' => true,
                 ])
             );
         }

--- a/js/admin/notifications.js
+++ b/js/admin/notifications.js
@@ -116,7 +116,7 @@ function getPush()
 				// Add customers notifications to the list
 				html = "";
 				$.each(json.customer.results, function(property, value) {
-					html += "<a class='notif' href='"+baseAdminDir+"index.php?tab=AdminCustomers&token=" + token_admin_customers + "&viewcustomer&id_customer=" + parseInt(value.id_customer) + "'>";
+					html += "<a class='notif' href='" + value.customer_view_url + "'>";
 					html += "#" + value.id_customer + " - <strong>" + value.customer_name + "</strong>"
           if (value.company !== "") {
             html += " (" + value.company + ")";


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.6.x
| Description?  | See issue.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13450
| How to test?  | Customer view url should not reference legacy controller anymore.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13764)
<!-- Reviewable:end -->
