### PR TITLE
Avoid people to destroy their database on schema update command

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -84,7 +84,7 @@ doctrine:
                 password: "%database_password%"
                 server_version: 5.1
                 charset:  UTF8
-                platform_service: prestashop.core.ignore_foreign_keys_platform
+                platform_service: prestashop.doctrine.ignore_foreign_keys_platform
                 # if using pdo_sqlite as your database driver:
                 #   1. add the path in parameters.yml
                 #     e.g. database_path: "%kernel.root_dir%/data/data.db3"

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -84,6 +84,7 @@ doctrine:
                 password: "%database_password%"
                 server_version: 5.1
                 charset:  UTF8
+                platform_service: prestashop.core.ignore_foreign_keys_platform
                 # if using pdo_sqlite as your database driver:
                 #   1. add the path in parameters.yml
                 #     e.g. database_path: "%kernel.root_dir%/data/data.db3"

--- a/config/services/common.yml
+++ b/config/services/common.yml
@@ -14,5 +14,8 @@ services:
         class: PrestaShopBundle\Service\Database\DoctrineNamingStrategy
         arguments: ['%database_prefix%']
 
+    prestashop.doctrine.ignore_foreign_keys_platform:
+        class: PrestaShopBundle\Doctrine\IgnoreForeignKeysPlatform
+
     annotation_reader:
         class: Doctrine\Common\Annotations\AnnotationReader

--- a/src/PrestaShopBundle/Doctrine/IgnoreForeignKeysPlatform.php
+++ b/src/PrestaShopBundle/Doctrine/IgnoreForeignKeysPlatform.php
@@ -1,29 +1,29 @@
 <?php
 
 /**
-* 2007-2019 PrestaShop and Contributors
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Open Software License (OSL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* https://opensource.org/licenses/OSL-3.0
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to https://www.prestashop.com for more information.
-*
-* @author    PrestaShop SA <contact@prestashop.com>
-* @copyright 2007-2019 PrestaShop SA and Contributors
-* @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
-* International Registered Trademark & Property of PrestaShop SA
-*/
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
 
 namespace PrestaShopBundle\Doctrine;
 
@@ -38,7 +38,7 @@ final class IgnoreForeignKeysPlatform extends MySQL57Platform
     {
         return false;
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/PrestaShopBundle/Doctrine/IgnoreForeignKeysPlatform.php
+++ b/src/PrestaShopBundle/Doctrine/IgnoreForeignKeysPlatform.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+* 2007-2019 PrestaShop and Contributors
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* https://opensource.org/licenses/OSL-3.0
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to https://www.prestashop.com for more information.
+*
+* @author    PrestaShop SA <contact@prestashop.com>
+* @copyright 2007-2019 PrestaShop SA and Contributors
+* @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+* International Registered Trademark & Property of PrestaShop SA
+*/
+
+namespace PrestaShopBundle\Doctrine;
+
+use Doctrine\DBAL\Platforms\MySQL57Platform;
+
+final class IgnoreForeignKeysPlatform extends MySQL57Platform
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsForeignKeyConstraints()
+    {
+        return false;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsForeignKeyOnUpdate()
+    {
+        return false;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -107,5 +107,5 @@ services:
         class: PrestaShop\PrestaShop\Core\Product\ProductCsvExporter
         arguments: ['@translator', '@prestashop.core.admin.data_provider.product_interface']
 
-    prestashop.core.ignore_foreign_keys_platform:
-        class: PrestaShopBundle\Doctrine\IgnoreForeignKeysPlatform
+    prestashop.doctrine.ignore_foreign_keys_platform:
+      class: PrestaShopBundle\Doctrine\IgnoreForeignKeysPlatform

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -106,3 +106,6 @@ services:
     prestashop.core.product.csv_exporter:
         class: PrestaShop\PrestaShop\Core\Product\ProductCsvExporter
         arguments: ['@translator', '@prestashop.core.admin.data_provider.product_interface']
+
+    prestashop.core.ignore_foreign_keys_platform:
+        class: PrestaShopBundle\Doctrine\IgnoreForeignKeysPlatform


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Since 1.7.1 our foreign keys are invalid and Doctrine ORM is not fine with it. For now, let's disable Foreign Keys support so people won't break their shop when using `php bin/console doctrine:schema:update --force`
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | None **yet**, but critical ones later
| How to test?  | Simple, using the Command line interface, do "php bin/console doctrine:schema:update" before and after this contribution. Ping @jolelievre for review :)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14458)
<!-- Reviewable:end -->
