### PR TITLE
Introduce the usage of Module user-displayable exceptions to handle module errors (part 2)

### DIFF
--- a/src/Core/Module/Exception/ModuleErrorException.php
+++ b/src/Core/Module/Exception/ModuleErrorException.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Module\Exception;
+
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+
+/**
+ * Default module error implementation
+ * The message of this exception will be displayed to the end-user
+ *
+ * You can use it in a module hooked on a Symfony page
+ */
+class ModuleErrorException extends CoreException implements ModuleErrorInterface
+{
+}

--- a/src/Core/Module/Exception/ModuleErrorInterface.php
+++ b/src/Core/Module/Exception/ModuleErrorInterface.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Module\Exception;
+
+/**
+ * If an exception that implements this ModuleErrorInterface
+ * is thrown, its message will be displayed to the end-user
+ */
+interface ModuleErrorInterface
+{
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmailAlreadyUsedException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidProfileException;
@@ -290,7 +291,7 @@ class EmployeeController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_employees_index');
             }
-        } catch (EmployeeException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -365,7 +366,7 @@ class EmployeeController extends FrameworkBundleAdminController
                     'employeeId' => $result->getIdentifiableObjectId(),
                 ]);
             }
-        } catch (EmployeeException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -464,11 +465,11 @@ class EmployeeController extends FrameworkBundleAdminController
     /**
      * Get human readable error messages.
      *
-     * @param EmployeeException $e
+     * @param Exception $e
      *
      * @return array
      */
-    protected function getErrorMessages($e)
+    protected function getErrorMessages(Exception $e)
     {
         return [
             InvalidEmployeeIdException::class => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Command\BulkDeleteProfileCommand;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Command\DeleteProfileCommand;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\CannotDeleteSuperAdminProfileException;
@@ -130,7 +131,7 @@ class ProfileController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_profiles_index');
             }
-        } catch (ProfileException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -172,7 +173,7 @@ class ProfileController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_profiles_index');
             }
-        } catch (ProfileException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             if ($e instanceof ProfileNotFoundException) {

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\DuplicateWebserviceKeyException;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceConstraintException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
@@ -102,7 +102,7 @@ class WebserviceController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_webservice_keys_index');
             }
-        } catch (DomainException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -140,7 +140,7 @@ class WebserviceController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_webservice_keys_index');
             }
-        } catch (DomainException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
@@ -26,10 +26,10 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Exception\DomainConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShop\PrestaShop\Core\Search\Filters\ContactFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -136,7 +136,7 @@ class ContactsController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_contacts_index');
             }
-        } catch (DomainException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages($exception))
@@ -178,7 +178,7 @@ class ContactsController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_contacts_index');
             }
-        } catch (DomainException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($exception, $this->getErrorMessages($exception))
@@ -254,11 +254,11 @@ class ContactsController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param DomainException $e
+     * @param Exception $e
      *
      * @return array
      */
-    private function getErrorMessages(DomainException $e)
+    private function getErrorMessages(Exception $e)
     {
         return [
             ContactNotFoundException::class => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -26,10 +26,10 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaException;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaNotFoundException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
@@ -171,7 +171,7 @@ class MetaController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_metas_index');
             }
-        } catch (MetaException $exception) {
+        } catch (Exception $exception) {
             $this->addFlash('error', $this->handleException($exception));
         }
 
@@ -204,7 +204,7 @@ class MetaController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_metas_index');
             }
-        } catch (MetaException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->handleException($e));
 
             return $this->redirectToRoute('admin_metas_index');
@@ -363,11 +363,13 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Handles exception by its type and status code or by its type only and returns error message.
      *
-     * @param MetaException $exception
+     * @param Exception $exception
      *
      * @return string
+     *
+     * @todo use FrameworkAdminBundleController::getErrorMessageForException() instead
      */
-    private function handleException(MetaException $exception)
+    private function handleException(Exception $exception)
     {
         if (0 !== $exception->getCode()) {
             return $this->getExceptionByClassAndErrorCode($exception);
@@ -379,11 +381,11 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Gets exception by class and error code.
      *
-     * @param MetaException $exception
+     * @param Exception $exception
      *
      * @return string
      */
-    private function getExceptionByClassAndErrorCode(MetaException $exception)
+    private function getExceptionByClassAndErrorCode(Exception $exception)
     {
         $exceptionDictionary = [
             MetaConstraintException::class => [
@@ -452,11 +454,11 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Gets exception by class type.
      *
-     * @param MetaException $exception
+     * @param Exception $exception
      *
      * @return string
      */
-    private function getExceptionByType(MetaException $exception)
+    private function getExceptionByType(Exception $exception)
     {
         $exceptionDictionary = [
             MetaNotFoundException::class => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -31,6 +31,7 @@ use Exception;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
+use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
 use PrestaShopBundle\Security\Voter\PageVoter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -462,6 +463,10 @@ class FrameworkBundleAdminController extends Controller
      */
     protected function getErrorMessageForException(Exception $e, array $messages)
     {
+        if ($e instanceof ModuleErrorInterface) {
+            return $e->getMessage();
+        }
+
         $exceptionType = get_class($e);
         $exceptionCode = $e->getCode();
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\Design;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkDeleteCmsPageCommand;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkDisableCmsPageCommand;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkEnableCmsPageCommand;
@@ -52,7 +53,6 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryE
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageParentCategoryIdForRedirection;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
@@ -213,7 +213,7 @@ class CmsPageController extends FrameworkBundleAdminController
                     'open_preview' => 1,
                 ]);
             }
-        } catch (DomainException $e) {
+        } catch (Exception $e) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($e, $this->getErrorMessages())
@@ -278,7 +278,7 @@ class CmsPageController extends FrameworkBundleAdminController
             /** @var EditableCmsPage $editableCmsPage */
             $editableCmsPage = $this->getQueryBus()->handle(new GetCmsPageForEditing($cmsPageId));
             $previewUrl = $editableCmsPage->getPreviewUrl();
-        } catch (DomainException $e) {
+        } catch (Exception $e) {
             $this->addFlash(
                 'error',
                 $this->getErrorMessageForException($e, $this->getErrorMessages())

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Command\DeleteCurrencyCommand;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Command\ToggleCurrencyStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Command\RefreshExchangeRatesCommand;
@@ -131,7 +132,7 @@ class CurrencyController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_currencies_index');
             }
-        } catch (CurrencyException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -171,7 +172,7 @@ class CurrencyController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_currencies_index');
             }
-        } catch (CurrencyException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -358,11 +359,11 @@ class CurrencyController extends FrameworkBundleAdminController
     /**
      * Gets an error by exception class and its code.
      *
-     * @param CurrencyException $e
+     * @param Exception $e
      *
      * @return array
      */
-    private function getErrorMessages(CurrencyException $e)
+    private function getErrorMessages(Exception $e)
     {
         return [
             CurrencyConstraintException::class => [

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\BulkDeleteLanguagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\BulkToggleLanguagesStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\DeleteLanguageCommand;
@@ -123,7 +124,7 @@ class LanguageController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_languages_index');
             }
-        } catch (LanguageException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -162,7 +163,7 @@ class LanguageController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_languages_index');
             }
-        } catch (LanguageException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
 
             if ($e instanceof LanguageNotFoundException) {
@@ -298,11 +299,11 @@ class LanguageController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param LanguageException $e
+     * @param Exception $e
      *
      * @return array
      */
-    private function getErrorMessages(LanguageException $e)
+    private function getErrorMessages(Exception $e)
     {
         return [
             LanguageNotFoundException::class => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Command\BulkDeleteTaxCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Command\BulkToggleTaxStatusCommand;
@@ -162,7 +163,7 @@ class TaxController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_taxes_index');
             }
-        } catch (TaxException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -201,7 +202,7 @@ class TaxController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_taxes_index');
             }
-        } catch (TaxException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             if ($e instanceof TaxNotFoundException) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDeleteCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDisableCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkEnableCategoriesCommand;
@@ -137,7 +138,7 @@ class CategoryController extends FrameworkBundleAdminController
                     'categoryId' => $categoryForm->getData()['id_parent'],
                 ]);
             }
-        } catch (CategoryException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -185,7 +186,7 @@ class CategoryController extends FrameworkBundleAdminController
                     'categoryId' => $this->configuration->getInt('PS_ROOT_CATEGORY'),
                 ]);
             }
-        } catch (CategoryException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -252,7 +253,7 @@ class CategoryController extends FrameworkBundleAdminController
                     'categoryId' => $categoryForm->getData()['id_parent'],
                 ]);
             }
-        } catch (CategoryException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -317,7 +318,7 @@ class CategoryController extends FrameworkBundleAdminController
                     'categoryId' => $this->configuration->getInt('PS_ROOT_CATEGORY'),
                 ]);
             }
-        } catch (CategoryException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -729,7 +730,7 @@ class CategoryController extends FrameworkBundleAdminController
     }
 
     /**
-     * Get translated error messsages for category exceptions
+     * Get translated error messages for category exceptions
      *
      * @return array
      */

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShop\PrestaShop\Core\Domain\Address\Command\BulkDeleteAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Address\Command\DeleteAddressCommand;
@@ -50,7 +51,6 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerAddressGridDe
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\ManufacturerAddressFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\ManufacturerFilters;
-use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerConstraintException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageOptimizationException;
@@ -156,7 +156,7 @@ class ManufacturerController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_manufacturers_index');
             }
-        } catch (CoreException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
@@ -226,7 +226,7 @@ class ManufacturerController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_manufacturers_index');
             }
-        } catch (CoreException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             if ($e instanceof ManufacturerNotFoundException) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDeleteSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDisableSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkEnableSupplierCommand;
@@ -393,11 +394,13 @@ class SupplierController extends FrameworkBundleAdminController
     /**
      * Gets error by exception type.
      *
-     * @param SupplierException $exception
+     * @param Exception $exception
      *
      * @return string
+     *
+     * @todo use FrameworkAdminBundleController::getErrorMessageForException() instead
      */
-    private function handleException(SupplierException $exception)
+    private function handleException(Exception $exception)
     {
         if (0 !== $exception->getCode()) {
             return $this->getExceptionMessageByExceptionCode($exception);
@@ -409,11 +412,11 @@ class SupplierController extends FrameworkBundleAdminController
     /**
      * Gets by exception type
      *
-     * @param SupplierException $exception
+     * @param Exception $exception
      *
      * @return string
      */
-    private function getExceptionMessageByType(SupplierException $exception)
+    private function getExceptionMessageByType(Exception $exception)
     {
         $exceptionTypeDictionary = [
             SupplierNotFoundException::class => $this->trans(
@@ -451,11 +454,11 @@ class SupplierController extends FrameworkBundleAdminController
     /**
      * Gets exception message by exception code.
      *
-     * @param SupplierException $exception
+     * @param Exception $exception
      *
      * @return string
      */
-    private function getExceptionMessageByExceptionCode(SupplierException $exception)
+    private function getExceptionMessageByExceptionCode(Exception $exception)
     {
         $exceptionConstraintDictionary = [
             SupplierConstraintException::class => [

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Customer;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\BulkDeleteCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\BulkDisableCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\BulkEnableCustomerCommand;
@@ -149,7 +150,7 @@ class CustomerController extends AbstractAdminController
 
                 return $this->redirectToRoute('admin_customers_index');
             }
-        } catch (CustomerException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
@@ -191,7 +192,7 @@ class CustomerController extends AbstractAdminController
 
                 return $this->redirectToRoute('admin_customers_index');
             }
-        } catch (CustomerException $e) {
+        } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
             if ($e instanceof CustomerNotFoundException) {
                 return $this->redirectToRoute('admin_customers_index');
@@ -730,11 +731,11 @@ class CustomerController extends AbstractAdminController
     /**
      * Get errors that can be used to translate exceptions into user friendly messages
      *
-     * @param CustomerException $e
+     * @param Exception $e
      *
      * @return array
      */
-    private function getErrorMessages(CustomerException $e)
+    private function getErrorMessages(Exception $e)
     {
         return [
             CustomerNotFoundException::class => $this->trans(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Allow hooked modules to throw a ModuleErrorException or ModuleErrorInterface to display error messages to end-user
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13490 last issue: "How to handle errors happening inside module (translation + display to user)"
| How to test?  | See below

# How to test

Attached is a demonstration module.
[module_for_pr_hook_error.zip](https://github.com/PrestaShop/PrestaShop/files/3300628/module_for_pr_hook_error.zip)


If you install it and test this PR,
- on Add form, if you save you'll see an error message "An unexpected error occurred. [RuntimeException code 0]"
- on Edit form, if you save you'll see an error message "This is a nice display message"

# PR notes

### Background

This PR solves 2 issues:
- How to display error messages from a module hooked on a Add/Edit form process (see https://github.com/PrestaShop/PrestaShop/issues/13490)
- It also handles the usecase "module does throw an uncatched exception". In the Core, we do not catch the generic `\Exception` because we consider our duty to handle all exception paths and make sure we display the right error message for each, however we cannot guarantee Modules will do the same. So we catch `\Exception` in order to avoid the "blank page" behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14239)
<!-- Reviewable:end -->
