### PR TITLE
Fix conditions in function deleteProduct

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1712,7 +1712,7 @@ class CartCore extends ObjectModel
                 WHERE `id_cart` = ' . (int) $this->id . '
                 AND `id_product` = ' . (int) $id_product . '
                 AND `id_customization` = ' . (int) $id_customization .
-                ($id_product_attribute != null ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
+                ($id_product_attribute != 0 ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
             );
         }
 
@@ -1723,7 +1723,7 @@ class CartCore extends ObjectModel
                 SET `quantity` = ' . (int) $preservedGifts[(int) $id_product . '-' . (int) $id_product_attribute] . '
                 WHERE `id_cart` = ' . (int) $this->id . '
                 AND `id_product` = ' . (int) $id_product .
-                ($id_product_attribute != null ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
+                ($id_product_attribute != 0 ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
             );
         }
 
@@ -1732,7 +1732,7 @@ class CartCore extends ObjectModel
         DELETE FROM `' . _DB_PREFIX_ . 'cart_product`
         WHERE `id_product` = ' . (int) $id_product . '
         AND `id_customization` = ' . (int) $id_customization .
-            (null !== $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '') . '
+            (0 !== $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '') . '
         AND `id_cart` = ' . (int) $this->id . '
         ' . ((int) $id_address_delivery ? 'AND `id_address_delivery` = ' . (int) $id_address_delivery : ''));
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the cart class in the function deleteProduct() we set in params default value for id_product_attribute = 0 but after in the code we test if $id_product_attribute != null.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | In the function deleteProduct of the class cart.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14501)
<!-- Reviewable:end -->
