### PR TITLE
Revert removed templates for mail dynamic contents, order mails mainly, create MailPartialTemplateRenderer to manage this feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ php-cs-fixer
 translations/*
 mails/*
 !mails/themes/
+!mails/_partials/
 themes/default-bootstrap/lang/*
 themes/default-bootstrap/modules/*/translations/*.php
 themes/default-bootstrap/mails/*

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -29,8 +29,9 @@ use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 
-class LanguageCore extends ObjectModel
+class LanguageCore extends ObjectModel implements LanguageInterface
 {
     const ALL_LANGUAGES_FILE = '/app/Resources/all_languages.json';
     const SF_LANGUAGE_PACK_URL = 'http://i18n.prestashop.com/translations/%version%/%locale%/%locale%.zip';
@@ -1490,5 +1491,45 @@ class LanguageCore extends ObjectModel
         return !empty($this->locale) ?
             $this->locale :
             $this->language_code;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCode()
+    {
+        return $this->iso_code;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLanguageCode()
+    {
+        return $this->language_code;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRTL()
+    {
+        return $this->is_rtl;
     }
 }

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -36,6 +36,9 @@ abstract class PaymentModuleCore extends Module
 
     const DEBUG_MODE = false;
 
+    /** @var MailPartialTemplateRenderer */
+    protected $partialRenderer;
+
     public function install()
     {
         if (!parent::install()) {
@@ -879,6 +882,18 @@ abstract class PaymentModuleCore extends Module
     }
 
     /**
+     * @return MailPartialTemplateRenderer
+     */
+    protected function getPartialRenderer()
+    {
+        if (!$this->partialRenderer) {
+            $this->partialRenderer = new MailPartialTemplateRenderer($this->context->smarty);
+        }
+
+        return $this->partialRenderer;
+    }
+
+    /**
      * Fetch the content of $template_name inside the folder
      * current_theme/mails/current_iso_lang/ if found, otherwise in
      * mails/current_iso_lang.
@@ -896,9 +911,7 @@ abstract class PaymentModuleCore extends Module
             return '';
         }
 
-        $partialRenderer = new MailPartialTemplateRenderer($this->context);
-
-        return $partialRenderer->render($template_name, $var);
+        return $this->getPartialRenderer()->render($template_name, $this->context->language, $var);
     }
 
     protected function createOrderFromCart(

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -24,6 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 use PrestaShop\PrestaShop\Adapter\StockManager;
+use PrestaShop\PrestaShop\Adapter\MailTemplate\MailPartialTemplateRenderer;
 
 abstract class PaymentModuleCore extends Module
 {
@@ -895,22 +896,9 @@ abstract class PaymentModuleCore extends Module
             return '';
         }
 
-        $pathToFindEmail = array(
-            _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . $this->context->language->iso_code . DIRECTORY_SEPARATOR . $template_name,
-            _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . 'en' . DIRECTORY_SEPARATOR . $template_name,
-            _PS_MAIL_DIR_ . $this->context->language->iso_code . DIRECTORY_SEPARATOR . $template_name,
-            _PS_MAIL_DIR_ . 'en' . DIRECTORY_SEPARATOR . $template_name,
-        );
+        $partialRenderer = new MailPartialTemplateRenderer($this->context);
 
-        foreach ($pathToFindEmail as $path) {
-            if (Tools::file_exists_cache($path)) {
-                $this->context->smarty->assign('list', $var);
-
-                return $this->context->smarty->fetch($path);
-            }
-        }
-
-        return '';
+        return $partialRenderer->render($template_name, $var);
     }
 
     protected function createOrderFromCart(

--- a/mails/_partials/order_conf_cart_rules.tpl
+++ b/mails/_partials/order_conf_cart_rules.tpl
@@ -1,0 +1,54 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+{foreach $list as $cart_rule}
+	<tr class="conf_body">
+		<td bgcolor="#f8f8f8" colspan="4" style="border:1px solid #D6D4D4;color:#333;padding:7px 0">
+			<table class="table" style="width:100%;border-collapse:collapse">
+				<tr>
+					<td width="5" style="color:#333;padding:0"></td>
+					<td align="right" style="color:#333;padding:0">
+						<font size="2" face="Open-sans, sans-serif" color="#555454">
+							<strong>{$cart_rule['voucher_name']}</strong>
+						</font>
+					</td>
+					<td width="5" style="color:#333;padding:0"></td>
+				</tr>
+			</table>
+		</td>
+		<td bgcolor="#f8f8f8" colspan="4" style="border:1px solid #D6D4D4;color:#333;padding:7px 0">
+			<table class="table" style="width:100%;border-collapse:collapse">
+				<tr>
+					<td width="5" style="color:#333;padding:0"></td>
+					<td align="right" style="color:#333;padding:0">
+						<font size="2" face="Open-sans, sans-serif" color="#555454">
+							{$cart_rule['voucher_reduction']}
+						</font>
+					</td>
+					<td width="5" style="color:#333;padding:0"></td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+{/foreach}

--- a/mails/_partials/order_conf_cart_rules.txt
+++ b/mails/_partials/order_conf_cart_rules.txt
@@ -1,0 +1,3 @@
+{foreach $list as $cart_rule}
+	{$cart_rule['voucher_name']}  {$cart_rule['voucher_reduction']}
+{/foreach}

--- a/mails/_partials/order_conf_product_list.tpl
+++ b/mails/_partials/order_conf_product_list.tpl
@@ -1,0 +1,136 @@
+{**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+{foreach $list as $product}
+<tr>
+	<td style="border:1px solid #D6D4D4;">
+		<table class="table">
+			<tr>
+				<td width="5">&nbsp;</td>
+				<td>
+					<font size="2" face="Open-sans, sans-serif" color="#555454">
+						{$product['reference']}
+					</font>
+				</td>
+				<td width="5">&nbsp;</td>
+			</tr>
+		</table>
+	</td>
+	<td style="border:1px solid #D6D4D4;">
+		<table class="table">
+			<tr>
+				<td width="5">&nbsp;</td>
+				<td>
+					<font size="2" face="Open-sans, sans-serif" color="#555454">
+						<strong>{$product['name']}</strong>
+						{if count($product['customization']) == 1}
+							<br>
+							{foreach $product['customization'] as $customization}
+								{$customization['customization_text']}
+							{/foreach}
+						{/if}
+
+						{hook h='displayProductPriceBlock' product=$product type="unit_price"}
+					</font>
+				</td>
+				<td width="5">&nbsp;</td>
+			</tr>
+		</table>
+	</td>
+	<td style="border:1px solid #D6D4D4;">
+		<table class="table">
+			<tr>
+				<td width="5">&nbsp;</td>
+				<td align="right">
+					<font size="2" face="Open-sans, sans-serif" color="#555454">
+						{$product['unit_price']}
+					</font>
+				</td>
+				<td width="5">&nbsp;</td>
+			</tr>
+		</table>
+	</td>
+	<td style="border:1px solid #D6D4D4;">
+		<table class="table">
+			<tr>
+				<td width="5">&nbsp;</td>
+				<td align="right">
+					<font size="2" face="Open-sans, sans-serif" color="#555454">
+						{$product['quantity']}
+					</font>
+				</td>
+				<td width="5">&nbsp;</td>
+			</tr>
+		</table>
+	</td>
+	<td style="border:1px solid #D6D4D4;">
+		<table class="table">
+			<tr>
+				<td width="5">&nbsp;</td>
+				<td align="right">
+					<font size="2" face="Open-sans, sans-serif" color="#555454">
+						{$product['price']}
+					</font>
+				</td>
+				<td width="5">&nbsp;</td>
+			</tr>
+		</table>
+	</td>
+</tr>
+  {if count($product['customization']) > 1}
+  	{foreach $product['customization'] as $customization}
+  		<tr>
+  		<td colspan="3" style="border:1px solid #D6D4D4;">
+  			<table class="table">
+  				<tr>
+  					<td width="5">&nbsp;</td>
+  					<td>
+  						<font size="2" face="Open-sans, sans-serif" color="#555454">
+  							{$customization['customization_text']}
+  						</font>
+  					</td>
+  					<td width="5">&nbsp;</td>
+  				</tr>
+  			</table>
+  		</td>
+  		<td style="border:1px solid #D6D4D4;">
+  			<table class="table">
+  				<tr>
+  					<td width="5">&nbsp;</td>
+  					<td align="right">
+  						<font size="2" face="Open-sans, sans-serif" color="#555454">
+  							{if count($product['customization']) > 1}
+  								{$customization['customization_quantity']}
+  							{/if}
+  						</font>
+  					</td>
+  					<td width="5">&nbsp;</td>
+  				</tr>
+  			</table>
+  		</td>
+  		<td style="border:1px solid #D6D4D4;"></td>
+  	</tr>
+  	{/foreach}
+  {/if}
+{/foreach}

--- a/mails/_partials/order_conf_product_list.txt
+++ b/mails/_partials/order_conf_product_list.txt
@@ -1,0 +1,20 @@
+{foreach $list as $product}
+						{$product['reference']}
+
+						{$product['name']}
+
+						{$product['price']}
+						{capture "productPriceBlock"}{hook h='displayProductPriceBlock' product=$product type="unit_price"}{/capture}{$smarty.capture.productPriceBlock|strip_tags|trim}
+
+						{$product['quantity']}
+
+						{$product['price']}
+
+	{foreach $product['customization'] as $customization}
+							{$customization['customization_text']}
+
+							{if count($product['customization']) > 1}
+								{$customization['customization_quantity']}
+							{/if}
+	{/foreach}
+{/foreach}

--- a/src/Adapter/MailTemplate/MailPartialTemplateRenderer.php
+++ b/src/Adapter/MailTemplate/MailPartialTemplateRenderer.php
@@ -26,7 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\MailTemplate;
 
-use Context as LegacyContext;
+use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
+use Smarty;
 use Tools;
 
 /**
@@ -35,15 +36,15 @@ use Tools;
  */
 class MailPartialTemplateRenderer
 {
-    /** @var LegacyContext */
-    private $context;
+    /** @var Smarty */
+    private $smarty;
 
     /**
-     * @param LegacyContext $context
+     * @param Smarty $smarty
      */
-    public function __construct(LegacyContext $context)
+    public function __construct(Smarty $smarty)
     {
-        $this->context = $context;
+        $this->smarty = $smarty;
     }
 
     /**
@@ -52,25 +53,26 @@ class MailPartialTemplateRenderer
      * mails/current_iso_lang.
      *
      * @param string $partialTemplateName template name with extension
+     * @param LanguageInterface $language
      * @param array $variables sent to smarty as 'list'
      *
      * @return string
      */
-    public function render($partialTemplateName, array $variables)
+    public function render($partialTemplateName, LanguageInterface $language, array $variables = [])
     {
         $potentialPaths = array(
-            _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . $this->context->language->iso_code . DIRECTORY_SEPARATOR . $partialTemplateName,
+            _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . $language->getIsoCode() . DIRECTORY_SEPARATOR . $partialTemplateName,
+            _PS_MAIL_DIR_ . $language->getIsoCode() . DIRECTORY_SEPARATOR . $partialTemplateName,
             _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . 'en' . DIRECTORY_SEPARATOR . $partialTemplateName,
-            _PS_MAIL_DIR_ . $this->context->language->iso_code . DIRECTORY_SEPARATOR . $partialTemplateName,
             _PS_MAIL_DIR_ . 'en' . DIRECTORY_SEPARATOR . $partialTemplateName,
             _PS_MAIL_DIR_ . '_partials' . DIRECTORY_SEPARATOR . $partialTemplateName,
         );
 
         foreach ($potentialPaths as $path) {
             if (Tools::file_exists_cache($path)) {
-                $this->context->smarty->assign('list', $variables);
+                $this->smarty->assign('list', $variables);
 
-                return $this->context->smarty->fetch($path);
+                return $this->smarty->fetch($path);
             }
         }
 

--- a/src/Adapter/MailTemplate/MailPartialTemplateRenderer.php
+++ b/src/Adapter/MailTemplate/MailPartialTemplateRenderer.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\MailTemplate;
+
+use Context as LegacyContext;
+use Tools;
+
+/**
+ * Class MailPartialTemplateRenderer renders partial mail templates (especially for order). This
+ * feature was moved in this service so that it can be shared between PaymentModule and MailPreviewVariablesBuilder.
+ */
+class MailPartialTemplateRenderer
+{
+    /** @var LegacyContext */
+    private $context;
+
+    /**
+     * @param LegacyContext $context
+     */
+    public function __construct(LegacyContext $context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * Fetch the content of $partialTemplateName inside the folder
+     * current_theme/mails/current_iso_lang/ if found, otherwise in
+     * mails/current_iso_lang.
+     *
+     * @param string $partialTemplateName template name with extension
+     * @param array $variables sent to smarty as 'list'
+     *
+     * @return string
+     */
+    public function render($partialTemplateName, array $variables)
+    {
+        $potentialPaths = array(
+            _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . $this->context->language->iso_code . DIRECTORY_SEPARATOR . $partialTemplateName,
+            _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . 'en' . DIRECTORY_SEPARATOR . $partialTemplateName,
+            _PS_MAIL_DIR_ . $this->context->language->iso_code . DIRECTORY_SEPARATOR . $partialTemplateName,
+            _PS_MAIL_DIR_ . 'en' . DIRECTORY_SEPARATOR . $partialTemplateName,
+            _PS_MAIL_DIR_ . '_partials' . DIRECTORY_SEPARATOR . $partialTemplateName,
+        );
+
+        foreach ($potentialPaths as $path) {
+            if (Tools::file_exists_cache($path)) {
+                $this->context->smarty->assign('list', $variables);
+
+                return $this->context->smarty->fetch($path);
+            }
+        }
+
+        return '';
+    }
+}

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -133,15 +133,15 @@ final class MailPreviewVariablesBuilder
 
         if (self::ORDER_CONFIRMATION == $mailLayout->getName()) {
             $productTemplateList = $this->getProductList($order);
-            $productListTxt = $this->mailPartialTemplateRenderer->render('order_conf_product_list.txt', $productTemplateList);
-            $productListHtml = $this->mailPartialTemplateRenderer->render('order_conf_product_list.tpl', $productTemplateList);
+            $productListTxt = $this->mailPartialTemplateRenderer->render('order_conf_product_list.txt', $this->context->language, $productTemplateList);
+            $productListHtml = $this->mailPartialTemplateRenderer->render('order_conf_product_list.tpl', $this->context->language, $productTemplateList);
 
             $cartRulesList[] = array(
                 'voucher_name' => 'Promo code',
                 'voucher_reduction' => '-' . Tools::displayPrice(5, $this->context->currency, false),
             );
-            $cartRulesListTxt = $this->mailPartialTemplateRenderer->render('order_conf_cart_rules.txt', $cartRulesList);
-            $cartRulesListHtml = $this->mailPartialTemplateRenderer->render('order_conf_cart_rules.tpl', $cartRulesList);
+            $cartRulesListTxt = $this->mailPartialTemplateRenderer->render('order_conf_cart_rules.txt', $this->context->language, $cartRulesList);
+            $cartRulesListHtml = $this->mailPartialTemplateRenderer->render('order_conf_cart_rules.tpl', $this->context->language, $cartRulesList);
 
             $productVariables = [
                 '{products}' => $productListHtml,

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -62,15 +62,20 @@ final class MailPreviewVariablesBuilder
     /** @var Context */
     private $context;
 
+    /** @var MailPartialTemplateRenderer */
+    private $mailPartialTemplateRenderer;
+
     public function __construct(
         ConfigurationInterface $configuration,
         LegacyContext $legacyContext,
-        ContextEmployeeProviderInterface $employeeProvider
+        ContextEmployeeProviderInterface $employeeProvider,
+        MailPartialTemplateRenderer $mailPartialTemplateRenderer
     ) {
         $this->configuration = $configuration;
         $this->legacyContext = $legacyContext;
         $this->context = $this->legacyContext->getContext();
         $this->employeeProvider = $employeeProvider;
+        $this->mailPartialTemplateRenderer = $mailPartialTemplateRenderer;
     }
 
     /**
@@ -128,15 +133,15 @@ final class MailPreviewVariablesBuilder
 
         if (self::ORDER_CONFIRMATION == $mailLayout->getName()) {
             $productTemplateList = $this->getProductList($order);
-            $productListTxt = $this->getEmailTemplateContent('order_conf_product_list.txt', $productTemplateList);
-            $productListHtml = $this->getEmailTemplateContent('order_conf_product_list.tpl', $productTemplateList);
+            $productListTxt = $this->mailPartialTemplateRenderer->render('order_conf_product_list.txt', $productTemplateList);
+            $productListHtml = $this->mailPartialTemplateRenderer->render('order_conf_product_list.tpl', $productTemplateList);
 
             $cartRulesList[] = array(
                 'voucher_name' => 'Promo code',
                 'voucher_reduction' => '-' . Tools::displayPrice(5, $this->context->currency, false),
             );
-            $cartRulesListTxt = $this->getEmailTemplateContent('order_conf_cart_rules.txt', $cartRulesList);
-            $cartRulesListHtml = $this->getEmailTemplateContent('order_conf_cart_rules.tpl', $cartRulesList);
+            $cartRulesListTxt = $this->mailPartialTemplateRenderer->render('order_conf_cart_rules.txt', $cartRulesList);
+            $cartRulesListHtml = $this->mailPartialTemplateRenderer->render('order_conf_cart_rules.tpl', $cartRulesList);
 
             $productVariables = [
                 '{products}' => $productListHtml,
@@ -344,39 +349,6 @@ final class MailPreviewVariablesBuilder
         }
 
         return $productTemplateList;
-    }
-
-    /**
-     * Fetch the content of $templateName inside the folder
-     * current_theme/mails/current_iso_lang/ if found, otherwise in
-     * mails/current_iso_lang.
-     *
-     * @param string $templateName template name with extension
-     * @param array $var sent to smarty as 'list'
-     *
-     * @return string
-     *
-     * @throws \SmartyException
-     */
-    private function getEmailTemplateContent($templateName, $var)
-    {
-        $pathToFindEmail = array(
-            _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . $this->context->language->iso_code . DIRECTORY_SEPARATOR . $templateName,
-            _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . 'en' . DIRECTORY_SEPARATOR . $templateName,
-            _PS_MAIL_DIR_ . $this->context->language->iso_code . DIRECTORY_SEPARATOR . $templateName,
-            _PS_MAIL_DIR_ . 'en' . DIRECTORY_SEPARATOR . $templateName,
-        );
-
-        foreach ($pathToFindEmail as $path) {
-            if (file_exists($path)) {
-                $smarty = $this->context->smarty;
-                $smarty->assign('list', $var);
-
-                return $smarty->fetch($path);
-            }
-        }
-
-        return '';
     }
 
     /**

--- a/src/Core/MailTemplate/Transformation/MailVariablesTransformation.php
+++ b/src/Core/MailTemplate/Transformation/MailVariablesTransformation.php
@@ -61,7 +61,7 @@ class MailVariablesTransformation extends AbstractTransformation
     {
         $replaceVariables = $this->replaceVariables;
         if (!empty($templateVariables['templateVars'])) {
-            $replaceVariables = array_merge(
+            $replaceVariables = array_merge_recursive(
                 $replaceVariables,
                 $templateVariables['templateVars']
             );

--- a/src/Core/MailTemplate/Transformation/MailVariablesTransformation.php
+++ b/src/Core/MailTemplate/Transformation/MailVariablesTransformation.php
@@ -26,22 +26,48 @@
 
 namespace PrestaShop\PrestaShop\Core\MailTemplate\Transformation;
 
+use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
+
 /**
  * Class MailVariablesTransformation is used only for preview, it replaces the
  * variables present in the mail templates (this replacement is usually performed
  * by the Mail class in real behavior).
  * You can set the variables using the actionBuildMailLayoutVariables and setting
- * them in the `templateVars` key.
+ * them in the `templateVars` key, or simply via the constructor.
  */
 class MailVariablesTransformation extends AbstractTransformation
 {
+    /**
+     * @var array
+     */
+    private $replaceVariables;
+
+    /**
+     * @param string $type
+     * @param array $replaceVariables
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct($type, array $replaceVariables = array())
+    {
+        parent::__construct($type);
+        $this->replaceVariables = $replaceVariables;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function apply($templateContent, array $templateVariables)
     {
+        $replaceVariables = $this->replaceVariables;
         if (!empty($templateVariables['templateVars'])) {
-            $templateContent = strtr($templateContent, $templateVariables['templateVars']);
+            $replaceVariables = array_merge(
+                $replaceVariables,
+                $templateVariables['templateVars']
+            );
+        }
+        if (!empty($replaceVariables)) {
+            $templateContent = strtr($templateContent, $replaceVariables);
         }
 
         return $templateContent;

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
@@ -34,11 +34,9 @@ use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
-use PrestaShop\PrestaShop\Core\Hook\HookDispatcher;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutInterface;
-use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutVariablesBuilderInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateRendererInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\ThemeCatalogInterface;
@@ -47,7 +45,6 @@ use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\MailVariablesTransfor
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\GenerateMailsType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use PrestaShopBundle\Service\Hook\HookEvent;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -436,15 +433,15 @@ class MailThemeController extends FrameworkBundleAdminController
             throw new InvalidArgumentException(sprintf('Cannot find Language with locale or isoCode %s', $locale));
         }
 
-        /** @var HookDispatcher $hookDispatcher */
-        $hookDispatcher = $this->get('prestashop.core.hook.dispatcher');
-        $hookDispatcher->addListener(LayoutVariablesBuilderInterface::BUILD_MAIL_LAYOUT_VARIABLES_HOOK, [$this, 'addLayoutVariablesListener']);
+        /** @var MailPreviewVariablesBuilder $variableBuilder */
+        $variablesBuilder = $this->get('prestashop.adapter.mail_template.preview_variables_builder');
+        $mailLayoutVariables = $variablesBuilder->buildTemplateVariables($layout);
 
         /** @var MailTemplateRendererInterface $renderer */
         $renderer = $this->get('prestashop.core.mail_template.mail_template_renderer');
         //Special case for preview, we fill the mail variables
-        $renderer->addTransformation(new MailVariablesTransformation(MailTemplateInterface::HTML_TYPE));
-        $renderer->addTransformation(new MailVariablesTransformation(MailTemplateInterface::TXT_TYPE));
+        $renderer->addTransformation(new MailVariablesTransformation(MailTemplateInterface::HTML_TYPE, $mailLayoutVariables));
+        $renderer->addTransformation(new MailVariablesTransformation(MailTemplateInterface::TXT_TYPE, $mailLayoutVariables));
 
         switch ($type) {
             case MailTemplateInterface::HTML_TYPE:
@@ -504,24 +501,6 @@ class MailThemeController extends FrameworkBundleAdminController
         }
 
         return $layout;
-    }
-
-    /**
-     * @param HookEvent $event
-     *
-     * @throws \SmartyException
-     */
-    public function addLayoutVariablesListener(HookEvent $event)
-    {
-        $hookParameters = $event->getHookParameters();
-        $mailLayoutVariables = $hookParameters['mailLayoutVariables'];
-
-        /** @var MailPreviewVariablesBuilder $variableBuilder */
-        $variablesBuilder = $this->get('prestashop.adapter.mail_template.preview_variables_builder');
-        $mailLayoutVariables['templateVars'] = $variablesBuilder->buildTemplateVariables($hookParameters['mailLayout']);
-
-        $hookParameters['mailLayoutVariables'] = $mailLayoutVariables;
-        $event->setHookParameters($hookParameters);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
@@ -19,7 +19,7 @@ services:
   prestashop.adapter.mail_template.partial_template_renderer:
     class: 'PrestaShop\PrestaShop\Adapter\MailTemplate\MailPartialTemplateRenderer'
     arguments:
-      - "@=service('prestashop.adapter.legacy.context').getContext()"
+      - "@=service('prestashop.adapter.legacy.context').getSmarty()"
 
   prestashop.adapter.mail_template.preview_variables_builder:
     class: 'PrestaShop\PrestaShop\Adapter\MailTemplate\MailPreviewVariablesBuilder'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
@@ -16,9 +16,15 @@ services:
         arguments:
           - '@prestashop.core.mail_template.transformation.html_textify'
 
+  prestashop.adapter.mail_template.partial_template_renderer:
+    class: 'PrestaShop\PrestaShop\Adapter\MailTemplate\MailPartialTemplateRenderer'
+    arguments:
+      - "@=service('prestashop.adapter.legacy.context').getContext()"
+
   prestashop.adapter.mail_template.preview_variables_builder:
     class: 'PrestaShop\PrestaShop\Adapter\MailTemplate\MailPreviewVariablesBuilder'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
       - '@prestashop.adapter.legacy.context'
       - '@prestashop.adapter.data_provider.employee'
+      - "@prestashop.adapter.mail_template.partial_template_renderer"

--- a/tests/Unit/Adapter/MailTemplate/MailPartialTemplateRendererTest.php
+++ b/tests/Unit/Adapter/MailTemplate/MailPartialTemplateRendererTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Adapter\MailTemplate;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\MailTemplate\MailPartialTemplateRenderer;
+use Context;
+use Language;
+use Smarty;
+
+class MailPartialTemplateRendererTest extends TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $requiredConstants = [
+            '_PS_THEME_DIR_' => _PS_ROOT_DIR_ . '/themes/classic/',
+            '_PS_MAIL_DIR_' => _PS_CORE_DIR_ . '/mails/',
+        ];
+        foreach ($requiredConstants as $constant => $value) {
+            if (!defined($constant)) {
+                define($constant, $value);
+            }
+        }
+    }
+
+    public function testUnknownTemplate()
+    {
+        $contextMock = $this->buildContextMock();
+
+        $renderer = new MailPartialTemplateRenderer($contextMock);
+        $this->assertEquals('', $renderer->render('unknown_template.tpl', []));
+    }
+
+    public function testOrderConfTemplate()
+    {
+        $contextMock = $this->buildContextMock('order_conf_template');
+
+        $renderer = new MailPartialTemplateRenderer($contextMock);
+        $this->assertEquals('order_conf_template', $renderer->render('order_conf_product_list.tpl', []));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Context
+     */
+    private function buildContextMock($template = '')
+    {
+        $contextMock = $this->getMockBuilder(Context::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $languageMock = $this->getMockBuilder(Language::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $languageMock->iso_code = 'en';
+        $contextMock->language = $languageMock;
+
+        $smartyMock = $this->getMockBuilder(Smarty::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        if (empty($template)) {
+            $smartyMock
+                ->expects($this->never())
+                ->method('fetch')
+            ;
+        } else {
+            $smartyMock
+                ->expects($this->once())
+                ->method('fetch')
+                ->willReturn($template)
+            ;
+        }
+
+        $contextMock->smarty = $smartyMock;
+
+        return $contextMock;
+    }
+}

--- a/tests/Unit/Adapter/MailTemplate/MailPartialTemplateRendererTest.php
+++ b/tests/Unit/Adapter/MailTemplate/MailPartialTemplateRendererTest.php
@@ -28,8 +28,7 @@ namespace Tests\Unit\Adapter\MailTemplate;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\MailTemplate\MailPartialTemplateRenderer;
-use Context;
-use Language;
+use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use Smarty;
 
 class MailPartialTemplateRendererTest extends TestCase
@@ -53,37 +52,27 @@ class MailPartialTemplateRendererTest extends TestCase
 
     public function testUnknownTemplate()
     {
-        $contextMock = $this->buildContextMock();
+        $smartyMock = $this->buildSmartyMock();
 
-        $renderer = new MailPartialTemplateRenderer($contextMock);
-        $this->assertEquals('', $renderer->render('unknown_template.tpl', []));
+        $renderer = new MailPartialTemplateRenderer($smartyMock);
+        $this->assertEquals('', $renderer->render('unknown_template.tpl', $this->buildLanguageMock(), []));
+        $this->assertEquals('', $renderer->render('unknown_template.tpl', $this->buildLanguageMock()));
     }
 
     public function testOrderConfTemplate()
     {
-        $contextMock = $this->buildContextMock('order_conf_template');
+        $smartyMock = $this->buildSmartyMock('order_conf_template');
 
-        $renderer = new MailPartialTemplateRenderer($contextMock);
-        $this->assertEquals('order_conf_template', $renderer->render('order_conf_product_list.tpl', []));
+        $renderer = new MailPartialTemplateRenderer($smartyMock);
+        $this->assertEquals('order_conf_template', $renderer->render('order_conf_product_list.tpl', $this->buildLanguageMock(), []));
+        $this->assertEquals('order_conf_template', $renderer->render('order_conf_product_list.tpl', $this->buildLanguageMock()));
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|Context
+     * @return \PHPUnit_Framework_MockObject_MockObject|Smarty
      */
-    private function buildContextMock($template = '')
+    private function buildSmartyMock($template = '')
     {
-        $contextMock = $this->getMockBuilder(Context::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $languageMock = $this->getMockBuilder(Language::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-        $languageMock->iso_code = 'en';
-        $contextMock->language = $languageMock;
-
         $smartyMock = $this->getMockBuilder(Smarty::class)
             ->disableOriginalConstructor()
             ->getMock()
@@ -96,14 +85,30 @@ class MailPartialTemplateRendererTest extends TestCase
             ;
         } else {
             $smartyMock
-                ->expects($this->once())
+                ->expects($this->exactly(2))
                 ->method('fetch')
                 ->willReturn($template)
             ;
         }
 
-        $contextMock->smarty = $smartyMock;
+        return $smartyMock;
+    }
 
-        return $contextMock;
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|LanguageInterface
+     */
+    private function buildLanguageMock()
+    {
+        $languageMock = $this->getMockBuilder(LanguageInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $languageMock
+            ->expects($this->exactly(2))
+            ->method('getIsoCode')
+            ->willReturn('en')
+        ;
+
+        return $languageMock;
     }
 }

--- a/tests/Unit/Core/MailTemplate/MailVariablesTransformationTest.php
+++ b/tests/Unit/Core/MailTemplate/MailVariablesTransformationTest.php
@@ -55,4 +55,16 @@ class MailVariablesTransformationTest extends TestCase
         $transformedTemplate = $transformation->apply($template, $layoutVariables);
         $this->assertEquals('Hello John Doe wasup mate?', $transformedTemplate);
     }
+
+    public function testApplyViaConstructor()
+    {
+        $template = 'Hello {firstname} {lastname} how are you?';
+        $transformation = new MailVariablesTransformation(MailTemplateInterface::HTML_TYPE, [
+            '{firstname}' => 'John',
+            '{lastname}' => 'Doe',
+            'how are you' => 'wasup mate',
+        ]);
+        $transformedTemplate = $transformation->apply($template, []);
+        $this->assertEquals('Hello John Doe wasup mate?', $transformedTemplate);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Revert removed templates for mail dynamic contents, order mails mainly, create MailPartialTemplateRenderer to manage this feature. Also fix the HookDispatcher which ignored events with any uppercase
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Test an order and check that the email is correctly sent (with the product list). You can also go to Design > Email Theme and check the `order_conf` preview

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14601)
<!-- Reviewable:end -->
