### PR TITLE
Fix go to the FO action

### DIFF
--- a/tests/E2E/test/campaigns/full/02_product/15_buttons_in_header_product_page.js
+++ b/tests/E2E/test/campaigns/full/02_product/15_buttons_in_header_product_page.js
@@ -65,10 +65,10 @@ scenario('Check that the buttons in header product page works successfully', () 
     test('should check that the "Product name" input exists', () => client.isExisting(AddProductPage.product_name_fr_input, 2000));
     test('should set the "Product name" input', () => client.waitAndSetValue(AddProductPage.product_name_fr_input, 'produit' + date_time));
     test('should click on "Save" button', () => client.waitForExistAndClick(AddProductPage.save_product_button, 2000));
+    test('should check and close the validation alert message', () => client.waitForVisibleAndClick(AddProductPage.close_validation_button));
     test('should go to the Front Office', () => {
       return promise
-        .then(() => client.waitForExistAndClick(AddProductPage.close_validation_button))
-        .then(() => client.waitForExistAndClick(AccessPageBO.shopname))
+        .then(() => client.waitForExistAndClick(AccessPageBO.shopname, 2000))
         .then(() => client.switchWindow(1));
     });
     test('should switch the front office language to French', () => client.changeLanguage('fr'));


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Add a waitForVisibleAndClick to close the validation alert and a pause to be able to click on the shopName and go to the Front office.
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH=full/02_product/15_buttons_in_header_product_page npm run specific-test -- --URL=SHOPURL --DIR=DOWNLOADPATH/


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14468)
<!-- Reviewable:end -->
