### PR TITLE
Fix wrong tax when duplicating product in BO with several taxes (multishop)

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4456,8 +4456,8 @@ class ProductCore extends ObjectModel
         if (!empty($results)) {
             foreach ($results as $result) {
                 Db::getInstance()->update(
-                    'product_shop', 
-                    array('id_tax_rules_group' => (int) $result['id_tax_rules_group']), 
+                    'product_shop',
+                    array('id_tax_rules_group' => (int) $result['id_tax_rules_group']),
                     'id_product=' . (int) $id_product_new . ' AND id_shop = ' . (int) $result['id_shop']
                 );
             }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4443,7 +4443,7 @@ class ProductCore extends ObjectModel
 
         return Db::getInstance()->insert('product_tag', $data);
     }
-    
+
     public static function duplicateTaxes($id_product_old, $id_product_new)
     {
         $query = new DbQuery();

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4455,11 +4455,13 @@ class ProductCore extends ObjectModel
 
         if (!empty($results)) {
             foreach ($results as $result) {
-                Db::getInstance()->update(
+                if (!Db::getInstance()->update(
                     'product_shop',
                     array('id_tax_rules_group' => (int) $result['id_tax_rules_group']),
                     'id_product=' . (int) $id_product_new . ' AND id_shop = ' . (int) $result['id_shop']
-                );
+                )) {
+                    return false;
+                }
             }
         }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4443,6 +4443,28 @@ class ProductCore extends ObjectModel
 
         return Db::getInstance()->insert('product_tag', $data);
     }
+    
+    public static function duplicateTaxes($id_product_old, $id_product_new)
+    {
+        $query = new DbQuery();
+        $query->select('id_tax_rules_group, id_shop');
+        $query->from('product_shop');
+        $query->where('`id_product` = ' . (int) $id_product_old);
+
+        $results = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query->build());
+
+        if (!empty($results)) {
+            foreach ($results as $result) {
+                Db::getInstance()->update(
+                    'product_shop', 
+                    array('id_tax_rules_group' => (int) $result['id_tax_rules_group']), 
+                    'id_product=' . (int) $id_product_new . ' AND id_shop = ' . (int) $result['id_shop']
+                );
+            }
+        }
+
+        return true;
+    }
 
     public static function duplicateDownload($id_product_old, $id_product_new)
     {

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -216,6 +216,7 @@ class AdminProductDataUpdater implements ProductInterface
             && Pack::duplicate($id_product_old, $product->id)
             && Product::duplicateCustomizationFields($id_product_old, $product->id)
             && Product::duplicateTags($id_product_old, $product->id)
+            && Product::duplicateTaxes($id_product_old, $product->id)
             && Product::duplicateDownload($id_product_old, $product->id)) {
             if ($product->hasAttributes()) {
                 Product::updateDefaultAttribute($product->id);

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -233,6 +233,7 @@ class AdminProductDataUpdater implements ProductInterface
                 return $product->id;
             }
         } else {
+            $product->delete();
             throw new \Exception('An error occurred while creating an object.', 5009);
         }
     }

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -233,7 +233,9 @@ class AdminProductDataUpdater implements ProductInterface
                 return $product->id;
             }
         } else {
-            $product->delete();
+            if ($product->id !== null) {
+                $product->delete();
+            }
             throw new \Exception('An error occurred while creating an object.', 5009);
         }
     }


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | A product duplicated from all shop context set the default shop's tax for all shops. It should set the same tax than the original product (the tax corresponding to the shop).
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14302 
| How to test?  | Steps to reproduce the behavior:
1. Set a multishop with 2 shops (or more) and several taxe rule. For instance:
    - shop FR with Tax rate FR 20%
    - shop CH with Tax rate CH 10%
2. Create a product in context all shop
3. On each shop set a specific tax rate
4. Finally on products board, select the previous product and click on duplicate product on all shop context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14308)
<!-- Reviewable:end -->
