### PR TITLE
[WIP] Migrate Improve > Design > Positions transplant (add to hook/edit) actions

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -27,6 +27,7 @@ module.exports = {
     geolocation: './js/pages/geolocation',
     imports: './js/pages/import',
     improve_design_positions: './js/pages/improve/design_positions',
+    improve_design_positions_module_hook_form: './js/pages/improve/design_positions/module-hook-form.js',
     invoices: './js/pages/invoices',
     language: './js/pages/language',
     localization: './js/pages/localization',

--- a/admin-dev/themes/new-theme/js/components/module-hook-selection-handler.js
+++ b/admin-dev/themes/new-theme/js/components/module-hook-selection-handler.js
@@ -1,0 +1,74 @@
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+const $ = window.$;
+/**
+ * @todo: document
+ */
+export default class ModuleHookSelectionHandler {
+  constructor(moduleInputSelector, hookSelector) {
+    this.$hookSelector = $(hookSelector);
+    this.$moduleInput = $(moduleInputSelector);
+    this.$moduleInput.on('change', () => this._handle());
+
+    // handle on page load
+    this._handle();
+
+    return {};
+  }
+
+  /**
+   * Handles module hooks selection
+   *
+   * @private
+   */
+  _handle() {
+    if (this.$moduleInput.val() === '' || this.$moduleInput.val() === 0) {
+      this.$hookSelector.prop('disabled', true);
+
+      return;
+    }
+    $.ajax({
+      url: this.$moduleInput.data('hooks-url'),
+      method: 'GET',
+      dataType: 'json',
+      data: {
+        id_module: this.$moduleInput.val(),
+      },
+    }).then((response) => {
+      this.$hookSelector.prop('disabled', false);
+      this.$hookSelector.empty();
+      const _this = this;
+
+      $.each(response.hooks, (index, value) => {
+        _this.$hookSelector.append($('<option></option>').attr('value', value).text(index));
+      });
+    }).catch((response) => {
+      if (typeof response.responseJSON !== 'undefined') {
+        showErrorMessage(response.responseJSON.message);
+      }
+    });
+  }
+}

--- a/src/Adapter/Form/ChoiceProvider/ModuleHookByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ModuleHookByIdChoiceProvider.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
+
+use Hook;
+use Module;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use PrestaShopException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Provides choices of available module hooks
+ */
+final class ModuleHookByIdChoiceProvider implements ConfigurableFormChoiceProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getChoices(array $options)
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+        $resolvedOptions = $resolver->resolve($options);
+
+        try {
+            $hooks_list = Hook::getHooks();
+            $hookableList = [];
+
+            $moduleInstance = Module::getInstanceById($options['id_module']);
+            foreach ($hooks_list as $hook) {
+                $hookName = trim($hook['name']);
+                if ('' !== $hook['description']) {
+                    $hookName .= ' (' . $hook['description'] . ')';
+                }
+                if ($moduleInstance->isHookableOn($hookName)) {
+                    $hookableList[$hookName] = $hook['id_hook'];
+                }
+            }
+        } catch (PrestaShopException $e) {
+            throw new CoreException(
+                sprintf(
+                    'An error occurred when getting hooks for module id "%s"',
+                    $resolvedOptions['id_module'])
+            );
+        }
+
+        return $hookableList;
+    }
+
+    /**
+     * Configures array parameters and default values
+     *
+     * @param OptionsResolver $resolver
+     */
+    private function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired('id_module');
+        $resolver->setAllowedTypes('id_module', 'int');
+        $this->allowIdCountryGreaterThanZero($resolver);
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     */
+    private function allowIdCountryGreaterThanZero(OptionsResolver $resolver)
+    {
+        $resolver->setAllowedValues('id_module', function ($value) {
+            return 0 < $value;
+        });
+    }
+}

--- a/src/Adapter/Form/ChoiceProvider/ModuleNameByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ModuleNameByIdChoiceProvider.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * 2007-2019 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
@@ -21,14 +22,32 @@
  * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
- *#}
+ */
 
-{% extends '@PrestaShop/Admin/layout.html.twig' %}
+namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 
-{% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Position/Blocks/form.html.twig', {}) }}
-    </div>
-  </div>
-{% endblock %}
+use Module;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+
+/**
+ * Provides array of modules where key is module name and value is module id
+ */
+final class ModuleNameByIdChoiceProvider implements FormChoiceProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getChoices()
+    {
+        $choices = [];
+        foreach (Module::getModulesInstalled() as $module) {
+            if ($choice = Module::getInstanceById($module['id_module'])) {
+                $choices[$choice->displayName] = $choice;
+            }
+            $choices[$module['name']] = $module['id_module'];
+        }
+        ksort($choices);
+
+        return $choices;
+    }
+}

--- a/src/Adapter/Form/ChoiceProvider/ModuleNameByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ModuleNameByIdChoiceProvider.php
@@ -40,11 +40,11 @@ final class ModuleNameByIdChoiceProvider implements FormChoiceProviderInterface
     public function getChoices()
     {
         $choices = [];
+
         foreach (Module::getModulesInstalled() as $module) {
-            if ($choice = Module::getInstanceById($module['id_module'])) {
-                $choices[$choice->displayName] = $choice;
+            if ($instance = Module::getInstanceById($module['id_module'])) {
+                $choices[$instance->displayName] = $instance->id;
             }
-            $choices[$module['name']] = $module['id_module'];
         }
         ksort($choices);
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -47,7 +48,7 @@ class PositionsController extends FrameworkBundleAdminController
     /**
      * Display hooks positions.
      *
-     * @Template("@PrestaShop/Admin/Improve/Design/positions.html.twig")
+     * @Template("@PrestaShop/Admin/Improve/Design/Position/index.html.twig")
      * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller')~'_')", message="Access denied.")
      *
      * @param Request $request
@@ -114,7 +115,7 @@ class PositionsController extends FrameworkBundleAdminController
         }
         $saveUrl = $legacyContextService->getAdminLink('AdminModulesPositions', true, $saveUrlParams);
 
-        return [
+        return $this->render('PrestaShopBundle:Admin/Improve/Design/Position:index.html.twig', [
             'layoutHeaderToolbarBtn' => [
                 'save' => [
                     'href' => $saveUrl,
@@ -132,7 +133,7 @@ class PositionsController extends FrameworkBundleAdminController
             'hooks' => $hooks,
             'modules' => $modules,
             'canMove' => $this->get('prestashop.adapter.shop.context')->isSingleShopContext(),
-        ];
+        ]);
     }
 
     /**
@@ -230,5 +231,29 @@ class PositionsController extends FrameworkBundleAdminController
                 $messages[$messageId]
             );
         }
+    }
+
+    /**
+     * Renders and processes form to add module to a hook
+     *
+     * @param Request $request
+     */
+    public function addToHookAction(Request $request)
+    {
+        return $this->render('PrestaShopBundle:Admin/Improve/Design/Position:add_to_hook.html.twig');
+    }
+
+    /**
+     * Renders and processes form for editing module-hook relation
+     *
+     * @param int $moduleId
+     * @param int $hookId
+     *
+     * @return RedirectResponse
+     */
+    public function editAction($moduleId, $hookId)
+    {
+        //@todo:implement
+        return $this->redirectToRoute('admin_modules_positions_add_to_hook');
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -27,10 +27,8 @@
 namespace PrestaShopBundle\Controller\Admin\Improve\Design;
 
 use Hook;
-use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -48,7 +46,6 @@ class PositionsController extends FrameworkBundleAdminController
     /**
      * Display hooks positions.
      *
-     * @Template("@PrestaShop/Admin/Improve/Design/Position/index.html.twig")
      * @AdminSecurity("is_granted(['read', 'update', 'create', 'delete'], request.get('_legacy_controller')~'_')", message="Access denied.")
      *
      * @param Request $request
@@ -240,7 +237,11 @@ class PositionsController extends FrameworkBundleAdminController
      */
     public function addToHookAction(Request $request)
     {
-        return $this->render('PrestaShopBundle:Admin/Improve/Design/Position:add_to_hook.html.twig');
+        $moduleHookForm = $this->get('prestashop.admin.module_hook.form_handler')->getForm();
+
+        return $this->render('PrestaShopBundle:Admin/Improve/Design/Position:add_to_hook.html.twig', [
+            'moduleHookForm' => $moduleHookForm->createView(),
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleHooksController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleHooksController.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Controller\Admin\Improve\Modules;
+
+use Exception;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Responsible for handling module hooks data
+ */
+class ModuleHooksController extends FrameworkBundleAdminController
+{
+    /**
+     * Provides available hooks for module in json response
+     *
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function getModuleHooksAction(Request $request)
+    {
+        try {
+            $moduleId = (int) $request->query->get('id_module');
+            $hooksProvider = $this->get('prestashop.adapter.form.choice_provider.module_hook_by_id');
+            $hooks = $hooksProvider->getChoices([
+                'id_module' => $moduleId,
+            ]);
+
+            return $this->json([
+                'hooks' => $hooks,
+            ]);
+        } catch (Exception $e) {
+            return $this->json([
+                    'message' => $this->getErrorMessageForException($e, []),
+                ],
+                Response::HTTP_INTERNAL_SERVER_ERROR
+            );
+        }
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Position/ModuleHookFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Position/ModuleHookFormDataProvider.php
@@ -26,49 +26,23 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\Design\Position;
 
-use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 
-/**
- * Defines Improve > Design > Positions > Transplant | Edit module-hook form
- */
-class ModuleHookType extends AbstractType
+class ModuleHookFormDataProvider implements FormDataProviderInterface
 {
     /**
-     * @var TranslatorInterface
+     * {@inheritdoc}
      */
-    private $translator;
-
-    /**
-     * @var array
-     */
-    private $moduleNameByIdChoices;
-
-    public function __construct(
-        TranslatorInterface $translator,
-        array $moduleNameByIdChoices
-    ) {
-        $this->translator = $translator;
-        $this->moduleNameByIdChoices = $moduleNameByIdChoices;
+    public function getData()
+    {
+        // TODO: Implement getData() method.
     }
 
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function setData(array $data)
     {
-        $builder
-            ->add('id_module', ChoiceType::class, [
-                'choices' => $this->moduleNameByIdChoices,
-            ])
-            ->add('id_hook', ChoiceType::class, [
-                'choices' => [],
-            ])
-            ->add('except_files', ChoiceType::class, [
-                'choices' => [],
-            ])
-        ;
+        // TODO: Implement setData() method.
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Position/ModuleHookType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Position/ModuleHookType.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Improve\Design\Position;
+
+use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Defines Improve > Design > Positions > Transplant | Edit module-hook form
+ */
+class ModuleHookType extends TranslatorAwareType
+{
+    /**
+     * @var array
+     */
+    private $allCmsCategories;
+
+    /**
+     * @var bool
+     */
+    private $isMultiShopEnabled;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param array $allCmsCategories
+     * @param $isMultiShopEnabled
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        array $allCmsCategories,
+        $isMultiShopEnabled)
+    {
+        parent::__construct($translator, $locales);
+
+        $this->allCmsCategories = $allCmsCategories;
+        $this->isMultiShopEnabled = $isMultiShopEnabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('page_category_id', MaterialChoiceTreeType::class, [
+                'required' => false,
+                'choices_tree' => $this->allCmsCategories,
+                'choice_value' => 'id_cms_category',
+            ]);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Position/ModuleHookType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Position/ModuleHookType.php
@@ -61,9 +61,14 @@ class ModuleHookType extends AbstractType
     {
         $builder
             ->add('id_module', ChoiceType::class, [
+                'label' => false,
+                'placeholder' => $this->translator->trans('Please select a module', [], 'Admin.Design.Help'),
                 'choices' => $this->moduleNameByIdChoices,
             ])
             ->add('id_hook', ChoiceType::class, [
+                'label' => false,
+                'placeholder' => $this->translator->trans(
+                    'Select a module above before choosing from available hooks', [], 'Admin.Design.Help'),
                 'choices' => [],
             ])
             ->add('except_files', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Position/ModuleHookType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Position/ModuleHookType.php
@@ -26,42 +26,25 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\Design\Position;
 
-use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
-use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Defines Improve > Design > Positions > Transplant | Edit module-hook form
  */
-class ModuleHookType extends TranslatorAwareType
+class ModuleHookType extends AbstractType
 {
     /**
-     * @var array
+     * @var TranslatorInterface
      */
-    private $allCmsCategories;
+    private $translator;
 
-    /**
-     * @var bool
-     */
-    private $isMultiShopEnabled;
-
-    /**
-     * @param TranslatorInterface $translator
-     * @param array $locales
-     * @param array $allCmsCategories
-     * @param $isMultiShopEnabled
-     */
     public function __construct(
-        TranslatorInterface $translator,
-        array $locales,
-        array $allCmsCategories,
-        $isMultiShopEnabled)
-    {
-        parent::__construct($translator, $locales);
-
-        $this->allCmsCategories = $allCmsCategories;
-        $this->isMultiShopEnabled = $isMultiShopEnabled;
+        TranslatorInterface $translator
+    ) {
+        $this->translator = $translator;
     }
 
     /**
@@ -70,10 +53,15 @@ class ModuleHookType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('page_category_id', MaterialChoiceTreeType::class, [
-                'required' => false,
-                'choices_tree' => $this->allCmsCategories,
-                'choice_value' => 'id_cms_category',
-            ]);
+            ->add('id_module', ChoiceType::class, [
+                'choices' => [],
+            ])
+            ->add('id_hook', ChoiceType::class, [
+                'choices' => [],
+            ])
+            ->add('except_files', ChoiceType::class, [
+                'choices' => [],
+            ])
+        ;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/positions.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/positions.yml
@@ -8,8 +8,25 @@ admin_modules_positions:
 
 admin_modules_positions_unhook:
     path: /unhook
-    methods: [POST,GET]
+    methods: [POST, GET]
     defaults:
         _controller: 'PrestaShopBundle:Admin\Improve\Design\Positions:unhook'
         _legacy_controller: AdminModulesPositions
         _legacy_link: AdminModulesPositions:unhook
+
+admin_modules_positions_add_to_hook:
+  path: /transplant
+  methods: [POST, GET]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\Positions:addToHook'
+    _legacy_controller: AdminModulesPositions
+    _legacy_link: AdminModulesPositions:addToHook
+
+
+admin_modules_positions_edit:
+  path: /{moduleId}/{hookId}/edit
+  methods: [POST, GET]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin\Improve\Design\Positions:edit'
+    _legacy_controller: AdminModulesPositions
+    _legacy_link: AdminModulesPositions:editGraft

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
@@ -120,3 +120,13 @@ admin_module_addons_store:
         _controller: 'PrestaShopBundle:Admin\Improve\Modules\AddonsStore:index'
         _legacy_controller: AdminAddonsCatalog
         _legacy_link: AdminAddonsCatalog
+
+admin_module_hooks:
+    path: /module-hooks
+    methods: [GET]
+    defaults:
+        _controller: 'PrestaShopBundle:Admin\Improve\Modules\ModuleHooks:getModuleHooks'
+        _legacy_controller: AdminModulesPositionsController
+        _legacy_link: AdminModulesPositionsController:ajaxProcessGetHookableList
+
+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
@@ -38,3 +38,6 @@ services:
 
   prestashop.adapter.form.choice_provider.country_state_by_id:
     class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\CountryStateByIdChoiceProvider'
+
+  prestashop.adapter.form.choice_provider.module_name_by_id:
+    class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ModuleNameByIdChoiceProvider'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
@@ -41,3 +41,6 @@ services:
 
   prestashop.adapter.form.choice_provider.module_name_by_id:
     class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ModuleNameByIdChoiceProvider'
+
+  prestashop.adapter.form.choice_provider.module_hook_by_id:
+    class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ModuleHookByIdChoiceProvider'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -182,3 +182,6 @@ services:
         class: 'PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\MailThemeFormDataProvider'
         arguments:
             - '@prestashop.core.mail_theme.configuration'
+
+    prestashop.admin.module_hook.form_data_provider:
+      class: 'PrestaShopBundle\Form\Admin\Improve\Design\Position\ModuleHookFormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -356,5 +356,5 @@ services:
         - '@prestashop.core.hook.dispatcher'
         - '@prestashop.admin.module_hook.form_data_provider'
         -
-          'options': 'PrestaShopBundle\Form\Admin\Improve\Design\Position\ModuleHookType'
+          'module_hooks': 'PrestaShopBundle\Form\Admin\Improve\Design\Position\ModuleHookType'
         - 'ModuleHook'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -348,3 +348,13 @@ services:
             -
               'configuration': 'PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\MailThemeConfigurationType'
             - 'MailTheme'
+
+    prestashop.admin.module_hook.form_handler:
+      class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'
+      arguments:
+        - '@=service("form.factory").createBuilder()'
+        - '@prestashop.core.hook.dispatcher'
+        - '@prestashop.admin.module_hook.form_data_provider'
+        -
+          'options': 'PrestaShopBundle\Form\Admin\Improve\Design\Position\ModuleHookType'
+        - 'ModuleHook'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -865,3 +865,11 @@ services:
             - '@=service("prestashop.core.form.choice_provider.mail_themes").getChoices()'
         tags:
             - { name: form.type }
+
+    form.type.improve.design.position.module_hook:
+      class: 'PrestaShopBundle\Form\Admin\Improve\Design\Position\ModuleHookType'
+      arguments:
+        - '@translator'
+        - '@=service("prestashop.adapter.form.choice_provider.module_name_by_id").getChoices()'
+      tags:
+        - { name: form.type }

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/Blocks/form.html.twig
@@ -1,0 +1,51 @@
+{#**
+  * 2007-2019 PrestaShop and Contributors
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Open Software License (OSL 3.0)
+  * that is bundled with this package in the file LICENSE.txt.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/OSL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to https://www.prestashop.com for more information.
+  *
+  * @author    PrestaShop SA <contact@prestashop.com>
+  * @copyright 2007-2019 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+  * International Registered Trademark & Property of PrestaShop SA
+  *#}
+
+{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+
+{{ form_start(moduleHookForm) }}
+<div class="card">
+  <div class="card-header">
+    {{ 'Positions'|trans({}, 'Admin.Design.Feature') }}
+  </div>
+  <div class="card-block row">
+    <div class="card-text">
+
+    </div>
+  </div>
+
+  <div class="card-footer">
+    <div class="d-inline-flex">
+      <a href="{{ path('admin_modules_positions_index') }}" class="btn btn-outline-secondary">
+        {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+      </a>
+    </div>
+    <div class="d-inline-flex float-right">
+      <button type="submit" class="btn btn-primary ml-3">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+    </div>
+  </div>
+
+</div>
+{{ form_end(moduleHookForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/Blocks/form.html.twig
@@ -32,6 +32,10 @@
   </div>
   <div class="card-block row">
     <div class="card-text">
+      {{ ps.form_group_row(moduleHookForm.module_hooks.id_module, {'attr': {
+        'data-hooks-url': path('admin_module_hooks') }}, {
+        'label': 'Module'|trans({}, 'Admin.Global'),
+      }) }}
       {{ form_rest(moduleHookForm) }}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/Blocks/form.html.twig
@@ -32,13 +32,13 @@
   </div>
   <div class="card-block row">
     <div class="card-text">
-
+      {{ form_rest(moduleHookForm) }}
     </div>
   </div>
 
   <div class="card-footer">
     <div class="d-inline-flex">
-      <a href="{{ path('admin_modules_positions_index') }}" class="btn btn-outline-secondary">
+      <a href="{{ path('admin_modules_positions') }}" class="btn btn-outline-secondary">
         {{ 'Cancel'|trans({}, 'Admin.Actions') }}
       </a>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/add_to_hook.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/add_to_hook.html.twig
@@ -32,3 +32,8 @@
     </div>
   </div>
 {% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+  <script src="{{ asset('themes/new-theme/public/improve_design_positions_module_hook_form.bundle.js') }}"></script>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/add_to_hook.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/add_to_hook.html.twig
@@ -1,0 +1,34 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  <div class="row justify-content-center">
+    <div class="col">
+{#      {{ include('@PrestaShop/Admin/Improve/Design/Position/Blocks/form.html.twig', {}) }}#}
+    </div>
+  </div>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/edit.html.twig
@@ -1,0 +1,34 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  <div class="row justify-content-center">
+    <div class="col">
+{#      {{ include('@PrestaShop/Admin/Improve/Design/Position/Blocks/form.html.twig', {}) }}#}
+    </div>
+  </div>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Position/index.html.twig
@@ -157,13 +157,16 @@
                             {% set linkParams = {
                               'id_module': moduleInstance.id,
                               'id_hook': hook['id_hook'],
-                              'editGraft': 1
                             } %}
-                            {% if selectedModule %}
-                              {% set linkParams = linkParams|merge({'show_modules': selectedModule}) %}
-                            {% endif %}
+                            {# recheck if this 'selectedModule` needed here, it might only controll the selection display #}
+{#                            {% if selectedModule %}#}
+{#                              {% set linkParams = linkParams|merge({'show_modules': selectedModule}) %}#}
+{#                            {% endif %}#}
 
-                            <a class="btn btn-outline-primary btn-sm" href="{{ getAdminLink('AdminModulesPositions', true, linkParams) }}">
+                            <a class="btn btn-outline-primary btn-sm" href="{{ path('admin_modules_positions_edit', {
+                              'moduleId' : moduleInstance.id,
+                              'hookId': hook['id_hook'],
+                            }) }}">
                               <i class="material-icons">edit</i>
                               {{ 'Edit' | trans({}, 'Admin.Actions') }}
                             </a>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Migrates missing actions in Improve > Design > Positions. The missing actions are: `Transplant a module` (a.k.a add to hook) and `Edit`. These actions shares the same view and can be considered similar as `add` and `edit` in other pages.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #13935
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13941)
<!-- Reviewable:end -->
