### PR TITLE
Do not use specific prices when displaying price with tax in BO product catalog

### DIFF
--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -374,7 +374,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
                 (int) Configuration::get('PS_PRICE_DISPLAY_PRECISION'),
                 null,
                 false,
-                true,
+                false,
                 1,
                 true,
                 null,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | The "final price" displayed on the BO catalog page was using the current specific prices. This PRs removes this check and only displays a price with tax added.
| Type?         | bug fix
| Category?     |  BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13731
| How to test?  | Even if a specific price is created for a product, it won't be used to display a product price on the catalog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14091)
<!-- Reviewable:end -->
