### PR TITLE
[POC] adds attribute rendering for LinkColumn

### DIFF
--- a/src/Core/Grid/Column/Type/Common/LinkColumn.php
+++ b/src/Core/Grid/Column/Type/Common/LinkColumn.php
@@ -50,6 +50,7 @@ final class LinkColumn extends AbstractColumn
         $resolver
             ->setDefaults([
                 'sortable' => true,
+                'attr' => [],
             ])
             ->setRequired([
                 'field',
@@ -62,6 +63,7 @@ final class LinkColumn extends AbstractColumn
             ->setAllowedTypes('route_param_name', 'string')
             ->setAllowedTypes('route_param_field', 'string')
             ->setAllowedTypes('sortable', 'bool')
+            ->setAllowedTypes('attr', 'array')
         ;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/link.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/link.html.twig
@@ -23,6 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-<a href="{{ path(column.options.route, { (column.options.route_param_name) : record[column.options.route_param_field]}) }}">
+<a {% for attribute,value in column.options.attr %} {{ attribute }}="{{ value }}" {% endfor %} href="{{ path(column.options.route, { (column.options.route_param_name) : record[column.options.route_param_field]}) }}">
   {{ record[column.options.field] }}
 </a>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In my specific case I needed the page to open in a new tab. `<a target="_blank"></a>` will fit my need so I improved `LinkColumn` - but I added more to it. More explanation below :arrow_double_down: 
| Type?         | improvement
| Category?     |  BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | partially required for https://github.com/PrestaShop/PrestaShop/pull/14267
| How to test?  | no need for manual testing


for me right now I only need `taget ="_blank"` attribute and property configuration for `<a></a>` tag. But what if I need more for this - anything from this huge list https://www.w3schools.com/tags/tag_a.asp. There are two options:

1. For each new attribute create new allowed type
2. (My proposal) lets add native `attr` type which already exists in symfony form types and apply it accordingly.

so the result would be:

```php

>add((new LinkColumn('name'))
                ->setName($this->trans('Name', [], 'Admin.Global'))
                ->setOptions([
                    'field' => 'name',
                    'route' => 'admin_cms_pages_index',
                    'route_param_name' => 'id_cms_category',
                    'route_param_field' => 'id_cms_category',
                    'attr' => [
                        'target' => '_blank',
                        'rel' => 'author',
                        'class' => 'btn btn-primary',
                    ],
                ])
            )

```

pros:
1. Highly customizable.
2. Symfony does this already for its form types

cons:
1. this will allow for devs to send even the css from php part ( or we can safelocks to prevent adding styles and class in attribures array :thinking:  ?)


@matks , @rokaszygmantas , @sarjon , @zuk3975, @PierreRambaud  wdyt?

P.s if confirmed this can be applied not only for LinkColumn


- [ ] update docs if any of the column is changed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14353)
<!-- Reviewable:end -->

