### PR TITLE
Fix: If Ask for birth date option is disabled, an exception is displayed in the FO

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -115,7 +115,7 @@ class CustomerFormCore extends AbstractForm
             ));
         }
 
-        // check birthdayField against null case is mandatory
+        // check birthdayField against null case is mandatory.
         $birthdayField = $this->getField('birthday');
         if (!empty($birthdayField) &&
             !empty($birthdayField->getValue()) &&

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -117,8 +117,9 @@ class CustomerFormCore extends AbstractForm
 
         // check birthdayField against null case is mandatory
         $birthdayField = $this->getField('birthday');
-        if (!empty($birthdayField) &&
-            Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
+        if (!empty($birthdayField) 
+            && !empty($birthdayField->getValue())
+            && Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
         ) {
             $dateBuilt = DateTime::createFromFormat(
                 Context::getContext()->language->date_format_lite,

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -117,8 +117,8 @@ class CustomerFormCore extends AbstractForm
 
         // check birthdayField against null case is mandatory
         $birthdayField = $this->getField('birthday');
-        if (!empty($birthdayField)
-            && Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
+        if (!empty($birthdayField) &&
+            Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
         ) {
             $dateBuilt = DateTime::createFromFormat(
                 Context::getContext()->language->date_format_lite,

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -126,7 +126,6 @@ class CustomerFormCore extends AbstractForm
             );
             $birthdayField->setValue($dateBuilt->format('Y-m-d'));
         }
-        
         $this->validateFieldsLengths();
         $this->validateByModules();
 

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -115,19 +115,18 @@ class CustomerFormCore extends AbstractForm
             ));
         }
 
-        // birthday is from input type text..., so we need to convert to a valid date
+        // check birthdayField against null case is mandatory
         $birthdayField = $this->getField('birthday');
-        if (!empty($birthdayField)) {
-            if (!empty($birthdayField->getValue()) &&
-                Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
-            ) {
-                $dateBuilt = DateTime::createFromFormat(
-                    Context::getContext()->language->date_format_lite,
-                    $birthdayField->getValue()
-                );
-                $birthdayField->setValue($dateBuilt->format('Y-m-d'));
-            }
+        if (!empty($birthdayField)
+            && Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
+        ) {
+            $dateBuilt = DateTime::createFromFormat(
+                Context::getContext()->language->date_format_lite,
+                $birthdayField->getValue()
+            );
+            $birthdayField->setValue($dateBuilt->format('Y-m-d'));
         }
+        
         $this->validateFieldsLengths();
         $this->validateByModules();
 

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -117,16 +117,17 @@ class CustomerFormCore extends AbstractForm
 
         // birthday is from input type text..., so we need to convert to a valid date
         $birthdayField = $this->getField('birthday');
-        if (!empty($birthdayField->getValue()) &&
-            Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
-        ) {
-            $dateBuilt = DateTime::createFromFormat(
-                Context::getContext()->language->date_format_lite,
-                $birthdayField->getValue()
-            );
-            $birthdayField->setValue($dateBuilt->format('Y-m-d'));
+        if (!empty($birthdayField)) {
+            if (!empty($birthdayField->getValue()) &&
+                Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
+            ) {
+                $dateBuilt = DateTime::createFromFormat(
+                    Context::getContext()->language->date_format_lite,
+                    $birthdayField->getValue()
+                );
+                $birthdayField->setValue($dateBuilt->format('Y-m-d'));
+            }
         }
-
         $this->validateFieldsLengths();
         $this->validateByModules();
 

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -117,9 +117,9 @@ class CustomerFormCore extends AbstractForm
 
         // check birthdayField against null case is mandatory
         $birthdayField = $this->getField('birthday');
-        if (!empty($birthdayField) 
-            && !empty($birthdayField->getValue())
-            && Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
+        if (!empty($birthdayField) &&
+            !empty($birthdayField->getValue()) &&
+            Validate::isBirthDate($birthdayField->getValue(), Context::getContext()->language->date_format_lite)
         ) {
             $dateBuilt = DateTime::createFromFormat(
                 Context::getContext()->language->date_format_lite,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Disabling the Ask for birthdate option in BO prevents account creation from FO and guest ordering.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13976
| How to test?  | Disable the option 'Ask for birth date' from BO, then do a new order as a guest from FO

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

The variable birthdayField could be a form array, empty variable , or null.
The previous commit only introduced the check-up for the form array, at which a fatal error will occur if getValue() was introduced with a  null value, such this bug: https://github.com/PrestaShop/PrestaShop/issues/13976.
The first if statement in this commit, is mainly a check for null case.
Also to keep in mind, customer birthdate is optional if enabled, which is why we need to check for empty array value. 

Mathieu's (@matks) have suggested to check the current configuration and then do a decision:

`$isBirthDateOptional = (bool) Configuration::get('PS_CUSTOMER_BIRTHDATE');`

This suggestion would be great, if we eliminated all the view checking (reduce all to a single if statement), but we are already doing a nested check for all the reasonable value's, and as I see it, this will introduce more redundancy.

So, a lot could be done to improve this code, but currently we have a bug #13976 that prevent an essential usecase, and the added modification actually replicate what was done in 1.7.5.x, which seems to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14075)
<!-- Reviewable:end -->
