### PR TITLE
Check table create privilege for InnoDB and MyISAM

### DIFF
--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -408,22 +408,25 @@ class DbMySQLiCore extends Db
             return false;
         }
 
-        if ($engine === null) {
-            $engine = 'MyISAM';
+        $enginesToTest = ['InnoDB', 'MyISAM'];
+        if ($engine !== null) {
+            $enginesToTest = [$engine];
         }
 
-        $result = $link->query('
-		CREATE TABLE `' . $prefix . 'test` (
-			`test` tinyint(1) unsigned NOT NULL
-		) ENGINE=' . $engine);
+        foreach ($enginesToTest as $engineToTest) {
+            $result = $link->query('
+            CREATE TABLE `' . $prefix . 'test` (
+                `test` tinyint(1) unsigned NOT NULL
+            ) ENGINE=' . $engineToTest);
 
-        if (!$result) {
-            return $link->error;
+            if ($result) {
+                $link->query('DROP TABLE `' . $prefix . 'test`');
+
+                return true;
+            }
         }
 
-        $link->query('DROP TABLE `' . $prefix . 'test`');
-
-        return true;
+        return $link->error;
     }
 
     /**

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -358,22 +358,27 @@ class DbPDOCore extends Db
             return false;
         }
 
-        if ($engine === null) {
-            $engine = 'MyISAM';
+        $enginesToTest = ['InnoDB', 'MyISAM'];
+        if ($engine !== null) {
+            $enginesToTest = [$engine];
         }
 
-        $result = $link->query('
-		CREATE TABLE `' . $prefix . 'test` (
-			`test` tinyint(1) unsigned NOT NULL
-		) ENGINE=' . $engine);
-        if (!$result) {
-            $error = $link->errorInfo();
+        foreach ($enginesToTest as $engineToTest) {
+            $result = $link->query('
+            CREATE TABLE `' . $prefix . 'test` (
+                `test` tinyint(1) unsigned NOT NULL
+            ) ENGINE=' . $engineToTest);
 
-            return $error[2];
+            if ($result) {
+                $link->query('DROP TABLE `' . $prefix . 'test`');
+
+                return true;
+            }
         }
-        $link->query('DROP TABLE `' . $prefix . 'test`');
 
-        return true;
+        $error = $link->errorInfo();
+
+        return $error[2];
     }
 
     /**


### PR DESCRIPTION
The previous implementation only checks MyISAM when no engine was specified.
The new implementation checks InnoDB and MyISAM if no engine is specified.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | During the database check the installation process tries to create a table under the specified database. The engine fallbacks to default one which in this case was MyISAM which on some hosting environments is not supported. This PR enables check also for InnoDB engine.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12675
| How to test?  | To test it easily you can try to install PrestaShop using MySQL engine with disabled MyISAM support. For example, using MySQL hosted on Azure.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14402)
<!-- Reviewable:end -->
