### PR TITLE
Fix cookie collisions from PR # 14116 and improve overall security

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -79,7 +79,7 @@ class CookieCore
         $this->_salt = $this->_standalone ? str_pad('', 32, md5('ps' . __FILE__)) : _COOKIE_IV_;
 
         if ($this->_standalone) {
-            $asciiSafeString = \Defuse\Crypto\Encoding::saveBytesToChecksummedAsciiSafeString(Key::KEY_CURRENT_VERSION, str_pad($name, Key::KEY_BYTE_SIZE, __FILE__));
+            $asciiSafeString = \Defuse\Crypto\Encoding::saveBytesToChecksummedAsciiSafeString(Key::KEY_CURRENT_VERSION, str_pad($name, Key::KEY_BYTE_SIZE, md5(__FILE__)));
             $this->cipherTool = new PhpEncryption($asciiSafeString);
         } else {
             $this->cipherTool = new PhpEncryption(_NEW_COOKIE_KEY_);

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -301,7 +301,7 @@ class CookieCore
             // remove the checksum which is the last element
             array_pop($tmpTab);
             $content_for_checksum = implode('¤', $tmpTab) . '¤';
-            $checksum = crc32($this->_salt . $content_for_checksum);
+            $checksum = hash('sha256', $this->_salt . $content_for_checksum);
             //printf("\$checksum = %s<br />", $checksum);
 
             /* Unserialize cookie content */
@@ -399,7 +399,7 @@ class CookieCore
         }
 
         /* Add checksum to cookie */
-        $newChecksum = crc32($this->_salt . $cookie);
+        $newChecksum = hash('sha256', $this->_salt . $cookie);
         // do not set cookie if the checksum is the same: it means the content has not changed!
         if ($previousChecksum === $newChecksum) {
             return;

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -76,7 +76,7 @@ class CookieCore
         $this->_domain = $this->getDomain($shared_urls);
         $this->_name = 'PrestaShop-' . md5(($this->_standalone ? '' : _PS_VERSION_) . $name . $this->_domain);
         $this->_allow_writing = true;
-        $this->_salt = $this->_standalone ? str_pad('', 8, md5('ps' . __FILE__)) : _COOKIE_IV_;
+        $this->_salt = $this->_standalone ? str_pad('', 32, md5('ps' . __FILE__)) : _COOKIE_IV_;
 
         if ($this->_standalone) {
             $asciiSafeString = \Defuse\Crypto\Encoding::saveBytesToChecksummedAsciiSafeString(Key::KEY_CURRENT_VERSION, str_pad($name, Key::KEY_BYTE_SIZE, __FILE__));

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -126,7 +126,7 @@ if ($lastParametersModificationTime) {
         define('_COOKIE_IV_', $config['parameters']['cookie_iv']);
     } else {
         // Define cookie IV if missing to prevent failure in composer post-install script
-        define('_COOKIE_IV_', Tools::passwdGen(8));
+        define('_COOKIE_IV_', Tools::passwdGen(32));
     }
 
     // New cookie

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -156,7 +156,7 @@ class Install extends AbstractInstall
 
         $secret = Tools::passwdGen(56);
         $cookie_key = defined('_COOKIE_KEY_') ? _COOKIE_KEY_ : Tools::passwdGen(56);
-        $cookie_iv = defined('_COOKIE_IV_') ? _COOKIE_IV_ : Tools::passwdGen(8);
+        $cookie_iv = defined('_COOKIE_IV_') ? _COOKIE_IV_ : Tools::passwdGen(32);
         $database_port = null;
 
         $splits = preg_split('#:#', $database_host);

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -154,8 +154,8 @@ class Install extends AbstractInstall
             return false;
         }
 
-        $secret = Tools::passwdGen(56);
-        $cookie_key = defined('_COOKIE_KEY_') ? _COOKIE_KEY_ : Tools::passwdGen(56);
+        $secret = Tools::passwdGen(64);
+        $cookie_key = defined('_COOKIE_KEY_') ? _COOKIE_KEY_ : Tools::passwdGen(64);
         $cookie_iv = defined('_COOKIE_IV_') ? _COOKIE_IV_ : Tools::passwdGen(32);
         $database_port = null;
 

--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -1167,7 +1167,7 @@ namespace PrestaShopBundle\Install {
                 @unlink($tmp_settings_file);
                 $factory = new RandomLib\Factory();
                 $generator = $factory->getLowStrengthGenerator();
-                $secret = $generator->generateString(56);
+                $secret = $generator->generateString(64);
 
                 if (!defined('_LEGACY_NEW_COOKIE_KEY_')) {
                     define('_LEGACY_NEW_COOKIE_KEY_', $default_parameters['parameters']['new_cookie_key']);

--- a/tests-legacy/Endpoints/AbstractEndpointAdminTest.php
+++ b/tests-legacy/Endpoints/AbstractEndpointAdminTest.php
@@ -50,7 +50,7 @@ abstract class AbstractEndpointAdminTest extends AbstractEndpointTest
     {
         $cipherTool = new PhpEncryption(_NEW_COOKIE_KEY_);
         $cookieContent = 'id_employee|1¤';
-        $cookieContent .= 'checksum|' . crc32(_COOKIE_IV_ . $cookieContent);
+        $cookieContent .= 'checksum|' . hash('sha256', _COOKIE_IV_ . $cookieContent);
         $cookieName = 'PrestaShop-' . md5(_PS_VERSION_ . 'psAdmin');
         $_COOKIE[$cookieName] = $cipherTool->encrypt($cookieContent);
         Cache::store('isLoggedBack' . 1, true);

--- a/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
+++ b/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
@@ -178,7 +178,7 @@ class ControllerTest extends TestCase
             define('_DB_PREFIX_', $configuration['parameters']['database_prefix']);
         }
         if (!defined('_COOKIE_KEY_')) {
-            define('_COOKIE_KEY_', Tools::passwdGen(56));
+            define('_COOKIE_KEY_', Tools::passwdGen(64));
         }
         if (!defined('_PS_VERSION_')) {
             define('_PS_VERSION_', '1.7');


### PR DESCRIPTION
Fix cookie collisions introduced in https://github.com/PrestaShop/PrestaShop/pull/14116 and several security improvements.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | See commit descriptions.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | No new functionality, no need for extra tests. You should be able to login & continue to navigate in FO and BO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14403)
<!-- Reviewable:end -->
