### PR TITLE
Make email display dependant on configuration from ps_contactinfo module

### DIFF
--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
@@ -49,14 +49,4 @@
       </div>
     </div>
   {/if}
-  {if $contact_infos.email}
-    <hr/>
-    <div class="block">
-      <div class="icon"><i class="material-icons">&#xE158;</i></div>
-      <div class="data email">
-        {l s='Email us:' d='Shop.Theme.Global'}<br/>
-       </div>
-       <a href="mailto:{$contact_infos.email}">{$contact_infos.email}</a>
-    </div>
-  {/if}
 </div>

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
@@ -49,4 +49,14 @@
       </div>
     </div>
   {/if}
+  {if $contact_infos.email && $display_email}
+    <hr/>
+    <div class="block">
+      <div class="icon"><i class="material-icons">&#xE158;</i></div>
+      <div class="data email">
+        {l s='Email us:' d='Shop.Theme.Global'}<br/>
+      </div>
+      <a href="mailto:{$contact_infos.email}">{$contact_infos.email}</a>
+    </div>
+  {/if}
 </div>

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -52,6 +52,19 @@
           d='Shop.Theme.Global'
         }
       {/if}
+      {if $contact_infos.email && $display_email}
+        <br>
+        {* [1][/1] is for a HTML tag. *}
+        {l
+          s='Email us: [1]%email%[/1]'
+          sprintf=[
+            '[1]' => '<a href="mailto:'|cat:$contact_infos.email|cat:'" class="dropdown">',
+            '[/1]' => '</a>',
+            '%email%' => $contact_infos.email
+          ]
+          d='Shop.Theme.Global'
+        }
+      {/if}
   </div>
   <div class="hidden-md-up">
     <div class="title">

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -52,19 +52,6 @@
           d='Shop.Theme.Global'
         }
       {/if}
-      {if $contact_infos.email}
-        <br>
-        {* [1][/1] is for a HTML tag. *}
-        {l
-          s='Email us: [1]%email%[/1]'
-          sprintf=[
-            '[1]' => '<a href="mailto:'|cat:$contact_infos.email|cat:'" class="dropdown">',
-            '[/1]' => '</a>',
-            '%email%' => $contact_infos.email
-          ]
-          d='Shop.Theme.Global'
-        }
-      {/if}
   </div>
   <div class="hidden-md-up">
     <div class="title">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Display email address or not depending on configuration variable 
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14416
| How to test?  | see #14416

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14539)
<!-- Reviewable:end -->
