### PR TITLE
Ignore index.php files in Doctrine entities scanning

### DIFF
--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -96,6 +96,11 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
     }
 
     /**
+     * This method is derived from DoctrineOrmMappingsPass::createAnnotationMappingDriver, sadly the driver includes
+     * ALL the files present in the folder and as modules include an index.php file containing an exit statement the
+     * whole process was stopped. So we manually create the DoctrineOrmMappingsPass so that AnnotationDriver ignores
+     * the index.php file.
+     *
      * @param string $moduleNamespace
      * @param string $moduleEntityDirectory
      * @param string $modulePrefix


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Change annotation driver settings so that it ignores index.php files present in Entities folder (the file contains an exit which stopped all doctrine commands execution)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Install productcomments module, try to run `doctrine:mapping:info` or `doctrine:schema:update` command without this PR nothing happens, with the PR it works correctly and the module's entities are listed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14460)
<!-- Reviewable:end -->
