### PR TITLE
Fix "14_discount/3_check_vouchers_in_FO" in full campaign

### DIFF
--- a/tests/E2E/test/campaigns/full/14_discount/3_check_vouchers_in_FO.js
+++ b/tests/E2E/test/campaigns/full/14_discount/3_check_vouchers_in_FO.js
@@ -84,9 +84,9 @@ scenario('Check the total price after applying vouchers in the Front Office', ()
     test('should set the "Quantity" input', () => client.waitAndSetValue(productPage.first_product_quantity, 3));
     test('should click on "ADD TO CART" button', () => client.waitForExistAndClick(CheckoutOrderPage.add_to_cart_button));
     test('should click on "PROCEED TO CHECKOUT" modal button', () => client.waitForVisibleAndClick(CheckoutOrderPage.proceed_to_checkout_modal_button));
-    test('should click on "Have a promo code?" link', () => client.waitForExistAndClick(CheckoutOrderPage.promo_code_link,4000));
+    test('should click on "Have a promo code?" link', () => client.waitForExistAndClick(CheckoutOrderPage.promo_code_link, 4000));
     test('should set the "Promo code" input', () => client.setPromoCode(CheckoutOrderPage.promo_code_input, CheckoutOrderPage.promo_code_add_button, 'codePromo1'));
-    test('should click on "Have a promo code?" link', () => client.waitForExistAndClick(CheckoutOrderPage.promo_code_link,4000));
+    test('should click on "Have a promo code?" link', () => client.waitForExistAndClick(CheckoutOrderPage.promo_code_link, 4000));
     test('should set the "Promo code" input', () => client.setPromoCode(CheckoutOrderPage.promo_code_input, CheckoutOrderPage.promo_code_add_button, 'codePromo2'));
     test('should check the total price after reduction', () => {
       return promise
@@ -95,7 +95,7 @@ scenario('Check the total price after applying vouchers in the Front Office', ()
         .then(() => client.checkTotalPrice(CheckoutOrderPage.cart_total));
     });
     test('should click on "Remove voucher" button', () => client.waitForExistAndClick(CheckoutOrderPage.remove_voucher_button));
-    test('should click on "Have a promo code?" link', () => client.waitForExistAndClick(CheckoutOrderPage.promo_code_link,4000));
+    test('should click on "Have a promo code?" link', () => client.waitForExistAndClick(CheckoutOrderPage.promo_code_link, 4000));
     test('should set the "Promo code" input', () => client.setPromoCode(CheckoutOrderPage.promo_code_input, CheckoutOrderPage.promo_code_add_button, 'codePromo3'));
     test('should check the total price after reduction (BOOM-2518)', () => {
       return promise

--- a/tests/E2E/test/clients/discount.js
+++ b/tests/E2E/test/clients/discount.js
@@ -27,8 +27,9 @@ class Discount extends CommonClient {
 
   setPromoCode(selectorInput, selectorButton, value) {
     return this.client
-      .waitAndSetValue(selectorInput, tab[value],2000)
-      .waitForExistAndClick(selectorButton,2000);
+      .waitForVisible(selectorInput)
+      .waitAndSetValue(selectorInput, tab[value], 2000)
+      .waitForExistAndClick(selectorButton, 2000);
   }
 
   checkTotalPrice(selector, option = 'percent') {
@@ -36,7 +37,7 @@ class Discount extends CommonClient {
       .pause(2000)
       .then(() => this.client.getText(selector))
       .then((code) => {
-        if(option === 'amount') {
+        if (option === 'amount') {
           expect(code.split('€')[1]).to.be.equal(((tab["totalProducts"].split('€')[1] * 0.5) - 24).toPrecision(4).toString());
         } else {
           expect(code.split('€')[1]).to.be.equal(((tab["totalProducts"].split('€')[1] * 0.5) * 0.5).toPrecision(4).toString());

--- a/tests/E2E/test/selectors/FO/order_page.js
+++ b/tests/E2E/test/selectors/FO/order_page.js
@@ -5,7 +5,7 @@ module.exports = {
     blockcart_modal: '#blockcart-modal',
     continue_shopping_button: '//*[@id="blockcart-modal"]//div[@class="cart-content-btn"]//button',
     proceed_to_checkout_button: '//*[@id="main"]//div[contains(@class,"checkout")]//a',
-    promo_code_link: '//*[@id="main"]//a[contains(@class, "promo-code")]',
+    promo_code_link: '//*[@id="main"]//a[contains(@href, "promo-code")]',
     promo_code_input: '//*[@id="promo-code"]//input[contains(@class, "promo-input")]',
     promo_code_add_button: '//*[@id="promo-code"]//button[@type="submit"]/span[text()="Add"]',
     remove_voucher_button: '(//*[@id="main"]//a[@data-link-action="remove-voucher"])[2]',


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fix promo_code_link selector and add a waitForVisible to wait for the visiblity of the code promo input
| Type?         | refacto
| Category?     |  TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH=full/14_discount/3_check_vouchers_in_FO npm run specific-test -- --URL=SHOP_URL --HEADLESS

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14221)
<!-- Reviewable:end -->
