### PR TITLE
Hook displayBackOfficeTop should be in nav container

### DIFF
--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -68,9 +68,8 @@
       <div class="component" id="header-employee-container">
         {include file="components/layout/employee_dropdown.tpl"}
       </div>
+      {if isset($displayBackOfficeTop)}{$displayBackOfficeTop}{/if}
     </nav>
-
-    {if isset($displayBackOfficeTop)}{$displayBackOfficeTop}{/if}
   </header>
 {/if}
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description? | In the new backoffice theme, the hook displayBackOfficeTop has been moved outside the nav container. We can't add buton in fixed navigation bar : It's a regression.
| Type?         | bug fix
| Category?     | BO
| Fixed ticket? | Fixes #13893

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13894)
<!-- Reviewable:end -->
