### PR TITLE
Fix resetting sort and items per page on list filters reset action

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -280,17 +280,22 @@ class CommonController extends FrameworkBundleAdminController
     public function resetSearchAction($controller = '', $action = '', $filterId = '')
     {
         $adminFiltersRepository = $this->get('prestashop.core.admin.admin_filter.repository');
+        $employeeId = $this->getUser()->getId();
+        $shopId = $this->getContext()->shop->id;
 
         // for compatibility when $controller and $action are used
         if (!empty($controller) && !empty($action)) {
-            $employeeId = $this->getUser()->getId();
-            $shopId = $this->getContext()->shop->id;
-
-            $adminFiltersRepository->removeByEmployeeAndRouteParams($employeeId, $shopId, $controller, $action);
+            $adminFilter = $adminFiltersRepository->findByEmployeeAndRouteParams(
+                $employeeId, $shopId, $controller, $action
+            );
         }
 
         if (!empty($filterId)) {
-            $adminFiltersRepository->removeByFilterId($filterId);
+            $adminFilter = $adminFiltersRepository->findByEmployeeAndFilterId($employeeId, $shopId, $filterId);
+        }
+
+        if (isset($adminFilter)) {
+            $adminFiltersRepository->resetFilters($adminFilter);
         }
 
         return new JsonResponse();

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -295,7 +295,7 @@ class CommonController extends FrameworkBundleAdminController
         }
 
         if (isset($adminFilter)) {
-            $adminFiltersRepository->resetFilters($adminFilter);
+            $adminFiltersRepository->unsetFilters($adminFilter);
         }
 
         return new JsonResponse();

--- a/src/PrestaShopBundle/Entity/Repository/AdminFilterRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AdminFilterRepository.php
@@ -99,23 +99,18 @@ class AdminFilterRepository extends EntityRepository
      * Removes filters from ps_admin_filter `filters` column using provided AdminFilter entity.
      *
      * @param AdminFilter $adminFilter
-     * @param array $filtersToKeep - Names of filters which values should not be removed
      *
      * @throws OptimisticLockException
      */
-    public function resetFilters(
-        AdminFilter $adminFilter,
-        array $filtersToKeep = ['limit', 'sortOrder', 'orderBy']
-    ) {
-        $currentFilters = json_decode($adminFilter->getFilter());
-        $newFilters = [];
+    public function unsetFilters(AdminFilter $adminFilter)
+    {
+        $currentFilters = json_decode($adminFilter->getFilter(), true);
 
-        foreach ($currentFilters as $filterName => $value) {
-            if (in_array($filterName, $filtersToKeep, true)) {
-                $newFilters[$filterName] = $value;
-            }
-        }
-        $adminFilter->setFilter(json_encode($newFilters));
+        // reset offset to show first page of list after filters resetting
+        $currentFilters['offset'] = 0;
+        // unset list columns filters
+        unset($currentFilters['filters']);
+        $adminFilter->setFilter(json_encode($currentFilters));
 
         $this->getEntityManager()->persist($adminFilter);
         $this->getEntityManager()->flush();

--- a/src/PrestaShopBundle/Entity/Repository/AdminFilterRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AdminFilterRepository.php
@@ -27,6 +27,8 @@
 namespace PrestaShopBundle\Entity\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMInvalidArgumentException;
 use PrestaShopBundle\Entity\AdminFilter;
 
 /**
@@ -74,19 +76,14 @@ class AdminFilterRepository extends EntityRepository
      * @param $controller
      * @param $action
      *
-     * @throws \Doctrine\ORM\ORMInvalidArgumentException
-     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws ORMInvalidArgumentException
+     * @throws OptimisticLockException
      *
      * @return bool Returns false if entity was not found
      */
     public function removeByEmployeeAndRouteParams($employeeId, $shopId, $controller, $action)
     {
-        $adminFilter = $this->findOneBy([
-            'employee' => $employeeId ?: 0,
-            'shop' => $shopId ?: 0,
-            'controller' => $controller,
-            'action' => $action,
-        ]);
+        $adminFilter = $this->findByEmployeeAndRouteParams($employeeId, $shopId, $controller, $action);
 
         if (null === $adminFilter) {
             return false;
@@ -99,21 +96,28 @@ class AdminFilterRepository extends EntityRepository
     }
 
     /**
-     * @param string $filterId
+     * Removes filters from ps_admin_filter `filters` column using provided AdminFilter entity.
      *
-     * @throws \Doctrine\ORM\OptimisticLockException
+     * @param AdminFilter $adminFilter
+     * @param array $filtersToKeep - Names of filters which values should not be removed
+     *
+     * @throws OptimisticLockException
      */
-    public function removeByFilterId($filterId)
-    {
-        $adminFilter = $this->findOneBy([
-            'filterId' => $filterId,
-        ]);
+    public function resetFilters(
+        AdminFilter $adminFilter,
+        array $filtersToKeep = ['limit', 'sortOrder', 'orderBy']
+    ) {
+        $currentFilters = json_decode($adminFilter->getFilter());
+        $newFilters = [];
 
-        if (null === $adminFilter) {
-            return;
+        foreach ($currentFilters as $filterName => $value) {
+            if (in_array($filterName, $filtersToKeep, true)) {
+                $newFilters[$filterName] = $value;
+            }
         }
+        $adminFilter->setFilter(json_encode($newFilters));
 
-        $this->getEntityManager()->remove($adminFilter);
+        $this->getEntityManager()->persist($adminFilter);
         $this->getEntityManager()->flush();
     }
 
@@ -125,7 +129,7 @@ class AdminFilterRepository extends EntityRepository
      * @param array $filters
      * @param string $filterId
      *
-     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws OptimisticLockException
      */
     public function createOrUpdateByEmployeeAndFilterId(
         $employeeId,
@@ -133,12 +137,7 @@ class AdminFilterRepository extends EntityRepository
         array $filters,
         $filterId
     ) {
-        $adminFilter = $this->findOneBy([
-            'employee' => $employeeId,
-            'shop' => $shopId,
-            'filterId' => $filterId,
-        ]);
-
+        $adminFilter = $this->findByEmployeeAndFilterId($employeeId, $shopId, $filterId);
         $adminFilter = null === $adminFilter ? new AdminFilter() : $adminFilter;
 
         $adminFilter
@@ -163,7 +162,7 @@ class AdminFilterRepository extends EntityRepository
      * @param string $controller
      * @param string $action
      *
-     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws OptimisticLockException
      */
     public function createOrUpdateByEmployeeAndRouteParams(
         $employeeId,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Modified filters reset action. Now its resetting list columns filters and offset, leaving `items per page` and `sorting` unchanged.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #13799
| How to test?  | Should work with all new migrated lists (except Products list, because it's not using same grid system, the Products list should not be affected by these changes). For example go to `Improve > International > Taxes` list and filter it by any column. Change sorting of any field and/or Items per page. After all these actions, press reset filters. **Filter fields should be resetted to defaults**. The **sort and items per page should not be resetted**. (sort and items per page should stay the same as previously selected).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13840)
<!-- Reviewable:end -->
