### PR TITLE
Remove useless die

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -317,7 +317,7 @@ class CustomerCore extends ObjectModel
     public function getByEmail($email, $passwd = null, $ignore_guest = true)
     {
         if (!Validate::isEmail($email) || ($passwd && !Validate::isPasswd($passwd))) {
-            die(Tools::displayError());
+            Tools::displayError();
         }
 
         $result = Db::getInstance()->getRow('


### PR DESCRIPTION
Why using die when email and password are invalid ?
Displaying error is not enough ?


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.6.1.x
| Description?  | The Customer::getByEmail send die when email and password are invalid
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | not found
| How to test?  | Overide the authcontroller and login using the method getByEmail

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13975)
<!-- Reviewable:end -->
