### PR TITLE
Fix modules listing in their correct categories, not in "Other"

### DIFF
--- a/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php
@@ -187,6 +187,8 @@ class CategoriesProvider
             foreach ($parentCategory->categories as $childCategory) {
                 if ($childCategory->name === $categoryName) {
                     return $parentCategory->name;
+                } elseif (isset($childCategory->tab) && $childCategory->tab === $categoryName) {
+                    return $parentCategory->name;
                 }
             }
         }
@@ -235,10 +237,13 @@ class CategoriesProvider
      *
      * @param ApiModule $installedProduct Installed product
      * @param array $categories Available categories
+     * @return string
      */
     private function findModuleCategory(ApiModule $installedProduct, array $categories)
     {
-        $moduleCategoryParent = $installedProduct->attributes->get('categoryParentEnglishName');
+        $moduleCategory = $installedProduct->attributes->get('tab');
+        $moduleCategoryParent = $this->getParentCategory($moduleCategory);
+
         if (!isset($categories['categories']->subMenu[$moduleCategoryParent])) {
             if (in_array($installedProduct->attributes->get('name'), $this->modulesTheme)) {
                 $moduleCategoryParent = self::CATEGORY_THEME;


### PR DESCRIPTION
Fixes the issue on Module Manager page where modules were not in their categories but in "Other".

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the Module Manager, most of the modules were listed in "Other" instead of the their correct categories (e.g.: "Trafic & Marketplaces", "Administration", etc). This pull request will fix that, see screenshot below.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | Fixes #15298
| How to test?  | Install the new PrestaShop 1.7.6.0, install a few modules, you'll see they are in "Other" category instead of the one set in **ModuleCore::$tab**.

Before :
![image](https://user-images.githubusercontent.com/2537607/61195014-a78de680-a6ef-11e9-987a-16c984a9479c.png)

After :
![image](https://user-images.githubusercontent.com/2537607/61195107-3a2e8580-a6f0-11e9-8b4f-c2533389094f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14645)
<!-- Reviewable:end -->
