### PR TITLE
Fix shared smarty compilation ID across shops / themes

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -675,12 +675,14 @@ class FrontControllerCore extends Controller
 
         $html = '';
 
+        $theme = $this->context->shop->theme->getName();
+
         if (is_array($content)) {
             foreach ($content as $tpl) {
-                $html .= $this->context->smarty->fetch($tpl, null, $this->getLayout());
+                $html .= $this->context->smarty->fetch($tpl, null, $theme . $this->getLayout());
             }
         } else {
-            $html = $this->context->smarty->fetch($content, null, $this->getLayout());
+            $html = $this->context->smarty->fetch($content, null, $theme . $this->getLayout());
         }
 
         Hook::exec('actionOutputHTMLBefore', array('html' => &$html));

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2451,6 +2451,9 @@ abstract class ModuleCore implements ModuleInterface
         if ($cache_id !== null) {
             Tools::enableCache();
         }
+        if ($compile_id == null) {
+            $compile_id = Context::getContext()->shop->theme->getName();
+        }
 
         $template = $this->context->smarty->createTemplate(
             $templatePath,

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2451,7 +2451,7 @@ abstract class ModuleCore implements ModuleInterface
         if ($cache_id !== null) {
             Tools::enableCache();
         }
-        if ($compile_id == null) {
+        if ($compile_id === null) {
             $compile_id = Context::getContext()->shop->theme->getName();
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In all version of PS 1.7, if you have several shops with different theme, they share the same compile ID. Consequently first theme in cache are used for all shops.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9763
| How to test?  | Install two shops with two different theme with cache active and force compile off. Each shop should be load its right theme. You can although try with a child theme and modify for instance only one template (for instance footer.tpl).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13804)
<!-- Reviewable:end -->
