### PR TITLE
Fix bug in FO translations with multiple resources and tpl inclusions

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -217,9 +217,13 @@ function smartyTranslate($params, $smarty)
     }
 
     $string = str_replace('\'', '\\\'', $params['s']);
-    $resourcePrefix = substr($smarty->source->resource, 0, strpos($smarty->source->resource, ':'));
-    $templatePrefix = substr($smarty->template_resource, 0, strpos($smarty->template_resource, ':'));
-    $filename = $resourcePrefix === $templatePrefix ? $smarty->source->resource : $smarty->template_resource;
+    
+    // fix inheritance template filename in case of includes from different cross sources between theme, modules, ...
+    $filename = $smarty->template_resource;
+    if (!isset($smarty->inheritance->sourceStack[0]) || $filename === $smarty->inheritance->sourceStack[0]->resource) {
+        $filename = $smarty->source->name;
+    }
+
     $basename = basename($filename, '.tpl');
     $key = $basename.'_'.md5($string);
 

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -217,7 +217,10 @@ function smartyTranslate($params, $smarty)
     }
 
     $string = str_replace('\'', '\\\'', $params['s']);
-    $basename = basename($smarty->source->name, '.tpl');
+    $resourcePrefix = substr($smarty->source->resource, 0, strpos($smarty->source->resource, ':'));
+    $templatePrefix = substr($smarty->template_resource, 0, strpos($smarty->template_resource, ':'));
+    $filename = $resourcePrefix === $templatePrefix ? $smarty->source->resource : $smarty->template_resource;
+    $basename = basename($filename, '.tpl');
     $key = $basename.'_'.md5($string);
 
     if (isset($smarty->source) && (strpos($smarty->source->filepath, DIRECTORY_SEPARATOR.'override'.DIRECTORY_SEPARATOR) !== false)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If you have several inclusions of templates the name returned by smarty is not correct. In this case, strings are not translated. For more information please find more details on #14470
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14470
| How to test?  | You'll found a zip with testing issue module. [issue.zip](https://github.com/PrestaShop/PrestaShop/files/3358912/issue.zip)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14507)
<!-- Reviewable:end -->
