### PR TITLE
fix: set customer thread status to closed when answering in backoffice

### DIFF
--- a/classes/CustomerThread.php
+++ b/classes/CustomerThread.php
@@ -25,6 +25,11 @@
  */
 class CustomerThreadCore extends ObjectModel
 {
+    const openStatus = 'open';
+    const closedStatus = 'closed';
+    const pending1Status = 'pending1';
+    const pending2Status = 'pending2';
+
     public $id;
     public $id_shop;
     public $id_lang;

--- a/classes/CustomerThread.php
+++ b/classes/CustomerThread.php
@@ -25,6 +25,8 @@
  */
 class CustomerThreadCore extends ObjectModel
 {
+    // TODO: remove those constants, they will be implemented in CustomerThreadStatus class
+    // in an incoming pull request (https://github.com/PrestaShop/PrestaShop/pull/14288/files)
     const openStatus = 'open';
     const closedStatus = 'closed';
     const pending1Status = 'pending1';

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -623,6 +623,8 @@ class AdminOrdersControllerCore extends AdminController
                             $customer_thread->add();
                         } else {
                             $customer_thread = new CustomerThread((int) $id_customer_thread);
+                            $customer_thread->status = $customer_thread::closedStatus;
+                            $customer_thread->update();
                         }
 
                         $customer_message = new CustomerMessage();

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -623,6 +623,8 @@ class AdminOrdersControllerCore extends AdminController
                             $customer_thread->add();
                         } else {
                             $customer_thread = new CustomerThread((int) $id_customer_thread);
+                            // TODO: use statuses from CustomerThreadStatus instead, once
+                            // this PR will be merged: https://github.com/PrestaShop/PrestaShop/pull/14288/files
                             $customer_thread->status = $customer_thread::closedStatus;
                             $customer_thread->update();
                         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes customer thread's status in customer service not being set to closed after the administrator answered.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14313
| How to test?  | The process is described in issue #14313

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14569)
<!-- Reviewable:end -->
