### PR TITLE
Allow package creation without updating version

### DIFF
--- a/tools/build/CreateRelease.php
+++ b/tools/build/CreateRelease.php
@@ -45,6 +45,10 @@ $releaseOptions = [
         'description' => 'Desired release version of PrestaShop',
         'longopt' => 'version:',
     ],
+    'no-setup-version' => [
+        'description' => 'Do not setup the version. Default: false.',
+        'longopt' => 'setup-version',
+    ],
     'no-zip' => [
         'description' => 'Do not zip the release directory. Default: false.',
         'longopt' => 'no-zip',
@@ -100,29 +104,21 @@ foreach ($releaseOptions as $optionName => $option) {
         exit(1);
     }
 }
-$destinationDir = '';
-$useZip = $useInstaller = true;
 
-if (isset($userOptions['version'])) {
-    $version = $userOptions['version'];
-} else {
-    $version = null;
-}
-
-if (isset($userOptions['no-zip'])) {
-    $useZip = false;
-}
-
-if (isset($userOptions['destination-dir'])) {
-    $destinationDir = $userOptions['destination-dir'];
-}
-
-if (isset($userOptions['no-installer'])) {
-    $useInstaller = false;
-}
+$version = isset($userOptions['version']) ? $userOptions['version'] : null;
+$setupVersion = !isset($userOptions['setup-version']);
+$useZip = !isset($userOptions['no-zip']);
+$useInstaller = !isset($userOptions['no-installer']);
+$destinationDir = isset($userOptions['destination-dir']) ? $userOptions['destination-dir'] : '';
 
 try {
-    $releaseCreator = new ReleaseCreator($version, $useInstaller, $useZip, $destinationDir);
+    $releaseCreator = new ReleaseCreator(
+        $version,
+        $useInstaller,
+        $useZip,
+        $destinationDir,
+        $setupVersion
+    );
     $releaseCreator->createRelease();
 } catch (Exception $e) {
     $consoleWrite->displayText(

--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -175,6 +175,13 @@ class ReleaseCreator
     protected $useZip;
 
     /**
+     * Do we setup the shop version?
+     *
+     * @var bool
+     */
+    protected $setupVersion;
+
+    /**
      * Consisting of prestashop_ and the version. e.g prestashop_1.7.3.4.zip
      *
      * @var string
@@ -196,7 +203,7 @@ class ReleaseCreator
      * @param bool $useZip
      * @param string $destinationDir
      */
-    public function __construct($version = null, $useInstaller = true, $useZip = true, $destinationDir = '')
+    public function __construct($version = null, $useInstaller = true, $useZip = true, $destinationDir = '', $setupVersion = true)
     {
         $this->consoleWriter = new ConsoleWriter();
         $tmpDir = sys_get_temp_dir();
@@ -208,6 +215,7 @@ class ReleaseCreator
         );
         $this->projectPath = realpath(__DIR__ . '/../../..');
         $this->version = $version ? $version : $this->getCurrentVersion();
+        $this->setupVersion = $setupVersion;
         $this->zipFileName = "prestashop_$this->version.zip";
 
         if (empty($this->version)) {
@@ -262,9 +270,13 @@ class ReleaseCreator
             ConsoleWriter::COLOR_GREEN
         );
         $this->createTmpProjectDir()
-            ->setFilesConstants()
-            ->setupShopVersion()
-            ->generateLicensesFile()
+            ->setFilesConstants();
+
+        if ($this->setupVersion) {
+            $this->setupShopVersion();
+        }
+
+        $this->generateLicensesFile()
             ->runComposerInstall()
             ->createPackage();
         $endTime = date('H:i:s');
@@ -350,7 +362,7 @@ class ReleaseCreator
 
     /**
      * Get the current version in the project
-     * 
+     *
      * @return string PrestaShop version
      */
     protected function getCurrentVersion()
@@ -477,6 +489,7 @@ class ReleaseCreator
         if (!file_put_contents($this->tempProjectPath . '/LICENSES', $content)) {
             throw new BuildException('Unable to create LICENSES file.');
         }
+
         $this->consoleWriter->displayText(" DONE{$this->lineSeparator}", ConsoleWriter::COLOR_GREEN);
 
         return $this;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | From this conversation https://github.com/PrestaShop/PrestaShop/issues/14086.<br>Add the capability to do `./tools/build/CreateRelease.php --no-setup-version` to create a package from the current working directory, without updating the version.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | You're still able to create a PrestaShop release, and you're able to create a with `./tools/build/CreateRelease.php --no-setup-version`.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14112)
<!-- Reviewable:end -->
