### PR TITLE
Combine consecutive issets()

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -34,6 +34,7 @@ return PhpCsFixer\Config::create()
         'self_accessor' => false,
         'yoda_style' => null,
         'non_printable_character' => true,
+        'combine_consecutive_issets' => true,
     ])
     ->setFinder($finder)
     ->setCacheFile(__DIR__.'/var/.php_cs.cache');

--- a/src/Adapter/Import/Handler/ProductImportHandler.php
+++ b/src/Adapter/Import/Handler/ProductImportHandler.php
@@ -629,7 +629,7 @@ final class ProductImportHandler extends AbstractImportHandler
             if ($product->tax_rate) {
                 $product->price = (float) number_format($product->price / (1 + $product->tax_rate / 100), 6, '.', '');
             }
-        } elseif (isset($product->price_tin) && isset($product->price_tex)) {
+        } elseif (isset($product->price_tin, $product->price_tex)) {
             $product->price = $product->price_tex;
         }
     }

--- a/tests/Resources/modules/ps_banner/ps_banner.php
+++ b/tests/Resources/modules/ps_banner/ps_banner.php
@@ -105,8 +105,7 @@ class Ps_Banner extends Module implements WidgetInterface
             $update_images_values = false;
 
             foreach ($languages as $lang) {
-                if (isset($_FILES['BANNER_IMG_' . $lang['id_lang']])
-                    && isset($_FILES['BANNER_IMG_' . $lang['id_lang']]['tmp_name'])
+                if (isset($_FILES['BANNER_IMG_' . $lang['id_lang']], $_FILES['BANNER_IMG_' . $lang['id_lang']]['tmp_name'])
                     && !empty($_FILES['BANNER_IMG_' . $lang['id_lang']]['tmp_name'])) {
                     if ($error = ImageManager::validateUpload($_FILES['BANNER_IMG_' . $lang['id_lang']], 4000000)) {
                         return $error;


### PR DESCRIPTION
Transfered from https://github.com/PrestaShop/PrestaShop/pull/13992 because of deleted fork.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add combine_consecutive_issets to php-cs-fixer conf
| Type?         | new feature
| Category?     | CO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | /
| How to test?  | /

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/13992)
<!-- Reviewable:end -->
