### PR TITLE
Make the movement of the Grid columns really easy

### DIFF
--- a/src/Core/Grid/Column/ColumnCollection.php
+++ b/src/Core/Grid/Column/ColumnCollection.php
@@ -108,26 +108,30 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
     }
 
     /**
-     * Swap two existing columns.
+     * Move an existing Column to a specific position.
      *
-     * @param string $idFrom the Column ID original position in the Collection
-     * @param string $idTo the Column ID destination position in the Collection
+     * @param string $id the Column ID original position in the Collection
+     * @param int $position the Column ID destination position in the Collection
      *
      * @return self
      */
-    public function swap($idFrom, $idTo)
+    public function move($id, $position)
     {
-        if (!array_key_exists($idFrom, $this->items) || !array_key_exists($idTo, $this->items)) {
+        if (!isset($this->items[$id])) {
             throw new ColumnNotFoundException(sprintf(
-                'Cannot swap nonexistent columns from collection. Column(s) for ids "%s" or "%s" were not found.',
-                $idFrom,
-                $idTo
+                'Cannot insert new column into collection. Column with id "%s" was not found.',
+                $id
             ));
         }
 
-        $fromColumn = $this->items[$idFrom];
-        $this->items[$idFrom] = $this->items[$idTo];
-        $this->items[$idTo] = $fromColumn;
+        $column = $this->items[$id];
+        unset($this->items[$id]);
+
+        $columns = array_slice($this->items, 0, $position, true) +
+            [$column->getId() => $column] +
+            array_slice($this->items, $position, $this->count(), true);
+
+        $this->items = $columns;
 
         return $this;
     }

--- a/src/Core/Grid/Column/ColumnCollection.php
+++ b/src/Core/Grid/Column/ColumnCollection.php
@@ -129,7 +129,7 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
 
         $columns = array_slice($this->items, 0, $position, true) +
             [$column->getId() => $column] +
-            array_slice($this->items, $position, $this->count(), true);
+            array_slice($this->items, $position, null, true);
 
         $this->items = $columns;
 
@@ -162,7 +162,7 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
 
         $columns = array_slice($this->items, 0, $existingColumnKeyPosition, true) +
             [$newColumn->getId() => $newColumn] +
-            array_slice($this->items, $existingColumnKeyPosition, $this->count(), true);
+            array_slice($this->items, $existingColumnKeyPosition, null, true);
 
         $this->items = $columns;
     }

--- a/src/Core/Grid/Column/ColumnCollection.php
+++ b/src/Core/Grid/Column/ColumnCollection.php
@@ -108,13 +108,38 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
     }
 
     /**
+     * Swap two existing columns.
+     *
+     * @param string $keyFrom the Column ID original position in the Collection
+     * @param string $keyTo the Column ID destination position in the Collection
+     *
+     * @return self
+     */
+    public function swap($keyFrom, $keyTo)
+    {
+        if (!array_key_exists($keyFrom, $this->items) || !array_key_exists($keyTo, $this->items)) {
+            throw new ColumnNotFoundException(sprintf(
+                'Cannot swap two existing columns from collection. Columns with ids "%s" or "%s" were not found.',
+                $keyFrom,
+                $keyTo
+            ));
+        }
+
+        $fromColumn = $this->items[$keyFrom];
+        $this->items[$keyFrom] = $this->items[$keyTo];
+        $this->items[$keyTo] = $fromColumn;
+
+        return $this;
+    }
+
+    /**
      * Insert new column into collection at given position.
      *
      * @param string $id Existing column id
      * @param ColumnInterface $newColumn Column to insert
      * @param string $position Position: "before" or "after"
      *
-     * @throws ColumnNotFoundException When column with gieven $id does not exist
+     * @throws ColumnNotFoundException When column with given $id does not exist
      */
     private function insertByPosition($id, ColumnInterface $newColumn, $position)
     {

--- a/src/Core/Grid/Column/ColumnCollection.php
+++ b/src/Core/Grid/Column/ColumnCollection.php
@@ -110,24 +110,24 @@ final class ColumnCollection extends AbstractCollection implements ColumnCollect
     /**
      * Swap two existing columns.
      *
-     * @param string $keyFrom the Column ID original position in the Collection
-     * @param string $keyTo the Column ID destination position in the Collection
+     * @param string $idFrom the Column ID original position in the Collection
+     * @param string $idTo the Column ID destination position in the Collection
      *
      * @return self
      */
-    public function swap($keyFrom, $keyTo)
+    public function swap($idFrom, $idTo)
     {
-        if (!array_key_exists($keyFrom, $this->items) || !array_key_exists($keyTo, $this->items)) {
+        if (!array_key_exists($idFrom, $this->items) || !array_key_exists($idTo, $this->items)) {
             throw new ColumnNotFoundException(sprintf(
-                'Cannot swap two existing columns from collection. Columns with ids "%s" or "%s" were not found.',
-                $keyFrom,
-                $keyTo
+                'Cannot swap nonexistent columns from collection. Column(s) for ids "%s" or "%s" were not found.',
+                $idFrom,
+                $idTo
             ));
         }
 
-        $fromColumn = $this->items[$keyFrom];
-        $this->items[$keyFrom] = $this->items[$keyTo];
-        $this->items[$keyTo] = $fromColumn;
+        $fromColumn = $this->items[$idFrom];
+        $this->items[$idFrom] = $this->items[$idTo];
+        $this->items[$idTo] = $fromColumn;
 
         return $this;
     }

--- a/tests-legacy/Unit/Core/Grid/Column/ColumnCollectionTest.php
+++ b/tests-legacy/Unit/Core/Grid/Column/ColumnCollectionTest.php
@@ -206,15 +206,15 @@ class ColumnCollectionTest extends TestCase
             ->move('test_2', 4)
         ;
 
-        $this->isColumnWithId($columns, 'test_5');
+        $this->assertValidColumnWithId($columns, 'test_5');
         $columns->next();
-        $this->isColumnWithId($columns, 'test_1');
+        $this->assertValidColumnWithId($columns, 'test_1');
         $columns->next();
         $columns->next();
         $columns->next();
-        $this->isColumnWithId($columns, 'test_2');
+        $this->assertValidColumnWithId($columns, 'test_2');
         $columns->next();
-        $this->isColumnWithId($columns, 'test_6');
+        $this->assertValidColumnWithId($columns, 'test_6');
 
         $this->assertCount(7, $columns);
     }
@@ -267,7 +267,7 @@ class ColumnCollectionTest extends TestCase
      * @param ColumnCollection $columnCollection
      * @param string $columnId
      */
-    private function isColumnWithId(ColumnCollection $columnCollection, $columnId)
+    private function assertValidColumnWithId(ColumnCollection $columnCollection, $columnId)
     {
         $this->assertSame($columnCollection->current()->getId(), $columnId);
     }

--- a/tests-legacy/Unit/Core/Grid/Column/ColumnCollectionTest.php
+++ b/tests-legacy/Unit/Core/Grid/Column/ColumnCollectionTest.php
@@ -31,6 +31,9 @@ use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
 use PrestaShop\PrestaShop\Core\Grid\Exception\ColumnNotFoundException;
 
+/**
+ * @doc ./vendor/bin/phpunit -c tests-legacy/phpunit.xml --filter=ColumnCollectionTest
+ */
 class ColumnCollectionTest extends TestCase
 {
     public function testItAddsColumnsToCollection()
@@ -184,6 +187,33 @@ class ColumnCollectionTest extends TestCase
 
         $this->assertInternalType('array', $columnsArray);
         $this->assertCount(3, $columnsArray);
+    }
+
+    public function testColumnsCanBeSwapped()
+    {
+        $columns = (new ColumnCollection())
+            ->add($test1 = $this->createColumnMock('test_1'))
+            ->add($this->createColumnMock('test_2'))
+            ->add($test3 = $this->createColumnMock('test_3'));
+
+        $columns->swap('test_1', 'test_3');
+
+        $this->assertSame($columns->current(), $test3);
+        $columns->next();
+        $columns->next();
+        $this->assertSame($columns->current(), $test1);
+    }
+
+    public function testColumnsSwapWithInvalidIdWillThrowsAnException()
+    {
+        $this->expectException(ColumnNotFoundException::class);
+
+        $columns = (new ColumnCollection())
+            ->add($this->createColumnMock('test_1'))
+            ->add($this->createColumnMock('test_2'))
+            ->add($this->createColumnMock('test_3'));
+
+        $columns->swap('test_1', 'undefined_id');
     }
 
     /**

--- a/tests-legacy/Unit/Core/Grid/Column/ColumnCollectionTest.php
+++ b/tests-legacy/Unit/Core/Grid/Column/ColumnCollectionTest.php
@@ -189,22 +189,37 @@ class ColumnCollectionTest extends TestCase
         $this->assertCount(3, $columnsArray);
     }
 
-    public function testColumnsCanBeSwapped()
+    public function testAColumnCanBeMoved()
     {
         $columns = (new ColumnCollection())
-            ->add($test1 = $this->createColumnMock('test_1'))
+            ->add($this->createColumnMock('test_1'))
             ->add($this->createColumnMock('test_2'))
-            ->add($test3 = $this->createColumnMock('test_3'));
+            ->add($this->createColumnMock('test_3'))
+            ->add($this->createColumnMock('test_4'))
+            ->add($this->createColumnMock('test_5'))
+            ->add($this->createColumnMock('test_6'))
+            ->add($this->createColumnMock('test_7'))
+        ;
 
-        $columns->swap('test_1', 'test_3');
+        $columns->move('test_1', 1)
+            ->move('test_5', 0)
+            ->move('test_2', 4)
+        ;
 
-        $this->assertSame($columns->current(), $test3);
+        $this->isColumnWithId($columns, 'test_5');
+        $columns->next();
+        $this->isColumnWithId($columns, 'test_1');
         $columns->next();
         $columns->next();
-        $this->assertSame($columns->current(), $test1);
+        $columns->next();
+        $this->isColumnWithId($columns, 'test_2');
+        $columns->next();
+        $this->isColumnWithId($columns, 'test_6');
+
+        $this->assertCount(7, $columns);
     }
 
-    public function testColumnsSwapWithInvalidIdWillThrowsAnException()
+    public function testColumnMoveWithInvalidIdWillThrowsAnException()
     {
         $this->expectException(ColumnNotFoundException::class);
 
@@ -213,7 +228,7 @@ class ColumnCollectionTest extends TestCase
             ->add($this->createColumnMock('test_2'))
             ->add($this->createColumnMock('test_3'));
 
-        $columns->swap('test_1', 'undefined_id');
+        $columns->move('undefined_id', 10);
     }
 
     /**
@@ -244,5 +259,16 @@ class ColumnCollectionTest extends TestCase
         }
 
         return $positions;
+    }
+
+    /**
+     * Helper assertion.
+     *
+     * @param ColumnCollection $columnCollection
+     * @param string $columnId
+     */
+    private function isColumnWithId(ColumnCollection $columnCollection, $columnId)
+    {
+        $this->assertSame($columnCollection->current()->getId(), $columnId);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | While it's already possible, swapping 2 existing columns is boring and error-prone with the current API. Let's create a specific function for that as the need is really common.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | yes, some developers will lose their job as it's now super easy to do that /c @MDWeb-Lille 
| Fixed ticket? | none
| How to test?  | There is nothing to do from a QA point of view, but we MUST update every docs and demonstration modules and training resources, starting from 1.7.7!

### Before

```php
// for a grid with 2 columns "a", "b" and "c".
$columnCollection
    ->remove('a')
    ->addAfter(
        'b',
        (new DataColumn('a'))
            ->setName('A')
            ->setOptions([...])
   );
// In this case, we must create again column A for no reasons!
// And we need to do it X times, X is the number of swaps
```

### After

```php
// Remember, the collection starts at position 0
$columnCollection->move('a', 1) // Column 'a' is now in position 2
    ->move('b', 2) // calls can be chained
    ->move('c', 0)
;
// Now, go grab a coffee or play baby foot
```
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13803)
<!-- Reviewable:end -->
