### PR TITLE
Keep Composer.lock file in release

### DIFF
--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -76,7 +76,6 @@ class ReleaseCreator
         '.gitignore',
         '.gitmodules',
         '.travis.yml',
-        'composer.lock',
         'package-lock.json',
         '.babelrc',
         'postcss.config.js',


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Composer.lock file must be kept in the release to avoid warning from Symfony requirements
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | This recommended message about composer must'nt be displayed<br>![image](https://user-images.githubusercontent.com/1462701/61458591-2d699600-a96b-11e9-8442-0349c4a3be7f.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14739)
<!-- Reviewable:end -->
