### PR TITLE
Fix editing shop association in Category and Manufacturer

### DIFF
--- a/src/Adapter/Category/CommandHandler/EditCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/EditCategoryHandler.php
@@ -105,10 +105,6 @@ final class EditCategoryHandler extends AbstractObjectModelHandler implements Ed
             $category->groupBox = $command->getAssociatedGroupIds();
         }
 
-        if ($command->getAssociatedShopIds()) {
-            $this->associateWithShops($category, $command->getAssociatedShopIds());
-        }
-
         if (false === $category->validateFields(false)) {
             throw new CategoryException('Invalid data when updating category');
         }
@@ -121,6 +117,10 @@ final class EditCategoryHandler extends AbstractObjectModelHandler implements Ed
             throw new CannotEditCategoryException(
                 sprintf('Failed to edit Category with id "%s".', $category->id)
             );
+        }
+
+        if ($command->getAssociatedShopIds()) {
+            $this->associateWithShops($category, $command->getAssociatedShopIds());
         }
     }
 }

--- a/src/Adapter/Manufacturer/CommandHandler/EditManufacturerHandler.php
+++ b/src/Adapter/Manufacturer/CommandHandler/EditManufacturerHandler.php
@@ -54,14 +54,14 @@ final class EditManufacturerHandler extends AbstractManufacturerHandler implemen
                 throw new ManufacturerException('Manufacturer contains invalid field values');
             }
 
-            if (null !== $command->getAssociatedShops()) {
-                $this->associateWithShops($manufacturer, $command->getAssociatedShops());
-            }
-
             if (!$manufacturer->update()) {
                 throw new ManufacturerException(
                     sprintf('Cannot update manufacturer with id "%s"', $manufacturer->id)
                 );
+            }
+
+            if (null !== $command->getAssociatedShops()) {
+                $this->associateWithShops($manufacturer, $command->getAssociatedShops());
             }
         } catch (PrestaShopException $e) {
             throw new ManufacturerException(

--- a/src/Adapter/Manufacturer/QueryHandler/GetManufacturerForEditingHandler.php
+++ b/src/Adapter/Manufacturer/QueryHandler/GetManufacturerForEditingHandler.php
@@ -68,7 +68,7 @@ final class GetManufacturerForEditingHandler extends AbstractManufacturerHandler
         return new EditableManufacturer(
             $manufacturerId,
             $manufacturer->name,
-            $manufacturer->active,
+            (bool) $manufacturer->active,
             $manufacturer->short_description,
             $manufacturer->description,
             $manufacturer->meta_title,


### PR DESCRIPTION
…egory edit handlers

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | `associateWithShops()` method of AbstractObjectModelHandler didn't work when used before object->update(). So it caused issues, when updating shop association (nr. 1@ https://github.com/PrestaShop/PrestaShop/pull/13485#issuecomment-510792137). This PR moves that method usage to be after update() and take effect in EditManufacturerHandler and EditCategoryHandler .
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Go to Manufacturers or Category page while having multiple shops, edit it -> change shop association. See the change is made after submit. (previously the change didn't take any effect)![Screenshot from 2019-07-15 14-49-58](https://user-images.githubusercontent.com/31609858/61214195-f0ee2e00-a70f-11e9-98a7-bb4424e740c7.png) ![Screenshot from 2019-07-15 14-51-26](https://user-images.githubusercontent.com/31609858/61214242-0d8a6600-a710-11e9-8518-79c89a831a4f.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14656)
<!-- Reviewable:end -->
