### PR TITLE
Introduce automatic Tab registration with symfony routes, menu now handles disabled modules

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -834,6 +834,7 @@ class LinkCore
      * @param array $tab
      *
      * @return string
+     *
      * @throws PrestaShopException
      */
     public function getTabLink(array $tab)

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -831,6 +831,26 @@ class LinkCore
     }
 
     /**
+     * @param array $tab
+     *
+     * @return string
+     * @throws PrestaShopException
+     */
+    public function getTabLink(array $tab)
+    {
+        if (!empty($tab['route_name'])) {
+            $sfContainer = SymfonyContainer::getInstance();
+            if (null !== $sfContainer) {
+                $sfRouter = $sfContainer->get('router');
+
+                return $sfRouter->generate($tab['route_name']);
+            }
+        }
+
+        return $this->getAdminLink($tab['class_name']);
+    }
+
+    /**
      * Used when you explicitly want to create a LEGACY admin link, this should be deprecated
      * in 1.8.0.
      *

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -150,11 +150,11 @@ class TabCore extends ObjectModel
              * This can happen if you want to create several tabs with the same class_name or route_name
              */
             $actionSlug = pSQL($slug . '_' . $action);
-            $authorizationRoleExists = Db::getInstance()->numRows(
-                'SELECT 1 FROM `' . _DB_PREFIX_ . 'authorization_role` ' .
+            $authorizationRole = Db::getInstance()->getRow(
+                'SELECT slug FROM `' . _DB_PREFIX_ . 'authorization_role` ' .
                 'WHERE `slug` = "' . $actionSlug . '"'
             );
-            if (!$authorizationRoleExists) {
+            if (empty($authorizationRole)) {
                 Db::getInstance()->execute(
                     'INSERT INTO `' . _DB_PREFIX_ . 'authorization_role` (`slug`) VALUES ("' . $actionSlug . '")'
                 );

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -145,10 +145,19 @@ class TabCore extends ObjectModel
         $slug = 'ROLE_MOD_TAB_' . strtoupper(self::getClassNameById($idTab));
 
         foreach (array('CREATE', 'READ', 'UPDATE', 'DELETE') as $action) {
-            //Check if authorization role does not exist (this can happen if you want to create several tabs with the same class_name or route_name)
-            $idAuthorizationRole = Db::getInstance()->getValue('SELECT id_authorization_role FROM `' . _DB_PREFIX_ . 'authorization_role` WHERE `slug` = "' . $slug . '_' . $action . '"');
-            if (empty($idAuthorizationRole)) {
-                Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'authorization_role` (`slug`) VALUES ("' . $slug . '_' . $action . '")');
+            /*
+             * Check if authorization role does not exist.
+             * This can happen if you want to create several tabs with the same class_name or route_name
+             */
+            $actionSlug = pSQL($slug . '_' . $action);
+            $authorizationRoleExists = Db::getInstance()->numRows(
+                'SELECT 1 FROM `' . _DB_PREFIX_ . 'authorization_role` ' .
+                'WHERE `slug` = "' . $actionSlug . '"'
+            );
+            if (!$authorizationRoleExists) {
+                Db::getInstance()->execute(
+                    'INSERT INTO `' . _DB_PREFIX_ . 'authorization_role` (`slug`) VALUES ("' . $actionSlug . '")'
+                );
             }
         }
 

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -49,6 +49,9 @@ class TabCore extends ObjectModel
     /** @var bool active */
     public $active = true;
 
+    /** @var bool enabled */
+    public $enabled = true;
+
     /** @var int hide_host_mode */
     public $hide_host_mode = false;
 
@@ -71,6 +74,7 @@ class TabCore extends ObjectModel
             'class_name' => array('type' => self::TYPE_STRING, 'required' => true, 'size' => 64),
             'route_name' => array('type' => self::TYPE_STRING, 'required' => false, 'size' => 256),
             'active' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),
+            'enabled' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),
             'hide_host_mode' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),
             'icon' => array('type' => self::TYPE_STRING, 'size' => 64),
             /* Lang fields */

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -595,7 +595,7 @@ class AdminControllerCore extends Controller
             'tab' => $dummy,
             'action' => $dummy,
         );
-        if (isset($tabs[0])) {
+        if (!empty($tabs[0])) {
             $this->addMetaTitle($tabs[0]['name']);
             $breadcrumbs2['tab']['name'] = $tabs[0]['name'];
             $breadcrumbs2['tab']['href'] = $this->context->link->getTabLink($tabs[0]);
@@ -603,7 +603,7 @@ class AdminControllerCore extends Controller
                 $breadcrumbs2['tab']['icon'] = 'icon-' . $tabs[0]['class_name'];
             }
         }
-        if (isset($tabs[1])) {
+        if (!empty($tabs[1])) {
             $breadcrumbs2['container']['name'] = $tabs[1]['name'];
             $breadcrumbs2['container']['href'] = $this->context->link->getTabLink($tabs[1]);
             $breadcrumbs2['container']['icon'] = 'icon-' . $tabs[1]['class_name'];
@@ -2067,6 +2067,7 @@ class AdminControllerCore extends Controller
 
         foreach ($tabs as $index => $tab) {
             if (!Tab::checkTabRights($tab['id_tab'])
+                || !$tab['enabled']
                 || ($tab['class_name'] == 'AdminStock' && Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') == 0)
                 || $tab['class_name'] == 'AdminCarrierWizard') {
                 unset($tabs[$index]);
@@ -4831,7 +4832,7 @@ class AdminControllerCore extends Controller
     private function getTabLinkFromSubTabs(array $subtabs)
     {
         foreach ($subtabs as $tab) {
-            if ($tab['active']) {
+            if ($tab['active'] && $tab['enabled']) {
                 return $tab['href'];
             }
         }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -598,14 +598,14 @@ class AdminControllerCore extends Controller
         if (isset($tabs[0])) {
             $this->addMetaTitle($tabs[0]['name']);
             $breadcrumbs2['tab']['name'] = $tabs[0]['name'];
-            $breadcrumbs2['tab']['href'] = $this->context->link->getAdminLink($tabs[0]['class_name']);
+            $breadcrumbs2['tab']['href'] = $this->context->link->getTabLink($tabs[0]);
             if (!isset($tabs[1])) {
                 $breadcrumbs2['tab']['icon'] = 'icon-' . $tabs[0]['class_name'];
             }
         }
         if (isset($tabs[1])) {
             $breadcrumbs2['container']['name'] = $tabs[1]['name'];
-            $breadcrumbs2['container']['href'] = $this->context->link->getAdminLink($tabs[1]['class_name']);
+            $breadcrumbs2['container']['href'] = $this->context->link->getTabLink($tabs[1]);
             $breadcrumbs2['container']['icon'] = 'icon-' . $tabs[1]['class_name'];
         }
 
@@ -2082,7 +2082,7 @@ class AdminControllerCore extends Controller
                 $tabs[$index]['current'] = false;
             }
             $tabs[$index]['img'] = null;
-            $tabs[$index]['href'] = $this->context->link->getAdminLink($tab['class_name']);
+            $tabs[$index]['href'] = $this->context->link->getTabLink($tab);
             $tabs[$index]['sub_tabs'] = array_values($this->getTabs($tab['id_tab'], $level + 1));
 
             $subTabHref = $this->getTabLinkFromSubTabs($tabs[$index]['sub_tabs']);

--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -8,446 +8,446 @@
     </fields>
     <entities>
 
-        <tab id="Dashboard" id_parent="" active="1" hide_host_mode="0" icon="trending_up">
+        <tab id="Dashboard" id_parent="" active="1" enabled="1" hide_host_mode="0" icon="trending_up">
             <class_name>AdminDashboard</class_name>
         </tab>
 
         <!--SELL-->
-        <tab id="SELL" id_parent="" active="1" hide_host_mode="0" icon="">
+        <tab id="SELL" id_parent="" active="1" enabled="1" hide_host_mode="0" icon="">
             <class_name>SELL</class_name>
         </tab>
 
             <!--ORDERS-->
-            <tab id="Orders" id_parent="SELL" active="1" hide_host_mode="0" icon="shopping_basket">
+            <tab id="Orders" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="shopping_basket">
                 <class_name>AdminParentOrders</class_name>
             </tab>
 
-                <tab id="Orders_1" id_parent="Orders" active="1" hide_host_mode="0" icon="">
+                <tab id="Orders_1" id_parent="Orders" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminOrders</class_name>
                 </tab>
-                <tab id="Invoices" id_parent="Orders" active="1" hide_host_mode="0" icon="">
+                <tab id="Invoices" id_parent="Orders" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminInvoices</class_name>
                 </tab>
-                <tab id="Credit_Slips" id_parent="Orders" active="1" hide_host_mode="0" icon="">
+                <tab id="Credit_Slips" id_parent="Orders" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminSlip</class_name>
                 </tab>
-                <tab id="Delivery_Slips" id_parent="Orders" active="1" hide_host_mode="0" icon="">
+                <tab id="Delivery_Slips" id_parent="Orders" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminDeliverySlip</class_name>
                 </tab>
-                <tab id="Shopping_Carts" id_parent="Orders" active="1" hide_host_mode="0" icon="">
+                <tab id="Shopping_Carts" id_parent="Orders" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminCarts</class_name>
                 </tab>
 
             <!--CATALOG-->
-            <tab id="Catalog" id_parent="SELL" active="1" hide_host_mode="0" icon="store">
+            <tab id="Catalog" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="store">
                 <class_name>AdminCatalog</class_name>
             </tab>
 
-                <tab id="Products" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
+                <tab id="Products" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminProducts</class_name>
                 </tab>
-                <tab id="Categories" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
+                <tab id="Categories" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminCategories</class_name>
                 </tab>
-                <tab id="Monitoring" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
+                <tab id="Monitoring" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminTracking</class_name>
                 </tab>
-                <tab id="Attributes_and_features" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
+                <tab id="Attributes_and_features" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentAttributesGroups</class_name>
                 </tab>
 
-                    <tab id="Attributes_and_Values" id_parent="Attributes_and_features" active="1" hide_host_mode="0" icon="">
+                    <tab id="Attributes_and_Values" id_parent="Attributes_and_features" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminAttributesGroups</class_name>
                     </tab>
-                    <tab id="Features" id_parent="Attributes_and_features" active="1" hide_host_mode="0" icon="">
+                    <tab id="Features" id_parent="Attributes_and_features" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminFeatures</class_name>
                     </tab>
 
-                <tab id="Manufacturers_and_suppliers" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
+                <tab id="Manufacturers_and_suppliers" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentManufacturers</class_name>
                 </tab>
 
-                    <tab id="Manufacturers" id_parent="Manufacturers_and_suppliers" active="1" hide_host_mode="0" icon="">
+                    <tab id="Manufacturers" id_parent="Manufacturers_and_suppliers" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminManufacturers</class_name>
                     </tab>
-                    <tab id="Suppliers" id_parent="Manufacturers_and_suppliers" active="1" hide_host_mode="0" icon="">
+                    <tab id="Suppliers" id_parent="Manufacturers_and_suppliers" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminSuppliers</class_name>
                     </tab>
 
-                <tab id="Attachments" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
+                <tab id="Attachments" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminAttachments</class_name>
                 </tab>
-                <tab id="Price_Rules" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
+                <tab id="Price_Rules" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentCartRules</class_name>
                 </tab>
 
-                    <tab id="Cart_Rules" id_parent="Price_Rules" active="1" hide_host_mode="0" icon="">
+                    <tab id="Cart_Rules" id_parent="Price_Rules" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminCartRules</class_name>
                     </tab>
-                    <tab id="Catalog_Price_Rules" id_parent="Price_Rules" active="1" hide_host_mode="0" icon="">
+                    <tab id="Catalog_Price_Rules" id_parent="Price_Rules" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminSpecificPriceRule</class_name>
                     </tab>
-                <tab id="Stock" id_parent="Catalog" active="1" hide_host_mode="0" icon="">
+                <tab id="Stock" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminStockManagement</class_name>
                 </tab>
 
             <!--CUSTOMERS-->
-            <tab id="Customers" id_parent="SELL" active="1" hide_host_mode="0" icon="account_circle">
+            <tab id="Customers" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="account_circle">
                 <class_name>AdminParentCustomer</class_name>
             </tab>
 
-                <tab id="Customers_2" id_parent="Customers" active="1" hide_host_mode="0" icon="">
+                <tab id="Customers_2" id_parent="Customers" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminCustomers</class_name>
                 </tab>
-                <tab id="Addresses" id_parent="Customers" active="1" hide_host_mode="0" icon="">
+                <tab id="Addresses" id_parent="Customers" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminAddresses</class_name>
                 </tab>
-                <tab id="Outstanding" id_parent="Customers" active="0" hide_host_mode="0" icon="">
+                <tab id="Outstanding" id_parent="Customers" active="0" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminOutstanding</class_name>
                 </tab>
 
             <!--CUSTOMER SERVICE-->
-            <tab id="Customer_Service" id_parent="SELL" active="1" hide_host_mode="0" icon="chat">
+            <tab id="Customer_Service" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="chat">
                 <class_name>AdminParentCustomerThreads</class_name>
             </tab>
 
-                <tab id="Customer_Service_2" id_parent="Customer_Service" active="1" hide_host_mode="0" icon="">
+                <tab id="Customer_Service_2" id_parent="Customer_Service" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminCustomerThreads</class_name>
                 </tab>
-                <tab id="Order_Messages" id_parent="Customer_Service" active="1" hide_host_mode="0" icon="">
+                <tab id="Order_Messages" id_parent="Customer_Service" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminOrderMessage</class_name>
                 </tab>
-                <tab id="Merchandise_Returns" id_parent="Customer_Service" active="1" hide_host_mode="0" icon="">
+                <tab id="Merchandise_Returns" id_parent="Customer_Service" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminReturn</class_name>
                 </tab>
 
             <!--STATISTICS-->
-            <tab id="Stats" id_parent="SELL" active="1" hide_host_mode="0" icon="assessment">
+            <tab id="Stats" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="assessment">
                 <class_name>AdminStats</class_name>
             </tab>
 
             <!--ADVANCED STOCK MANAGEMENT-->
-            <tab id="Advanced_stock_management" id_parent="SELL" active="1" hide_host_mode="0" icon="store">
+            <tab id="Advanced_stock_management" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="store">
                 <class_name>AdminStock</class_name>
             </tab>
 
-                <tab id="Warehouses" id_parent="Advanced_stock_management" active="1" hide_host_mode="0" icon="">
+                <tab id="Warehouses" id_parent="Advanced_stock_management" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminWarehouses</class_name>
                 </tab>
-                <tab id="Stock_Management" id_parent="Advanced_stock_management" active="1" hide_host_mode="0" icon="">
+                <tab id="Stock_Management" id_parent="Advanced_stock_management" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentStockManagement</class_name>
                 </tab>
 
-                    <tab id="Stock_Management" id_parent="Stock_Management" active="1" hide_host_mode="0" icon="">
+                    <tab id="Stock_Management" id_parent="Stock_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStockManagement</class_name>
                     </tab>
-                    <tab id="Stock_Movement" id_parent="Stock_Management" active="1" hide_host_mode="0" icon="">
+                    <tab id="Stock_Movement" id_parent="Stock_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStockMvt</class_name>
                     </tab>
-                    <tab id="Instant_Stock_Status" id_parent="Stock_Management" active="1" hide_host_mode="0" icon="">
+                    <tab id="Instant_Stock_Status" id_parent="Stock_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStockInstantState</class_name>
                     </tab>
-                    <tab id="Stock_Coverage" id_parent="Stock_Management" active="1" hide_host_mode="0" icon="">
+                    <tab id="Stock_Coverage" id_parent="Stock_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStockCover</class_name>
                     </tab>
 
-                <tab id="Supply_orders" id_parent="Advanced_stock_management" active="1" hide_host_mode="0" icon="">
+                <tab id="Supply_orders" id_parent="Advanced_stock_management" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminSupplyOrders</class_name>
                 </tab>
-                <tab id="Configuration" id_parent="Advanced_stock_management" active="1" hide_host_mode="0" icon="">
+                <tab id="Configuration" id_parent="Advanced_stock_management" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminStockConfiguration</class_name>
                 </tab>
 
 
         <!--IMPROVE-->
-        <tab id="IMPROVE" id_parent="" active="1" hide_host_mode="0" icon="">
+        <tab id="IMPROVE" id_parent="" active="1" enabled="1" hide_host_mode="0" icon="">
             <class_name>IMPROVE</class_name>
         </tab>
 
             <!--MODULES-->
-            <tab id="Modules" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="extension">
+            <tab id="Modules" id_parent="IMPROVE" active="1" enabled="1" hide_host_mode="0" icon="extension">
                 <class_name>AdminParentModulesSf</class_name>
             </tab>
-                <tab id="Module_Page" id_parent="Modules" active="1" hide_host_mode="0" icon="">
+                <tab id="Module_Page" id_parent="Modules" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminModulesSf</class_name>
                 </tab>
-                    <tab id="Module_Page_Manage" id_parent="Module_Page" active="1" hide_host_mode="0" icon="">
+                    <tab id="Module_Page_Manage" id_parent="Module_Page" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminModulesManage</class_name>
                     </tab>
-                    <tab id="Module_Page_Notifications" id_parent="Module_Page" active="1" hide_host_mode="0" icon="">
+                    <tab id="Module_Page_Notifications" id_parent="Module_Page" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminModulesNotifications</class_name>
                     </tab>
-                    <tab id="Module_Page_Updates" id_parent="Module_Page" active="1" hide_host_mode="0" icon="">
+                    <tab id="Module_Page_Updates" id_parent="Module_Page" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminModulesUpdates</class_name>
                     </tab>
-                <tab id="Module_Catalog" id_parent="Modules" active="1" hide_host_mode="0" icon="">
+                <tab id="Module_Catalog" id_parent="Modules" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentModulesCatalog</class_name>
                 </tab>
-                    <tab id="Module_Page_Catalog" id_parent="Module_Catalog" active="1" hide_host_mode="0" icon="">
+                    <tab id="Module_Page_Catalog" id_parent="Module_Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminModulesCatalog</class_name>
                     </tab>
-                    <tab id="Marketing_tools" id_parent="Module_Catalog" active="1" hide_host_mode="0" icon="">
+                    <tab id="Marketing_tools" id_parent="Module_Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminAddonsCatalog</class_name>
                     </tab>
-                <tab id="Module_Page_old" id_parent="Modules" active="0" hide_host_mode="0" icon="">
+                <tab id="Module_Page_old" id_parent="Modules" active="0" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminModules</class_name>
                 </tab>
 
             <!--LOOK & FEEL-->
-            <tab id="Look_feel" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="desktop_mac">
+            <tab id="Look_feel" id_parent="IMPROVE" active="1" enabled="1" hide_host_mode="0" icon="desktop_mac">
                 <class_name>AdminParentThemes</class_name>
             </tab>
 
-                <tab id="Themes" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
+                <tab id="Themes" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminThemes</class_name>
                 </tab>
-                <tab id="Themes_Catalog" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
+                <tab id="Themes_Catalog" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminThemesCatalog</class_name>
                 </tab>
-                <tab id="Mail_Theme_Parent" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
+                <tab id="Mail_Theme_Parent" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                   <class_name>AdminMailThemeParent</class_name>
                 </tab>
-                    <tab id="Mail_Theme" id_parent="Mail_Theme_Parent" active="1" hide_host_mode="0" icon="">
+                    <tab id="Mail_Theme" id_parent="Mail_Theme_Parent" active="1" enabled="1" hide_host_mode="0" icon="">
                       <class_name>AdminMailTheme</class_name>
                     </tab>
 
-                <tab id="Pages" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
+                <tab id="Pages" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminCmsContent</class_name>
                 </tab>
-                <tab id="Positions" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
+                <tab id="Positions" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminModulesPositions</class_name>
                 </tab>
-                <tab id="Image_Settings" id_parent="Look_feel" active="1" hide_host_mode="0" icon="">
+                <tab id="Image_Settings" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminImages</class_name>
                 </tab>
 
-                <tab id="Shipping" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="local_shipping">
+                <tab id="Shipping" id_parent="IMPROVE" active="1" enabled="1" hide_host_mode="0" icon="local_shipping">
                     <class_name>AdminParentShipping</class_name>
                 </tab>
 
-                    <tab id="Carriers" id_parent="Shipping" active="1" hide_host_mode="0" icon="">
+                    <tab id="Carriers" id_parent="Shipping" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminCarriers</class_name>
                     </tab>
-                    <tab id="Shipping_1" id_parent="Shipping" active="1" hide_host_mode="0" icon="">
+                    <tab id="Shipping_1" id_parent="Shipping" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminShipping</class_name>
                     </tab>
 
-                <tab id="Payment" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="payment">
+                <tab id="Payment" id_parent="IMPROVE" active="1" enabled="1" hide_host_mode="0" icon="payment">
                     <class_name>AdminParentPayment</class_name>
                 </tab>
 
-                    <tab id="Payment_methods" id_parent="Payment" active="1" hide_host_mode="0" icon="">
+                    <tab id="Payment_methods" id_parent="Payment" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminPayment</class_name>
                     </tab>
-                    <tab id="Payment_preferences" id_parent="Payment" active="1" hide_host_mode="0" icon="">
+                    <tab id="Payment_preferences" id_parent="Payment" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminPaymentPreferences</class_name>
                     </tab>
 
             <!--INTERNATIONAL OK-->
-            <tab id="International" id_parent="IMPROVE" active="1" hide_host_mode="0" icon="language">
+            <tab id="International" id_parent="IMPROVE" active="1" enabled="1" hide_host_mode="0" icon="language">
                 <class_name>AdminInternational</class_name>
             </tab>
 
-                <tab id="Localization" id_parent="International" active="1" hide_host_mode="0" icon="">
+                <tab id="Localization" id_parent="International" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentLocalization</class_name>
                 </tab>
 
-                    <tab id="Localization_1" id_parent="Localization" active="1" hide_host_mode="0" icon="">
+                    <tab id="Localization_1" id_parent="Localization" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminLocalization</class_name>
                     </tab>
-                    <tab id="Languages" id_parent="Localization" active="1" hide_host_mode="0" icon="">
+                    <tab id="Languages" id_parent="Localization" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminLanguages</class_name>
                     </tab>
-                    <tab id="Currencies" id_parent="Localization" active="1" hide_host_mode="0" icon="">
+                    <tab id="Currencies" id_parent="Localization" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminCurrencies</class_name>
                     </tab>
-                    <tab id="Geolocation" id_parent="Localization" active="1" hide_host_mode="0" icon="">
+                    <tab id="Geolocation" id_parent="Localization" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminGeolocation</class_name>
                     </tab>
 
-                <tab id="Locations" id_parent="International" active="1" hide_host_mode="0" icon="">
+                <tab id="Locations" id_parent="International" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentCountries</class_name>
                 </tab>
-                    <tab id="Zones" id_parent="Locations" active="1" hide_host_mode="0" icon="">
+                    <tab id="Zones" id_parent="Locations" active="1" enabled="1" hide_host_mode="0" icon="">
                       <class_name>AdminZones</class_name>
                     </tab>
-                    <tab id="Countries" id_parent="Locations" active="1" hide_host_mode="0" icon="">
+                    <tab id="Countries" id_parent="Locations" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminCountries</class_name>
                     </tab>
-                    <tab id="States" id_parent="Locations" active="1" hide_host_mode="0" icon="">
+                    <tab id="States" id_parent="Locations" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStates</class_name>
                     </tab>
 
-                <tab id="Tax_Management" id_parent="International" active="1" hide_host_mode="0" icon="">
+                <tab id="Tax_Management" id_parent="International" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentTaxes</class_name>
                 </tab>
 
-                    <tab id="Taxes" id_parent="Tax_Management" active="1" hide_host_mode="0" icon="">
+                    <tab id="Taxes" id_parent="Tax_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminTaxes</class_name>
                     </tab>
-                    <tab id="Tax_Rules" id_parent="Tax_Management" active="1" hide_host_mode="0" icon="">
+                    <tab id="Tax_Rules" id_parent="Tax_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminTaxRulesGroup</class_name>
                     </tab>
 
-                <tab id="Translations" id_parent="International" active="1" hide_host_mode="0" icon="">
+                <tab id="Translations" id_parent="International" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminTranslations</class_name>
                 </tab>
 
         <!--CONFIGURE-->
-        <tab id="CONFIGURE" id_parent="" active="1" hide_host_mode="0" icon="">
+        <tab id="CONFIGURE" id_parent="" active="1" enabled="1" hide_host_mode="0" icon="">
             <class_name>CONFIGURE</class_name>
         </tab>
 
             <!--SHOP PARAMETERS-->
-            <tab id="Shop_parameters" id_parent="CONFIGURE" active="1" hide_host_mode="0" icon="settings">
+            <tab id="Shop_parameters" id_parent="CONFIGURE" active="1" enabled="1" hide_host_mode="0" icon="settings">
                 <class_name>ShopParameters</class_name>
             </tab>
 
-                <tab id="General" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="General" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentPreferences</class_name>
                 </tab>
 
-                    <tab id="General_1" id_parent="General" active="1" hide_host_mode="0" icon="">
+                    <tab id="General_1" id_parent="General" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminPreferences</class_name>
                     </tab>
-                    <tab id="Maintenance" id_parent="General" active="1" hide_host_mode="0" icon="">
+                    <tab id="Maintenance" id_parent="General" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminMaintenance</class_name>
                     </tab>
 
-                <tab id="Order_settings" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Order_settings" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentOrderPreferences</class_name>
                 </tab>
 
-                    <tab id="Order_settings_2" id_parent="Order_settings" active="1" hide_host_mode="0" icon="">
+                    <tab id="Order_settings_2" id_parent="Order_settings" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminOrderPreferences</class_name>
                     </tab>
-                    <tab id="Statuses" id_parent="Order_settings" active="1" hide_host_mode="0" icon="">
+                    <tab id="Statuses" id_parent="Order_settings" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStatuses</class_name>
                     </tab>
 
-                <tab id="Products_1" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Products_1" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminPPreferences</class_name>
                 </tab>
-                <tab id="Customer_settings" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Customer_settings" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentCustomerPreferences</class_name>
                 </tab>
 
-                    <tab id="Customers_2" id_parent="Customer_settings" active="1" hide_host_mode="0" icon="">
+                    <tab id="Customers_2" id_parent="Customer_settings" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminCustomerPreferences</class_name>
                     </tab>
-                    <tab id="Groups" id_parent="Customer_settings" active="1" hide_host_mode="0" icon="">
+                    <tab id="Groups" id_parent="Customer_settings" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminGroups</class_name>
                     </tab>
-                    <tab id="Titles" id_parent="Customer_settings" active="1" hide_host_mode="0" icon="">
+                    <tab id="Titles" id_parent="Customer_settings" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminGenders</class_name>
                     </tab>
 
-                <tab id="Contact" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Contact" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentStores</class_name>
                 </tab>
 
-                    <tab id="Contacts" id_parent="Contact" active="1" hide_host_mode="0" icon="">
+                    <tab id="Contacts" id_parent="Contact" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminContacts</class_name>
                     </tab>
-                    <tab id="Store_Contacts" id_parent="Contact" active="1" hide_host_mode="0" icon="">
+                    <tab id="Store_Contacts" id_parent="Contact" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStores</class_name>
                     </tab>
 
-                <tab id="Traffic" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Traffic" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentMeta</class_name>
                 </tab>
 
-                    <tab id="SEO_URLs" id_parent="Traffic" active="1" hide_host_mode="0" icon="">
+                    <tab id="SEO_URLs" id_parent="Traffic" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminMeta</class_name>
                     </tab>
-                    <tab id="Search_Engines" id_parent="Traffic" active="1" hide_host_mode="0" icon="">
+                    <tab id="Search_Engines" id_parent="Traffic" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminSearchEngines</class_name>
                     </tab>
-                    <tab id="Referrers" id_parent="Traffic" active="1" hide_host_mode="0" icon="">
+                    <tab id="Referrers" id_parent="Traffic" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminReferrers</class_name>
                     </tab>
 
-                <tab id="Search" id_parent="Shop_parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Search" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentSearchConf</class_name>
                 </tab>
 
-                    <tab id="Search_1" id_parent="Search" active="1" hide_host_mode="0" icon="">
+                    <tab id="Search_1" id_parent="Search" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminSearchConf</class_name>
                     </tab>
-                    <tab id="Tags" id_parent="Search" active="1" hide_host_mode="0" icon="">
+                    <tab id="Tags" id_parent="Search" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminTags</class_name>
                     </tab>
 
             <!--ADVANCED PARAMETERS-->
-            <tab id="Advanced_Parameters" id_parent="CONFIGURE" active="1" hide_host_mode="0" icon="settings_applications">
+            <tab id="Advanced_Parameters" id_parent="CONFIGURE" active="1" enabled="1" hide_host_mode="0" icon="settings_applications">
                 <class_name>AdminAdvancedParameters</class_name>
             </tab>
 
-                <tab id="Information" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Information" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminInformation</class_name>
                 </tab>
-                <tab id="Performance" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Performance" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminPerformance</class_name>
                 </tab>
-                <tab id="Administration" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Administration" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminAdminPreferences</class_name>
                 </tab>
-                <tab id="E-mail" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="E-mail" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminEmails</class_name>
                 </tab>
-                <tab id="CSV_Import" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="CSV_Import" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminImport</class_name>
                 </tab>
 
-                <tab id="Employees" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Employees" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentEmployees</class_name>
                 </tab>
 
-                    <tab id="Employees_1" id_parent="Employees" active="1" hide_host_mode="0" icon="">
+                    <tab id="Employees_1" id_parent="Employees" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminEmployees</class_name>
                     </tab>
-                    <tab id="Profiles" id_parent="Employees" active="1" hide_host_mode="0" icon="">
+                    <tab id="Profiles" id_parent="Employees" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminProfiles</class_name>
                     </tab>
-                    <tab id="Permissions" id_parent="Employees" active="1" hide_host_mode="0" icon="">
+                    <tab id="Permissions" id_parent="Employees" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminAccess</class_name>
                     </tab>
 
-                <tab id="Database" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Database" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentRequestSql</class_name>
                 </tab>
 
-                    <tab id="SQL_Manager" id_parent="Database" active="1" hide_host_mode="0" icon="">
+                    <tab id="SQL_Manager" id_parent="Database" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminRequestSql</class_name>
                     </tab>
-                    <tab id="DB_Backup" id_parent="Database" active="1" hide_host_mode="0" icon="">
+                    <tab id="DB_Backup" id_parent="Database" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminBackup</class_name>
                     </tab>
 
-                <tab id="Logs" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Logs" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminLogs</class_name>
                 </tab>
-                <tab id="Webservice" id_parent="Advanced_Parameters" active="1" hide_host_mode="0" icon="">
+                <tab id="Webservice" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminWebservice</class_name>
                 </tab>
-                <tab id="Multistore" id_parent="Advanced_Parameters" active="0" hide_host_mode="0" icon="">
+                <tab id="Multistore" id_parent="Advanced_Parameters" active="0" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminShopGroup</class_name>
                 </tab>
-                <tab id="Multistore" id_parent="Advanced_Parameters" active="0" hide_host_mode="0" icon="">
+                <tab id="Multistore" id_parent="Advanced_Parameters" active="0" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminShopUrl</class_name>
                 </tab>
 
       <!--QUICK ACCESS-->
-      <tab id="Quick_Access" id_parent="-1" active="1" hide_host_mode="0" icon="">
+      <tab id="Quick_Access" id_parent="-1" active="1" enabled="1" hide_host_mode="0" icon="">
         <class_name>AdminQuickAccesses</class_name>
       </tab>
 
       <!--DEFAULT-->
-      <tab id="DEFAULT" id_parent="" active="1" hide_host_mode="0" icon="">
+      <tab id="DEFAULT" id_parent="" active="1" enabled="1" hide_host_mode="0" icon="">
         <class_name>DEFAULT</class_name>
       </tab>
 
-      <tab id="Patterns" id_parent="-1" active="1" hide_host_mode="0" icon="">
+      <tab id="Patterns" id_parent="-1" active="1" enabled="1" hide_host_mode="0" icon="">
         <class_name>AdminPatterns</class_name>
       </tab>
     </entities>

--- a/install-dev/upgrade/php/ps_1770_preset_tab_enabled.php
+++ b/install-dev/upgrade/php/ps_1770_preset_tab_enabled.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Preset enabled new column in tabs to true for all (except for disabled modules)
+ */
+function ps_1770_preset_tab_enabled() {
+    //First set all tabs enabled
+    Db::getInstance()->execute(
+        'UPDATE `'._DB_PREFIX_.'tab` SET `enabled`= 1'
+    );
+
+    //Then search for inactive modules and disable their tabs
+    $inactiveModules = Db::getInstance()->executeS(
+        'SELECT `name` FROM `'._DB_PREFIX_.'module` WHERE `active` != 1'
+    );
+    $moduleNames = [];
+    foreach ($inactiveModules as $inactiveModule) {
+        $moduleNames[] = $inactiveModule['name'];
+    }
+    Db::getInstance()->execute(
+        'UPDATE `'._DB_PREFIX_.'tab` SET `enabled`= 0 WHERE `module` IN (' . implode(',', $moduleNames) . ')'
+    );
+}

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -3,4 +3,4 @@ SET NAMES 'utf8';
 
 ALTER TABLE `PREFIX_search_word` MODIFY `word` VARCHAR(30) NOT NULL;
 
-ALTER TABLE `PREFIX_tab` ADD `route_name` varchar(256) DEFAULT NULL AFTER `class_name`;
+/* PHP:ps_1770_preset_tab_enabled(); */;

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -1,4 +1,6 @@
-SET SESSION sql_mode='';
+SET SESSION sql_mode = '';
 SET NAMES 'utf8';
 
 ALTER TABLE `PREFIX_search_word` MODIFY `word` VARCHAR(30) NOT NULL;
+
+ALTER TABLE `PREFIX_tab` ADD `route_name` varchar(256) DEFAULT NULL AFTER `class_name`;

--- a/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
+++ b/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
@@ -58,6 +58,8 @@ class ModuleTabManagementSubscriber implements EventSubscriberInterface
         return [
             ModuleManagementEvent::INSTALL => 'onModuleInstall',
             ModuleManagementEvent::UNINSTALL => 'onModuleUninstall',
+            ModuleManagementEvent::ENABLE => 'onModuleEnable',
+            ModuleManagementEvent::DISABLE => 'onModuleDisable',
         ];
     }
 
@@ -75,5 +77,21 @@ class ModuleTabManagementSubscriber implements EventSubscriberInterface
     public function onModuleUninstall(ModuleManagementEvent $event)
     {
         $this->moduleTabUnregister->unregisterTabs($event->getModule());
+    }
+
+    /**
+     * @param ModuleManagementEvent $event
+     */
+    public function onModuleEnable(ModuleManagementEvent $event)
+    {
+        $this->moduleTabRegister->enableTabs($event->getModule());
+    }
+
+    /**
+     * @param ModuleManagementEvent $event
+     */
+    public function onModuleDisable(ModuleManagementEvent $event)
+    {
+        $this->moduleTabUnregister->disableTabs($event->getModule());
     }
 }

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -122,6 +122,14 @@ class ModuleTabRegister
     }
 
     /**
+     * @param Module $module
+     */
+    public function enableTabs(Module $module)
+    {
+        $this->tabRepository->changeEnabledByModuleName($module->get('name'), true);
+    }
+
+    /**
      * Looks for ModuleAdminControllers not declared as Tab and
      * add them to the list to register.
      *
@@ -282,6 +290,7 @@ class ModuleTabRegister
          */
         $tab = new Tab();
         $tab->active = $tabDetails->getBoolean('visible', true);
+        $tab->enabled = true;
         $tab->class_name = $tabDetails->get('class_name');
         $tab->route_name = $tabDetails->get('route_name');
         $tab->module = $module->get('name');

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -112,7 +112,6 @@ class ModuleTabRegister
         }
 
         $tabs = $this->addUndeclaredTabs($module->get('name'), $module->getInstance()->getTabs());
-
         foreach ($tabs as $tab) {
             try {
                 $this->registerTab($module, new ParameterBag($tab));
@@ -176,7 +175,7 @@ class ModuleTabRegister
             throw new Exception('Missing class name of tab');
         }
         // Check controller exists
-        if (!in_array($className . 'Controller.php', $this->getModuleAdminControllersFilename($moduleName))) {
+        if (empty($data->get('route_name')) && !in_array($className . 'Controller.php', $this->getModuleAdminControllersFilename($moduleName))) {
             throw new Exception(sprintf('Class "%sController" not found in controllers/admin', $className));
         }
         // Deprecation check
@@ -284,6 +283,7 @@ class ModuleTabRegister
         $tab = new Tab();
         $tab->active = $tabDetails->getBoolean('visible', true);
         $tab->class_name = $tabDetails->get('class_name');
+        $tab->route_name = $tabDetails->get('route_name');
         $tab->module = $module->get('name');
         $tab->name = $this->getTabNames($tabDetails->get('name', $tab->class_name));
         $tab->icon = $tabDetails->get('icon');

--- a/src/Adapter/Module/Tab/ModuleTabUnregister.php
+++ b/src/Adapter/Module/Tab/ModuleTabUnregister.php
@@ -87,6 +87,14 @@ class ModuleTabUnregister
     }
 
     /**
+     * @param Module $module
+     */
+    public function disableTabs(Module $module)
+    {
+        $this->tabRepository->changeEnabledByModuleName($module->get('name'), false);
+    }
+
+    /**
      * Uninstalls a tab given its defined structure.
      *
      * @param Tab $tab the instance of entity tab

--- a/src/PrestaShopBundle/Entity/Repository/TabRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/TabRepository.php
@@ -99,4 +99,18 @@ class TabRepository extends EntityRepository
             $this->getEntityManager()->flush();
         }
     }
+
+    /**
+     * @param string $moduleName
+     * @param bool $enabled
+     */
+    public function changeEnabledByModuleName($moduleName, $enabled)
+    {
+        $tabs = $this->findByModule($moduleName);
+        /** @var Tab $tab */
+        foreach ($tabs as $tab) {
+            $tab->setEnabled($enabled);
+        }
+        $this->getEntityManager()->flush();
+    }
 }

--- a/src/PrestaShopBundle/Entity/Tab.php
+++ b/src/PrestaShopBundle/Entity/Tab.php
@@ -69,9 +69,16 @@ class Tab
     /**
      * @var string
      *
-     * @ORM\Column(name="class_name", type="string", length=64, nullable=true)
+     * @ORM\Column(name="class_name", type="string", length=64)
      */
     private $className;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="route_name", type="string", length=256, nullable=true)
+     */
+    private $routeName;
 
     /**
      * @var bool
@@ -154,6 +161,26 @@ class Tab
     public function setActive($active)
     {
         $this->active = $active;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRouteName()
+    {
+        return $this->routeName;
+    }
+
+    /**
+     * @param string $routeName
+     *
+     * @return Tab
+     */
+    public function setRouteName($routeName)
+    {
+        $this->routeName = $routeName;
 
         return $this;
     }

--- a/src/PrestaShopBundle/Entity/Tab.php
+++ b/src/PrestaShopBundle/Entity/Tab.php
@@ -90,6 +90,13 @@ class Tab
     /**
      * @var bool
      *
+     * @ORM\Column(name="enabled", type="boolean")
+     */
+    private $enabled = true;
+
+    /**
+     * @var bool
+     *
      * @ORM\Column(name="hide_host_mode", type="boolean")
      */
     private $hideHostMode;
@@ -181,6 +188,26 @@ class Tab
     public function setRouteName($routeName)
     {
         $this->routeName = $routeName;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param bool $enabled
+     *
+     * @return Tab
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = $enabled;
 
         return $this;
     }

--- a/tests-legacy/Integration/classes/AccessTest.php
+++ b/tests-legacy/Integration/classes/AccessTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace LegacyTests\Integration\classes;
+
+use LegacyTests\TestCase\IntegrationTestCase;
+use Access;
+use Db;
+use Language;
+use Tab;
+
+class AccessTest extends IntegrationTestCase
+{
+    /** @var Tab */
+    private $classNameTab;
+
+    /** @var Tab */
+    private $classNameTabChild;
+
+    /** @var Tab */
+    private $routeNameTab;
+
+    /** @var Tab */
+    private $routeNameTabChild;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->removeTestTabs();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->removeTestTabs();
+    }
+
+    public function testFindSlugByIdTab()
+    {
+        $this->createTestTabs();
+        $classSlug = Access::findSlugByIdTab($this->classNameTab->id);
+        $this->assertEquals('ROLE_MOD_TAB_ADMINCLASSNAMETEST_', $classSlug);
+
+        $routeSlug = Access::findSlugByIdTab($this->routeNameTab->id);
+        $this->assertEquals('ROLE_MOD_TAB_ADMINCLASSNAMETEST_', $routeSlug);
+    }
+
+    public function testFindSlugByIdParentTab()
+    {
+        $this->createTestTabs();
+        $this->createTestTabsChildren();
+
+        $classSlugs = Access::findSlugByIdParentTab($this->classNameTab->id);
+        $this->assertNotEmpty($classSlugs);
+        $this->assertEquals('AdminClassNameTestChild', $classSlugs[0]['class_name']);
+
+        $routeSlugs = Access::findSlugByIdParentTab($this->routeNameTab->id);
+        $this->assertNotEmpty($routeSlugs);
+        $this->assertEquals('AdminClassNameTestChild', $classSlugs[0]['class_name']);
+    }
+
+    public function testSluggifyTab()
+    {
+        $this->assertEquals('ROLE_MOD_TAB_ADMINCLASSNAMETEST_', Access::sluggifyTab(['class_name' => 'AdminClassNameTest']));
+        $this->assertEquals('ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ', Access::sluggifyTab(['class_name' => 'AdminClassNameTest'], 'READ'));
+        $this->assertEquals('ROLE_MOD_TAB_ADMINCLASSNAMETEST_', Access::sluggifyTab(['class_name' => 'AdminClassNameTest', 'route_name' => null]));
+        $this->assertEquals('ROLE_MOD_TAB_ADMINCLASSNAMETEST_read', Access::sluggifyTab(['class_name' => 'AdminClassNameTest', 'route_name' => null], 'read'));
+
+        $this->assertEquals('ROLE_MOD_TAB_ADMINCLASSNAMETEST_', Access::sluggifyTab(['class_name' => 'AdminClassNameTest', 'route_name' => 'admin_route_name_test']));
+        $this->assertEquals('ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ', Access::sluggifyTab(['class_name' => 'AdminClassNameTest', 'route_name' => 'admin_route_name_test'], 'READ'));
+    }
+
+    public function testFindIdTabByAuthSlug()
+    {
+        $this->createTestTabs();
+
+        $idTab = Access::findIdTabByAuthSlug('ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ');
+        $this->assertEquals($this->classNameTab->id, $idTab);
+    }
+
+    private function createTestTabs()
+    {
+        $this->classNameTab = new Tab();
+        $this->classNameTab->active = 1;
+        $this->classNameTab->class_name = 'AdminClassNameTest';
+        $this->classNameTab->name = array();
+        foreach (Language::getLanguages(true) as $lang) {
+            $this->classNameTab->name[$lang['id_lang']] = 'Class name tab';
+        }
+        $this->classNameTab->id_parent = (int) Tab::getIdFromClassName('AdminParentThemes');
+        $this->classNameTab->module = 'module_test_tab';
+        $this->classNameTab->add(true, true);
+
+        $this->routeNameTab = new Tab();
+        $this->routeNameTab->active = 1;
+        $this->routeNameTab->class_name = 'AdminClassNameTest';
+        $this->routeNameTab->route_name = 'admin_route_name_test';
+        $this->routeNameTab->name = array();
+        foreach (Language::getLanguages(true) as $lang) {
+            $this->routeNameTab->name[$lang['id_lang']] = 'Route name tab';
+        }
+        $this->routeNameTab->id_parent = (int) Tab::getIdFromClassName('AdminParentThemes');
+        $this->routeNameTab->module = 'module_test_tab';
+        $this->routeNameTab->add(true, true);
+    }
+
+    private function createTestTabsChildren()
+    {
+        $this->classNameTabChild = new Tab();
+        $this->classNameTabChild->active = 1;
+        $this->classNameTabChild->class_name = 'AdminClassNameTestChild';
+        $this->classNameTabChild->name = array();
+        foreach (Language::getLanguages(true) as $lang) {
+            $this->classNameTabChild->name[$lang['id_lang']] = 'Class name tab child';
+        }
+        $this->classNameTabChild->id_parent = $this->classNameTab->id;
+        $this->classNameTabChild->module = 'module_test_tab';
+        $this->classNameTabChild->add(true, true);
+
+        $this->routeNameTabChild = new Tab();
+        $this->routeNameTabChild->active = 1;
+        $this->routeNameTabChild->class_name = 'AdminClassNameTestChild';
+        $this->routeNameTabChild->route_name = 'admin_route_name_test_child';
+        $this->routeNameTabChild->name = array();
+        foreach (Language::getLanguages(true) as $lang) {
+            $this->routeNameTabChild->name[$lang['id_lang']] = 'Route name tab child';
+        }
+        $this->routeNameTabChild->id_parent = $this->routeNameTab->id;
+        $this->routeNameTabChild->module = 'module_test_tab';
+        $this->routeNameTabChild->add(true, true);
+    }
+
+    private function removeTestTabs()
+    {
+        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('SELECT id_tab, class_name, route_name FROM `' . _DB_PREFIX_ . 'tab` WHERE `module` = "module_test_tab"', true, false);
+        foreach ($result as $tabRow) {
+            $tab = new Tab($tabRow['id_tab']);
+            $tab->delete();
+        }
+        $this->classNameTab = null;
+        $this->routeNameTab = null;
+        $this->classNameTabChild = null;
+        $this->routeNameTabChild = null;
+    }
+}

--- a/tests-legacy/Integration/classes/TabTest.php
+++ b/tests-legacy/Integration/classes/TabTest.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace LegacyTests\Integration\classes;
+
+use LegacyTests\TestCase\IntegrationTestCase;
+use Db;
+use Language;
+use Tab;
+
+class TabTest extends IntegrationTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::removeTestTabs();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+        self::removeTestTabs();
+    }
+
+    private static function removeTestTabs()
+    {
+        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('SELECT id_tab, class_name, route_name FROM `' . _DB_PREFIX_ . 'tab` WHERE `module` = "module_test_tab"', true, false);
+        foreach ($result as $tabRow) {
+            $tab = new Tab($tabRow['id_tab']);
+            $tab->delete();
+        }
+    }
+
+    public function testAddTabWithClassName()
+    {
+        $classNameTab = new Tab();
+        $classNameTab->active = 1;
+        $classNameTab->class_name = 'AdminClassNameTest';
+        $classNameTab->name = array();
+        foreach (Language::getLanguages(true) as $lang) {
+            $classNameTab->name[$lang['id_lang']] = 'Class name tab';
+        }
+        $classNameTab->id_parent = (int) Tab::getIdFromClassName('AdminParentThemes');
+        $classNameTab->module = 'module_test_tab';
+        $classNameTab->add();
+
+        $expectedRoles = [
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
+        ];
+        $this->checkExpectedRoles($expectedRoles);
+    }
+
+    /**
+     * @depends testAddTabWithClassName
+     */
+    public function testDeleteTabWithClassName()
+    {
+        $tab = new Tab(Tab::getIdFromClassName('AdminClassNameTest'));
+        $this->assertNotFalse($tab->id);
+        $this->assertEquals('AdminClassNameTest', $tab->class_name);
+        $tab->delete();
+
+        $unexpectedRoles = [
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
+        ];
+        $this->checkUnexpectedRoles($unexpectedRoles);
+    }
+
+    public function testAddMultipleTabsWithClassName()
+    {
+        $this->removeTestTabs();
+        for ($i = 0; $i < 3; $i++) {
+            $classNameTab = new Tab();
+            $classNameTab->active = 1;
+            $classNameTab->class_name = 'AdminClassNameTest';
+            $classNameTab->name = array();
+            foreach (Language::getLanguages(true) as $lang) {
+                $classNameTab->name[$lang['id_lang']] = 'Class name tab';
+            }
+            $classNameTab->id_parent = (int) Tab::getIdFromClassName('AdminParentThemes');
+            $classNameTab->module = 'module_test_tab';
+            $classNameTab->add();
+        }
+
+        $expectedRoles = [
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
+        ];
+        $this->checkExpectedRoles($expectedRoles);
+    }
+
+    public function testAddTabWithRouteName()
+    {
+        $routeNameTab = new Tab();
+        $routeNameTab->active = 1;
+        $routeNameTab->class_name = 'AdminClassNameTest';
+        $routeNameTab->route_name = 'admin_route_name_test';
+        $routeNameTab->name = array();
+        foreach (Language::getLanguages(true) as $lang) {
+            $routeNameTab->name[$lang['id_lang']] = 'Route name tab';
+        }
+        $routeNameTab->id_parent = (int) Tab::getIdFromClassName('AdminParentThemes');
+        $routeNameTab->module = 'module_test_tab';
+        $routeNameTab->add();
+
+        $expectedRoles = [
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
+        ];
+        $this->checkExpectedRoles($expectedRoles);
+    }
+
+    /**
+     * @depends testAddTabWithRouteName
+     */
+    public function testDeleteTabWithRouteName()
+    {
+        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            'SELECT id_tab FROM `' . _DB_PREFIX_ . 'tab` WHERE `route_name` = "admin_route_name_test"',
+            true,
+            false
+        );
+        $this->assertNotEmpty($result);
+
+        $tab = new Tab($result[0]['id_tab']);
+        $this->assertNotFalse($tab->id);
+        $this->assertEquals('admin_route_name_test', $tab->route_name);
+        $tab->delete();
+
+        $unexpectedRoles = [
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
+        ];
+        $this->checkUnexpectedRoles($unexpectedRoles);
+    }
+
+    public function testAddMultipleTabsWithRouteName()
+    {
+        for ($i = 0; $i < 3; $i++) {
+            $routeNameTab = new Tab();
+            $routeNameTab->active = 1;
+            $routeNameTab->class_name = 'AdminClassNameTest';
+            $routeNameTab->route_name = 'admin_route_name_test';
+            $routeNameTab->name = array();
+            foreach (Language::getLanguages(true) as $lang) {
+                $routeNameTab->name[$lang['id_lang']] = 'Route name tab';
+            }
+            $routeNameTab->id_parent = (int) Tab::getIdFromClassName('AdminParentThemes');
+            $routeNameTab->module = 'module_test_tab';
+            $routeNameTab->add();
+        }
+
+        $expectedRoles = [
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
+        ];
+        $this->checkExpectedRoles($expectedRoles);
+    }
+
+    /**
+     * @param array $expectedRoles
+     * @throws \PrestaShopDatabaseException
+     */
+    private function checkExpectedRoles(array $expectedRoles)
+    {
+        foreach ($expectedRoles as $expectedRole) {
+            $roles = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+                'SELECT id_authorization_role, slug FROM `' . _DB_PREFIX_ . 'authorization_role` WHERE `slug` = "' . $expectedRole .'"',
+                true,
+                false
+            );
+            $this->assertNotEmpty($roles);
+            $this->assertCount(1, $roles);
+            $role = $roles[0];
+            $this->assertEquals($expectedRole, $role['slug']);
+
+            $accesses = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+                'SELECT id_profile, id_authorization_role FROM `' . _DB_PREFIX_ . 'access` WHERE `id_authorization_role` = ' . $role['id_authorization_role'],
+                true,
+                false
+            );
+            $this->assertNotEmpty($accesses);
+            $this->assertCount(1, $accesses);
+            $access = $accesses[0];
+            $this->assertEquals(1, $access['id_profile']);
+        }
+    }
+
+    /**
+     * @param array $unexpectedRoles
+     * @throws \PrestaShopDatabaseException
+     */
+    private function checkUnexpectedRoles(array $unexpectedRoles)
+    {
+        foreach ($unexpectedRoles as $unexpectedRole) {
+            $roles = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+                'SELECT id_authorization_role, slug FROM `' . _DB_PREFIX_ . 'authorization_role` WHERE `slug` = "' . $unexpectedRole .'"',
+                true,
+                false
+            );
+            $this->assertEmpty($roles);
+        }
+    }
+}

--- a/tests-legacy/Integration/classes/TabTest.php
+++ b/tests-legacy/Integration/classes/TabTest.php
@@ -62,6 +62,14 @@ class TabTest extends IntegrationTestCase
 
     public function testAddTabWithClassName()
     {
+        $expectedRoles = [
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
+        ];
+        $this->checkUnexpectedRoles($expectedRoles);
+
         $classNameTab = new Tab();
         $classNameTab->active = 1;
         $classNameTab->class_name = 'AdminClassNameTest';
@@ -73,12 +81,6 @@ class TabTest extends IntegrationTestCase
         $classNameTab->module = 'module_test_tab';
         $classNameTab->add();
 
-        $expectedRoles = [
-            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
-            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
-            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
-            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
-        ];
         $this->checkExpectedRoles($expectedRoles);
     }
 
@@ -87,11 +89,25 @@ class TabTest extends IntegrationTestCase
      */
     public function testDeleteTabWithClassName()
     {
+        $unexpectedRoles = [
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
+        ];
+        $this->checkExpectedRoles($unexpectedRoles);
+
         $tab = new Tab(Tab::getIdFromClassName('AdminClassNameTest'));
         $this->assertNotFalse($tab->id);
         $this->assertEquals('AdminClassNameTest', $tab->class_name);
         $tab->delete();
 
+        $this->checkUnexpectedRoles($unexpectedRoles);
+    }
+
+    public function testAddMultipleTabsWithClassName()
+    {
+        $this->removeTestTabs();
         $unexpectedRoles = [
             'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
             'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
@@ -99,11 +115,7 @@ class TabTest extends IntegrationTestCase
             'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
         ];
         $this->checkUnexpectedRoles($unexpectedRoles);
-    }
 
-    public function testAddMultipleTabsWithClassName()
-    {
-        $this->removeTestTabs();
         for ($i = 0; $i < 3; $i++) {
             $classNameTab = new Tab();
             $classNameTab->active = 1;
@@ -128,6 +140,15 @@ class TabTest extends IntegrationTestCase
 
     public function testAddTabWithRouteName()
     {
+        $this->removeTestTabs();
+        $unexpectedRoles = [
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
+            'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
+        ];
+        $this->checkUnexpectedRoles($unexpectedRoles);
+
         $routeNameTab = new Tab();
         $routeNameTab->active = 1;
         $routeNameTab->class_name = 'AdminClassNameTest';
@@ -161,17 +182,19 @@ class TabTest extends IntegrationTestCase
         );
         $this->assertNotEmpty($result);
 
-        $tab = new Tab($result[0]['id_tab']);
-        $this->assertNotFalse($tab->id);
-        $this->assertEquals('admin_route_name_test', $tab->route_name);
-        $tab->delete();
-
         $unexpectedRoles = [
             'ROLE_MOD_TAB_ADMINCLASSNAMETEST_CREATE',
             'ROLE_MOD_TAB_ADMINCLASSNAMETEST_READ',
             'ROLE_MOD_TAB_ADMINCLASSNAMETEST_UPDATE',
             'ROLE_MOD_TAB_ADMINCLASSNAMETEST_DELETE',
         ];
+        $this->checkExpectedRoles($unexpectedRoles);
+
+        $tab = new Tab($result[0]['id_tab']);
+        $this->assertNotFalse($tab->id);
+        $this->assertEquals('admin_route_name_test', $tab->route_name);
+        $tab->delete();
+
         $this->checkUnexpectedRoles($unexpectedRoles);
     }
 

--- a/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
+++ b/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
@@ -312,6 +312,7 @@ class ControllerTest extends TestCase
     protected function prophesizeLink()
     {
         $linkProphecy = $this->prophesize(Link::class);
+        $linkProphecy->getTabLink(Argument::type('array'))->willReturn('/link');
         $linkProphecy->getAdminLink(Argument::any(), Argument::cetera())->willReturn('/link');
 
         return $linkProphecy;

--- a/tests-legacy/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
+++ b/tests-legacy/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
@@ -52,6 +52,13 @@ class ModuleTabRegisterTest extends UnitTestCase
                 'exception' => 'Class "AdminMissingController" not found in controllers/admin',
             ),
         ),
+        'symfony' => array(
+            // modules with routes are added regardless of the controller existing or not
+            array(
+                'class_name' => 'UnknownLegacyController',
+                'route_name' => 'some_fancy_symfony_route',
+            ),
+        ),
     );
 
     protected $moduleAdminControllers = array(
@@ -62,6 +69,7 @@ class ModuleTabRegisterTest extends UnitTestCase
     protected $expectedTabsToAdd = array(
         'gamification' => array('AdminGamification'),
         'doge' => array('Wololo', 'AdminMissing', 'AdminMy'),
+        'symfony' => array('UnknownLegacyController'),
     );
 
     protected $languages = array(


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Manage automatic tab registration with symfony tabs (even when controller is missing), the menu is now able to use this new `route_name` parameter to generate the urls. The enable/disable feature now hides the tabs linked to the module automatically
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11578 and #12640
| How to test?  | You can use this branch of the ps_linklist module https://github.com/PrestaShop/ps_linklist/pull/70 It uses the new automatic tab creation and symfony route, just check that after installation its tab is correctly displayed (right url)<br/>Then you can test the enable/disable feature on this module, when the module is disabled the link in the menu disappears

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14679)
<!-- Reviewable:end -->
