### PR TITLE
Enable global kernel for legacy compatibility for Behat tests

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -53,7 +53,6 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
         global $kernel;
         $kernel = self::$kernel;
 
-        $employeeId = \Employee::employeeExists('test@prestashop.com');
         $employee = new \Employee();
         \Context::getContext()->employee = $employee->getByEmail('test@prestashop.com');
     }

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -49,6 +49,12 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
 
         self::$kernel = new AppKernel('test', true);
         self::$kernel->boot();
+
+        global $kernel;
+        $kernel = self::$kernel;
+
+        $employeeId = \Employee::employeeExists('test@prestashop.com');
+        \Context::getContext()->employee = new \Employee($employeeId);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -54,7 +54,8 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
         $kernel = self::$kernel;
 
         $employeeId = \Employee::employeeExists('test@prestashop.com');
-        \Context::getContext()->employee = new \Employee($employeeId);
+        $employee = new \Employee();
+        \Context::getContext()->employee = $employee->getByEmail('test@prestashop.com');
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Some core prestashop classes require a global kernel declared. In order to mimic this environment, I added it to Behat fixtures. I also added a fake employee login in order to allow some services (that require one) to work.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Travis is green

Should help https://github.com/PrestaShop/PrestaShop/pull/13554

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13826)
<!-- Reviewable:end -->
