### PR TITLE
Wrong path of products thumbnails in back office

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/mixins/product-desc.js
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/mixins/product-desc.js
@@ -26,9 +26,9 @@ export default {
   computed: {
     thumbnail() {
       if (this.product.combination_thumbnail !== 'N/A') {
-        return `${window.data.baseUrl}/${this.product.combination_thumbnail}`;
+        return `${this.product.combination_thumbnail}`;
       } else if (this.product.product_thumbnail !== 'N/A') {
-        return `${window.data.baseUrl}/${this.product.product_thumbnail}`;
+        return `${this.product.product_thumbnail}`;
       }
       return null;
     },

--- a/admin-dev/themes/new-theme/public/stock.bundle.js
+++ b/admin-dev/themes/new-theme/public/stock.bundle.js
@@ -77,7 +77,7 @@ var T=function(t){function e(){var t=this.$options;t.store?this.$store="function
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-e.default={computed:{thumbnail:function(){return"N/A"!==this.product.combination_thumbnail?window.data.baseUrl+"/"+this.product.combination_thumbnail:"N/A"!==this.product.product_thumbnail?window.data.baseUrl+"/"+this.product.product_thumbnail:null},combinationName:function(){var t=this.product.combination_name.split(","),e="";return t.forEach(function(t){var n=t.split("-");e+=e.length?" - "+n[1]:n[1]}),e},hasCombination:function(){return!!this.product.combination_id}}}},function(t,e,n){"use strict";Object.defineProperty(e,"__esModule",{value:!0});/**
+e.default={computed:{thumbnail:function(){return"N/A"!==this.product.combination_thumbnail?""+this.product.combination_thumbnail:"N/A"!==this.product.product_thumbnail?""+this.product.product_thumbnail:null},combinationName:function(){var t=this.product.combination_name.split(","),e="";return t.forEach(function(t){var n=t.split("-");e+=e.length?" - "+n[1]:n[1]}),e},hasCombination:function(){return!!this.product.combination_id}}}},function(t,e,n){"use strict";Object.defineProperty(e,"__esModule",{value:!0});/**
  * 2007-2019 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE

--- a/src/Core/Image/Parser/ImageTagSourceParser.php
+++ b/src/Core/Image/Parser/ImageTagSourceParser.php
@@ -65,6 +65,6 @@ final class ImageTagSourceParser implements ImageTagSourceParserInterface
             return null;
         }
 
-        return sprintf('%s%s', $this->shopRootUri, $path[1]);
+        return sprintf('/%s', $path[1]);
     }
 }

--- a/tests/Unit/Core/Image/Parser/ImageTagSourceParserTest.php
+++ b/tests/Unit/Core/Image/Parser/ImageTagSourceParserTest.php
@@ -56,31 +56,31 @@ class ImageTagSourceParserTest extends TestCase
         return [
             [
                 '<img src="/path/to/my_image.jpg">',
-                '/my-shop/path/to/my_image.jpg',
+                '/path/to/my_image.jpg',
             ],
             [
                 '<img src="../path/to/my_image.jpg">',
-                '/my-shop/path/to/my_image.jpg',
+                '/path/to/my_image.jpg',
             ],
             [
                 '<img class="test" src="../path/to/my_image.jpg" alt="some alt text">',
-                '/my-shop/path/to/my_image.jpg',
+                '/path/to/my_image.jpg',
             ],
             [
                 '<img class="test" src="../path/to/my_image.jpg?time=123" alt="some alt text">',
-                '/my-shop/path/to/my_image.jpg?time=123',
+                '/path/to/my_image.jpg?time=123',
             ],
             [
                 '<img class="test" src="../.././path/to/my_image.jpg?time=123" alt="some alt text">',
-                '/my-shop/path/to/my_image.jpg?time=123',
+                '/path/to/my_image.jpg?time=123',
             ],
             [
                 '<img class="test" src="../../../../../../../path/to/my_image.jpg?time=123" alt="some alt text">',
-                '/my-shop/path/to/my_image.jpg?time=123',
+                '/path/to/my_image.jpg?time=123',
             ],
             [
                 '<img class="test" src="./../../../path/to/my_image.jpg?time=123" alt="some alt text">',
-                '/my-shop/path/to/my_image.jpg?time=123',
+                '/path/to/my_image.jpg?time=123',
             ],
             [
                 '<img class="test">',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes broken product image in backoffice > stock list page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14374
| How to test?  | Go in backoffice > catalogue > stocks, and see that products thumbnails are displayed correctly, also in category edition page, and in brand and manufacturer list page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14543)
<!-- Reviewable:end -->
