### PR TITLE
Fix saving of selected BO language

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
@@ -30,6 +30,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * This form class is responsible to create a translatable form.
@@ -37,6 +38,44 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class TranslateType extends CommonAbstractType
 {
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    /**
+     * @var bool
+     */
+    private $saveFormLocaleChoice;
+
+    /**
+     * @var int
+     */
+    private $defaultFormLanguageId;
+
+    /**
+     * @var int
+     */
+    private $defaultShopLanguageId;
+
+    /**
+     * @param UrlGeneratorInterface $urlGenerator
+     * @param bool $saveFormLocaleChoice
+     * @param int $defaultFormLanguageId
+     * @param int $defaultShopLanguageId
+     */
+    public function __construct(
+        UrlGeneratorInterface $urlGenerator,
+        $saveFormLocaleChoice,
+        $defaultFormLanguageId,
+        $defaultShopLanguageId
+    ) {
+        $this->urlGenerator = $urlGenerator;
+        $this->saveFormLocaleChoice = $saveFormLocaleChoice;
+        $this->defaultFormLanguageId = $defaultFormLanguageId;
+        $this->defaultShopLanguageId = $defaultShopLanguageId;
+    }
+
     /**
      * {@inheritdoc}
      *
@@ -67,8 +106,14 @@ class TranslateType extends CommonAbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['locales'] = $options['locales'];
-        $view->vars['defaultLocale'] = $options['locales'][0];
+        $view->vars['defaultLocale'] = $this->getDefaultLocale($options['locales']);
         $view->vars['hideTabs'] = $options['hideTabs'];
+
+        if ($this->saveFormLocaleChoice) {
+            $view->vars['change_form_language_url'] = $this->urlGenerator->generate(
+                'admin_employees_change_form_language'
+            );
+        }
     }
 
     /**
@@ -92,5 +137,33 @@ class TranslateType extends CommonAbstractType
     public function getBlockPrefix()
     {
         return 'translatefields';
+    }
+
+    /**
+     * Get default locale.
+     *
+     * @param array $locales
+     *
+     * @return array
+     */
+    private function getDefaultLocale(array $locales)
+    {
+        if ($this->defaultFormLanguageId) {
+            // Searching for a locale that matches default form language
+            foreach ($locales as $locale) {
+                if ($locale['id_lang'] == $this->defaultFormLanguageId) {
+                    return $locale;
+                }
+            }
+        }
+
+        // Searching for locale that matches default shop language
+        foreach ($locales as $locale) {
+            if ($locale['id_lang'] == $this->defaultShopLanguageId) {
+                return $locale;
+            }
+        }
+
+        return reset($locales);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
@@ -148,18 +148,12 @@ class TranslateType extends CommonAbstractType
      */
     private function getDefaultLocale(array $locales)
     {
-        if ($this->defaultFormLanguageId) {
-            // Searching for a locale that matches default form language
-            foreach ($locales as $locale) {
-                if ($locale['id_lang'] == $this->defaultFormLanguageId) {
-                    return $locale;
-                }
-            }
-        }
+        // If default form language is not available we will use default shop language
+        $languageId = $this->defaultFormLanguageId ?: $this->defaultShopLanguageId;
 
-        // Searching for locale that matches default shop language
+        // Searching for a locale that matches the selected language
         foreach ($locales as $locale) {
-            if ($locale['id_lang'] == $this->defaultShopLanguageId) {
+            if ($locale['id_lang'] == $languageId) {
                 return $locale;
             }
         }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -28,6 +28,11 @@ services:
     form.type.product.translate:
         class: 'PrestaShopBundle\Form\Admin\Type\TranslateType'
         parent: 'form.type.common_type'
+        arguments:
+            - '@router.default'
+            - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_BO_ALLOW_EMPLOYEE_FORM_LANG')"
+            - "@=service('prestashop.adapter.legacy.context').getContext().cookie.employee_form_lang"
+            - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
         public: true
         tags:
             - { name: form.type }

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -659,6 +659,9 @@
         <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
                 type="button"
                 data-toggle="dropdown"
+                {% if change_form_language_url is defined %}
+                  data-change-language-url="{{ form.vars.change_form_language_url }}"
+                {% endif %}
                 aria-haspopup="true"
                 aria-expanded="false"
                 id="{{ form.vars.id }}"


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There is a setting, which enables saving of selected language in BO forms. When enabled, whenever you choose a language in translatable field, the language will be memorized and preselected in all forms. This feature was not working in migrated pages.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | No
| How to test?  | Steps below.

Steps to test:
1. Enable _Memorize the language used in Admin panel forms_ setting at `/admin-dev/index.php/configure/advanced/employees/`
2. Go to a migrated form that has translatable inputs, e.g. `/admin-dev/index.php/configure/shop/product-preferences/` or any other.
3. Change language on translatable input.
4. Refresh the page - language should remain the same as have selected before.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14466)
<!-- Reviewable:end -->
