### PR TITLE
CO: Fix getDeliveryOption for multiple instances of different Cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3111,6 +3111,7 @@ class CartCore extends ObjectModel
         if (empty($delivery_option) || count($delivery_option) == 0) {
             $this->delivery_option = '';
             $this->id_carrier = 0;
+            static::$cacheDeliveryOption = array();
 
             return;
         }
@@ -3134,6 +3135,7 @@ class CartCore extends ObjectModel
         }
 
         $this->delivery_option = json_encode($delivery_option);
+        static::$cacheDeliveryOption = array();
 
         // update auto cart rules
         CartRule::autoRemoveFromCart();
@@ -3173,7 +3175,7 @@ class CartCore extends ObjectModel
      */
     public function getDeliveryOption($default_country = null, $dontAutoSelectOptions = false, $use_cache = true)
     {
-        $cache_id = (int) (is_object($default_country) ? $default_country->id : 0) . '-' . (int) $dontAutoSelectOptions;
+        $cache_id = (int) (is_object($default_country) ? $default_country->id : 0) . '-' . (int) $dontAutoSelectOptions . (int) $this->id;
         if (isset(static::$cacheDeliveryOption[$cache_id]) && $use_cache) {
             return static::$cacheDeliveryOption[$cache_id];
         }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3175,7 +3175,7 @@ class CartCore extends ObjectModel
      */
     public function getDeliveryOption($default_country = null, $dontAutoSelectOptions = false, $use_cache = true)
     {
-        $cache_id = (int) (is_object($default_country) ? $default_country->id : 0) . '-' . (int) $dontAutoSelectOptions . (int) $this->id;
+        $cache_id = (int) (is_object($default_country) ? $default_country->id : 0) . '-' . (int) $dontAutoSelectOptions . '-' . (int) $this->id;
         if (isset(static::$cacheDeliveryOption[$cache_id]) && $use_cache) {
             return static::$cacheDeliveryOption[$cache_id];
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop and all version of PS
| Description?  | Fix getDeliveryOption for multiple instances of different Cart in same code
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no

If the same code is present this code:

`$cart1 = new Cart(xx);`
`$d1 = $cart1->getDeliveryOption();`
`$cart2 = new Cart(yy);`

This line cause one problem:

`$d2 = $cart2->getDeliveryOption(); //<<<--- This return delivery_option of $cart1!...`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14117)
<!-- Reviewable:end -->
