### PR TITLE
Fix cart rule calculation for free gift

### DIFF
--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -115,8 +115,8 @@ class CartRuleCalculator
                     && ($product['id_product_attribute'] == $cartRule->gift_product_attribute
                         || !(int) $cartRule->gift_product_attribute)
                 ) {
-                    $cartRow->applyFlatDiscount($cartRow->getFinalUnitPrice());
                     $cartRuleData->addDiscountApplied($cartRow->getFinalUnitPrice());
+                    $cartRow->applyFlatDiscount($cartRow->getFinalUnitPrice());
                 }
             }
         }

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
@@ -193,3 +193,41 @@ Feature: Check cart to order data copy
     Then current cart order should have a discount in position 1 with an amount of 20.6 tax included and 19.81 tax excluded
     Then customer "customer1" should have 1 cart rules that apply to him
     Then cart rule for customer "customer1" in position 1 should apply a discount of 480.19
+
+    @current
+  Scenario: 1 product in cart, 1 cart rule offering free gift
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product4" with a price of 35.567 and 1000 items in stock
+    Given there is a cart rule named "cartrule13" that applies no discount with priority 13, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule13" has a discount code "foo13"
+    Given cart rule "cartrule13" offers a gift product "product4"
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given product "product4" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I use the discount "cartrule13"
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    Then current cart order total for products should be 57.59 tax included
+    Then current cart order total for products should be 55.38 tax excluded
+    Then current cart order total discount should be 36.99 tax included
+    Then current cart order total discount should be 35.57 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded
+    Then current cart order should have a discount in position 1 with an amount of 36.99 tax included and 35.57 tax excluded
+    Then customer "customer1" should have 0 cart rules that apply to him

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
@@ -194,7 +194,6 @@ Feature: Check cart to order data copy
     Then customer "customer1" should have 1 cart rules that apply to him
     Then cart rule for customer "customer1" in position 1 should apply a discount of 480.19
 
-    @current
   Scenario: 1 product in cart, 1 cart rule offering free gift
     Given I have an empty default cart
     Given email sending is disabled
@@ -225,6 +224,44 @@ Feature: Check cart to order data copy
     When I validate my cart using payment module fake
     Then current cart order total for products should be 57.59 tax included
     Then current cart order total for products should be 55.38 tax excluded
+    Then current cart order total discount should be 36.99 tax included
+    Then current cart order total discount should be 35.57 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded
+    Then current cart order should have a discount in position 1 with an amount of 36.99 tax included and 35.57 tax excluded
+    Then customer "customer1" should have 0 cart rules that apply to him
+
+  Scenario: 2 product in cart, 1 cart rule offering free gift, offering same product as already existing in cart
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product4" with a price of 35.567 and 1000 items in stock
+    Given there is a cart rule named "cartrule13" that applies no discount with priority 13, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule13" has a discount code "foo13"
+    Given cart rule "cartrule13" offers a gift product "product4"
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given product "product4" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I add 1 items of product "product4" in my cart
+    When I use the discount "cartrule13"
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    Then current cart order total for products should be 94.58 tax included
+    Then current cart order total for products should be 90.94 tax excluded
     Then current cart order total discount should be 36.99 tax included
     Then current cart order total discount should be 35.57 tax excluded
     Then current cart order shipping fees should be 7.0 tax included


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fixes an issue calculating cart rule on order details when order contains a free gift
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13767
| How to test?  | see https://github.com/PrestaShop/PrestaShop/issues/13767

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13866)
<!-- Reviewable:end -->
