### PR TITLE
Disallow ordering a product that was transformed from regular into product with combinations

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4828,7 +4828,8 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Are all products of the Cart still exist?
+     * Are all products of the Cart still available in the current state ? They might have been converted to another
+     * type of product since then
      *
      * @return bool False if not all products in the cart still exist
      */

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4832,7 +4832,7 @@ class CartCore extends ObjectModel
      *
      * @return bool False if not all products in the cart still exist
      */
-    public function isAllProductsStillExist()
+    public function checkAllProductsAreStillAvailableInThisState()
     {
         foreach ($this->getProducts(false, false, null, false) as $product) {
             $currentProduct = new Product();
@@ -4842,6 +4842,8 @@ class CartCore extends ObjectModel
                 return false;
             }
         }
+
+        return true;
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4281,6 +4281,14 @@ class CartCore extends ObjectModel
         $success = true;
         $products = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'cart_product` WHERE `id_cart` = ' . (int) $this->id);
 
+        foreach ($products as $key => $product) {
+            $currentProduct = new Product();
+            $currentProduct->hydrate($product);
+            if ($currentProduct->hasAttributes() && $product['id_product_attribute'] === 0) {
+                unset($products[$key]);
+            }
+        }
+        
         $orderId = Order::getIdByCartId((int) $this->id);
         $product_gift = array();
         if ($orderId) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4831,7 +4831,7 @@ class CartCore extends ObjectModel
      * Are all products of the Cart still available in the current state ? They might have been converted to another
      * type of product since then
      *
-     * @return bool False if not all products in the cart still exist
+     * @return bool False if one of the products from the cart has been changed into a new type of product
      */
     public function checkAllProductsAreStillAvailableInThisState()
     {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4281,14 +4281,6 @@ class CartCore extends ObjectModel
         $success = true;
         $products = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'cart_product` WHERE `id_cart` = ' . (int) $this->id);
 
-        foreach ($products as $key => $product) {
-            $currentProduct = new Product();
-            $currentProduct->hydrate($product);
-            if ($currentProduct->hasAttributes() && $product['id_product_attribute'] === 0) {
-                unset($products[$key]);
-            }
-        }
-        
         $orderId = Order::getIdByCartId((int) $this->id);
         $product_gift = array();
         if ($orderId) {
@@ -4833,6 +4825,23 @@ class CartCore extends ObjectModel
             FROM `' . _DB_PREFIX_ . 'customer` cu
             LEFT JOIN `' . _DB_PREFIX_ . 'cart` ca ON (ca.`id_customer` = cu.`id_customer`)
             WHERE ca.`id_cart` = ' . (int) $id_cart);
+    }
+
+    /**
+     * Are all products of the Cart still exist?
+     *
+     * @return bool False if not all products in the cart still exist
+     */
+    public function isAllProductsStillExist()
+    {
+        foreach ($this->getProducts(false, false, null, false) as $product) {
+            $currentProduct = new Product();
+            $currentProduct->hydrate($product);
+
+            if ($currentProduct->hasAttributes() && $product['id_product_attribute'] === '0') {
+                return false;
+            }
+        }
     }
 
     /**

--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -43,9 +43,11 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
 
     public function handleRequest(array $requestParams = array())
     {
-        $allProductsInStock = $this->getCheckoutSession()->getCart()->isAllProductsInStock();
+        $cart = $this->getCheckoutSession()->getCart();
+        $allProductsInStock = $cart->isAllProductsInStock();
+        $allProductsExist = $cart->isAllProductsStillExist();
 
-        if ($allProductsInStock !== true) {
+        if ($allProductsInStock !== true || $allProductsExist !== true) {
             $cartShowUrl = $this->context->link->getPageLink(
                 'cart',
                 null,

--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -45,7 +45,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
     {
         $cart = $this->getCheckoutSession()->getCart();
         $allProductsInStock = $cart->isAllProductsInStock();
-        $allProductsExist = $cart->isAllProductsStillExist();
+        $allProductsExist = $cart->checkAllProductsAreStillAvailableInThisState();
 
         if ($allProductsInStock !== true || $allProductsExist !== true) {
             $cartShowUrl = $this->context->link->getPageLink(

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -597,11 +597,27 @@ class CartControllerCore extends FrontController
      */
     protected function areProductsAvailable()
     {
+        $products = $this->context->cart->getProducts();
+
+        foreach ($products as $product) {
+            $currentProduct = new Product();
+            $currentProduct->hydrate($product);
+
+            if ($currentProduct->hasAttributes() && $product['id_product_attribute'] === '0') {
+                return $this->trans(
+                    'The item %product% in your cart is no longer available in this version. You cannot proceed with your order until you delete or replace your product by a new one with attribute.',
+                    array('%product%' => $product['name']),
+                    'Shop.Notifications.Error'
+                );
+            }
+        }
+
         $product = $this->context->cart->checkQuantities(true);
 
         if (true === $product || !is_array($product)) {
             return true;
         }
+
         if ($product['active']) {
             return $this->trans(
                 'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -520,7 +520,7 @@ class CartControllerCore extends FrontController
                 } elseif ($this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
                     // check quantity after cart quantity update
                     $this->{$ErrorKey}[] = $this->trans(
-                        'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
+                        'The item %product% in your cart is now a product with attributes. Please delete it and choose one of its combinations to proceed with your order.',
                         array('%product%' => $product->name),
                         'Shop.Notifications.Error'
                     );

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -520,8 +520,8 @@ class CartControllerCore extends FrontController
                 } elseif ($this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
                     // check quantity after cart quantity update
                     $this->{$ErrorKey}[] = $this->trans(
-                        'The item %product% in your cart is now a product with attributes. Please delete it and choose one of its combinations to proceed with your order.',
-                        array('%product%' => $product->name),
+                        'The product is no longer available in this quantity.',
+                        array(),
                         'Shop.Notifications.Error'
                     );
                 }
@@ -605,7 +605,7 @@ class CartControllerCore extends FrontController
 
             if ($currentProduct->hasAttributes() && $product['id_product_attribute'] === '0') {
                 return $this->trans(
-                    'The item %product% in your cart is no longer available in this version. You cannot proceed with your order until you delete or replace your product by a new one with attribute.',
+                   'The item %product% in your cart is now a product with attributes. Please delete it and choose one of its combinations to proceed with your order.',
                     array('%product%' => $product['name']),
                     'Shop.Notifications.Error'
                 );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | It is possible to order perviously created simple product after its transformation to a product with combinations. (so, the simple product should be unavailable for order)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13497
| How to test?  | Please see original issue #13497. Please also check "standard" checkout usecases

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14489)
<!-- Reviewable:end -->
