### PR TITLE
Handle bad theme error nicely

### DIFF
--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -239,7 +239,7 @@ class ThemeManager implements AddonManagerInterface
      *
      * @param string $themeName The technical theme name
      *
-     * @return array|false
+     * @return array|string|bool
      */
     public function getErrors($themeName)
     {

--- a/src/Core/Domain/Theme/CommandHandler/EnableThemeHandler.php
+++ b/src/Core/Domain/Theme/CommandHandler/EnableThemeHandler.php
@@ -86,9 +86,17 @@ final class EnableThemeHandler implements EnableThemeHandlerInterface
 
         if (!$this->themeManager->enable($plainThemeName)) {
             $errors = $this->themeManager->getErrors($plainThemeName);
-            $error = is_array($errors) ? reset($errors) : '';
 
-            throw new CannotEnableThemeException(reset($error));
+            if (is_array($errors)) {
+                $error = reset($errors);
+            } elseif ($errors) {
+                $error = $errors;
+            } else {
+                // handle bad error usecases
+                $error = '';
+            }
+
+            throw new CannotEnableThemeException($error);
         }
 
         $this->smartyCacheClearer->clear();

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -509,7 +509,7 @@ class ThemeController extends AbstractAdminController
                     'Admin.Modules.Notification',
                     [
                         '%action%' => strtolower($this->trans('Install', 'Admin.Actions')),
-                        '%module%' => $e->getModuleName(),
+                        '%module%' => ($e instanceof FailedToEnableThemeModuleException) ? $e->getModuleName() : '',
                         '%error_details%' => $e->getMessage(),
                     ]
                 ),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | If Theme Install fails and return a string error message, displays it nicely
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14326
| How to test?  | See ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14331)
<!-- Reviewable:end -->
