### PR TITLE
Catching exceptions from module

### DIFF
--- a/src/Core/Exception/ModuleException.php
+++ b/src/Core/Exception/ModuleException.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Exception;
 
 use Exception;
-use Throwable;
 
 /**
  * Exception that is thrown in modules context.
@@ -42,9 +41,9 @@ class ModuleException extends Exception
     /**
      * @param string $message
      * @param int $code
-     * @param Throwable|null $previous
+     * @param Exception|null $previous
      */
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Core/Exception/ModuleException.php
+++ b/src/Core/Exception/ModuleException.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Exception;
+
+use Exception;
+
+class ModuleException extends Exception
+{
+    /**
+     * @var string[]
+     */
+    private $errors;
+
+    public function __construct(array $errors, $message = "", $code = 0, $previous = null)
+    {
+        $this->setErrors($errors);
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @param string[] $errors
+     *
+     * @return ModuleException
+     */
+    public static function buildFromArray(array $errors)
+    {
+        return new self($errors);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @param string[] $errors
+     */
+    private function setErrors(array $errors)
+    {
+        $this->errors = $errors;
+    }
+}

--- a/src/Core/Exception/ModuleException.php
+++ b/src/Core/Exception/ModuleException.php
@@ -27,43 +27,52 @@
 namespace PrestaShop\PrestaShop\Core\Exception;
 
 use Exception;
+use Throwable;
 
+/**
+ * Exception that is thrown in modules context.
+ */
 class ModuleException extends Exception
 {
     /**
      * @var string[]
      */
-    private $errors;
+    private $messages = [];
 
-    public function __construct(array $errors, $message = "", $code = 0, $previous = null)
+    /**
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
     {
-        $this->setErrors($errors);
         parent::__construct($message, $code, $previous);
+
+        if (!empty($message)) {
+            $this->messages[] = $message;
+        }
     }
 
     /**
-     * @param string[] $errors
+     * Build exception instance with an array of messages.
      *
-     * @return ModuleException
+     * @param string[] $messages
+     *
+     * @return self
      */
-    public static function buildFromArray(array $errors)
+    public static function buildWithMessages(array $messages)
     {
-        return new self($errors);
+        $instance = new self();
+        $instance->messages = $messages;
+
+        return $instance;
     }
 
     /**
      * @return string[]
      */
-    public function getErrors()
+    public function getMessages()
     {
-        return $this->errors;
-    }
-
-    /**
-     * @param string[] $errors
-     */
-    private function setErrors(array $errors)
-    {
-        $this->errors = $errors;
+        return $this->messages;
     }
 }

--- a/src/Core/Exception/ModuleException.php
+++ b/src/Core/Exception/ModuleException.php
@@ -43,7 +43,7 @@ class ModuleException extends Exception
      * @param int $code
      * @param Exception|null $previous
      */
-    public function __construct($message = "", $code = 0, $previous = null)
+    public function __construct($message = '', $code = 0, $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Core/Exception/ModuleHookException.php
+++ b/src/Core/Exception/ModuleHookException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Exception;
+
+/**
+ * Thrown from module hooks.
+ */
+class ModuleHookException extends ModuleException
+{
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\MissingShopAssociationE
 use PrestaShop\PrestaShop\Core\Domain\Employee\Query\GetEmployeeForEditing;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler;
 use PrestaShop\PrestaShop\Core\Search\Filters\EmployeeFilters;
@@ -46,7 +47,6 @@ use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeCannotChangeIts
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidEmployeeIdException;
-use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\EmployeeId;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -292,6 +292,8 @@ class EmployeeController extends FrameworkBundleAdminController
             }
         } catch (EmployeeException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         $templateVars = [
@@ -367,6 +369,8 @@ class EmployeeController extends FrameworkBundleAdminController
             }
         } catch (EmployeeException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         try {

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Query\GetProfileForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Profile\QueryResult\EditableProfile;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProfileFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -132,6 +133,8 @@ class ProfileController extends FrameworkBundleAdminController
             }
         } catch (ProfileException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/create.html.twig', [
@@ -178,6 +181,8 @@ class ProfileController extends FrameworkBundleAdminController
             if ($e instanceof ProfileNotFoundException) {
                 return $this->redirectToRoute('admin_profiles_index');
             }
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         /** @var EditableProfile $editableProfiler */

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetSqlRequestSettings;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\SqlRequestExecutionResult;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\SqlRequestSettings;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\ValueObject\SqlRequestId;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Export\Exception\FileWritingException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
@@ -178,7 +179,11 @@ class SqlManagerController extends FrameworkBundleAdminController
         $sqlRequestForm = $this->getSqlRequestFormBuilder()->getForm($data);
         $sqlRequestForm->handleRequest($request);
 
-        $result = $this->getSqlRequestFormHandler()->handle($sqlRequestForm);
+        try {
+            $result = $this->getSqlRequestFormHandler()->handle($sqlRequestForm);
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
+        }
 
         if (null !== $result->getIdentifiableObjectId()) {
             $this->addFlash('success', $this->trans('Successful creation.', 'Admin.Notifications.Success'));
@@ -231,6 +236,8 @@ class SqlManagerController extends FrameworkBundleAdminController
             );
 
             return $this->redirectToRoute('admin_sql_requests_index');
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/edit.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -105,7 +105,7 @@ class WebserviceController extends FrameworkBundleAdminController
             }
         } catch (DomainException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
-        }  catch (ModuleException $e) {
+        } catch (ModuleException $e) {
             $this->setModuleErrorMessages($e);
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\DuplicateWebserviceKeyException;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceConstraintException;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\WebserviceKeyFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
@@ -104,6 +105,8 @@ class WebserviceController extends FrameworkBundleAdminController
             }
         } catch (DomainException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        }  catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render(
@@ -142,6 +145,8 @@ class WebserviceController extends FrameworkBundleAdminController
             }
         } catch (DomainException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactConstraintExcepti
 use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Exception\DomainConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Search\Filters\ContactFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -141,6 +142,8 @@ class ContactsController extends FrameworkBundleAdminController
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages($exception))
             );
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/create.html.twig', [
@@ -183,6 +186,8 @@ class ContactsController extends FrameworkBundleAdminController
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages($exception))
             );
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/edit.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaException;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaNotFoundException;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\MetaFilters;
@@ -173,6 +174,8 @@ class MetaController extends FrameworkBundleAdminController
             }
         } catch (MetaException $exception) {
             $this->addFlash('error', $this->handleException($exception));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/create.html.twig', [
@@ -208,6 +211,8 @@ class MetaController extends FrameworkBundleAdminController
             $this->addFlash('error', $this->handleException($e));
 
             return $this->redirectToRoute('admin_metas_index');
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/edit.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -493,7 +493,7 @@ class FrameworkBundleAdminController extends Controller
     {
         $moduleErrors = [];
 
-        foreach ($e->getErrors() as $error) {
+        foreach ($e->getMessages() as $error) {
             if (is_string($error)) {
                 $moduleErrors[] = $error;
             }

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
 use PrestaShopBundle\Security\Voter\PageVoter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -481,5 +482,32 @@ class FrameworkBundleAdminController extends Controller
             $exceptionType,
             $exceptionCode
         );
+    }
+
+    /**
+     * Sets error messages raised from module.
+     *
+     * @param ModuleException $e
+     */
+    protected function setModuleErrorMessages(ModuleException $e)
+    {
+        $moduleErrors = [];
+
+        foreach ($e->getErrors() as $error) {
+            if (is_string($error)) {
+                $moduleErrors[] = $error;
+            }
+        }
+
+        if (empty($moduleErrors)) {
+            $this->addFlash(
+                'error',
+                $this->getFallbackErrorMessage(get_class($e), $e->getCode())
+            );
+        }
+
+        foreach ($moduleErrors as $moduleError) {
+            $this->addFlash('error', $moduleError);
+        }
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -55,6 +55,7 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategor
 use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CmsPageCategoryDefinitionFactory;
@@ -218,6 +219,8 @@ class CmsPageController extends FrameworkBundleAdminController
                 'error',
                 $this->getErrorMessageForException($e, $this->getErrorMessages())
             );
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render(
@@ -234,7 +237,9 @@ class CmsPageController extends FrameworkBundleAdminController
     }
 
     /**
-     *  @AdminSecurity(
+     * Edit CMS page action.
+     *
+     * @AdminSecurity(
      *     "is_granted('update', request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
@@ -287,6 +292,8 @@ class CmsPageController extends FrameworkBundleAdminController
             if ($e instanceof CmsPageNotFoundException) {
                 return $this->redirectToRoute('admin_cms_pages_index');
             }
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render(
@@ -340,6 +347,8 @@ class CmsPageController extends FrameworkBundleAdminController
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
             );
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render(
@@ -392,6 +401,8 @@ class CmsPageController extends FrameworkBundleAdminController
             if ($exception instanceof CmsPageCategoryNotFoundException) {
                 return $this->redirectToParentIndexPage((int) $cmsCategoryId);
             }
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render(

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyConstraintExcep
 use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyException;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\AutomateExchangeRatesUpdateException;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CurrencyGridDefinitionFactory;
@@ -133,6 +134,8 @@ class CurrencyController extends FrameworkBundleAdminController
             }
         } catch (CurrencyException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Improve/International/Currency/create.html.twig', [
@@ -173,6 +176,8 @@ class CurrencyController extends FrameworkBundleAdminController
             }
         } catch (CurrencyException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Improve/International/Currency/edit.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageImageUploadingE
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Language\Query\GetLanguageForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Language\QueryResult\EditableLanguage;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\LanguageFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
@@ -125,6 +126,8 @@ class LanguageController extends FrameworkBundleAdminController
             }
         } catch (LanguageException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Improve/International/Language/create.html.twig', [
@@ -168,6 +171,8 @@ class LanguageController extends FrameworkBundleAdminController
             if ($e instanceof LanguageNotFoundException) {
                 return $this->redirectToRoute('admin_languages_index');
             }
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         /** @var EditableLanguage $editableLanguage */

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Command\BulkDeleteTaxCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Command\BulkToggleTaxStatusCommand;
@@ -164,6 +165,8 @@ class TaxController extends FrameworkBundleAdminController
             }
         } catch (TaxException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Improve/International/Tax/create.html.twig', [
@@ -207,6 +210,8 @@ class TaxController extends FrameworkBundleAdminController
             if ($e instanceof TaxNotFoundException) {
                 return $this->redirectToRoute('admin_taxes_index');
             }
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         /** @var EditableTax $editableTax */

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -46,6 +46,7 @@ use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\MenuThumbnailId;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Search\Filters\CategoryFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
@@ -139,6 +140,8 @@ class CategoryController extends FrameworkBundleAdminController
             }
         } catch (CategoryException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         $defaultGroups = $this->get('prestashop.adapter.group.provider.default_groups_provider')->getGroups();
@@ -187,6 +190,8 @@ class CategoryController extends FrameworkBundleAdminController
             }
         } catch (CategoryException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         $defaultGroups = $this->get('prestashop.adapter.group.provider.default_groups_provider')->getGroups();
@@ -254,6 +259,8 @@ class CategoryController extends FrameworkBundleAdminController
             }
         } catch (CategoryException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         $defaultGroups = $this->get('prestashop.adapter.group.provider.default_groups_provider')->getGroups();
@@ -319,6 +326,8 @@ class CategoryController extends FrameworkBundleAdminController
             }
         } catch (CategoryException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         $defaultGroups = $this->get('prestashop.adapter.group.provider.default_groups_provider')->getGroups();

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -45,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerNotFoun
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\UpdateManufacturerException;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Query\GetManufacturerForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\QueryResult\EditableManufacturer;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerAddressGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerGridDefinitionFactory;
@@ -158,6 +159,8 @@ class ManufacturerController extends FrameworkBundleAdminController
             }
         } catch (CoreException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Manufacturer/add.html.twig', [
@@ -232,6 +235,8 @@ class ManufacturerController extends FrameworkBundleAdminController
             if ($e instanceof ManufacturerNotFoundException) {
                 return $this->redirectToRoute('admin_manufacturers_index');
             }
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         /** @var EditableManufacturer $editableManufacturer */
@@ -572,6 +577,8 @@ class ManufacturerController extends FrameworkBundleAdminController
             if ($e instanceof ManufacturerConstraintException) {
                 return $this->redirectToRoute('admin_manufacturers_index');
             }
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Manufacturer/Address/create.html.twig', [
@@ -626,6 +633,8 @@ class ManufacturerController extends FrameworkBundleAdminController
             if ($e instanceof AddressNotFoundException || $e instanceof AddressConstraintException) {
                 return $this->redirectToRoute('admin_manufacturers_index');
             }
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Manufacturer/Address/edit.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -37,7 +37,6 @@ use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotUpdateSupplierSta
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
-use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 use PrestaShop\PrestaShop\Core\Search\Filters\SupplierFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -48,6 +48,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\ViewableCustomer;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
+use PrestaShop\PrestaShop\Core\Exception\ModuleException;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForViewing;
@@ -196,6 +197,8 @@ class CustomerController extends AbstractAdminController
             if ($e instanceof CustomerNotFoundException) {
                 return $this->redirectToRoute('admin_customers_index');
             }
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Sell/Customer/edit.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -152,6 +152,8 @@ class CustomerController extends AbstractAdminController
             }
         } catch (CustomerException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        } catch (ModuleException $e) {
+            $this->setModuleErrorMessages($e);
         }
 
         return $this->render('@PrestaShop/Admin/Sell/Customer/create.html.twig', [


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | in module exception is thrown and in core exception is catched and handled. See :arrow_double_down:  for sample usage within module
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13490
| How to test?  | no testing data provided yet.

in module:

```php
throw \PrestaShop\PrestaShop\Core\Exception\ModuleException::buildFromArray(
            [
                $this->getTranslator()->trans('First error from module', [], 'Modules.Democqrshooksusage.Admin'),
                $this->getTranslator()->trans('Second error from module', [], 'Modules.Democqrshooksusage.Admin'),
            ]
        );
```

in core controller:

```php
catch (ModuleException $e) {
            $this->setModuleErrorMessages($e);
        }
```

Result:

![Screenshot (2)](https://user-images.githubusercontent.com/17051250/59339895-b0b11f80-8d0d-11e9-9bd6-5f46ffc36206.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14161)
<!-- Reviewable:end -->
