### PR TITLE
Modules removed from filesystem should be listed in modules catalog

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -266,7 +266,10 @@ class AdminModuleDataProvider implements ModuleInterface
                 'module_name' => $addon->attributes->get('name'),
             ));
 
-            if ($addon->database->has('installed') && $addon->database->getBoolean('installed')) {
+            if ($addon->database->has('installed')
+                && $addon->database->getBoolean('installed')
+                && $addon->disk->getBoolean('is_present')
+            ) {
                 if (!$addon->database->getBoolean('active')) {
                     $url_active = 'enable';
                     unset(

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -293,7 +293,9 @@ class ModuleManager implements AddonManagerInterface
             $source = null;
         }
 
-        if ($this->moduleProvider->isInstalled($name)) {
+        if ($this->moduleProvider->isInstalled($name)
+            && $this->moduleProvider->isOnDisk($name)
+        ) {
             return $this->upgrade($name, 'latest', $source);
         }
 

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -233,7 +233,8 @@ class ModuleRepository implements ModuleRepositoryInterface
 
             // Part Two : Remove module not installed if specified
             if ($filter->status != AddonListFilterStatus::ALL) {
-                if ($module->database->get('installed') == 1
+                if (($module->database->get('installed') == 1
+                        && $module->disk->get('is_present') == 1)
                     && ($filter->hasStatus(AddonListFilterStatus::UNINSTALLED)
                         || !$filter->hasStatus(AddonListFilterStatus::INSTALLED))) {
                     unset($modules[$key]);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Modules deleted from the filesystem weren't displayed anymore in the module catalog / modules manager. From now, it appears again in the module catalog with the "install" button.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | /
| How to test?  | Take one of the installed native modules, then rename its folder. It should be displayed in the module catalog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14253)
<!-- Reviewable:end -->
