### PR TITLE
Check if Combination id is set before deleting Associations from database to prevent accidentally removing all products without attributes from all carts

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -226,7 +226,7 @@ class CombinationCore extends ObjectModel
      */
     public function deleteAssociations()
     {
-        if (!$this->id || (int)$this->id === 0) {
+        if ((int) $this->id === 0) {
             return false;
         }
         $result = Db::getInstance()->delete('product_attribute_combination', '`id_product_attribute` = ' . (int) $this->id);

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -226,6 +226,9 @@ class CombinationCore extends ObjectModel
      */
     public function deleteAssociations()
     {
+        if (!$this->id || (int)$this->id === 0) {
+            return false;
+        }
         $result = Db::getInstance()->delete('product_attribute_combination', '`id_product_attribute` = ' . (int) $this->id);
         $result &= Db::getInstance()->delete('cart_product', '`id_product_attribute` = ' . (int) $this->id);
         $result &= Db::getInstance()->delete('product_attribute_image', '`id_product_attribute` = ' . (int) $this->id);


### PR DESCRIPTION

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Checks if Combination id is set before removing its data from the DB. If not set returns false.
| Type?         | bug fix
| Category?     | CO
| BC breaks?  | no
| Deprecations? | no
| Fixed ticket? | Fixes #14041 
| How to test? | Call `(new Combination())->deleteAssociations()` . Before the patch it will remove all products without combinations from all existing carts, which is an unintended consequence of the API. After the patch it won't.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14043)
<!-- Reviewable:end -->
