### PR TITLE
Introduces async bulk action

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -1,0 +1,130 @@
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+const $ = window.$;
+
+export default class AsyncSubmitBulkActionExtension {
+  constructor() {
+    return {
+      extend: grid => this.extend(grid),
+    };
+  }
+
+  /**
+   * Extend grid with bulk action submitting
+   *
+   * @param {Grid} grid
+   */
+  extend(grid) {
+    grid.getContainer().on('click', '.js-bulk-action-submit-async-btn', (event) => {
+      this.submit(event, grid);
+    });
+  }
+
+  submit(event, grid) {
+    const $submitBtn = $(event.currentTarget);
+    const confirmMessage = $submitBtn.data('confirm-message');
+
+    if (typeof confirmMessage !== 'undefined' && confirmMessage.length > 0 && !confirm(confirmMessage)) {
+      return;
+    }
+
+    const $form = $(`#${grid.getId()}_filter_form`);
+    const $checkedInputs = this.getCheckedInputs($form);
+    const ids = this.getCheckedIds($checkedInputs);
+
+    const inputName = this.getInputName($checkedInputs);
+    const chunkSize = parseInt($submitBtn.data('step'), 10);
+    const chunkedIds = this.chunkArray(ids, chunkSize);
+    const submitMethod = $submitBtn.data('form-method');
+    const formUrl = $submitBtn.data('form-url');
+
+    if (!['POST', 'GET', 'DELETE', 'PUT'].includes(submitMethod)) {
+      return;
+    }
+
+    const asyncSubmit = (items, successCallback, errorCallback) => {
+      if (items.length === 0) {
+        return;
+      }
+
+      const firstIdsChunk = items.shift();
+      const data = {};
+      data[inputName] = firstIdsChunk;
+
+      $.ajax({
+        type: submitMethod,
+        url: formUrl,
+        data,
+        dataType: 'json',
+      }).then((response) => {
+        if (!response.success) {
+          errorCallback(response);
+        }
+
+        if (response.success && items.length > 0) {
+          asyncSubmit(items, successCallback, errorCallback);
+        } else {
+          successCallback(response);
+        }
+      }).catch((error) => {
+        const response = error.responseJSON;
+        errorCallback(response);
+      });
+    };
+
+    asyncSubmit(
+      chunkedIds,
+      (response) => {
+        showSuccessMessage(response.message);
+        window.location.reload();
+      },
+      (response) => {
+        showErrorMessage(response.message);
+        window.location.reload();
+      });
+  }
+
+  getCheckedInputs($form) {
+    return $form.find('.js-bulk-action-checkbox:checked');
+  }
+
+  getCheckedIds($inputs) {
+    return $inputs.map((index, el) => parseInt($(el).val(), 10));
+  }
+
+  getInputName($inputs) {
+    return $inputs.attr('name').replace('[]', '');
+  }
+
+  chunkArray(array, chunkSize) {
+    const results = [];
+    while (array.length) {
+      results.push(array.splice(0, chunkSize));
+    }
+
+    return results;
+  }
+}

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -43,6 +43,11 @@ export default class AsyncSubmitBulkActionExtension {
     });
   }
 
+  /**
+   * Collects required data and submits the form.
+   * @param event
+   * @param grid
+   */
   submit(event, grid) {
     const $submitBtn = $(event.currentTarget);
     const confirmMessage = $submitBtn.data('confirm-message');
@@ -65,6 +70,12 @@ export default class AsyncSubmitBulkActionExtension {
       return;
     }
 
+    /**
+     * Async submit action which repeats itself in recursive order.
+     * @param items
+     * @param successCallback
+     * @param errorCallback
+     */
     const asyncSubmit = (items, successCallback, errorCallback) => {
       if (items.length === 0) {
         return;
@@ -107,18 +118,39 @@ export default class AsyncSubmitBulkActionExtension {
       });
   }
 
+  /**
+   * Gets the only checked inputs.
+   * @param $form
+   * @return {*}
+   */
   getCheckedInputs($form) {
     return $form.find('.js-bulk-action-checkbox:checked');
   }
 
+  /**
+   * From checked inputs it returns input values
+   * @param $inputs
+   * @return {*}
+   */
   getCheckedIds($inputs) {
     return $inputs.map((index, el) => parseInt($(el).val(), 10));
   }
 
+  /**
+   * Since bulk action has same name we can return single name from all.
+   * @param $inputs
+   * @return {*}
+   */
   getInputName($inputs) {
     return $inputs.attr('name').replace('[]', '');
   }
 
+  /**
+   * Divides results by chunk size.
+   * @param array
+   * @param chunkSize
+   * @return {Array}
+   */
   chunkArray(array, chunkSize) {
     const results = [];
     while (array.length) {

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -123,7 +123,7 @@ export default class AsyncSubmitBulkActionExtension {
     const chunkSize = parseInt($submitBtn.data('chunkSize'), 10);
     const chunkedIds = this.chunkArray([...ids], chunkSize);
     const submitMethod = $submitBtn.data('formMethod');
-    const formUrl = $submitBtn.data('form-url');
+    const formUrl = $submitBtn.data('formUrl');
 
     if (!['POST', 'GET', 'DELETE', 'PUT'].includes(submitMethod)) {
       return;

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -54,7 +54,6 @@ export default class AsyncSubmitBulkActionExtension {
     const $submitBtn = $(event.currentTarget);
     const confirmMessage = $submitBtn.data('confirm-message');
     const confirmTitle = $submitBtn.data('confirmTitle');
-
     const hasConfirmTitle = confirmTitle !== undefined;
     const hasConfirmationMessage = confirmMessage !== undefined && confirmMessage.length > 0;
     const hasAllConfirmationMessages = hasConfirmationMessage && hasConfirmTitle;
@@ -149,7 +148,7 @@ export default class AsyncSubmitBulkActionExtension {
       confirmButtonLabel,
       closeButtonLabel,
       confirmButtonClass,
-    }, () => this.postForm($submitBtn, grid));
+    }, () => this.submitForm($submitBtn, grid));
 
     modal.show();
   }

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -132,6 +132,9 @@ export default class AsyncSubmitBulkActionExtension {
       const data = {};
       data[inputName] = firstIdsChunk;
 
+      // initialises the start of an ajax call
+      this.progressCallback({}, ids, ids);
+
       $.ajax({
         type: submitMethod,
         url: formUrl,

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -125,7 +125,7 @@ export default class AsyncSubmitBulkActionExtension {
     const submitMethod = $submitBtn.data('formMethod');
     const formUrl = $submitBtn.data('formUrl');
 
-    if (!['POST', 'GET', 'DELETE', 'PUT'].includes(submitMethod)) {
+    if (!['POST', 'GET', 'DELETE', 'PUT'].includes(submitMethod.toUpperCase())) {
       return;
     }
 

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -25,12 +25,12 @@
 
 import ConfirmModal from '../../modal';
 
-const $ = window.$;
+const {$} = window;
 
 export default class AsyncSubmitBulkActionExtension {
   constructor() {
     return {
-      extend: grid => this.extend(grid),
+      extend: (grid) => this.extend(grid),
     };
   }
 

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -28,10 +28,34 @@ import ConfirmModal from '../../modal';
 const {$} = window;
 
 export default class AsyncSubmitBulkActionExtension {
-  constructor() {
+
+  constructor({ successCallback = null, errorCallback = null, } = {}) {
+    this.successCallback = this.setSuccessCallback(successCallback);
+    this.errorCallback = this.setErrorCallback(errorCallback);
+
     return {
       extend: (grid) => this.extend(grid),
     };
+  }
+
+   setSuccessCallback(callback) {
+    return this.isCallback(callback) ? callback :
+      (response) => {
+        window.showSuccessMessage(response.message);
+        window.location.reload();
+      }
+  }
+
+  setErrorCallback(callback) {
+    return this.isCallback(callback) ? callback :
+      (response) => {
+        window.showErrorMessage(response.message);
+        window.location.reload();
+      }
+  }
+
+  isCallback(callback) {
+    return callback && typeof callback === "function";
   }
 
   /**
@@ -118,16 +142,7 @@ export default class AsyncSubmitBulkActionExtension {
       });
     };
 
-    asyncSubmit(
-      chunkedIds,
-      (response) => {
-        showSuccessMessage(response.message);
-        window.location.reload();
-      },
-      (response) => {
-        showErrorMessage(response.message);
-        window.location.reload();
-      });
+    asyncSubmit(chunkedIds, this.successCallback, this.errorCallback);
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -122,7 +122,7 @@ export default class AsyncSubmitBulkActionExtension {
     const inputName = this.getInputName($checkedInputs);
     const chunkSize = parseInt($submitBtn.data('chunkSize'), 10);
     const chunkedIds = this.chunkArray([...ids], chunkSize);
-    const submitMethod = $submitBtn.data('form-method');
+    const submitMethod = $submitBtn.data('formMethod');
     const formUrl = $submitBtn.data('form-url');
 
     if (!['POST', 'GET', 'DELETE', 'PUT'].includes(submitMethod)) {

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -60,7 +60,7 @@ export default class AsyncSubmitBulkActionExtension {
 
     if (hasAllConfirmationMessages) {
       this.showConfirmModal($submitBtn, grid, confirmMessage, confirmTitle);
-    } else if (hasConfirmationMessage && !hasAllConfirmationMessages && confirm(confirmMessage)) {
+    } else if (hasConfirmationMessage && confirm(confirmMessage)) {
       this.submitForm($submitBtn, grid);
     } else {
       this.submitForm($submitBtn, grid);
@@ -73,7 +73,7 @@ export default class AsyncSubmitBulkActionExtension {
     const ids = this.getCheckedIds($checkedInputs);
 
     const inputName = this.getInputName($checkedInputs);
-    const chunkSize = parseInt($submitBtn.data('step'), 10);
+    const chunkSize = parseInt($submitBtn.data('chunkSize'), 10);
     const chunkedIds = this.chunkArray(ids, chunkSize);
     const submitMethod = $submitBtn.data('form-method');
     const formUrl = $submitBtn.data('form-url');

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -149,12 +149,12 @@ export default class AsyncSubmitBulkActionExtension {
         url: formUrl,
         data,
         dataType: 'json',
-      }).then((response) => {
+      }).always((response) => {
         this.progressCallback(response, firstIdsChunk, ids);
 
-        if (!response.success) {
-          errorCallback(response);
-        } else if (response.success && items.length > 0) {
+        const isSuccessfulResponse = 'success' in response && response.success;
+
+        if (isSuccessfulResponse && items.length > 0) {
           asyncSubmit(items, successCallback, errorCallback);
         } else {
           successCallback(response);

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -151,11 +151,10 @@ export default class AsyncSubmitBulkActionExtension {
         dataType: 'json',
       }).then((response) => {
         this.progressCallback(response, firstIdsChunk, ids);
+
         if (!response.success) {
           errorCallback(response);
-        }
-
-        if (response.success && items.length > 0) {
+        } else if (response.success && items.length > 0) {
           asyncSubmit(items, successCallback, errorCallback);
         } else {
           successCallback(response);

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -23,6 +23,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+import ConfirmModal from '../../modal';
+
 const $ = window.$;
 
 export default class AsyncSubmitBulkActionExtension {
@@ -51,11 +53,22 @@ export default class AsyncSubmitBulkActionExtension {
   submit(event, grid) {
     const $submitBtn = $(event.currentTarget);
     const confirmMessage = $submitBtn.data('confirm-message');
+    const confirmTitle = $submitBtn.data('confirmTitle');
 
-    if (typeof confirmMessage !== 'undefined' && confirmMessage.length > 0 && !confirm(confirmMessage)) {
-      return;
+    const hasConfirmTitle = confirmTitle !== undefined;
+    const hasConfirmationMessage = confirmMessage !== undefined && confirmMessage.length > 0;
+    const hasAllConfirmationMessages = hasConfirmationMessage && hasConfirmTitle;
+
+    if (hasAllConfirmationMessages) {
+      this.showConfirmModal($submitBtn, grid, confirmMessage, confirmTitle);
+    } else if (hasConfirmationMessage && !hasAllConfirmationMessages && confirm(confirmMessage)) {
+      this.submitForm($submitBtn, grid);
+    } else {
+      this.submitForm($submitBtn, grid);
     }
+  }
 
+  submitForm($submitBtn, grid) {
     const $form = $(`#${grid.getId()}_filter_form`);
     const $checkedInputs = this.getCheckedInputs($form);
     const ids = this.getCheckedIds($checkedInputs);
@@ -116,6 +129,29 @@ export default class AsyncSubmitBulkActionExtension {
         showErrorMessage(response.message);
         window.location.reload();
       });
+  }
+
+  /**
+   * @param {jQuery} $submitBtn
+   * @param {Grid} grid
+   * @param {string} confirmMessage
+   * @param {string} confirmTitle
+   */
+  showConfirmModal($submitBtn, grid, confirmMessage, confirmTitle) {
+    const confirmButtonLabel = $submitBtn.data('confirmButtonLabel');
+    const closeButtonLabel = $submitBtn.data('closeButtonLabel');
+    const confirmButtonClass = $submitBtn.data('confirmButtonClass');
+
+    const modal = new ConfirmModal({
+      id: `${grid.getId()}_grid_confirm_modal`,
+      confirmTitle,
+      confirmMessage,
+      confirmButtonLabel,
+      closeButtonLabel,
+      confirmButtonClass,
+    }, () => this.postForm($submitBtn, grid));
+
+    modal.show();
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/async-submit-bulk-action-extension.js
@@ -27,14 +27,26 @@ import ConfirmModal from '../../modal';
 
 const {$} = window;
 
+/**
+ * Performs submit actions by partially sending data to the server.
+ */
 export default class AsyncSubmitBulkActionExtension {
-
+  /**
+   *
+   * @param {function|null} successCallback - if defined it overrides current success callback. Accepts response object
+   * as argument
+   * @param {function|null} errorCallback - if defined it overrides current error callback. Accepts response object
+   * as argument
+   * @param {function|null} progressCallback - if defined it tracks progress of executed ajax calls. First parameter
+   * is response object.Second parameter is currently sent ids and last parameter is the total ids array
+   * @return {{extend: (function(*=): void)}}
+   */
   constructor({
-                successCallback = null,
-                errorCallback = null,
-                progressCallback = () => {}
+    successCallback = null,
+    errorCallback = null,
+    progressCallback = () => {},
   } = {}) {
-    this.progressCallback = progressCallback
+    this.progressCallback = progressCallback;
     this.successCallback = this.setSuccessCallback(successCallback);
     this.errorCallback = this.setErrorCallback(errorCallback);
 
@@ -43,30 +55,30 @@ export default class AsyncSubmitBulkActionExtension {
     };
   }
 
-   setSuccessCallback(callback) {
-    return this.isCallback(callback) ? callback :
-      (response) => {
+  setSuccessCallback(callback) {
+    return this.isCallback(callback) ? callback
+      : (response) => {
         if ('message' in response) {
           window.showSuccessMessage(response.message);
         }
 
         window.location.reload();
-      }
+      };
   }
 
   setErrorCallback(callback) {
-    return this.isCallback(callback) ? callback :
-      (response) => {
+    return this.isCallback(callback) ? callback
+      : (response) => {
         if ('message' in response) {
           window.showErrorMessage(response.message);
         }
 
         window.location.reload();
-      }
+      };
   }
 
   isCallback(callback) {
-    return callback && typeof callback === "function";
+    return callback && typeof callback === 'function';
   }
 
   /**
@@ -95,7 +107,7 @@ export default class AsyncSubmitBulkActionExtension {
 
     if (hasAllConfirmationMessages) {
       this.showConfirmModal($submitBtn, grid, confirmMessage, confirmTitle);
-    } else if (hasConfirmationMessage && confirm(confirmMessage)) {
+    } else if (hasConfirmationMessage && window.confirm(confirmMessage)) {
       this.submitForm($submitBtn, grid);
     } else {
       this.submitForm($submitBtn, grid);
@@ -131,9 +143,6 @@ export default class AsyncSubmitBulkActionExtension {
       const firstIdsChunk = items.shift();
       const data = {};
       data[inputName] = firstIdsChunk;
-
-      // initialises the start of an ajax call
-      this.progressCallback({}, ids, ids);
 
       $.ajax({
         type: submitMethod,

--- a/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
+++ b/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
@@ -2,7 +2,47 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type;
 
-class SubmitAsyncBulkAction
-{
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\AbstractBulkAction;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * initialises async process of submitting data to server - this helps to divide request to server. Useful for large
+ * operations.
+ */
+final class SubmitAsyncBulkAction extends AbstractBulkAction
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'submit_async';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setRequired([
+                'submit_route',
+            ])
+            ->setDefaults([
+                'confirm_message' => null,
+                'submit_method' => 'POST',
+                'route_params' => [],
+                'step' => 1,
+            ])
+            ->setAllowedTypes('submit_route', 'string')
+            ->setAllowedTypes('confirm_message', ['string', 'null'])
+            ->setAllowedValues('submit_method', ['POST', 'GET', 'DELETE', 'PUT'])
+            ->setAllowedTypes('route_params', 'array')
+            ->setAllowedTypes('step', 'int')
+        ;
+
+        $resolver->setAllowedValues('step', static function ($value) {
+            return $value >= 1;
+        });
+    }
 }

--- a/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
+++ b/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type;
+
+class SubmitAsyncBulkAction
+{
+
+}

--- a/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
+++ b/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
@@ -3,6 +3,7 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\AbstractBulkAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -31,12 +32,14 @@ final class SubmitAsyncBulkAction extends AbstractBulkAction
             ->setDefaults([
                 'confirm_message' => null,
                 'submit_method' => 'POST',
+                'modal_options' => null,
                 'route_params' => [],
                 'step' => 1,
             ])
             ->setAllowedTypes('submit_route', 'string')
             ->setAllowedTypes('confirm_message', ['string', 'null'])
             ->setAllowedValues('submit_method', ['POST', 'GET', 'DELETE', 'PUT'])
+            ->setAllowedTypes('modal_options', [ModalOptions::class, 'null'])
             ->setAllowedTypes('route_params', 'array')
             ->setAllowedTypes('step', 'int')
         ;

--- a/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
+++ b/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
@@ -32,7 +32,7 @@ final class SubmitAsyncBulkAction extends AbstractBulkAction
             ])
             ->setDefaults([
                 'confirm_message' => null,
-                'submit_method' => 'POST',
+                'submit_method' => Request::METHOD_POST,
                 'modal_options' => null,
                 'route_params' => [],
                 'chunk_size' => 1,

--- a/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
+++ b/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
@@ -4,6 +4,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\AbstractBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -38,7 +39,12 @@ final class SubmitAsyncBulkAction extends AbstractBulkAction
             ])
             ->setAllowedTypes('submit_route', 'string')
             ->setAllowedTypes('confirm_message', ['string', 'null'])
-            ->setAllowedValues('submit_method', ['POST', 'GET', 'DELETE', 'PUT'])
+            ->setAllowedValues('submit_method', [
+                Request::METHOD_POST,
+                Request::METHOD_GET,
+                Request::METHOD_DELETE,
+                Request::METHOD_PUT
+            ])
             ->setAllowedTypes('modal_options', [ModalOptions::class, 'null'])
             ->setAllowedTypes('route_params', 'array')
             ->setAllowedTypes('chunk_size', 'int')

--- a/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
+++ b/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
@@ -41,7 +41,7 @@ final class SubmitAsyncBulkAction extends AbstractBulkAction
             ->setAllowedValues('submit_method', ['POST', 'GET', 'DELETE', 'PUT'])
             ->setAllowedTypes('modal_options', [ModalOptions::class, 'null'])
             ->setAllowedTypes('route_params', 'array')
-            ->setAllowedTypes('step', 'int')
+            ->setAllowedTypes('chunk_size', 'int')
         ;
 
         $resolver->setAllowedValues('chunk_size', static function ($value) {

--- a/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
+++ b/src/Core/Grid/Action/Bulk/Type/SubmitAsyncBulkAction.php
@@ -34,7 +34,7 @@ final class SubmitAsyncBulkAction extends AbstractBulkAction
                 'submit_method' => 'POST',
                 'modal_options' => null,
                 'route_params' => [],
-                'step' => 1,
+                'chunk_size' => 1,
             ])
             ->setAllowedTypes('submit_route', 'string')
             ->setAllowedTypes('confirm_message', ['string', 'null'])
@@ -44,7 +44,7 @@ final class SubmitAsyncBulkAction extends AbstractBulkAction
             ->setAllowedTypes('step', 'int')
         ;
 
-        $resolver->setAllowedValues('step', static function ($value) {
+        $resolver->setAllowedValues('chunk_size', static function ($value) {
             return $value >= 1;
         });
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Bulk/submit_async.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Bulk/submit_async.html.twig
@@ -1,0 +1,35 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+<button id="{{ '%s_grid_bulk_action_%s'|format(grid.id, action.id) }}"
+        class="dropdown-item js-bulk-action-submit-async-btn"
+        type="button"
+        data-form-url="{{ path(action.options.submit_route, action.options.route_params) }}"
+        data-form-method="{{ action.options.submit_method }}"
+        data-confirm-message="{{ action.options.confirm_message }}"
+        data-step="{{ action.options.step }}"
+>
+  {{ action.name }}
+</button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Bulk/submit_async.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Bulk/submit_async.html.twig
@@ -30,6 +30,12 @@
         data-form-method="{{ action.options.submit_method }}"
         data-confirm-message="{{ action.options.confirm_message }}"
         data-step="{{ action.options.step }}"
+        {% if action.options.modal_options %}
+          data-close-button-label="{{ action.options.modal_options.options.close_button_label|default('Close'|trans({}, 'Admin.Actions')) }}"
+          data-confirm-title="{{ action.options.modal_options.options.title }}"
+          data-confirm-button-class="{{ action.options.modal_options.options.confirm_button_class|default('btn-primary') }}"
+          data-confirm-button-label="{{ action.options.modal_options.options.confirm_button_label|default('Confirm'|trans({}, 'Admin.Actions')) }}"
+        {% endif %}
 >
   {{ action.name }}
 </button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Bulk/submit_async.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Bulk/submit_async.html.twig
@@ -29,7 +29,7 @@
         data-form-url="{{ path(action.options.submit_route, action.options.route_params) }}"
         data-form-method="{{ action.options.submit_method }}"
         data-confirm-message="{{ action.options.confirm_message }}"
-        data-step="{{ action.options.step }}"
+        data-chunk-size="{{ action.options.chunk_size }}"
         {% if action.options.modal_options %}
           data-close-button-label="{{ action.options.modal_options.options.close_button_label|default('Close'|trans({}, 'Admin.Actions')) }}"
           data-confirm-title="{{ action.options.modal_options.options.title }}"


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As in products page right now each bulk action submits partial data - 1 product at the time. By having thousands of products performing cost efficient operation this solution can be good. I added new type and grid javascript extension to handle this case in reusable way for each grid. I also added **step** property which can determine how much data to send to the server in 1 iteration. Next step would be to add loading pop-up animation due to currently it has nothing which can evaluate loading state.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | partially required for product list
| How to test?  | this PR will only be used in product list so no need for manual tesing for this one

- [ ] docs after merged

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14542)
<!-- Reviewable:end -->
