### PR TITLE
Add 'disable dev shm usage' to chrome options for headless chrome

### DIFF
--- a/tests/E2E/test/common.webdriverio.js
+++ b/tests/E2E/test/common.webdriverio.js
@@ -172,7 +172,7 @@ module.exports = {
       options['desiredCapabilities'] = {
         browserName: 'chrome',
         chromeOptions: {
-          args: ['--headless', '--disable-gpu', '--window-size=1270,899'],
+          args: ['--headless', '--disable-gpu', '--window-size=1270,899', '--disable-dev-shm-usage'],
           prefs: {
             'download.default_directory': global.downloadsFolderPath,
           }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.6.x
| Description?  | When running E2E tests in env like Docker where resources are limited, we got this error "Invalid session id", so I add --disable-dev-shm-usage to use /tmp instead of /dev/shm
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Run tests with docker <br/> (To reproduce 'Invalid session Id error', you could run test full/11_international/1_localization/4_create_edit_delete_live_exchange_rate_currency without this fix)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14053)
<!-- Reviewable:end -->
