### PR TITLE
Extract theme folder scanning into an external class FolderThemeScanner

### DIFF
--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -204,9 +204,13 @@
                 <tab id="Themes_Catalog" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
                     <class_name>AdminThemesCatalog</class_name>
                 </tab>
-                <tab id="Mail_Theme" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
-                  <class_name>AdminMailTheme</class_name>
+                <tab id="Mail_Theme_Parent" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
+                  <class_name>AdminMailThemeParent</class_name>
                 </tab>
+                    <tab id="Mail_Theme" id_parent="Mail_Theme_Parent" active="1" hide_host_mode="0" icon="">
+                      <class_name>AdminMailTheme</class_name>
+                    </tab>
+
                 <tab id="Pages" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
                     <class_name>AdminCmsContent</class_name>
                 </tab>

--- a/install-dev/langs/en/data/tab.xml
+++ b/install-dev/langs/en/data/tab.xml
@@ -64,6 +64,7 @@
     <tab id="Logs" name="Logs" />
     <tab id="Look_feel" name="Design" />
     <tab id="Mail_Theme" name="Email Theme" />
+    <tab id="Mail_Theme_Parent" name="Email Theme" />
     <tab id="Maintenance" name="Maintenance" />
     <tab id="Manufacturers_and_suppliers" name="Brands &amp; Suppliers" />
     <tab id="Manufacturers" name="Brands" />

--- a/install-dev/upgrade/php/ps_1760_update_tabs.php
+++ b/install-dev/upgrade/php/ps_1760_update_tabs.php
@@ -31,9 +31,13 @@ function ps_1760_update_tabs()
 {
     // STEP 1: Add new sub menus for modules (tab may exist but we need authorization roles to be added as well)
     $moduleTabsToBeAdded = array(
-        'AdminMailTheme' => [
+        'AdminMailThemeParent' => [
             'translations' => 'en:Email Themes',
             'parent' => 'AdminParentThemes',
+        ],
+        'AdminMailTheme' => [
+            'translations' => 'en:Email Themes',
+            'parent' => 'AdminMailThemeParent',
         ],
         'AdminModulesUpdates' => array(
             'translations' => 'en:Updates|fr:Mises à jour|es:Actualizaciones|de:Aktualisierung|it:Aggiornamenti',

--- a/src/Core/MailTemplate/FolderThemeCatalog.php
+++ b/src/Core/MailTemplate/FolderThemeCatalog.php
@@ -50,13 +50,17 @@ final class FolderThemeCatalog implements ThemeCatalogInterface
 
     /**
      * @param string $mailThemesFolder
+     * @param FolderThemeScanner $scanner
      * @param HookDispatcherInterface $hookDispatcher
      */
-    public function __construct($mailThemesFolder, HookDispatcherInterface $hookDispatcher)
-    {
+    public function __construct(
+        $mailThemesFolder,
+        FolderThemeScanner $scanner,
+        HookDispatcherInterface $hookDispatcher
+    ) {
         $this->mailThemesFolder = $mailThemesFolder;
+        $this->scanner = $scanner;
         $this->hookDispatcher = $hookDispatcher;
-        $this->scanner = new FolderThemeScanner();
     }
 
     /**

--- a/src/Core/MailTemplate/FolderThemeCatalog.php
+++ b/src/Core/MailTemplate/FolderThemeCatalog.php
@@ -30,28 +30,23 @@ use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Exception\TypeException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
-use PrestaShop\PrestaShop\Core\MailTemplate\Layout\Layout;
-use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutCollection;
-use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutCollectionInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * This is a basic mail layouts catalog, not a lot of intelligence it is based
  * simply on existing files on the $mailThemesFolder (no database, or config files).
- * If a module includes its own theme folder it can override the default one through
- * the hook:
- *  FolderThemeCatalog::GET_MAIL_THEME_FOLDER_HOOK => actionGetMailThemeFolder
  */
-class FolderThemeCatalog implements ThemeCatalogInterface
+final class FolderThemeCatalog implements ThemeCatalogInterface
 {
-    const GET_MAIL_THEME_FOLDER_HOOK = 'actionGetMailThemeFolder';
-
     /** @var string */
     private $mailThemesFolder;
 
     /** @var HookDispatcherInterface */
     private $hookDispatcher;
+
+    /** @var FolderThemeScanner */
+    private $scanner;
 
     /**
      * @param string $mailThemesFolder
@@ -61,6 +56,7 @@ class FolderThemeCatalog implements ThemeCatalogInterface
     {
         $this->mailThemesFolder = $mailThemesFolder;
         $this->hookDispatcher = $hookDispatcher;
+        $this->scanner = new FolderThemeScanner();
     }
 
     /**
@@ -81,12 +77,8 @@ class FolderThemeCatalog implements ThemeCatalogInterface
         $mailThemes = new ThemeCollection();
         /** @var SplFileInfo $mailThemeFolder */
         foreach ($finder as $mailThemeFolder) {
-            $dirFinder = new Finder();
-            $dirFinder->files()->in($mailThemeFolder->getRealPath());
-            if ($dirFinder->count() > 0) {
-                $mailTheme = new Theme($mailThemeFolder->getFilename());
-                $layouts = $this->findThemeLayouts($mailTheme->getName());
-                $mailTheme->setLayouts($layouts);
+            $mailTheme = $this->scanner->scan($mailThemeFolder->getRealPath());
+            if ($mailTheme->getLayouts()->count() > 0) {
                 $mailThemes[] = $mailTheme;
             }
         }
@@ -130,129 +122,6 @@ class FolderThemeCatalog implements ThemeCatalogInterface
     }
 
     /**
-     * @param string $mailTheme
-     *
-     * @throws FileNotFoundException
-     * @throws TypeException
-     *
-     * @return LayoutCollectionInterface
-     */
-    private function findThemeLayouts($mailTheme)
-    {
-        $mailThemeFolder = implode(DIRECTORY_SEPARATOR, [$this->mailThemesFolder, $mailTheme]);
-        //This hook allows to change the mail them folder
-        $this->hookDispatcher->dispatchWithParameters(
-            static::GET_MAIL_THEME_FOLDER_HOOK,
-            [
-                'mailTheme' => $mailTheme,
-                'mailThemeFolder' => &$mailThemeFolder,
-            ]
-        );
-        $this->checkThemeFolder($mailThemeFolder);
-
-        $mailThemeLayouts = new LayoutCollection();
-        $this->addCoreLayouts($mailThemeLayouts, $mailThemeFolder);
-        $this->addModulesLayouts($mailThemeLayouts, $mailThemeFolder);
-
-        return $mailThemeLayouts;
-    }
-
-    /**
-     * @param LayoutCollectionInterface $collection
-     * @param string $mailThemeFolder
-     */
-    private function addCoreLayouts(LayoutCollectionInterface $collection, $mailThemeFolder)
-    {
-        $coreLayoutsFolder = implode(DIRECTORY_SEPARATOR, [
-            $mailThemeFolder,
-            MailTemplateInterface::CORE_CATEGORY,
-        ]);
-        if (!is_dir($coreLayoutsFolder)) {
-            return;
-        }
-
-        $this->addLayoutsFromFolder($collection, $coreLayoutsFolder);
-    }
-
-    /**
-     * @param LayoutCollectionInterface $collection
-     * @param string $mailThemeFolder
-     */
-    private function addModulesLayouts(LayoutCollectionInterface $collection, $mailThemeFolder)
-    {
-        $moduleLayoutsFolder = implode(DIRECTORY_SEPARATOR, [
-            $mailThemeFolder,
-            MailTemplateInterface::MODULES_CATEGORY,
-        ]);
-        if (!is_dir($moduleLayoutsFolder)) {
-            return;
-        }
-
-        $moduleFinder = new Finder();
-        $moduleFinder->directories()->in($moduleLayoutsFolder)->depth(0);
-
-        /* @var SplFileInfo $fileInfo */
-        foreach ($moduleFinder as $moduleFileInfo) {
-            $moduleName = $moduleFileInfo->getFilename();
-            $moduleFolder = implode(DIRECTORY_SEPARATOR, [$moduleLayoutsFolder, $moduleName]);
-            $this->addLayoutsFromFolder($collection, $moduleFolder, $moduleName);
-        }
-    }
-
-    /**
-     * @param LayoutCollectionInterface $collection
-     * @param string $folder
-     * @param string $moduleName
-     */
-    private function addLayoutsFromFolder(
-        LayoutCollectionInterface $collection,
-        $folder,
-        $moduleName = ''
-    ) {
-        $layoutFiles = [];
-        $finder = new Finder();
-        $finder->files()->in($folder)->sortByName();
-        /** @var SplFileInfo $fileInfo */
-        foreach ($finder as $fileInfo) {
-            //Get filename without any extension (ex: account.html.twig -> account)
-            $layoutName = preg_replace('/\..+/', '', $fileInfo->getBasename());
-            if (!isset($layoutFiles[$layoutName])) {
-                $layoutFiles[$layoutName] = [
-                    MailTemplateInterface::HTML_TYPE => '',
-                    MailTemplateInterface::TXT_TYPE => '',
-                ];
-            }
-            $templateType = $this->getTemplateType($fileInfo);
-            $layoutFiles[$layoutName][$templateType] = $fileInfo->getRealPath();
-        }
-
-        foreach ($layoutFiles as $layoutName => $layouts) {
-            $collection->add(new Layout(
-                $layoutName,
-                $layouts[MailTemplateInterface::HTML_TYPE],
-                $layouts[MailTemplateInterface::TXT_TYPE],
-                $moduleName
-            ));
-        }
-    }
-
-    /**
-     * @param SplFileInfo $fileInfo
-     *
-     * @return string
-     */
-    private function getTemplateType(SplFileInfo $fileInfo)
-    {
-        $ext = !empty($fileInfo->getExtension()) ? '.' . $fileInfo->getExtension() : '';
-        $htmlTypeRegexp = sprintf('/.+\.%s%s/', MailTemplateInterface::HTML_TYPE, $ext);
-        if (preg_match($htmlTypeRegexp, $fileInfo->getFilename())) {
-            return MailTemplateInterface::HTML_TYPE;
-        }
-
-        return MailTemplateInterface::TXT_TYPE;
-    }
-
-    /**
      * @throws FileNotFoundException
      */
     private function checkThemesFolder()
@@ -261,19 +130,6 @@ class FolderThemeCatalog implements ThemeCatalogInterface
             throw new FileNotFoundException(sprintf(
                 'Invalid mail themes folder "%s": no such directory',
                 $this->mailThemesFolder
-            ));
-        }
-    }
-
-    /**
-     * @throws FileNotFoundException
-     */
-    private function checkThemeFolder($mailThemeFolder)
-    {
-        if (!is_dir($mailThemeFolder)) {
-            throw new FileNotFoundException(sprintf(
-                'Invalid mail theme folder "%s": no such directory',
-                $mailThemeFolder
             ));
         }
     }

--- a/src/Core/MailTemplate/FolderThemeScanner.php
+++ b/src/Core/MailTemplate/FolderThemeScanner.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\MailTemplate;
+
+use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\Exception\TypeException;
+use PrestaShop\PrestaShop\Core\MailTemplate\Layout\Layout;
+use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutCollection;
+use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutCollectionInterface;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Class FolderThemeScanner is used to scan a mail theme folder, it returns a ThemeInterface with all
+ * its layouts.
+ */
+final class FolderThemeScanner
+{
+    /**
+     * @param string $mailThemeFolder
+     *
+     * @return ThemeInterface|null
+     *
+     * @throws FileNotFoundException
+     * @throws TypeException
+     */
+    public function scan($mailThemeFolder)
+    {
+        $this->checkThemeFolder($mailThemeFolder);
+
+        $mailTheme = new Theme(basename($mailThemeFolder));
+
+        $finder = new Finder();
+        $finder->files()->in($mailThemeFolder);
+        if ($finder->count() > 0) {
+            $mailTheme->setLayouts($this->findThemeLayouts($mailThemeFolder));
+        }
+
+        return $mailTheme;
+    }
+
+    /**
+     * @param string $mailThemeFolder
+     *
+     * @throws TypeException
+     *
+     * @return LayoutCollectionInterface
+     */
+    private function findThemeLayouts($mailThemeFolder)
+    {
+        $mailThemeLayouts = new LayoutCollection();
+        $this->addCoreLayouts($mailThemeLayouts, $mailThemeFolder);
+        $this->addModulesLayouts($mailThemeLayouts, $mailThemeFolder);
+
+        return $mailThemeLayouts;
+    }
+
+    /**
+     * @param LayoutCollectionInterface $collection
+     * @param string $mailThemeFolder
+     */
+    private function addCoreLayouts(LayoutCollectionInterface $collection, $mailThemeFolder)
+    {
+        $coreLayoutsFolder = implode(DIRECTORY_SEPARATOR, [
+            $mailThemeFolder,
+            MailTemplateInterface::CORE_CATEGORY,
+        ]);
+        if (!is_dir($coreLayoutsFolder)) {
+            return;
+        }
+
+        $this->addLayoutsFromFolder($collection, $coreLayoutsFolder);
+    }
+
+    /**
+     * @param LayoutCollectionInterface $collection
+     * @param string $mailThemeFolder
+     */
+    private function addModulesLayouts(LayoutCollectionInterface $collection, $mailThemeFolder)
+    {
+        $moduleLayoutsFolder = implode(DIRECTORY_SEPARATOR, [
+            $mailThemeFolder,
+            MailTemplateInterface::MODULES_CATEGORY,
+        ]);
+        if (!is_dir($moduleLayoutsFolder)) {
+            return;
+        }
+
+        $moduleFinder = new Finder();
+        $moduleFinder->directories()->in($moduleLayoutsFolder)->depth(0);
+
+        /* @var SplFileInfo $moduleFolder */
+        foreach ($moduleFinder as $moduleFolder) {
+            $this->addLayoutsFromFolder($collection, $moduleFolder->getRealPath(), $moduleFolder->getFilename());
+        }
+    }
+
+    /**
+     * @param LayoutCollectionInterface $collection
+     * @param string $folder
+     * @param string $moduleName
+     */
+    private function addLayoutsFromFolder(
+        LayoutCollectionInterface $collection,
+        $folder,
+        $moduleName = ''
+    ) {
+        $layoutFiles = [];
+        $finder = new Finder();
+        $finder->files()->in($folder)->sortByName();
+        /** @var SplFileInfo $fileInfo */
+        foreach ($finder as $fileInfo) {
+            //Get filename without any extension (ex: account.html.twig -> account)
+            $layoutName = preg_replace('/\..+/', '', $fileInfo->getBasename());
+            if (!isset($layoutFiles[$layoutName])) {
+                $layoutFiles[$layoutName] = [
+                    MailTemplateInterface::HTML_TYPE => '',
+                    MailTemplateInterface::TXT_TYPE => '',
+                ];
+            }
+            $templateType = $this->getTemplateType($fileInfo);
+            $layoutFiles[$layoutName][$templateType] = $fileInfo->getRealPath();
+        }
+
+        foreach ($layoutFiles as $layoutName => $layouts) {
+            $collection->add(new Layout(
+                $layoutName,
+                $layouts[MailTemplateInterface::HTML_TYPE],
+                $layouts[MailTemplateInterface::TXT_TYPE],
+                $moduleName
+            ));
+        }
+    }
+
+    /**
+     * @param SplFileInfo $fileInfo
+     *
+     * @return string
+     */
+    private function getTemplateType(SplFileInfo $fileInfo)
+    {
+        $ext = !empty($fileInfo->getExtension()) ? '.' . $fileInfo->getExtension() : '';
+        $htmlTypeRegexp = sprintf('/.+\.%s%s/', MailTemplateInterface::HTML_TYPE, $ext);
+        if (preg_match($htmlTypeRegexp, $fileInfo->getFilename())) {
+            return MailTemplateInterface::HTML_TYPE;
+        }
+
+        return MailTemplateInterface::TXT_TYPE;
+    }
+
+    /**
+     * @throws FileNotFoundException
+     */
+    private function checkThemeFolder($mailThemeFolder)
+    {
+        if (!is_dir($mailThemeFolder)) {
+            throw new FileNotFoundException(sprintf(
+                'Invalid mail theme folder "%s": no such directory',
+                $mailThemeFolder
+            ));
+        }
+    }
+}

--- a/src/Core/MailTemplate/Layout/LayoutCollection.php
+++ b/src/Core/MailTemplate/Layout/LayoutCollection.php
@@ -37,4 +37,49 @@ class LayoutCollection extends AbstractTypedCollection implements LayoutCollecti
     {
         return LayoutInterface::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function merge(LayoutCollectionInterface $collection)
+    {
+        /** @var LayoutInterface $newLayout */
+        foreach ($collection as $newLayout) {
+            if (null !== ($oldLayout = $this->getLayout($newLayout->getName(), $newLayout->getModuleName()))) {
+                $this->replace($oldLayout, $newLayout);
+            } else {
+                $this->add($newLayout);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function replace(LayoutInterface $oldLayout, LayoutInterface $newLayout)
+    {
+        if (!$this->contains($oldLayout)) {
+            return false;
+        }
+
+        $oldLayoutIndex = $this->indexOf($oldLayout);
+        $this->offsetSet($oldLayoutIndex, $newLayout);
+
+        return $this->contains($newLayout);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLayout($layoutName, $moduleName)
+    {
+        /** @var LayoutInterface $layout */
+        foreach ($this as $layout) {
+            if ($layoutName === $layout->getName() && $moduleName === $layout->getModuleName()) {
+                return $layout;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Core/MailTemplate/Layout/LayoutCollectionInterface.php
+++ b/src/Core/MailTemplate/Layout/LayoutCollectionInterface.php
@@ -50,4 +50,25 @@ interface LayoutCollectionInterface extends \IteratorAggregate, \Countable
      * @param LayoutInterface $layout
      */
     public function remove($layout);
+
+    /**
+     * @param LayoutInterface $oldLayout
+     * @param LayoutInterface $newLayout
+     *
+     * @return bool
+     */
+    public function replace(LayoutInterface $oldLayout, LayoutInterface $newLayout);
+
+    /**
+     * @param string $layoutName
+     * @param string $moduleName
+     *
+     * @return LayoutInterface|null
+     */
+    public function getLayout($layoutName, $moduleName);
+
+    /**
+     * @param LayoutCollectionInterface $collection
+     */
+    public function merge(LayoutCollectionInterface $collection);
 }

--- a/src/Core/MailTemplate/Theme.php
+++ b/src/Core/MailTemplate/Theme.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\MailTemplate;
 
+use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutCollection;
 use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutCollectionInterface;
 
 /**
@@ -47,6 +48,7 @@ class Theme implements ThemeInterface
     public function __construct($name)
     {
         $this->name = $name;
+        $this->layouts = new LayoutCollection();
     }
 
     /**

--- a/src/Core/MailTemplate/ThemeCollection.php
+++ b/src/Core/MailTemplate/ThemeCollection.php
@@ -40,4 +40,21 @@ class ThemeCollection extends AbstractTypedCollection implements ThemeCollection
     {
         return ThemeInterface::class;
     }
+
+    /**
+     * @param string $themeName
+     *
+     * @return ThemeInterface|null
+     */
+    public function getByName($themeName)
+    {
+        /** @var ThemeInterface $theme */
+        foreach ($this as $theme) {
+            if ($themeName === $theme->getName()) {
+                return $theme;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Core/MailTemplate/ThemeCollection.php
+++ b/src/Core/MailTemplate/ThemeCollection.php
@@ -49,7 +49,7 @@ class ThemeCollection extends AbstractTypedCollection implements ThemeCollection
     public function getByName($themeName)
     {
         /** @var ThemeInterface $theme */
-        foreach ($this as $theme) {
+        foreach ($this->getValues() as $theme) {
             if ($themeName === $theme->getName()) {
                 return $theme;
             }

--- a/src/Core/MailTemplate/ThemeCollectionInterface.php
+++ b/src/Core/MailTemplate/ThemeCollectionInterface.php
@@ -49,4 +49,11 @@ interface ThemeCollectionInterface extends \IteratorAggregate, \Countable
      * @param ThemeInterface $theme
      */
     public function remove($theme);
+
+    /**
+     * @param string $themeName
+     *
+     * @return ThemeInterface|null
+     */
+    public function getByName($themeName);
 }

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShopBundle\Command;
 
+use Employee;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -82,6 +84,14 @@ class ModuleCommand extends ContainerAwareCommand
         $this->input = $input;
         $this->output = $output;
         require $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
+        /** @var LegacyContext $legacyContext */
+        $legacyContext = $this->getContainer()->get('prestashop.adapter.legacy.context');
+        //We need to have an employee or the module hooks don't work
+        //see LegacyHookSubscriber
+        if (!$legacyContext->getContext()->employee) {
+            //Even a non existing employee is fine
+            $legacyContext->getContext()->employee = new Employee(42);
+        }
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
@@ -5,10 +5,14 @@ services:
   prestashop.core.mail_template.mail_template_renderer: '@prestashop.adapter.mail_template.twig_renderer'
   prestashop.core.mail_template.theme_catalog: '@prestashop.core.mail_template.theme_folder_catalog'
 
+  prestashop.core.mail_template.theme_folder_scanner:
+    class: 'PrestaShop\PrestaShop\Core\MailTemplate\FolderThemeScanner'
+
   prestashop.core.mail_template.theme_folder_catalog:
     class: 'PrestaShop\PrestaShop\Core\MailTemplate\FolderThemeCatalog'
     arguments:
       - '%mail_themes_dir%'
+      - '@prestashop.core.mail_template.theme_folder_scanner'
       - '@prestashop.core.hook.dispatcher'
 
   prestashop.core.mail_template.variables_builder:

--- a/tests/Unit/Core/MailTemplate/FolderThemeCatalogTest.php
+++ b/tests/Unit/Core/MailTemplate/FolderThemeCatalogTest.php
@@ -30,6 +30,7 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\FolderThemeCatalog;
+use PrestaShop\PrestaShop\Core\MailTemplate\FolderThemeScanner;
 use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutCollectionInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateInterface;
@@ -84,7 +85,7 @@ class FolderThemeCatalogTest extends TestCase
             ->getMock()
         ;
 
-        $catalog = new FolderThemeCatalog($this->tempDir, $dispatcherMock);
+        $catalog = new FolderThemeCatalog($this->tempDir, new FolderThemeScanner(), $dispatcherMock);
         $this->assertNotNull($catalog);
     }
 
@@ -93,7 +94,7 @@ class FolderThemeCatalogTest extends TestCase
         /** @var HookDispatcherInterface $dispatcherMock */
         $dispatcherMock = $this->createHookDispatcherMock(8);
 
-        $catalog = new FolderThemeCatalog($this->tempDir, $dispatcherMock);
+        $catalog = new FolderThemeCatalog($this->tempDir, new FolderThemeScanner(), $dispatcherMock);
         $listedThemes = $catalog->listThemes();
         $this->assertEquals($this->expectedThemes->count(), $listedThemes->count());
         /** @var ThemeInterface $theme */
@@ -149,7 +150,7 @@ class FolderThemeCatalogTest extends TestCase
             ->getMock()
         ;
 
-        $catalog = new FolderThemeCatalog($this->tempDir, $dispatcherMock);
+        $catalog = new FolderThemeCatalog($this->tempDir, new FolderThemeScanner(), $dispatcherMock);
         $this->assertNotNull($catalog);
 
         $theme = $catalog->getByName('classic');
@@ -173,7 +174,7 @@ class FolderThemeCatalogTest extends TestCase
             ->getMock()
         ;
 
-        $catalog = new FolderThemeCatalog($this->tempDir, $dispatcherMock);
+        $catalog = new FolderThemeCatalog($this->tempDir, new FolderThemeScanner(), $dispatcherMock);
         $this->assertNotNull($catalog);
 
         $catalog->getByName('unknown');
@@ -191,7 +192,7 @@ class FolderThemeCatalogTest extends TestCase
             DIRECTORY_SEPARATOR,
             [$this->tempDir, 'invisible']
         );
-        $catalog = new FolderThemeCatalog($fakeFolder, $dispatcherMock);
+        $catalog = new FolderThemeCatalog($fakeFolder, new FolderThemeScanner(), $dispatcherMock);
         $this->assertNotNull($catalog);
 
         $caughtException = null;
@@ -207,7 +208,7 @@ class FolderThemeCatalogTest extends TestCase
 
     public function testListThemesWithoutCoreFolder()
     {
-        $catalog = new FolderThemeCatalog($this->tempDir, $this->createHookDispatcherMock(4));
+        $catalog = new FolderThemeCatalog($this->tempDir, new FolderThemeScanner(), $this->createHookDispatcherMock(4));
         //No bug occurs if the folder does not exist
         $this->fs->remove(implode(DIRECTORY_SEPARATOR, [$this->tempDir, 'classic', MailTemplateInterface::CORE_CATEGORY]));
 
@@ -222,7 +223,7 @@ class FolderThemeCatalogTest extends TestCase
 
     public function testListThemesWithoutModulesFolder()
     {
-        $catalog = new FolderThemeCatalog($this->tempDir, $this->createHookDispatcherMock(4));
+        $catalog = new FolderThemeCatalog($this->tempDir, new FolderThemeScanner(), $this->createHookDispatcherMock(4));
         $this->fs->remove(implode(DIRECTORY_SEPARATOR, [$this->tempDir, 'classic', MailTemplateInterface::MODULES_CATEGORY]));
         /** @var ThemeCollectionInterface $themeList */
         $themes = $catalog->listThemes();

--- a/tests/Unit/Core/MailTemplate/FolderThemeCatalogTest.php
+++ b/tests/Unit/Core/MailTemplate/FolderThemeCatalogTest.php
@@ -91,7 +91,7 @@ class FolderThemeCatalogTest extends TestCase
     public function testListThemes()
     {
         /** @var HookDispatcherInterface $dispatcherMock */
-        $dispatcherMock = $this->createHookDispatcherMock($this->tempDir, 8);
+        $dispatcherMock = $this->createHookDispatcherMock(8);
 
         $catalog = new FolderThemeCatalog($this->tempDir, $dispatcherMock);
         $listedThemes = $catalog->listThemes();
@@ -207,7 +207,7 @@ class FolderThemeCatalogTest extends TestCase
 
     public function testListThemesWithoutCoreFolder()
     {
-        $catalog = new FolderThemeCatalog($this->tempDir, $this->createHookDispatcherMock($this->tempDir, 4));
+        $catalog = new FolderThemeCatalog($this->tempDir, $this->createHookDispatcherMock(4));
         //No bug occurs if the folder does not exist
         $this->fs->remove(implode(DIRECTORY_SEPARATOR, [$this->tempDir, 'classic', MailTemplateInterface::CORE_CATEGORY]));
 
@@ -222,7 +222,7 @@ class FolderThemeCatalogTest extends TestCase
 
     public function testListThemesWithoutModulesFolder()
     {
-        $catalog = new FolderThemeCatalog($this->tempDir, $this->createHookDispatcherMock($this->tempDir, 4));
+        $catalog = new FolderThemeCatalog($this->tempDir, $this->createHookDispatcherMock(4));
         $this->fs->remove(implode(DIRECTORY_SEPARATOR, [$this->tempDir, 'classic', MailTemplateInterface::MODULES_CATEGORY]));
         /** @var ThemeCollectionInterface $themeList */
         $themes = $catalog->listThemes();
@@ -270,33 +270,19 @@ class FolderThemeCatalogTest extends TestCase
     }
 
     /**
-     * @param string $tempDir
      * @param int $layoutsCount
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|HookDispatcherInterface
      */
-    private function createHookDispatcherMock($tempDir, $layoutsCount)
+    private function createHookDispatcherMock($layoutsCount)
     {
         $dispatcherMock = $this->getMockBuilder(HookDispatcherInterface::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;
 
-        $mailThemeFolder = implode(DIRECTORY_SEPARATOR, [$tempDir, 'classic']);
         $dispatcherMock
             ->expects($this->at(0))
-            ->method('dispatchWithParameters')
-            ->with(
-                $this->equalTo(FolderThemeCatalog::GET_MAIL_THEME_FOLDER_HOOK),
-                $this->equalTo([
-                    'mailTheme' => 'classic',
-                    'mailThemeFolder' => $mailThemeFolder,
-                ])
-            )
-        ;
-
-        $dispatcherMock
-            ->expects($this->at(2))
             ->method('dispatchWithParameters')
             ->with(
                 $this->equalTo(ThemeCatalogInterface::LIST_MAIL_THEMES_HOOK),

--- a/tests/Unit/Core/MailTemplate/ThemeCollectionTest.php
+++ b/tests/Unit/Core/MailTemplate/ThemeCollectionTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop and Contributors
+ * 2007-2019 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -16,7 +16,7 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://www.prestashop.com for more information.
+ * needs please refer to http://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright 2007-2019 PrestaShop SA and Contributors
@@ -24,32 +24,27 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\MailTemplate;
+namespace Tests\Unit\Core\MailTemplate;
 
-use PrestaShop\PrestaShop\Core\Data\AbstractTypedCollection;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\MailTemplate\Theme;
+use PrestaShop\PrestaShop\Core\MailTemplate\ThemeCollection;
 
-/**
- * Class MailThemeCollection is a collection of MailThemeInterface elements.
- */
-class ThemeCollection extends AbstractTypedCollection implements ThemeCollectionInterface
+class ThemeCollectionTest extends TestCase
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getType()
+    public function testGetByName()
     {
-        return ThemeInterface::class;
-    }
-
-    /**
-     * @param string $themeName
-     *
-     * @return ThemeInterface|null
-     */
-    public function getByName($themeName)
-    {
-        return $this->filter(function (ThemeInterface $theme) use ($themeName) {
-            return $themeName === $theme->getName();
-        })->first();
+        $theme1 = new Theme('theme1');
+        $theme2 = new Theme('theme2');
+        $theme3 = new Theme('theme1');
+        $collection = new ThemeCollection([
+            $theme1,
+            $theme2,
+            $theme3,
+        ]);
+        $this->assertEquals(3, $collection->count());
+        $this->assertEquals($theme1, $collection->getByName('theme1'));
+        $this->assertEquals($theme2, $collection->getByName('theme2'));
+        $this->assertEquals(null, $collection->getByName('theme3'));
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Extract theme folder scanning into an external class `FolderThemeScanner` which will help the modules a lot, add a few interfaces on collections, remove `actionGetMailThemeFolder` hook
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | No QA required as the automatic tests validate the refacto didn't break anything

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13869)
<!-- Reviewable:end -->
