### PR TITLE
When upgrading, grant the same rights to the parent tabs

### DIFF
--- a/classes/Access.php
+++ b/classes/Access.php
@@ -356,6 +356,17 @@ class AccessCore extends ObjectModel
             $whereClauses[] = ' `slug` LIKE "' . $slugLike . '"';
         }
 
+        // We do not use Tab::recursiveTab which is risky during an upgrade
+        $idParent = (int) Db::getInstance()->getValue('
+            SELECT `id_parent`
+            FROM `' . _DB_PREFIX_ . 'tab`
+            WHERE `id_tab` = "' . (int) $idTab . '"
+        ');
+        // Add the same rights to the parent tab (don't do it in case of rights deletion)
+        if ($enabled && $idParent) {
+            $this->updateLgcAccess($idProfile, $idParent, $lgcAuth, $enabled, 0);
+        }
+
         if ($addFromParent == 1) {
             foreach (self::findSlugByIdParentTab($idTab) as $child) {
                 $child = self::sluggifyTab($child);

--- a/classes/Access.php
+++ b/classes/Access.php
@@ -363,7 +363,7 @@ class AccessCore extends ObjectModel
             WHERE `id_tab` = "' . (int) $idTab . '"
         ');
         // Add the same rights to the parent tab (don't do it in case of rights deletion)
-        if ($enabled && $idParent) {
+        if ($enabled && $idParent > 0) {
             $this->updateLgcAccess($idProfile, $idParent, $lgcAuth, $enabled, 0);
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PRs aims to fix the permission issues detected for non SuperAdmin profiles when uprading from 1.6
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes #9513
| How to test?  | Upgrade from 1.6 and check the permissions you had are still valid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14481)
<!-- Reviewable:end -->
