### PR TITLE
Fix currency precision from CLDR at install

### DIFF
--- a/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
@@ -81,7 +81,7 @@ final class AddCurrencyHandler extends AbstractCurrencyHandler implements AddCur
             $entity->active = $command->isEnabled();
             $entity->conversion_rate = $command->getExchangeRate()->getValue();
             // CLDR locale give us the CLDR reference specification
-            $cldrLocale = $this->localeRepoCLDR->getLocale($this->defaultLanguage->locale);
+            $cldrLocale = $this->localeRepoCLDR->getLocale($this->defaultLanguage->getLocale());
             // CLDR currency gives data from CLDR reference, for the given language
             $cldrCurrency = $cldrLocale->getCurrency($entity->iso_code);
             if (!empty($cldrCurrency)) {

--- a/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
@@ -51,11 +51,18 @@ final class AddCurrencyHandler extends AbstractCurrencyHandler implements AddCur
     private $localeRepoCLDR;
 
     /**
-     * @param LocaleRepository $localeRepoCLDR
+     * @var Language
      */
-    public function __construct(LocaleRepository $localeRepoCLDR)
+    private $defaultLanguage;
+
+    /**
+     * @param LocaleRepository $localeRepoCLDR
+     * @param Language $defaultLanguage
+     */
+    public function __construct(LocaleRepository $localeRepoCLDR, $defaultLanguageId)
     {
         $this->localeRepoCLDR = $localeRepoCLDR;
+        $this->defaultLanguage = new Language((int) $defaultLanguageId);
     }
 
     /**
@@ -73,9 +80,8 @@ final class AddCurrencyHandler extends AbstractCurrencyHandler implements AddCur
             $entity->iso_code = $command->getIsoCode()->getValue();
             $entity->active = $command->isEnabled();
             $entity->conversion_rate = $command->getExchangeRate()->getValue();
-            $defaultLang = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
             // CLDR locale give us the CLDR reference specification
-            $cldrLocale = $this->localeRepoCLDR->getLocale($defaultLang->locale);
+            $cldrLocale = $this->localeRepoCLDR->getLocale($this->defaultLanguage->locale);
             // CLDR currency gives data from CLDR reference, for the given language
             $cldrCurrency = $cldrLocale->getCurrency($entity->iso_code);
             if (!empty($cldrCurrency)) {

--- a/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Currency\CommandHandler;
 
-use Configuration;
 use Currency;
 use Language;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Command\AddCurrencyCommand;

--- a/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
@@ -22,6 +22,7 @@ services:
         class: 'PrestaShop\PrestaShop\Adapter\Currency\CommandHandler\AddCurrencyHandler'
         arguments:
             - '@prestashop.core.localization.cldr.locale_repository'
+            - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
         tags:
             - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Currency\Command\AddCurrencyCommand' }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | When adding new currency, precision must be correctly set
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13990
| How to test?  | BO : add new currency. DB : check added currency has field "precision" correctly populated (table `currency`)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14007)
<!-- Reviewable:end -->
