### PR TITLE
Adds missing fields validation in tax create/edit handlers

### DIFF
--- a/src/Adapter/Tax/CommandHandler/AddTaxHandler.php
+++ b/src/Adapter/Tax/CommandHandler/AddTaxHandler.php
@@ -53,6 +53,10 @@ final class AddTaxHandler extends AbstractTaxHandler implements AddTaxHandlerInt
         $tax->active = $command->isEnabled();
 
         try {
+            if (false === $tax->validateFields(false) || false === $tax->validateFieldsLang(false)) {
+                throw new TaxException('Tax contains invalid field values');
+            }
+
             if (!$tax->save()) {
                 throw new TaxException(
                     sprintf('Cannot create tax with id "%s"', $tax->id)

--- a/src/Adapter/Tax/CommandHandler/EditTaxHandler.php
+++ b/src/Adapter/Tax/CommandHandler/EditTaxHandler.php
@@ -58,6 +58,10 @@ final class EditTaxHandler extends AbstractTaxHandler implements EditTaxHandlerI
         }
 
         try {
+            if (false === $tax->validateFields(false) || false === $tax->validateFieldsLang(false)) {
+                throw new TaxException('Tax contains invalid field values');
+            }
+
             if (!$tax->update()) {
                 throw new TaxException(
                     sprintf('Cannot update tax with id "%s"', $tax->id)


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Tax handlers where missing fields validation. This PR adds validation to create and edit tax handlers.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No visible changes, because currently the tax form is taking care of validation before getting to handlers.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14310)
<!-- Reviewable:end -->
