### PR TITLE
[POC] - allowing module developers to insert form element to any position we like in the form.

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Extension/OrderPositionExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/OrderPositionExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PrestaShopBundle\Form\Admin\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class OrderPositionExtension extends AbstractTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'order' => null, // cant thing of better name
+            ])
+            ->setAllowedTypes('order', ['null', 'int'])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        if ($form->isRoot()) {
+//            here I'll reiterate over form elements and set the order to form element view.
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return FormType::class;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Extension/OrderPositionExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/OrderPositionExtension.php
@@ -17,7 +17,7 @@ class OrderPositionExtension extends AbstractTypeExtension
     {
         $resolver
             ->setDefaults([
-                'order' => null, // cant thing of better name
+                'order' => null, // not sure if its a good name
             ])
             ->setAllowedTypes('order', ['null', 'int'])
         ;

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
@@ -36,53 +36,63 @@
         {{ 'Customer'|trans({}, 'Admin.Global') }}
       </h3>
       <div class="card-block row">
-        <div class="card-text">
+        <div class="card-text" style="display: flex; flex-direction: column;">
           {{ ps.form_group_row(customerForm.gender_id, {}, {
-            'label': 'Social title'|trans({}, 'Admin.Global')
+            'label': 'Social title'|trans({}, 'Admin.Global'),
+            'order': 1
           }) }}
 
           {{ ps.form_group_row(customerForm.first_name, {}, {
             'label': 'First name'|trans({}, 'Admin.Global'),
-            'help': '%s %s'|format('Invalid characters:'|trans({}, 'Admin.Notifications.Info'), allowedNameChars)
+            'help': '%s %s'|format('Invalid characters:'|trans({}, 'Admin.Notifications.Info'), allowedNameChars),
+            'order': 2
           }) }}
 
           {{ ps.form_group_row(customerForm.last_name, {}, {
             'label': 'Last name'|trans({}, 'Admin.Global'),
-            'help': '%s %s'|format('Invalid characters:'|trans({}, 'Admin.Notifications.Info'), allowedNameChars)
+            'help': '%s %s'|format('Invalid characters:'|trans({}, 'Admin.Notifications.Info'), allowedNameChars),
+            'order': 3
           }) }}
 
           {{ ps.form_group_row(customerForm.email, {}, {
-            'label': 'Email'|trans({}, 'Admin.Global')
+            'label': 'Email'|trans({}, 'Admin.Global'),
+            'order': 4
           }) }}
 
           {{ ps.form_group_row(customerForm.password, {}, {
             'label': 'Password'|trans({}, 'Admin.Global'),
             'help': 'Password should be at least %length% characters long.'|trans({'%length%': minPasswordLength}, 'Admin.Notifications.Info'),
-            'class': isGuest ? 'd-none' : ''
+            'class': isGuest ? 'd-none' : '',
+            'order': 5
           }) }}
 
           {{ ps.form_group_row(customerForm.birthday, {}, {
-            'label': 'Birthday'|trans({}, 'Admin.Orderscustomers.Feature')
+            'label': 'Birthday'|trans({}, 'Admin.Orderscustomers.Feature'),
+            'order': 6
           }) }}
 
           {{ ps.form_group_row(customerForm.is_enabled, {}, {
             'label': 'Enabled'|trans({}, 'Admin.Global'),
-            'help': 'Enable or disable customer login.'|trans({}, 'Admin.Orderscustomers.Help')
+            'help': 'Enable or disable customer login.'|trans({}, 'Admin.Orderscustomers.Help'),
+            'order': 7
           }) }}
 
           {{ ps.form_group_row(customerForm.is_partner_offers_subscribed, {}, {
             'label': 'Partner offers'|trans({}, 'Admin.Orderscustomers.Feature'),
-            'help': 'This customer will receive your ads via email.'|trans({}, 'Admin.Orderscustomers.Help')
+            'help': 'This customer will receive your ads via email.'|trans({}, 'Admin.Orderscustomers.Help'),
+            'order': 8
           }) }}
 
           {{ ps.form_group_row(customerForm.group_ids, {}, {
             'label': 'Group access'|trans({}, 'Admin.Orderscustomers.Feature'),
-            'help': 'Select all the groups that you would like to apply to this customer.'|trans({}, 'Admin.Orderscustomers.Help')
+            'help': 'Select all the groups that you would like to apply to this customer.'|trans({}, 'Admin.Orderscustomers.Help'),
+            'order': 9
           }) }}
 
           {{ ps.form_group_row(customerForm.default_group_id, {}, {
             'label': 'Default customer group'|trans({}, 'Admin.Orderscustomers.Feature'),
-            'help': '%s %s'|format('This group will be the user\'s default group.'|trans({}, 'Admin.Orderscustomers.Help'), 'Only the discount for the selected group will be applied to this customer.'|trans({}, 'Admin.Orderscustomers.Help'))
+            'help': '%s %s'|format('This group will be the user\'s default group.'|trans({}, 'Admin.Orderscustomers.Help'), 'Only the discount for the selected group will be applied to this customer.'|trans({}, 'Admin.Orderscustomers.Help')),
+            'order': 10
           }) }}
 
           {% if isB2bFeatureActive %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
@@ -36,11 +36,14 @@
         {{ 'Customer'|trans({}, 'Admin.Global') }}
       </h3>
       <div class="card-block row">
+{#   ofcourse we will apply this css property to all .card-text classes within the form. as I saw it does not brake anything     #}
         <div class="card-text" style="display: flex; flex-direction: column;">
           {{ ps.form_group_row(customerForm.gender_id, {}, {
             'label': 'Social title'|trans({}, 'Admin.Global'),
             'order': 1
           }) }}
+
+{#    order: 1 -  this ofcousre will be retrieved using OrderPositionExtension #}
 
           {{ ps.form_group_row(customerForm.first_name, {}, {
             'label': 'First name'|trans({}, 'Admin.Global'),

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -254,7 +254,7 @@
 
   {% set class = extraVars.class|default('') %}
 
-  <div class="form-group row {{ class }}">
+  <div class="form-group row {{ class }}" {% if extraVars.order is defined %} style="order: {{ extraVars.order }}; -webkit-order: {{ extraVars.order }}" {% endif %}>
     {% set extraVars = extraVars|default({}) %}
 
     {% if extraVars.label is defined %}

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -253,7 +253,6 @@
   {% import '@PrestaShop/Admin/macros.html.twig' as self %}
 
   {% set class = extraVars.class|default('') %}
-
   <div class="form-group row {{ class }}" {% if extraVars.order is defined %} style="order: {{ extraVars.order }}; -webkit-order: {{ extraVars.order }}" {% endif %}>
     {% set extraVars = extraVars|default({}) %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | By using css flex and order properties for each element we can control in which position elements are placed. So if an element from the module appears below every other elements we can assign order: 0 to module form element and it will appear in the top of all elements in flex container.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13876
| How to test?  | Currently its Proof of concept - not testing information available right now

[POC] - **PROOF OF CONCEPT** . The code is not suppose to be working. Some parts are only theories as this PR purpose is just to explain all parts involved in making this feature to work. If we agree for this when I'll remove POC and implement everything

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14094)
<!-- Reviewable:end -->
