### PR TITLE
Wrong way to retrieve CLDR information

### DIFF
--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -59,16 +59,17 @@ class Factory
     {
         $decimalPattern = $cldrLocale->getDecimalPattern();
         $numbersSymbols = $cldrLocale->getAllNumberSymbols();
+        $positivePattern = $this->getPositivePattern($decimalPattern);
 
         return new NumberSpecification(
-            $this->getPositivePattern($decimalPattern),
+            $positivePattern,
             $this->getNegativePattern($decimalPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits,
-            $this->getMinFractionDigits($decimalPattern),
+            $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed,
-            $this->getPrimaryGroupSize($decimalPattern),
-            $this->getSecondaryGroupSize($decimalPattern)
+            $this->getPrimaryGroupSize($positivePattern),
+            $this->getSecondaryGroupSize($positivePattern)
         );
     }
 

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -102,16 +102,18 @@ class Factory
     ) {
         $currencyPattern = $cldrLocale->getCurrencyPattern();
         $numbersSymbols = $cldrLocale->getAllNumberSymbols();
+        // Use positive pattern to retrieve information
+        $positivePattern = $this->getPositivePattern($currencyPattern);
 
         return new PriceSpecification(
-            $this->getPositivePattern($currencyPattern),
+            $positivePattern,
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
-            $this->getMaxFractionDigits($currencyPattern),
-            $this->getMinFractionDigits($currencyPattern),
-            $numberGroupingUsed && $this->getPrimaryGroupSize($currencyPattern) > 1,
-            $this->getPrimaryGroupSize($currencyPattern),
-            $this->getSecondaryGroupSize($currencyPattern),
+            $this->getMaxFractionDigits($positivePattern),
+            $this->getMinFractionDigits($positivePattern),
+            $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
+            $this->getPrimaryGroupSize($positivePattern),
+            $this->getSecondaryGroupSize($positivePattern),
             $currencyDisplayType,
             $currency->getSymbol($localeCode),
             $currency->getIsoCode()

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -59,6 +59,7 @@ class Factory
     {
         $decimalPattern = $cldrLocale->getDecimalPattern();
         $numbersSymbols = $cldrLocale->getAllNumberSymbols();
+        // Use positive pattern to retrieve information
         $positivePattern = $this->getPositivePattern($decimalPattern);
 
         return new NumberSpecification(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Because pattern can contains the negative and the positive pattern (`¤ #,##0.00;¤ -#,##0.00`), min / max fractions digits aren't count properly, same for group size and decimals.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14392 
| How to test?  | Follow ticket instruction

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14400)
<!-- Reviewable:end -->
