### PR TITLE
Fixes toggling Category status in Monitoring page

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_action_enable.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_action_enable.tpl
@@ -22,6 +22,12 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
+
+{* Workaround to add compatibility for enable/disable actions to be able to use symfony endpoints *}
+{if isset($migrated_url_enable)}
+  {assign var="url_enable" value=$migrated_url_enable}
+{/if}
+
 <a class="list-action-enable{if isset($ajax) && $ajax} ajax_table_link{/if}{if $enabled} action-enabled{else} action-disabled{/if}" href="{$url_enable|escape:'html':'UTF-8'}"{if isset($confirm)} onclick="return confirm('{$confirm}');"{/if} title="{if $enabled}{l s='Enabled' d='Admin.Global'}{else}{l s='Disabled' d='Admin.Global'}{/if}">
 	<i class="icon-check{if !$enabled} hidden{/if}"></i>
 	<i class="icon-remove{if $enabled} hidden{/if}"></i>

--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -34,7 +34,7 @@
           // otherwise if response comes from legacy controller
           // then data has "success" and "text" properties.
 
-					if (data.success == 1 || data.status == true) {
+					if (data.success == 1 || data.status === true) {
 						showSuccessMessage(data.text || data.message);
 						if (link.hasClass('action-disabled')){
 							link.removeClass('action-disabled').addClass('action-enabled');

--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -29,8 +29,13 @@
 			$(".ajax_table_link").click(function () {
 				var link = $(this);
 				$.post($(this).attr('href'), function (data) {
-					if (data.success == 1) {
-						showSuccessMessage(data.text);
+				  // If response comes from symfony controller
+          // then data has "status" and "message" properties
+          // otherwise if response comes from legacy controller
+          // then data has "success" and "text" properties.
+
+					if (data.success == 1 || data.status == true) {
+						showSuccessMessage(data.text || data.message);
 						if (link.hasClass('action-disabled')){
 							link.removeClass('action-disabled').addClass('action-enabled');
 						} else {
@@ -44,7 +49,7 @@
 							}
 						});
 					} else {
-						showErrorMessage(data.text);
+						showErrorMessage(data.text || data.message);
 					}
 				}, 'json');
 				return false;

--- a/controllers/admin/AdminTrackingController.php
+++ b/controllers/admin/AdminTrackingController.php
@@ -93,8 +93,6 @@ class AdminTrackingControllerCore extends AdminController
 
         $this->addRowAction('edit');
         $this->addRowAction('view');
-        $this->addRowAction('delete');
-        $this->addRowActionSkipList('delete', array((int) Configuration::get('PS_ROOT_CATEGORY')));
         $this->addRowActionSkipList('edit', array((int) Configuration::get('PS_ROOT_CATEGORY')));
 
         $this->fields_list = (array(

--- a/controllers/admin/AdminTrackingController.php
+++ b/controllers/admin/AdminTrackingController.php
@@ -326,7 +326,7 @@ class AdminTrackingControllerCore extends AdminController
             'id_product' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'class' => 'fixed-width-xs', 'align' => 'center'),
             'reference' => array('title' => $this->trans('Reference', array(), 'Admin.Global')),
             'name' => array('title' => $this->trans('Name', array(), 'Admin.Global'), 'filter_key' => 'b!name'),
-            'active' => array('title' => $this->trans('Status', array(), 'Admin.Global'), 'type' => 'bool', 'active' => 'status', 'align' => 'center', 'class' => 'fixed-width-xs'),
+            'active' => array('title' => $this->trans('Status', array(), 'Admin.Global'), 'type' => 'bool', 'active' => 'status', 'align' => 'center', 'class' => 'fixed-width-xs', 'ajax' => true),
         );
         $this->clearFilters();
         $this->_join = Shop::addSqlAssociation('product', 'a');

--- a/controllers/admin/AdminTrackingController.php
+++ b/controllers/admin/AdminTrackingController.php
@@ -24,6 +24,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+
 /**
  * @property Product|Category $object
  */
@@ -185,7 +187,7 @@ class AdminTrackingControllerCore extends AdminController
             'id_product' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'class' => 'fixed-width-xs', 'align' => 'center'),
             'reference' => array('title' => $this->trans('Reference', array(), 'Admin.Global')),
             'name' => array('title' => $this->trans('Name', array(), 'Admin.Global')),
-            'active' => array('title' => $this->trans('Status', array(), 'Admin.Global'), 'type' => 'bool', 'active' => 'status', 'align' => 'center', 'class' => 'fixed-width-xs', 'filter_key' => 'a!active'),
+            'active' => array('title' => $this->trans('Status', array(), 'Admin.Global'), 'type' => 'bool', 'active' => 'status', 'align' => 'center', 'class' => 'fixed-width-xs', 'filter_key' => 'a!active', 'ajax' => 1),
         );
         $this->clearFilters();
 
@@ -382,6 +384,29 @@ class AdminTrackingControllerCore extends AdminController
         $this->_helper_list->currentIndex = $this->_list_index;
         $this->_helper_list->identifier = $this->identifier;
         $this->_helper_list->table = $this->table;
+
+        // Since Categories controller is migrated to Symfony
+        // it makes use of new endpoint instead of relaying on legacy controller
+        if ($this->list_id === 'empty_categories') {
+            $url = SymfonyContainer::getInstance()->get('router')->generate('admin_categories_toggle_status', [
+                'categoryId' => $id,
+            ]);
+            $this->context->smarty->assign('migrated_url_enable', $url);
+
+            $html = $this->_helper_list->displayEnableLink(
+                $this->_list_token,
+                $id,
+                $value,
+                $active,
+                $id_category,
+                $id_product,
+                true
+            );
+
+            $this->context->smarty->clearAssign('migrated_url_enable');
+
+            return $html;
+        }
 
         return $this->_helper_list->displayEnableLink($this->_list_token, $id, $value, $active, $id_category, $id_product);
     }

--- a/controllers/admin/AdminTrackingController.php
+++ b/controllers/admin/AdminTrackingController.php
@@ -187,7 +187,7 @@ class AdminTrackingControllerCore extends AdminController
             'id_product' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'class' => 'fixed-width-xs', 'align' => 'center'),
             'reference' => array('title' => $this->trans('Reference', array(), 'Admin.Global')),
             'name' => array('title' => $this->trans('Name', array(), 'Admin.Global')),
-            'active' => array('title' => $this->trans('Status', array(), 'Admin.Global'), 'type' => 'bool', 'active' => 'status', 'align' => 'center', 'class' => 'fixed-width-xs', 'filter_key' => 'a!active', 'ajax' => 1),
+            'active' => array('title' => $this->trans('Status', array(), 'Admin.Global'), 'type' => 'bool', 'active' => 'status', 'align' => 'center', 'class' => 'fixed-width-xs', 'filter_key' => 'a!active'),
         );
         $this->clearFilters();
 

--- a/controllers/admin/AdminTrackingController.php
+++ b/controllers/admin/AdminTrackingController.php
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | See ticket.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #13541 
| How to test?  | Toggling category action in Monitoring page should work now. Monitoring page should work as before.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13813)
<!-- Reviewable:end -->
