### PR TITLE
Avoid added suffixes in ids when a specific id is set

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -845,7 +845,7 @@
 				{if isset($fieldset['form']['submit']) || isset($fieldset['form']['buttons'])}
 					<div class="panel-footer">
 						{if isset($fieldset['form']['submit']) && !empty($fieldset['form']['submit'])}
-						<button type="submit" value="1"	id="{if isset($fieldset['form']['submit']['id'])}{$fieldset['form']['submit']['id']}{else}{$table}_form_submit_btn{/if}{if $smarty.capture.form_submit_btn > 1}_{($smarty.capture.form_submit_btn - 1)|intval}{/if}" name="{if isset($fieldset['form']['submit']['name'])}{$fieldset['form']['submit']['name']}{else}{$submit_action}{/if}{if isset($fieldset['form']['submit']['stay']) && $fieldset['form']['submit']['stay']}AndStay{/if}" class="{if isset($fieldset['form']['submit']['class'])}{$fieldset['form']['submit']['class']}{else}btn btn-default pull-right{/if}">
+						<button type="submit" value="1"	id="{if isset($fieldset['form']['submit']['id'])}{$fieldset['form']['submit']['id']}{else}{$table}_form_submit_btn{if $smarty.capture.form_submit_btn > 1}_{($smarty.capture.form_submit_btn - 1)|intval}{/if}{/if}" name="{if isset($fieldset['form']['submit']['name'])}{$fieldset['form']['submit']['name']}{else}{$submit_action}{/if}{if isset($fieldset['form']['submit']['stay']) && $fieldset['form']['submit']['stay']}AndStay{/if}" class="{if isset($fieldset['form']['submit']['class'])}{$fieldset['form']['submit']['class']}{else}btn btn-default pull-right{/if}">
 							<i class="{if isset($fieldset['form']['submit']['icon'])}{$fieldset['form']['submit']['icon']}{else}process-icon-save{/if}"></i> {$fieldset['form']['submit']['title']}
 						</button>
 						{/if}


### PR DESCRIPTION
fix 'id' button submit if name 'id' is specified

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | This is a bug into form.tpl. It doesn't appear into Prestashop, but into modules.<br>If a module add several switch button in a same form (On / Off), HTML id is broken because form.tpl add a number just after the id. <br>For example:<br>1.submitTruncateCatalog,<br>2.submitTruncateSales_1, (_1 was added)<br>3.module_form_submit_btn_2, (_2 was added)<br>4.submitTruncateClient_3, (_3 was added)<br>5.module_form_submit_btn_4, (_4 was added)<br>This is a problem because the module cannot know what will be the id with function like this:<br>$("#submitTruncateCatalog").click(function(){<br>if ($('#checkTruncateCatalog_on').attr('checked') != "checked")<br>{<br>   alert(' ... ');<br>   return false;<br>}<br>if (confirm(' ... '))<br>   return true;<br>return false;<br>});<br>My proposal allows module’s developer to keep control on his id. <br>
| Type?         | improvement 
| Category?     | BO 
| BC breaks?    | Does it break backward compatibility? yes
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | 
| How to test?  | With module Prestashop pscleaner

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13792)
<!-- Reviewable:end -->
