### PR TITLE
Update facetedsearch to 3.0.6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3789,16 +3789,16 @@
         },
         {
             "name": "prestashop/ps_facetedsearch",
-            "version": "v3.0.5",
+            "version": "v3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_facetedsearch.git",
-                "reference": "e2b6045ddf3421bda6474b4834d97495c9c106ba"
+                "reference": "2b8a461669715c9989aa223f2205f45e608b5d23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_facetedsearch/zipball/e2b6045ddf3421bda6474b4834d97495c9c106ba",
-                "reference": "e2b6045ddf3421bda6474b4834d97495c9c106ba",
+                "url": "https://api.github.com/repos/PrestaShop/ps_facetedsearch/zipball/2b8a461669715c9989aa223f2205f45e608b5d23",
+                "reference": "2b8a461669715c9989aa223f2205f45e608b5d23",
                 "shasum": ""
             },
             "require": {
@@ -3834,7 +3834,7 @@
             ],
             "description": "PrestaShop module ps_facetedsearch",
             "homepage": "https://github.com/PrestaShop/ps_facetedsearch",
-            "time": "2019-06-19T09:39:30+00:00"
+            "time": "2019-07-01T16:31:53+00:00"
         },
         {
             "name": "prestashop/ps_faviconnotificationbo",


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Update to facetedsearch 3.0.6.
| Type?         | bug fix
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Faceted search must be installed in 3.0.6.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14453)
<!-- Reviewable:end -->
