### PR TITLE
fix for missing border of text editor on category and brand pages

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_tinymce.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tinymce.scss
@@ -1221,4 +1221,5 @@ i.mce-i-backcolor {
 .nav-pills.translationsLocales {
   border-left: 1px solid #dfdfdf;
   border-right: 1px solid #dfdfdf;
+  border-bottom: none;
 }

--- a/admin-dev/themes/new-theme/scss/components/_tinymce.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tinymce.scss
@@ -1207,6 +1207,7 @@ i.mce-i-backcolor {
 .tab-content.translationsFields {
   padding: 0;
   .mce-tinymce {
+    border-top: 1px solid #DFDFDF !important;
     border-bottom: 1px solid #DFDFDF !important;
     border-left: 1px solid #DFDFDF !important;
     border-right: 1px solid #DFDFDF !important;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | fix for missing border of text editor on category and brand pages
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14448
| How to test?  |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14449)
<!-- Reviewable:end -->
