### PR TITLE
Fix english mail generation on fresh install

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1154,7 +1154,7 @@ class LanguageCore extends ObjectModel
             return;
         }
 
-        $mailTheme = Configuration::get('PS_MAIL_THEME');
+        $mailTheme = Configuration::get('PS_MAIL_THEME', null, null, null, 'modern');
         /** @var GenerateThemeMailTemplatesCommand $generateCommand */
         $generateCommand = new GenerateThemeMailTemplatesCommand(
             $mailTheme,

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -151,34 +151,38 @@ class MailCore extends ObjectModel
             $idShop = Context::getContext()->shop->id;
         }
 
-        $keepGoing = array_reduce(
-            Hook::exec(
-                'actionEmailSendBefore',
-                [
-                    'idLang' => &$idLang,
-                    'template' => &$template,
-                    'subject' => &$subject,
-                    'templateVars' => &$templateVars,
-                    'to' => &$to,
-                    'toName' => &$toName,
-                    'from' => &$from,
-                    'fromName' => &$fromName,
-                    'fileAttachment' => &$fileAttachment,
-                    'mode_smtp' => &$mode_smtp,
-                    'templatePath' => &$templatePath,
-                    'die' => &$die,
-                    'idShop' => &$idShop,
-                    'bcc' => &$bcc,
-                    'replyTo' => &$replyTo,
-                ],
-                null,
-                true
-            ),
-            function ($carry, $item) {
-                return ($item === false) ? false : $carry;
-            },
+        $keepGoing = Hook::exec(
+            'actionEmailSendBefore',
+            [
+                'idLang' => &$idLang,
+                'template' => &$template,
+                'subject' => &$subject,
+                'templateVars' => &$templateVars,
+                'to' => &$to,
+                'toName' => &$toName,
+                'from' => &$from,
+                'fromName' => &$fromName,
+                'fileAttachment' => &$fileAttachment,
+                'mode_smtp' => &$mode_smtp,
+                'templatePath' => &$templatePath,
+                'die' => &$die,
+                'idShop' => &$idShop,
+                'bcc' => &$bcc,
+                'replyTo' => &$replyTo,
+            ],
+            null,
             true
         );
+
+        if ($keepGoing) {
+            $keepGoing = array_reduce(
+                $keepGoing,
+                function ($carry, $item) {
+                    return ($item === false) ? false : $carry;
+                },
+                true
+            );
+        }
 
         if (!$keepGoing) {
             return true;

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -151,7 +151,7 @@ class MailCore extends ObjectModel
             $idShop = Context::getContext()->shop->id;
         }
 
-        $keepGoing = Hook::exec(
+        $hookBeforeEmailResult = Hook::exec(
             'actionEmailSendBefore',
             [
                 'idLang' => &$idLang,
@@ -174,9 +174,11 @@ class MailCore extends ObjectModel
             true
         );
 
-        if ($keepGoing) {
+        if ($hookBeforeEmailResult === null) {
+            $keepGoing = false;
+        } else {
             $keepGoing = array_reduce(
-                $keepGoing,
+                $hookBeforeEmailResult,
                 function ($carry, $item) {
                     return ($item === false) ? false : $carry;
                 },


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | English mails were not installed on fresh install, because the default theme was not in database yet, also fix a warning in Mail::send which was annoying during CLI install (logs tried to be sent by mail causing lots of Warning lines)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Perform a fresh install and check that english mails use the modern theme

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14298)
<!-- Reviewable:end -->
