### PR TITLE
Fix SQL error due do while not ended

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6371,7 +6371,7 @@ class ProductCore extends ObjectModel
                 $orderred[] = $row['id_attribute'];
             }
 
-            while ($idProductAttribute === false && count($orderred) > 0) {
+            while ($idProductAttribute === false && count($orderred) > 1) {
                 array_pop($orderred);
                 $idProductAttribute = Db::getInstance()->getValue(
                     '


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Bad while end condition , array_pop end at 1
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | sorry, no
| How to test?  | please see below



- when you try to reproduce the issue described on : https://github.com/PrestaShop/PrestaShop/issues/9919 , `500 errors can happen , because of the confusions of Attributes groups linked to a product
- this pull request does not correct #9919 but return the correct Exeption `PrestaShopObjectNotFoundException('Can not retrieve the id_product_attribute')` instead of the Sql error onas you can see below

![image](https://user-images.githubusercontent.com/3170104/59692348-06416c80-91e5-11e9-9172-419df42475a6.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14273)
<!-- Reviewable:end -->
