### PR TITLE
Make last breadcrumb element not clickable

### DIFF
--- a/themes/classic/templates/_partials/breadcrumb.tpl
+++ b/themes/classic/templates/_partials/breadcrumb.tpl
@@ -28,9 +28,13 @@
       {foreach from=$breadcrumb.links item=path name=breadcrumb}
         {block name='breadcrumb_item'}
           <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-            <a itemprop="item" href="{$path.url}">
-              <span itemprop="name">{$path.title}</span>
-            </a>
+              {if not $smarty.foreach.breadcrumb.last}
+                <a itemprop="item" href="{$path.url}">
+              {/if}
+                <span itemprop="name">{$path.title}</span>
+              {if not $smarty.foreach.breadcrumb.last}
+                </a>
+              {/if}
             <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
           </li>
         {/block}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Make breadcrumb's last element not clickable, for SEO purpose
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13083
| How to test?  | Go to any page having a breadcrumb in front office (category, product, etc), and check that the last breadcrumb element is not clickable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14710)
<!-- Reviewable:end -->
