### PR TITLE
Sprintf function broken in 1.7.6 for custom module templates

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -230,8 +230,6 @@ class TranslateCore
                 ) {
                     $string = Translate::checkAndReplaceArgs($string, $sprintf);
                 }
-
-                $ret = str_replace('"', '&quot;', $string);
             }
 
             $currentKey = strtolower('<{' . $name . '}' . _THEME_NAME_ . '>' . $source) . '_' . $key;

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -222,16 +222,6 @@ class TranslateCore
         if (isset($langCache[$cacheKey])) {
             $ret = $langCache[$cacheKey];
         } else {
-            if ($_MODULES == null) {
-                if (
-                    $sprintf !== null &&
-                    (!is_array($sprintf) || !empty($sprintf)) &&
-                    !(count($sprintf) === 1 && isset($sprintf['legacy']))
-                ) {
-                    $string = Translate::checkAndReplaceArgs($string, $sprintf);
-                }
-            }
-
             $currentKey = strtolower('<{' . $name . '}' . _THEME_NAME_ . '>' . $source) . '_' . $key;
             $defaultKey = strtolower('<{' . $name . '}prestashop>' . $source) . '_' . $key;
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When using the sprintf function in a front office module template, the translation function is called twice on the input string to be translated.  As far as I can see in the code, the line I have removed is not used as the variable being set is immediately overwritten.  It does however translate the input string, which in then passed into the translation a second time, this corrupts the output.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14706
| How to test?  | There is a test module attached to the original ticket.  If installed in 1.7.6 clean, you will see the error.  Apply this change and the corrupted string is fixed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14786)
<!-- Reviewable:end -->
