### PR TITLE
[POC/Perf] Improved cache configuration

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -20,6 +20,11 @@ framework:
     assets:
         version: !php/const \AppKernel::VERSION
 
+    cache:
+        pools:
+            prestashop.cache:
+                adapter: cache.adapter.filesystem
+                default_lifetime: 0
     #esi:             ~
     secret:          "%secret%"
     translator:      { fallbacks: ["default"] }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -72,6 +72,8 @@ services:
     # Legacy Hooks registrator
     prestashop.adapter.legacy.hook.subscriber:
         class: PrestaShop\PrestaShop\Adapter\LegacyHookSubscriber
+        arguments:
+          - '@prestashop.cache'
 
     prestashop.adapter.legacy.block.helper.subscriber:
             class: PrestaShop\PrestaShop\Adapter\Admin\LegacyBlockHelperSubscriber

--- a/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
@@ -17,15 +17,11 @@ services:
         arguments:
             - '@router'
 
-    # We set this alias so that we can override it in test environment (to avoid memory limit crashes)
-    prestashop.bundle.routing.converter.cache:
-        alias: Symfony\Component\Cache\Adapter\AdapterInterface
-
     prestashop.bundle.routing.converter.cache_provider:
         class: 'PrestaShopBundle\Routing\Converter\CacheProvider'
         arguments:
             - '@prestashop.bundle.routing.converter.router_provider'
-            - '@prestashop.bundle.routing.converter.cache'
+            - '@prestashop.cache'
             - '@prestashop.bundle.routing.converter.routing_cache_key_generator'
 
     prestashop.bundle.routing.converter.routing_cache_key_generator:

--- a/src/PrestaShopBundle/Routing/Converter/CacheProvider.php
+++ b/src/PrestaShopBundle/Routing/Converter/CacheProvider.php
@@ -36,7 +36,7 @@ class CacheProvider extends AbstractLegacyRouteProvider
     /**
      * @var AdapterInterface
      */
-    private $cache;
+    protected $cache;
 
     /**
      * @var LegacyRouteProviderInterface
@@ -61,6 +61,8 @@ class CacheProvider extends AbstractLegacyRouteProvider
         $this->legacyRouteProvider = $legacyRouteProvider;
         $this->cache = $cache;
         $this->cacheKeyGenerator = $cacheKeyGenerator;
+
+        parent::__construct($cache);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Sniffed some cache optimizations
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Test suite should pass

> atm I'm not sure of the impacts, just 2 ideas of perf I wanted to test.

### Blackfire (once cache is wired)

https://blackfire.io/profiles/compare/a5add6c5-77b0-430b-a2cc-a630c9e0ac21/graph

-11% time, -3% RAM on all the back office.

No regressions, assuming that installing or uninstalling a module clear the cache: if not, we need to trigger a clear of these specific caches.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13907)
<!-- Reviewable:end -->
