### PR TITLE
Move Cart secure_key setter at the right place

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -335,15 +335,16 @@ class ContextCore
 
         if (Configuration::get('PS_CART_FOLLOWING') && (empty($this->cookie->id_cart) || Cart::getNbProducts($this->cookie->id_cart) == 0) && $idCart = (int) Cart::lastNoneOrderedCart($this->customer->id)) {
             $this->cart = new Cart($idCart);
+            $this->cart->secure_key = $customer->secure_key;
         } else {
             $idCarrier = (int) $this->cart->id_carrier;
+            $this->cart->secure_key = $customer->secure_key;
             $this->cart->id_carrier = 0;
             $this->cart->setDeliveryOption(null);
             $this->cart->updateAddressId($this->cart->id_address_delivery, (int) Address::getFirstCustomerAddressId((int) ($customer->id)));
             $this->cart->id_address_delivery = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
             $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
         }
-        $this->cart->secure_key = $customer->secure_key;
         $this->cart->id_customer = (int) $customer->id;
 
         if (isset($idCarrier) && $idCarrier) {

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -332,7 +332,6 @@ class ContextCore
         $customer->logged = 1;
         $this->cookie->email = $customer->email;
         $this->cookie->is_guest = $customer->isGuest();
-        $this->cart->secure_key = $customer->secure_key;
 
         if (Configuration::get('PS_CART_FOLLOWING') && (empty($this->cookie->id_cart) || Cart::getNbProducts($this->cookie->id_cart) == 0) && $idCart = (int) Cart::lastNoneOrderedCart($this->customer->id)) {
             $this->cart = new Cart($idCart);
@@ -344,6 +343,7 @@ class ContextCore
             $this->cart->id_address_delivery = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
             $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
         }
+        $this->cart->secure_key = $customer->secure_key;
         $this->cart->id_customer = (int) $customer->id;
 
         if (isset($idCarrier) && $idCarrier) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix potentiel issue with setting the wrong secureKey to an existing cart
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | fill a cart while not logged, and verify cart is still ok after login

Let say we do the following:

```
$cart = new Cart($idCart1); // $idCart1 belongs to customer 2
$context = Context::getContext();
$context->cart = $cart;
$customer = new Customer($idCustomer);
$context->updateCustomer($idCustomer);
$cart->save();
```
before the fix, if PS_CART_FOLLOWING is set and $idCustomer have a not ordered cart, the $context->cart (and hence $cart) will have its secure key updated, but not its $id_customer, because $context->cart and $cart are copied by reference.
This could cause some nasty bugs, especially in modules handling "loginAsCustomer"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14352)
<!-- Reviewable:end -->
