### PR TITLE
Do not set a cookie if it finally has not changed

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -298,6 +298,7 @@ class CookieCore
 
             /* Get cookie checksum */
             $tmpTab = explode('¤', $content);
+            // remove the checksum which is the last element
             array_pop($tmpTab);
             $content_for_checksum = implode('¤', $tmpTab) . '¤';
             $checksum = crc32($this->_salt . $content_for_checksum);
@@ -386,10 +387,11 @@ class CookieCore
             return;
         }
 
-        $cookie = '';
+        $previousChecksum = $cookie = '';
 
         /* Serialize cookie content */
         if (isset($this->_content['checksum'])) {
+            $previousChecksum = $this->_content['checksum'];
             unset($this->_content['checksum']);
         }
         foreach ($this->_content as $key => $value) {
@@ -397,7 +399,12 @@ class CookieCore
         }
 
         /* Add checksum to cookie */
-        $cookie .= 'checksum|' . crc32($this->_salt . $cookie);
+        $newChecksum = crc32($this->_salt . $cookie);
+        // do not set cookie if the checksum is the same: it means the content has not changed!
+        if ($previousChecksum === $newChecksum) {
+            return;
+        }
+        $cookie .= 'checksum|' . $newChecksum;
         $this->_modified = false;
         /* Cookies are encrypted for evident security reasons */
         return $this->encryptAndSetCookie($cookie);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Do not set a cookie which has finally not changed
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

This modification could be useful if we are modifying several times the content of the prestashop cookie, to finally put at the end the same value than at the beginning.

Let's say for exemple we have 

$this->context->cookie->last_visited_category == null

The front ProductController sets $this->context->cookie->last_visited_category = 2;
Hence _modified inside the cookie will be set to true.
Then we put back $this->context->cookie->last_visited_category = null; through a module

The _modified flag will still be true, and hence the cookie will be written even if there's no change inside it. This PR modify this behavior to avoir writing an unchanged cookie.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14116)
<!-- Reviewable:end -->
