### PR TITLE
Improve tests orders and category

### DIFF
--- a/tests/E2E/test/campaigns/common_scenarios/category.js
+++ b/tests/E2E/test/campaigns/common_scenarios/category.js
@@ -116,7 +116,7 @@ module.exports = {
         return promise
           .then(() => client.waitForExistAndClickJs(CategorySubMenu.update_button))
           .then(() => client.getURL(2000))
-          .then((res) => global.param['id_category'] = res.value.match(/\d+/g)[0]);
+          .then((res) => global.param['id_category'] = /categories\/(\d+)\//g.exec(res.value)[1]);
       });
       test('should check the category name', () => client.checkAttributeValue(CategorySubMenu.name_input, 'value', categoryData.name + date_time));
       test('should check that the image is well displayed', () => client.checkImage(CategorySubMenu.image_link));

--- a/tests/E2E/test/campaigns/full/01_orders/01_create_order_in_BO.js
+++ b/tests/E2E/test/campaigns/full/01_orders/01_create_order_in_BO.js
@@ -245,13 +245,13 @@ scenario('Create order in the Back Office', () => {
     });
     test('should choose "British Pound Sterling" from currency list', () => {
       return promise
-        .then(() => client.waitAndSelectByValue(CreateOrder.currency_select, '2'))
+        .then(() => client.selectByVisibleText(CreateOrder.currency_select, 'British Pound'))
         .then(() => client.pause(2000));
     });
     test('should verify that the price is changed', () => client.checkTextValue(CreateOrder.price_product_column, global.tab['price_product'], 'notequal'));
     test('should choose "Euro" from currency list', () => {
       return promise
-        .then(() => client.waitAndSelectByValue(CreateOrder.currency_select, '1'))
+        .then(() => client.selectByVisibleText(CreateOrder.currency_select, 'Euro'))
         .then(() => client.pause(2000));
     });
     test('should verify that the price is changed', () => client.checkTextValue(CreateOrder.price_product_column, global.tab['price_product'], 'equal'));

--- a/tests/E2E/test/campaigns/full/01_orders/05_create_order_without_account.js
+++ b/tests/E2E/test/campaigns/full/01_orders/05_create_order_without_account.js
@@ -305,10 +305,10 @@ scenario('Create order by a guest from the Front Office', client => {
   stockCommonScenarios.checkStockProduct(client, productData[0].name + date_time, Menu, Stock, '50', '0', '50');
   stockCommonScenarios.checkStockProduct(client, productData[1].name + date_time, Menu, Stock, '50', '0', '50');
   scenario('Check the movement of the "' + productData[0].name + date_time + '"', client => {
-    test('should go to "Employee" page', () => {
-      return promise
-        .then(() => client.waitForExistAndClick(Menu.Sell.Catalog.catalog_menu))
-        .then(() => client.goToSubtabMenuPage(Menu.Configure.AdvancedParameters.advanced_parameters_menu, Menu.Configure.AdvancedParameters.team_submenu));
+    test('should go to "Employee" page', async () => {
+      await client.waitForExistAndClick(Menu.Sell.Catalog.catalog_menu);
+      await client.waitForVisible(Menu.Configure.AdvancedParameters.advanced_parameters_menu);
+      await client.goToSubtabMenuPage(Menu.Configure.AdvancedParameters.advanced_parameters_menu, Menu.Configure.AdvancedParameters.team_submenu);
     });
     test('should get  the Employee "Name" and "Last Name"', async () => {
       await client.getTextInVar(Employee.employee_column_information.replace('%COL', 4), 'employee_last_name');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x 
| Description?  | Fixing tests orders and using better regex for test category
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH=full/03_category/* npm run specific-test -- --URL=shop_URL <br/> TEST_PATH=full/01_orders/01_create_order_in_BO npm run specific-test -- --URL=shop_URL<br/> TEST_PATH=full/01_orders/05_create_order_without_account npm run specific-test -- --URL=shop_URL

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13776)
<!-- Reviewable:end -->
