### PR TITLE
Case-insensitive hook dispatching

### DIFF
--- a/src/Adapter/Hook/HookDispatcher.php
+++ b/src/Adapter/Hook/HookDispatcher.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Hook;
 
-use PrestaShop\PrestaShop\Core\Foundation\IoC\Container;
 use PrestaShop\PrestaShop\Core\Hook\Hook;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookInterface;

--- a/src/Adapter/Hook/HookDispatcher.php
+++ b/src/Adapter/Hook/HookDispatcher.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Hook;
 
+use PrestaShop\PrestaShop\Core\Foundation\IoC\Container;
 use PrestaShop\PrestaShop\Core\Hook\Hook;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookInterface;
@@ -66,11 +67,16 @@ class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
         if ($event === null) {
             $event = new HookEvent();
         }
+
         if (!$event instanceof HookEvent) {
             throw new \Exception('HookDispatcher must dispatch a HookEvent subclass only. ' . get_class($event) . ' given.');
         }
 
-        return parent::dispatch($eventName, $event);
+        if ($listeners = $this->getListeners(strtolower($eventName))) {
+            $this->doDispatch($listeners, $eventName, $event);
+        }
+
+        return $event;
     }
 
     /**

--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -234,7 +234,7 @@ class LegacyHookSubscriber implements EventSubscriberInterface
 
         if (is_array($hooks)) {
             foreach ($hooks as $hook) {
-                $name = $hook['name'];
+                $name = strtolower($hook['name']);
                 $id = $hook['id_hook'];
 
                 $moduleListeners = array();

--- a/tests/Unit/Adapter/Hook/HookDispatcherTest.php
+++ b/tests/Unit/Adapter/Hook/HookDispatcherTest.php
@@ -48,11 +48,12 @@ class HookDispatcherTest extends TestCase
         $this->hookDispatcherMock
             ->method('getListeners')
             ->with($lowerCasedEventName)
-            ->willReturn($lowerCasedEventName)
+            ->willReturn([$lowerCasedEventName])
         ;
 
         $this->hookDispatcherMock
             ->expects($this->once())
+            ->with([$lowerCasedEventName], $eventName, $this->hookEventMock)
             ->method('doDispatch')
         ;
 

--- a/tests/Unit/Adapter/Hook/HookDispatcherTest.php
+++ b/tests/Unit/Adapter/Hook/HookDispatcherTest.php
@@ -53,8 +53,8 @@ class HookDispatcherTest extends TestCase
 
         $this->hookDispatcherMock
             ->expects($this->once())
-            ->with([$lowerCasedEventName], $eventName, $this->hookEventMock)
             ->method('doDispatch')
+            ->with([$lowerCasedEventName], $eventName, $this->hookEventMock)
         ;
 
         $this->hookDispatcherMock->dispatch($eventName, $this->hookEventMock);

--- a/tests/Unit/Adapter/Hook/HookDispatcherTest.php
+++ b/tests/Unit/Adapter/Hook/HookDispatcherTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Adapter\Hook;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Hook\HookDispatcher;
+use PrestaShopBundle\Service\Hook\HookEvent;
+
+class HookDispatcherTest extends TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|HookEvent
+     */
+    private $hookEventMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|HookDispatcher
+     */
+    private $hookDispatcherMock;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->hookEventMock = $this
+            ->getMockBuilder(HookEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->hookDispatcherMock = $this
+            ->getMockBuilder(HookDispatcher::class)
+            ->setMethods(['getListeners', 'doDispatch'])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @dataProvider getHookEventNames
+     *
+     * @param string $eventName
+     */
+    public function testItCallsHookDispatcherWithCaseInsensitiveEventNames($eventName)
+    {
+        $lowerCasedEventName = strtolower($eventName);
+
+        $this->hookDispatcherMock
+            ->method('getListeners')
+            ->with($lowerCasedEventName)
+            ->willReturn($lowerCasedEventName)
+        ;
+
+        $this->hookDispatcherMock
+            ->expects($this->once())
+            ->method('doDispatch')
+        ;
+
+        $this->hookDispatcherMock->dispatch($eventName, $this->hookEventMock);
+    }
+
+    public function getHookEventNames()
+    {
+        yield [
+            'normalHook',
+        ];
+
+        yield [
+            'HOOKINUPPERCASE',
+        ];
+
+        yield [
+            'hookINanyCASE',
+        ];
+
+        yield [
+            'lowercasehookalso',
+        ];
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | dispatching the hook **abcFooBar** or **ABCFooBar** or **abcFOOBAR** makes the module hook being triggered in all cases.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/10412
| How to test?  | Automated tests should cover all possible cases for this 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14249)
<!-- Reviewable:end -->
