### PR TITLE
Fix a case where shipping cost is always free

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3253,22 +3253,21 @@ class CartCore extends ObjectModel
         if (null === $delivery_option) {
             $delivery_option = $this->getDeliveryOption($default_country, false, false);
         }
+        $delivery_option_list = $this->getDeliveryOptionList($default_country)
+        $_total_shipping = 0.0;
 
-        $_total_shipping = array(
-            'with_tax' => 0,
-            'without_tax' => 0,
-        );
-        $delivery_option_list = $this->getDeliveryOptionList($default_country);
         foreach ($delivery_option as $id_address => $key) {
             if (!isset($delivery_option_list[$id_address]) || !isset($delivery_option_list[$id_address][$key])) {
                 continue;
             }
-
-            $_total_shipping['with_tax'] += $delivery_option_list[$id_address][$key]['total_price_with_tax'];
-            $_total_shipping['without_tax'] += $delivery_option_list[$id_address][$key]['total_price_without_tax'];
+            if ($use_tax) {
+                $_total_shipping += $delivery_option_list[$id_address][$key]['total_price_with_tax'];
+            } else {
+                $_total_shipping += $delivery_option_list[$id_address][$key]['total_price_without_tax'];
+            }
         }
 
-        return ($use_tax) ? $_total_shipping['with_tax'] : $_total_shipping['without_tax'];
+        return $_total_shipping;
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3253,7 +3253,7 @@ class CartCore extends ObjectModel
         if (null === $delivery_option) {
             $delivery_option = $this->getDeliveryOption($default_country, false, false);
         }
-        $delivery_option_list = $this->getDeliveryOptionList($default_country)
+        $delivery_option_list = $this->getDeliveryOptionList($default_country);
         $_total_shipping = 0.0;
 
         foreach ($delivery_option as $id_address => $key) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Solves an issue where the shipping was always free. For some reason the sum of shipping remained 0.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/pull/12710
| How to test?  | https://github.com/PrestaShop/PrestaShop/pull/12710

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14626)
<!-- Reviewable:end -->
