### PR TITLE
Fix manufacturers, taxes lists id filtering

### DIFF
--- a/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
+++ b/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
@@ -99,16 +99,6 @@ final class ManufacturerAddressQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     private function getQueryBuilderByFilters(array $filters)
     {
-        $allowedFilters = [
-            'id_address',
-            'name',
-            'firstname',
-            'lastname',
-            'postcode',
-            'city',
-            'country',
-        ];
-
         $qb = $this->connection
             ->createQueryBuilder()
             ->from($this->dbPrefix . 'address', 'a')
@@ -129,49 +119,46 @@ final class ManufacturerAddressQueryBuilder extends AbstractDoctrineQueryBuilder
             ->andWhere('a.id_warehouse = 0')
             ->andWhere('a.deleted = 0')
         ;
+        $this->applyFilters($qb, $filters);
 
-        foreach ($filters as $name => $value) {
-            if (!in_array($name, $allowedFilters, true)) {
+        return $qb;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param array $filters
+     */
+    private function applyFilters(QueryBuilder $qb, array $filters)
+    {
+        $allowedFiltersMap = [
+            'id_address' => 'a.id_address',
+            'name' => 'm.name',
+            'firstname' => 'a.firstname',
+            'lastname' => 'a.lastname',
+            'postcode' => 'a.postcode',
+            'city' => 'a.city',
+            'country' => 'a.id_country',
+        ];
+        $exactMatchingFilters = ['id_address', 'country'];
+
+        foreach ($filters as $filterName => $value) {
+            if (!array_key_exists($filterName, $allowedFiltersMap)) {
                 continue;
             }
 
-            if ('id_address' === $name) {
-                $qb
-                    ->andWhere("a.id_address = :$name")
-                    ->setParameter($name, $value)
-                ;
-
-                continue;
-            }
-
-            if ('name' === $name) {
-                $qb
-                    ->andWhere("m.name LIKE :$name")
-                    ->setParameter($name, '%' . $value . '%')
-                ;
-
-                continue;
-            }
-
-            if ('country' === $name) {
+            if (in_array($filterName, $exactMatchingFilters, true)) {
                 if (empty($value)) {
                     continue;
                 }
 
-                $qb
-                    ->andWhere("a.id_country = :$name")
-                    ->setParameter($name, $value)
-                ;
+                $qb->andWhere($allowedFiltersMap[$filterName] . " = :$filterName")
+                    ->setParameter($filterName, $value);
 
                 continue;
             }
 
-            $qb
-                ->andWhere("a.$name LIKE :$name")
-                ->setParameter($name, '%' . $value . '%')
-            ;
+            $qb->andWhere($allowedFiltersMap[$filterName] . " LIKE :$filterName")
+                ->setParameter($filterName, '%' . $value . '%');
         }
-
-        return $qb;
     }
 }

--- a/src/Core/Grid/Query/ManufacturerQueryBuilder.php
+++ b/src/Core/Grid/Query/ManufacturerQueryBuilder.php
@@ -134,18 +134,14 @@ final class ManufacturerQueryBuilder extends AbstractDoctrineQueryBuilder
             if (!in_array($filterName, $allowedFilters, true)) {
                 continue;
             }
-            if ('active' === $filterName) {
-                $qb->andWhere('m.`active` = :active');
-                $qb->setParameter('active', $value);
-                continue;
-            }
+
             if ('name' === $filterName) {
                 $qb->andWhere('m.`name` LIKE :' . $filterName)
                     ->setParameter($filterName, '%' . $value . '%');
                 continue;
             }
-            $qb->andWhere('m.`' . $filterName . '` LIKE :' . $filterName)
-                ->setParameter($filterName, '%' . $value . '%');
+            $qb->andWhere('m.`' . $filterName . '` = :' . $filterName)
+                ->setParameter($filterName, $value);
         }
 
         $qb->andWhere('ms.`id_shop` IN (:contextShopIds)');

--- a/src/Core/Grid/Query/TaxQueryBuilder.php
+++ b/src/Core/Grid/Query/TaxQueryBuilder.php
@@ -142,7 +142,7 @@ final class TaxQueryBuilder extends AbstractDoctrineQueryBuilder
                 continue;
             }
 
-            $qb->andWhere($allowedFiltersMap[$filterName] . '` LIKE :' . $filterName)
+            $qb->andWhere($allowedFiltersMap[$filterName] . ' LIKE :' . $filterName)
                 ->setParameter($filterName, '%' . $value . '%');
         }
     }

--- a/src/Core/Grid/Query/TaxQueryBuilder.php
+++ b/src/Core/Grid/Query/TaxQueryBuilder.php
@@ -103,13 +103,6 @@ final class TaxQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     private function getQueryBuilder(array $filters)
     {
-        $allowedFilters = [
-            'id_tax',
-            'name',
-            'rate',
-            'active',
-        ];
-
         $qb = $this->connection
             ->createQueryBuilder()
             ->from($this->dbPrefix . 'tax', 't')
@@ -118,34 +111,39 @@ final class TaxQueryBuilder extends AbstractDoctrineQueryBuilder
                 $this->dbPrefix . 'tax_lang',
                 'tl',
                 't.`id_tax` = tl.`id_tax`'
-        );
+            );
         $qb->andWhere('tl.`id_lang` = :employee_id_lang');
         $qb->andWhere('t.`deleted` = 0');
 
         $qb->setParameter('employee_id_lang', $this->employeeIdLang);
-
-        foreach ($filters as $filterName => $value) {
-            if (!in_array($filterName, $allowedFilters, true)) {
-                continue;
-            }
-
-            if ('active' === $filterName) {
-                $qb->andWhere('t.`active` = :active');
-                $qb->setParameter('active', $value);
-
-                continue;
-            }
-
-            if ('name' === $filterName) {
-                $qb->andWhere('tl.`name` LIKE :' . $filterName)
-                    ->setParameter($filterName, '%' . $value . '%');
-                continue;
-            }
-
-            $qb->andWhere('t.`' . $filterName . '` LIKE :' . $filterName)
-                ->setParameter($filterName, '%' . $value . '%');
-        }
+        $this->applyFilters($qb, $filters);
 
         return $qb;
+    }
+
+    private function applyFilters(QueryBuilder $qb, array $filters)
+    {
+        $allowedFiltersMap = [
+            'id_tax' => 't.id_tax',
+            'name' => 'tl.name',
+            'rate' => 't.rate',
+            'active' => 't.active',
+        ];
+
+        foreach ($filters as $filterName => $value) {
+            if (!array_key_exists($filterName, $allowedFiltersMap)) {
+                continue;
+            }
+
+            if ('active' === $filterName || 'id_tax' === $filterName) {
+                $qb->andWhere($allowedFiltersMap[$filterName] . ' = :' . $filterName);
+                $qb->setParameter($filterName, $value);
+
+                continue;
+            }
+
+            $qb->andWhere($allowedFiltersMap[$filterName] . '` LIKE :' . $filterName)
+                ->setParameter($filterName, '%' . $value . '%');
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | `Manufacturers` (a.k.a Brands), `Manufacturer addresses` and `Tax` lists filtering the id value was done with sql `LIKE` query, but it should work with exact match. In this PR i modified Query builders to fix that.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | `Sell > Catalog > Brands & Suppliers` and `Improve > International > Tax` page lists filtering should all work the same as before, except the identification fields (id_manufacturer, id_address, id_tax). Those fields filter should match exact values. For example if you write filter id of 12, it should find only item which id is equal to 12. (previous behavior would find numbers containing 12, like: 12, 122, 112 etc..).
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13821)
<!-- Reviewable:end -->
