### PR TITLE
Calculating Unit Prices,Bugfix for 9603

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -36,6 +36,7 @@ use Context;
 use Cart;
 use Product;
 use Configuration;
+use Combination;
 use Symfony\Component\Translation\TranslatorInterface;
 use TaxConfiguration;
 use CartRule;
@@ -140,6 +141,8 @@ class CartPresenter implements PresenterInterface
                 $rawProduct[$field] = '';
             }
         }
+        
+        $price_tax_exc = $rawProduct['price'];
 
         if ($this->includeTaxes()) {
             $rawProduct['price_amount'] = $rawProduct['price_wt'];
@@ -150,6 +153,14 @@ class CartPresenter implements PresenterInterface
         }
 
         if ($rawProduct['price_amount'] && $rawProduct['unit_price_ratio'] > 0) {
+            if($rawProduct['id_product_attribute'] > 0) {
+				$combination = new Combination($rawProduct['id_product_attribute']);
+
+				if (0 != $combination->unit_price_impact && 0 != $rawProduct['unit_price_ratio']) {
+					$unitPrice = ($price_tax_exc / $rawProduct['unit_price_ratio']) + $combination->unit_price_impact;
+					$rawProduct['unit_price_ratio'] = $price_tax_exc / $unitPrice;
+				}
+			}
             $rawProduct['unit_price'] = $rawProduct['price_amount'] / $rawProduct['unit_price_ratio'];
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes calculating of unit prices with price impact of combinations
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/9603
| How to test?  | Add a product with combination and unit price impact in your cart and see the unit price of the product in the pop up. This is wrong calculated

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14167)
<!-- Reviewable:end -->
