### PR TITLE
Fix shop URL with port in header HOST

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -331,7 +331,7 @@ class ShopCore extends ObjectModel
         if (!($id_shop = Tools::getValue('id_shop')) || defined('_PS_ADMIN_DIR_')) {
             $found_uri = '';
             $is_main_uri = false;
-            $host = Tools::getHttpHost();
+            $host = Tools::getHttpHost(false, false, true);
             $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
 
             $sql = 'SELECT s.id_shop, CONCAT(su.physical_uri, su.virtual_uri) AS uri, su.domain, su.main


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a server send a request with an host with port in HTTPS, Prestashop don't found the shop and send a redirection to HTTP url. 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | yes, potential BC with shop not on standart port 80 and/or 443
| Deprecations? | no
| Fixed ticket? | Fixes  #14085
| How to test?  | Le CLI curl -I -H "Host: www.my-prestashop.tld:443" https://www.my-prestashop.tld/ need return 200 status code not 301

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14089)
<!-- Reviewable:end -->
