### PR TITLE
Restore legacy controller and template files deleted late in beta

### DIFF
--- a/admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl
@@ -23,6 +23,10 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
+{**
+ * @deprecated since 1.7.6, to be removed in the next minor
+ *}
+
 {extends file="helpers/form/form.tpl"}
 {block name="input"}
 	{if $input.name == "link_rewrite"}

--- a/admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl
@@ -1,0 +1,69 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+{extends file="helpers/form/form.tpl"}
+{block name="input"}
+	{if $input.name == "link_rewrite"}
+		<script type="text/javascript">
+		{if isset($PS_ALLOW_ACCENTED_CHARS_URL) && $PS_ALLOW_ACCENTED_CHARS_URL}
+			var PS_ALLOW_ACCENTED_CHARS_URL = 1;
+		{else}
+			var PS_ALLOW_ACCENTED_CHARS_URL = 0;
+		{/if}
+		</script>
+		{$smarty.block.parent}
+	{else}
+		{$smarty.block.parent}
+	{/if}
+{/block}
+{block name="script"}
+	$(document).ready(function() {
+		$('#active_on').bind('click', function(){
+			toggleDraftWarning(false);
+		});
+		$('#active_off').bind('click', function(){
+			toggleDraftWarning(true);
+		});
+	});
+{/block}
+
+{block name="leadin"}
+	<div style="{if $active}display:none{/if}">
+		<p class="alert alert-warning">
+			{l s='Your page will be saved as a draft' d='Admin.Design.Notification'}
+		</p>
+	</div>
+{/block}
+
+{block name="input"}
+	{if $input.type == 'select_category'}
+		<select name="{$input.name}">
+			{$input.options.html}
+		</select>
+	{else}
+		{$smarty.block.parent}
+	{/if}
+{/block}
+

--- a/admin-dev/themes/default/template/controllers/cms/helpers/form/index.php
+++ b/admin-dev/themes/default/template/controllers/cms/helpers/form/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/cms/helpers/index.php
+++ b/admin-dev/themes/default/template/controllers/cms/helpers/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/cms/index.php
+++ b/admin-dev/themes/default/template/controllers/cms/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/cms_categories/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cms_categories/helpers/form/form.tpl
@@ -23,6 +23,10 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
+{**
+ * @deprecated since 1.7.6, to be removed in the next minor
+ *}
+
 {extends file="helpers/form/form.tpl"}
 {block name="input"}
 	{if $input.name == "link_rewrite"}

--- a/admin-dev/themes/default/template/controllers/cms_categories/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cms_categories/helpers/form/form.tpl
@@ -1,0 +1,54 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+{extends file="helpers/form/form.tpl"}
+{block name="input"}
+	{if $input.name == "link_rewrite"}
+		<script type="text/javascript">
+		{if isset($PS_ALLOW_ACCENTED_CHARS_URL) && $PS_ALLOW_ACCENTED_CHARS_URL}
+			var PS_ALLOW_ACCENTED_CHARS_URL = 1;
+		{else}
+			var PS_ALLOW_ACCENTED_CHARS_URL = 0;
+		{/if}
+		</script>
+		{$smarty.block.parent}
+	{else}
+		{$smarty.block.parent}
+	{/if}
+{/block}
+{block name="input"}
+	{if $input.type == 'select_category'}
+		<div class="col-lg-9">
+			<div class="row">
+				<select name="id_parent">
+					{$input.options.html}
+				</select>
+			</div>
+		</div>
+	{else}
+		{$smarty.block.parent}
+	{/if}
+{/block}
+

--- a/admin-dev/themes/default/template/controllers/cms_categories/helpers/form/index.php
+++ b/admin-dev/themes/default/template/controllers/cms_categories/helpers/form/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/cms_categories/helpers/index.php
+++ b/admin-dev/themes/default/template/controllers/cms_categories/helpers/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/cms_categories/index.php
+++ b/admin-dev/themes/default/template/controllers/cms_categories/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/cms_content/content.tpl
+++ b/admin-dev/themes/default/template/controllers/cms_content/content.tpl
@@ -23,6 +23,10 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
+{**
+ * @deprecated since 1.7.6, to be removed in the next minor
+ *}
+
 {if isset($cms_breadcrumb)}
 	<ul class="breadcrumb cat_bar">
 		{$cms_breadcrumb}

--- a/admin-dev/themes/default/template/controllers/cms_content/content.tpl
+++ b/admin-dev/themes/default/template/controllers/cms_content/content.tpl
@@ -1,0 +1,43 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+{if isset($cms_breadcrumb)}
+	<ul class="breadcrumb cat_bar">
+		{$cms_breadcrumb}
+	</ul>
+{/if}
+
+{$content}
+
+{if isset($url_prev)}
+	<script type="text/javascript">
+	$(document).ready(function () {
+		var re = /url_preview=(.*)/;
+		var url = re.exec(window.location.href);
+		if (typeof url !== 'undefined' && url !== null && typeof url[1] !== 'undefined' && url[1] === "1")
+			window.open("{$url_prev}", "_blank");
+	});
+	</script>
+{/if}

--- a/admin-dev/themes/default/template/controllers/cms_content/index.php
+++ b/admin-dev/themes/default/template/controllers/cms_content/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/manufacturers/helpers/index.php
+++ b/admin-dev/themes/default/template/controllers/manufacturers/helpers/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/manufacturers/helpers/view/index.php
+++ b/admin-dev/themes/default/template/controllers/manufacturers/helpers/view/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl
@@ -23,6 +23,10 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
+{**
+ * @deprecated since 1.7.6, to be removed in the next minor
+ *}
+
 {extends file="helpers/view/view.tpl"}
 
 {block name="override_tpl"}

--- a/admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl
@@ -1,0 +1,146 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+{extends file="helpers/view/view.tpl"}
+
+{block name="override_tpl"}
+<div class="panel">
+	<h3>{l s='Addresses' d='Admin.Global'} <span class="badge">{count($addresses)}</span></h3>
+	{if !count($addresses)}
+		{l s='No address has been found for this brand.' d='Admin.Catalog.Notification'}
+	{else}
+		{foreach $addresses AS $addresse}
+		<div class="panel">
+			<div class="panel-heading">
+				{$addresse.firstname} {$addresse.lastname}
+				<div class="pull-right">
+					<a class="btn btn-default" href="{$link->getAdminLink('AdminManufacturers', true, [], ['id_address' => $addresse.id_address, 'editaddresses' => 1])|escape:'html':'UTF-8'}">
+						<i class="icon-edit"></i>
+						{l s='Edit' d='Admin.Actions'}</a>
+				</div>
+			</div>
+
+			<table class="table">
+				<tbody>
+					<tr>
+						<td>
+							{$addresse.address1}<br />
+							{if $addresse.address2}{$addresse.address2}<br />{/if}
+							{$addresse.postcode} {$addresse.city}<br />
+							{if $addresse.state}{$addresse.state}<br />{/if}
+							<b>{$addresse.country}</b><br />
+							{if $addresse.phone}{$addresse.phone}<br />{/if}
+							{if $addresse.phone_mobile}{$addresse.phone_mobile}<br />{/if}
+							{if $addresse.other}<div ><br />
+								<i>{$addresse.other|nl2br}</i></div>
+							{/if}
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		{/foreach}
+	{/if}
+</div>
+<div class="panel">
+	<h3>{l s='Products' d='Admin.Global'} <span class="badge">{count($products)}</span></h3>
+
+	{foreach $products AS $product}
+		{if !$product->hasAttributes()}
+			<div class="panel">
+				<div class="panel-heading">
+					{$product->name}
+					<div class="pull-right">
+						<a href="{$link->getAdminLink('AdminProducts', true, ['id_product' => $product->id|intval, 'updateproduct' => '1'])|escape:'html':'UTF-8'}" class="btn btn-default btn-sm">
+							<i class="icon-edit"></i> {l s='Edit' d='Admin.Actions'}
+						</a>
+						<a href="{$link->getAdminLink('AdminProducts', true, ['id_product' => $product->id|intval, 'deleteproduct' => '1'])|escape:'html':'UTF-8'}" class="btn btn-default btn-sm" onclick="return confirm('{l s='Delete item #'}{$product->id} ?');">
+							<i class="icon-trash"></i> {l s='Delete' d='Admin.Actions'}
+						</a>
+					</div>
+				</div>
+
+				<table class="table">
+					<thead>
+						<tr>
+							{if !empty($product->reference)}<th><span class="title_box">{l s='Ref:' d='Admin.Catalog.Feature'}</span> {$product->reference}</th>{/if}
+							{if !empty($product->ean13)}<th><span class="title_box">{l s='EAN13:' d='Admin.Catalog.Feature'}</span> {$product->ean13}</th>{/if}
+							{if !empty($product->upc)}<th><span class="title_box">{l s='UPC:' d='Admin.Catalog.Feature'}</span> {$product->upc}</th>{/if}
+							{if $stock_management}<th><span class="title_box">{l s='Qty:' d='Admin.Catalog.Feature'}</span> {$product->quantity}</th>{/if}
+						</tr>
+					</thead>
+				</table>
+			</div>
+		{else}
+			<div class="panel">
+				<div class="panel-heading">
+
+					<a href="{$link->getAdminLink('AdminProducts', true, ['id_product' => $product->id|intval, 'updateproduct' => '1'])|escape:'html':'UTF-8'}">
+						{$product->name}
+					</a>
+					<div class="pull-right">
+						<a href="{$link->getAdminLink('AdminProducts', true, ['id_product' => $product->id|intval, 'updateproduct' => '1'])|escape:'html':'UTF-8'}" class="btn btn-default btn-sm">
+							<i class="icon-edit"></i>
+							{l s='Edit' d='Admin.Actions'}
+						</a>
+						<a href="{$link->getAdminLink('AdminProducts', true, ['id_product' => $product->id|intval, 'deleteproduct' => '1'])|escape:'html':'UTF-8'}" class="btn btn-default btn-sm" onclick="return confirm('{l s='Delete item #'}{$product->id} ?');">
+							<i class="icon-trash"></i>
+							{l s='Delete' d='Admin.Actions'}
+						</a>
+					</div>
+
+				</div>
+
+				<table class="table">
+					<thead>
+						<tr>
+							<th><span class="title_box">{l s='Attribute name' d='Admin.Catalog.Feature'}</span></th>
+							<th><span class="title_box">{l s='Reference' d='Admin.Global'}</span></th>
+							<th><span class="title_box">{l s='EAN13' d='Admin.Catalog.Feature'}</span></th>
+							<th><span class="title_box">{l s='UPC' d='Admin.Catalog.Feature'}</span></th>
+							{if $stock_management && $shopContext != Shop::CONTEXT_ALL}
+								<th><span class="title_box">{l s='Available quantity' d='Admin.Catalog.Feature'}</span></th>
+							{/if}
+						</tr>
+					</thead>
+					<tbody>
+					{foreach $product->combination AS $id_product_attribute => $product_attribute}
+						<tr {if $id_product_attribute %2}class="alt_row"{/if} >
+							<td>{$product_attribute.attributes}</td>
+							<td>{$product_attribute.reference}</td>
+							<td>{$product_attribute.ean13}</td>
+							<td>{$product_attribute.upc}</td>
+							{if $stock_management && $shopContext != Shop::CONTEXT_ALL}
+								<td class="right">{$product_attribute.quantity}</td>
+							{/if}
+						</tr>
+					{/foreach}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	{/foreach}
+</div>
+{/block}

--- a/admin-dev/themes/default/template/controllers/manufacturers/index.php
+++ b/admin-dev/themes/default/template/controllers/manufacturers/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
@@ -23,6 +23,10 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
+{**
+ * @deprecated since 1.7.6, to be removed in the next minor
+ *}
+
 <div class="leadin">{block name="leadin"}{/block}</div>
 
 <form action="{$url_submit|escape:'html':'UTF-8'}" id="{$table}_form" method="post" class="form-horizontal">

--- a/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
@@ -1,0 +1,140 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+<div class="leadin">{block name="leadin"}{/block}</div>
+
+<form action="{$url_submit|escape:'html':'UTF-8'}" id="{$table}_form" method="post" class="form-horizontal">
+	{if $display_key}
+		<input type="hidden" name="show_modules" value="{$display_key}" />
+	{/if}
+	<div class="panel">
+		<h3>
+			<i class="icon-paste"></i>
+			{l s='Transplant a module' d='Admin.Design.Feature'}
+		</h3>
+		<div class="form-group">
+			<label class="control-label col-lg-3 required"> {l s='Module' d='Admin.Global'}</label>
+			<div class="col-lg-9">
+				<select class="chosen" name="id_module" {if $edit_graft} disabled="disabled"{/if}>
+					{if !$hooks}
+						<option value="0" selected disabled>{l s='Please select a module' d='Admin.Design.Help'}</option>
+					{/if}
+					{foreach $modules as $module}
+						<option value="{$module->id|intval}"{if $id_module == $module->id || (!$id_module && $show_modules == $module->id)} selected="selected"{/if}>{$module->displayName|stripslashes}</option>
+					{/foreach}
+				</select>
+			</div>
+		</div>
+		<div class="form-group">
+			<label class="control-label col-lg-3 required"> {l s='Transplant to' d='Admin.Design.Feature'}</label>
+			<div class="col-lg-9">
+				<select name="id_hook"{if !$hooks|@count} disabled="disabled"{/if}>
+					{if !$hooks|@count}
+						<option value="0">{l s='Select a module above before choosing from available hooks' d='Admin.Design.Help'}</option>
+					{/if}
+
+					<optgroup id="hooks_unregistered" label="{l s='Available hooks' d='Admin.Design.Feature'}">
+					{foreach $hooks as $hook}
+						{if !$hook['registered']}
+							<option value="{$hook['id_hook']}" {if $id_hook == $hook['id_hook']} selected="selected"{/if}>{$hook['name']}{if $hook['name'] != $hook['title']} ({$hook['title']}){/if}{if isset($hook['description'])} ({$hook['description']|escape:'htmlall':'UTF-8'}){/if}</option>
+						{/if}
+					{/foreach}
+					</optgroup>
+
+					<optgroup id="hooks_registered" label="{l s='Already registered hooks' d='Admin.Design.Feature'}" disabled>
+					{foreach $hooks as $hook}
+						{if $hook['registered']}
+							<option value="{$hook['id_hook']}" {if $id_hook == $hook['id_hook']} selected="selected"{/if}>{$hook['name']}{if $hook['name'] != $hook['title']} ({$hook['title']}){/if}{if isset($hook['description'])} ({$hook['description']|escape:'htmlall':'UTF-8'}){/if}</option>
+						{/if}
+					{/foreach}
+					</optgroup>
+				</select>
+			</div>
+		</div>
+		<div class="form-group">
+			<label class="control-label col-lg-3">{l s='Exceptions' d='Admin.Design.Feature'}</label>
+			<div class="col-lg-9">
+				<div class="well">
+					<div>
+						{l s='Please specify the files for which you do not want the module to be displayed.' d='Admin.Design.Help'}<br />
+						{l s='Please input each filename, separated by a comma (",").' d='Admin.Design.Help'}<br />
+						{l s='You can also click the filename in the list below, and even make a multiple selection by keeping the Ctrl key pressed while clicking, or choose a whole range of filename by keeping the Shift key pressed while clicking.' d='Admin.Design.Help'}<br />
+						{if !$except_diff}
+							{$exception_list}
+						{else}
+							{foreach $exception_list_diff as $value}
+								{$value}
+							{/foreach}
+						{/if}
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="panel-footer">
+			{if $edit_graft}
+				<input type="hidden" name="id_module" value="{$id_module}" />
+				<input type="hidden" name="id_hook" value="{$id_hook}" />
+				<input type="hidden" name="new_hook" id="new_hook" value="{$id_hook}" />
+			{/if}
+			<button type="submit" name="{if $edit_graft}submitEditGraft{else}submitAddToHook{/if}" id="{$table}_form_submit_btn" class="btn btn-default pull-right"><i class="process-icon-save"></i> {l s='Save' d='Admin.Actions'}</button>
+		</div>
+	</div>
+</form>
+<script type="text/javascript">
+	//<![CDATA
+	function position_exception_textchange() {
+		// TODO : Add & Remove automatically the "custom pages" in the "em_list_x"
+		var obj = $(this);
+		var shopID = obj.attr('id').replace(/\D/g, '');
+		var list = obj.closest('form').find('#em_list_' + shopID);
+		var values = obj.val().split(',');
+		var len = values.length;
+
+		list.find('option').prop('selected', false);
+		for (var i = 0; i < len; i++)
+			list.find('option[value="' + $.trim(values[i]) + '"]').prop('selected', true);
+	}
+	function position_exception_listchange() {
+		var obj = $(this);
+		var shopID = obj.attr('id').replace(/\D/g, '');
+		var val = obj.val();
+		var str = '';
+		if (val)
+			str = val.join(', ');
+		obj.closest('form').find('#em_text_' + shopID).val(str);
+	}
+	$(document).ready(function(){
+		$('form[id="hook_module_form"] input[id^="em_text_"]').each(function(){
+			$(this).change(position_exception_textchange).change();
+		});
+		$('form[id="hook_module_form"] select[id^="em_list_"]').each(function(){
+			$(this).change(position_exception_listchange);
+		});
+		$('select[name=id_hook]').on('change', function() {
+			$('#new_hook').attr('value', $(this).val());
+		});
+	});
+	//]]>
+</script>

--- a/admin-dev/themes/default/template/controllers/modules_positions/index.php
+++ b/admin-dev/themes/default/template/controllers/modules_positions/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../../');
+exit;

--- a/admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl
@@ -23,6 +23,10 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
+{**
+ * @deprecated since 1.7.6, to be removed in the next minor
+ *}
+
 <script type="text/javascript">
 	var come_from = 'AdminModulesPositions';
 </script>

--- a/admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl
@@ -1,0 +1,215 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+<script type="text/javascript">
+	var come_from = 'AdminModulesPositions';
+</script>
+
+<div>{block name="leadin"}{/block}</div>
+
+{if !$can_move}
+					<p class="alert alert-warning">
+						{l s='If you want to order/move the following data, please select a shop from the shop list.' d='Admin.Design.Notification'}
+					</p>
+{/if}
+
+<div class="row">
+	<div class="col-lg-9">
+		<div class="panel">
+			<form class="well form-horizontal" id="position_filer">
+				<div class="row">
+					<div class="form-group col-lg-6 col-sm-12">
+						<label class="control-label col-lg-4" style="text-align: left">{l s='Show' d='Admin.Actions'}</label>
+						<div class="col-lg-7">
+							<select id="show_modules" class="filter" style="width: 100%;">
+								<option value="all">{l s='All modules' d='Admin.Design.Feature'}&nbsp;</option>
+								{foreach $modules as $module}
+									<option value="{$module->id|intval}"{if $display_key == $module->id} selected="selected"{/if}>{$module->displayName|escape:'html':'UTF-8'}</option>
+								{/foreach}
+							</select>
+						</div>
+					</div>
+					<div class="form-group col-lg-6 col-sm-12">
+						<label class="control-label col-lg-offset-1 col-lg-4" style="text-align: left">{l s='Search for a hook' d='Admin.Design.Feature'}</label>
+						<div class="col-lg-7">
+							<div class="input-group">
+								<div class="input-group-addon"><i class="icon icon-search"></i></div>
+								<input type="text" class="form-control" id="hook_search" name="hook_search" placeholder="">
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="row">
+					<div class="col-sm-12">
+							<p class="checkbox">
+								<label class="control-label" for="hook_position">
+									<input type="checkbox" id="hook_position"/>
+									{l s='Display non-positionable hooks' d='Admin.Design.Feature'}
+								</label>
+							</p>
+					</div>
+				</div>
+			</form>
+			<div id="modulePosition">
+				<form method="post" action="{$url_submit|escape:'html':'UTF-8'}" >
+					{foreach $hooks as $hook}
+					<section class="hook_panel {if $hook['position'] == 0}hook_position{/if}" {if $hook['position'] == 0}style="display:none;"{/if}>
+						<a name="{$hook['name']}"></a>
+						<header class="hook_panel_header">
+							<span class="hook_name">{$hook['name']}</span>
+							<!-- <span class="hook_title">{$hook['title']}</span> -->
+							<span class="badge pull-right">
+								{if $hook['module_count'] && $can_move}
+								<input type="checkbox" id="Ghook{$hook['id_hook']}" onclick="hookCheckboxes({$hook['id_hook']}, 0, this)"/>
+								{/if}
+								{$hook['module_count']} {if $hook['module_count'] > 1}{l s='Modules' d='Admin.Global'}{else}{l s='Module' d='Admin.Global'}{/if}
+							</span>
+
+							{if !empty($hook['description'])}
+							<div class="hook_description">{$hook['description']}</div>
+							{/if}
+						</header>
+
+						{if $hook['module_count']}
+						<section class="module_list">
+						<ul class="list-unstyled{if $hook['modules']|count > 1} sortable{/if}">
+
+							{foreach $hook['modules'] as $position => $module}
+							{if isset($module['instance'])}
+							<li id="{$hook['id_hook']|intval}_{$module['instance']->id|intval}" class="module_position_{$module['instance']->id|intval} module_list_item{if $can_move && $hook['module_count'] >= 2} draggable{/if}">
+								<div class="module_col_select">
+									<input type="checkbox" id="mod{$hook['id_hook']|intval}_{$module['instance']->id|intval}" class="modules-position-checkbox hook{$hook['id_hook']}" onclick="hookCheckboxes({$hook['id_hook']}, 1, this)" name="unhooks[]" value="{$hook['id_hook']}_{$module['instance']->id}"/>
+								</div>
+								{if !$display_key}
+								<div class="module_col_position{if $can_move && $hook['module_count'] >= 2} dragHandle{/if}" id="td_{$hook['id_hook']|intval}_{$module['instance']->id}">
+									<span class="positions">{$module@iteration}</span>
+									{if $can_move}
+									<div class="btn-group-vertical">
+										<a class="btn btn-default btn-xs" href="{$current|escape:'html':'UTF-8'}&amp;id_module={$module['instance']->id|intval}&amp;id_hook={$hook['id_hook']|intval}&amp;direction=0&amp;token={$token|escape:'html':'UTF-8'}&amp;changePosition#{$hook['name']}">
+											<i class="icon-chevron-up"></i>
+										</a>
+
+										<a class="btn btn-default btn-xs" href="{$current|escape:'html':'UTF-8'}&amp;id_module={$module['instance']->id|intval}&amp;id_hook={$hook['id_hook']|intval}&amp;direction=1&amp;token={$token|escape:'html':'UTF-8'}&amp;changePosition#{$hook['name']}">
+											<i class="icon-chevron-down"></i>
+										</a>
+									</div>
+									{/if}
+								</div>
+								{/if}
+								<div class="module_col_icon">
+									<img width="57" src="../modules/{$module['instance']->name}/logo.png" alt="{$module['instance']->name|stripslashes}" />
+								</div>
+								<div class="module_col_infos">
+									<span class="module_name">
+										{$module['instance']->displayName|stripslashes} {if $module['instance']->version}
+										<small class="text-muted">&nbsp;-&nbsp;v{if $module['instance']->version|intval == $module['instance']->version}{sprintf('%.1f', $module['instance']->version)}{else}{$module['instance']->version|floatval}{/if}</small>{/if}
+									</span>
+									<div class="module_description">{$module['instance']->description}</div>
+								</div>
+								<div class="module_col_actions">
+									<!-- <div class="lab_modules_positions" for="mod{$hook['id_hook']}_{$module['instance']->id}"></div> -->
+									<div class="btn-group">
+										<a class="btn btn-default" href="{$current|escape:'html':'UTF-8'}&amp;id_module={$module['instance']->id|intval}&amp;id_hook={$hook['id_hook']}&amp;editGraft{if $display_key}&amp;show_modules={$display_key}{/if}&amp;token={$token|escape:'html':'UTF-8'}">
+											<i class="icon-pencil"></i>
+											{l s='Edit' d='Admin.Actions'}
+										</a>
+										<a class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+											<span class="caret"></span>&nbsp;
+										</a>
+										<ul class="dropdown-menu">
+											<li>
+												<a href="{$current|escape:'html':'UTF-8'}&amp;id_module={$module['instance']->id|intval}&amp;id_hook={$hook['id_hook']}&amp;deleteGraft{if $display_key}&amp;show_modules={$display_key}{/if}&amp;token={$token|escape:'html':'UTF-8'}">
+													<i class="icon-minus-sign-alt"></i>
+													{l s='Unhook' d='Admin.Design.Feature'}
+												</a>
+											</li>
+										</ul>
+									</div>
+								</div>
+							</li>
+							{/if}
+						{/foreach}
+						</ul>
+						</section>
+	{else}
+							<!-- <p>{l s='No module was found for this hook.'}</p> -->
+	{/if}
+					</section>
+{/foreach}
+					<div id="unhook_button_position_bottom">
+						<button type="submit" class="btn btn-default" name="unhookform">
+							<i class="icon-minus-sign-alt"></i>
+							{l s='Unhook the selection' d='Admin.Design.Feature'}
+						</button>
+					</div>
+				</form>
+			</div>
+		</div>
+	</div>
+	<div class="col-lg-3">
+		<div class="panel" id="modules-position-selection-panel">
+			<h3><i class="icon-check"></i> {l s='Selection' d='Admin.Global'}</h3>
+			<p>
+				<span id="modules-position-single-selection">{l s='1 module selected' d='Admin.Design.Feature'}</span>
+				<span id="modules-position-multiple-selection">
+					<span id="modules-position-selection-count"></span> {l s='modules selected' d='Admin.Design.Feature'}
+				</span>
+			</p>
+			<div class="text-center">
+				<button class="btn btn-default"><i class="icon-remove"></i> {l s='Unhook the selection' d='Admin.Design.Feature'}</button>
+			</div>
+		</div>
+	</div>
+</div>
+<script type="text/javascript">
+	$('.sortable').sortable({
+		forcePlaceholderSize: true
+	}).bind('sortupdate', function(e, ui) {
+		var ids = ui.item.attr('id').split('_');
+		var way = (ui.start_index < ui.end_index)? 1 : 0;
+		var data = ids[0]+'[]=';
+
+		$.each(e.target.children, function(index, element) {
+			data += '&'+ids[0]+'[]='+$(element).attr('id');
+		});
+
+		$.ajax({
+			type: 'POST',
+			headers: { "cache-control": "no-cache" },
+			async: false,
+			url: currentIndex + '&token=' + token + '&' + 'rand=' + new Date().getTime(),
+			data: data + '&action=updatePositions&id_hook='+ids[0]+'&id_module='+ids[1]+'&way='+way+'&ajax=1' ,
+			success: function(data) {
+				start = 0;
+
+				$.each(e.target.children, function(index, element) {
+					$(element).find('.positions').html(++start);
+				});
+
+				showSuccessMessage(update_success_msg);
+			}
+		});
+	});
+</script>

--- a/admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl
@@ -23,6 +23,10 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
+{**
+ * @deprecated since 1.7.6, to be removed in the next minor
+ *}
+
 {extends file="helpers/form/form.tpl"}
 
 {block name="after"}

--- a/admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl
@@ -1,0 +1,116 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+{extends file="helpers/form/form.tpl"}
+
+{block name="after"}
+<div class="row">
+	<div class="col-lg-3">
+		<div class="panel">
+			<h3><i class="icon-list"></i> {l s='List of MySQL Tables' d='Admin.Advparameters.Feature'}</h3>
+			<div class="form-group" id="selectTables">
+				<select id="table" size="10">
+					{foreach $tables as $table}
+						<option value="{$table}">{$table}</option>
+					{/foreach}
+				</select>
+			</div>
+			<div class="form-group">
+				<button type="button" id="add_table" class="btn btn-default"><i class="icon-plus-sign"></i> {l s='Add table name to SQL query' d='Admin.Advparameters.Feature'}</button>
+			</div>
+		</div>
+	</div>
+	<div class="col-lg-9">
+		<div class="panel">
+			<h3><i class="icon-list"></i> {l s='List of attributes for this MySQL table' d='Admin.Advparameters.Feature'}</h3>
+			<div id="listAttributes">
+				<div class="alert alert-warning">{l s='Please choose a MySQL table' d='Admin.Advparameters.Notification'}</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+{/block}
+
+{block name="script"}
+	$(document).ready(function() {
+		$('#selectTables select option').click(function(){
+			var table = $(this).val();
+			//list attributes:
+			$.ajax({
+				url: 'index.php',
+				data: {
+					table: table,
+					controller: 'adminrequestsql',
+					token: '{$token|escape:'html':'UTF-8'}',
+					action: 'addrequest_sql',
+					ajax: true
+				},
+				context: document.body,
+				dataType: 'json',
+				context: this,
+				async: false,
+				success: function(data){
+					var html = "<table class='table'>";
+						html += "<thead>";
+							html += "<tr>";
+								html += "<th><span class=\"title_box\">{l s='Attribute'}</span></th>";
+								html += "<th class=\"fixed-width-md\"><span class=\"title_box\">{l s='Type' d='Admin.Global'}</span></th>";
+								html += "<th class=\"fixed-width-md\"><span class=\"title_box\">{l s='Action' d='Admin.Advparameters.Feature'}</span></th>";
+							html += "</tr>";
+						html += "</thead>";
+						html += "<tbody>";
+						for (var i=0; i < data.length; i++)
+						{
+							html += "<tr>";
+								html += "<td>"+data[i].Field+"</td>";
+								html += "<td>"+data[i].Type+"</td>";
+								html += "<td><button type=\"button\" class=\"btn btn-default\" onclick=\"javascript:AddRequestSql('"+data[i].Field+"');\">{l s='Add attribute to SQL query' d='Admin.Advparameters.Feature'}</button></td>";
+							html += "</tr>";
+						}
+						html += "</tbody>";
+					html += "</table>";
+					$('#listAttributes').html(html);
+				}
+			});
+		});
+
+		$('#add_table').click(function(){
+			var table = $('#selectTables select').val();
+
+			if (!table)
+				jAlert("{l s='Please choose a table.' js=1 d='Admin.Advparameters.Feature'}");
+			else
+				AddRequestSql(table);
+		});
+	});
+
+	function AddRequestSql(string)
+	{
+		var sql = $('#sql').val();
+		$('#sql').val(sql+' '+string);
+		return false;
+	}
+{/block}

--- a/admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl
@@ -23,6 +23,10 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
+{**
+ * @deprecated since 1.7.6, to be removed in the next minor
+ *}
+
 {extends file="helpers/view/view.tpl"}
 
 {block name="override_tpl"}

--- a/admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl
@@ -1,0 +1,67 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+{extends file="helpers/view/view.tpl"}
+
+{block name="override_tpl"}
+<div class="panel">
+	<h3><i class="icon-cog"></i> {l s='SQL query result' d='Admin.Advparameters.Feature'}</h3>
+	{if isset($view['error'])}
+		<div class="alert alert-warning">{l s='This SQL query has no result.' d='Admin.Advparameters.Notification'}</div>
+	{else}
+		<table class="table" id="viewRequestSql">
+			<thead>
+				<tr>
+					{foreach $view['key'] AS $key}
+					<th><span class="title_box">{$key}</span></th>
+					{/foreach}
+				</tr>
+			</thead>
+			<tbody>
+			{foreach $view['results'] AS $result}
+				<tr>
+					{foreach $view['key'] AS $name}
+						{if isset($view['attributes'][$name])}
+							<td>{$view['attributes'][$name]|escape:'html':'UTF-8'}</td>
+						{else}
+							<td>{$result[$name]|escape:'html':'UTF-8'}</td>
+						{/if}
+					{/foreach}
+				</tr>
+			{/foreach}
+			</tbody>
+		</table>
+
+		<script type="text/javascript">
+			$(function(){
+				var width = $('#viewRequestSql').width();
+				if (width > 990){
+					$('#viewRequestSql').css('display','block').css('overflow-x', 'scroll');
+				}
+			});
+		</script>
+	{/if}
+</div>
+{/block}

--- a/admin-dev/themes/default/template/controllers/request_sql/list_action_export.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/list_action_export.tpl
@@ -22,6 +22,11 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
+
+{**
+ * @deprecated since 1.7.6, to be removed in the next minor
+ *}
+
 <a href="{$href|escape:'html':'UTF-8'}" title="{$action}" class="btn btn-default">
 	<i class="icon-cloud-upload"></i> {$action}
 </a>

--- a/admin-dev/themes/default/template/controllers/request_sql/list_action_export.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/list_action_export.tpl
@@ -1,0 +1,27 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+<a href="{$href|escape:'html':'UTF-8'}" title="{$action}" class="btn btn-default">
+	<i class="icon-cloud-upload"></i> {$action}
+</a>

--- a/controllers/admin/AdminCmsCategoriesController.php
+++ b/controllers/admin/AdminCmsCategoriesController.php
@@ -34,8 +34,16 @@ class AdminCmsCategoriesControllerCore extends AdminController
 
     protected $position_identifier = 'id_cms_category_to_move';
 
+    /**
+     * @deprecated since 1.7.6, to be removed in the next minor
+     */
     public function __construct()
     {
+        @trigger_error(
+            'The AdminCmsCategoriesController is deprecated and will be removed in the next minor',
+            E_USER_DEPRECATED
+        );
+
         $this->bootstrap = true;
         $this->is_cms = true;
         $this->table = 'cms_category';

--- a/controllers/admin/AdminCmsCategoriesController.php
+++ b/controllers/admin/AdminCmsCategoriesController.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * @property CMSCategory $object
+ */
+class AdminCmsCategoriesControllerCore extends AdminController
+{
+    /** @var object CMSCategory() instance for navigation */
+    protected $cms_category;
+
+    protected $position_identifier = 'id_cms_category_to_move';
+
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        $this->is_cms = true;
+        $this->table = 'cms_category';
+        $this->list_id = 'cms_category';
+        $this->className = 'CMSCategory';
+        $this->lang = true;
+        $this->addRowAction('view');
+        $this->addRowAction('edit');
+        $this->addRowAction('delete');
+        $this->_orderBy = 'position';
+
+        parent::__construct();
+
+        $this->bulk_actions = array(
+            'delete' => array(
+                'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
+                'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
+                'icon' => 'icon-trash',
+            ),
+        );
+        $this->tpl_list_vars['icon'] = 'icon-folder-close';
+        $this->tpl_list_vars['title'] = $this->trans('Categories', array(), 'Admin.Catalog.Feature');
+        $this->fields_list = array(
+            'id_cms_category' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'align' => 'center', 'class' => 'fixed-width-xs'),
+            'name' => array('title' => $this->trans('Name', array(), 'Admin.Global'), 'width' => 'auto', 'callback' => 'hideCMSCategoryPosition', 'callback_object' => 'CMSCategory'),
+            'description' => array('title' => $this->trans('Description', array(), 'Admin.Global'), 'maxlength' => 90, 'orderby' => false),
+            'position' => array('title' => $this->trans('Position', array(), 'Admin.Global'), 'filter_key' => 'position', 'align' => 'center', 'class' => 'fixed-width-sm', 'position' => 'position'),
+            'active' => array(
+                'title' => $this->trans('Displayed', array(), 'Admin.Global'), 'class' => 'fixed-width-sm', 'active' => 'status',
+                'align' => 'center', 'type' => 'bool', 'orderby' => false,
+            ),
+        );
+
+        // The controller can't be call directly
+        // In this case, AdminCmsContentController::getCurrentCMSCategory() is null
+        if (!AdminCmsContentController::getCurrentCMSCategory()) {
+            $this->redirect_after = '?controller=AdminCmsContent&token=' . Tools::getAdminTokenLite('AdminCmsContent');
+            $this->redirect();
+        }
+
+        $this->cms_category = AdminCmsContentController::getCurrentCMSCategory();
+        $this->_where = ' AND `id_parent` = ' . (int) $this->cms_category->id;
+        $this->_select = 'position ';
+    }
+
+    public function getTabSlug()
+    {
+        return 'ROLE_MOD_TAB_ADMINCMSCONTENT_';
+    }
+
+    public function renderList()
+    {
+        $this->initToolbar();
+        $this->_group = 'GROUP BY a.`id_cms_category`';
+        if (isset($this->toolbar_btn['new'])) {
+            $this->toolbar_btn['new']['href'] .= '&id_parent=' . (int) Tools::getValue('id_cms_category');
+        }
+
+        return parent::renderList();
+    }
+
+    public function postProcess()
+    {
+        if (Tools::isSubmit('submitAdd' . $this->table)) {
+            $this->action = 'save';
+            if ($id_cms_category = (int) Tools::getValue('id_cms_category')) {
+                $this->id_object = $id_cms_category;
+                if (!CMSCategory::checkBeforeMove($id_cms_category, (int) Tools::getValue('id_parent'))) {
+                    $this->errors[] = $this->trans('The page Category cannot be moved here.', array(), 'Admin.Design.Notification');
+
+                    return false;
+                }
+            }
+            $object = parent::postProcess();
+            $this->updateAssoShop((int) Tools::getValue('id_cms_category'));
+            if ($object !== false) {
+                Tools::redirectAdmin(self::$currentIndex . '&conf=3&id_cms_category=' . (int) $object->id . '&token=' . Tools::getValue('token'));
+            }
+
+            return $object;
+        } elseif (Tools::isSubmit('statuscms_category') && Tools::getValue($this->identifier)) {
+            // Change object statuts (active, inactive)
+            if ($this->access('edit')) {
+                if (Validate::isLoadedObject($object = $this->loadObject())) {
+                    if ($object->toggleStatus()) {
+                        $identifier = ((int) $object->id_parent ? '&id_cms_category=' . (int) $object->id_parent : '');
+                        Tools::redirectAdmin(self::$currentIndex . '&conf=5' . $identifier . '&token=' . Tools::getValue('token'));
+                    } else {
+                        $this->errors[] = $this->trans('An error occurred while updating the status.', array(), 'Admin.Notifications.Error');
+                    }
+                } else {
+                    $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error')
+                        . ' <b>' . $this->table . '</b> ' . $this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
+                }
+            } else {
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
+            }
+        } elseif (Tools::isSubmit('delete' . $this->table)) {
+            // Delete object
+            if ($this->access('delete')) {
+                if (Validate::isLoadedObject($object = $this->loadObject()) && isset($this->fieldImageSettings)) {
+                    // check if request at least one object with noZeroObject
+                    if (isset($object->noZeroObject) && count($taxes = call_user_func(array($this->className, $object->noZeroObject))) <= 1) {
+                        $this->errors[] = $this->trans('You need at least one object.', array(), 'Admin.Notifications.Error')
+                            . ' <b>' . $this->table . '</b><br />' . $this->trans('You cannot delete all of the items.', array(), 'Admin.Notifications.Error');
+                    } else {
+                        $identifier = ((int) $object->id_parent ? '&' . $this->identifier . '=' . (int) $object->id_parent : '');
+                        if ($this->deleted) {
+                            $object->deleted = 1;
+                            if ($object->update()) {
+                                Tools::redirectAdmin(self::$currentIndex . '&conf=1&token=' . Tools::getValue('token') . $identifier);
+                            }
+                        } elseif ($object->delete()) {
+                            Tools::redirectAdmin(self::$currentIndex . '&conf=1&token=' . Tools::getValue('token') . $identifier);
+                        }
+                        $this->errors[] = $this->trans('An error occurred during deletion.', array(), 'Admin.Notifications.Error');
+                    }
+                } else {
+                    $this->errors[] = $this->trans('An error occurred while deleting the object.', array(), 'Admin.Notifications.Error')
+                        . ' <b>' . $this->table . '</b> ' . $this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
+                }
+            } else {
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
+            }
+        } elseif (Tools::isSubmit('position')) {
+            $object = new CMSCategory((int) Tools::getValue($this->identifier, Tools::getValue('id_cms_category_to_move', 1)));
+            if (!$this->access('edit')) {
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
+            } elseif (!Validate::isLoadedObject($object)) {
+                $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error')
+                    . ' <b>' . $this->table . '</b> ' . $this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
+            } elseif (!$object->updatePosition((int) Tools::getValue('way'), (int) Tools::getValue('position'))) {
+                $this->errors[] = $this->trans('Failed to update the position.', array(), 'Admin.Notifications.Error');
+            } else {
+                $identifier = ((int) $object->id_parent ? '&' . $this->identifier . '=' . (int) $object->id_parent : '');
+                $token = Tools::getAdminTokenLite('AdminCmsContent');
+                Tools::redirectAdmin(
+                    self::$currentIndex . '&' . $this->table . 'Orderby=position&' . $this->table . 'Orderway=asc&conf=5' . $identifier . '&token=' . $token
+                );
+            }
+        } elseif (Tools::getValue('submitDel' . $this->table) || Tools::getValue('submitBulkdelete' . $this->table)) {
+            // Delete multiple objects
+            if ($this->access('delete')) {
+                if (Tools::isSubmit($this->table . 'Box')) {
+                    $cms_category = new CMSCategory();
+                    $result = true;
+                    $result = $cms_category->deleteSelection(Tools::getValue($this->table . 'Box'));
+                    if ($result) {
+                        $cms_category->cleanPositions((int) Tools::getValue('id_cms_category'));
+                        $token = Tools::getAdminTokenLite('AdminCmsContent');
+                        Tools::redirectAdmin(self::$currentIndex . '&conf=2&token=' . $token . '&id_cms_category=' . (int) Tools::getValue('id_cms_category'));
+                    }
+                    $this->errors[] = $this->trans('An error occurred while deleting this selection.', array(), 'Admin.Notifications.Error');
+                } else {
+                    $this->errors[] = $this->trans('You must select at least one element to delete.', array(), 'Admin.Notifications.Error');
+                }
+            } else {
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
+            }
+        }
+        parent::postProcess();
+    }
+
+    public function renderForm()
+    {
+        $this->display = 'edit';
+        $this->initToolbar();
+        if (!$this->loadObject(true)) {
+            return;
+        }
+
+        $categories = CMSCategory::getCategories($this->context->language->id, false);
+        $html_categories = CMSCategory::recurseCMSCategory($categories, $categories[0][1], 1, $this->getFieldValue($this->object, 'id_parent'), 1);
+
+        $this->fields_form = array(
+            'legend' => array(
+                'title' => $this->trans('CMS Category', array(), 'Admin.Design.Feature'),
+                'icon' => 'icon-folder-close',
+            ),
+            'input' => array(
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Name', array(), 'Admin.Global'),
+                    'name' => 'name',
+                    'class' => 'copyMeta2friendlyURL',
+                    'required' => true,
+                    'lang' => true,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'switch',
+                    'label' => $this->trans('Displayed', array(), 'Admin.Global'),
+                    'name' => 'active',
+                    'required' => false,
+                    'is_bool' => true,
+                    'values' => array(
+                        array(
+                            'id' => 'active_on',
+                            'value' => 1,
+                            'label' => $this->trans('Enabled', array(), 'Admin.Global'),
+                        ),
+                        array(
+                            'id' => 'active_off',
+                            'value' => 0,
+                            'label' => $this->trans('Disabled', array(), 'Admin.Global'),
+                        ),
+                    ),
+                ),
+                // custom template
+                array(
+                    'type' => 'select_category',
+                    'label' => $this->trans('Parent category', array(), 'Admin.Design.Feature'),
+                    'name' => 'id_parent',
+                    'options' => array(
+                        'html' => $html_categories,
+                    ),
+                ),
+                array(
+                    'type' => 'textarea',
+                    'label' => $this->trans('Description', array(), 'Admin.Global'),
+                    'name' => 'description',
+                    'lang' => true,
+                    'rows' => 5,
+                    'cols' => 40,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Meta title', array(), 'Admin.Global'),
+                    'name' => 'meta_title',
+                    'lang' => true,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Meta description', array(), 'Admin.Global'),
+                    'name' => 'meta_description',
+                    'lang' => true,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Meta keywords', array(), 'Admin.Global'),
+                    'name' => 'meta_keywords',
+                    'lang' => true,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Friendly URL', array(), 'Admin.Global'),
+                    'name' => 'link_rewrite',
+                    'required' => true,
+                    'lang' => true,
+                    'hint' => $this->trans('Only letters and the minus (-) character are allowed.', array(), 'Admin.Catalog.Help'),
+                ),
+            ),
+            'submit' => array(
+                'title' => $this->trans('Save', array(), 'Admin.Actions'),
+            ),
+        );
+
+        if (Shop::isFeatureActive()) {
+            $this->fields_form['input'][] = array(
+                'type' => 'shop',
+                'label' => $this->trans('Shop association', array(), 'Admin.Global'),
+                'name' => 'checkBoxShopAsso',
+            );
+        }
+
+        $this->tpl_form_vars['PS_ALLOW_ACCENTED_CHARS_URL'] = (int) Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL');
+
+        return parent::renderForm();
+    }
+}

--- a/controllers/admin/AdminCmsContentController.php
+++ b/controllers/admin/AdminCmsContentController.php
@@ -38,8 +38,16 @@ class AdminCmsContentControllerCore extends AdminController
     /** @var object Category() instance for navigation */
     protected static $category = null;
 
+    /**
+     * @deprecated since 1.7.6, to be removed in the next minor
+     */
     public function __construct()
     {
+        @trigger_error(
+            'The AdminCmsContentController is deprecated and will be removed in the next minor',
+            E_USER_DEPRECATED
+        );
+
         $this->bootstrap = true;
         /* Get current category */
         $id_cms_category = (int) Tools::getValue('id_cms_category', Tools::getValue('id_cms_category_parent', 1));

--- a/controllers/admin/AdminCmsContentController.php
+++ b/controllers/admin/AdminCmsContentController.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * @property CMS $object
+ */
+class AdminCmsContentControllerCore extends AdminController
+{
+    /** @var object adminCMSCategories() instance */
+    protected $admin_cms_categories;
+
+    /** @var object adminCMS() instance */
+    protected $admin_cms;
+
+    /** @var object Category() instance for navigation */
+    protected static $category = null;
+
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        /* Get current category */
+        $id_cms_category = (int) Tools::getValue('id_cms_category', Tools::getValue('id_cms_category_parent', 1));
+        self::$category = new CMSCategory($id_cms_category);
+        if (!Validate::isLoadedObject(self::$category)) {
+            die('Category cannot be loaded');
+        }
+
+        parent::__construct();
+
+        $this->table = 'cms';
+        $this->className = 'CMS';
+        $this->bulk_actions = array(
+            'delete' => array(
+                'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
+                'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
+                'icon' => 'icon-trash',
+            ),
+        );
+
+        $this->admin_cms_categories = new AdminCmsCategoriesController();
+        $this->admin_cms_categories->tabAccess = $this->tabAccess;
+        $this->admin_cms_categories->init();
+        $this->admin_cms = new AdminCmsController();
+        $this->admin_cms->tabAccess = $this->tabAccess;
+        $this->admin_cms->init();
+        $this->context->controller = $this;
+    }
+
+    /**
+     * Return current category.
+     *
+     * @return object
+     */
+    public static function getCurrentCMSCategory()
+    {
+        return self::$category;
+    }
+
+    public function initProcess()
+    {
+        if (((Tools::isSubmit('submitAddcms_category') || Tools::isSubmit('submitAddcms_categoryAndStay')) && count($this->admin_cms_categories->errors))
+            || Tools::isSubmit('updatecms_category')
+            || Tools::isSubmit('addcms_category')) {
+            $this->display = 'edit_category';
+        } elseif (((Tools::isSubmit('submitAddcms') || Tools::isSubmit('submitAddcmsAndStay')) && count($this->admin_cms->errors))
+            || Tools::isSubmit('updatecms')
+            || Tools::isSubmit('addcms')) {
+            $this->display = 'edit_page';
+        } else {
+            $this->display = 'list';
+        }
+    }
+
+    public function initContent()
+    {
+        $id_cms_category = (int) Tools::getValue('id_cms_category');
+
+        if (!$id_cms_category) {
+            $id_cms_category = 1;
+        }
+
+        if ($this->display == 'list') {
+            $this->page_header_toolbar_btn['new_cms_category'] = array(
+                'href' => self::$currentIndex . '&addcms_category&token=' . $this->token,
+                'desc' => $this->trans('Add new page category', array(), 'Admin.Design.Help'),
+                'icon' => 'process-icon-new',
+            );
+            $this->page_header_toolbar_btn['new_cms_page'] = array(
+                'href' => self::$currentIndex . '&addcms&id_cms_category=' . (int) $id_cms_category . '&token=' . $this->token,
+                'desc' => $this->trans('Add new page', array(), 'Admin.Design.Help'),
+                'icon' => 'process-icon-new',
+            );
+        }
+
+        $this->page_header_toolbar_title = implode(' ' . Configuration::get('PS_NAVIGATION_PIPE') . ' ', $this->toolbar_title);
+
+        if (is_array($this->page_header_toolbar_btn)
+            && $this->page_header_toolbar_btn instanceof Traversable
+            || trim($this->page_header_toolbar_title) != '') {
+            $this->show_page_header_toolbar = true;
+        }
+
+        $this->admin_cms_categories->token = $this->token;
+        $this->admin_cms->token = $this->token;
+
+        if ($this->display == 'edit_category') {
+            $this->content .= $this->admin_cms_categories->renderForm();
+        } elseif ($this->display == 'edit_page') {
+            $this->content .= $this->admin_cms->renderForm();
+        } elseif ($this->display == 'list') {
+            $id_cms_category = (int) Tools::getValue('id_cms_category');
+            if (!$id_cms_category) {
+                $id_cms_category = 1;
+            }
+
+            // CMS categories breadcrumb
+            $cms_tabs = array('cms_category', 'cms');
+            // Cleaning links
+            $cat_bar_index = self::$currentIndex;
+            foreach ($cms_tabs as $tab) {
+                if (Tools::getValue($tab . 'Orderby') && Tools::getValue($tab . 'Orderway')) {
+                    $cat_bar_index = preg_replace('/&' . $tab . 'Orderby=([a-z _]*)&' . $tab . 'Orderway=([a-z]*)/i', '', self::$currentIndex);
+                }
+            }
+            $this->context->smarty->assign(array(
+                'cms_breadcrumb' => Tools::getPath($cat_bar_index, $id_cms_category, '', '', 'cms'),
+            ));
+
+            $this->content .= $this->admin_cms_categories->renderList();
+            $this->admin_cms->id_cms_category = $id_cms_category;
+            $this->content .= $this->admin_cms->renderList();
+        }
+
+        $this->context->smarty->assign(array(
+            'content' => $this->content,
+            'show_page_header_toolbar' => $this->show_page_header_toolbar,
+            'title' => $this->page_header_toolbar_title,
+            'toolbar_btn' => $this->page_header_toolbar_btn,
+            'page_header_toolbar_btn' => $this->page_header_toolbar_btn,
+            'page_header_toolbar_title' => $this->toolbar_title,
+        ));
+    }
+
+    public function initToolbarTitle()
+    {
+        $this->toolbar_title = is_array($this->breadcrumbs) ? array_unique($this->breadcrumbs) : array($this->breadcrumbs);
+
+        $id_cms_category = (int) Tools::getValue('id_cms_category');
+        if ($id_cms_category && $id_cms_category !== 1) {
+            $cms_category = new CMSCategory($id_cms_category);
+        }
+        $id_cms_page = Tools::getValue('id_cms');
+
+        if ($this->display == 'edit_category') {
+            if (Tools::getValue('addcms_category') !== false) {
+                $this->toolbar_title[] = $this->trans('Add new category', array(), 'Admin.Design.Feature');
+            } else {
+                if (isset($cms_category)) {
+                    $this->toolbar_title[] = $this->trans('Edit category: %name%', array('%name%' => $cms_category->name[$this->context->employee->id_lang]), 'Admin.Design.Feature');
+                }
+            }
+        } elseif ($this->display == 'edit_page') {
+            if (Tools::getValue('addcms') !== false) {
+                $this->toolbar_title[] = $this->trans('Add new page', array(), 'Admin.Design.Feature');
+            } elseif ($id_cms_page) {
+                $cms_page = new CMS($id_cms_page);
+                $this->toolbar_title[] = $this->trans('Edit page: %meta_title%', array('%meta_title%' => $cms_page->meta_title[$this->context->employee->id_lang]), 'Admin.Design.Feature');
+            }
+        } elseif ($this->display == 'list' && isset($cms_category)) {
+            $this->toolbar_title[] = $this->trans('Category: %category%', array('%category%' => $cms_category->name[$this->context->employee->id_lang]), 'Admin.Design.Feature');
+        }
+    }
+
+    public function postProcess()
+    {
+        $this->admin_cms->postProcess();
+        $this->admin_cms_categories->postProcess();
+
+        parent::postProcess();
+
+        if (isset($this->admin_cms->errors)) {
+            $this->errors = array_merge($this->errors, $this->admin_cms->errors);
+        }
+
+        if (isset($this->admin_cms_categories->errors)) {
+            $this->errors = array_merge($this->errors, $this->admin_cms_categories->errors);
+        }
+    }
+
+    public function setMedia($isNewTheme = false)
+    {
+        parent::setMedia($isNewTheme);
+        $this->addJqueryUi('ui.widget');
+        $this->addJqueryPlugin('tagify');
+    }
+
+    public function ajaxProcessUpdateCmsPositions()
+    {
+        if ($this->access('edit')) {
+            $id_cms = (int) Tools::getValue('id_cms');
+            $id_category = (int) Tools::getValue('id_cms_category');
+            $way = (int) Tools::getValue('way');
+            $positions = Tools::getValue('cms');
+            if (is_array($positions)) {
+                foreach ($positions as $key => $value) {
+                    $pos = explode('_', $value);
+                    if ((isset($pos[1], $pos[2])) && ($pos[1] == $id_category && $pos[2] == $id_cms)) {
+                        $position = $key;
+
+                        break;
+                    }
+                }
+            }
+            $cms = new CMS($id_cms);
+            if (Validate::isLoadedObject($cms)) {
+                if (isset($position) && $cms->updatePosition($way, $position)) {
+                    die(true);
+                } else {
+                    die('{"hasError" : true, "errors" : "Can not update cms position"}');
+                }
+            } else {
+                die('{"hasError" : true, "errors" : "This cms can not be loaded"}');
+            }
+        }
+    }
+
+    public function ajaxProcessUpdateCmsCategoriesPositions()
+    {
+        if ($this->access('edit')) {
+            $id_cms_category_to_move = (int) Tools::getValue('id_cms_category_to_move');
+            $id_cms_category_parent = (int) Tools::getValue('id_cms_category_parent');
+            $way = (int) Tools::getValue('way');
+            $positions = Tools::getValue('cms_category');
+            if (is_array($positions)) {
+                foreach ($positions as $key => $value) {
+                    $pos = explode('_', $value);
+                    if ((isset($pos[1], $pos[2])) && ($pos[1] == $id_cms_category_parent && $pos[2] == $id_cms_category_to_move)) {
+                        $position = $key;
+
+                        break;
+                    }
+                }
+            }
+            $cms_category = new CMSCategory($id_cms_category_to_move);
+            if (Validate::isLoadedObject($cms_category)) {
+                if (isset($position) && $cms_category->updatePosition($way, $position)) {
+                    die(true);
+                } else {
+                    die('{"hasError" : true, "errors" : "Can not update cms categories position"}');
+                }
+            } else {
+                die('{"hasError" : true, "errors" : "This cms category can not be loaded"}');
+            }
+        }
+    }
+
+    public function ajaxProcessPublishCMS()
+    {
+        if ($this->access('edit')) {
+            if ($id_cms = (int) Tools::getValue('id_cms')) {
+                $bo_cms_url = _PS_BASE_URL_ . __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/index.php?tab=AdminCmsContent&id_cms=' . (int) $id_cms . '&updatecms&token=' . $this->token;
+
+                if (Tools::getValue('redirect')) {
+                    die($bo_cms_url);
+                }
+
+                $cms = new CMS((int) (Tools::getValue('id_cms')));
+                if (!Validate::isLoadedObject($cms)) {
+                    die('error: invalid id');
+                }
+
+                $cms->active = 1;
+                if ($cms->save()) {
+                    die($bo_cms_url);
+                } else {
+                    die('error: saving');
+                }
+            } else {
+                die('error: parameters');
+            }
+        }
+    }
+}

--- a/controllers/admin/AdminCmsController.php
+++ b/controllers/admin/AdminCmsController.php
@@ -1,0 +1,460 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * @property CMS $object
+ */
+class AdminCmsControllerCore extends AdminController
+{
+    protected $category;
+
+    public $id_cms_category;
+
+    protected $position_identifier = 'id_cms';
+
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        $this->table = 'cms';
+        $this->list_id = 'cms';
+        $this->className = 'CMS';
+        $this->lang = true;
+        $this->addRowAction('edit');
+        $this->addRowAction('delete');
+        $this->_orderBy = 'position';
+
+        parent::__construct();
+
+        $this->bulk_actions = array(
+            'delete' => array(
+                'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
+                'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
+                'icon' => 'icon-trash',
+            ),
+        );
+        $this->fields_list = array(
+            'id_cms' => array(
+                'title' => $this->trans('ID', array(), 'Admin.Global'),
+                'align' => 'center',
+                'class' => 'fixed-width-xs',
+            ),
+            'link_rewrite' => array(
+                'title' => $this->trans('URL', array(), 'Admin.Global'),
+            ),
+            'meta_title' => array(
+                'title' => $this->trans('Title', array(), 'Admin.Global'),
+                'filter_key' => 'b!meta_title',
+                'maxlength' => 50,
+            ),
+            'head_seo_title' => array(
+                'title' => $this->trans('Meta title', array(), 'Admin.Global'),
+                'filter_key' => 'b!head_seo_title',
+                'maxlength' => 50,
+            ),
+            'position' => array(
+                'title' => $this->trans('Position', array(), 'Admin.Global'),
+                'filter_key' => 'position',
+                'align' => 'center',
+                'class' => 'fixed-width-sm',
+                'position' => 'position',
+            ),
+            'active' => array(
+                'title' => $this->trans('Displayed', array(), 'Admin.Global'),
+                'align' => 'center',
+                'active' => 'status',
+                'class' => 'fixed-width-sm',
+                'type' => 'bool',
+                'orderby' => false,
+            ),
+        );
+
+        // The controller can't be call directly
+        // In this case, AdminCmsContentController::getCurrentCMSCategory() is null
+        if (!AdminCmsContentController::getCurrentCMSCategory()) {
+            $this->redirect_after = '?controller=AdminCmsContent&token=' . Tools::getAdminTokenLite('AdminCmsContent');
+            $this->redirect();
+        }
+
+        $this->_category = AdminCmsContentController::getCurrentCMSCategory();
+        $this->tpl_list_vars['icon'] = 'icon-folder-close';
+        $this->tpl_list_vars['title'] = $this->trans('Pages in category "%name%"', array('%name%' => $this->_category->name[Context::getContext()->employee->id_lang]), 'Admin.Design.Feature');
+        $this->_join = '
+		LEFT JOIN `' . _DB_PREFIX_ . 'cms_category` c ON (c.`id_cms_category` = a.`id_cms_category`)';
+        $this->_select = 'a.position ';
+        $this->_where = ' AND c.id_cms_category = ' . (int) $this->_category->id;
+    }
+
+    public function getTabSlug()
+    {
+        return 'ROLE_MOD_TAB_ADMINCMSCONTENT_';
+    }
+
+    public function initPageHeaderToolbar()
+    {
+        $this->page_header_toolbar_btn['save-and-preview'] = array(
+            'href' => '#',
+            'desc' => $this->trans('Save and preview', array(), 'Admin.Actions'),
+        );
+        $this->page_header_toolbar_btn['save-and-stay'] = array(
+            'short' => $this->trans('Save and stay', array(), 'Admin.Actions'),
+            'href' => '#',
+            'desc' => $this->trans('Save and stay', array(), 'Admin.Actions'),
+        );
+
+        return parent::initPageHeaderToolbar();
+    }
+
+    public function renderForm()
+    {
+        if (!$this->loadObject(true)) {
+            return;
+        }
+
+        if (Validate::isLoadedObject($this->object)) {
+            $this->display = 'edit';
+        } else {
+            $this->display = 'add';
+        }
+
+        $this->initToolbar();
+        $this->initPageHeaderToolbar();
+
+        $categories = CMSCategory::getCategories($this->context->language->id, false);
+        $html_categories = CMSCategory::recurseCMSCategory($categories, $categories[0][1], 1, $this->getFieldValue($this->object, 'id_cms_category'), 1);
+
+        $this->fields_form = array(
+            'tinymce' => true,
+            'legend' => array(
+                'title' => $this->l('Page'),
+                'icon' => 'icon-folder-close',
+            ),
+            'input' => array(
+                // custom template
+                array(
+                    'type' => 'select_category',
+                    'label' => $this->trans('Page Category', array(), 'Admin.Design.Feature'),
+                    'name' => 'id_cms_category',
+                    'options' => array(
+                        'html' => $html_categories,
+                    ),
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Title', array(), 'Admin.Global'),
+                    'name' => 'meta_title',
+                    'id' => 'name', // for copyMeta2friendlyURL compatibility
+                    'lang' => true,
+                    'required' => true,
+                    'class' => 'copyMeta2friendlyURL',
+                    'hint' => array(
+                        $this->trans('Used in the h1 page tag, and as the default title tag value.', array(), 'Admin.Design.Help'),
+                        $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                    ),
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Meta title', array(), 'Admin.Global'),
+                    'name' => 'head_seo_title',
+                    'lang' => true,
+                    'hint' => array(
+                        $this->trans('Used to override the title tag value. If left blank, the default title value is used.', array(), 'Admin.Design.Help'),
+                        $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                    ),
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Meta description', array(), 'Admin.Global'),
+                    'name' => 'meta_description',
+                    'lang' => true,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'tags',
+                    'label' => $this->trans('Meta keywords', array(), 'Admin.Global'),
+                    'name' => 'meta_keywords',
+                    'lang' => true,
+                    'hint' => array(
+                        $this->trans('To add "tags" click in the field, write something, and then press "Enter."', array(), 'Admin.Design.Help'),
+                        $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                    ),
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Friendly URL', array(), 'Admin.Global'),
+                    'name' => 'link_rewrite',
+                    'required' => true,
+                    'lang' => true,
+                    'hint' => $this->trans('Only letters and the hyphen (-) character are allowed.', array(), 'Admin.Design.Feature'),
+                ),
+                array(
+                    'type' => 'textarea',
+                    'label' => $this->trans('Page content', array(), 'Admin.Design.Feature'),
+                    'name' => 'content',
+                    'autoload_rte' => true,
+                    'lang' => true,
+                    'rows' => 5,
+                    'cols' => 40,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' <>;=#{}',
+                ),
+                array(
+                    'type' => 'switch',
+                    'label' => $this->trans('Indexation by search engines', array(), 'Admin.Design.Feature'),
+                    'name' => 'indexation',
+                    'required' => false,
+                    'class' => 't',
+                    'is_bool' => true,
+                    'values' => array(
+                        array(
+                            'id' => 'indexation_on',
+                            'value' => 1,
+                            'label' => $this->trans('Enabled', array(), 'Admin.Global'),
+                        ),
+                        array(
+                            'id' => 'indexation_off',
+                            'value' => 0,
+                            'label' => $this->trans('Disabled', array(), 'Admin.Global'),
+                        ),
+                    ),
+                ),
+                array(
+                    'type' => 'switch',
+                    'label' => $this->trans('Displayed', array(), 'Admin.Global'),
+                    'name' => 'active',
+                    'required' => false,
+                    'is_bool' => true,
+                    'values' => array(
+                        array(
+                            'id' => 'active_on',
+                            'value' => 1,
+                            'label' => $this->trans('Enabled', array(), 'Admin.Global'),
+                        ),
+                        array(
+                            'id' => 'active_off',
+                            'value' => 0,
+                            'label' => $this->trans('Disabled', array(), 'Admin.Global'),
+                        ),
+                    ),
+                ),
+            ),
+            'submit' => array(
+                'title' => $this->trans('Save', array(), 'Admin.Actions'),
+            ),
+            'buttons' => array(
+                'save_and_preview' => array(
+                    'name' => 'viewcms',
+                    'type' => 'submit',
+                    'title' => $this->trans('Save and preview', array(), 'Admin.Actions'),
+                    'class' => 'btn btn-default pull-right',
+                    'icon' => 'process-icon-preview',
+                ),
+            ),
+        );
+
+        if (Shop::isFeatureActive()) {
+            $this->fields_form['input'][] = array(
+                'type' => 'shop',
+                'label' => $this->trans('Shop association', array(), 'Admin.Global'),
+                'name' => 'checkBoxShopAsso',
+            );
+        }
+
+        if (Validate::isLoadedObject($this->object)) {
+            $this->context->smarty->assign('url_prev', $this->getPreviewUrl($this->object));
+        }
+
+        $this->tpl_form_vars = array(
+            'active' => $this->object->active,
+            'PS_ALLOW_ACCENTED_CHARS_URL', (int) Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL'),
+        );
+
+        return parent::renderForm();
+    }
+
+    public function renderList()
+    {
+        $this->_group = 'GROUP BY a.`id_cms`';
+        //self::$currentIndex = self::$currentIndex.'&cms';
+        $this->position_group_identifier = (int) $this->id_cms_category;
+
+        $this->toolbar_title = $this->trans('Pages in this category', array(), 'Admin.Design.Feature');
+        $this->toolbar_btn['new'] = array(
+            'href' => self::$currentIndex . '&add' . $this->table . '&id_cms_category=' . (int) $this->id_cms_category . '&token=' . $this->token,
+            'desc' => $this->trans('Add new', array(), 'Admin.Actions'),
+        );
+
+        return parent::renderList();
+    }
+
+    public function displayList($token = null)
+    {
+        /* Display list header (filtering, pagination and column names) */
+        $this->displayListHeader($token);
+        if (!count($this->_list)) {
+            echo '<tr><td class="center" colspan="' . (count($this->fields_list) + 2) . '">' . $this->trans('No items found', array(), 'Admin.Design.Notification') . '</td></tr>';
+        }
+
+        /* Show the content of the table */
+        $this->displayListContent($token);
+
+        /* Close list table and submit button */
+        $this->displayListFooter($token);
+    }
+
+    public function postProcess()
+    {
+        if (Tools::isSubmit('viewcms') && ($id_cms = (int) Tools::getValue('id_cms'))) {
+            parent::postProcess();
+            if (($cms = new CMS($id_cms, $this->context->language->id)) && Validate::isLoadedObject($cms)) {
+                Tools::redirectAdmin(self::$currentIndex . '&id_cms=' . $id_cms . '&conf=4&updatecms&token=' . Tools::getAdminTokenLite('AdminCmsContent') . '&url_preview=1');
+            }
+        } elseif (Tools::isSubmit('deletecms')) {
+            if (Tools::getValue('id_cms') == Configuration::get('PS_CONDITIONS_CMS_ID')) {
+                Configuration::updateValue('PS_CONDITIONS', 0);
+                Configuration::updateValue('PS_CONDITIONS_CMS_ID', 0);
+            }
+            $cms = new CMS((int) Tools::getValue('id_cms'));
+            $cms->cleanPositions($cms->id_cms_category);
+            if (!$cms->delete()) {
+                $this->errors[] = $this->trans('An error occurred while deleting the object.', array(), 'Admin.Notifications.Error')
+                    . ' <b>' . $this->table . ' (' . Db::getInstance()->getMsgError() . ')</b>';
+            } else {
+                Tools::redirectAdmin(self::$currentIndex . '&id_cms_category=' . $cms->id_cms_category . '&conf=1&token=' . Tools::getAdminTokenLite('AdminCmsContent'));
+            }
+        } elseif (Tools::getValue('submitDel' . $this->table)) {
+            // Delete multiple objects
+            if ($this->access('delete')) {
+                if (Tools::isSubmit($this->table . 'Box')) {
+                    $cms = new CMS();
+                    $result = true;
+                    $result = $cms->deleteSelection(Tools::getValue($this->table . 'Box'));
+                    if ($result) {
+                        $cms->cleanPositions((int) Tools::getValue('id_cms_category'));
+                        $token = Tools::getAdminTokenLite('AdminCmsContent');
+                        Tools::redirectAdmin(self::$currentIndex . '&conf=2&token=' . $token . '&id_cms_category=' . (int) Tools::getValue('id_cms_category'));
+                    }
+                    $this->errors[] = $this->trans('An error occurred while deleting this selection.', array(), 'Admin.Notifications.Error');
+                } else {
+                    $this->errors[] = $this->trans('You must select at least one element to delete.', array(), 'Admin.Notifications.Error');
+                }
+            } else {
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
+            }
+        } elseif (Tools::isSubmit('submitAddcms') || Tools::isSubmit('submitAddcmsAndPreview')) {
+            parent::validateRules();
+            if (count($this->errors)) {
+                return false;
+            }
+            if (!$id_cms = (int) Tools::getValue('id_cms')) {
+                $cms = new CMS();
+                $this->copyFromPost($cms, 'cms');
+                if (!$cms->add()) {
+                    $this->errors[] = $this->trans('An error occurred while creating an object.', array(), 'Admin.Notifications.Error') . ' <b>' . $this->table . ' (' . Db::getInstance()->getMsgError() . ')</b>';
+                } else {
+                    $this->updateAssoShop($cms->id);
+                }
+            } else {
+                $cms = new CMS($id_cms);
+                $this->copyFromPost($cms, 'cms');
+                if (!$cms->update()) {
+                    $this->errors[] = $this->trans('An error occurred while updating an object.', array(), 'Admin.Notifications.Error') . ' <b>' . $this->table . ' (' . Db::getInstance()->getMsgError() . ')</b>';
+                } else {
+                    $this->updateAssoShop($cms->id);
+                }
+            }
+            if (Tools::isSubmit('view' . $this->table)) {
+                Tools::redirectAdmin(self::$currentIndex . '&id_cms=' . $cms->id . '&conf=4&updatecms&token=' . Tools::getAdminTokenLite('AdminCmsContent') . '&url_preview=1');
+            } elseif (Tools::isSubmit('submitAdd' . $this->table . 'AndStay')) {
+                Tools::redirectAdmin(self::$currentIndex . '&' . $this->identifier . '=' . $cms->id . '&conf=4&update' . $this->table . '&token=' . Tools::getAdminTokenLite('AdminCmsContent'));
+            } else {
+                Tools::redirectAdmin(self::$currentIndex . '&id_cms_category=' . $cms->id_cms_category . '&conf=4&token=' . Tools::getAdminTokenLite('AdminCmsContent'));
+            }
+        } elseif (Tools::isSubmit('way') && Tools::isSubmit('id_cms') && (Tools::isSubmit('position'))) {
+            /* @var CMS $object */
+            if (!$this->access('edit')) {
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
+            } elseif (!Validate::isLoadedObject($object = $this->loadObject())) {
+                $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error')
+                    . ' <b>' . $this->table . '</b> ' . $this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
+            } elseif (!$object->updatePosition((int) Tools::getValue('way'), (int) Tools::getValue('position'))) {
+                $this->errors[] = $this->trans('Failed to update the position.', array(), 'Admin.Notifications.Error');
+            } else {
+                Tools::redirectAdmin(self::$currentIndex . '&' . $this->table . 'Orderby=position&' . $this->table . 'Orderway=asc&conf=4&id_cms_category=' . (int) $object->id_cms_category . '&token=' . Tools::getAdminTokenLite('AdminCmsContent'));
+            }
+        } elseif (Tools::isSubmit('statuscms') && Tools::isSubmit($this->identifier)) {
+            // Change object status (active, inactive)
+            if ($this->access('edit')) {
+                if (Validate::isLoadedObject($object = $this->loadObject())) {
+                    /** @var CMS $object */
+                    if ($object->toggleStatus()) {
+                        Tools::redirectAdmin(self::$currentIndex . '&conf=5&id_cms_category=' . (int) $object->id_cms_category . '&token=' . Tools::getValue('token'));
+                    } else {
+                        $this->errors[] = $this->trans('An error occurred while updating the status.', array(), 'Admin.Notifications.Error');
+                    }
+                } else {
+                    $this->errors[] = $this->trans('An error occurred while updating the status for an object.', array(), 'Admin.Notifications.Error')
+                        . ' <b>' . $this->table . '</b> ' . $this->trans('(cannot load object)', array(), 'Admin.Notifications.Error');
+                }
+            } else {
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
+            }
+        } elseif (Tools::isSubmit('submitBulkdeletecms')) {
+            // Delete multiple CMS content
+            if ($this->access('delete')) {
+                $this->action = 'bulkdelete';
+                $this->boxes = Tools::getValue($this->table . 'Box');
+                if (is_array($this->boxes) && array_key_exists(0, $this->boxes)) {
+                    $firstCms = new CMS((int) $this->boxes[0]);
+                    $id_cms_category = (int) $firstCms->id_cms_category;
+                    if (!$res = parent::postProcess(true)) {
+                        return $res;
+                    }
+                    Tools::redirectAdmin(self::$currentIndex . '&conf=2&token=' . Tools::getAdminTokenLite('AdminCmsContent') . '&id_cms_category=' . $id_cms_category);
+                }
+            } else {
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
+            }
+        } else {
+            parent::postProcess(true);
+        }
+    }
+
+    public function getPreviewUrl(CMS $cms)
+    {
+        $preview_url = $this->context->link->getCMSLink($cms, null, null, $this->context->language->id);
+        if (!$cms->active) {
+            $params = http_build_query(
+                array(
+                    'adtoken' => Tools::getAdminTokenLite('AdminCmsContent'),
+                    'ad' => basename(_PS_ADMIN_DIR_),
+                    'id_employee' => (int) $this->context->employee->id,
+                )
+            );
+            $preview_url .= (strpos($preview_url, '?') === false ? '?' : '&') . $params;
+        }
+
+        return $preview_url;
+    }
+}

--- a/controllers/admin/AdminCmsController.php
+++ b/controllers/admin/AdminCmsController.php
@@ -35,8 +35,16 @@ class AdminCmsControllerCore extends AdminController
 
     protected $position_identifier = 'id_cms';
 
+    /**
+     * @deprecated since 1.7.6, to be removed in the next minor
+     */
     public function __construct()
     {
+        @trigger_error(
+            'The AdminCmsController is deprecated and will be removed in the next minor',
+            E_USER_DEPRECATED
+        );
+
         $this->bootstrap = true;
         $this->table = 'cms';
         $this->list_id = 'cms';

--- a/controllers/admin/AdminManufacturersController.php
+++ b/controllers/admin/AdminManufacturersController.php
@@ -33,8 +33,16 @@ class AdminManufacturersControllerCore extends AdminController
     /** @var array countries list */
     protected $countries_array = array();
 
+    /**
+     * @deprecated since 1.7.6, to be removed in the next minor
+     */
     public function __construct()
     {
+        @trigger_error(
+            'The AdminManufacturersController is deprecated and will be removed in the next minor',
+            E_USER_DEPRECATED
+        );
+
         $this->table = 'manufacturer';
         $this->className = 'Manufacturer';
         $this->lang = false;

--- a/controllers/admin/AdminManufacturersController.php
+++ b/controllers/admin/AdminManufacturersController.php
@@ -1,0 +1,870 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * @property Manufacturer $object
+ */
+class AdminManufacturersControllerCore extends AdminController
+{
+    public $bootstrap = true;
+    /** @var array countries list */
+    protected $countries_array = array();
+
+    public function __construct()
+    {
+        $this->table = 'manufacturer';
+        $this->className = 'Manufacturer';
+        $this->lang = false;
+        $this->deleted = false;
+        $this->allow_export = true;
+        $this->list_id = 'manufacturer';
+        $this->identifier = 'id_manufacturer';
+        $this->_defaultOrderBy = 'name';
+        $this->_defaultOrderWay = 'ASC';
+
+        parent::__construct();
+
+        $this->bulk_actions = array(
+            'delete' => array(
+                'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
+                'icon' => 'icon-trash',
+                'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
+            ),
+        );
+
+        $this->fieldImageSettings = array(
+            'name' => 'logo',
+            'dir' => 'm',
+        );
+
+        $this->fields_list = array(
+            'id_manufacturer' => array(
+                'title' => $this->trans('ID', array(), 'Admin.Global'),
+                'align' => 'center',
+                'class' => 'fixed-width-xs',
+            ),
+            'logo' => array(
+                'title' => $this->trans('Logo', array(), 'Admin.Global'),
+                'image' => 'm',
+                'orderby' => false,
+                'search' => false,
+                'align' => 'center',
+            ),
+            'name' => array(
+                'title' => $this->trans('Name', array(), 'Admin.Global'),
+                'width' => 'auto',
+            ),
+            'addresses' => array(
+                'title' => $this->trans('Addresses', array(), 'Admin.Catalog.Feature'),
+                'search' => false,
+                'align' => 'center',
+            ),
+            'products' => array(
+                'title' => $this->trans('Products', array(), 'Admin.Catalog.Feature'),
+                'search' => false,
+                'align' => 'center',
+            ),
+            'active' => array(
+                'title' => $this->trans('Enabled', array(), 'Admin.Global'),
+                'active' => 'status',
+                'type' => 'bool',
+                'align' => 'center',
+                'class' => 'fixed-width-xs',
+                'orderby' => false,
+            ),
+        );
+    }
+
+    public function setMedia($isNewTheme = false)
+    {
+        parent::setMedia($isNewTheme);
+        $this->addJqueryUi('ui.widget');
+        $this->addJqueryPlugin('tagify');
+    }
+
+    public function initPageHeaderToolbar()
+    {
+        if (empty($this->display)) {
+            $this->page_header_toolbar_btn['new_manufacturer'] = array(
+                'href' => self::$currentIndex . '&addmanufacturer&token=' . $this->token,
+                'desc' => $this->trans('Add new brand', array(), 'Admin.Catalog.Feature'),
+                'icon' => 'process-icon-new',
+            );
+            $this->page_header_toolbar_btn['new_manufacturer_address'] = array(
+                'href' => self::$currentIndex . '&addaddress&token=' . $this->token,
+                'desc' => $this->trans('Add new brand address', array(), 'Admin.Catalog.Feature'),
+                'icon' => 'process-icon-new',
+            );
+        } elseif ($this->display == 'editaddresses' || $this->display == 'addaddress') {
+            // Default cancel button - like old back link
+            if (!isset($this->no_back) || $this->no_back == false) {
+                $back = Tools::safeOutput(Tools::getValue('back', ''));
+                if (empty($back)) {
+                    $back = self::$currentIndex . '&token=' . $this->token;
+                }
+
+                $this->page_header_toolbar_btn['cancel'] = array(
+                    'href' => $back,
+                    'desc' => $this->trans('Cancel', array(), 'Admin.Actions'),
+                );
+            }
+        }
+
+        parent::initPageHeaderToolbar();
+    }
+
+    public function initListManufacturer()
+    {
+        $this->addRowAction('view');
+        $this->addRowAction('edit');
+        $this->addRowAction('delete');
+
+        $this->_select = '
+            COUNT(`id_product`) AS `products`, (
+                SELECT COUNT(ad.`id_manufacturer`) as `addresses`
+                FROM `' . _DB_PREFIX_ . 'address` ad
+                WHERE ad.`id_manufacturer` = a.`id_manufacturer`
+                    AND ad.`deleted` = 0
+                GROUP BY ad.`id_manufacturer`) as `addresses`';
+        $this->_join = 'LEFT JOIN `' . _DB_PREFIX_ . 'product` p ON (a.`id_manufacturer` = p.`id_manufacturer`)';
+        $this->_group = 'GROUP BY a.`id_manufacturer`';
+
+        $this->context->smarty->assign('title_list', $this->trans('List of brands', array(), 'Admin.Catalog.Feature'));
+
+        $this->content .= parent::renderList();
+    }
+
+    protected function getAddressFieldsList()
+    {
+        // Sub tab addresses
+        $countries = Country::getCountries($this->context->language->id);
+        foreach ($countries as $country) {
+            $this->countries_array[$country['id_country']] = $country['name'];
+        }
+
+        return array(
+            'id_address' => array(
+                'title' => $this->trans('ID', array(), 'Admin.Global'),
+                'align' => 'center',
+                'class' => 'fixed-width-xs',
+            ),
+            'manufacturer_name' => array(
+                'title' => $this->trans('Brand', array(), 'Admin.Global'),
+                'width' => 'auto',
+                'filter_key' => 'm!name',
+            ),
+            'firstname' => array(
+                'title' => $this->trans('First name', array(), 'Admin.Global'),
+                'maxlength' => 30,
+            ),
+            'lastname' => array(
+                'title' => $this->trans('Last name', array(), 'Admin.Global'),
+                'filter_key' => 'a!lastname',
+                'maxlength' => 30,
+            ),
+            'postcode' => array(
+                'title' => $this->trans('Zip/Postal code', array(), 'Admin.Global'),
+                'align' => 'right',
+            ),
+            'city' => array(
+                'title' => $this->trans('City', array(), 'Admin.Global'),
+            ),
+            'country' => array(
+                'title' => $this->trans('Country', array(), 'Admin.Global'),
+                'type' => 'select',
+                'list' => $this->countries_array,
+                'filter_key' => 'cl!id_country',
+            ),
+        );
+    }
+
+    public function processExport($text_delimiter = '"')
+    {
+        if (strtolower($this->table) == 'address') {
+            $this->_defaultOrderBy = 'id_manufacturer';
+            $this->_where = 'AND a.`id_customer` = 0 AND a.`id_supplier` = 0 AND a.`id_warehouse` = 0 AND a.`deleted`= 0';
+        }
+
+        return parent::processExport($text_delimiter);
+    }
+
+    public function initListManufacturerAddresses()
+    {
+        $this->toolbar_title = $this->trans('Addresses', array(), 'Admin.Catalog.Feature');
+        // reset actions and query vars
+        $this->actions = array();
+        unset($this->fields_list, $this->_select, $this->_join, $this->_group, $this->_filterHaving, $this->_filter);
+
+        $this->table = 'address';
+        $this->list_id = 'address';
+        $this->identifier = 'id_address';
+        $this->deleted = true;
+
+        $this->_defaultOrderBy = 'id_address';
+        $this->_defaultOrderWay = 'ASC';
+
+        $this->_orderBy = null;
+
+        $this->addRowAction('editaddresses');
+        $this->addRowAction('delete');
+
+        // test if a filter is applied for this list
+        if (Tools::isSubmit('submitFilter' . $this->table) || $this->context->cookie->{'submitFilter' . $this->table} !== false) {
+            $this->filter = true;
+        }
+
+        // test if a filter reset request is required for this list
+        $this->action = (isset($_POST['submitReset' . $this->table]) ? 'reset_filters' : '');
+
+        $this->fields_list = $this->getAddressFieldsList();
+        $this->bulk_actions = array(
+            'delete' => array(
+                'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
+                'icon' => 'icon-trash',
+                'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
+            ),
+        );
+
+        $this->_select = 'cl.`name` as country, m.`name` AS manufacturer_name';
+        $this->_join = '
+			LEFT JOIN `' . _DB_PREFIX_ . 'country_lang` cl
+				ON (cl.`id_country` = a.`id_country` AND cl.`id_lang` = ' . (int) $this->context->language->id . ') ';
+        $this->_join .= '
+			LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m
+				ON (a.`id_manufacturer` = m.`id_manufacturer`)';
+        $this->_where = 'AND a.`id_customer` = 0 AND a.`id_supplier` = 0 AND a.`id_warehouse` = 0 AND a.`deleted`= 0';
+
+        $this->context->smarty->assign('title_list', $this->trans('Brand addresses', array(), 'Admin.Catalog.Feature'));
+
+        // call postProcess() for take care about actions and filters
+        $this->postProcess();
+
+        $this->initToolbar();
+
+        $this->content .= parent::renderList();
+    }
+
+    public function renderList()
+    {
+        $this->initListManufacturer();
+        $this->initListManufacturerAddresses();
+    }
+
+    /**
+     * Display editaddresses action link.
+     *
+     * @param string $token the token to add to the link
+     * @param int $id the identifier to add to the link
+     *
+     * @return string
+     */
+    public function displayEditaddressesLink($token, $id)
+    {
+        if (!array_key_exists('editaddresses', self::$cache_lang)) {
+            self::$cache_lang['editaddresses'] = $this->trans('Edit', array(), 'Admin.Actions');
+        }
+
+        $this->context->smarty->assign(array(
+            'href' => self::$currentIndex .
+                '&' . $this->identifier . '=' . $id .
+                '&editaddresses&token=' . ($token != null ? $token : $this->token),
+            'action' => self::$cache_lang['editaddresses'],
+        ));
+
+        return $this->context->smarty->fetch('helpers/list/list_action_edit.tpl');
+    }
+
+    public function renderForm()
+    {
+        if (!($manufacturer = $this->loadObject(true))) {
+            return;
+        }
+
+        $image = _PS_MANU_IMG_DIR_ . $manufacturer->id . '.jpg';
+        $image_url = ImageManager::thumbnail(
+            $image,
+            $this->table . '_' . (int) $manufacturer->id . '.' . $this->imageType,
+            350,
+            $this->imageType,
+            true,
+            true
+        );
+        $image_size = file_exists($image) ? filesize($image) / 1000 : false;
+
+        $this->fields_form = array(
+            'tinymce' => true,
+            'legend' => array(
+                'title' => $this->trans('Brands', array(), 'Admin.Catalog.Feature'),
+                'icon' => 'icon-certificate',
+            ),
+            'input' => array(
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Name', array(), 'Admin.Global'),
+                    'name' => 'name',
+                    'col' => 4,
+                    'required' => true,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'textarea',
+                    'label' => $this->trans('Short description', array(), 'Admin.Catalog.Feature'),
+                    'name' => 'short_description',
+                    'lang' => true,
+                    'cols' => 60,
+                    'rows' => 10,
+                    'autoload_rte' => 'rte', //Enable TinyMCE editor for short description
+                    'col' => 6,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'textarea',
+                    'label' => $this->trans('Description', array(), 'Admin.Global'),
+                    'name' => 'description',
+                    'lang' => true,
+                    'cols' => 60,
+                    'rows' => 10,
+                    'col' => 6,
+                    'autoload_rte' => 'rte', //Enable TinyMCE editor for description
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'file',
+                    'label' => $this->trans('Logo', array(), 'Admin.Global'),
+                    'name' => 'logo',
+                    'image' => $image_url ? $image_url : false,
+                    'size' => $image_size,
+                    'display_image' => true,
+                    'col' => 6,
+                    'hint' => $this->trans('Upload a brand logo from your computer.', array(), 'Admin.Catalog.Help'),
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Meta title', array(), 'Admin.Global'),
+                    'name' => 'meta_title',
+                    'lang' => true,
+                    'col' => 4,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('Meta description', array(), 'Admin.Global'),
+                    'name' => 'meta_description',
+                    'lang' => true,
+                    'col' => 6,
+                    'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                ),
+                array(
+                    'type' => 'tags',
+                    'label' => $this->trans('Meta keywords', array(), 'Admin.Global'),
+                    'name' => 'meta_keywords',
+                    'lang' => true,
+                    'col' => 6,
+                    'hint' => array(
+                        $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                        $this->trans('To add "tags," click inside the field, write something, and then press "Enter."', array(), 'Admin.Catalog.Help'),
+                    ),
+                ),
+                array(
+                    'type' => 'switch',
+                    'label' => $this->trans('Enable', array(), 'Admin.Actions'),
+                    'name' => 'active',
+                    'required' => false,
+                    'class' => 't',
+                    'is_bool' => true,
+                    'values' => array(
+                        array(
+                            'id' => 'active_on',
+                            'value' => 1,
+                            'label' => $this->trans('Enabled', array(), 'Admin.Global'),
+                        ),
+                        array(
+                            'id' => 'active_off',
+                            'value' => 0,
+                            'label' => $this->trans('Disabled', array(), 'Admin.Global'),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        if (!($manufacturer = $this->loadObject(true))) {
+            return;
+        }
+
+        if (Shop::isFeatureActive()) {
+            $this->fields_form['input'][] = array(
+                'type' => 'shop',
+                'label' => $this->trans('Shop association', array(), 'Admin.Global'),
+                'name' => 'checkBoxShopAsso',
+            );
+        }
+
+        $this->fields_form['submit'] = array(
+            'title' => $this->trans('Save', array(), 'Admin.Actions'),
+        );
+
+        foreach ($this->_languages as $language) {
+            $this->fields_value['short_description_' . $language['id_lang']] = htmlentities(stripslashes($this->getFieldValue(
+                $manufacturer,
+                'short_description',
+                $language['id_lang']
+            )), ENT_COMPAT, 'UTF-8');
+
+            $this->fields_value['description_' . $language['id_lang']] = htmlentities(stripslashes($this->getFieldValue(
+                $manufacturer,
+                'description',
+                $language['id_lang']
+            )), ENT_COMPAT, 'UTF-8');
+        }
+
+        return parent::renderForm();
+    }
+
+    public function renderFormAddress()
+    {
+        // Change table and className for addresses
+        $this->table = 'address';
+        $this->className = 'ManufacturerAddress';
+        $id_address = Tools::getValue('id_address');
+
+        // Create Object Address
+        $address = new ManufacturerAddress($id_address);
+
+        $res = $address->getFieldsRequiredDatabase();
+        $required_fields = array();
+        foreach ($res as $row) {
+            $required_fields[(int) $row['id_required_field']] = $row['field_name'];
+        }
+
+        $form = array(
+            'legend' => array(
+                'title' => $this->trans('Addresses', array(), 'Admin.Catalog.Feature'),
+                'icon' => 'icon-building',
+            ),
+        );
+
+        if (!$address->id_manufacturer || !Manufacturer::manufacturerExists($address->id_manufacturer)) {
+            $form['input'][] = array(
+                'type' => 'select',
+                'label' => $this->trans('Choose the brand', array(), 'Admin.Catalog.Feature'),
+                'name' => 'id_manufacturer',
+                'options' => array(
+                    'query' => Manufacturer::getManufacturers(),
+                    'id' => 'id_manufacturer',
+                    'name' => 'name',
+                ),
+            );
+        } else {
+            $form['input'][] = array(
+                'type' => 'text',
+                'label' => $this->trans('Brand', array(), 'Admin.Global'),
+                'name' => 'name',
+                'col' => 4,
+                'disabled' => true,
+            );
+
+            $form['input'][] = array(
+                'type' => 'hidden',
+                'name' => 'id_manufacturer',
+            );
+        }
+
+        $form['input'][] = array(
+            'type' => 'hidden',
+            'name' => 'alias',
+        );
+
+        $form['input'][] = array(
+            'type' => 'hidden',
+            'name' => 'id_address',
+        );
+
+        if (in_array('company', $required_fields)) {
+            $form['input'][] = array(
+                'type' => 'text',
+                'label' => $this->trans('Company', array(), 'Admin.Global'),
+                'name' => 'company',
+                'display' => in_array('company', $required_fields),
+                'required' => in_array('company', $required_fields),
+                'maxlength' => 16,
+                'col' => 4,
+                'hint' => $this->trans('Company name for this brand', array(), 'Admin.Catalog.Help'),
+            );
+        }
+
+        $form['input'][] = array(
+            'type' => 'text',
+            'label' => $this->trans('Last name', array(), 'Admin.Global'),
+            'name' => 'lastname',
+            'required' => true,
+            'col' => 4,
+            'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' 0-9!&lt;&gt;,;?=+()@#"�{}_$%:',
+        );
+        $form['input'][] = array(
+            'type' => 'text',
+            'label' => $this->trans('First name', array(), 'Admin.Global'),
+            'name' => 'firstname',
+            'required' => true,
+            'col' => 4,
+            'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' 0-9!&lt;&gt;,;?=+()@#"�{}_$%:',
+        );
+        $form['input'][] = array(
+            'type' => 'text',
+            'label' => $this->trans('Address', array(), 'Admin.Global'),
+            'name' => 'address1',
+            'col' => 6,
+            'required' => true,
+        );
+        $form['input'][] = array(
+            'type' => 'text',
+            'label' => $this->trans('Address (2)', array(), 'Admin.Global'),
+            'name' => 'address2',
+            'col' => 6,
+            'required' => in_array('address2', $required_fields),
+        );
+        $form['input'][] = array(
+            'type' => 'text',
+            'label' => $this->trans('Zip/postal code', array(), 'Admin.Global'),
+            'name' => 'postcode',
+            'col' => 2,
+            'required' => in_array('postcode', $required_fields),
+        );
+        $form['input'][] = array(
+            'type' => 'text',
+            'label' => $this->trans('City', array(), 'Admin.Global'),
+            'name' => 'city',
+            'col' => 4,
+            'required' => true,
+        );
+        $form['input'][] = array(
+            'type' => 'select',
+            'label' => $this->trans('Country', array(), 'Admin.Global'),
+            'name' => 'id_country',
+            'required' => false,
+            'default_value' => (int) $this->context->country->id,
+            'col' => 4,
+            'options' => array(
+                'query' => Country::getCountries($this->context->language->id),
+                'id' => 'id_country',
+                'name' => 'name',
+            ),
+        );
+        $form['input'][] = array(
+            'type' => 'select',
+            'label' => $this->trans('State', array(), 'Admin.Global'),
+            'name' => 'id_state',
+            'required' => false,
+            'col' => 4,
+            'options' => array(
+                'query' => array(),
+                'id' => 'id_state',
+                'name' => 'name',
+            ),
+        );
+        $form['input'][] = array(
+            'type' => 'text',
+            'label' => $this->trans('Home phone', array(), 'Admin.Global'),
+            'name' => 'phone',
+            'col' => 4,
+            'required' => in_array('phone', $required_fields),
+        );
+        $form['input'][] = array(
+            'type' => 'text',
+            'label' => $this->trans('Mobile phone', array(), 'Admin.Global'),
+            'name' => 'phone_mobile',
+            'col' => 4,
+            'required' => in_array('phone_mobile', $required_fields),
+        );
+        $form['input'][] = array(
+            'type' => 'textarea',
+            'label' => $this->trans('Other', array(), 'Admin.Global'),
+            'name' => 'other',
+            'required' => false,
+            'hint' => $this->trans('Invalid characters:', array(), 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+            'rows' => 2,
+            'cols' => 10,
+            'col' => 6,
+        );
+        $form['submit'] = array(
+            'title' => $this->trans('Save', array(), 'Admin.Actions'),
+        );
+
+        $this->fields_value = array(
+            'name' => Manufacturer::getNameById($address->id_manufacturer),
+            'alias' => 'manufacturer',
+            'id_country' => $address->id_country,
+        );
+
+        $this->initToolbar();
+        $this->fields_form[0]['form'] = $form;
+        $this->getlanguages();
+        $helper = new HelperForm();
+        $helper->show_cancel_button = true;
+
+        $back = Tools::safeOutput(Tools::getValue('back', ''));
+        if (empty($back)) {
+            $back = self::$currentIndex . '&token=' . $this->token;
+        }
+        if (!Validate::isCleanHtml($back)) {
+            die(Tools::displayError());
+        }
+
+        $helper->back_url = $back;
+        $helper->currentIndex = self::$currentIndex;
+        $helper->token = $this->token;
+        $helper->table = $this->table;
+        $helper->identifier = $this->identifier;
+        $helper->title = $this->trans('Edit Addresses', array(), 'Admin.Catalog.Feature');
+        $helper->id = $address->id;
+        $helper->toolbar_scroll = true;
+        $helper->languages = $this->_languages;
+        $helper->default_form_language = $this->default_form_language;
+        $helper->allow_employee_form_lang = $this->allow_employee_form_lang;
+        $helper->fields_value = $this->getFieldsValue($address);
+        $helper->toolbar_btn = $this->toolbar_btn;
+        $this->content .= $helper->generateForm($this->fields_form);
+    }
+
+    /**
+     * AdminController::initToolbar() override.
+     *
+     * @see AdminController::initToolbar()
+     */
+    public function initToolbar()
+    {
+        switch ($this->display) {
+            case 'editaddresses':
+            case 'addaddress':
+                $this->toolbar_btn['save'] = array(
+                    'href' => '#',
+                    'desc' => $this->trans('Save', array(), 'Admin.Actions'),
+                );
+
+                // Default cancel button - like old back link
+                if (!isset($this->no_back) || $this->no_back == false) {
+                    $back = Tools::safeOutput(Tools::getValue('back', ''));
+                    if (empty($back)) {
+                        $back = self::$currentIndex . '&token=' . $this->token;
+                    }
+
+                    $this->toolbar_btn['cancel'] = array(
+                        'href' => $back,
+                        'desc' => $this->trans('Cancel', array(), 'Admin.Actions'),
+                    );
+                }
+
+                break;
+
+            default:
+                parent::initToolbar();
+
+                if ($this->can_import) {
+                    $this->toolbar_btn['import'] = array(
+                        'href' => $this->context->link->getAdminLink('AdminImport', true) . '&import_type=manufacturers',
+                        'desc' => $this->trans('Import', array(), 'Admin.Actions'),
+                    );
+                }
+        }
+    }
+
+    public function renderView()
+    {
+        if (!($manufacturer = $this->loadObject())) {
+            return;
+        }
+
+        /* @var Manufacturer $manufacturer */
+
+        $this->toolbar_btn['new'] = array(
+            'href' => $this->context->link->getAdminLink('AdminManufacturers') . '&addaddress=1&id_manufacturer=' . (int) $manufacturer->id,
+            'desc' => $this->trans('Add address', array(), 'Admin.Catalog.Feature'),
+        );
+
+        $this->toolbar_title = is_array($this->breadcrumbs) ? array_unique($this->breadcrumbs) : array($this->breadcrumbs);
+        $this->toolbar_title[] = $manufacturer->name;
+
+        $addresses = $manufacturer->getAddresses($this->context->language->id);
+
+        $products = $manufacturer->getProductsLite($this->context->language->id);
+        $total_product = count($products);
+        for ($i = 0; $i < $total_product; ++$i) {
+            $products[$i] = new Product($products[$i]['id_product'], false, $this->context->language->id);
+            $products[$i]->loadStockData();
+            /* Build attributes combinations */
+            $combinations = $products[$i]->getAttributeCombinations($this->context->language->id);
+            foreach ($combinations as $combination) {
+                $comb_array[$combination['id_product_attribute']]['reference'] = $combination['reference'];
+                $comb_array[$combination['id_product_attribute']]['ean13'] = $combination['ean13'];
+                $comb_array[$combination['id_product_attribute']]['upc'] = $combination['upc'];
+                $comb_array[$combination['id_product_attribute']]['quantity'] = $combination['quantity'];
+                $comb_array[$combination['id_product_attribute']]['attributes'][] = array(
+                    $combination['group_name'],
+                    $combination['attribute_name'],
+                    $combination['id_attribute'],
+                );
+            }
+
+            if (isset($comb_array)) {
+                foreach ($comb_array as $key => $product_attribute) {
+                    $list = '';
+                    foreach ($product_attribute['attributes'] as $attribute) {
+                        $list .= $attribute[0] . ' - ' . $attribute[1] . ', ';
+                    }
+                    $comb_array[$key]['attributes'] = rtrim($list, ', ');
+                }
+                isset($comb_array) ? $products[$i]->combination = $comb_array : '';
+                unset($comb_array);
+            }
+        }
+
+        $this->tpl_view_vars = array(
+            'manufacturer' => $manufacturer,
+            'addresses' => $addresses,
+            'products' => $products,
+            'stock_management' => Configuration::get('PS_STOCK_MANAGEMENT'),
+            'shopContext' => Shop::getContext(),
+        );
+
+        return parent::renderView();
+    }
+
+    public function initContent()
+    {
+        if ($this->display == 'editaddresses' || $this->display == 'addaddress') {
+            $this->content .= $this->renderFormAddress();
+        } elseif ($this->display == 'edit' || $this->display == 'add') {
+            if (!$this->loadObject(true)) {
+                return;
+            }
+            $this->content .= $this->renderForm();
+        } elseif ($this->display == 'view') {
+            // Some controllers use the view action without an object
+            if ($this->className) {
+                $this->loadObject(true);
+            }
+            $this->content .= $this->renderView();
+        } elseif (!$this->ajax) {
+            $this->content .= $this->renderList();
+            $this->content .= $this->renderOptions();
+        }
+
+        $this->context->smarty->assign(array(
+            'content' => $this->content,
+        ));
+    }
+
+    /**
+     * AdminController::init() override.
+     *
+     * @see AdminController::init()
+     */
+    public function init()
+    {
+        parent::init();
+
+        if (Tools::isSubmit('editaddresses')) {
+            $this->display = 'editaddresses';
+        } elseif (Tools::isSubmit('updateaddress')) {
+            $this->display = 'editaddresses';
+        } elseif (Tools::isSubmit('addaddress')) {
+            $this->display = 'addaddress';
+        } elseif (Tools::isSubmit('submitAddaddress')) {
+            $this->action = 'save';
+        } elseif (Tools::isSubmit('deleteaddress')) {
+            $this->action = 'delete';
+        }
+    }
+
+    public function initProcess()
+    {
+        if (Tools::isSubmit('submitAddaddress') || Tools::isSubmit('deleteaddress') || Tools::isSubmit('submitBulkdeleteaddress') || Tools::isSubmit('exportaddress')) {
+            $this->table = 'address';
+            $this->className = 'ManufacturerAddress';
+            $this->identifier = 'id_address';
+            $this->deleted = true;
+            $this->fields_list = $this->getAddressFieldsList();
+        }
+        parent::initProcess();
+    }
+
+    protected function afterImageUpload()
+    {
+        $res = true;
+        $generate_hight_dpi_images = (bool) Configuration::get('PS_HIGHT_DPI');
+
+        /* Generate image with differents size */
+        if (($id_manufacturer = (int) Tools::getValue('id_manufacturer')) &&
+            isset($_FILES) &&
+            count($_FILES) &&
+            file_exists(_PS_MANU_IMG_DIR_ . $id_manufacturer . '.jpg')) {
+            $images_types = ImageType::getImagesTypes('manufacturers');
+            foreach ($images_types as $image_type) {
+                $res &= ImageManager::resize(
+                    _PS_MANU_IMG_DIR_ . $id_manufacturer . '.jpg',
+                    _PS_MANU_IMG_DIR_ . $id_manufacturer . '-' . stripslashes($image_type['name']) . '.jpg',
+                    (int) $image_type['width'],
+                    (int) $image_type['height']
+                );
+
+                if ($generate_hight_dpi_images) {
+                    $res &= ImageManager::resize(
+                        _PS_MANU_IMG_DIR_ . $id_manufacturer . '.jpg',
+                        _PS_MANU_IMG_DIR_ . $id_manufacturer . '-' . stripslashes($image_type['name']) . '2x.jpg',
+                        (int) $image_type['width'] * 2,
+                        (int) $image_type['height'] * 2
+                    );
+                }
+            }
+
+            $current_logo_file = _PS_TMP_IMG_DIR_ . 'manufacturer_mini_' . $id_manufacturer . '_' . $this->context->shop->id . '.jpg';
+
+            if ($res && file_exists($current_logo_file)) {
+                unlink($current_logo_file);
+            }
+        }
+
+        if (!$res) {
+            $this->errors[] = $this->trans('Unable to resize one or more of your pictures.', array(), 'Admin.Catalog.Notification');
+        }
+
+        return $res;
+    }
+
+    protected function beforeDelete($object)
+    {
+        return true;
+    }
+
+    public function processSave()
+    {
+        if (Tools::isSubmit('submitAddaddress')) {
+            $this->display = 'editaddresses';
+        }
+
+        return parent::processSave();
+    }
+}

--- a/controllers/admin/AdminModulesPositionsController.php
+++ b/controllers/admin/AdminModulesPositionsController.php
@@ -27,8 +27,16 @@ class AdminModulesPositionsControllerCore extends AdminController
 {
     protected $display_key = 0;
 
+    /**
+     * @deprecated since 1.7.6, to be removed in the next minor
+     */
     public function __construct()
     {
+        @trigger_error(
+            'The AdminModulesPositionsController is deprecated and will be removed in the next minor',
+            E_USER_DEPRECATED
+        );
+
         $this->bootstrap = true;
         parent::__construct();
     }

--- a/controllers/admin/AdminModulesPositionsController.php
+++ b/controllers/admin/AdminModulesPositionsController.php
@@ -1,0 +1,636 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+class AdminModulesPositionsControllerCore extends AdminController
+{
+    protected $display_key = 0;
+
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        parent::__construct();
+    }
+
+    public function postProcess()
+    {
+        // Getting key value for display
+        if (Tools::getValue('show_modules') && (string) (Tools::getValue('show_modules')) != 'all') {
+            $this->display_key = (int) Tools::getValue('show_modules');
+        }
+
+        $this->addjQueryPlugin(array(
+            'select2',
+        ));
+
+        $this->addJS(array(
+            _PS_JS_DIR_ . 'admin/modules-position.js',
+            _PS_JS_DIR_ . 'jquery/plugins/select2/select2_locale_' . $this->context->language->iso_code . '.js',
+        ));
+
+        $baseUrl = $this->context->link->getAdminLink('AdminModulesPositions');
+        if (strpos($baseUrl, '?') === false) {
+            $baseUrl .= '?';
+        }
+
+        // Change position in hook
+        if (array_key_exists('changePosition', $_GET)) {
+            if ($this->access('edit')) {
+                $id_module = (int) Tools::getValue('id_module');
+                $id_hook = (int) Tools::getValue('id_hook');
+                $module = Module::getInstanceById($id_module);
+                if (Validate::isLoadedObject($module)) {
+                    $module->updatePosition($id_hook, (int) Tools::getValue('direction'));
+                    Tools::redirectAdmin($baseUrl . ($this->display_key ? '&show_modules=' . $this->display_key : '') . '&token=' . $this->token);
+                } else {
+                    $this->errors[] = $this->trans('This module cannot be loaded.', array(), 'Admin.Modules.Notification');
+                }
+            } else {
+                $this->errors[] = $this->trans('You do not have permission to edit this.', array(), 'Admin.Notifications.Error');
+            }
+        } elseif (Tools::isSubmit('submitAddToHook')) {
+            // Add new module in hook
+            if ($this->access('add')) {
+                // Getting vars...
+                $id_module = (int) Tools::getValue('id_module');
+                $module = Module::getInstanceById($id_module);
+                $id_hook = (int) Tools::getValue('id_hook');
+                $hook = new Hook($id_hook);
+
+                if (!$id_module || !Validate::isLoadedObject($module)) {
+                    $this->errors[] = $this->trans('This module cannot be loaded.', array(), 'Admin.Modules.Notification');
+                } elseif (!$id_hook || !Validate::isLoadedObject($hook)) {
+                    $this->errors[] = $this->trans('Hook cannot be loaded.', array(), 'Admin.Modules.Notification');
+                } elseif (Hook::getModulesFromHook($id_hook, $id_module)) {
+                    $this->errors[] = $this->trans('This module has already been transplanted to this hook.', array(), 'Admin.Modules.Notification');
+                } elseif (!$module->isHookableOn($hook->name)) {
+                    $this->errors[] = $this->trans('This module cannot be transplanted to this hook.', array(), 'Admin.Modules.Notification');
+                } else {
+                    // Adding vars...
+                    if (!$module->registerHook($hook->name, Shop::getContextListShopID())) {
+                        $this->errors[] = $this->trans('An error occurred while transplanting the module to its hook.', array(), 'Admin.Modules.Notification');
+                    } else {
+                        $exceptions = Tools::getValue('exceptions');
+                        $exceptions = (isset($exceptions[0])) ? $exceptions[0] : array();
+                        $exceptions = explode(',', str_replace(' ', '', $exceptions));
+                        $exceptions = array_unique($exceptions);
+
+                        foreach ($exceptions as $key => $except) {
+                            if (empty($except)) {
+                                unset($exceptions[$key]);
+                            } elseif (!empty($except) && !Validate::isFileName($except)) {
+                                $this->errors[] = $this->trans('No valid value for field exceptions has been defined.', array(), 'Admin.Notifications.Error');
+                            }
+                        }
+                        if (!$this->errors && !$module->registerExceptions($id_hook, $exceptions, Shop::getContextListShopID())) {
+                            $this->errors[] = $this->trans('An error occurred while transplanting the module to its hook.', array(), 'Admin.Notifications.Error');
+                        }
+                    }
+                    if (!$this->errors) {
+                        Tools::redirectAdmin($baseUrl . '&conf=16' . ($this->display_key ? '&show_modules=' . $this->display_key : '') . '&token=' . $this->token);
+                    }
+                }
+            } else {
+                $this->errors[] = $this->trans('You do not have permission to add this.', array(), 'Admin.Notifications.Error');
+            }
+        } elseif (Tools::isSubmit('submitEditGraft')) {
+            // Edit module from hook
+            if ($this->access('add')) {
+                // Getting vars...
+                $id_module = (int) Tools::getValue('id_module');
+                $module = Module::getInstanceById($id_module);
+                $id_hook = (int) Tools::getValue('id_hook');
+                $new_hook = (int) Tools::getValue('new_hook');
+                $hook = new Hook($new_hook);
+
+                if (!$id_module || !Validate::isLoadedObject($module)) {
+                    $this->errors[] = $this->trans('This module cannot be loaded.', array(), 'Admin.Modules.Notification');
+                } elseif (!$id_hook || !Validate::isLoadedObject($hook)) {
+                    $this->errors[] = $this->trans('Hook cannot be loaded.', array(), 'Admin.Modules.Notification');
+                } else {
+                    if ($new_hook !== $id_hook) {
+                        /* Connect module to a newer hook */
+                        if (!$module->registerHook($hook->name, Shop::getContextListShopID())) {
+                            $this->errors[] = $this->trans('An error occurred while transplanting the module to its hook.', array(), 'Admin.Modules.Notification');
+                        }
+                        /* Unregister module from hook & exceptions linked to module */
+                        if (!$module->unregisterHook($id_hook, Shop::getContextListShopID())
+                            || !$module->unregisterExceptions($id_hook, Shop::getContextListShopID())) {
+                            $this->errors[] = $this->trans('An error occurred while deleting the module from its hook.', array(), 'Admin.Modules.Notification');
+                        }
+                        $id_hook = $new_hook;
+                    }
+                    $exceptions = Tools::getValue('exceptions');
+                    if (is_array($exceptions)) {
+                        foreach ($exceptions as $id => $exception) {
+                            $exception = explode(',', str_replace(' ', '', $exception));
+                            $exception = array_unique($exception);
+                            // Check files name
+                            foreach ($exception as $except) {
+                                if (!empty($except) && !Validate::isFileName($except)) {
+                                    $this->errors[] = $this->trans('No valid value for field exceptions has been defined.', array(), 'Admin.Notifications.Error');
+                                }
+                            }
+
+                            $exceptions[$id] = $exception;
+                        }
+
+                        // Add files exceptions
+                        if (!$module->editExceptions($id_hook, $exceptions)) {
+                            $this->errors[] = $this->trans('An error occurred while transplanting the module to its hook.', array(), 'Admin.Modules.Notification');
+                        }
+
+                        if (!$this->errors) {
+                            Tools::redirectAdmin($baseUrl . '&conf=16' . ($this->display_key ? '&show_modules=' . $this->display_key : '') . '&token=' . $this->token);
+                        }
+                    } else {
+                        $exceptions = explode(',', str_replace(' ', '', $exceptions));
+                        $exceptions = array_unique($exceptions);
+
+                        // Check files name
+                        foreach ($exceptions as $except) {
+                            if (!empty($except) && !Validate::isFileName($except)) {
+                                $this->errors[] = $this->trans('No valid value for field exceptions has been defined.', array(), 'Admin.Notifications.Error');
+                            }
+                        }
+
+                        // Add files exceptions
+                        if (!$module->editExceptions($id_hook, $exceptions, Shop::getContextListShopID())) {
+                            $this->errors[] = $this->trans('An error occurred while transplanting the module to its hook.', array(), 'Admin.Modules.Notification');
+                        } else {
+                            Tools::redirectAdmin($baseUrl . '&conf=16' . ($this->display_key ? '&show_modules=' . $this->display_key : '') . '&token=' . $this->token);
+                        }
+                    }
+                }
+            } else {
+                $this->errors[] = $this->trans('You do not have permission to add this.', array(), 'Admin.Notifications.Error');
+            }
+        } elseif (array_key_exists('deleteGraft', $_GET)) {
+            // Delete module from hook
+            if ($this->access('delete')) {
+                $id_module = (int) Tools::getValue('id_module');
+                $module = Module::getInstanceById($id_module);
+                $id_hook = (int) Tools::getValue('id_hook');
+                $hook = new Hook($id_hook);
+                if (!Validate::isLoadedObject($module)) {
+                    $this->errors[] = $this->trans('This module cannot be loaded.', array(), 'Admin.Modules.Notification');
+                } elseif (!$id_hook || !Validate::isLoadedObject($hook)) {
+                    $this->errors[] = $this->trans('Hook cannot be loaded.', array(), 'Admin.Modules.Notification');
+                } else {
+                    if (!$module->unregisterHook($id_hook, Shop::getContextListShopID())
+                        || !$module->unregisterExceptions($id_hook, Shop::getContextListShopID())) {
+                        $this->errors[] = $this->trans('An error occurred while deleting the module from its hook.', array(), 'Admin.Modules.Notification');
+                    } else {
+                        Tools::redirectAdmin($baseUrl . '&conf=17' . ($this->display_key ? '&show_modules=' . $this->display_key : '') . '&token=' . $this->token);
+                    }
+                }
+            } else {
+                $this->errors[] = $this->trans('You do not have permission to delete this.', array(), 'Admin.Notifications.Error');
+            }
+        } elseif (Tools::isSubmit('unhookform')) {
+            if (!($unhooks = Tools::getValue('unhooks')) || !is_array($unhooks)) {
+                $this->errors[] = $this->trans('Please select a module to unhook.', array(), 'Admin.Modules.Notification');
+            } else {
+                foreach ($unhooks as $unhook) {
+                    $explode = explode('_', $unhook);
+                    $id_hook = $explode[0];
+                    $id_module = $explode[1];
+                    $module = Module::getInstanceById((int) $id_module);
+                    $hook = new Hook((int) $id_hook);
+                    if (!Validate::isLoadedObject($module)) {
+                        $this->errors[] = $this->trans('This module cannot be loaded.', array(), 'Admin.Modules.Notification');
+                    } elseif (!$id_hook || !Validate::isLoadedObject($hook)) {
+                        $this->errors[] = $this->trans('Hook cannot be loaded.', array(), 'Admin.Modules.Notification');
+                    } else {
+                        if (!$module->unregisterHook((int) $id_hook) || !$module->unregisterExceptions((int) $id_hook)) {
+                            $this->errors[] = $this->trans('An error occurred while deleting the module from its hook.', array(), 'Admin.Modules.Notification');
+                        }
+                    }
+                }
+                if (!count($this->errors)) {
+                    Tools::redirectAdmin($baseUrl . '&conf=17' . ($this->display_key ? '&show_modules=' . $this->display_key : '') . '&token=' . $this->token);
+                }
+            }
+        } else {
+            parent::postProcess();
+        }
+    }
+
+    public function initContent()
+    {
+        $this->addjqueryPlugin('sortable');
+
+        if (array_key_exists('addToHook', $_GET) || array_key_exists('editGraft', $_GET) || (Tools::isSubmit('submitAddToHook') && $this->errors)) {
+            $this->display = 'edit';
+
+            $this->content .= $this->renderForm();
+        } else {
+            $this->content .= $this->initMain();
+        }
+
+        $this->context->smarty->assign(array(
+            'content' => $this->content,
+        ));
+    }
+
+    public function initPageHeaderToolbar()
+    {
+        $this->page_header_toolbar_btn['save'] = array(
+            'href' => self::$currentIndex . '&addToHook' . ($this->display_key ? '&show_modules=' . $this->display_key : '') . '&token=' . $this->token,
+            'desc' => $this->trans('Transplant a module', array(), 'Admin.Design.Feature'),
+            'icon' => 'process-icon-anchor',
+        );
+
+        return parent::initPageHeaderToolbar();
+    }
+
+    public function initMain()
+    {
+        // Init toolbar
+        $this->initToolbarTitle();
+
+        $admin_dir = basename(_PS_ADMIN_DIR_);
+        $modules = Module::getModulesInstalled();
+
+        $assoc_modules_id = array();
+        foreach ($modules as $module) {
+            if ($tmp_instance = Module::getInstanceById((int) $module['id_module'])) {
+                // We want to be able to sort modules by display name
+                $module_instances[$tmp_instance->displayName] = $tmp_instance;
+                // But we also want to associate hooks to modules using the modules IDs
+                $assoc_modules_id[(int) $module['id_module']] = $tmp_instance->displayName;
+            }
+        }
+        ksort($module_instances);
+        $hooks = Hook::getHooks(false, false);
+        foreach ($hooks as $key => $hook) {
+            $hooks[$key]['position'] = Hook::isDisplayHookName($hook['name']);
+
+            // Get all modules for this hook or only the filtered module
+            $hooks[$key]['modules'] = Hook::getModulesFromHook($hook['id_hook'], $this->display_key);
+            $hooks[$key]['module_count'] = count($hooks[$key]['modules']);
+            if ($hooks[$key]['module_count']) {
+                // If modules were found, link to the previously created Module instances
+                if (is_array($hooks[$key]['modules']) && !empty($hooks[$key]['modules'])) {
+                    foreach ($hooks[$key]['modules'] as $module_key => $module) {
+                        if (isset($assoc_modules_id[$module['id_module']])) {
+                            $hooks[$key]['modules'][$module_key]['instance'] = $module_instances[$assoc_modules_id[$module['id_module']]];
+                        }
+                    }
+                }
+            } else {
+                unset($hooks[$key]);
+            }
+        }
+
+        $this->addJqueryPlugin('tablednd');
+
+        $this->toolbar_btn['save'] = array(
+            'href' => self::$currentIndex . '&addToHook' . ($this->display_key ? '&show_modules=' . $this->display_key : '') . '&token=' . $this->token,
+            'desc' => $this->trans('Transplant a module', array(), 'Admin.Design.Feature'),
+        );
+
+        $this->context->smarty->assign(array(
+            'show_toolbar' => true,
+            'toolbar_btn' => $this->toolbar_btn,
+            'title' => $this->toolbar_title,
+            'toolbar_scroll' => 'false',
+            'token' => $this->token,
+            'url_show_modules' => self::$currentIndex . '&token=' . $this->token . '&show_modules=',
+            'modules' => $module_instances,
+            'url_show_invisible' => self::$currentIndex . '&token=' . $this->token . '&show_modules=' . (int) Tools::getValue('show_modules') . '&hook_position=',
+            'display_key' => $this->display_key,
+            'hooks' => $hooks,
+            'url_submit' => self::$currentIndex . '&token=' . $this->token,
+            'can_move' => (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) ? false : true,
+        ));
+
+        return $this->createTemplate('list_modules.tpl')->fetch();
+    }
+
+    public function renderForm()
+    {
+        // Init toolbar
+        $this->initToolbarTitle();
+        // toolbar (save, cancel, new, ..)
+        $this->initToolbar();
+        $id_module = (int) Tools::getValue('id_module');
+        $id_hook = (int) Tools::getValue('id_hook');
+        $show_modules = (int) Tools::getValue('show_modules');
+
+        if (Tools::isSubmit('editGraft')) {
+            // Check auth for this page
+            if (!$id_module || !$id_hook) {
+                Tools::redirectAdmin(self::$currentIndex . '&token=' . $this->token);
+            }
+
+            $sql = 'SELECT id_module
+					FROM ' . _DB_PREFIX_ . 'hook_module
+					WHERE id_module = ' . $id_module . '
+						AND id_hook = ' . $id_hook . '
+						AND id_shop IN(' . implode(', ', Shop::getContextListShopID()) . ')';
+            if (!Db::getInstance()->getValue($sql)) {
+                Tools::redirectAdmin(self::$currentIndex . '&token=' . $this->token);
+            }
+
+            $sl_module = Module::getInstanceById($id_module);
+            $excepts_list = $sl_module->getExceptions($id_hook, true);
+            $excepts_diff = false;
+            $excepts = '';
+            if ($excepts_list) {
+                $first = current($excepts_list);
+                foreach ($excepts_list as $k => $v) {
+                    if (array_diff($v, $first) || array_diff($first, $v)) {
+                        $excepts_diff = true;
+                    }
+                }
+
+                if (!$excepts_diff) {
+                    $excepts = implode(', ', $first);
+                }
+            }
+        } else {
+            $excepts_diff = false;
+            $excepts_list = Tools::getValue('exceptions', array(array()));
+        }
+        $modules = Module::getModulesInstalled(0);
+
+        $instances = array();
+        foreach ($modules as $module) {
+            if ($tmp_instance = Module::getInstanceById($module['id_module'])) {
+                $instances[$tmp_instance->displayName] = $tmp_instance;
+            }
+        }
+        ksort($instances);
+        $modules = $instances;
+
+        $hooks = array();
+        if ($show_modules || (Tools::getValue('id_hook') > 0)) {
+            $module_instance = Module::getInstanceById((int) Tools::getValue('id_module', $show_modules));
+            $hooks = $module_instance->getPossibleHooksList();
+        }
+
+        $exception_list_diff = array();
+        foreach ($excepts_list as $shop_id => $file_list) {
+            $exception_list_diff[] = $this->displayModuleExceptionList($file_list, $shop_id);
+        }
+
+        $tpl = $this->createTemplate('form.tpl');
+        $tpl->assign(array(
+            'url_submit' => self::$currentIndex . '&token=' . $this->token,
+            'edit_graft' => Tools::isSubmit('editGraft'),
+            'id_module' => (int) Tools::getValue('id_module'),
+            'id_hook' => (int) Tools::getValue('id_hook'),
+            'show_modules' => $show_modules,
+            'hooks' => $hooks,
+            'exception_list' => $this->displayModuleExceptionList(array_shift($excepts_list), 0),
+            'exception_list_diff' => $exception_list_diff,
+            'except_diff' => isset($excepts_diff) ? $excepts_diff : null,
+            'display_key' => $this->display_key,
+            'modules' => $modules,
+            'show_toolbar' => true,
+            'toolbar_btn' => $this->toolbar_btn,
+            'toolbar_scroll' => $this->toolbar_scroll,
+            'title' => $this->toolbar_title,
+            'table' => 'hook_module',
+        ));
+
+        return $tpl->fetch();
+    }
+
+    public function displayModuleExceptionList($file_list, $shop_id)
+    {
+        if (!is_array($file_list)) {
+            $file_list = ($file_list) ? array($file_list) : array();
+        }
+
+        $content = '<p><input type="text" name="exceptions[' . $shop_id . ']" value="' . implode(', ', $file_list) . '" id="em_text_' . $shop_id . '" placeholder="' . $this->trans('E.g. address, addresses, attachment', array(), 'Admin.Design.Help') . '"/></p>';
+
+        if ($shop_id) {
+            $shop = new Shop($shop_id);
+            $content .= ' (' . $shop->name . ')';
+        }
+
+        $content .= '<p>
+					<select size="25" id="em_list_' . $shop_id . '" multiple="multiple">
+					<option disabled="disabled">'
+                    . $this->trans('___________ CUSTOM ___________', array(), 'Admin.Design.Feature')
+                    . '</option>';
+
+        /** @todo do something better with controllers */
+        $controllers = Dispatcher::getControllers(_PS_FRONT_CONTROLLER_DIR_);
+        ksort($controllers);
+
+        foreach ($file_list as $k => $v) {
+            if (!array_key_exists($v, $controllers)) {
+                $content .= '<option value="' . $v . '">' . $v . '</option>';
+            }
+        }
+
+        $content .= '<option disabled="disabled">' . $this->trans('____________ CORE ____________', array(), 'Admin.Design.Feature') . '</option>';
+
+        foreach ($controllers as $k => $v) {
+            $content .= '<option value="' . $k . '">' . $k . '</option>';
+        }
+
+        $modules_controllers_type = array('admin' => $this->trans('Admin modules controller', array(), 'Admin.Design.Feature'), 'front' => $this->trans('Front modules controller', array(), 'Admin.Design.Feature'));
+        foreach ($modules_controllers_type as $type => $label) {
+            $content .= '<option disabled="disabled">____________ ' . $label . ' ____________</option>';
+            $all_modules_controllers = Dispatcher::getModuleControllers($type);
+            foreach ($all_modules_controllers as $module => $modules_controllers) {
+                foreach ($modules_controllers as $cont) {
+                    $content .= '<option value="module-' . $module . '-' . $cont . '">module-' . $module . '-' . $cont . '</option>';
+                }
+            }
+        }
+
+        $content .= '</select>
+					</p>';
+
+        return $content;
+    }
+
+    public function ajaxProcessUpdatePositions()
+    {
+        if ($this->access('edit')) {
+            $id_module = (int) (Tools::getValue('id_module'));
+            $id_hook = (int) (Tools::getValue('id_hook'));
+            $way = (int) (Tools::getValue('way'));
+            $positions = Tools::getValue((string) $id_hook);
+            $position = (is_array($positions)) ? array_search($id_hook . '_' . $id_module, $positions) : null;
+            $module = Module::getInstanceById($id_module);
+            if (Validate::isLoadedObject($module)) {
+                if ($module->updatePosition($id_hook, $way, $position)) {
+                    die(true);
+                } else {
+                    die('{"hasError" : true, "errors" : "Cannot update module position."}');
+                }
+            } else {
+                die('{"hasError" : true, "errors" : "This module cannot be loaded."}');
+            }
+        }
+    }
+
+    public function ajaxProcessGetHookableList()
+    {
+        if ($this->access('view')) {
+            /* PrestaShop demo mode */
+            if (_PS_MODE_DEMO_) {
+                die('{"hasError" : true, "errors" : ["Live Edit: This functionality has been disabled."]}');
+            }
+
+            if (!count(Tools::getValue('hooks_list'))) {
+                die('{"hasError" : true, "errors" : ["Live Edit: no module on this page."]}');
+            }
+
+            $modules_list = Tools::getValue('modules_list');
+            $hooks_list = Tools::getValue('hooks_list');
+            $hookableList = array();
+
+            foreach ($modules_list as $module) {
+                $module = trim($module);
+                if (!$module) {
+                    continue;
+                }
+
+                if (!Validate::isModuleName($module)) {
+                    die('{"hasError" : true, "errors" : ["Live Edit: module is invalid."]}');
+                }
+
+                $moduleInstance = Module::getInstanceByName($module);
+                foreach ($hooks_list as $hook_name) {
+                    $hook_name = trim($hook_name);
+                    if (!$hook_name) {
+                        continue;
+                    }
+                    if (!array_key_exists($hook_name, $hookableList)) {
+                        $hookableList[$hook_name] = array();
+                    }
+                    if ($moduleInstance->isHookableOn($hook_name)) {
+                        $hookableList[$hook_name][] = str_replace('_', '-', $module);
+                    }
+                }
+            }
+            $hookableList['hasError'] = false;
+            die(json_encode($hookableList));
+        }
+    }
+
+    public function ajaxProcessGetHookableModuleList()
+    {
+        if ($this->access('view')) {
+            /* PrestaShop demo mode */
+            if (_PS_MODE_DEMO_) {
+                die('{"hasError" : true, "errors" : ["Live Edit: This functionality has been disabled."]}');
+            }
+            /* PrestaShop demo mode*/
+
+            $hook_name = Tools::getValue('hook');
+            $hookableModulesList = array();
+            $modules = Db::getInstance()->executeS('SELECT id_module, name FROM `' . _DB_PREFIX_ . 'module` ');
+            foreach ($modules as $module) {
+                if (!Validate::isModuleName($module['name'])) {
+                    continue;
+                }
+                if (file_exists(_PS_MODULE_DIR_ . $module['name'] . '/' . $module['name'] . '.php')) {
+                    include_once _PS_MODULE_DIR_ . $module['name'] . '/' . $module['name'] . '.php';
+
+                    /** @var Module $mod */
+                    $mod = new $module['name']();
+                    if ($mod->isHookableOn($hook_name)) {
+                        $hookableModulesList[] = array('id' => (int) $mod->id, 'name' => $mod->displayName, 'display' => Hook::exec($hook_name, array(), (int) $mod->id));
+                    }
+                }
+            }
+            die(json_encode($hookableModulesList));
+        }
+    }
+
+    public function ajaxProcessSaveHook()
+    {
+        if ($this->access('edit')) {
+            /* PrestaShop demo mode */
+            if (_PS_MODE_DEMO_) {
+                die('{"hasError" : true, "errors" : ["Live Edit: This functionality has been disabled."]}');
+            }
+
+            $hooks_list = explode(',', Tools::getValue('hooks_list'));
+            $id_shop = (int) Tools::getValue('id_shop');
+            if (!$id_shop) {
+                $id_shop = Context::getContext()->shop->id;
+            }
+
+            $res = true;
+            $hookableList = array();
+            // $_POST['hook'] is an array of id_module
+            $hooks_list = Tools::getValue('hook');
+
+            foreach ($hooks_list as $id_hook => $modules) {
+                // 1st, drop all previous hooked modules
+                $sql = 'DELETE FROM `' . _DB_PREFIX_ . 'hook_module` WHERE `id_hook` =  ' . (int) $id_hook . ' AND id_shop = ' . (int) $id_shop;
+                $res &= Db::getInstance()->execute($sql);
+
+                $i = 1;
+                $value = '';
+                $ids = array();
+                // then prepare sql query to rehook all chosen modules(id_module, id_shop, id_hook, position)
+                // position is i (autoincremented)
+                if (is_array($modules) && count($modules)) {
+                    foreach ($modules as $id_module) {
+                        if ($id_module && !in_array($id_module, $ids)) {
+                            $ids[] = (int) $id_module;
+                            $value .= '(' . (int) $id_module . ', ' . (int) $id_shop . ', ' . (int) $id_hook . ', ' . (int) $i . '),';
+                        }
+                        ++$i;
+                    }
+
+                    if ($value) {
+                        $value = rtrim($value, ',');
+                        $res &= Db::getInstance()->execute('INSERT INTO  `' . _DB_PREFIX_ . 'hook_module` (id_module, id_shop, id_hook, position) VALUES ' . $value);
+                    }
+                }
+            }
+            if ($res) {
+                $hasError = true;
+            } else {
+                $hasError = false;
+            }
+            die('{"hasError" : false, "errors" : ""}');
+        }
+    }
+
+    /**
+     * Return a json array containing the possible hooks for a module.
+     */
+    public function ajaxProcessGetPossibleHookingListForModule()
+    {
+        $module_id = (int) Tools::getValue('module_id');
+        if ($module_id == 0) {
+            die('{"hasError" : true, "errors" : ["Wrong module ID."]}');
+        }
+
+        $module_instance = Module::getInstanceById($module_id);
+        die(json_encode($module_instance->getPossibleHooksList()));
+    }
+}

--- a/controllers/admin/AdminPreferencesController.php
+++ b/controllers/admin/AdminPreferencesController.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * @property Configuration $object
+ */
+class AdminPreferencesControllerCore extends AdminController
+{
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        $this->className = 'Configuration';
+        $this->table = 'configuration';
+
+        parent::__construct();
+
+        // Prevent classes which extend AdminPreferences to load useless data
+        if (get_class($this) == 'AdminPreferencesController') {
+            $round_mode = array(
+                array(
+                    'value' => PS_ROUND_HALF_UP,
+                    'name' => $this->trans('Round up away from zero, when it is half way there (recommended)', array(), 'Admin.Shopparameters.Feature'),
+                ),
+                array(
+                    'value' => PS_ROUND_HALF_DOWN,
+                    'name' => $this->trans('Round down towards zero, when it is half way there', array(), 'Admin.Shopparameters.Feature'),
+                ),
+                array(
+                    'value' => PS_ROUND_HALF_EVEN,
+                    'name' => $this->trans('Round towards the next even value', array(), 'Admin.Shopparameters.Feature'),
+                ),
+                array(
+                    'value' => PS_ROUND_HALF_ODD,
+                    'name' => $this->trans('Round towards the next odd value', array(), 'Admin.Shopparameters.Feature'),
+                ),
+                array(
+                    'value' => PS_ROUND_UP,
+                    'name' => $this->trans('Round up to the nearest value', array(), 'Admin.Shopparameters.Feature'),
+                ),
+                array(
+                    'value' => PS_ROUND_DOWN,
+                    'name' => $this->trans('Round down to the nearest value', array(), 'Admin.Shopparameters.Feature'),
+                ),
+            );
+            $activities1 = array(
+                0 => $this->trans('-- Please choose your main activity --', array(), 'Install'),
+                2 => $this->trans('Animals and Pets', array(), 'Install'),
+                3 => $this->trans('Art and Culture', array(), 'Install'),
+                4 => $this->trans('Babies', array(), 'Install'),
+                5 => $this->trans('Beauty and Personal Care', array(), 'Install'),
+                6 => $this->trans('Cars', array(), 'Install'),
+                7 => $this->trans('Computer Hardware and Software', array(), 'Install'),
+                8 => $this->trans('Download', array(), 'Install'),
+                9 => $this->trans('Fashion and accessories', array(), 'Install'),
+                10 => $this->trans('Flowers, Gifts and Crafts', array(), 'Install'),
+                11 => $this->trans('Food and beverage', array(), 'Install'),
+                12 => $this->trans('HiFi, Photo and Video', array(), 'Install'),
+                13 => $this->trans('Home and Garden', array(), 'Install'),
+                14 => $this->trans('Home Appliances', array(), 'Install'),
+                15 => $this->trans('Jewelry', array(), 'Install'),
+                1 => $this->trans('Lingerie and Adult', array(), 'Install'),
+                16 => $this->trans('Mobile and Telecom', array(), 'Install'),
+                17 => $this->trans('Services', array(), 'Install'),
+                18 => $this->trans('Shoes and accessories', array(), 'Install'),
+                19 => $this->trans('Sport and Entertainment', array(), 'Install'),
+                20 => $this->trans('Travel', array(), 'Install'),
+            );
+            $activities2 = array();
+            foreach ($activities1 as $value => $name) {
+                $activities2[] = array('value' => $value, 'name' => $name);
+            }
+
+            $fields = array(
+                'PS_SSL_ENABLED' => array(
+                    'title' => $this->trans('Enable SSL', array(), 'Admin.Shopparameters.Feature'),
+                    'desc' => $this->trans('If you own an SSL certificate for your shop\'s domain name, you can activate SSL encryption (https://) for customer account identification and order processing.', array(), 'Admin.Shopparameters.Help'),
+                    'hint' => $this->trans('If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.', array(), 'Admin.Shopparameters.Help'),
+                    'validation' => 'isBool',
+                    'cast' => 'intval',
+                    'type' => 'bool',
+                    'default' => '0',
+                ),
+            );
+
+            $fields['PS_SSL_ENABLED_EVERYWHERE'] = array(
+                'title' => $this->trans('Enable SSL on all pages', array(), 'Admin.Shopparameters.Feature'),
+                'desc' => $this->trans('When enabled, all the pages of your shop will be SSL-secured.', array(), 'Admin.Shopparameters.Help'),
+                'validation' => 'isBool',
+                'cast' => 'intval',
+                'type' => 'bool',
+                'default' => '0',
+                'disabled' => (Tools::getValue('PS_SSL_ENABLED', Configuration::get('PS_SSL_ENABLED'))) ? false : true,
+            );
+
+            $fields = array_merge($fields, array(
+                'PS_TOKEN_ENABLE' => array(
+                    'title' => $this->trans('Increase front office security', array(), 'Admin.Shopparameters.Feature'),
+                    'desc' => $this->trans('Enable or disable token in the Front Office to improve PrestaShop\'s security.', array(), 'Admin.Shopparameters.Help'),
+                    'validation' => 'isBool',
+                    'cast' => 'intval',
+                    'type' => 'bool',
+                    'default' => '0',
+                    'visibility' => Shop::CONTEXT_ALL,
+                ),
+                'PS_ALLOW_HTML_IFRAME' => array(
+                    'title' => $this->trans('Allow iframes on HTML fields', array(), 'Admin.Shopparameters.Feature'),
+                    'desc' => $this->trans('Allow iframes on text fields like product description. We recommend that you leave this option disabled.', array(), 'Admin.Shopparameters.Help'),
+                    'validation' => 'isBool',
+                    'cast' => 'intval',
+                    'type' => 'bool',
+                    'default' => '0',
+                ),
+                'PS_USE_HTMLPURIFIER' => array(
+                    'title' => $this->trans('Use HTMLPurifier Library', array(), 'Admin.Shopparameters.Feature'),
+                    'desc' => $this->trans('Clean the HTML content on text fields. We recommend that you leave this option enabled.', array(), 'Admin.Shopparameters.Help'),
+                    'validation' => 'isBool',
+                    'cast' => 'intval',
+                    'type' => 'bool',
+                    'default' => '0',
+                ),
+                'PS_PRICE_ROUND_MODE' => array(
+                    'title' => $this->trans('Round mode', array(), 'Admin.Shopparameters.Feature'),
+                    'desc' => $this->trans('You can choose among 6 different ways of rounding prices. "Round up away from zero ..." is the recommended behavior.', array(), 'Admin.Shopparameters.Help'),
+                    'validation' => 'isInt',
+                    'cast' => 'intval',
+                    'type' => 'select',
+                    'list' => $round_mode,
+                    'identifier' => 'value',
+                ),
+                'PS_ROUND_TYPE' => array(
+                    'title' => $this->trans('Round type', array(), 'Admin.Shopparameters.Feature'),
+                    'desc' => $this->trans('You can choose when to round prices: either on each item, each line or the total (of an invoice, for example).', array(), 'Admin.Shopparameters.Help'),
+                    'cast' => 'intval',
+                    'type' => 'select',
+                    'list' => array(
+                        array(
+                            'name' => $this->trans('Round on each item', array(), 'Admin.Shopparameters.Feature'),
+                            'id' => Order::ROUND_ITEM,
+                        ),
+                        array(
+                            'name' => $this->trans('Round on each line', array(), 'Admin.Shopparameters.Feature'),
+                            'id' => Order::ROUND_LINE,
+                        ),
+                        array(
+                            'name' => $this->trans('Round on the total', array(), 'Admin.Shopparameters.Feature'),
+                            'id' => Order::ROUND_TOTAL,
+                        ),
+                    ),
+                    'identifier' => 'id',
+                ),
+                'PS_PRICE_DISPLAY_PRECISION' => array(
+                    'title' => $this->trans('Number of decimals', array(), 'Admin.Shopparameters.Feature'),
+                    'desc' => $this->trans('Choose how many decimals you want to display', array(), 'Admin.Shopparameters.Help'),
+                    'validation' => 'isUnsignedInt',
+                    'cast' => 'intval',
+                    'type' => 'text',
+                    'class' => 'fixed-width-xxl',
+                ),
+                'PS_DISPLAY_SUPPLIERS' => array(
+                    'title' => $this->trans('Display brands and suppliers', array(), 'Admin.Shopparameters.Feature'),
+                    'desc' => $this->trans('Enable brands and suppliers pages on your front office even when their respective modules are disabled.', array(), 'Admin.Shopparameters.Help'),
+                    'validation' => 'isBool',
+                    'cast' => 'intval',
+                    'type' => 'bool',
+                ),
+                'PS_DISPLAY_BEST_SELLERS' => array(
+                    'title' => $this->trans('Display best sellers', array(), 'Admin.Shopparameters.Feature'),
+                    'desc' => $this->trans('Enable best sellers page on your front office even when its respective module is disabled.', array(), 'Admin.Shopparameters.Help'),
+                    'validation' => 'isBool',
+                    'cast' => 'intval',
+                    'type' => 'bool',
+                ),
+                'PS_MULTISHOP_FEATURE_ACTIVE' => array(
+                    'title' => $this->trans('Enable Multistore', array(), 'Admin.Shopparameters.Feature'),
+                    'desc' => $this->trans('The multistore feature allows you to manage several e-shops with one Back Office. If this feature is enabled, a "Multistore" page will be available in the "Advanced Parameters" menu.', array(), 'Admin.Shopparameters.Help'),
+                    'validation' => 'isBool',
+                    'cast' => 'intval',
+                    'type' => 'bool',
+                    'visibility' => Shop::CONTEXT_ALL,
+                ),
+                'PS_SHOP_ACTIVITY' => array(
+                    'title' => $this->trans('Main Shop Activity', array(), 'Admin.Shopparameters.Feature'),
+                    'validation' => 'isInt',
+                    'cast' => 'intval',
+                    'type' => 'select',
+                    'list' => $activities2,
+                    'identifier' => 'value',
+                ),
+            ));
+
+            // No HTTPS activation if you haven't already.
+            if (!Tools::usingSecureMode() && !Configuration::get('PS_SSL_ENABLED')) {
+                $requestUri = '';
+                if (array_key_exists('REQUEST_URI', $_SERVER)) {
+                    $requestUri = $_SERVER['REQUEST_URI'];
+                }
+
+                $fields['PS_SSL_ENABLED']['type'] = 'disabled';
+                $fields['PS_SSL_ENABLED']['disabled'] = '<a class="btn btn-link" href="https://' .
+                    Tools::getShopDomainSsl() .
+                    Tools::safeOutput($requestUri) . '">' .
+                    $this->trans('Please click here to check if your shop supports HTTPS.', array(), 'Admin.Shopparameters.Feature') . '</a>';
+            }
+
+            $this->fields_options = array(
+                'general' => array(
+                    'title' => $this->trans('General', array(), 'Admin.Global'),
+                    'icon' => 'icon-cogs',
+                    'fields' => $fields,
+                    'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions')),
+                ),
+            );
+        }
+    }
+}

--- a/controllers/admin/AdminPreferencesController.php
+++ b/controllers/admin/AdminPreferencesController.php
@@ -29,8 +29,16 @@
  */
 class AdminPreferencesControllerCore extends AdminController
 {
+    /**
+     * @deprecated since 1.7.6, to be removed in the next minor
+     */
     public function __construct()
     {
+        @trigger_error(
+            'The AdminPreferencesController is deprecated and will be removed in the next minor',
+            E_USER_DEPRECATED
+        );
+
         $this->bootstrap = true;
         $this->className = 'Configuration';
         $this->table = 'configuration';

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -37,8 +37,16 @@ class AdminRequestSqlControllerCore extends AdminController
         array('value' => 2, 'name' => 'iso-8859-1'),
     );
 
+    /**
+     * @deprecated since 1.7.6, to be removed in the next minor
+     */
     public function __construct()
     {
+        @trigger_error(
+            'The AdminRequestSqlController is deprecated and will be removed in the next minor',
+            E_USER_DEPRECATED
+        );
+
         $this->bootstrap = true;
         $this->table = 'request_sql';
         $this->className = 'RequestSql';

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -1,0 +1,547 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * @property RequestSql $object
+ */
+class AdminRequestSqlControllerCore extends AdminController
+{
+    /**
+     * @var array : List of encoding type for a file
+     */
+    public static $encoding_file = array(
+        array('value' => 1, 'name' => 'utf-8'),
+        array('value' => 2, 'name' => 'iso-8859-1'),
+    );
+
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        $this->table = 'request_sql';
+        $this->className = 'RequestSql';
+        $this->lang = false;
+        $this->export = true;
+
+        parent::__construct();
+
+        $this->fields_list = array(
+            'id_request_sql' => array('title' => $this->trans('ID', array(), 'Admin.Global'), 'class' => 'fixed-width-xs'),
+            'name' => array('title' => $this->trans('SQL query Name', array(), 'Admin.Advparameters.Feature')),
+            'sql' => array(
+                'title' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature'),
+                'filter_key' => 'a!sql',
+            ),
+        );
+
+        $this->fields_options = array(
+            'general' => array(
+                'title' => $this->trans('Settings', array(), 'Admin.Global'),
+                'fields' => array(
+                    'PS_ENCODING_FILE_MANAGER_SQL' => array(
+                        'title' => $this->trans('Select your default file encoding', array(), 'Admin.Advparameters.Feature'),
+                        'cast' => 'intval',
+                        'type' => 'select',
+                        'identifier' => 'value',
+                        'list' => self::$encoding_file,
+                        'visibility' => Shop::CONTEXT_ALL,
+                    ),
+                ),
+                'submit' => array('title' => $this->trans('Save', array(), 'Admin.Actions')),
+            ),
+        );
+
+        $this->bulk_actions = array(
+            'delete' => array(
+                'text' => $this->trans('Delete selected', array(), 'Admin.Actions'),
+                'confirm' => $this->trans('Delete selected items?', array(), 'Admin.Notifications.Warning'),
+                'icon' => 'icon-trash',
+            ),
+        );
+    }
+
+    public function renderOptions()
+    {
+        // Set toolbar options
+        $this->display = 'options';
+        $this->show_toolbar = true;
+        $this->toolbar_scroll = true;
+        $this->initToolbar();
+
+        return parent::renderOptions();
+    }
+
+    public function initToolbar()
+    {
+        if ($this->display == 'view' && $id_request = Tools::getValue('id_request_sql')) {
+            $this->toolbar_btn['edit'] = array(
+                'href' => self::$currentIndex . '&amp;updaterequest_sql&amp;token=' . $this->token . '&amp;id_request_sql=' . (int) $id_request,
+                'desc' => $this->trans('Edit this SQL query', array(), 'Admin.Advparameters.Feature'),
+            );
+        }
+
+        parent::initToolbar();
+
+        if ($this->display == 'options') {
+            unset($this->toolbar_btn['new']);
+        }
+    }
+
+    public function renderList()
+    {
+        // Set toolbar options
+        $this->display = null;
+        $this->initToolbar();
+
+        $this->displayWarning($this->trans('When saving the query, only the "SELECT" SQL statement is allowed.', array(), 'Admin.Advparameters.Notification'));
+        $this->displayInformation('
+		<strong>' . $this->trans('How do I create a new SQL query?', array(), 'Admin.Advparameters.Help') . '</strong><br />
+		<ul>
+			<li>' . $this->trans('Click "Add New".', array(), 'Admin.Advparameters.Help') . '</li>
+			<li>' . $this->trans('Fill in the fields and click "Save".', array(), 'Admin.Advparameters.Help') . '</li>
+			<li>' . $this->trans('You can then view the query results by clicking on the Edit action in the dropdown menu', array(), 'Admin.Advparameters.Help') . ' <i class="icon-pencil"></i></li>
+			<li>' . $this->trans('You can also export the query results as a CSV file by clicking on the Export button', array(), 'Admin.Advparameters.Help') . ' <i class="icon-cloud-upload"></i></li>
+		</ul>');
+
+        $this->addRowAction('export');
+        $this->addRowAction('view');
+        $this->addRowAction('edit');
+        $this->addRowAction('delete');
+
+        return parent::renderList();
+    }
+
+    public function renderForm()
+    {
+        $this->fields_form = array(
+            'legend' => array(
+                'title' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature'),
+                'icon' => 'icon-cog',
+            ),
+            'input' => array(
+                array(
+                    'type' => 'text',
+                    'label' => $this->trans('SQL query name', array(), 'Admin.Advparameters.Feature'),
+                    'name' => 'name',
+                    'size' => 103,
+                    'required' => true,
+                ),
+                array(
+                    'type' => 'textarea',
+                    'label' => $this->trans('SQL query', array(), 'Admin.Advparameters.Feature'),
+                    'name' => 'sql',
+                    'cols' => 100,
+                    'rows' => 10,
+                    'required' => true,
+                ),
+            ),
+            'submit' => array(
+                'title' => $this->trans('Save', array(), 'Admin.Actions'),
+            ),
+        );
+
+        $request = new RequestSql();
+        $this->tpl_form_vars = array('tables' => $request->getTables());
+
+        return parent::renderForm();
+    }
+
+    public function postProcess()
+    {
+        /* PrestaShop demo mode */
+        if (_PS_MODE_DEMO_) {
+            $this->errors[] = $this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error');
+
+            return;
+        }
+
+        return parent::postProcess();
+    }
+
+    /**
+     * method call when ajax request is made with the details row action.
+     *
+     * @see AdminController::postProcess()
+     */
+    public function ajaxProcess()
+    {
+        /* PrestaShop demo mode */
+        if (_PS_MODE_DEMO_) {
+            die($this->trans('This functionality has been disabled.', array(), 'Admin.Notifications.Error'));
+        }
+        if ($table = Tools::getValue('table')) {
+            $request_sql = new RequestSql();
+            $attributes = $request_sql->getAttributesByTable($table);
+            foreach ($attributes as $key => $attribute) {
+                unset(
+                    $attributes[$key]['Null'],
+                    $attributes[$key]['Key'],
+                    $attributes[$key]['Default'],
+                    $attributes[$key]['Extra']
+                );
+            }
+            die(json_encode($attributes));
+        }
+    }
+
+    public function renderView()
+    {
+        /** @var RequestSql $obj */
+        if (!($obj = $this->loadObject(true))) {
+            return;
+        }
+
+        $view = array();
+        if ($results = Db::getInstance()->executeS($obj->sql)) {
+            foreach (array_keys($results[0]) as $key) {
+                $tab_key[] = $key;
+            }
+
+            $view['name'] = $obj->name;
+            $view['key'] = $tab_key;
+            $view['results'] = $results;
+
+            $this->toolbar_title = $obj->name;
+
+            $request_sql = new RequestSql();
+            $view['attributes'] = $request_sql->attributes;
+        } else {
+            $view['error'] = true;
+        }
+
+        $this->tpl_view_vars = array(
+            'view' => $view,
+        );
+
+        return parent::renderView();
+    }
+
+    public function _childValidation()
+    {
+        if (Tools::getValue('submitAdd' . $this->table) && $sql = Tools::getValue('sql')) {
+            $request_sql = new RequestSql();
+            $parser = $request_sql->parsingSql($sql);
+            $validate = $request_sql->validateParser($parser, false, $sql);
+
+            if (!$validate || count($request_sql->error_sql)) {
+                $this->displayError($request_sql->error_sql);
+            }
+        }
+    }
+
+    /**
+     * Display export action link.
+     *
+     * @param $token
+     * @param int $id
+     *
+     * @return string
+     *
+     * @throws Exception
+     * @throws SmartyException
+     */
+    public function displayExportLink($token, $id)
+    {
+        $tpl = $this->createTemplate('list_action_export.tpl');
+
+        $tpl->assign(array(
+            'href' => self::$currentIndex . '&token=' . $this->token . '&' . $this->identifier . '=' . $id . '&export' . $this->table . '=1',
+            'action' => $this->trans('Export', array(), 'Admin.Actions'),
+        ));
+
+        return $tpl->fetch();
+    }
+
+    public function initProcess()
+    {
+        parent::initProcess();
+        if (Tools::getValue('export' . $this->table)) {
+            $this->display = 'export';
+            $this->action = 'export';
+        }
+    }
+
+    public function initContent()
+    {
+        if ($this->display == 'edit' || $this->display == 'add') {
+            if (!$this->loadObject(true)) {
+                return;
+            }
+
+            $this->content .= $this->renderForm();
+        } elseif ($this->display == 'view') {
+            // Some controllers use the view action without an object
+            if ($this->className) {
+                $this->loadObject(true);
+            }
+            $this->content .= $this->renderView();
+        } elseif ($this->display == 'export') {
+            $this->processExport();
+        } elseif (!$this->ajax) {
+            $this->content .= $this->renderList();
+            $this->content .= $this->renderOptions();
+        }
+
+        $this->context->smarty->assign(array(
+            'content' => $this->content,
+        ));
+    }
+
+    public function initPageHeaderToolbar()
+    {
+        if (empty($this->display)) {
+            $this->page_header_toolbar_btn['new_request'] = array(
+                'href' => self::$currentIndex . '&addrequest_sql&token=' . $this->token,
+                'desc' => $this->trans('Add new SQL query', array(), 'Admin.Advparameters.Feature'),
+                'icon' => 'process-icon-new',
+            );
+        }
+
+        parent::initPageHeaderToolbar();
+    }
+
+    /**
+     * Genrating a export file.
+     */
+    public function processExport($textDelimiter = '"')
+    {
+        $id = Tools::getValue($this->identifier);
+        $export_dir = defined('_PS_HOST_MODE_') ? _PS_ROOT_DIR_ . '/export/' : _PS_ADMIN_DIR_ . '/export/';
+        if (!Validate::isFileName($id)) {
+            die(Tools::displayError());
+        }
+        $file = 'request_sql_' . $id . '.csv';
+        if ($csv = fopen($export_dir . $file, 'wb')) {
+            $sql = RequestSql::getRequestSqlById($id);
+
+            if ($sql) {
+                $results = Db::getInstance()->executeS($sql[0]['sql']);
+                foreach (array_keys($results[0]) as $key) {
+                    $tab_key[] = $key;
+                    fwrite($csv, $key . ';');
+                }
+                foreach ($results as $result) {
+                    fwrite($csv, "\n");
+                    foreach ($tab_key as $name) {
+                        fwrite($csv, $textDelimiter . strip_tags($result[$name]) . $textDelimiter . ';');
+                    }
+                }
+                if (file_exists($export_dir . $file)) {
+                    $filesize = filesize($export_dir . $file);
+                    $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
+                    if ($filesize < $upload_max_filesize) {
+                        if (Configuration::get('PS_ENCODING_FILE_MANAGER_SQL')) {
+                            $charset = Configuration::get('PS_ENCODING_FILE_MANAGER_SQL');
+                        } else {
+                            $charset = self::$encoding_file[0]['name'];
+                        }
+
+                        header('Content-Type: text/csv; charset=' . $charset);
+                        header('Cache-Control: no-store, no-cache');
+                        header('Content-Disposition: attachment; filename="' . $file . '"');
+                        header('Content-Length: ' . $filesize);
+                        readfile($export_dir . $file);
+                        die();
+                    } else {
+                        $this->errors[] = $this->trans('The file is too large and cannot be downloaded. Please use the LIMIT clause in this query.', array(), 'Admin.Advparameters.Notification');
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Display all errors.
+     *
+     * @param $e : array of errors
+     */
+    public function displayError($e)
+    {
+        foreach (array_keys($e) as $key) {
+            switch ($key) {
+                case 'checkedFrom':
+                    if (isset($e[$key]['table'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%tablename%" table does not exist.',
+                            array(
+                                '%tablename%' => $e[$key]['table'],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } elseif (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                                'The "%attribute%" attribute does not exist in the "%table%" table.',
+                                array(
+                                    '%attribute%' => $e[$key]['attribut'][0],
+                                    '%table%' => $e[$key]['attribut'][1],
+                                ),
+                                'Admin.Advparameters.Notification'
+                            );
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedForm'), 'Admin.Advparameters.Notification');
+                    }
+
+                    break;
+
+                case 'checkedSelect':
+                    if (isset($e[$key]['table'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%tablename%" table does not exist.',
+                            array(
+                                '%tablename%' => $e[$key]['table'],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } elseif (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } elseif (isset($e[$key]['*'])) {
+                        $this->errors[] = $this->trans('The "*" operator cannot be used in a nested query.', array(), 'Admin.Advparameters.Notification');
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedSelect'), 'Admin.Advparameters.Notification');
+                    }
+
+                    break;
+
+                case 'checkedWhere':
+                    if (isset($e[$key]['operator'])) {
+                        $this->errors[] = $this->trans(
+                            'The operator "%s" is incorrect.',
+                            array(
+                                '%operator%' => $e[$key]['operator'],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } elseif (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedWhere'), 'Admin.Advparameters.Notification');
+                    }
+
+                    break;
+
+                case 'checkedHaving':
+                    if (isset($e[$key]['operator'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%operator%" operator is incorrect.',
+                            array(
+                                '%operator%' => $e[$key]['operator'],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } elseif (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedHaving'), 'Admin.Advparameters.Notification');
+                    }
+
+                    break;
+
+                case 'checkedOrder':
+                    if (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedOrder'), 'Admin.Advparameters.Notification');
+                    }
+
+                    break;
+
+                case 'checkedGroupBy':
+                    if (isset($e[$key]['attribut'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%attribute%" attribute does not exist in the "%table%" table.',
+                            array(
+                                '%attribute%' => $e[$key]['attribut'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } else {
+                        $this->errors[] = $this->trans('Undefined "%s" error', array('checkedGroupBy'), 'Admin.Advparameters.Notification');
+                    }
+
+                    break;
+
+                case 'checkedLimit':
+                    $this->errors[] = $this->trans('The LIMIT clause must contain numeric arguments.', array(), 'Admin.Advparameters.Notification');
+
+                    break;
+
+                case 'returnNameTable':
+                    if (isset($e[$key]['reference'])) {
+                        $this->errors[] = $this->trans(
+                            'The "%reference%" reference does not exist in the "%table%" table.',
+                            array(
+                                '%reference%' => $e[$key]['reference'][0],
+                                '%table%' => $e[$key]['attribut'][1],
+                            ),
+                            'Admin.Advparameters.Notification'
+                        );
+                    } else {
+                        $this->errors[] = $this->trans('When multiple tables are used, each attribute must refer back to a table.', array(), 'Admin.Advparameters.Notification');
+                    }
+
+                    break;
+
+                case 'testedRequired':
+                    $this->errors[] = $this->trans('"%key%" does not exist.', array('%key%' => $e[$key]), 'Admin.Notifications.Error');
+
+                    break;
+
+                case 'testedUnauthorized':
+                    $this->errors[] = $this->trans('"%key%" is an unauthorized keyword.', array('%key%' => $e[$key]), 'Admin.Advparameters.Notification');
+
+                    break;
+            }
+        }
+    }
+}

--- a/controllers/admin/AdminStatsTabController.php
+++ b/controllers/admin/AdminStatsTabController.php
@@ -23,12 +23,12 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-abstract class AdminStatsTabControllerCore extends AdminController
+abstract class AdminStatsTabControllerCore extends AdminPreferencesControllerCore
 {
     public function init()
     {
         parent::init();
-        $this->bootstrap = true;
+
         $this->action = 'view';
         $this->display = 'view';
     }

--- a/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
+++ b/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
@@ -120,6 +120,7 @@ class ControllerTest extends TestCase
             array('AdminLoginController'),
             array('AdminQuickAccessesController'),
             array('AdminCustomerThreadsController'),
+            array('AdminManufacturersController'),
             array('AdminReferrersController'),
             array('AdminAttachmentsController'),
             array('AdminReturnController'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | We removed legacy template and controllers file late in beta period for 1.7.6.0. The pages were migrated so these files are supposed to be useless now however we have detected several regressions both from manual QA testing and automated E2E testing. Considering how close the release date is, we choose to restore these files with a deprecation notice and perform the removal in the early phase of v1.7.7 development.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | yes, it deprecates some legacy template and controller files
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13935
| How to test?  | Please check that recent regressions are fixed thanks to this, including (but not only) https://github.com/PrestaShop/PrestaShop/issues/13935

This PR reverts:
- https://github.com/PrestaShop/PrestaShop/pull/13910
- https://github.com/PrestaShop/PrestaShop/pull/13852
- https://github.com/PrestaShop/PrestaShop/pull/13850
- https://github.com/PrestaShop/PrestaShop/pull/13849
- https://github.com/PrestaShop/PrestaShop/pull/13847

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13956)
<!-- Reviewable:end -->
