### PR TITLE
Added help property (backported from Symfony 4 framework)

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Extension/HelpTextExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/HelpTextExtension.php
@@ -24,7 +24,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-
 namespace PrestaShopBundle\Form\Admin\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;

--- a/src/PrestaShopBundle/Form/Admin/Extension/HelpTextExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/HelpTextExtension.php
@@ -45,10 +45,8 @@ class HelpTextExtension extends AbstractTypeExtension
     {
         $resolver
             ->setDefaults([
-                'label_help_text' => null,
                 'help' => null,
             ])
-            ->setAllowedTypes('label_help_text', ['null', 'string'])
             ->setAllowedTypes('help', ['null', 'string'])
         ;
     }
@@ -58,10 +56,6 @@ class HelpTextExtension extends AbstractTypeExtension
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if (isset($options['label_help_text'])) {
-            $view->vars['label_help_text'] = $options['label_help_text'];
-        }
-
         if (isset($options['help'])) {
             $view->vars['help'] = $options['help'];
         }

--- a/src/PrestaShopBundle/Form/Admin/Extension/HelpTextExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/HelpTextExtension.php
@@ -56,7 +56,7 @@ class HelpTextExtension extends AbstractTypeExtension
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         if (isset($options['help'])) {
-            $view->vars['help'] = $options['help'];
+            $view->vars['help'] = isset($options['help']) ? $options['help'] : null;
         }
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Extension/HelpTextExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/HelpTextExtension.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+
+namespace PrestaShopBundle\Form\Admin\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Class HelpTextExtension extends every form type with additional help text options.
+ */
+class HelpTextExtension extends AbstractTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'label_help_text' => null,
+                'help' => null,
+            ])
+            ->setAllowedTypes('label_help_text', ['null', 'string'])
+            ->setAllowedTypes('help', ['null', 'string'])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        if (isset($options['label_help_text'])) {
+            $view->vars['label_help_text'] = $options['label_help_text'];
+        }
+
+        if (isset($options['help'])) {
+            $view->vars['help'] = $options['help'];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return FormType::class;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Extension/HelpTextExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/HelpTextExtension.php
@@ -55,9 +55,7 @@ class HelpTextExtension extends AbstractTypeExtension
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if (isset($options['help'])) {
-            $view->vars['help'] = isset($options['help']) ? $options['help'] : null;
-        }
+        $view->vars['help'] = isset($options['help']) ? $options['help'] : null;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -11,3 +11,8 @@ services:
         class: 'PrestaShopBundle\Form\Admin\Type\ResizableTextType'
         tags:
             - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\TextType }
+
+    form.extension.help_text:
+        class: 'PrestaShopBundle\Form\Admin\Extension\HelpTextExtension'
+        tags:
+            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\FormType }

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
@@ -340,9 +340,13 @@
 {%- endblock form_errors -%}
 
 {%- block form_rest -%}
+  {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+
   {% for child in form -%}
     {% if not child.rendered %}
-      {{- form_row(child) -}}
+      {{- ps.form_group_row(child, { attr: child.vars.attr }, {
+        'label': child.vars.label
+      }) -}}
     {% endif %}
   {%- endfor %}
 {% endblock form_rest %}

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -113,10 +113,10 @@
 
   {{ form_widget(form, vars) }}
 
-  {% if extraVars.help is defined or form.vars.help is defined %}
-{#    todo: which one should take the priority or both of them should be concated?#}
-
-    <small class="form-text">{{ extraVars.help|default('') ~ form.vars.help|default('') }}</small>
+  {% if extraVars.help is defined and extraVars.help%}
+      <small class="form-text">{{ extraVars.help }}</small>
+    {% elseif form.vars.help is defined and form.vars.help %}
+      <small class="form-text">{{ form.vars.help }}</small>
   {% endif %}
 
   {{ self.form_error_with_popover(form) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -113,8 +113,10 @@
 
   {{ form_widget(form, vars) }}
 
-  {% if extraVars.help is defined %}
-    <small class="form-text">{{ extraVars.help }}</small>
+  {% if extraVars.help is defined or form.vars.help is defined %}
+{#    todo: which one should take the priority or both of them should be concated?#}
+
+    <small class="form-text">{{ extraVars.help|default('') ~ form.vars.help|default('') }}</small>
   {% endif %}
 
   {{ self.form_error_with_popover(form) }}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | If we add form elements when using module hooks they are placed in the wrong position and look is not consistent. With this PR we finally create a consistent view and module developers will be able to extend form elements without returning any html. See example below.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/11389
| How to test?  | Instructions provided below :arrow_down_small: 


**HOW TO TEST**

A module with new hook system implementation is required. Here's how to get one:

1. Download zip from here https://github.com/friends-of-prestashop/demo-cqrs-hooks-usage-module
2. Extract it somewhere on your computer, rename the inner folder to `ps_democqrshooksusage`
3. Using terminal go to the folder you have just renamed and execute command `composer install`. If you do not have composer locally then **https://getcomposer.org/** should help to get it.
4. Compress the folder again to `zip` format. ( Or you can copy the folder to Prestashops modules folder)
5. While on this branch install this module using zip or if it already copied then just find module and install it
6. Go to customers list **admin-dev/index.php/sell/customers/**
7. Click "add new customer" or "edit" existing one - you will notice the last form element "Allow reviews" which comes from module and is aligned with the remaining form fields. 
8. If you switch to any other branch then you will notice this form field is in incorrect position.





E.g of usage withing module:

 Code inside hook `hookActionCustomerFormBuilderModifier`:

```php

/** @var FormBuilderInterface $formBuilder */
        $formBuilder = $params['form_builder'];
        $formBuilder->add('is_allowed_for_review', SwitchType::class, [
            'label' => $this->getTranslator()->trans('Allow reviews', [], 'Modules.Ps_DemoCQRSHooksUsage'),
            'required' => false,
        ]);

```

Before it rendered this view:

![allow_reviews_1](https://user-images.githubusercontent.com/17051250/58023804-6aefa580-7b19-11e9-9ebc-2e3e8225c4bf.png)


now it renders  like this:

![form_w-2](https://user-images.githubusercontent.com/17051250/58023860-8ce92800-7b19-11e9-8a44-e9c2d7787109.png)


very important factor is that `form_rest` should be located in the same container as other form fields - if not then it will be miss aligned as well. Within this PR completion we should check if form_rest is included everywhere in the right place.  
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13875)
<!-- Reviewable:end -->
