### PR TITLE
Fix manufacturers grid logo to not depend from shop context

### DIFF
--- a/src/Adapter/Image/Uploader/ManufacturerImageUploader.php
+++ b/src/Adapter/Image/Uploader/ManufacturerImageUploader.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Image\Uploader;
 
 use Configuration;
-use Context;
 use ImageManager;
 use ImageType;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageOptimizationException;
@@ -113,11 +112,7 @@ final class ManufacturerImageUploader extends AbstractImageUploader
                     }
                 }
 
-                $currentLogo = _PS_TMP_IMG_DIR_ . 'manufacturer_mini_' . $manufacturerId .
-                    '_' .
-                    Context::getContext()->shop->id .
-                    '.jpg'
-                ;
+                $currentLogo = _PS_TMP_IMG_DIR_ . 'manufacturer_mini_' . $manufacturerId . '.jpg';
 
                 if ($resized && file_exists($currentLogo)) {
                     unlink($currentLogo);

--- a/src/Adapter/Manufacturer/ManufacturerLogoThumbnailProvider.php
+++ b/src/Adapter/Manufacturer/ManufacturerLogoThumbnailProvider.php
@@ -67,7 +67,7 @@ final class ManufacturerLogoThumbnailProvider implements ImageProviderInterface
 
         $imageTag = ImageManager::thumbnail(
             $pathToImage,
-            'manufacturer_mini_' . $manufacturerId . '_' . $this->contextShopId . '.jpg',
+            'manufacturer_mini_' . $manufacturerId . '.jpg',
             HelperList::LIST_THUMBNAIL_SIZE
         );
 

--- a/src/Adapter/Manufacturer/ManufacturerLogoThumbnailProvider.php
+++ b/src/Adapter/Manufacturer/ManufacturerLogoThumbnailProvider.php
@@ -42,20 +42,12 @@ final class ManufacturerLogoThumbnailProvider implements ImageProviderInterface
     private $imageTagSourceParser;
 
     /**
-     * @var int
-     */
-    private $contextShopId;
-
-    /**
      * @param ImageTagSourceParserInterface $imageTagSourceParser
-     * @param int $contextShopId
      */
     public function __construct(
-        ImageTagSourceParserInterface $imageTagSourceParser,
-        $contextShopId
+        ImageTagSourceParserInterface $imageTagSourceParser
     ) {
         $this->imageTagSourceParser = $imageTagSourceParser;
-        $this->contextShopId = $contextShopId;
     }
 
     /**

--- a/src/Adapter/Manufacturer/QueryHandler/GetManufacturerForEditingHandler.php
+++ b/src/Adapter/Manufacturer/QueryHandler/GetManufacturerForEditingHandler.php
@@ -89,7 +89,7 @@ final class GetManufacturerForEditingHandler extends AbstractManufacturerHandler
         $pathToImage = _PS_MANU_IMG_DIR_ . $manufacturerId->getValue() . '.jpg';
         $imageTag = ImageManager::thumbnail(
             $pathToImage,
-            'manufacturer_' . $manufacturerId->getValue() . '_' . $this->contextShopId . '.jpg',
+            'manufacturer_' . $manufacturerId->getValue() . '.jpg',
             350,
             'jpg',
             true,

--- a/src/Adapter/Manufacturer/QueryHandler/GetManufacturerForEditingHandler.php
+++ b/src/Adapter/Manufacturer/QueryHandler/GetManufacturerForEditingHandler.php
@@ -44,17 +44,10 @@ final class GetManufacturerForEditingHandler extends AbstractManufacturerHandler
      */
     private $imageTagSourceParser;
 
-    /**
-     * @var int
-     */
-    private $contextShopId;
-
     public function __construct(
-        ImageTagSourceParserInterface $imageTagSourceParser,
-        $contextShopId
+        ImageTagSourceParserInterface $imageTagSourceParser
     ) {
         $this->imageTagSourceParser = $imageTagSourceParser;
-        $this->contextShopId = $contextShopId;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/adapter/manufacturer.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/manufacturer.yml
@@ -8,7 +8,6 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Manufacturer\ManufacturerLogoThumbnailProvider'
     arguments:
       - '@prestashop.core.image.parser.image_tag_source_parser'
-      - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
 
   prestashop.adapter.manufacturer.command_handler.toggle_manufacturer_status_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Manufacturer\CommandHandler\ToggleManufacturerStatusHandler'
@@ -34,7 +33,6 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Manufacturer\QueryHandler\GetManufacturerForEditingHandler'
     arguments:
       - '@prestashop.core.image.parser.image_tag_source_parser'
-      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Manufacturer\Query\GetManufacturerForEditing'


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Changed source path of list logo image (this image is still taken from `img/tmp`, however  now it doesn't depend from shop id). Example of previously taken image path: `img/tmp/manufacturer_1_2.jpg` (first number stands for manufacturerId, second was the shopId), changed to: `img/tmp/manufacturer_1.jpg` (only the id). This Pr intends only fixing the bug. The code should be optimized in following versions by joining some common image parsing/uploading methods.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | Changed cached image name which is used to render image in grid, but it shouldn't be a problem.
| Fixed ticket? | #14299
| How to test?  | Overall manufacturers page shouldn't change, images should be rendered as before. Some behavior regarding multishop should be fixed. Refer the issue #14299 for more info. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14307)
<!-- Reviewable:end -->
