### PR TITLE
Add missing check for CMS page category existence on create/edit actions

### DIFF
--- a/src/Adapter/CMS/Page/CommandHandler/AbstractCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/AbstractCmsPageHandler.php
@@ -30,6 +30,8 @@ use CMS;
 use PrestaShop\PrestaShop\Adapter\Domain\AbstractObjectModelHandler;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryNotFoundException;
 use PrestaShopException;
 
 /**
@@ -66,5 +68,29 @@ abstract class AbstractCmsPageHandler extends AbstractObjectModelHandler
         }
 
         return $cms;
+    }
+
+    /**
+     * Checks whether cms page category exists by provided id.
+     *
+     * @param $cmsCategoryId
+     *
+     * @throws CmsPageCategoryException
+     */
+    protected function assertCmsCategoryExists($cmsCategoryId)
+    {
+        try {
+            $cmsCategory = new CMS($cmsCategoryId);
+
+            if (0 >= $cmsCategory->id) {
+                throw new CmsPageCategoryNotFoundException(
+                    sprintf('Cms page category with id "%s" not found', $cmsCategoryId)
+                );
+            }
+        } catch (PrestaShopException $exception) {
+            throw new CmsPageCategoryException(
+                sprintf('An error occurred when trying to get cms page category with id %s', $cmsCategoryId)
+            );
+        }
     }
 }

--- a/src/Adapter/CMS/Page/CommandHandler/AbstractCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/AbstractCmsPageHandler.php
@@ -49,7 +49,6 @@ abstract class AbstractCmsPageHandler extends AbstractObjectModelHandler
      * @return CMS
      *
      * @throws CmsPageException
-     * @throws CmsPageNotFoundException
      */
     protected function getCmsPageIfExistsById($cmsId)
     {

--- a/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
@@ -32,7 +32,6 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPage\CommandHandler\AddCmsPageHandlerIn
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotAddCmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
-use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
 use PrestaShopException;
 
 /**
@@ -42,9 +41,6 @@ final class AddCmsPageHandler extends AbstractCmsPageHandler implements AddCmsPa
 {
     /**
      * {@inheritdoc}
-     *
-     * @throws CmsPageException
-     * @throws PrestaShopException
      */
     public function handle(AddCmsPageCommand $command)
     {
@@ -76,9 +72,6 @@ final class AddCmsPageHandler extends AbstractCmsPageHandler implements AddCmsPa
      * @param AddCmsPageCommand $command
      *
      * @return CMS
-     *
-     * @throws PrestaShopException
-     * @throws CmsPageCategoryException
      */
     protected function createCmsFromCommand(AddCmsPageCommand $command)
     {

--- a/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/AddCmsPageHandler.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPage\CommandHandler\AddCmsPageHandlerIn
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotAddCmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
 use PrestaShopException;
 
 /**
@@ -77,13 +78,17 @@ final class AddCmsPageHandler extends AbstractCmsPageHandler implements AddCmsPa
      * @return CMS
      *
      * @throws PrestaShopException
+     * @throws CmsPageCategoryException
      */
     protected function createCmsFromCommand(AddCmsPageCommand $command)
     {
+        $cmsCategoryId = $command->getCmsPageCategory()->getValue();
+        $this->assertCmsCategoryExists($cmsCategoryId);
+
         $cms = new CMS();
+        $cms->id_cms_category = $cmsCategoryId;
         $cms->meta_title = $command->getLocalizedTitle();
         $cms->head_seo_title = $command->getLocalizedMetaTitle();
-        $cms->id_cms_category = $command->getCmsPageCategory()->getValue();
         $cms->meta_description = $command->getLocalizedMetaDescription();
         $cms->meta_keywords = $command->getLocalizedMetaKeyword();
         $cms->link_rewrite = $command->getLocalizedFriendlyUrl();

--- a/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPage\CommandHandler\EditCmsPageHandlerI
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotEditCmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
 use PrestaShopException;
 
 /**
@@ -43,6 +44,7 @@ final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCms
      * {@inheritdoc}
      *
      * @throws CmsPageException
+     * @throws CmsPageCategoryException
      */
     public function handle(EditCmsPageCommand $command)
     {
@@ -79,10 +81,16 @@ final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCms
      *
      * @throws CmsPageException
      * @throws CmsPageNotFoundException
+     * @throws CmsPageCategoryException
      */
     private function createCmsFromCommand(EditCmsPageCommand $command)
     {
         $cms = $this->getCmsPageIfExistsById($command->getCmsPageId()->getValue());
+        $cmsCategoryId = $command->getCmsPageCategoryId()->getValue();
+
+        if (null !== $cmsCategoryId && $this->assertCmsCategoryExists($cmsCategoryId)) {
+            $cms->id_cms_category = $cmsCategoryId;
+        }
 
         if (null !== $command->getLocalizedTitle()) {
             $cms->meta_title = $command->getLocalizedTitle();
@@ -90,10 +98,6 @@ final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCms
 
         if (null !== $command->getLocalizedMetaTitle()) {
             $cms->head_seo_title = $command->getLocalizedMetaTitle();
-        }
-
-        if (null !== $command->getCmsPageCategoryId()) {
-            $cms->id_cms_category = $command->getCmsPageCategoryId()->getValue();
         }
 
         if (null !== $command->getLocalizedMetaDescription()) {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -97,7 +97,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 ->get('prestashop.core.cms_page.data_provider.cms_page_view')
                 ->getView($cmsCategoryParentId)
             ;
-        } catch (CmsPageCategoryException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -261,7 +261,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 ]),
             ]);
             $form->handleRequest($request);
-        } catch (CmsPageException $e) {
+        } catch (Exception $e) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($e, $this->getErrorMessages())
@@ -341,7 +341,7 @@ class CmsPageController extends FrameworkBundleAdminController
 
                 return $this->redirectToIndexPageById($result->getIdentifiableObjectId());
             }
-        } catch (CmsPageCategoryException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -370,8 +370,6 @@ class CmsPageController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @return Response
-     *
-     * @throws CmsPageCategoryException
      */
     public function editCmsCategoryAction($cmsCategoryId, Request $request)
     {
@@ -389,7 +387,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 return $this->redirectToIndexPageById($result->getIdentifiableObjectId());
             }
             $cmsCategoryParentId = $this->getParentCategoryId((int) $cmsCategoryId)->getValue();
-        } catch (CmsPageCategoryException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -426,12 +424,9 @@ class CmsPageController extends FrameworkBundleAdminController
      * @param int $cmsCategoryId
      *
      * @return RedirectResponse
-     *
-     * @throws CmsPageCategoryException
      */
     public function deleteCmsCategoryAction($cmsCategoryId)
     {
-        $redirectResponse = $this->redirectToParentIndexPage((int) $cmsCategoryId);
         try {
             $this->getCommandBus()->handle(
                 new DeleteCmsPageCategoryCommand((int) $cmsCategoryId)
@@ -441,14 +436,14 @@ class CmsPageController extends FrameworkBundleAdminController
                 'success',
                 $this->trans('Successful deletion.', 'Admin.Notifications.Success')
             );
-        } catch (CmsPageCategoryException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
             );
         }
 
-        return $redirectResponse;
+        return $this->redirectToParentIndexPage((int) $cmsCategoryId);
     }
 
     /**
@@ -468,13 +463,10 @@ class CmsPageController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @return RedirectResponse
-     *
-     * @throws CmsPageCategoryException
      */
     public function deleteBulkCmsCategoryAction(Request $request)
     {
         $cmsCategoriesToDelete = $request->request->get('cms_page_category_bulk');
-        $redirectResponse = $this->redirectToParentIndexPageByCategoryBulkIds($cmsCategoriesToDelete);
 
         try {
             $cmsCategoriesToDelete = array_map(function ($item) { return (int) $item; }, $cmsCategoriesToDelete);
@@ -487,14 +479,14 @@ class CmsPageController extends FrameworkBundleAdminController
                 'success',
                 $this->trans('The selection has been successfully deleted.', 'Admin.Notifications.Success')
             );
-        } catch (CmsPageCategoryException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
             );
         }
 
-        return $redirectResponse;
+        return $this->redirectToParentIndexPageByCategoryBulkIds($cmsCategoriesToDelete);
     }
 
     /**
@@ -514,8 +506,6 @@ class CmsPageController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @return RedirectResponse
-     *
-     * @throws CmsPageCategoryException
      */
     public function updateCmsCategoryPositionAction(Request $request)
     {
@@ -569,8 +559,6 @@ class CmsPageController extends FrameworkBundleAdminController
      * )
      *
      * @return RedirectResponse
-     *
-     * @throws CmsPageCategoryException
      */
     public function updateCmsPositionAction(Request $request)
     {
@@ -625,8 +613,6 @@ class CmsPageController extends FrameworkBundleAdminController
      * @param int $cmsCategoryId
      *
      * @return RedirectResponse
-     *
-     * @throws CmsPageCategoryException
      */
     public function toggleCmsCategoryAction($cmsCategoryId)
     {
@@ -639,7 +625,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 'success',
                 $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
             );
-        } catch (CmsPageCategoryException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -666,8 +652,6 @@ class CmsPageController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @return RedirectResponse
-     *
-     * @throws CmsPageCategoryException
      */
     public function bulkCmsPageCategoryStatusEnableAction(Request $request)
     {
@@ -684,7 +668,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 'success',
                 $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
             );
-        } catch (CmsPageCategoryException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -711,8 +695,6 @@ class CmsPageController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @return RedirectResponse
-     *
-     * @throws CmsPageCategoryException
      */
     public function bulkCmsPageCategoryStatusDisableAction(Request $request)
     {
@@ -732,7 +714,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 'success',
                 $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
             );
-        } catch (CmsPageCategoryException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -769,7 +751,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 'success',
                 $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
             );
-        } catch (CmsPageException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -812,7 +794,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 'success',
                 $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
             );
-        } catch (CmsPageException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -860,7 +842,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 'success',
                 $this->trans('The status has been successfully updated.', 'Admin.Notifications.Success')
             );
-        } catch (CmsPageException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -910,7 +892,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 'success',
                 $this->trans('The selection has been successfully deleted.', 'Admin.Notifications.Success')
             );
-        } catch (CmsPageException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -949,7 +931,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 'success',
                 $this->trans('Successful deletion.', 'Admin.Notifications.Success')
             );
-        } catch (CmsPageException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages())
@@ -984,8 +966,6 @@ class CmsPageController extends FrameworkBundleAdminController
      * @param array $cmsPageCategoryIds
      *
      * @return RedirectResponse
-     *
-     * @throws CmsPageCategoryException
      */
     private function redirectToParentIndexPageByCategoryBulkIds(array $cmsPageCategoryIds)
     {
@@ -1018,14 +998,16 @@ class CmsPageController extends FrameworkBundleAdminController
      * @param int $cmsPageCategoryId
      *
      * @return RedirectResponse
-     *
-     * @throws CmsPageCategoryException
      */
     private function redirectToParentIndexPage($cmsPageCategoryId)
     {
-        $cmsPageCategoryParentId = $this->getParentCategoryId($cmsPageCategoryId);
+        try {
+            $cmsPageCategoryParentId = $this->getParentCategoryId($cmsPageCategoryId)->getValue();
+        } catch (CmsPageCategoryException $e) {
+            $cmsPageCategoryParentId = CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID;
+        }
 
-        return $this->redirectToIndexPageById($cmsPageCategoryParentId->getValue());
+        return $this->redirectToIndexPageById($cmsPageCategoryParentId);
     }
 
     /**
@@ -1036,12 +1018,12 @@ class CmsPageController extends FrameworkBundleAdminController
     private function redirectToParentIndexPageByCmsPageId($cmsPageId)
     {
         try {
-            $cmsCategoryId = $this->getQueryBus()->handle(new GetCmsCategoryIdForRedirection((int) $cmsPageId));
+            $cmsCategoryId = $this->getQueryBus()->handle(new GetCmsCategoryIdForRedirection((int) $cmsPageId))->getValue();
         } catch (CmsPageException $e) {
             $cmsCategoryId = CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID;
         }
 
-        return $this->redirectToIndexPageById($cmsCategoryId->getValue());
+        return $this->redirectToIndexPageById($cmsCategoryId);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There was missing `check if cms category exists by provided id` when creating or editing the cms page. Without this check it was possible to create cms page for non existing cms category. ( To reproduce this you need to change cms category checkbox value manually within webtools, or execute the command from command line, because the form in front-end doesn't allow to select wrong value).
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Go to Improve > Design > Pages > Create new page. Inspect category checkbox and change its value to non existing cms category id (e.g. 350). Fill other required fields and save the form. You should get an error "Object cannot be loaded (or found)" and cms page will not be created in database `ps_cms` table.. Before this PR you would be able to create cms page for non-existing category and this would provoke further issues.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14168)
<!-- Reviewable:end -->
