### PR TITLE
Introduce the usage of Module user-displayable exceptions to handle module errors

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2110,5 +2110,12 @@
       <description>This hook allows to modify data which is about to be used in template for cms page grid
       </description>
     </hook>
+    <hook id="actionGetEloquentExceptionsFromModule">
+      <name>actionGetEloquentExceptionsFromModule</name>
+      <title>Enable direct exception message display in data forms</title>
+      <description>This hook allows to provide to the Core a list of Exception classes whose behavior should be the same
+        as a ModuleEloquentException (i.e exception message must be displayed to end-user)
+      </description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.6.0.sql
+++ b/install-dev/upgrade/sql/1.7.6.0.sql
@@ -251,7 +251,9 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionTaxGridPresenterModifier', 'Modify tax grid template data', 'This hook allows to modify data which is about to be used in template for tax grid', '1 '),
   (NULL, 'actionManufacturerGridPresenterModifier', 'Modify manufacturer grid template data', 'This hook allows to modify data which is about to be used in template for manufacturer grid', '1 '),
   (NULL, 'actionManufacturerAddressGridPresenterModifier', 'Modify manufacturer address grid template data', 'This hook allows to modify data which is about to be used in template for manufacturer address grid', '1 '),
-  (NULL, 'actionCmsPageGridPresenterModifier', 'Modify cms page grid template data', 'This hook allows to modify data which is about to be used in template for cms page grid', '1 ');
+  (NULL, 'actionCmsPageGridPresenterModifier', 'Modify cms page grid template data', 'This hook allows to modify data which is about to be used in template for cms page grid', '1 '),
+  (NULL, 'actionGetEloquentExceptionsFromModule', 'Enable direct exception message display in data forms', 'This hook allows to provide to the Core a list of Exception classes whose behavior should be the same
+        as a ModuleEloquentException (i.e exception message must be displayed to end-user)', '1 ');
 
 INSERT IGNORE INTO `PREFIX_authorization_role` (`slug`) VALUES
   ('ROLE_MOD_TAB_ADMINMODULESMANAGE_CREATE'),

--- a/src/Core/Module/ModuleEloquentException.php
+++ b/src/Core/Module/ModuleEloquentException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Module;
+
+/**
+ * Module Exception whose message can be displayed directly to end-user
+ */
+class ModuleEloquentException extends ModuleException
+{
+}

--- a/src/Core/Module/ModuleException.php
+++ b/src/Core/Module/ModuleException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Module;
+
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+
+/**
+ * Base class for all module exceptions
+ */
+class ModuleException extends CoreException
+{
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmailAlreadyUsedException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidProfileException;
@@ -290,7 +291,7 @@ class EmployeeController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_employees_index');
             }
-        } catch (EmployeeException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -365,7 +366,7 @@ class EmployeeController extends FrameworkBundleAdminController
                     'employeeId' => $result->getIdentifiableObjectId(),
                 ]);
             }
-        } catch (EmployeeException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Command\BulkDeleteProfileCommand;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Command\DeleteProfileCommand;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\CannotDeleteSuperAdminProfileException;
@@ -130,7 +131,7 @@ class ProfileController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_profiles_index');
             }
-        } catch (ProfileException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -172,7 +173,7 @@ class ProfileController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_profiles_index');
             }
-        } catch (ProfileException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             if ($e instanceof ProfileNotFoundException) {

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\DuplicateWebserviceKeyException;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceConstraintException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
@@ -102,7 +102,7 @@ class WebserviceController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_webservice_keys_index');
             }
-        } catch (DomainException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -140,7 +140,7 @@ class WebserviceController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_webservice_keys_index');
             }
-        } catch (DomainException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Exception\DomainConstraintException;
@@ -136,7 +137,7 @@ class ContactsController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_contacts_index');
             }
-        } catch (DomainException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages($exception))
@@ -178,7 +179,7 @@ class ContactsController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_contacts_index');
             }
-        } catch (DomainException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages($exception))
@@ -258,7 +259,7 @@ class ContactsController extends FrameworkBundleAdminController
      *
      * @return array
      */
-    private function getErrorMessages(DomainException $e)
+    private function getErrorMessages(Exception $e)
     {
         return [
             ContactNotFoundException::class => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -30,7 +30,6 @@ use Exception;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaException;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaNotFoundException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaConstraintException;
@@ -171,7 +172,7 @@ class MetaController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_metas_index');
             }
-        } catch (MetaException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash('error', $this->handleException($exception));
         }
 
@@ -204,7 +205,7 @@ class MetaController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_metas_index');
             }
-        } catch (MetaException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->handleException($e));
 
             return $this->redirectToRoute('admin_metas_index');
@@ -363,11 +364,11 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Handles exception by its type and status code or by its type only and returns error message.
      *
-     * @param MetaException $exception
+     * @param Exception $exception
      *
      * @return string
      */
-    private function handleException(MetaException $exception)
+    private function handleException(Exception $exception)
     {
         if (0 !== $exception->getCode()) {
             return $this->getExceptionByClassAndErrorCode($exception);
@@ -379,11 +380,13 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Gets exception by class and error code.
      *
-     * @param MetaException $exception
+     * @todo: use FrameworkBundleAdminController::getErrorMessageForException() instead
+     *
+     * @param Exception $exception
      *
      * @return string
      */
-    private function getExceptionByClassAndErrorCode(MetaException $exception)
+    private function getExceptionByClassAndErrorCode(Exception $exception)
     {
         $exceptionDictionary = [
             MetaConstraintException::class => [
@@ -452,11 +455,11 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Gets exception by class type.
      *
-     * @param MetaException $exception
+     * @param Exception $exception
      *
      * @return string
      */
-    private function getExceptionByType(MetaException $exception)
+    private function getExceptionByType(Exception $exception)
     {
         $exceptionDictionary = [
             MetaNotFoundException::class => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -475,6 +475,9 @@ class FrameworkBundleAdminController extends Controller
         ]);
         if (is_array($whitelist)) {
             foreach ($whitelist as $whitelistItem) {
+                if (!is_string($whitelistItem) && !is_object($whitelistItem)) {
+                    continue;
+                }
                 if ($e instanceof $whitelistItem) {
                     return $e->getMessage();
                 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\Design;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkDeleteCmsPageCommand;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkDisableCmsPageCommand;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkEnableCmsPageCommand;
@@ -213,7 +214,7 @@ class CmsPageController extends FrameworkBundleAdminController
                     'open_preview' => 1,
                 ]);
             }
-        } catch (DomainException $e) {
+        } catch (Exception $e) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($e, $this->getErrorMessages())
@@ -278,7 +279,7 @@ class CmsPageController extends FrameworkBundleAdminController
             /** @var EditableCmsPage $editableCmsPage */
             $editableCmsPage = $this->getQueryBus()->handle(new GetCmsPageForEditing($cmsPageId));
             $previewUrl = $editableCmsPage->getPreviewUrl();
-        } catch (DomainException $e) {
+        } catch (Exception $e) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($e, $this->getErrorMessages())

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -53,7 +53,6 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryE
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageParentCategoryIdForRedirection;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Command\DeleteCurrencyCommand;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Command\ToggleCurrencyStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Command\RefreshExchangeRatesCommand;
@@ -131,7 +132,7 @@ class CurrencyController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_currencies_index');
             }
-        } catch (CurrencyException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -171,7 +172,7 @@ class CurrencyController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_currencies_index');
             }
-        } catch (CurrencyException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -358,11 +359,11 @@ class CurrencyController extends FrameworkBundleAdminController
     /**
      * Gets an error by exception class and its code.
      *
-     * @param CurrencyException $e
+     * @param Exception $e
      *
      * @return array
      */
-    private function getErrorMessages(CurrencyException $e)
+    private function getErrorMessages(Exception $e)
     {
         return [
             CurrencyConstraintException::class => [

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\BulkDeleteLanguagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\BulkToggleLanguagesStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\DeleteLanguageCommand;
@@ -123,7 +124,7 @@ class LanguageController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_languages_index');
             }
-        } catch (LanguageException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -162,7 +163,7 @@ class LanguageController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_languages_index');
             }
-        } catch (LanguageException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
 
             if ($e instanceof LanguageNotFoundException) {
@@ -298,11 +299,11 @@ class LanguageController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param LanguageException $e
+     * @param Exception $e
      *
      * @return array
      */
-    private function getErrorMessages(LanguageException $e)
+    private function getErrorMessages(Exception $e)
     {
         return [
             LanguageNotFoundException::class => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Command\BulkDeleteTaxCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Command\BulkToggleTaxStatusCommand;
@@ -162,7 +163,7 @@ class TaxController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_taxes_index');
             }
-        } catch (TaxException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -201,7 +202,7 @@ class TaxController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_taxes_index');
             }
-        } catch (TaxException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             if ($e instanceof TaxNotFoundException) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDeleteCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDisableCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkEnableCategoriesCommand;
@@ -137,7 +138,7 @@ class CategoryController extends FrameworkBundleAdminController
                     'categoryId' => $categoryForm->getData()['id_parent'],
                 ]);
             }
-        } catch (CategoryException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -185,7 +186,7 @@ class CategoryController extends FrameworkBundleAdminController
                     'categoryId' => $this->configuration->getInt('PS_ROOT_CATEGORY'),
                 ]);
             }
-        } catch (CategoryException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -252,7 +253,7 @@ class CategoryController extends FrameworkBundleAdminController
                     'categoryId' => $categoryForm->getData()['id_parent'],
                 ]);
             }
-        } catch (CategoryException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -317,7 +318,7 @@ class CategoryController extends FrameworkBundleAdminController
                     'categoryId' => $this->configuration->getInt('PS_ROOT_CATEGORY'),
                 ]);
             }
-        } catch (CategoryException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -50,7 +50,6 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerAddressGridDe
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\ManufacturerAddressFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\ManufacturerFilters;
-use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerConstraintException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageOptimizationException;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
-use DomainException;
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Address\Command\BulkDeleteAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Address\Command\DeleteAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressConstraintException;
@@ -156,7 +156,7 @@ class ManufacturerController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_manufacturers_index');
             }
-        } catch (CoreException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -226,7 +226,7 @@ class ManufacturerController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_manufacturers_index');
             }
-        } catch (CoreException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             if ($e instanceof ManufacturerNotFoundException) {
@@ -566,7 +566,7 @@ class ManufacturerController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_manufacturers_index');
             }
-        } catch (DomainException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             if ($e instanceof ManufacturerConstraintException) {
@@ -620,7 +620,7 @@ class ManufacturerController extends FrameworkBundleAdminController
 
             /** @var EditableManufacturerAddress $editableAddress */
             $editableAddress = $this->getQueryBus()->handle(new GetManufacturerAddressForEditing($addressId));
-        } catch (DomainException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             if ($e instanceof AddressNotFoundException || $e instanceof AddressConstraintException) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Customer;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\BulkDeleteCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\BulkDisableCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\BulkEnableCustomerCommand;
@@ -149,7 +150,7 @@ class CustomerController extends AbstractAdminController
 
                 return $this->redirectToRoute('admin_customers_index');
             }
-        } catch (CustomerException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -191,7 +192,7 @@ class CustomerController extends AbstractAdminController
 
                 return $this->redirectToRoute('admin_customers_index');
             }
-        } catch (CustomerException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
             if ($e instanceof CustomerNotFoundException) {
                 return $this->redirectToRoute('admin_customers_index');
@@ -734,7 +735,7 @@ class CustomerController extends AbstractAdminController
      *
      * @return array
      */
-    private function getErrorMessages(CustomerException $e)
+    private function getErrorMessages(Exception $e)
     {
         return [
             CustomerNotFoundException::class => $this->trans(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Add a hook that allow to manage the mapping in controllers for error messages
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13490 last issue: "How to handle errors happening inside module (translation + display to user)"
| How to test?  | See below

# How to test

Attached is a demonstration module.
If you install it on develop, it's going to hook on the Add a Customer form and the Edit a Customer form.
- on Add form, if you save you'll see a Symfony HTTP 500 error "Uncatched error"
- on Edit form, if you save you'll see a Symfony HTTP 500 error "This is a nice display message"

If you use this branch,
- on Add form, if you save you'll see an error message "An unexpected error occurred. [RuntimeException code 0]"
- on Edit form, if you save you'll see an error message "This is a nice display message"


# PR notes

### Background

This PR solves 2 issues:
- How to display error messages from a module hooked on a Add/Edit form process (see https://github.com/PrestaShop/PrestaShop/issues/13490)
- It also handles the usecase "module does throw an uncatched exception". In the Core, we do not catch the generic `\Exception` because we consider our duty to handle all exception paths and make sure we display the right error message for each, however we cannot guarantee Modules will do the same. So we catch `\Exception` in order to avoid the "blank page" behavior.

### Example of usage

In a module that extends the Customer Form, so it's hooked on `hookActionAfterUpdateCustomerFormHandler`

If an error is found in hook `hookActionAfterUpdateCustomerFormHandler`, the module has 2 possibilities:

- throw a ModuleEloquentException that will be displayed to the merchant
`throw new \PrestaShop\PrestaShop\Core\Module\ModuleEloquentException('This error message should be displayed to the merchant')`

- or, if it uses its own Exceptions, it can use hook `actionGetEloquentExceptionsFromModule` to provide to the Core a list of Exception classes whose behavior should be the same as a ModuleEloquentException
```
    public function hookActionAfterUpdateCustomerFormHandler(array $params)
    {
        throw new \MyModule\Exception\BadBehaviorException(
            'This is a beautiful error message'
        );
    }

    public function hookActionGetEloquentExceptionsFromModule(array $params)
    {
        $whitelist = $params['whitelist'];
        $whitelist[] = \MyModule\Exception\BadBehaviorException::class;
        $params['whitelist'] = $whitelist;
    }
```
The Core will take this whitelist and use it to know whether it should return the exception error message directly.

Final result:
<img width="1203" alt="Capture d’écran 2019-06-14 à 10 35 19" src="https://user-images.githubusercontent.com/3830050/59496840-92c0f780-8e92-11e9-8fac-28a8ecdb6cef.png">

### To be decided

1) Naming "ModuleEloquentException" might be improved
2) I put ModuleEloquentException in namespace `PrestaShop\PrestaShop\Core\Module`, is that right ?
3) If Module throws an uncatched Exception, it will be displayed like this:
<img width="1218" alt="Capture d’écran 2019-06-14 à 10 56 18" src="https://user-images.githubusercontent.com/3830050/59497112-111d9980-8e93-11e9-922a-2e09ca99ad7d.png">

Because of current generic fallback error message
```
    protected function getFallbackErrorMessage($type, $code)
    {
        return $this->trans(
            'An unexpected error occurred. [%type% code %code%]',
            'Admin.Notifications.Error',
            [
                '%type%' => $type,
                '%code%' => $code,
            ]
        );
    }
```
⏩ should we update it ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14206)
<!-- Reviewable:end -->

[module_for_pr_hook_error.zip](https://github.com/PrestaShop/PrestaShop/files/3290604/module_for_pr_hook_error.zip)
