### PR TITLE
Add missing legacy link for translations routes

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -785,7 +785,10 @@ class LinkCore
                     break;
                 }
 
-                $routeName = 'admin_international_translations_show_settings';
+                // When params are empty or only token exists we want to use default translations route.
+                if (empty($params) || 1 === count($params) && isset($params['token'])) {
+                    $routeName = 'admin_international_translations_show_settings';
+                }
 
                 break;
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
@@ -12,6 +12,7 @@ admin_international_translations_export_theme:
     defaults:
         _controller: PrestaShopBundle:Admin/Translations:exportThemeLanguage
         _legacy_controller: AdminTranslations
+        _legacy_link: AdminTranslations:submitExport
 
 admin_international_translations_show_settings:
     path: /settings
@@ -34,6 +35,7 @@ admin_international_translations_add_update_language:
     defaults:
         _controller: PrestaShopBundle:Admin/Translations:addUpdateLanguage
         _legacy_controller: AdminTranslations
+        _legacy_link: AdminTranslations:submitAddLanguage
 
 admin_international_translations_copy_language:
     path: /copy
@@ -41,10 +43,4 @@ admin_international_translations_copy_language:
     defaults:
         _controller: PrestaShopBundle:Admin/Translations:copyLanguage
         _legacy_controller: AdminTranslations
-
-admin_international_translations_export_language:
-    path: /export-language
-    methods: [POST]
-    defaults:
-        _controller: PrestaShopBundle:Admin/Translations:exportLanguage
-        _legacy_controller: AdminTranslations
+        _legacy_link: AdminTranslations:submitCopyLang

--- a/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -223,6 +223,10 @@ class LegacyUrlConverterTest extends SymfonyIntegrationTestCase
             'admin_employees_bulk_delete' => ['/configure/advanced/employees/bulk-delete', 'AdminEmployees', 'submitBulkdeleteemployee'],
             'admin_employees_create' => ['/configure/advanced/employees/new', 'AdminEmployees', 'addemployee'],
             'admin_employees_edit' => ['/configure/advanced/employees/1000/edit', 'AdminEmployees', 'updateemployee', ['id_employee' => 1000]],
+
+            'admin_international_translations_export_theme' => ['/improve/international/translations/export', 'AdminTranslations', 'submitExport'],
+            'admin_international_translations_add_update_language' => ['/improve/international/translations/add-update-language', 'AdminTranslations', 'submitAddLanguage'],
+            'admin_international_translations_copy_language' => ['/improve/international/translations/copy', 'AdminTranslations', 'submitCopyLang'],
         ];
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | This PR adds missing `_legacy_link` parameters for translations routes, enabling to link legacy urls to migrated routes.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13746
| How to test?  | Make sure that all actions in `/admin-dev/index.php/improve/international/translations/settings` are working

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14030)
<!-- Reviewable:end -->
