### PR TITLE
Fix: If Ask for birth date option is disabled, an exception is displayed in the FO

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -117,15 +117,16 @@ class CustomerFormCore extends AbstractForm
 
         // birthday is from input type text..., so we need to convert to a valid date
         $birthdayField = $this->getField('birthday');
-        if (!empty($birthdayField->getValue()) &&
-            Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
-        ) {
-            $dateBuilt = DateTime::createFromFormat(
-                Context::getContext()->language->date_format_lite,
-                $birthdayField->getValue()
-            );
-            $birthdayField->setValue($dateBuilt->format('Y-m-d'));
-        }
+        if (!empty($birthdayField) {
+          if (!empty($birthdayField->getValue()) &&
+              Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
+          ) {
+              $dateBuilt = DateTime::createFromFormat(
+                  Context::getContext()->language->date_format_lite,
+                  $birthdayField->getValue()
+              );
+              $birthdayField->setValue($dateBuilt->format('Y-m-d'));
+         }}
 
         $this->validateFieldsLengths();
         $this->validateByModules();

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -117,16 +117,17 @@ class CustomerFormCore extends AbstractForm
 
         // birthday is from input type text..., so we need to convert to a valid date
         $birthdayField = $this->getField('birthday');
-        if (!empty($birthdayField) {
-          if (!empty($birthdayField->getValue()) &&
-              Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
-          ) {
-              $dateBuilt = DateTime::createFromFormat(
-                  Context::getContext()->language->date_format_lite,
-                  $birthdayField->getValue()
-              );
-              $birthdayField->setValue($dateBuilt->format('Y-m-d'));
-         }}
+        if (!empty($birthdayField)) {
+            if (!empty($birthdayField->getValue()) &&
+                Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
+            ) {
+                $dateBuilt = DateTime::createFromFormat(
+                    Context::getContext()->language->date_format_lite,
+                    $birthdayField->getValue()
+                );
+                $birthdayField->setValue($dateBuilt->format('Y-m-d'));
+            }
+        }
 
         $this->validateFieldsLengths();
         $this->validateByModules();


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Disabling the Ask for birthdate option in BO prevents account creation from FO and guest ordering.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13976 
| How to test?  | Disable the option 'Ask for birth date' from BO, then do a new order as a guest from FO

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

The variable birthdayField could be a form array, empty variable , or null.
The commit https://github.com/PrestaShop/PrestaShop/pull/11470/commits/0f35b6b5e104d9022b61f5542ab3348c5dd640ee only introduced the check-up for a selected value from a form array, at which there might be no array if the corresponding option is disabled in BO.

This pull request should correct the variable check-up, to include empty and null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14035)
<!-- Reviewable:end -->
