### PR TITLE
Whitelist filters for the Logs Page

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/LogRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LogRepository.php
@@ -212,6 +212,18 @@ class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterfac
      */
     private function buildGridQuery(SearchCriteriaInterface $searchCriteria)
     {
+        $allowedFilters = [
+            'id_log',
+            'firstname',
+            'lastname',
+            'severity',
+            'message',
+            'object_type',
+            'object_id',
+            'error_code',
+            'date_add',
+        ];
+
         $employeeTable = $this->databasePrefix . 'employee';
 
         $qb = $this->connection
@@ -226,6 +238,9 @@ class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterfac
         $filters = $searchCriteria->getFilters();
         foreach ($filters as $filterName => $filterValue) {
             if (empty($filterValue)) {
+                continue;
+            }
+            if (!in_array($filterName, $allowedFilters)) {
                 continue;
             }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Filters in logs page are now whitelisted
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | Fixes #12835 
| How to test?  | * Go to BO Logs page, URL should be something like http://localhost/admin-dev/index.php/configure/advanced/logs/<br>* Perform a filter search, for example filter logs on the word "Back", the URL should be something like http://localhost/admin-dev/index.php/configure/advanced/logs/?filters%5Bmessage%5D=Back&_token=[your token]<br>* Modify this URL and replace "message" by "mossage"<br>* Refresh with the modified URL<br>* The filter will not filtered because it is not in the white list

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14450)
<!-- Reviewable:end -->
