### PR TITLE
Allow to buy a product without stock when other combinations have stock and unavailable product attributes are not displayed

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1007,13 +1007,15 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     private function tryToGetAvailableIdProductAttribute($checkedIdProductAttribute)
     {
         if (!Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
-            $availableProductAttributes = array_filter(
-                $this->product->getAttributeCombinations(),
-                function ($elem) {
-                    return $elem['quantity'] > 0;
-                }
-            );
-
+            $availableProductAttributes = $this->product->getAttributeCombinations();
+            if (!Product::isAvailableWhenOutOfStock($this->product->out_of_stock)) {
+                $availableProductAttributes = array_filter(
+                    $availableProductAttributes,
+                    function ($elem) {
+                        return $elem['quantity'] > 0;
+                    }
+                );
+            }
             $availableProductAttribute = array_filter(
                 $availableProductAttributes,
                 function ($elem) use ($checkedIdProductAttribute) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Permit to buy a product without stock when other combination have stock and unavailable product attributes are not displayed
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9667 
| How to test?  | * Create a product with combinations. Put stock in some combination but not in all.<br>* Allow to buy products out of stock.<br>* Disable the option "Display unavailable product attributes on the product page" in Product Settings page<br>* In FO, combinations out of stock can be selected

@colinegin @TristanLDD I think that correct the bug #9667 but the behavior is not perfect : when you deny to buy products out of stock, the combination (which doesn't have stock) reset

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14452)
<!-- Reviewable:end -->
