### PR TITLE
Revert "Only run deploy if the triggered commit is recent"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,6 @@ matrix:
         local-dir: "/tmp/ps-release"
         on:
           all_branches: true
-          condition: "$(date --date \"$(git show -s --format=%cI $TRAVIS_COMMIT)\" +%s)\" -gt \"$(date --date '1 day ago' +%s)\""
   exclude:
     - php: 7.2 # Replaced with additional tests
       env: PRESTASHOP_TEST_TYPE=e2e


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Reverts PrestaShop/PrestaShop#13018<br>Because Travis says bullshit `condition: deploy when a single bash condition evaluates to true. This must be a string value, and is equivalent to if [[ <condition> ]]; then <deploy>; fi. For example, $CC = gcc` which is wrong, only accept specific condition (`=`, `!=`, `~=`) :/
 Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Travis must be green.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13827)
<!-- Reviewable:end -->
