### PR TITLE
Fix compile id {render} override issue on theme

### DIFF
--- a/classes/form/AbstractForm.php
+++ b/classes/form/AbstractForm.php
@@ -110,12 +110,16 @@ abstract class AbstractFormCore implements FormInterface
             $this->smarty
         );
 
+        $context = Context::getContext();
+        $theme = $context->shop->theme->getName();
+
         $scope->assign($extraVariables);
         $scope->assign($this->getTemplateVariables());
 
         $tpl = $this->smarty->createTemplate(
             $this->getTemplate(),
-            $scope
+            $scope,
+            $theme
         );
 
         return $tpl->fetch();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?   |  In case of multishop with multiple active theme theme, the smarty tag: `{render file='module:mymodule/views/templates/front/_partials/form.tpl' ui=$form}` is not compile properly. It's the same bug in an other case than #9763 and in fact partially fixed by #13804
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9763
| How to test?  | You need to have multishop and a different theme activated. you need include a sub template from a module with the {render} smarty tag. The option on backoffice is set to "never recompile templates". You'll see that you will show only one version of the compiled template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14727)
<!-- Reviewable:end -->
