### PR TITLE
Refactor theme usage of product flags - apply DRY

### DIFF
--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -82,14 +82,7 @@
         {/block}
       </div>
 
-      <!-- @todo: use include file='catalog/_partials/product-flags.tpl'} -->
-      {block name='product_flags'}
-        <ul class="product-flags">
-          {foreach from=$product.flags item=flag}
-            <li class="product-flag {$flag.type}">{$flag.label}</li>
-          {/foreach}
-        </ul>
-      {/block}
+      {include file='catalog/_partials/product-flags.tpl'}
 
       <div class="highlighted-informations{if !$product.main_variants} no-variants{/if} hidden-sm-down">
         {block name='quick_view'}

--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -57,14 +57,7 @@
         {block name='page_content_container'}
           <section class="page-content" id="content">
             {block name='page_content'}
-              <!-- @todo: use include file='catalog/_partials/product-flags.tpl'} -->
-              {block name='product_flags'}
-                <ul class="product-flags">
-                  {foreach from=$product.flags item=flag}
-                    <li class="product-flag {$flag.type}">{$flag.label}</li>
-                  {/foreach}
-                </ul>
-              {/block}
+              {include file='catalog/_partials/product-flags.tpl'}
 
               {block name='product_cover_thumbnails'}
                 {include file='catalog/_partials/product-cover-thumbnails.tpl'}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I added a `@todo` in PR https://github.com/PrestaShop/PrestaShop/pull/14325 because it was not the right moment to perform some impacting refactoring. Now is the good time, so I de-duplicated some HTML in Classic Theme. See https://github.com/PrestaShop/PrestaShop/pull/14325#discussion_r296225852
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Please check that https://github.com/PrestaShop/PrestaShop/issues/14321 issue is still solved and Product page and FO pages that have a list of product display correctly the small label on the image (see https://github.com/PrestaShop/PrestaShop/issues/14321)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14422)
<!-- Reviewable:end -->
