### PR TITLE
order-final-summary shipping carrier name remove

### DIFF
--- a/themes/classic/templates/checkout/_partials/order-final-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary.tpl
@@ -70,14 +70,11 @@
               {if $selected_delivery_option.logo}
                 <img src="{$selected_delivery_option.logo}" alt="{$selected_delivery_option.name}">
               {else}
-                &nbsp;
+                <span class="carrier-name">{$selected_delivery_option.name}</span>
               {/if}
             </div>
           </div>
-          <div class="col-md-4">
-            <span class="carrier-name">{$selected_delivery_option.name}</span>
-          </div>
-          <div class="col-md-4">
+          <div class="col-md-8">
             <span class="carrier-delay">{$selected_delivery_option.delay}</span>
           </div>
           <div class="col-md-2">


### PR DESCRIPTION
When the selected carrier delay contains text, that is most likely the widest column. On the other hand the carrier image is most often the company logo.

**Before screenshot**
![Classic theme_ product with combinations_ checkout shows base product name instead of chosen combination name · Issue #14361 · PrestaShop_PrestaShop](https://user-images.githubusercontent.com/515451/60366383-ab312600-99eb-11e9-943c-181047f85327.png)

When the company logo is displayed, is no need to display the name in the 2nd column, as it is already the alternative text of the image. This change re-uses the first column in the summary to display the selected carrier name when no carrier images is present. By that change the carrier-name column can be removed, and the selected_delivery_option.delay column with can be doubled.

**After screenshot**
![order-final-summary after improvement](https://user-images.githubusercontent.com/515451/60366499-fb0fed00-99eb-11e9-93ce-d64704c166c3.png)

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | classic theme
| Type?         | improvement
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) 
| How to test?  | In the BO => Shop Parameters => Order Settings page => We need to enable the "final summary" to reproduce the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14426)
<!-- Reviewable:end -->
