### PR TITLE
Tax must be returned depending on PS_TAX_DISPLAY only

### DIFF
--- a/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
@@ -171,6 +171,7 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
         }
 
         $tax = $this->order->total_paid_tax_incl - $this->order->total_paid_tax_excl;
+
         return array(
             'type' => 'tax',
             'label' => $this->translator->trans('Tax', array(), 'Shop.Theme.Checkout'),

--- a/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
@@ -161,24 +161,24 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
      */
     public function getTax()
     {
-        $tax = $this->order->total_paid_tax_incl - $this->order->total_paid_tax_excl;
-        if ((float) $tax && Configuration::get('PS_TAX_DISPLAY')) {
+        if (!Configuration::get('PS_TAX_DISPLAY')) {
             return array(
                 'type' => 'tax',
-                'label' => $this->translator->trans('Tax', array(), 'Shop.Theme.Checkout'),
-                'amount' => $tax,
-                'value' => $this->priceFormatter->format(
-                    $tax,
-                    Currency::getCurrencyInstance((int) $this->order->id_currency)
-                ),
+                'label' => null,
+                'amount' => null,
+                'value' => '',
             );
         }
 
+        $tax = $this->order->total_paid_tax_incl - $this->order->total_paid_tax_excl;
         return array(
             'type' => 'tax',
-            'label' => null,
-            'amount' => null,
-            'value' => '',
+            'label' => $this->translator->trans('Tax', array(), 'Shop.Theme.Checkout'),
+            'amount' => $tax,
+            'value' => $this->priceFormatter->format(
+                $tax,
+                Currency::getCurrencyInstance((int) $this->order->id_currency)
+            ),
         );
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | The tax number must be returned even if the value is empty.
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13819 
| How to test?  | Follow ticket instruction, but all pages which display order information must be tested..

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13919)
<!-- Reviewable:end -->
