### PR TITLE
Incorrect translation arguments passed in cms page form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -237,10 +237,10 @@ class CmsPageType extends TranslatorAwareType
                     new NotBlank([
                         'message' => $this->trans(
                             'The %s field is required.',
+                            'Admin.Notifications.Error',
                             [
                                 sprintf('"%s"', $this->trans('Shop association', 'Admin.Global')),
-                            ],
-                            'Admin.Notifications.Error'
+                            ]
                         ),
                     ]),
                 ],

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/SurvivalTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/SurvivalTest.php
@@ -154,6 +154,7 @@ class SurvivalTest extends WebTestCase
             'admin_employees_create' => ['Add new employee', 'admin_employees_create'],
             'admin_cms_pages_index' => ['Cms page', 'admin_cms_pages_index'],
             'admin_cms_pages_category_create' => ['Add new cms category page', 'admin_cms_pages_category_create'],
+            'admin_cms_pages_create' => ['Add new cms page', 'admin_cms_pages_create'],
             'admin_profiles_index' => ['Profiles', 'admin_profiles_index'],
             'admin_profiles_create' => ['Add new profile', 'admin_profiles_create'],
             'admin_taxes_index' => ['Taxes', 'admin_taxes_index'],

--- a/tests-legacy/Integration/PrestaShopBundle/Test/LightWebTestCase.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Test/LightWebTestCase.php
@@ -30,6 +30,7 @@ use Context;
 use Currency;
 use Employee;
 use Language;
+use Link;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use Psr\Log\NullLogger;
@@ -131,6 +132,13 @@ class LightWebTestCase extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(['getDefaultCurrencyIsoCode', 'getDefaultCurrency'])
             ->getMock();
+
+        $linkMock = $this
+            ->getMockBuilder(Link::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $contextMock->link = $linkMock;
 
         $currencyDataProviderMock->method('getDefaultCurrencyIsoCode')
             ->will($this->returnValue('en'));


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Incorrect argument positions causes whole page to crash in CMS Page Create or Edit form. Also added missing automated test for this page which would have helped to avoid the issue
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Just go to to page Create/Edit CMS Page - right now it is loaded.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13777)
<!-- Reviewable:end -->
