### PR TITLE
Init properly the Kernel on major *manual* upgrades

### DIFF
--- a/install-dev/upgrade/upgrade.php
+++ b/install-dev/upgrade/upgrade.php
@@ -45,8 +45,11 @@ if (isset($_GET['adminDir']) && $_GET['adminDir'] && !defined('_PS_ADMIN_DIR_'))
     define('_PS_ADMIN_DIR_', base64_decode($_GET['adminDir']));
 }
 
-require_once dirname(__FILE__).'/../init.php';
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../config/defines.inc.php';
+require_once __DIR__ . '/../../config/autoload.php';
 Upgrade::migrateSettingsFile();
+require_once dirname(__FILE__).'/../init.php';
 require_once _PS_CONFIG_DIR_.'bootstrap.php';
 
 $logDir = _PS_ROOT_DIR_.'/var/logs/'.(_PS_MODE_DEV_ ? 'dev' : 'prod').'/';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Upgrades to PS 1.7.6 require the kernel to run. Unfornately, the migration of the settings file when upgrading from PS < 1.7 was done AFTER the checks allowing the kernel to be enabled. This PR orders the functions calls accordingly.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/14591 & https://github.com/PrestaShop/PrestaShop/issues/14617
| How to test?  | Follow https://github.com/PrestaShop/PrestaShop/issues/14591#issuecomment-510841509

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14620)
<!-- Reviewable:end -->
