### PR TITLE
Using shm_size in docker File instead of 'disable dev shm usage' in chromeOptions 

### DIFF
--- a/tests/E2E/docker-compose.yml
+++ b/tests/E2E/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - "prestashop"
     volumes:
       - selenium-downloads:/home/seluser/Downloads
+    shm_size: 2gb
     networks:
       default:
         aliases:

--- a/tests/E2E/test/common.webdriverio.js
+++ b/tests/E2E/test/common.webdriverio.js
@@ -172,7 +172,7 @@ module.exports = {
       options['desiredCapabilities'] = {
         browserName: 'chrome',
         chromeOptions: {
-          args: ['--headless', '--disable-gpu', '--window-size=1270,899', '--disable-dev-shm-usage'],
+          args: ['--headless', '--disable-gpu', '--window-size=1270,899'],
           prefs: {
             'download.default_directory': global.downloadsFolderPath,
           }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Using shm_size in docker File instead of 'disable dev shm usage' in chromeOptions (@toutantic comment  in #14053 )
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Run test with docker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14055)
<!-- Reviewable:end -->
