### PR TITLE
Adds missing form_rest in Shop Parameters > Preferences

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
@@ -33,14 +33,14 @@
 {% block content %}
     {{ form_start(form, {'attr' : {'class': 'form', 'id': 'configuration_form'} }) }}
     <div class="row justify-content-center">
-        {% block preferences_form_general %}
-            <div class="col-xl-10">
-                <div class="card">
-                    <h3 class="card-header">
-                        <i class="material-icons">settings</i> {{ 'General'|trans({}, 'Admin.Global') }}
-                    </h3>
-                    <div class="card-block row">
-                        <div class="card-text">
+        <div class="col-xl-10">
+            <div class="card">
+                <h3 class="card-header">
+                    <i class="material-icons">settings</i> {{ 'General'|trans({}, 'Admin.Global') }}
+                </h3>
+                <div class="card-block row">
+                    <div class="card-text">
+                        {% block preferences_form_general %}
                             <div class="form-group row">
                                 {{ ps.label_with_help(
                                     ('Enable SSL'|trans),
@@ -165,21 +165,20 @@
                                     {{ form_widget(generalForm.shop_activity) }}
                                 </div>
                             </div>
-                        </div>
+                        {% endblock %}
+
+                        {% block shop_preferences_form_rest %}
+                          {{ form_rest(form) }}
+                        {% endblock %}
                     </div>
-                    <div class="card-footer">
-                        <div class="d-flex justify-content-end">
-                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-                        </div>
+                </div>
+                <div class="card-footer">
+                    <div class="d-flex justify-content-end">
+                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
                     </div>
                 </div>
             </div>
-        {% endblock %}
-
+        </div>
     </div>
     {{ form_end(form) }}
-  
-    {% block shop_preferences_form_rest %}
-      {{ form_rest(form) }}
-    {% endblock %}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
@@ -33,14 +33,14 @@
 {% block content %}
     {{ form_start(form, {'attr' : {'class': 'form', 'id': 'configuration_form'} }) }}
     <div class="row justify-content-center">
-        <div class="col-xl-10">
-            <div class="card">
-                <h3 class="card-header">
-                    <i class="material-icons">settings</i> {{ 'General'|trans({}, 'Admin.Global') }}
-                </h3>
-                <div class="card-block row">
-                    <div class="card-text">
-                        {% block preferences_form_general %}
+        {% block preferences_form_general %}
+            <div class="col-xl-10">
+                <div class="card">
+                    <h3 class="card-header">
+                        <i class="material-icons">settings</i> {{ 'General'|trans({}, 'Admin.Global') }}
+                    </h3>
+                    <div class="card-block row">
+                        <div class="card-text">
                             <div class="form-group row">
                                 {{ ps.label_with_help(
                                     ('Enable SSL'|trans),
@@ -165,20 +165,20 @@
                                     {{ form_widget(generalForm.shop_activity) }}
                                 </div>
                             </div>
-                        {% endblock %}
-
-                        {% block shop_preferences_form_rest %}
-                          {{ form_rest(form) }}
-                        {% endblock %}
+                            {% block shop_preferences_form_rest %}
+                              {{ form_rest(form) }}
+                            {% endblock %}
+                        </div>
                     </div>
-                </div>
-                <div class="card-footer">
-                    <div class="d-flex justify-content-end">
-                        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                    <div class="card-footer">
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        {% endblock %}
+
     </div>
     {{ form_end(form) }}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
@@ -178,4 +178,8 @@
 
     </div>
     {{ form_end(form) }}
+  
+    {% block shop_preferences_form_rest %}
+      {{ form_rest(form) }}
+    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Adds missing form_rest in `PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig`
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  
| How to test?  | No current visible changes in front-end. When form contains fields that are not rendered manually in twig(e.g. if form is extended by module), those fields should be automatically rendered in same block as all general fields.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14137)
<!-- Reviewable:end -->
