### PR TITLE
Fix ecotaxe data map to form

### DIFF
--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -528,7 +528,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
     {
         return array(
             'price' => $product->price,
-            'ecotax' => $product->ecotax,
+            'ecotax' => round($product->ecotax * (1 + $this->taxRuleDataProvider->getProductEcotaxRate() / 100), 2),
             'id_tax_rules_group' => isset($product->id_tax_rules_group)
                 ? (int) $product->id_tax_rules_group
                 : $this->taxRuleDataProvider->getIdTaxRulesGroupMostUsed(),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.x.x
| Description?  | Fix-ecotaxe map from database to product form; because actually save and load aren't same, who create always moving product price.
| Type?         | bug fix / critial
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Yes: i don't have time to list all the ticket ... 
| How to test?  | Just check if ecotaxe always change when edit product

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14526)
<!-- Reviewable:end -->
