### PR TITLE
Avoid Language::updateLanguagePack to crash when DB has no settings yet

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1214,15 +1214,23 @@ class LanguageCore extends ObjectModel
     {
         $lang_pack = self::getLangDetails($iso);
         if (!empty($lang_pack['locale'])) {
-            //Update locale field if empty (manually created, or imported without it)
-            $language = new Language(Language::getIdByIso($iso));
-            if ($language->id && empty($language->locale)) {
-                $language->locale = $lang_pack['locale'];
-                $language->save();
+            //Check that DB settings are available to avoid a bug during installation
+            if (defined(_DB_SERVER_)) {
+                //Update locale field if empty (manually created, or imported without it)
+                $language = new Language(Language::getIdByIso($iso));
+                if ($language->id && empty($language->locale)) {
+                    $language->locale = $lang_pack['locale'];
+                    $language->save();
+                }
             }
 
+
             self::installSfLanguagePack($lang_pack['locale'], $errors);
-            Language::updateMultilangTable($iso);
+            //Check that DB settings are available to avoid a bug during installation
+            if (defined(_DB_SERVER_)) {
+                Language::updateMultilangTable($iso);
+            }
+
             self::generateEmailsLanguagePack($lang_pack, $errors, false);
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Avoid Language::updateLanguagePack to crash when DB has no settings yet
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Try to perform a fresh install from the browser

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14303)
<!-- Reviewable:end -->
