### PR TITLE
Move travis scope from 5.6 to 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ sudo: required
 dist: trusty
 
 php:
-  - 5.6
+  - 7.1
   - 7.2
 
 env:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Stop testing on php5.6 as we drop it for PS 1.7.7 and it generates random unit test failures
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Travis should be green

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14725)
<!-- Reviewable:end -->
