### PR TITLE
Use POST method with _method parameter 'PUT'

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -816,6 +816,10 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
      */
     protected function manageDeclinatedImagesCRUD($filename_exists, $filename, $image_sizes, $directory)
     {
+        if ($this->wsObject->method == 'POST' && $_POST['_method'] == 'PUT') {
+            $this->wsObject->method = 'PUT';
+        }
+
         switch ($this->wsObject->method) {
             // Display the image
             case 'GET':


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There is bug in PrestaShop WS, when making PUT request to update product image, when using PUT method $_FILES is always empty, this fix uses POST method with additional parameter _method set to PUT
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no

How to test?
actual, not working method, returns error:
```
curl -X PUT \
  'https://localhost/api/images/products/PRODUCT_ID/IMAGE_ID?output_format=XML' \
  -H 'Authorization: Basic BASE64_API_KEY' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW' \
  -F image=@/path/to/image.jpeg
```
after fix use this method, returns updated image:
```
curl -X POST \
  'https://localhost/api/images/products/PRODUCT_ID/IMAGE_ID?output_format=XML' \
  -H 'Authorization: Basic BASE64_API_KEY' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW' \
  -F image=@/path/to/image.jpeg \
  -F _method=PUT
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13994)
<!-- Reviewable:end -->
