### PR TITLE
Allow to overwrite theme mails if they have modules OR mail templates

### DIFF
--- a/src/Core/Form/ChoiceProvider/ThemeByNameWithEmailsChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ThemeByNameWithEmailsChoiceProvider.php
@@ -60,7 +60,7 @@ final class ThemeByNameWithEmailsChoiceProvider implements FormChoiceProviderInt
         foreach ($this->themeCollection as $theme) {
             $coreMailsFolder = $theme->getDirectory() . '/mails';
             $modulesMailFolder = $theme->getDirectory() . '/modules';
-            if (is_dir($coreMailsFolder) && is_dir($modulesMailFolder)) {
+            if (is_dir($coreMailsFolder) || is_dir($modulesMailFolder)) {
                 $themeChoices[$theme->getName()] = $theme->getName();
             }
         }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
@@ -118,8 +118,12 @@ class MailThemeController extends FrameworkBundleAdminController
                 //Overwrite theme folder if selected
                 if (!empty($data['theme'])) {
                     $themeFolder = $this->getParameter('themes_dir') . '/' . $data['theme'];
-                    $coreMailsFolder = $themeFolder . '/mails';
-                    $modulesMailFolder = $themeFolder . '/modules';
+                    if (is_dir($themeFolder . '/mails')) {
+                        $coreMailsFolder = $themeFolder . '/mails';
+                    }
+                    if (is_dir($themeFolder . '/modules')) {
+                        $modulesMailFolder = $themeFolder . '/modules';
+                    }
                 }
 
                 $generateCommand = new GenerateThemeMailTemplatesCommand(


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Allow to overwrite theme mails if they have modules OR mail templates, use default as fallback instead
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13586
| How to test?  | From a fresh install, check that `classic` theme has a folder `modules` but no folder `mails` With this PR you can still select the classic theme to overwrite the modules mails When you generate email (with overwrite and classic theme selected) check that email templates are generated in theme's folder for modules (for example in module `ps_emailsubscription`) and in root `mails` folder for core emails

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13779)
<!-- Reviewable:end -->
