### PR TITLE
Introduces category tree button type, submit on tree option select functionality, unselect all functionality

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/choice-tree.js
+++ b/admin-dev/themes/new-theme/js/components/form/choice-tree.js
@@ -29,6 +29,7 @@ const {$} = window;
  * Handles UI interactions of choice tree
  */
 export default class ChoiceTree {
+
   /**
    * @param {String} treeSelector
    */
@@ -51,11 +52,14 @@ export default class ChoiceTree {
       enableAutoCheckChildren: () => this.enableAutoCheckChildren(),
       enableAllInputs: () => this.enableAllInputs(),
       disableAllInputs: () => this.disableAllInputs(),
+      enableInstantSubmit: () => this.enableInstantSubmit(),
     };
   }
 
   /**
    * Enable automatic check/uncheck of clicked item's children.
+   *
+   * @return {ChoiceTree}
    */
   enableAutoCheckChildren() {
     this.$container.on('change', 'input[type="checkbox"]', (event) => {
@@ -66,20 +70,44 @@ export default class ChoiceTree {
         .find('ul input[type="checkbox"]')
         .prop('checked', $clickedCheckbox.is(':checked'));
     });
+
+    return this;
+  }
+
+  /**
+   * If the tree is in form then it will trigger form submit if change input action is triggered.
+   *
+   * @return {ChoiceTree}
+   */
+  enableInstantSubmit() {
+    this.$container.on('change', '.js-input-wrapper input', (event) => {
+      const $input = $(event.currentTarget);
+      $input.closest('form').submit();
+    });
+
+    return this;
   }
 
   /**
    * Enable all inputs in the choice tree.
+   *
+   * @return {ChoiceTree}
    */
   enableAllInputs() {
     this.$container.find('input').removeAttr('disabled');
+
+    return this;
   }
 
   /**
    * Disable all inputs in the choice tree.
+   *
+   * @return {ChoiceTree}
    */
   disableAllInputs() {
     this.$container.find('input').attr('disabled', 'disabled');
+
+    return this;
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/components/form/choice-tree.js
+++ b/admin-dev/themes/new-theme/js/components/form/choice-tree.js
@@ -48,11 +48,21 @@ export default class ChoiceTree {
       this.toggleTree($action);
     });
 
+    this.$container.on('click', '.js-unselect-all', (event) => {
+      event.preventDefault();
+
+      const hasCheckedElement = this.$container.find('.js-input-wrapper input:checked').length > 0;
+
+      if (hasCheckedElement) {
+        this._unselectAll();
+      }
+    });
+
     return {
       enableAutoCheckChildren: () => this.enableAutoCheckChildren(),
       enableAllInputs: () => this.enableAllInputs(),
       disableAllInputs: () => this.disableAllInputs(),
-      enableInstantSubmit: () => this.enableInstantSubmit(),
+      enableRadioInputInstantSubmit: () => this.enableRadioInputInstantSubmit(),
     };
   }
 
@@ -79,11 +89,8 @@ export default class ChoiceTree {
    *
    * @return {ChoiceTree}
    */
-  enableInstantSubmit() {
-    this.$container.on('change', '.js-input-wrapper input', (event) => {
-      const $input = $(event.currentTarget);
-      $input.closest('form').submit();
-    });
+  enableRadioInputInstantSubmit() {
+    this.$container.on('change', '.js-input-wrapper input[type="radio"]', event => event.currentTarget.form.submit());
 
     return this;
   }
@@ -182,5 +189,13 @@ export default class ChoiceTree {
     $action.data('action', config.nextAction[action]);
     $action.find('.material-icons').text($action.data(config.icon[action]));
     $action.find('.js-toggle-text').text($action.data(config.text[action]));
+  }
+
+  /**
+   * Unselects all inputs.
+   * @private
+   */
+  _unselectAll() {
+    this.$container.find('.js-input-wrapper input').prop('checked', false);
   }
 }

--- a/admin-dev/themes/new-theme/js/components/form/choice-tree.js
+++ b/admin-dev/themes/new-theme/js/components/form/choice-tree.js
@@ -29,7 +29,6 @@ const {$} = window;
  * Handles UI interactions of choice tree
  */
 export default class ChoiceTree {
-
   /**
    * @param {String} treeSelector
    */
@@ -54,7 +53,7 @@ export default class ChoiceTree {
       const hasCheckedElement = this.$container.find('.js-input-wrapper input:checked').length > 0;
 
       if (hasCheckedElement) {
-        this._unselectAll();
+        this.unselectAll();
       }
     });
 
@@ -90,7 +89,7 @@ export default class ChoiceTree {
    * @return {ChoiceTree}
    */
   enableRadioInputInstantSubmit() {
-    this.$container.on('change', '.js-input-wrapper input[type="radio"]', event => event.currentTarget.form.submit());
+    this.$container.on('change', '.js-input-wrapper input[type="radio"]', (event) => event.currentTarget.form.submit());
 
     return this;
   }
@@ -195,7 +194,7 @@ export default class ChoiceTree {
    * Unselects all inputs.
    * @private
    */
-  _unselectAll() {
+  unselectAll() {
     this.$container.find('.js-input-wrapper input').prop('checked', false);
   }
 }

--- a/admin-dev/themes/new-theme/scss/components/_material_choice_tree.scss
+++ b/admin-dev/themes/new-theme/scss/components/_material_choice_tree.scss
@@ -18,8 +18,28 @@
 
       .checkbox,
       .radio {
-        padding-left: 20px;
+        padding-left: 18px;
         padding-top: 0;
+
+        i.material-icons {
+          &::before {
+            content: "radio_button_unchecked";
+          }
+
+          padding-right: 1px;
+        }
+
+        input[type="radio"] {
+          &:checked {
+            + i.material-icons {
+              &::before {
+                content: "radio_button_checked";
+              }
+            }
+          }
+
+          display: none;
+        }
       }
 
       .checkbox {

--- a/admin-dev/themes/new-theme/scss/components/_material_choice_tree.scss
+++ b/admin-dev/themes/new-theme/scss/components/_material_choice_tree.scss
@@ -7,6 +7,10 @@
     margin-bottom: 10px;
   }
 
+  .unselect-all {
+    cursor: pointer;
+  }
+
   ul.choice-tree {
     padding: 0;
     margin: 0;

--- a/admin-dev/themes/new-theme/scss/components/_material_choice_tree.scss
+++ b/admin-dev/themes/new-theme/scss/components/_material_choice_tree.scss
@@ -99,7 +99,7 @@
   }
 }
 
-.category-dropdown-button {
+.category-choice-tree-button {
   .material-choice-tree-container {
     border: none;
   }

--- a/admin-dev/themes/new-theme/scss/components/_material_choice_tree.scss
+++ b/admin-dev/themes/new-theme/scss/components/_material_choice_tree.scss
@@ -24,7 +24,14 @@
         i.material-icons {
           &::before {
             content: "radio_button_unchecked";
+            color: $medium-gray;
           }
+
+          cursor: pointer;
+
+          width: 22px;
+          height: 22px;
+          font-size: 1.3rem;
 
           padding-right: 1px;
         }
@@ -34,7 +41,14 @@
             + i.material-icons {
               &::before {
                 content: "radio_button_checked";
+                color: $primary;
               }
+            }
+          }
+          &:disabled {
+            + i.material-icons {
+              cursor: not-allowed;
+              opacity: .5;
             }
           }
 

--- a/admin-dev/themes/new-theme/scss/components/_material_choice_tree.scss
+++ b/admin-dev/themes/new-theme/scss/components/_material_choice_tree.scss
@@ -98,3 +98,9 @@
     }
   }
 }
+
+.category-dropdown-button {
+  .material-choice-tree-container {
+    border: none;
+  }
+}

--- a/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeButtonType.php
@@ -1,4 +1,28 @@
 <?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
 
 namespace PrestaShopBundle\Form\Admin\Type;
 

--- a/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeButtonType.php
@@ -33,6 +33,7 @@ class CategoryChoiceTreeButtonType extends AbstractType
             'choices_tree' => $this->categoryTreeChoices,
             'choice_label' => 'name',
             'choice_value' => 'id_category',
+            'display_unselect_all' => true,
         ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeButtonType.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Displays button which has category tree pre-rendered.
+ */
+class CategoryChoiceTreeButtonType extends AbstractType
+{
+    /**
+     * @var array
+     */
+    private $categoryTreeChoices;
+
+    /**
+     * @param array $categoryTreeChoices
+     */
+    public function __construct(array $categoryTreeChoices)
+    {
+        $this->categoryTreeChoices = $categoryTreeChoices;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choices_tree' => $this->categoryTreeChoices,
+            'choice_label' => 'name',
+            'choice_value' => 'id_category',
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return MaterialChoiceTreeType::class;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeButtonType.php
@@ -31,7 +31,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Displays button which has category tree pre-rendered.
+ * Displays button which has category tree pre-rendered. Choose this component if you want to render categories in a
+ * button. If you want traditional category choice tree choose CategoryChoiceTreeType component.
  */
 class CategoryChoiceTreeButtonType extends AbstractType
 {

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTreeType.php
@@ -50,6 +50,7 @@ class MaterialChoiceTreeType extends AbstractType
         $view->vars['choice_children'] = $options['choice_children'];
         $view->vars['disabled_values'] = $options['disabled_values'];
         $view->vars['selected_values'] = $selectedData;
+        $view->vars['display_unselect_all'] = $options['display_unselect_all'];
     }
 
     /**
@@ -67,6 +68,7 @@ class MaterialChoiceTreeType extends AbstractType
                 'disabled' => false,
                 'multiple' => false,
                 'compound' => false,
+                'display_unselect_all' => false,
             ])
             ->setAllowedTypes('choices_tree', 'array')
             ->setAllowedTypes('multiple', 'bool')
@@ -75,6 +77,7 @@ class MaterialChoiceTreeType extends AbstractType
             ->setAllowedTypes('choice_children', 'string')
             ->setAllowedTypes('disabled_values', 'array')
             ->setAllowedTypes('disabled', 'bool')
+            ->setAllowedTypes('display_unselect_all', 'bool')
             ->addAllowedValues('compound', false);
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -900,6 +900,12 @@ services:
         public: true
         calls:
           - { method: setTranslator, arguments: ['@translator'] }
+
+    form.type.category_choice_tree_button:
+        class: 'PrestaShopBundle\Form\Admin\Type\CategoryChoiceTreeButtonType'
+        public: true
+        arguments:
+            - '@=service("prestashop.adapter.form.choice_provider.category_tree_choice_provider").getChoices()'
         tags:
           - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -835,7 +835,7 @@
       aria-haspopup="true"
       aria-expanded="false"
     >
-      {{ label }}
+      {{ label ? label : form.vars.label }}
     </button>
     <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}_container">
       {{ form_widget(form) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -827,7 +827,7 @@
 {% endblock text_widget %}
 
 {% block category_choice_tree_button_widget %}
-  <div class="dropdown category-dropdown-button dropdown-clickable" id="{{ form.vars.id }}_container">
+  <div class="dropdown category-choice-tree-button dropdown-clickable" id="{{ form.vars.id }}_container">
     <button
       class="btn btn-outline-secondary dropdown-toggle"
       type="button"

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -827,7 +827,18 @@
 {% endblock text_widget %}
 
 {% block category_choice_tree_button_widget %}
-  <button>
-    hello world!
-  </button>
+  <div class="dropdown category-dropdown-button dropdown-clickable" id="{{ form.vars.id }}_container">
+    <button
+      class="btn btn-outline-secondary dropdown-toggle"
+      type="button"
+      data-toggle="dropdown"
+      aria-haspopup="true"
+      aria-expanded="false"
+    >
+      {{ label }}
+    </button>
+    <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}_container">
+      {{ form_widget(form) }}
+    </div>
+  </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -825,3 +825,9 @@
     </datalist>
   {% endif %}
 {% endblock text_widget %}
+
+{% block category_choice_tree_button_widget %}
+  <button>
+    hello world!
+  </button>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
@@ -30,7 +30,7 @@
       <span>
         <div class="radio js-unselect-all">
           <label>
-            <input type="radio" name="unselect_all" value="1"> {{ 'Unselect'|trans({}, 'Admin.Actions') }}
+            <input type="radio" name="{{ form.vars.full_name }}_unselect_all" value="1"> {{ 'Unselect all'|trans({}, 'Admin.Actions') }}
           </label>
         </div>
       </span>
@@ -94,8 +94,7 @@
              {% if choice[choice_value] in selected_values %}checked{% endif %}
              {% if disabled or choice[choice_value] in disabled_values %}disabled{% endif %}
       >
-      <i class="material-icons">
-      </i>
+      <i class="material-icons"></i>
       {{ choice[choice_label] }}
     </label>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
@@ -36,13 +36,16 @@
       <i class="material-icons">expand_more</i>
       <span class="js-toggle-text">{{ 'Expand'|trans({}, 'Admin.Actions') }}</span>
     </span>
-    <span class="float-right">
+
+    {% if display_unselect_all %}
+      <span class="float-right">
       <div class="radio js-unselect-all">
         <label>
           <input type="radio" name="unselect_all" value="1"> {{ 'Unselect'|trans({}, 'Admin.Actions') }}
         </label>
       </div>
     </span>
+    {% endif %}
   </div>
 
   <ul class="choice-tree">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
@@ -26,25 +26,14 @@
 {% block material_choice_tree_widget %}
 <div class="material-choice-tree-container js-choice-tree-container" id="{{ form.vars.id }}">
   <div class="choice-tree-actions">
-    <span class="form-control-label js-toggle-choice-tree-action"
-          data-expanded-text="{{ 'Expand'|trans({}, 'Admin.Actions') }}"
-          data-expanded-icon="expand_more"
-          data-collapsed-text="{{ 'Collapse'|trans({}, 'Admin.Actions') }}"
-          data-collapsed-icon="expand_less"
-          data-action="expand"
-    >
-      <i class="material-icons">expand_more</i>
-      <span class="js-toggle-text">{{ 'Expand'|trans({}, 'Admin.Actions') }}</span>
-    </span>
-
     {% if display_unselect_all %}
-      <span class="float-right">
-      <div class="radio js-unselect-all">
-        <label>
-          <input type="radio" name="unselect_all" value="1"> {{ 'Unselect'|trans({}, 'Admin.Actions') }}
-        </label>
-      </div>
-    </span>
+      <span>
+        <div class="radio js-unselect-all">
+          <label>
+            <input type="radio" name="unselect_all" value="1"> {{ 'Unselect'|trans({}, 'Admin.Actions') }}
+          </label>
+        </div>
+      </span>
     {% endif %}
   </div>
 
@@ -105,6 +94,8 @@
              {% if choice[choice_value] in selected_values %}checked{% endif %}
              {% if disabled or choice[choice_value] in disabled_values %}disabled{% endif %}
       >
+      <i class="material-icons">
+      </i>
       {{ choice[choice_label] }}
     </label>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
@@ -36,6 +36,13 @@
       <i class="material-icons">expand_more</i>
       <span class="js-toggle-text">{{ 'Expand'|trans({}, 'Admin.Actions') }}</span>
     </span>
+    <span class="float-right">
+      <div class="radio js-unselect-all">
+        <label>
+          <input type="radio" name="unselect_all" value="1"> {{ 'Unselect'|trans({}, 'Admin.Actions') }}
+        </label>
+      </div>
+    </span>
   </div>
 
   <ul class="choice-tree">


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In legacy product list there is a button with category tree. Unfortunately it does not suit well with our new architecture so I created new one which reuses existing category tree. Added extra functionalities including : submit on radio button change, unselect all and unselect all and submit. **Collapse/Expand all** functionality has been removed from every tree
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | partially required for product list
| How to test?  | Please check Categories page, if categories choice tree does not break.

- [ ] docs


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14619)
<!-- Reviewable:end -->
