### PR TITLE
Install poppler-utils in e2e-tests container and use endAll to delete Selenium sessions

### DIFF
--- a/tests/E2E/.docker/Dockerfile
+++ b/tests/E2E/.docker/Dockerfile
@@ -11,7 +11,8 @@ RUN apt install -y \
     gnupg2 \
     curl \
     git \
-    software-properties-common
+    software-properties-common \
+    poppler-utils
 
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/tests/E2E/test/clients/common_client.js
+++ b/tests/E2E/test/clients/common_client.js
@@ -152,7 +152,7 @@ class CommonClient {
   }
 
   close() {
-    return this.client.end();
+    return this.client.endAll();
   }
 
   closeWindow(id) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Install poppler-utils in e2e-tests container to convert pdf to text and replace end by endAll to delete Selenium sessions
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Run tests with docker 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14002)
<!-- Reviewable:end -->
