### PR TITLE
Fix adding product in order

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1146,7 +1146,7 @@ class OrderCore extends ObjectModel
     {
         $id_order = (int) self::getIdByCartId((int) $id_cart);
 
-        return ($id_order > 0) ? new self($id_order) : null;
+        return ($id_order > 0) ? new static($id_order) : null;
     }
 
     /**

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2104,7 +2104,8 @@ class AdminOrdersControllerCore extends AdminController
         )));
     }
 
-    protected function addProductToOrder(Order $order, $product_informations, $invoice_informations = [], $warehouseId = false){
+    protected function addProductToOrder(Order $order, $product_informations, $invoice_informations = [], $warehouseId = false)
+    {
         if (!Validate::isLoadedObject($order)) {
             die(json_encode(array(
                 'result' => false,

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -34,7 +34,6 @@ use LegacyTests\Unit\Core\Cart\CartToOrder\PaymentModuleFake;
 use Order;
 use OrderCartRule;
 use Context;
-use Employee;
 
 class OrderFeatureContext extends AbstractPrestaShopFeatureContext
 {
@@ -182,8 +181,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
         $product = $this->productFeatureContext->getProductWithName($productName);
 
         // need to disable some behaviour to avoid mocking the world !
-        $adminOrderController = new class extends AdminOrdersControllerCore
-        {
+        $adminOrderController = new class() extends AdminOrdersControllerCore {
             public function access($action, $disable = false)
             {
                 return true;
@@ -191,8 +189,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
 
             public function createTemplate($tpl_name)
             {
-                return new class
-                {
+                return new class() {
                     public function fetch()
                     {
                         return true;

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product.feature
@@ -1,0 +1,37 @@
+@reset-database-before-feature
+Feature: Check cart to order data copy
+  As a BO user
+  I must be able to add products in existing order
+
+  Scenario: 1 product in cart
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given product "product2" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
+    Then current cart order total for products should be 87.97 tax included
+    Then current cart order total for products should be 84.59 tax excluded
+    Then current cart order total discount should be 0.0 tax included
+    Then current cart order total discount should be 0.0 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded
+    Then current cart order should have no discount

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product_with_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product_with_cart_rule.feature
@@ -1,0 +1,106 @@
+@reset-database-before-feature
+Feature: Check cart to order data copy
+  As a BO user
+  I must be able to add products in existing order, calculation must be done correctly with cart rule
+
+  Scenario: 1 product in cart, add new product from order with restricted amount discount exceeding product price
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given product "product2" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    Given there is a cart rule named "cartrule5" that applies an amount discount of 500.0 with priority 5, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule5" is restricted to product "product2"
+    When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
+    Then current cart order total for products should be 87.97 tax included
+    Then current cart order total for products should be 84.59 tax excluded
+    Then current cart order total discount should be 67.37 tax included
+    Then current cart order total discount should be 64.78 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded
+
+  Scenario: 1 product in cart, add new product from order with restricted amount discount
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given product "product2" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    Given there is a cart rule named "cartrule5" that applies an amount discount of 5.0 with priority 5, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule5" is restricted to product "product2"
+    When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
+    Then current cart order total for products should be 87.97 tax included
+    Then current cart order total for products should be 84.59 tax excluded
+    Then current cart order total discount should be 5.2 tax included
+    Then current cart order total discount should be 5.0 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded
+
+  Scenario: 1 product in cart, add new product from order with restricted percent discount
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given product "product2" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    Given there is a cart rule named "cartrule5" that applies a percent discount of 15.0% with priority 5, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule5" is restricted to product "product2"
+    When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
+    Then current cart order total for products should be 87.97 tax included
+    Then current cart order total for products should be 84.59 tax excluded
+    Then current cart order total discount should be 10.11 tax included
+    Then current cart order total discount should be 9.72 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Adding a product in existing order from BO when a cart rule is applying was not calculating properly
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | fixes https://github.com/PrestaShop/PrestaShop/issues/13880
| How to test?  | refer to ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14208)
<!-- Reviewable:end -->
