### PR TITLE
Introduce hook to manage error messages for modules

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -465,6 +465,12 @@ class FrameworkBundleAdminController extends Controller
         $exceptionType = get_class($e);
         $exceptionCode = $e->getCode();
 
+        $this->get('prestashop.core.hook.dispatcher')->dispatchWithParameters('actionGetErrorMessagesInController', [
+            'controller_name' => get_class($this),
+            'exception' => $e,
+            'messages' => &$messages,
+        ]);
+
         if (isset($messages[$exceptionType])) {
             $message = $messages[$exceptionType];
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -736,7 +736,7 @@ class CustomerController extends AbstractAdminController
      */
     private function getErrorMessages(CustomerException $e)
     {
-        $mapping = [
+        return [
             CustomerNotFoundException::class => $this->trans(
                 'This customer does not exist.',
                 'Admin.Orderscustomers.Notification'
@@ -803,12 +803,5 @@ class CustomerController extends AbstractAdminController
                 ]
             ),
         ];
-
-        $this->get('prestashop.core.hook.dispatcher')->dispatchWithParameters('actionGetErrorMessagesCustomerController', [
-            'exception' => $e,
-            'mapping' => &$mapping,
-        ]);
-
-        return $mapping;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -736,7 +736,7 @@ class CustomerController extends AbstractAdminController
      */
     private function getErrorMessages(CustomerException $e)
     {
-        return [
+        $mapping = [
             CustomerNotFoundException::class => $this->trans(
                 'This customer does not exist.',
                 'Admin.Orderscustomers.Notification'
@@ -803,5 +803,12 @@ class CustomerController extends AbstractAdminController
                 ]
             ),
         ];
+
+        $this->get('prestashop.core.hook.dispatcher')->dispatchWithParameters('actionGetErrorMessagesCustomerController', [
+            'exception' => $e,
+            'mapping' => &$mapping,
+        ]);
+
+        return $mapping;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Add a hook that allow to manage the mapping in controllers for error messages
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13490 last issue: "How to handle errors happening inside module (translation + display to user)"
| How to test?  | Incoming

### Example of usage

In a module that extends the Customer Form, so it's hooked on `hookActionAfterUpdateCustomerFormHandler`

If an error is found in hook `hookActionAfterUpdateCustomerFormHandler`, we can raise a `CustomerException` (because it's related CustomerController which catches CustomerException only)
```
    public function hookActionAfterUpdateCustomerFormHandler(array $params)
    {
        throw new CustomerException(
            'This is a beautiful error message'
        );
    }
```
And we make sure this Customer Exception has proper error message using the new hook:
```
    public function hookActionGetErrorMessagesInController(array $params)
    {
        $messages = $params['messages'];
        $exception = $params['exception'];
        $controllerName = $params['controller_name'];

        // filter by controller name as hook is generic
        if ($controllerName !== 'PrestaShopBundle\Controller\Admin\Sell\Customer\CustomerController') {
            return;
        }

        $messages[CustomerException::class] = 'Custom error message : '.$exception->getMessage();
        $params['messages'] = $messages;
    }
```

Final result:
![Capture d’écran 2019-06-13 à 17 19 25](https://user-images.githubusercontent.com/3830050/59445592-3c0add80-8e00-11e9-8bad-206d2d2533f4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14200)
<!-- Reviewable:end -->
