### PR TITLE
Adds missing legacy links for currency controller

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/currencies.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/currencies.yml
@@ -29,6 +29,8 @@ admin_currencies_edit:
         _controller: 'PrestaShopBundle:Admin\Improve\International\Currency:edit'
         _legacy_controller: AdminCurrencies
         _legacy_link: AdminCurrencies:updatecurrency
+        _legacy_parameters:
+          id_currency: currencyId
     requirements:
         currencyId: \d+
 
@@ -39,6 +41,8 @@ admin_currencies_delete:
         _controller: 'PrestaShopBundle:Admin\Improve\International\Currency:delete'
         _legacy_controller: AdminCurrencies
         _legacy_link: AdminCurrencies:deletecurrency
+        _legacy_parameters:
+          id_currency: currencyId
     requirements:
         currencyId: \d+
 
@@ -49,6 +53,8 @@ admin_currencies_toggle_status:
         _controller: 'PrestaShopBundle:Admin\Improve\International\Currency:toggleStatus'
         _legacy_controller: AdminCurrencies
         _legacy_link: AdminCurrencies:statuscurrency
+        _legacy_parameters:
+          id_currency: currencyId
     requirements:
         currencyId: \d+
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/currencies.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/currencies.yml
@@ -12,6 +12,7 @@ admin_currencies_search:
     defaults:
         _controller: 'PrestaShopBundle:Admin\Improve\International\Currency:search'
         _legacy_controller: AdminCurrencies
+        _legacy_link: AdminCurrencies:submitFiltercurrency
 
 admin_currencies_create:
     path: /new
@@ -19,6 +20,7 @@ admin_currencies_create:
     defaults:
         _controller: 'PrestaShopBundle:Admin\Improve\International\Currency:create'
         _legacy_controller: AdminCurrencies
+        _legacy_link: AdminCurrencies:addcurrency
 
 admin_currencies_edit:
     path: /{currencyId}/edit
@@ -26,6 +28,7 @@ admin_currencies_edit:
     defaults:
         _controller: 'PrestaShopBundle:Admin\Improve\International\Currency:edit'
         _legacy_controller: AdminCurrencies
+        _legacy_link: AdminCurrencies:updatecurrency
     requirements:
         currencyId: \d+
 
@@ -35,6 +38,7 @@ admin_currencies_delete:
     defaults:
         _controller: 'PrestaShopBundle:Admin\Improve\International\Currency:delete'
         _legacy_controller: AdminCurrencies
+        _legacy_link: AdminCurrencies:deletecurrency
     requirements:
         currencyId: \d+
 
@@ -44,6 +48,7 @@ admin_currencies_toggle_status:
     defaults:
         _controller: 'PrestaShopBundle:Admin\Improve\International\Currency:toggleStatus'
         _legacy_controller: AdminCurrencies
+        _legacy_link: AdminCurrencies:statuscurrency
     requirements:
         currencyId: \d+
 
@@ -60,4 +65,5 @@ admin_currencies_refresh_exchange_rates:
     defaults:
         _controller: 'PrestaShopBundle:Admin\Improve\International\Currency:refreshExchangeRates'
         _legacy_controller: AdminCurrencies
+        _legacy_link: AdminCurrencies:SubmitExchangesRates
 

--- a/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -210,7 +210,7 @@ class LegacyUrlConverterTest extends SymfonyIntegrationTestCase
             'admin_currencies_create' => ['/improve/international/currencies/new', 'AdminCurrencies', 'addcurrency'],
             'admin_currencies_edit' => ['/improve/international/currencies/1000/edit', 'AdminCurrencies', 'updatecurrency', ['id_currency' => 1000]],
             'admin_currencies_delete' => ['/improve/international/currencies/1000/delete', 'AdminCurrencies', 'deletecurrency', ['id_currency' => 1000]],
-            'admin_currencies_toggle_status' => ['/improve/international/currencies/1000/toggle-status', 'AdminCurrencies', 'statuscurrency'],
+            'admin_currencies_toggle_status' => ['/improve/international/currencies/1000/toggle-status', 'AdminCurrencies', 'statuscurrency', ['id_currency' => 1000]],
             'admin_currencies_refresh_exchange_rates' => ['/improve/international/currencies/refresh-exchange-rates', 'AdminCurrencies', 'SubmitExchangesRates'],
         ];
     }

--- a/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -204,6 +204,14 @@ class LegacyUrlConverterTest extends SymfonyIntegrationTestCase
             'admin_profiles_edit' => ['/configure/advanced/profiles/1000/edit', 'AdminProfiles', 'updateprofile', ['id_profile' => 1000]],
             'admin_profiles_bulk_delete' => ['/configure/advanced/profiles/delete/bulk', 'AdminProfiles', 'submitBulkdeleteprofile'],
             'admin_profiles_delete' => ['/configure/advanced/profiles/12/delete', 'AdminProfiles', 'deleteprofile', ['id_profile' => 12]],
+
+            'admin_currencies_index' => ['/improve/international/currencies/', 'AdminCurrencies'],
+            'admin_currencies_search' => ['/improve/international/currencies/', 'AdminCurrencies', 'submitFiltercurrency'],
+            'admin_currencies_create' => ['/improve/international/currencies/new', 'AdminCurrencies', 'addcurrency'],
+            'admin_currencies_edit' => ['/improve/international/currencies/1000/edit', 'AdminCurrencies', 'updatecurrency', ['id_currency' => 1000]],
+            'admin_currencies_delete' => ['/improve/international/currencies/1000/delete', 'AdminCurrencies', 'deletecurrency', ['id_currency' => 1000]],
+            'admin_currencies_toggle_status' => ['/improve/international/currencies/1000/toggle-status', 'AdminCurrencies', 'statuscurrency'],
+            'admin_currencies_refresh_exchange_rates' => ['/improve/international/currencies/refresh-exchange-rates', 'AdminCurrencies', 'SubmitExchangesRates'],
         ];
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Missing legacy links for currency controller
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13744
| How to test?  | Automated tests will test this functionality - no need for QA

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13797)
<!-- Reviewable:end -->
