### PR TITLE
Fix modules translations files in theme erased by modules translations that are in modules folder

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -198,13 +198,13 @@ class TranslateCore
 
         if (!isset($translationsMerged[$name][$iso])) {
             $filesByPriority = array(
-                // Translations in theme
-                _PS_THEME_DIR_ . 'modules/' . $name . '/translations/' . $iso . '.php',
-                _PS_THEME_DIR_ . 'modules/' . $name . '/' . $iso . '.php',
                 // PrestaShop 1.5 translations
                 _PS_MODULE_DIR_ . $name . '/translations/' . $iso . '.php',
                 // PrestaShop 1.4 translations
                 _PS_MODULE_DIR_ . $name . '/' . $iso . '.php',
+                // Translations in theme
+                _PS_THEME_DIR_ . 'modules/' . $name . '/translations/' . $iso . '.php',
+                _PS_THEME_DIR_ . 'modules/' . $name . '/' . $iso . '.php',
             );
             foreach ($filesByPriority as $file) {
                 if (file_exists($file)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Modules translations files in theme erased by modules translations are in modules folder.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14570 
| How to test?  | Create a translations for a module in classic theme: themes/classic/modules/marketplace/translations/fr.php and edit a translation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14609)
<!-- Reviewable:end -->
