### PR TITLE
Fixes updating name and symbol for currency

### DIFF
--- a/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
@@ -40,7 +40,6 @@ use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CannotUpdateCurrencyExc
 use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyException;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyNotFoundException;
-use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository;
 use PrestaShopException;
 use Shop;
@@ -63,13 +62,20 @@ final class EditCurrencyHandler extends AbstractCurrencyHandler implements EditC
     private $localeRepository;
 
     /**
+     * @var string
+     */
+    private $contextLocale;
+
+    /**
      * @param int $defaultCurrencyId
      * @param LocaleRepository $localeRepository
+     * @param string $contextLocale
      */
-    public function __construct($defaultCurrencyId, LocaleRepository $localeRepository)
+    public function __construct($defaultCurrencyId, LocaleRepository $localeRepository, $contextLocale)
     {
         $this->defaultCurrencyId = (int) $defaultCurrencyId;
         $this->localeRepository = $localeRepository;
+        $this->contextLocale = $contextLocale;
     }
 
     /**
@@ -254,8 +260,7 @@ final class EditCurrencyHandler extends AbstractCurrencyHandler implements EditC
      */
     private function updateNameAndSymbol(Currency $entity, $newIsoCode)
     {
-        $contextLocale = Context::getContext()->language->getLocale();
-        $locale = $this->localeRepository->getLocale($contextLocale);
+        $locale = $this->localeRepository->getLocale($this->contextLocale);
 
         if (null !== $locale) {
             $currency = $locale->getCurrency($newIsoCode);

--- a/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Currency\CommandHandler;
 
 use Configuration;
-use Context;
 use Currency;
 use Language;
 use PrestaShop\PrestaShop\Adapter\Entity\Db;

--- a/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
@@ -266,7 +266,6 @@ final class EditCurrencyHandler extends AbstractCurrencyHandler implements EditC
 
             if (null !== $currency) {
                 $langIds = Language::getLanguages(true, false, true);
-
                 $entity->name = [];
                 $entity->symbol = [];
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
@@ -30,6 +30,7 @@ services:
         class: 'PrestaShop\PrestaShop\Adapter\Currency\CommandHandler\EditCurrencyHandler'
         arguments:
           - '@=service("prestashop.adapter.legacy.configuration").get("PS_CURRENCY_DEFAULT")'
+          - '@prestashop.core.localization.cldr.locale_repository'
         tags:
             - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Currency\Command\EditCurrencyCommand' }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
@@ -31,6 +31,7 @@ services:
         arguments:
           - '@=service("prestashop.adapter.legacy.configuration").get("PS_CURRENCY_DEFAULT")'
           - '@prestashop.core.localization.cldr.locale_repository'
+          - '@=service("prestashop.adapter.legacy.context").getContext().language.getLocale()'
         tags:
             - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Currency\Command\EditCurrencyCommand' }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | See ticket.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #13952 
| How to test?  | Currency name and symbol should be updated correctly after editing currency in form.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14084)
<!-- Reviewable:end -->
