### PR TITLE
Fix broken translations in module list page

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -53,14 +53,9 @@ class AdminModuleDataProvider implements ModuleInterface
     const _DAY_IN_SECONDS_ = 86400; /* Cache for One Day */
 
     /**
-     * @var array of defined and callable module actions
+     * @const array giving a translation domain key for each module action
      */
-    protected $moduleActions = array('install', 'uninstall', 'enable', 'disable', 'enable_mobile', 'disable_mobile', 'reset', 'upgrade');
-
-    /**
-     * @var array giving a translation domain key for each module action
-     */
-    protected $actionsTranslationDomains = array(
+    const _ACTIONS_TRANSLATION_DOMAINS_ = array(
         'install' => 'Admin.Actions',
         'uninstall' => 'Admin.Actions',
         'enable' => 'Admin.Actions',
@@ -71,6 +66,11 @@ class AdminModuleDataProvider implements ModuleInterface
         'upgrade' => 'Admin.Actions',
         'configure' => 'Admin.Actions',
     );
+
+    /**
+     * @var array of defined and callable module actions
+     */
+    protected $moduleActions = array('install', 'uninstall', 'enable', 'disable', 'enable_mobile', 'disable_mobile', 'reset', 'upgrade');
 
     /**
      * @var int
@@ -346,7 +346,7 @@ class AdminModuleDataProvider implements ModuleInterface
 
             $urls = $this->filterAllowedActions($urls, $addon->attributes->get('name'));
             $addon->attributes->set('urls', $urls);
-            $addon->attributes->set('actionTranslationDomains', $this->actionsTranslationDomains);
+            $addon->attributes->set('actionTranslationDomains', self::_ACTIONS_TRANSLATION_DOMAINS_);
             if ($specific_action && array_key_exists($specific_action, $urls)) {
                 $addon->attributes->set('url_active', $specific_action);
             } elseif ($url_active === 'buy' || array_key_exists($url_active, $urls)) {

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -58,6 +58,21 @@ class AdminModuleDataProvider implements ModuleInterface
     protected $moduleActions = array('install', 'uninstall', 'enable', 'disable', 'enable_mobile', 'disable_mobile', 'reset', 'upgrade');
 
     /**
+     * @var array giving a translation domain key for each module action
+     */
+    protected $actionsTranslationDomains = array(
+        'install' => 'Admin.Actions',
+        'uninstall' => 'Admin.Actions',
+        'enable' => 'Admin.Actions',
+        'disable' => 'Admin.Actions',
+        'enable_mobile' => 'Admin.Modules.Feature',
+        'disable_mobile' => 'Admin.Modules.Feature',
+        'reset' => 'Admin.Actions',
+        'upgrade' => 'Admin.Actions',
+        'configure' => 'Admin.Actions',
+    );
+
+    /**
      * @var int
      */
     private $languageISO;
@@ -331,6 +346,7 @@ class AdminModuleDataProvider implements ModuleInterface
 
             $urls = $this->filterAllowedActions($urls, $addon->attributes->get('name'));
             $addon->attributes->set('urls', $urls);
+            $addon->attributes->set('actionTranslationDomains', $this->actionsTranslationDomains);
             if ($specific_action && array_key_exists($specific_action, $urls)) {
                 $addon->attributes->set('url_active', $specific_action);
             } elseif ($url_active === 'buy' || array_key_exists($url_active, $urls)) {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -115,7 +115,6 @@ class ModuleController extends ModuleAbstractController
             ->removeStatus(AddonListFilterStatus::UNINSTALLED);
         $installedProducts = $moduleRepository->getFilteredList($filters);
         $categories = $this->getCategories($modulesProvider, $installedProducts);
-
         $bulkActions = [
             'bulk-uninstall' => $this->trans('Uninstall', 'Admin.Actions'),
             'bulk-disable' => $this->trans('Disable', 'Admin.Actions'),

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_button.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_button.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% set displayAction = action|capitalize|replace({'_': " "})|trans({}, 'Admin.Actions') %}
+{% set displayAction = action|title|replace({'_': " "})|trans({}, transDomain[action]) %}
 
 {% if (action == 'configure') %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -22,15 +22,16 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-{% set url, priceRaw, priceDisplay, url_active, urls, name =
+{% set url, priceRaw, priceDisplay, url_active, urls, name, transDomains =
   module.attributes.url,
   module.attributes.price.raw,
   module.attributes.price.displayPrice,
   module.attributes.url_active,
   module.attributes.urls,
-  module.attributes.name
+  module.attributes.name,
+  module.attributes.actionTranslationDomains
 %}
- <div class="btn-group module-actions"> 
+ <div class="btn-group module-actions">
   {% if url_active == 'buy' %}
     <a class="btn btn-primary btn-primary-reverse btn-block btn-outline-primary module_action_menu_go_to_addons" href="{{ url }}" target="_blank">
       {{ 'Discover'|trans({}, 'Admin.Modules.Feature') }}
@@ -41,7 +42,8 @@
         'classes_form': 'btn-group form-action-button',
         'classes' : 'btn btn-primary-reverse btn-outline-primary',
         'url': urls[url_active],
-        'action': url_active}
+        'action': url_active,
+        'transDomain': transDomains}
     %}
     {% if (urls|length > 1) %}
         <input type="hidden" class="btn" /> 
@@ -57,7 +59,8 @@
                       'name': name,
                       'classes' : 'dropdown-item',
                       'url': module_url,
-                      'action': module_action}
+                      'action': module_action,
+                      'transDomain': transDomains}
                   %}
                 </li>
             {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -701,6 +701,11 @@
 {% endblock birthday_widget %}
 
 {% block file_widget %}
+  <style>
+    .custom-file-label:after {
+      content: "{{ "Browse"|trans({}, 'Admin.Actions')  }}";
+    }
+  </style>
   <div class="custom-file">
     {% set attr = attr|merge({
       class: (attr.class|default('') ~ ' custom-file-input')|trim,


### PR DESCRIPTION
- link module actions names to related translation domain
- fix module action display name generation
- use correct translation domain

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Translation broken in module listing page, in the action dropdown of each item.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14589
| How to test?  | See description in the issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14613)
<!-- Reviewable:end -->
