### PR TITLE
Fix unclosed div element

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -157,6 +157,8 @@
             {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/layouts_configuration.html.twig' %}
           </div>
         </div>
+      </div>
+    </div>
   </div>
 {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes unclosed <div> element in Themes & Logos template.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Not needed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14738)
<!-- Reviewable:end -->
