### PR TITLE
Fix typo mistake in product_preferences.yml

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/product_preferences.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/product_preferences.yml
@@ -3,13 +3,13 @@ admin_product_preferences:
     methods: [GET]
     defaults:
         _controller: 'PrestaShopBundle:Admin\Configure\ShopParameters\ProductPreferences:index'
-        _legacy_controller: AdminPPreferences
-        _legacy_link: AdminPPreferences
+        _legacy_controller: AdminPreferences
+        _legacy_link: AdminPreferences
 
 admin_product_preferences_process:
     path: /
     methods: [POST]
     defaults:
         _controller: 'PrestaShopBundle:Admin\Configure\ShopParameters\ProductPreferences:process'
-        _legacy_controller: AdminPPreferences
-        _legacy_link: AdminPPreferences:update
+        _legacy_controller: AdminPreferences
+        _legacy_link: AdminPreferences:update


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Tiny typo mistake- in routing file product_preferences.yml 'AdminPPreferences' (referenced in _legacy_controller and _legacy_link keys) changed to AdminPreferences
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  |

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13842)
<!-- Reviewable:end -->
