### PR TITLE
Missing legacy link for themes page

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
@@ -12,6 +12,7 @@ admin_themes_upload_logos:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:uploadLogos
     _legacy_controller: AdminThemes
+    _legacy_link: AdminThemes:submitOptionsconfiguration
 
 admin_themes_export_current:
   path: /export
@@ -19,6 +20,9 @@ admin_themes_export_current:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:export
     _legacy_controller: AdminThemes
+    _legacy_link: AdminThemes
+    _legacy_parameters:
+      action: exporttheme
 
 admin_themes_import:
   path: /import
@@ -26,6 +30,9 @@ admin_themes_import:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:import
     _legacy_controller: AdminThemes
+    _legacy_link: AdminThemes:submitAddconfiguration
+    _legacy_parameters:
+      action: importtheme
 
 admin_themes_enable:
   path: /{themeName}/enable/
@@ -33,6 +40,10 @@ admin_themes_enable:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:enable
     _legacy_controller: AdminThemes
+    _legacy_link: AdminThemes
+    _legacy_parameters:
+      action: enableTheme
+      theme_name: themeName
   requirements:
     themeName: "^[a-zA-Z0-9_.-]+$"
 
@@ -42,6 +53,10 @@ admin_themes_delete:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:delete
     _legacy_controller: AdminThemes
+    _legacy_link: AdminThemes
+    _legacy_parameters:
+      action: deleteTheme
+      theme_name: themeName
   requirements:
     themeName: "^[a-zA-Z0-9_.-]+$"
 
@@ -51,6 +66,7 @@ admin_themes_adapt_to_rtl_languages:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:adaptToRTLLanguages
     _legacy_controller: AdminThemes
+    _legacy_link: AdminThemes:submitGenerateRTL
   requirements:
     themeName: "^[a-zA-Z0-9_.-]+$"
 
@@ -60,6 +76,7 @@ admin_theme_customize_layouts:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:customizeLayouts
     _legacy_controller: AdminThemes
+    _legacy_link: AdminThemes:submitConfigureLayouts
 
 admin_themes_reset_layouts:
   path: /{themeName}/reset-layouts
@@ -67,5 +84,9 @@ admin_themes_reset_layouts:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:resetLayouts
     _legacy_controller: AdminThemes
+    _legacy_link: AdminThemes
+    _legacy_parameters:
+      action: resetToDefaults
+      theme_name: themeName
   requirements:
     themeName: "^[a-zA-Z0-9_.-]+$"

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
@@ -20,9 +20,7 @@ admin_themes_export_current:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:export
     _legacy_controller: AdminThemes
-    _legacy_link: AdminThemes
-    _legacy_parameters:
-      action: exporttheme
+    _legacy_link: AdminThemes:exporttheme
 
 admin_themes_import:
   path: /import
@@ -40,9 +38,8 @@ admin_themes_enable:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:enable
     _legacy_controller: AdminThemes
-    _legacy_link: AdminThemes
+    _legacy_link: AdminThemes:enableTheme
     _legacy_parameters:
-      action: enableTheme
       theme_name: themeName
   requirements:
     themeName: "^[a-zA-Z0-9_.-]+$"
@@ -53,9 +50,8 @@ admin_themes_delete:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:delete
     _legacy_controller: AdminThemes
-    _legacy_link: AdminThemes
+    _legacy_link: AdminThemes:deleteTheme
     _legacy_parameters:
-      action: deleteTheme
       theme_name: themeName
   requirements:
     themeName: "^[a-zA-Z0-9_.-]+$"
@@ -84,9 +80,8 @@ admin_themes_reset_layouts:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:resetLayouts
     _legacy_controller: AdminThemes
-    _legacy_link: AdminThemes
+    _legacy_link: AdminThemes:resetToDefaults
     _legacy_parameters:
-      action: resetToDefaults
       theme_name: themeName
   requirements:
     themeName: "^[a-zA-Z0-9_.-]+$"

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
@@ -28,9 +28,7 @@ admin_themes_import:
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:import
     _legacy_controller: AdminThemes
-    _legacy_link: AdminThemes:submitAddconfiguration
-    _legacy_parameters:
-      action: importtheme
+    _legacy_link: AdminThemes:importtheme
 
 admin_themes_enable:
   path: /{themeName}/enable/

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
@@ -43,7 +43,7 @@ admin_themes_enable:
     themeName: "^[a-zA-Z0-9_.-]+$"
 
 admin_themes_delete:
-  path: /{themeName}/delete/
+  path: /{themeName}/delete
   methods: [POST]
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:delete
@@ -55,7 +55,7 @@ admin_themes_delete:
     themeName: "^[a-zA-Z0-9_.-]+$"
 
 admin_themes_adapt_to_rtl_languages:
-  path: /adapt-to-rtl-languages/
+  path: /adapt-to-rtl-languages
   methods: [POST]
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:adaptToRTLLanguages

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/theme.yml
@@ -31,7 +31,7 @@ admin_themes_import:
     _legacy_link: AdminThemes:importtheme
 
 admin_themes_enable:
-  path: /{themeName}/enable/
+  path: /{themeName}/enable
   methods: [POST]
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\Theme:enable

--- a/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -227,6 +227,16 @@ class LegacyUrlConverterTest extends SymfonyIntegrationTestCase
             'admin_international_translations_export_theme' => ['/improve/international/translations/export', 'AdminTranslations', 'submitExport'],
             'admin_international_translations_add_update_language' => ['/improve/international/translations/add-update-language', 'AdminTranslations', 'submitAddLanguage'],
             'admin_international_translations_copy_language' => ['/improve/international/translations/copy', 'AdminTranslations', 'submitCopyLang'],
+
+            'admin_themes_index' => ['/improve/design/themes/', 'AdminThemes'],
+            'admin_themes_upload_logos' => ['/improve/design/themes/upload-logos', 'AdminThemes', 'submitOptionsconfiguration'],
+            'admin_themes_export_current' => ['/improve/design/themes/export', 'AdminThemes', 'exporttheme'],
+            'admin_themes_import' => ['/improve/design/themes/import', 'AdminThemes', 'submitAddconfiguration', ['action' => 'importtheme']],
+            'admin_themes_enable' => ['/improve/design/themes/prestashop_theme/enable', 'AdminThemes', 'enableTheme', ['theme_name' => 'prestashop_theme']],
+            'admin_themes_delete' => ['/improve/design/themes/prestashop_theme/delete', 'AdminThemes', 'deleteTheme', ['theme_name' => 'prestashop_theme']],
+            'admin_themes_adapt_to_rtl_languages' => ['/improve/design/themes/adapt-to-rtl-languages', 'AdminThemes', 'submitGenerateRTL'],
+            'admin_theme_customize_layouts' => ['/improve/design/themes/customize-layouts', 'AdminThemes', 'submitConfigureLayouts'],
+            'admin_themes_reset_layouts' => ['/improve/design/themes/prestashop_theme/reset-layouts', 'AdminThemes', 'resetToDefaults', ['theme_name' => 'prestashop_theme']],
         ];
     }
 

--- a/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -231,7 +231,7 @@ class LegacyUrlConverterTest extends SymfonyIntegrationTestCase
             'admin_themes_index' => ['/improve/design/themes/', 'AdminThemes'],
             'admin_themes_upload_logos' => ['/improve/design/themes/upload-logos', 'AdminThemes', 'submitOptionsconfiguration'],
             'admin_themes_export_current' => ['/improve/design/themes/export', 'AdminThemes', 'exporttheme'],
-            'admin_themes_import' => ['/improve/design/themes/import', 'AdminThemes', 'submitAddconfiguration', ['action' => 'importtheme']],
+            'admin_themes_import' => ['/improve/design/themes/import', 'AdminThemes', 'importtheme'],
             'admin_themes_enable' => ['/improve/design/themes/prestashop_theme/enable', 'AdminThemes', 'enableTheme', ['theme_name' => 'prestashop_theme']],
             'admin_themes_delete' => ['/improve/design/themes/prestashop_theme/delete', 'AdminThemes', 'deleteTheme', ['theme_name' => 'prestashop_theme']],
             'admin_themes_adapt_to_rtl_languages' => ['/improve/design/themes/adapt-to-rtl-languages', 'AdminThemes', 'submitGenerateRTL'],


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Missing legacy links for theme controller
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13747
| How to test?  | Automated tests will handle all cases

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14029)
<!-- Reviewable:end -->
