### PR TITLE
Add missing null check in EditCmsPageHandler

### DIFF
--- a/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
@@ -57,7 +57,9 @@ final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCms
                     sprintf('Failed to update cms page with id %s', $command->getCmsPageId()->getValue())
                 );
             }
-            $this->associateWithShops($cms, $command->getShopAssociation());
+            if (null !== $command->getShopAssociation()) {
+                $this->associateWithShops($cms, $command->getShopAssociation());
+            }
         } catch (PrestaShopException $e) {
             throw new CmsPageException(
                 sprintf(


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | `EditCmsPageHandler` was missing one if statement, which checks whether shop association was set. This PR adds that missing statement. Without it, calling `EditCmsPageCommand` with `shopAssociation null` value would cause an error.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | It is not reproducible in prestashop web enviroment, because form always fills command with shop association values. After this PR `Improve > Design > Pages > edit page` should work as before.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14156)
<!-- Reviewable:end -->
