### PR TITLE
Improved error handling when theme is uploaded or activated

### DIFF
--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -32,6 +32,7 @@ use Exception;
 use Language;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Exception\ThemeAlreadyExistsException;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\FailedToEnableThemeModuleException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeConstraintException;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem as PsFileSystem;
 use PrestaShop\PrestaShop\Core\Module\HookConfigurator;
@@ -283,6 +284,12 @@ class ThemeManager implements AddonManagerInterface
         return $this;
     }
 
+    /**
+     * @param array $modules
+     * @return $this
+     *
+     * @throws FailedToEnableThemeModuleException
+     */
     private function doEnableModules(array $modules)
     {
         $moduleManagerBuilder = ModuleManagerBuilder::getInstance();
@@ -292,16 +299,9 @@ class ThemeManager implements AddonManagerInterface
             if (!$moduleManager->isInstalled($moduleName)
                 && !$moduleManager->install($moduleName)
             ) {
-                throw new PrestaShopException(
-                    $this->translator->trans(
-                        'Cannot %action% module %module%. %error_details%',
-                        array(
-                            '%action%' => 'install',
-                            '%module%' => $moduleName,
-                            '%error_details%' => $moduleManager->getError($moduleName),
-                        ),
-                        'Admin.Modules.Notification'
-                    )
+                throw new FailedToEnableThemeModuleException(
+                    $moduleName,
+                    $moduleManager->getError($moduleName)
                 );
             }
             if (!$moduleManager->isEnabled($moduleName)) {

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -41,10 +41,8 @@ use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShopBundle\Service\TranslationService;
 use PrestaShopBundle\Translation\Provider\TranslationFinderTrait;
-use PrestaShopException;
 use PrestaShopLogger;
 use Shop;
-use Symfony\Component\Debug\Exception\ContextErrorException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -286,6 +284,7 @@ class ThemeManager implements AddonManagerInterface
 
     /**
      * @param array $modules
+     *
      * @return $this
      *
      * @throws FailedToEnableThemeModuleException

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -365,7 +365,7 @@ class ThemeManager implements AddonManagerInterface
         if (!file_exists($themeConfigurationFile)) {
             throw new ThemeConstraintException(
                 'Missing theme configuration file which should be in located in /config/theme.yml',
-                ThemeConstraintException::MISSING_THEME_CONFIGURATION_FILE
+                ThemeConstraintException::MISSING_CONFIGURATION_FILE
             );
         }
 
@@ -384,7 +384,7 @@ class ThemeManager implements AddonManagerInterface
                         true
                     )
                 ),
-                ThemeConstraintException::INVALID_THEME_DATA,
+                ThemeConstraintException::INVALID_DATA,
                 $exception
             );
         }
@@ -402,7 +402,7 @@ class ThemeManager implements AddonManagerInterface
                         true
                     )
                 ),
-                ThemeConstraintException::INVALID_THEME_CONFIGURATION
+                ThemeConstraintException::INVALID_CONFIGURATION
             );
         }
 

--- a/src/Core/Domain/Theme/CommandHandler/ImportThemeHandler.php
+++ b/src/Core/Domain/Theme/CommandHandler/ImportThemeHandler.php
@@ -32,11 +32,8 @@ use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeUploaderInterface;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Command\ImportThemeCommand;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ImportedThemeAlreadyExistsException;
-use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeImportSource;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeName;
-use Symfony\Component\Debug\Exception\ContextErrorException;
 
 /**
  * Class ImportThemeHandler
@@ -98,8 +95,7 @@ final class ImportThemeHandler implements ImportThemeHandlerInterface
                 0,
                 $e
             );
-        }
-        finally {
+        } finally {
             if (ThemeImportSource::FROM_ARCHIVE === $type) {
                 @unlink($themePath);
             }

--- a/src/Core/Domain/Theme/CommandHandler/ImportThemeHandler.php
+++ b/src/Core/Domain/Theme/CommandHandler/ImportThemeHandler.php
@@ -32,8 +32,11 @@ use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeUploaderInterface;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Command\ImportThemeCommand;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ImportedThemeAlreadyExistsException;
+use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeImportSource;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeName;
+use Symfony\Component\Debug\Exception\ContextErrorException;
 
 /**
  * Class ImportThemeHandler
@@ -95,7 +98,8 @@ final class ImportThemeHandler implements ImportThemeHandlerInterface
                 0,
                 $e
             );
-        } finally {
+        }
+        finally {
             if (ThemeImportSource::FROM_ARCHIVE === $type) {
                 @unlink($themePath);
             }

--- a/src/Core/Domain/Theme/Exception/FailedToEnableThemeModuleException.php
+++ b/src/Core/Domain/Theme/Exception/FailedToEnableThemeModuleException.php
@@ -11,7 +11,7 @@ class FailedToEnableThemeModuleException extends ThemeException
 
     public function __construct(
         $moduleName,
-        $message = "",
+        $message = '',
         $code = 0,
         $previous = null
     ) {

--- a/src/Core/Domain/Theme/Exception/FailedToEnableThemeModuleException.php
+++ b/src/Core/Domain/Theme/Exception/FailedToEnableThemeModuleException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Domain\Theme\Exception;
+
+class FailedToEnableThemeModuleException extends ThemeException
+{
+    /**
+     * @var string
+     */
+    private $moduleName;
+
+    public function __construct(
+        $moduleName,
+        $message = "",
+        $code = 0,
+        $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+
+        $this->moduleName = $moduleName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getModuleName()
+    {
+        return $this->moduleName;
+    }
+}

--- a/src/Core/Domain/Theme/Exception/ThemeConstraintException.php
+++ b/src/Core/Domain/Theme/Exception/ThemeConstraintException.php
@@ -40,4 +40,14 @@ class ThemeConstraintException extends ThemeException
      * When trying to upload zip file which does not contain theme.yml configuration file.
      */
     const MISSING_THEME_CONFIGURATION_FILE = 2;
+
+    /**
+     * Its either theme has missing required files or some required properties in theme.yml
+     */
+    const INVALID_THEME_CONFIGURATION = 3;
+
+    /**
+     * Some mandatory files are missing.
+     */
+    const INVALID_THEME_DATA = 4;
 }

--- a/src/Core/Domain/Theme/Exception/ThemeConstraintException.php
+++ b/src/Core/Domain/Theme/Exception/ThemeConstraintException.php
@@ -39,15 +39,15 @@ class ThemeConstraintException extends ThemeException
     /**
      * When trying to upload zip file which does not contain theme.yml configuration file.
      */
-    const MISSING_THEME_CONFIGURATION_FILE = 2;
+    const MISSING_CONFIGURATION_FILE = 2;
 
     /**
      * Its either theme has missing required files or some required properties in theme.yml
      */
-    const INVALID_THEME_CONFIGURATION = 3;
+    const INVALID_CONFIGURATION = 3;
 
     /**
      * Some mandatory files are missing.
      */
-    const INVALID_THEME_DATA = 4;
+    const INVALID_DATA = 4;
 }

--- a/src/Core/Domain/Theme/Exception/ThemeConstraintException.php
+++ b/src/Core/Domain/Theme/Exception/ThemeConstraintException.php
@@ -35,4 +35,9 @@ class ThemeConstraintException extends ThemeException
      * When trying to change theme in multi-shop context
      */
     const RESTRICTED_ONLY_FOR_SINGLE_SHOP = 1;
+
+    /**
+     * When trying to upload zip file which does not contain theme.yml configuration file.
+     */
+    const MISSING_THEME_CONFIGURATION_FILE = 2;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -495,7 +495,7 @@ class ThemeController extends AbstractAdminController
                     '%theme_name%' => $e instanceof ImportedThemeAlreadyExistsException ? $e->getThemeName()->getValue() : '',
                 ]
             ),
-            OutOfMemoryException::class => $e->getMessage()
+            OutOfMemoryException::class => $e->getMessage(),
         ];
     }
 
@@ -509,14 +509,12 @@ class ThemeController extends AbstractAdminController
         return [
             CannotEnableThemeException::class => $e->getMessage(),
             ThemeConstraintException::class => [
-                ThemeConstraintException::RESTRICTED_ONLY_FOR_SINGLE_SHOP =>
-                    $this->trans(
+                ThemeConstraintException::RESTRICTED_ONLY_FOR_SINGLE_SHOP => $this->trans(
                         'You must select a shop from the above list if you wish to choose a theme.',
                         'Admin.Design.Help'
-                    )
+                    ),
             ],
-            FailedToEnableThemeModuleException::class =>
-                $this->trans(
+            FailedToEnableThemeModuleException::class => $this->trans(
                     'Cannot %action% module %module%. %error_details%',
                     'Admin.Modules.Notification',
                     [
@@ -524,7 +522,7 @@ class ThemeController extends AbstractAdminController
                         '%module%' => $e->getModuleName(),
                         '%error_details%' => $e->getMessage(),
                     ]
-                )
+                ),
         ];
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -56,6 +56,7 @@ use PrestaShopBundle\Form\Admin\Improve\Design\Theme\ImportThemeType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use PrestaShopBundle\Security\Voter\PageVoter;
+use Symfony\Component\Debug\Exception\OutOfMemoryException;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -238,6 +239,8 @@ class ThemeController extends AbstractAdminController
                 $this->addFlash('error', $this->handleImportThemeException($e));
 
                 return $this->redirectToRoute('admin_themes_import');
+            } catch (OutOfMemoryException $e) {
+                $this->addFlash('error', $this->handleImportThemeException($e));
             }
         }
 
@@ -459,11 +462,11 @@ class ThemeController extends AbstractAdminController
     }
 
     /**
-     * @param ThemeException $e
+     * @param Exception $e
      *
      * @return string
      */
-    private function handleImportThemeException(ThemeException $e)
+    private function handleImportThemeException(Exception $e)
     {
         $type = get_class($e);
 
@@ -475,6 +478,7 @@ class ThemeController extends AbstractAdminController
                     '%theme_name%' => $e instanceof ImportedThemeAlreadyExistsException ? $e->getThemeName()->getValue() : '',
                 ]
             ),
+            OutOfMemoryException::class => $e->getMessage(),
         ];
 
         if ($errorMessages[$type]) {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -57,7 +57,6 @@ use PrestaShopBundle\Form\Admin\Improve\Design\Theme\ImportThemeType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use PrestaShopBundle\Security\Voter\PageVoter;
-use Symfony\Component\Debug\Exception\OutOfMemoryException;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -246,14 +245,6 @@ class ThemeController extends AbstractAdminController
                 );
 
                 return $this->redirectToRoute('admin_themes_import');
-            } catch (OutOfMemoryException $e) {
-                $this->addFlash(
-                    'error',
-                    $this->getErrorMessageForException(
-                        $e,
-                        $this->handleImportThemeException($e)
-                    )
-                );
             }
         }
 
@@ -495,7 +486,6 @@ class ThemeController extends AbstractAdminController
                     '%theme_name%' => $e instanceof ImportedThemeAlreadyExistsException ? $e->getThemeName()->getValue() : '',
                 ]
             ),
-            OutOfMemoryException::class => $e->getMessage(),
         ];
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -236,11 +236,23 @@ class ThemeController extends AbstractAdminController
 
                 return $this->redirectToRoute('admin_themes_index');
             } catch (ThemeException $e) {
-                $this->addFlash('error', $this->handleImportThemeException($e));
+                $this->addFlash(
+                    'error',
+                    $this->getErrorMessageForException(
+                        $e,
+                        $this->handleImportThemeException($e)
+                    )
+                );
 
                 return $this->redirectToRoute('admin_themes_import');
             } catch (OutOfMemoryException $e) {
-                $this->addFlash('error', $this->handleImportThemeException($e));
+                $this->addFlash(
+                    'error',
+                    $this->getErrorMessageForException(
+                        $e,
+                        $this->handleImportThemeException($e)
+                    )
+                );
             }
         }
 
@@ -464,13 +476,11 @@ class ThemeController extends AbstractAdminController
     /**
      * @param Exception $e
      *
-     * @return string
+     * @return array
      */
     private function handleImportThemeException(Exception $e)
     {
-        $type = get_class($e);
-
-        $errorMessages = [
+        return [
             ImportedThemeAlreadyExistsException::class => $this->trans(
                 'There is already a theme %theme_name% in your themes/ folder. Remove it if you want to continue.',
                 'Admin.Design.Notification',
@@ -479,13 +489,11 @@ class ThemeController extends AbstractAdminController
                 ]
             ),
             OutOfMemoryException::class => $e->getMessage(),
+            ThemeConstraintException::class => [
+                ThemeConstraintException::MISSING_THEME_CONFIGURATION_FILE =>
+                 'some meaningful message that themes.yml file is missing',
+            ]
         ];
-
-        if ($errorMessages[$type]) {
-            return $errorMessages[$type];
-        }
-
-        return $this->getFallbackErrorMessage($type, $e->getCode());
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -489,10 +489,6 @@ class ThemeController extends AbstractAdminController
                 ]
             ),
             OutOfMemoryException::class => $e->getMessage(),
-            ThemeConstraintException::class => [
-                ThemeConstraintException::MISSING_THEME_CONFIGURATION_FILE =>
-                 'some meaningful message that themes.yml file is missing',
-            ]
         ];
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -42,6 +42,7 @@ use PrestaShop\PrestaShop\Core\Domain\Theme\Command\ResetThemeLayoutsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\CannotAdaptThemeToRTLLanguagesException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\CannotDeleteThemeException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\CannotEnableThemeException;
+use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\FailedToEnableThemeModuleException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ImportedThemeAlreadyExistsException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeException;
@@ -281,7 +282,13 @@ class ThemeController extends AbstractAdminController
             $this->getCommandBus()->handle(new EnableThemeCommand(new ThemeName($themeName)));
             $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
         } catch (ThemeException $e) {
-            $this->addFlash('error', $this->handleEnableThemeException($e));
+            $this->addFlash(
+                'error',
+                $this->getErrorMessageForException(
+                    $e,
+                    $this->handleEnableThemeException($e)
+                )
+            );
 
             return $this->redirectToRoute('admin_themes_index');
         }
@@ -488,37 +495,37 @@ class ThemeController extends AbstractAdminController
                     '%theme_name%' => $e instanceof ImportedThemeAlreadyExistsException ? $e->getThemeName()->getValue() : '',
                 ]
             ),
-            OutOfMemoryException::class => $e->getMessage(),
+            OutOfMemoryException::class => $e->getMessage()
         ];
     }
 
     /**
      * @param ThemeException $e
      *
-     * @return string
+     * @return array
      */
     private function handleEnableThemeException(ThemeException $e)
     {
-        $type = get_class($e);
-
-        $errorMessages = [
+        return [
             CannotEnableThemeException::class => $e->getMessage(),
+            ThemeConstraintException::class => [
+                ThemeConstraintException::RESTRICTED_ONLY_FOR_SINGLE_SHOP =>
+                    $this->trans(
+                        'You must select a shop from the above list if you wish to choose a theme.',
+                        'Admin.Design.Help'
+                    )
+            ],
+            FailedToEnableThemeModuleException::class =>
+                $this->trans(
+                    'Cannot %action% module %module%. %error_details%',
+                    'Admin.Modules.Notification',
+                    [
+                        '%action%' => strtolower($this->trans('Install', 'Admin.Actions')),
+                        '%module%' => $e->getModuleName(),
+                        '%error_details%' => $e->getMessage(),
+                    ]
+                )
         ];
-
-        if ($e instanceof ThemeConstraintException &&
-            $e->getCode() === ThemeConstraintException::RESTRICTED_ONLY_FOR_SINGLE_SHOP
-        ) {
-            return $this->trans(
-                'You must select a shop from the above list if you wish to choose a theme.',
-                'Admin.Design.Help'
-            );
-        }
-
-        if (isset($errorMessages[$type])) {
-            return $errorMessages[$type];
-        }
-
-        return $this->getFallbackErrorMessage($type, $e->getCode());
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | There are some cases which still makes the whole page go down - in this PR  I tried to cover as much as possible without changing too much code which would take some time . Ofcourse in my opinion we should not try to hide critical errors with beautiful error messages which does not say what happened  -  the better approach would be to merge this https://github.com/PrestaShop/PrestaShop/pull/10780. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  https://github.com/PrestaShop/PrestaShop/issues/13783
| How to test?  | Try to re-create same problems as mentioned in both issues. Error messages should appear instead of the whole page hoes down. For issue with memory, the error message should be exactly as the exception message which was displayed in whole page. For missing theme.yml or invalid  theme configuration there should be an exception class and error code appearance



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14021)
<!-- Reviewable:end -->
