### PR TITLE
View button doesn't have href

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
@@ -129,7 +129,7 @@
                   <td class="text-right">
                     <div class="btn-group-action">
                       <div class="btn-group">
-                        <a href=""
+                        <a href="{{ orderViewUrl }}"
                            class="btn tooltip-link dropdown-item"
                            data-toggle="pstooltip"
                            data-placement="top"


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | View button doesn't have href.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14359 .
| How to test?  | Follow ticket instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14364)
<!-- Reviewable:end -->
