### PR TITLE
Check if index.php file exists before ignoring it

### DIFF
--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -111,7 +111,10 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
     {
         $reader = new Reference('annotation_reader');
         $driverDefinition = new Definition('Doctrine\ORM\Mapping\Driver\AnnotationDriver', [$reader, [$moduleEntityDirectory]]);
-        $driverDefinition->addMethodCall('addExcludePaths', [[$moduleEntityDirectory . '/index.php']]);
+        $indexFile = $moduleEntityDirectory . '/index.php';
+        if (file_exists($indexFile)) {
+            $driverDefinition->addMethodCall('addExcludePaths', [[$moduleEntityDirectory . '/index.php']]);
+        }
 
         return new DoctrineOrmMappingsPass($driverDefinition, [$moduleNamespace], [], false, [$modulePrefix => $moduleNamespace]);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | When creating annotation driver we need to check if the file exists or the annotation scanning will fail
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Test the `./bin/console doctrine:mapping:info` with the productcomments module installed (which contains an index.php file) AND the doctrine example module from https://github.com/friends-of-presta/doctrine (which does not contain an index.php file). The entities from both modules need to be scanned correctly.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14532)
<!-- Reviewable:end -->
