### PR TITLE
Adds missing form data arguments in hooks

### DIFF
--- a/src/Core/Form/IdentifiableObject/Handler/FormHandler.php
+++ b/src/Core/Form/IdentifiableObject/Handler/FormHandler.php
@@ -159,9 +159,11 @@ final class FormHandler implements FormHandlerInterface
     {
         $data = $form->getData();
 
-        $this->hookDispatcher->dispatchWithParameters('actionBeforeCreate' . Container::camelize($form->getName()) . 'FormHandler', [
-            'form_data' => &$data,
-        ]);
+        $this->hookDispatcher->dispatchWithParameters(
+            'actionBeforeCreate' . Container::camelize($form->getName()) . 'FormHandler', [
+                'form_data' => &$data,
+            ]
+        );
 
         $id = $this->dataHandler->create($data);
 

--- a/src/Core/Form/IdentifiableObject/Handler/FormHandler.php
+++ b/src/Core/Form/IdentifiableObject/Handler/FormHandler.php
@@ -144,7 +144,7 @@ final class FormHandler implements FormHandlerInterface
 
         $this->hookDispatcher->dispatchWithParameters('actionAfterUpdate' . Container::camelize($form->getName()) . 'FormHandler', [
             'id' => $id,
-            'form_data' => $data,
+            'form_data' => &$data,
         ]);
 
         return FormHandlerResult::createWithId($id);
@@ -169,7 +169,7 @@ final class FormHandler implements FormHandlerInterface
 
         $this->hookDispatcher->dispatchWithParameters('actionAfterCreate' . Container::camelize($form->getName()) . 'FormHandler', [
             'id' => $id,
-            'form_data' => $data,
+            'form_data' => &$data,
         ]);
 
         return FormHandlerResult::createWithId($id);

--- a/src/Core/Form/IdentifiableObject/Handler/FormHandler.php
+++ b/src/Core/Form/IdentifiableObject/Handler/FormHandler.php
@@ -144,6 +144,7 @@ final class FormHandler implements FormHandlerInterface
 
         $this->hookDispatcher->dispatchWithParameters('actionAfterUpdate' . Container::camelize($form->getName()) . 'FormHandler', [
             'id' => $id,
+            'form_data' => $data,
         ]);
 
         return FormHandlerResult::createWithId($id);
@@ -166,6 +167,7 @@ final class FormHandler implements FormHandlerInterface
 
         $this->hookDispatcher->dispatchWithParameters('actionAfterCreate' . Container::camelize($form->getName()) . 'FormHandler', [
             'id' => $id,
+            'form_data' => $data,
         ]);
 
         return FormHandlerResult::createWithId($id);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | As a module developer when I want to get form data withing identifiable object hook I need to get it from **Request** object - things would be way easier if we can just retrieve data from hook argument directly
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13944
| How to test?  | This PR is not in testable state - the only test will be achieved when this update will be used directly in module ( I have sample module already using this place so I'll modify some code there once this is merged)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14008)
<!-- Reviewable:end -->
