### PR TITLE
Handle shoppingcart error returns properly - part 2

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -520,7 +520,7 @@ class CartControllerCore extends FrontController
                 } elseif ($this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
                     // check quantity after cart quantity update
                     $this->{$ErrorKey}[] = $this->trans(
-                        'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
+                        'The item %product% in your cart is no longer available in this quantity.',
                         array('%product%' => $product->name),
                         'Shop.Notifications.Error'
                     );

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -425,7 +425,7 @@ class CartControllerCore extends FrontController
         if ('update' !== $mode && $this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
             $this->{$ErrorKey}[] = $this->trans(
                 'The product is no longer available in this quantity.',
-                array('%product%' => $product->name),
+                array(),
                 'Shop.Notifications.Error'
             );
         }
@@ -520,8 +520,8 @@ class CartControllerCore extends FrontController
                 } elseif ($this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
                     // check quantity after cart quantity update
                     $this->{$ErrorKey}[] = $this->trans(
-                        'The item %product% in your cart is no longer available in this quantity.',
-                        array('%product%' => $product->name),
+                        'The product is no longer available in this quantity.',
+                        array(),
                         'Shop.Notifications.Error'
                     );
                 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Updates returned error message to handle properly "add to cart an out-of-stock product" error in Shopping Cart module, see https://github.com/PrestaShop/ps_shoppingcart/pull/41#issuecomment-500909906
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Will help to fix https://github.com/PrestaShop/PrestaShop/issues/11631
| How to test?  | Please test in combination with https://github.com/PrestaShop/ps_shoppingcart/pull/41, see below

### How to test
Please use :
- this PR for the Core
- the PR https://github.com/PrestaShop/ps_shoppingcart/pull/41 for the ps_shoppingcart module

#### Expected behavior

- Go to a FO page product with stock.
- In BO go to this product and update the quantity to 0.
- Back to FO product page (⚠️ dont refresh the page), add the product to cart.
- Shopping cart modal does not open and we see a nice error message below the "add to cart button "The item ... in your cart is no longer available in this quantity."
- If you go on Cart page, you'll see error message "The item ... in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted."

This is currently true for a product with combinations. This PR makes it also true for products without combinations and virtual products.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14214)
<!-- Reviewable:end -->
