### PR TITLE
Remove redundant condition in cart.php

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3339,17 +3339,14 @@ class CartCore extends ObjectModel
             $default_country = Context::getContext()->country;
         }
 
-        if (null !== $product_list) {
+        if (null === $product_list) {
+            $products = $this->getProducts(false, false, null, true);
+        } else {
             foreach ($product_list as $key => $value) {
                 if ($value['is_virtual'] == 1) {
                     unset($product_list[$key]);
                 }
             }
-        }
-
-        if (null === $product_list) {
-            $products = $this->getProducts(false, false, null, true);
-        } else {
             $products = $product_list;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify redundant condition on cart.php
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

Simplify ` if (null !== $product_list)` and ` if (null === $product_list)`

Before
```
        if (null !== $product_list) {
            // unset some...
        }
        if (null === $product_list) {
            $products = $this->getProducts(false, false, null, true);
        } else {
            $products = $product_list;
        }
```
After
```
        if (null === $product_list) {
            $products = $this->getProducts(false, false, null, true);
        } else {
           // unset some...
            $products = $product_list;
        }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13818)
<!-- Reviewable:end -->
