### PR TITLE
Update LegacyHookSubscriber.php

### DIFF
--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -246,7 +246,7 @@ class LegacyHookSubscriber implements EventSubscriberInterface
 
                 if (is_array($modules)) {
                     foreach ($modules as $order => $module) {
-                        $moduleId = $module['id_module'];
+                        $moduleId = $module[0]['id_module'];
                         $functionName = 'call_' . $id . '_' . $moduleId;
                         $moduleListeners[] = array($functionName, 2000 - $order);
                     }


### PR DESCRIPTION
My version prestashop: 1.7.5.2
variable $module looks like:
```
array(1) {
  [0]=>
  array(3) {
    ["id_hook"]=>
    string(2) "45"
    ["module"]=>
    string(10) "htmlboxpro"
    ["id_module"]=>
    string(2) "75"
  }
}
```
$module['id_module'] should be changed for $module[0]['id_module']

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.6.x / 1.6.1.x
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc.
| Type?         | bug fix / improvement / new feature / refacto / critical
| Category?     | FO / BO / CO / IN / WS / TE
| BC breaks?    | Does it break backward compatibility? yes/no
| Deprecations? | Does it deprecate an existing feature? yes/no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14705)
<!-- Reviewable:end -->
