### PR TITLE
Fixed date format on product page

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -771,7 +771,7 @@ class ProductLazyArray extends AbstractLazyArray
 
         if ($show_availability) {
             if ($product['quantity'] - $product['quantity_wanted'] >= 0) {
-                $this->product['availability_date'] = $product['available_date'];
+                $this->product['availability_date'] = Tools::displayDate($product['available_date']);
 
                 if ($product['quantity'] < $settings->lastRemainingItems) {
                     $this->applyLastItemsInStockDisplayRule();
@@ -783,7 +783,7 @@ class ProductLazyArray extends AbstractLazyArray
             } elseif ($product['allow_oosp']) {
                 $this->product['availability_message'] = $product['available_later'] ? $product['available_later']
                     : Configuration::get('PS_LABEL_OOS_PRODUCTS_BOA', $language->id);
-                $this->product['availability_date'] = $product['available_date'];
+                $this->product['availability_date'] = Tools::displayDate($product['available_date']);
                 $this->product['availability'] = 'available';
             } elseif ($product['quantity_wanted'] > 0 && $product['quantity'] > 0) {
                 $this->product['availability_message'] = $this->translator->trans(
@@ -799,12 +799,12 @@ class ProductLazyArray extends AbstractLazyArray
                     array(),
                     'Shop.Theme.Catalog'
                 );
-                $this->product['availability_date'] = $product['available_date'];
+                $this->product['availability_date'] = Tools::displayDate($product['available_date']);
                 $this->product['availability'] = 'unavailable';
             } else {
                 $this->product['availability_message'] =
                     Configuration::get('PS_LABEL_OOS_PRODUCTS_BOD', $language->id);
-                $this->product['availability_date'] = $product['available_date'];
+                $this->product['availability_date'] = Tools::displayDate($product['available_date']);
                 $this->product['availability'] = 'unavailable';
             }
         } else {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Date format was not formatted according to the shop specific settings
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | Enter Localization > Languages in back office and change "Date format" to something different (e.g. Y/M/D). Set "Availability date" for a product. View the change in front office in the Product Details tab for a product.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13926)
<!-- Reviewable:end -->
