### PR TITLE
Fixes saving private note about customer from order page

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -632,7 +632,10 @@
                   <i class="icon-eye-slash"></i>
                   {l s='Private note' d='Admin.Orderscustomers.Feature'}
                 </div>
-                <form id="customer_note" class="form-horizontal" action="ajax.php" method="post" onsubmit="saveCustomerNote({$customer->id});return false;" >
+                <form id="customer_note"
+                      class="form-horizontal"
+                      action="{$link->getAdminLink('AdminCustomers', true, [], ['updateCustomerNote' => 1, 'id_customer' => $customer->id])}"
+                      method="post" onsubmit="saveCustomerNote();return false;" >
                   <div class="form-group">
                     <div class="col-lg-12">
                       <textarea name="note" id="noteContent" class="textarea-autosize" onkeyup="$(this).val().length > 0 ? $('#submitCustomerNote').removeAttr('disabled') : $('#submitCustomerNote').attr('disabled', 'disabled')">{$customer->note}</textarea>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1544,20 +1544,21 @@ function checkLangPack(token){
 
 function redirect(new_page) { window.location = new_page; }
 
-function saveCustomerNote(customerId){
+function saveCustomerNote(){
+  var $customerNoteForm = $('#customer_note');
 	var noteContent = $('#noteContent').val();
-	var data = 'token=' + token_admin_customers + '&tab=AdminCustomers&ajax=1&action=updateCustomerNote&id_customer=' + customerId + '&note=' + encodeURIComponent(noteContent);
+
 	$.ajax({
 		type: "POST",
-		url: "index.php",
-		data: data,
+		url: $customerNoteForm.attr('action'),
+		data: {
+		  'private_note': {
+		    'note': encodeURIComponent(noteContent)
+      }
+    },
 		async : true,
 		success: function(r) {
-
-			if (r == 'ok') {
-				$('#submitCustomerNote').attr('disabled', true);
-			}
-			showSuccessMessage(update_success_msg);
+			showSuccessMessage(r.message);
 		}
 	});
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -263,7 +263,7 @@ class CustomerController extends AbstractAdminController
      * @param int $customerId
      * @param Request $request
      *
-     * @return RedirectResponse
+     * @return Response
      */
     public function savePrivateNoteAction($customerId, Request $request)
     {
@@ -278,6 +278,13 @@ class CustomerController extends AbstractAdminController
                     (int) $customerId,
                     $data['note']
                 ));
+
+                if ($request->isXmlHttpRequest()) {
+                    return $this->json([
+                        'success' => true,
+                        'message' => $this->trans('Successful update.', 'Admin.Notifications.Success'),
+                    ]);
+                }
 
                 $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
             } catch (CustomerException $e) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fixes described issue.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13428
| How to test?  | Saving private note from Order page should work now.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13916)
<!-- Reviewable:end -->
