### PR TITLE
 Allow choice of date column for statistics

### DIFF
--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -265,12 +265,12 @@ class AdminStatsControllerCore extends AdminStatsTabController
             $sales = array();
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
-			SELECT LEFT(`invoice_date`, 10) AS date, SUM((total_paid_tax_excl - total_shipping_tax_excl) / o.conversion_rate) AS sales
+			SELECT LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 10) AS date, SUM((total_paid_tax_excl - total_shipping_tax_excl) / o.conversion_rate) AS sales
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o') . '
-			GROUP BY LEFT(`invoice_date`, 10)'
+			GROUP BY LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 10)'
             );
             foreach ($result as $row) {
                 $sales[strtotime($row['date'])] = $row['sales'];
@@ -281,12 +281,12 @@ class AdminStatsControllerCore extends AdminStatsTabController
             $sales = array();
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
-			SELECT LEFT(`invoice_date`, 7) AS date, SUM((total_paid_tax_excl - total_shipping_tax_excl) / o.conversion_rate) AS sales
+			SELECT LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 7) AS date, SUM((total_paid_tax_excl - total_shipping_tax_excl) / o.conversion_rate) AS sales
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o') . '
-			GROUP BY LEFT(`invoice_date`, 7)'
+			GROUP BY LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 7)'
             );
             foreach ($result as $row) {
                 $sales[strtotime($row['date'] . '-01')] = $row['sales'];
@@ -299,7 +299,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			SELECT SUM((total_paid_tax_excl - total_shipping_tax_excl) / o.conversion_rate)
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o')
             );
         }
@@ -312,7 +312,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 		SELECT COUNT(DISTINCT od.product_id)
 		FROM `' . _DB_PREFIX_ . 'orders` o
 		LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON o.id_order = od.id_order
-		WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59"
+		WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59"
 		' . Shop::addSqlRestriction(false, 'o')
         );
         if (!$distinct_products) {
@@ -328,12 +328,12 @@ class AdminStatsControllerCore extends AdminStatsTabController
             $orders = array();
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
-			SELECT LEFT(`invoice_date`, 10) AS date, COUNT(*) AS orders
+			SELECT LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 10) AS date, COUNT(*) AS orders
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o') . '
-			GROUP BY LEFT(`invoice_date`, 10)'
+			GROUP BY LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 10)'
             );
             foreach ($result as $row) {
                 $orders[strtotime($row['date'])] = $row['orders'];
@@ -344,12 +344,12 @@ class AdminStatsControllerCore extends AdminStatsTabController
             $orders = array();
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
-			SELECT LEFT(`invoice_date`, 7) AS date, COUNT(*) AS orders
+			SELECT LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 7) AS date, COUNT(*) AS orders
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o') . '
-			GROUP BY LEFT(`invoice_date`, 7)'
+			GROUP BY LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 7)'
             );
             foreach ($result as $row) {
                 $orders[strtotime($row['date'] . '-01')] = $row['orders'];
@@ -362,7 +362,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			SELECT COUNT(*) AS orders
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o')
             );
         }
@@ -429,7 +429,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 				FROM `' . _DB_PREFIX_ . 'product` pr
 				LEFT OUTER JOIN `' . _DB_PREFIX_ . 'order_detail` cp ON pr.`id_product` = cp.`product_id`
 				LEFT JOIN `' . _DB_PREFIX_ . 'orders` o ON o.`id_order` = cp.`id_order`
-				WHERE o.invoice_date BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59"
+				WHERE o.'. AdminStatsController::GetStatisticsDateColumn() .' BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59"
 				GROUP BY pr.`id_product`
 			) t ON t.`id_product` = pr.`id_product`
 		) t	ON t.`id_product` = capr.`id_product`
@@ -450,7 +450,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 		SELECT a.id_country, COUNT(*) AS orders
 		FROM `' . _DB_PREFIX_ . 'orders` o
 		LEFT JOIN `' . _DB_PREFIX_ . 'address` a ON o.id_address_delivery = a.id_address
-		WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59"
+		WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59"
 		' . Shop::addSqlRestriction()
         );
         $row['orders'] = round(100 * $row['orders'] / $total_orders, 1);
@@ -535,7 +535,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
 			SELECT
-				LEFT(`invoice_date`, 10) as date,
+				LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 10) as date,
 				SUM(od.`product_quantity` * IF(
 					od.`purchase_supplier_price` > 0,
 					od.`purchase_supplier_price` / `conversion_rate`,
@@ -544,9 +544,9 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON o.id_order = od.id_order
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o') . '
-			GROUP BY LEFT(`invoice_date`, 10)'
+			GROUP BY LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 10)'
             );
             foreach ($result as $row) {
                 $purchases[strtotime($row['date'])] = $row['total_purchase_price'];
@@ -564,7 +564,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_detail` od ON o.id_order = od.id_order
 			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-			WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+			WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
 			' . Shop::addSqlRestriction(false, 'o')
             );
         }
@@ -577,7 +577,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
         $orders = Db::getInstance()->executeS(
             '
 		SELECT
-			LEFT(`invoice_date`, 10) AS date,
+			LEFT(o.`'. AdminStatsController::GetStatisticsDateColumn() .'`, 10) AS date,
 			total_paid_tax_incl / o.conversion_rate AS total_paid_tax_incl,
 			total_shipping_tax_excl / o.conversion_rate AS total_shipping_tax_excl,
 			o.module,
@@ -588,7 +588,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 		LEFT JOIN `' . _DB_PREFIX_ . 'address` a ON o.id_address_delivery = a.id_address
 		LEFT JOIN `' . _DB_PREFIX_ . 'carrier` c ON o.id_carrier = c.id_carrier
 		LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON o.current_state = os.id_order_state
-		WHERE `invoice_date` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
+		WHERE o.`'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL($date_from) . ' 00:00:00" AND "' . pSQL($date_to) . ' 23:59:59" AND os.logable = 1
 		' . Shop::addSqlRestriction(false, 'o')
         );
         foreach ($orders as $order) {
@@ -951,7 +951,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
 					COUNT(`id_order`) AS orders,
 					SUM(`total_paid_tax_excl` / `conversion_rate`) AS total_paid_tax_excl
 				FROM `' . _DB_PREFIX_ . 'orders`
-				WHERE `invoice_date` BETWEEN "' . pSQL(date('Y-m-d', strtotime('-31 day'))) . ' 00:00:00" AND "' . pSQL(
+				WHERE `'. AdminStatsController::GetStatisticsDateColumn() .'` BETWEEN "' . pSQL(date('Y-m-d', strtotime('-31 day'))) . ' 00:00:00" AND "' . pSQL(
                         date('Y-m-d', strtotime('-1 day'))
                     ) . ' 23:59:59"
 				' . Shop::addSqlRestriction()
@@ -1099,5 +1099,20 @@ class AdminStatsControllerCore extends AdminStatsTabController
 
         $grid->create($render, $type, $width, $height, $start, $limit, $sort, $dir);
         $grid->render();
+    }
+    
+    /**
+     * Get from configuration the appropriate date column name from orders table to be used to display statistics
+     *
+     * @return string
+     */
+    public static function GetStatisticsDateColumn()  {
+        $options = array('invoice_date','delivery_date','date_add','date_upd');
+        $id = Configuration::get('PS_ORDER_STATS_DATE_RANGE_COLUMN');
+        if ($id >= 0 && $id < 5) {
+            return $options[$id];
+        } else {
+            return 'invoice_date';
+        }
     }
 }

--- a/src/Adapter/Order/GeneralConfiguration.php
+++ b/src/Adapter/Order/GeneralConfiguration.php
@@ -59,6 +59,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             'allow_delayed_shipping' => $this->configuration->getBoolean('PS_SHIP_WHEN_AVAILABLE'),
             'enable_tos' => $this->configuration->getBoolean('PS_CONDITIONS'),
             'tos_cms_id' => $this->configuration->get('PS_CONDITIONS_CMS_ID'),
+            'order_stats_column_id' => $this->configuration->get('PS_ORDER_STATS_DATE_RANGE_COLUMN'),
         ];
     }
 
@@ -77,6 +78,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             $this->configuration->set('PS_SHIP_WHEN_AVAILABLE', $configuration['allow_delayed_shipping']);
             $this->configuration->set('PS_CONDITIONS', $configuration['enable_tos']);
             $this->configuration->set('PS_CONDITIONS_CMS_ID', $configuration['tos_cms_id']);
+            $this->configuration->set('PS_ORDER_STATS_DATE_RANGE_COLUMN', $configuration['order_stats_column_id']);
         }
 
         return [];
@@ -96,7 +98,8 @@ class GeneralConfiguration implements DataConfigurationInterface
             $configuration['allow_multishipping'],
             $configuration['allow_delayed_shipping'],
             $configuration['enable_tos'],
-            $configuration['tos_cms_id']
+            $configuration['tos_cms_id'],
+            $configuration['order_stats_column_id']
         );
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -91,8 +91,7 @@ class GeneralType extends TranslatorAwareType
             ->add('enable_tos', SwitchType::class)
             ->add('tos_cms_id', ChoiceType::class, [
                 'placeholder' => $this->trans('None', 'Admin.Global'),
-                'choices' => $this->tosCmsChoices,
-            ])
+                'choices' => $this->tosCmsChoices,            
             ])
             ->add('order_stats_column_id', ChoiceType::class, [                
                 'choices' => ['Invoice Date' => 0, 'Delivery Date' => 1, 'Order Added Date'  => 2, 'Order Updated Date' => 3],

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -92,6 +92,10 @@ class GeneralType extends TranslatorAwareType
             ->add('tos_cms_id', ChoiceType::class, [
                 'placeholder' => $this->trans('None', 'Admin.Global'),
                 'choices' => $this->tosCmsChoices,
+            ])
+            ])
+            ->add('order_stats_column_id', ChoiceType::class, [                
+                'choices' => ['Invoice Date' => 0, 'Delivery Date' => 1, 'Order Added Date'  => 2, 'Order Updated Date' => 3],
             ]);
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
@@ -99,6 +99,13 @@
                       {{ form_widget(generalForm.tos_cms_id) }}
                     </div>
                 </div>
+                <div class="form-group row">
+                    {{ ps.label_with_help(('Display order statistics based on'|trans), ('Select on which kind of date to base the dashboard statistics on.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+                    <div class="col-sm">
+                      {{ form_errors(generalForm.order_stats_column_id) }}
+                      {{ form_widget(generalForm.order_stats_column_id) }}
+                    </div>
+                </div>
 
                 {% block order_general_preferences_form_rest %}
                   {{ form_rest(generalForm) }}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This will give the option to users to choose based on which date column they want their dashboard statistics to display. Currently if shop owners don't generate any invoices at all, then they cannot see statistics for their orders, because statistics use the "invoice_date" column in orders table for date range. It adds a drop-down in "Shop Parameters -> Order Settings -> General" with four options: Invoice Date, Delivery Date, Order Added Date and Order Updated Date.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #12027 #15319
| How to test?  | Turn off invoices in Prestashop and use order statuses that don't generate invoices. Any orders you make will not appear in back-office statistics.

![new-order-option](https://user-images.githubusercontent.com/5149317/59511925-3e347100-8ec0-11e9-8236-7d1eb8b77935.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14215)
<!-- Reviewable:end -->
