### PR TITLE
Fixes form_rest placing

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig
@@ -59,6 +59,8 @@
                   {{ form_widget(logsByEmailForm.logs_by_email) }}
                 </div>
               </div>
+
+              {{ form_rest(logsByEmailForm) }}
             </div>
           </div>
           <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig
@@ -60,7 +60,9 @@
                 </div>
               </div>
 
-              {{ form_rest(logsByEmailForm) }}
+              {% block logs_by_email_form_rest %}
+                {{ form_rest(logsByEmailForm) }}
+              {% endblock %}
             </div>
           </div>
           <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
@@ -67,11 +67,11 @@
             'label': 'Shop association'|trans({}, 'Admin.Global')
           }) }}
         {% endif %}
-      </div>
 
-      {% block webservice_key_form_rest %}
-        {{ form_rest(webserviceKeyForm) }}
-      {% endblock %}
+        {% block webservice_key_form_rest %}
+          {{ form_rest(webserviceKeyForm) }}
+        {% endblock %}
+      </div>
     </div>
     <div class="card-footer">
       <a href="{{ path('admin_webservice_keys_index') }}" class="btn btn-outline-secondary">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig
@@ -65,6 +65,7 @@
           </div>
         </div>
 
+        {{ form_rest(webserviceConfigurationForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig
@@ -65,7 +65,9 @@
           </div>
         </div>
 
-        {{ form_rest(webserviceConfigurationForm) }}
+        {% block webservice_configuration_form_rest %}
+          {{ form_rest(webserviceConfigurationForm) }}
+        {% endblock %}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
@@ -77,7 +77,9 @@
                     </div>
                 </div>
 
-                {{ form_rest(generalForm) }}
+                {% block customer_general_preferences_form_rest %}
+                  {{ form_rest(generalForm) }}
+                {% endblock %}
             </div>
         </div>
         <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
@@ -76,6 +76,8 @@
                       {{ form_widget(generalForm.enable_offers) }}
                     </div>
                 </div>
+
+                {{ form_rest(generalForm) }}
             </div>
         </div>
         <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
@@ -86,6 +86,8 @@
             {{ form_widget(generalForm.default_status) }}
           </div>
         </div>
+
+        {{ form_rest(generalForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
@@ -87,7 +87,9 @@
           </div>
         </div>
 
-        {{ form_rest(generalForm) }}
+        {% block product_general_preferences_form_rest %}
+          {{ form_rest(generalForm) }}
+        {% endblock %}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
@@ -87,7 +87,9 @@
         </div>
       </div>
 
-      {{ form_rest(pageForm) }}
+      {% block product_page_preferences_form_rest %}
+        {{ form_rest(pageForm) }}
+      {% endblock %}
     </div>
     <div class="card-footer">
       <div class="d-flex justify-content-end">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
@@ -86,6 +86,8 @@
           </div>
         </div>
       </div>
+
+      {{ form_rest(pageForm) }}
     </div>
     <div class="card-footer">
       <div class="d-flex justify-content-end">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
@@ -55,6 +55,8 @@
             {{ form_widget(paginationForm.default_order_way) }}
           </div>
         </div>
+
+        {{ form_rest(paginationForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
@@ -56,7 +56,9 @@
           </div>
         </div>
 
-        {{ form_rest(paginationForm) }}
+        {% block product_pagination_preferences_form_rest %}
+          {{ form_rest(paginationForm) }}
+        {% endblock %}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
@@ -100,6 +100,8 @@
             {{ form_widget(stockForm.pack_stock_management) }}
           </div>
         </div>
+
+        {{ form_rest(stockForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
@@ -101,7 +101,9 @@
           </div>
         </div>
 
-        {{ form_rest(stockForm) }}
+        {% block product_stock_preferences_form_rest %}
+          {{ form_rest(stockForm) }}
+        {% endblock %}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
@@ -99,6 +99,8 @@
                       {{ form_widget(generalForm.tos_cms_id) }}
                     </div>
                 </div>
+
+                {{ form_rest(generalForm) }}
             </div>
         </div>
         <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
@@ -100,7 +100,9 @@
                     </div>
                 </div>
 
-                {{ form_rest(generalForm) }}
+                {% block order_general_preferences_form_rest %}
+                  {{ form_rest(generalForm) }}
+                {% endblock %}
             </div>
         </div>
         <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
@@ -67,7 +67,9 @@
                     </div>
                 </div>
 
-                {{ form_rest(giftOptionsForm) }}
+                {% block order_gift_options_preferences_form_rest %}
+                  {{ form_rest(giftOptionsForm) }}
+                {% endblock %}
             </div>
         </div>
         <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
@@ -66,6 +66,8 @@
                       {{ form_widget(giftOptionsForm.offer_recyclable_pack) }}
                     </div>
                 </div>
+
+                {{ form_rest(giftOptionsForm) }}
             </div>
         </div>
         <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig
@@ -32,7 +32,13 @@
     </div>
     <div class="card-block row">
       <div class="card-text">
-        {{ ps.form_group_row(metaForm.page_name, {'attr': {'class': 'js-meta-page-name', 'data-toggle': 'select2', 'data-minimumResultsForSearch': '7'}}, {
+        {{ ps.form_group_row(metaForm.page_name, {
+          'attr': {
+            'class': 'js-meta-page-name',
+            'data-toggle': 'select2',
+            'data-minimumResultsForSearch': '7'
+          }
+        }, {
           'label': 'Page name'|trans({}, 'Admin.Shopparameters.Feature'),
           'help': 'Name of the related page.'|trans({}, 'Admin.Shopparameters.Help')
         }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig
@@ -25,75 +25,73 @@
 
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
-{% block form %}
-    {{ form_start(metaForm) }}
-      <div class="card">
-        <div class="card-header">
-          {{ 'Meta tags'|trans({}, 'Admin.Shopparameters.Feature') }}
-        </div>
-        <div class="card-block row">
-          <div class="card-text">
-            {{ ps.form_group_row(metaForm.page_name, {'attr': {'class': 'js-meta-page-name', 'data-toggle': 'select2', 'data-minimumResultsForSearch': '7'}}, {
-              'label': 'Page name'|trans({}, 'Admin.Shopparameters.Feature'),
-              'help': 'Name of the related page.'|trans({}, 'Admin.Shopparameters.Help')
-            }) }}
+{{ form_start(metaForm) }}
+  <div class="card">
+    <div class="card-header">
+      {{ 'Meta tags'|trans({}, 'Admin.Shopparameters.Feature') }}
+    </div>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ ps.form_group_row(metaForm.page_name, {'attr': {'class': 'js-meta-page-name', 'data-toggle': 'select2', 'data-minimumResultsForSearch': '7'}}, {
+          'label': 'Page name'|trans({}, 'Admin.Shopparameters.Feature'),
+          'help': 'Name of the related page.'|trans({}, 'Admin.Shopparameters.Help')
+        }) }}
 
-            {% set pageTitleHelpLabel %}
-              {{ 'Title of this page.'|trans({}, 'Admin.Shopparameters.Help') }}
-              {{ 'Invalid characters:'|trans({}, 'Admin.Shopparameters.Help') ~ '  <>={}'}}
-            {% endset %}
+        {% set pageTitleHelpLabel %}
+          {{ 'Title of this page.'|trans({}, 'Admin.Shopparameters.Help') }}
+          {{ 'Invalid characters:'|trans({}, 'Admin.Shopparameters.Help') ~ '  <>={}'}}
+        {% endset %}
 
-            {{ ps.form_group_row(metaForm.page_title, {}, {
-              'label': 'Page title'|trans({}, 'Admin.Shopparameters.Feature'),
-              'help': pageTitleHelpLabel
-            }) }}
+        {{ ps.form_group_row(metaForm.page_title, {}, {
+          'label': 'Page title'|trans({}, 'Admin.Shopparameters.Feature'),
+          'help': pageTitleHelpLabel
+        }) }}
 
-            {% set metaDescriptionHelpLabel %}
-              {{ 'A short description of your shop.'|trans({}, 'Admin.Shopparameters.Help') }}
-              {{ 'Invalid characters:'|trans({}, 'Admin.Shopparameters.Help') ~ ' <>={}' }}
-            {% endset %}
+        {% set metaDescriptionHelpLabel %}
+          {{ 'A short description of your shop.'|trans({}, 'Admin.Shopparameters.Help') }}
+          {{ 'Invalid characters:'|trans({}, 'Admin.Shopparameters.Help') ~ ' <>={}' }}
+        {% endset %}
 
-            {{ ps.form_group_row(metaForm.meta_description, {}, {
-              'label': 'Meta description'|trans({}, 'Admin.Global'),
-              'help': metaDescriptionHelpLabel
-            }) }}
+        {{ ps.form_group_row(metaForm.meta_description, {}, {
+          'label': 'Meta description'|trans({}, 'Admin.Global'),
+          'help': metaDescriptionHelpLabel
+        }) }}
 
-            {% set metaKeywordsHelpLabel %}
-              {{ 'List of keywords for search engines.'|trans({}, 'Admin.Shopparameters.Help') }}
-              {{ 'To add tags, click in the field, write something, and then press the "Enter" key.'|trans({}, 'Admin.Shopparameters.Help') }}
-              {{ 'Invalid characters:'|trans({}, 'Admin.Shopparameters.Help') ~ ' <>={}' }}
-            {% endset %}
+        {% set metaKeywordsHelpLabel %}
+          {{ 'List of keywords for search engines.'|trans({}, 'Admin.Shopparameters.Help') }}
+          {{ 'To add tags, click in the field, write something, and then press the "Enter" key.'|trans({}, 'Admin.Shopparameters.Help') }}
+          {{ 'Invalid characters:'|trans({}, 'Admin.Shopparameters.Help') ~ ' <>={}' }}
+        {% endset %}
 
-            {{ ps.form_group_row(metaForm.meta_keywords, {}, {
-              'label': 'Meta keywords'|trans({}, 'Admin.Global'),
-              'help': metaKeywordsHelpLabel
-            }) }}
+        {{ ps.form_group_row(metaForm.meta_keywords, {}, {
+          'label': 'Meta keywords'|trans({}, 'Admin.Global'),
+          'help': metaKeywordsHelpLabel
+        }) }}
 
-            {% set rewriteUrlHelpLabel %}
-              {{ 'For instance, "contacts" for http://example.com/shop/contacts to redirect to http://example.com/shop/contact-form.php'|trans({}, 'Admin.Shopparameters.Help') }}
-              {{ 'Only letters and hyphens are allowed.'|trans({}, 'Admin.Shopparameters.Help') }}
-            {% endset %}
+        {% set rewriteUrlHelpLabel %}
+          {{ 'For instance, "contacts" for http://example.com/shop/contacts to redirect to http://example.com/shop/contact-form.php'|trans({}, 'Admin.Shopparameters.Help') }}
+          {{ 'Only letters and hyphens are allowed.'|trans({}, 'Admin.Shopparameters.Help') }}
+        {% endset %}
 
-            {{ ps.form_group_row(metaForm.url_rewrite, {'attr': {'class': 'js-url-rewrite'}}, {
-              'label': 'Rewritten URL'|trans({}, 'Admin.Shopparameters.Feature'),
-              'help': rewriteUrlHelpLabel
-            }) }}
+        {{ ps.form_group_row(metaForm.url_rewrite, {'attr': {'class': 'js-url-rewrite'}}, {
+          'label': 'Rewritten URL'|trans({}, 'Admin.Shopparameters.Feature'),
+          'help': rewriteUrlHelpLabel
+        }) }}
 
-            {% block meta_form_rest %}
-              {{ form_rest(metaForm) }}
-            {% endblock %}
-          </div>
-        </div>
-        <div class="card-footer">
-          <div class="d-inline-flex">
-            <a href="{{ path('admin_metas_index') }}" class="btn btn-outline-secondary">
-              {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-            </a>
-          </div>
-          <div class="d-inline-flex float-right">
-            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-          </div>
-        </div>
+        {% block meta_form_rest %}
+          {{ form_rest(metaForm) }}
+        {% endblock %}
       </div>
-    {{ form_end(metaForm) }}
-{% endblock %}
+    </div>
+    <div class="card-footer">
+      <div class="d-inline-flex">
+        <a href="{{ path('admin_metas_index') }}" class="btn btn-outline-secondary">
+          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+        </a>
+      </div>
+      <div class="d-inline-flex float-right">
+        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
+  </div>
+{{ form_end(metaForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
@@ -56,7 +56,9 @@
                   </tbody>
                 </table>
 
-                {{ form_rest(pageLayoutCustomizationForm) }}
+                {% block page_layout_customization_form_rest %}
+                  {{ form_rest(pageLayoutCustomizationForm) }}
+                {% endblock %}
               </div>
               <div class="card-footer">
                 <div class="d-flex justify-content-end">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
@@ -55,6 +55,8 @@
                     {% endfor %}
                   </tbody>
                 </table>
+
+                {{ form_rest(pageLayoutCustomizationForm) }}
               </div>
               <div class="card-footer">
                 <div class="d-flex justify-content-end">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
@@ -120,8 +120,10 @@
               </div>
             </div>
           </div>
-          
-          {{ form_rest(importThemeForm) }}
+
+          {% block import_theme_form_rest %}
+            {{ form_rest(importThemeForm) }}
+          {% endblock %}
         </div>
 
       {{ form_end(importThemeForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
@@ -120,6 +120,8 @@
               </div>
             </div>
           </div>
+          
+          {{ form_rest(importThemeForm) }}
         </div>
 
       {{ form_end(importThemeForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
@@ -59,7 +59,9 @@
           }) }}
         {% endif %}
 
-        {{ form_rest(currencyForm) }}
+        {% block currency_form_rest %}
+          {{ form_rest(currencyForm) }}
+        {% endblock %}
       </div>
     </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
@@ -58,6 +58,8 @@
             'label': 'Shop association'|trans({}, 'Admin.Global'),
           }) }}
         {% endif %}
+
+        {{ form_rest(currencyForm) }}
       </div>
     </div>
 
@@ -73,6 +75,5 @@
     </div>
 
   </div>
-  {{ form_rest(currencyForm) }}
   {{ form_end(currencyForm) }}
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fixes position of `form_reset` in templates.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Nothing to test.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13820)
<!-- Reviewable:end -->
