### PR TITLE
Module form_rest() outside div

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
@@ -120,11 +120,11 @@
               </div>
             </div>
           </div>
-
-          {% block import_theme_form_rest %}
-            {{ form_rest(importThemeForm) }}
-          {% endblock %}
         </div>
+
+        {% block import_theme_form_rest %}
+          {{ form_rest(importThemeForm) }}
+        {% endblock %}
 
       {{ form_end(importThemeForm) }}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/index.html.twig
@@ -54,11 +54,11 @@
       <div class="col-xl-10">
         {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig' %}
       </div>
-
-      {% block geolocation_form_rest %}
-        {{ form_rest(geolocationForm) }}
-      {% endblock %}
     </div>
+
+    {% block geolocation_form_rest %}
+      {{ form_rest(geolocationForm) }}
+    {% endblock %}
   {{ form_end(geolocationForm) }}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/index.html.twig
@@ -46,11 +46,12 @@
       <div class="col-xl-10">
         {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig' %}
       </div>
-
-      {% block localization_settings_form_rest %}
-        {{ form_rest(localizationForm) }}
-      {% endblock %}
     </div>
+
+    {% block localization_settings_form_rest %}
+      {{ form_rest(localizationForm) }}
+    {% endblock %}
+
   {{ form_end(localizationForm) }}
 {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Move form_rest blocks to aoid breaking design
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14186
| How to test?  | See issue, also test International / Localization / Geolocation page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14242)
<!-- Reviewable:end -->
