### PR TITLE
Add getter for current locale

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -236,6 +236,14 @@ class ContextCore
     }
 
     /**
+     * @return Locale
+     */
+    public function getCurrentLocale()
+    {
+        return $this->currentLocale;
+    }
+
+    /**
      * Checks if mobile context is possible.
      *
      * @return bool

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -787,7 +787,7 @@ class ToolsCore
      */
     protected static function getContextLocale(Context $context)
     {
-        $locale = $context->currentLocale;
+        $locale = $context->getCurrentLocale();
         if (null !== $locale) {
             return $locale;
         }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1973,7 +1973,7 @@ class AdminControllerCore extends Controller
             'version' => _PS_VERSION_,
             'lang_iso' => $this->context->language->iso_code,
             'full_language_code' => $this->context->language->language_code,
-            'full_cldr_language_code' => $this->context->currentLocale->getCode(),
+            'full_cldr_language_code' => $this->context->getCurrentLocale()->getCode(),
             'link' => $this->context->link,
             'shop_name' => Configuration::get('PS_SHOP_NAME'),
             'base_url' => $this->context->shop->getBaseURL(),
@@ -4810,7 +4810,7 @@ class AdminControllerCore extends Controller
         /* @var Currency */
         $currency = $context->currency;
         /* @var PriceSpecification */
-        $priceSpecification = $context->currentLocale->getPriceSpecification($currency->iso_code);
+        $priceSpecification = $context->getCurrentLocale()->getPriceSpecification($currency->iso_code);
         if (empty($priceSpecification)) {
             return [];
         }
@@ -4831,7 +4831,7 @@ class AdminControllerCore extends Controller
     private function prepareNumberSpecifications(Context $context)
     {
         /* @var NumberSpecification */
-        $numberSpecification = $context->currentLocale->getNumberSpecification();
+        $numberSpecification = $context->getCurrentLocale()->getNumberSpecification();
         if (empty($numberSpecification)) {
             return [];
         }

--- a/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
+++ b/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
@@ -282,6 +282,9 @@ class ControllerTest extends TestCase
         $translatorProphecy = $this->prophesizeTranslator();
         $contextProphecy->getTranslator()->willReturn($translatorProphecy->reveal());
         $contextProphecy->getDevice()->willReturn(null);
+        $contextProphecy->getCurrentLocale()->willReturn(
+            $this->prophesizeLocale()->reveal()
+        );
 
         $templateEngineProphecy = $this->prophesizeTemplateEngine();
 
@@ -339,10 +342,15 @@ class ControllerTest extends TestCase
         Tools::resetRequest();
     }
 
+    protected function prophesizeLocale()
+    {
+        return $this->prophesize(Locale::class);
+    }
+
     protected function prophesizeLocaleRepository()
     {
         $localeRepositoryProphecy = $this->prophesize(LocaleRepository::class);
-        $localeProphecy           = $this->prophesize(Locale::class);
+        $localeProphecy = $this->prophesizeLocale();
         $localeRepositoryProphecy
             ->getLocale(Argument::any())
             ->willReturn($localeProphecy->reveal());


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Add missing getter for currentLocale in Context. We wouldn't want to encourage people to access properties directly...
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | no test needed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13925)
<!-- Reviewable:end -->
