### PR TITLE
Fixed free shipping voucher not applying

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2840,13 +2840,9 @@ class CartCore extends ObjectModel
                             if (isset($carrier['id_carrier']) && $carrier['id_carrier']) {
                                 if ($cart_rule['free_shipping']) {
                                     $free_carriers_rules[] = (int)$carrier['id_carrier'];
-                                    if ($defaultCarrierId > 0 && $defaultCarrierId == $carrier['id_carrier'] && !in_array($cart_rule['id_cart_rule'], $cart_rules_in_cart)) {
-                                        $context->cart->addCartRule((int)$cart_rule['id_cart_rule']);
-                                    }
-                                } else {
-                                    if ($defaultCarrierId > 0 && $defaultCarrierId == $carrier['id_carrier'] && !in_array($cart_rule['id_cart_rule'], $cart_rules_in_cart)) {
-                                        $context->cart->addCartRule((int)$cart_rule['id_cart_rule']);
-                                    }
+                                }
+                                if ($defaultCarrierId > 0 && $defaultCarrierId == $carrier['id_carrier'] && !in_array($cart_rule['id_cart_rule'], $cart_rules_in_cart)) {
+                                    $context->cart->addCartRule((int)$cart_rule['id_cart_rule']);
                                 }
                             }
                         }


### PR DESCRIPTION
If you create a voucher with free shipping, without code and also restrict it using carriers, then it will not automatically apply when the customer is in cart page or in the delivery step at checkout. In order for the voucher to apply the customer must manually select carriers or proceed to the payment step. There is also no indication of "Free" next to the carrier name. After the customer proceeds to the payment step everything works fine, but many people might abandon their order if they are expecting to get free shipping and don't see it.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The issue exists at least on versions 1.7.4.4 and 1.7.5.2. Tested with PHP 7.2.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Make sure you have at least two active carriers for your store, with different costs and none of them free. Then create a new Voucher with Free Shipping, no code and allow it only for the cheapest carrier. In your shipping preferences also make sure you have "Best Price" selected as default carrier. Then put something in your cart and go to the cart page. The Voucher doesn't get applied. If you proceed to checkout, select address and proceed to delivery step, again you see no voucher or "Free" indication for one of the carriers. If you proceed to payment step, then the voucher gets applied and if you refresh the page and go back to delivery step, the carrier is now showing correctly as "Free".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13929)
<!-- Reviewable:end -->
