### PR TITLE
Bug with select multilang objects

### DIFF
--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -336,7 +336,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
         $this->is_hydrated = true;
 
         $alias = $this->generateAlias();
-        $this->query->select('*, ' . $alias . '.`' . $this->definition['primary'] . '`');
+        $this->query->select($alias . '*');
         $this->query->from($this->definition['table'], $alias);
 
         // If multilang, create association to lang table

--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -336,7 +336,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
         $this->is_hydrated = true;
 
         $alias = $this->generateAlias();
-        $this->query->select($alias . '*');
+        $this->query->select($alias . '*, ' . $alias . '.`' . $this->definition['primary'] . '`');
         $this->query->from($this->definition['table'], $alias);
 
         // If multilang, create association to lang table

--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -336,7 +336,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
         $this->is_hydrated = true;
 
         $alias = $this->generateAlias();
-        $this->query->select('*, a0.`' . $this->definition['primary'] . '`');
+        $this->query->select('*, ' . $alias . '.`' . $this->definition['primary'] . '`');
         $this->query->from($this->definition['table'], $alias);
 
         // If multilang, create association to lang table

--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -336,7 +336,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
         $this->is_hydrated = true;
 
         $alias = $this->generateAlias();
-        $this->query->select('*, a0.`'.$this->definition['primary'].'`');
+        $this->query->select('*, a0.`' . $this->definition['primary'] . '`');
         $this->query->from($this->definition['table'], $alias);
 
         // If multilang, create association to lang table

--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -336,7 +336,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
         $this->is_hydrated = true;
 
         $alias = $this->generateAlias();
-        //$this->query->select($alias.'.*');
+        $this->query->select('*, a0.`'.$this->definition['primary'].'`');
         $this->query->from($this->definition['table'], $alias);
 
         // If multilang, create association to lang table


### PR DESCRIPTION
When there is no data in the multilanguage entity there is no data in the multilanguage table

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When there is no data in the multilanguage entity there is no data in the multilanguage table
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | When there is no data in the multilanguage entity there is no data in the multilanguage table. When there is no data in the multilanguage object, there is no data in the multilanguage table. By default, the query selects the "primary" value from the multilanguage table, since there it is empty, it will return null and there will be a bug

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14169)
<!-- Reviewable:end -->
