### PR TITLE
Allow modifying email body contents

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
@@ -46,6 +46,8 @@ use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\GenerateMailsType;
 use PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\TranslateMailsBodyType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use PrestaShopBundle\Service\Hook\HookEvent;
+use PrestaShopBundle\Service\TranslationService;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -377,10 +379,16 @@ class MailThemeController extends FrameworkBundleAdminController
 
             return $this->redirectToRoute('admin_mail_theme_index');
         }
+
         $translateData = $translateMailsBodyForm->getData();
+        $language = $translateData['language'];
+        /** @var TranslationService $translationService */
+        $translationService = $this->get('prestashop.service.translation');
+        $locale = $translationService->langToLocale($language);
 
         return $this->redirectToRoute('admin_international_translation_overview', [
-            'lang' => $translateData['language'],
+            'lang' => $language,
+            'locale' => $locale,
             'type' => 'mails_body',
             'selected' => 'body',
         ]);

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
@@ -46,7 +46,6 @@ use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\GenerateMailsType;
 use PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\TranslateMailsBodyType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use PrestaShopBundle\Service\Hook\HookEvent;
 use PrestaShopBundle\Service\TranslationService;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
@@ -390,7 +389,6 @@ class MailThemeController extends FrameworkBundleAdminController
             'lang' => $language,
             'locale' => $locale,
             'type' => 'mails_body',
-            'selected' => 'body',
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
@@ -372,7 +372,7 @@ class MailThemeController extends FrameworkBundleAdminController
             $this->addFlash(
                 'error',
                 $this->trans(
-                    'Cannot send translate body contents for e-mail',
+                    'Cannot translate body contents for e-mail',
                     'Admin.Notifications.Error'
                 )
             );

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\MailTemplate\ThemeInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\MailVariablesTransformation;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\GenerateMailsType;
+use PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\TranslateMailsBodyType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
@@ -72,6 +73,7 @@ class MailThemeController extends FrameworkBundleAdminController
     {
         $legacyController = $request->attributes->get('_legacy_controller');
         $generateThemeMailsForm = $this->createForm(GenerateMailsType::class);
+        $translateMailsBodyForm = $this->createForm(TranslateMailsBodyType::class);
         /** @var ThemeCatalogInterface $themeCatalog */
         $themeCatalog = $this->get('prestashop.core.mail_template.theme_catalog');
         $mailThemes = $themeCatalog->listThemes();
@@ -83,6 +85,7 @@ class MailThemeController extends FrameworkBundleAdminController
             'help_link' => $this->generateSidebarLink($legacyController),
             'mailThemeConfigurationForm' => $this->getMailThemeFormHandler()->getForm()->createView(),
             'generateMailsForm' => $generateThemeMailsForm->createView(),
+            'translateMailsBodyForm' => $translateMailsBodyForm->createView(),
             'mailThemes' => $mailThemes,
         ]);
     }
@@ -351,6 +354,36 @@ class MailThemeController extends FrameworkBundleAdminController
         }
 
         return $this->redirectToRoute('admin_mail_theme_preview', ['theme' => $theme]);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function translateBodyAction(Request $request)
+    {
+        $translateMailsBodyForm = $this->createForm(TranslateMailsBodyType::class);
+        $translateMailsBodyForm->handleRequest($request);
+
+        if (!$translateMailsBodyForm->isSubmitted() || !$translateMailsBodyForm->isValid()) {
+            $this->addFlash(
+                'error',
+                $this->trans(
+                    'Cannot send translate body contents for e-mail',
+                    'Admin.Notifications.Error'
+                )
+            );
+
+            return $this->redirectToRoute('admin_mail_theme_index');
+        }
+        $translateData = $translateMailsBodyForm->getData();
+
+        return $this->redirectToRoute('admin_international_translation_overview', [
+            'lang' => $translateData['language'],
+            'type' => 'mails_body',
+            'selected' => 'body',
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
@@ -372,7 +372,7 @@ class MailThemeController extends FrameworkBundleAdminController
             $this->addFlash(
                 'error',
                 $this->trans(
-                    'Cannot translate body contents for e-mail',
+                    'Cannot translate emails body contents',
                     'Admin.Notifications.Error'
                 )
             );

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -150,9 +150,11 @@ class TranslationController extends ApiController
                     break;
 
                 case 'mails':
-                    // when emails body will be implemented, it should be a different type
-                    // because domain routes only support "type" & "selected/theme" as parameters
                     $tree = $this->getMailsSubjectTree($lang, $search);
+                    break;
+
+                case 'mails_body':
+                    $tree = $this->getMailsBodyTree($lang, $search);
                     break;
 
                 default:
@@ -367,6 +369,22 @@ class TranslationController extends ApiController
 
         $treeBuilder = new TreeBuilder($this->translationService->langToLocale($lang), $theme);
         $catalogue = $this->translationService->getTranslationsCatalogue($lang, 'mails', $theme, $search);
+
+        return $this->getCleanTree($treeBuilder, $catalogue, $theme, $search);
+    }
+
+    /**
+     * @param string $lang Two-letter iso code
+     * @param null $search
+     *
+     * @return array
+     */
+    private function getMailsBodyTree($lang, $search = null)
+    {
+        $theme = null;
+
+        $treeBuilder = new TreeBuilder($this->translationService->langToLocale($lang), $theme);
+        $catalogue = $this->translationService->getTranslationsCatalogue($lang, 'mails_body', $theme, $search);
 
         return $this->getCleanTree($treeBuilder, $catalogue, $theme, $search);
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/TranslateMailsBodyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/TranslateMailsBodyType.php
@@ -16,7 +16,7 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to http://www.prestashop.com for more information.
+ * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright 2007-2019 PrestaShop SA and Contributors

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/TranslateMailsBodyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/TranslateMailsBodyType.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * 2007-2019 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
@@ -15,38 +16,37 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://www.prestashop.com for more information.
+ * needs please refer to http://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
- *#}
+ */
 
-{% extends '@PrestaShop/Admin/layout.html.twig' %}
+namespace PrestaShopBundle\Form\Admin\Improve\Design\MailTheme;
 
-{% block content %}
-  {{
-    include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig', {
-      'mailThemeConfigurationForm': mailThemeConfigurationForm
-    })
-  }}
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
 
-  {{
-    include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig', {
-      'generateMailsForm': generateMailsForm
-    })
-  }}
-
-  {{
-  include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig', {
-    'generateMailsForm': generateMailsForm
-  })
-  }}
-
-  {{
-    include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/list_mail_themes.html.twig', {
-      'mailThemes': mailThemes
-    })
-  }}
-{% endblock %}
+/**
+ * Class TranslateMailsBodyType manages the form allowing to select a language
+ * and translate Emails body content.
+ */
+class TranslateMailsBodyType extends TranslatorAwareType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('language', ChoiceType::class, [
+                'placeholder' => $this->trans('Language', 'Admin.Global'),
+                'choices' => $this->getLocaleChoices(),
+                'choice_translation_domain' => false,
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/_mail_theme_alias.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/_mail_theme_alias.yml
@@ -1,0 +1,22 @@
+# These are alias routes used to manage legacy urls that were badly formatted (camel case)
+_admin_mail_theme_save_configuration_alias:
+  path: /saveConfiguration
+  defaults:
+    _controller: FrameworkBundle:Redirect:redirect
+    route: admin_mail_theme_save_configuration
+    permanent: true
+
+_admin_mail_theme_send_test_mail_alias:
+  path: /sendTestMail/{locale}/{theme}/{layout}
+  defaults:
+    _controller: FrameworkBundle:Redirect:redirect
+    route: admin_mail_theme_send_test_mail
+    permanent: true
+
+_admin_mail_theme_send_test_module_mail_mail:
+  path: /sendTestMail/{locale}/{theme}/{module}/{layout}
+  methods: [GET]
+  defaults:
+    _controller: FrameworkBundle:Redirect:redirect
+    route: admin_mail_theme_send_test_module_mail
+    permanent: true

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/_mail_theme_deprecated.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/_mail_theme_deprecated.yml
@@ -1,19 +1,19 @@
 # These are alias routes used to manage legacy urls that were badly formatted (camel case)
-_admin_mail_theme_save_configuration_alias:
+admin_mail_theme_save_configuration_deprecated:
   path: /saveConfiguration
   defaults:
     _controller: FrameworkBundle:Redirect:redirect
     route: admin_mail_theme_save_configuration
     permanent: true
 
-_admin_mail_theme_send_test_mail_alias:
+admin_mail_theme_send_test_mail_deprecated:
   path: /sendTestMail/{locale}/{theme}/{layout}
   defaults:
     _controller: FrameworkBundle:Redirect:redirect
     route: admin_mail_theme_send_test_mail
     permanent: true
 
-_admin_mail_theme_send_test_module_mail_mail:
+admin_mail_theme_send_test_module_mail_deprecated:
   path: /sendTestMail/{locale}/{theme}/{module}/{layout}
   methods: [GET]
   defaults:

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/mail_theme.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/mail_theme.yml
@@ -1,3 +1,7 @@
+_mail_theme_alias:
+  resource: "_mail_theme_alias.yml"
+  prefix: /
+
 admin_mail_theme_index:
   path: /
   methods: [GET]
@@ -15,7 +19,7 @@ admin_mail_theme_generate:
     _legacy_link: AdminMailTheme:postGenerateMails
 
 admin_mail_theme_save_configuration:
-  path: /saveConfiguration
+  path: /save-configuration
   methods: [POST]
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\MailTheme:saveConfiguration
@@ -66,7 +70,7 @@ admin_mail_theme_raw_module_layout:
     _legacy_controller: AdminMailTheme
 
 admin_mail_theme_send_test_mail:
-  path: /sendTestMail/{locale}/{theme}/{layout}
+  path: /send-test-mail/{locale}/{theme}/{layout}
   methods: [GET]
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\MailTheme:sendTestMail
@@ -75,7 +79,7 @@ admin_mail_theme_send_test_mail:
     module: ''
 
 admin_mail_theme_send_test_module_mail:
-  path: /sendTestMail/{locale}/{theme}/{module}/{layout}
+  path: /send-test-mail/{locale}/{theme}/{module}/{layout}
   methods: [GET]
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\MailTheme:sendTestMail
@@ -83,7 +87,7 @@ admin_mail_theme_send_test_module_mail:
     _legacy_controller: AdminMailTheme
 
 admin_mail_theme_translate_body:
-  path: /translateBody
+  path: /translate-body
   methods: [POST]
   defaults:
     _controller: PrestaShopBundle:Admin\Improve\Design\MailTheme:translateBody

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/mail_theme.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/mail_theme.yml
@@ -81,3 +81,11 @@ admin_mail_theme_send_test_module_mail:
     _controller: PrestaShopBundle:Admin\Improve\Design\MailTheme:sendTestMail
     _legacy_link: AdminMailTheme:rawModuleLayout
     _legacy_controller: AdminMailTheme
+
+admin_mail_theme_translate_body:
+  path: /translateBody
+  methods: [POST]
+  defaults:
+    _controller: PrestaShopBundle:Admin\Improve\Design\MailTheme:translateBody
+    _legacy_controller: AdminMailTheme
+    _legacy_link: AdminMailTheme:translateBody

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/mail_theme.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/mail_theme.yml
@@ -1,5 +1,5 @@
-_mail_theme_alias:
-  resource: "_mail_theme_alias.yml"
+_mail_theme_deprecated:
+  resource: "_mail_theme_deprecated.yml"
   prefix: /
 
 admin_mail_theme_index:

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
@@ -22,7 +22,7 @@ admin_international_translations_show_settings:
         _legacy_controller: AdminTranslations
         _legacy_link: AdminTranslations:settings
 
-_admin_international_translations_modify:
+admin_international_translations_modify:
     path: /modify
     methods: [GET]
     defaults:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -947,3 +947,10 @@ services:
         - '@prestashop.core.form.choice_provider.currency_by_id'
       tags:
         - { name: form.type }
+
+    form.type.localization.translate_mails_body:
+      class: 'PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\TranslateMailsBodyType'
+      parent: 'form.type.translatable.aware'
+      public: true
+      tags:
+        - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -43,6 +43,14 @@ services:
         tags:
             - { name: "ps.translation_provider" }
 
+    prestashop.translation.mails_body_provider:
+        class: PrestaShopBundle\Translation\Provider\MailsBodyProvider
+        arguments:
+          - "@prestashop.translation.database_loader"
+          - "%translations_dir%"
+        tags:
+          - { name: "ps.translation_provider" }
+
     prestashop.translation.others_provider:
             class: PrestaShopBundle\Translation\Provider\OthersProvider
             arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
@@ -1,5 +1,5 @@
 {#**
- * 2007-2019 PrestaShop and Contributors
+ * 2007-2019 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
@@ -34,7 +34,6 @@
 
       <div class="card-block row">
         <div class="card-text">
-
           <div class="form-group row">
             <label class="form-control-label">
               {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}
@@ -44,7 +43,6 @@
               {{ form_widget(translateMailsBodyForm.language) }}
             </div>
           </div>
-
         </div>
       </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
@@ -1,0 +1,63 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% block translateMailsBodyFormBlock %}
+<div class="row justify-content-center">
+  <div class="col-xl-10">
+    {{ form_start(translateMailsBodyForm, {'action': path('admin_mail_theme_translate_body')}) }}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">email</i> {{ 'Translate emails'|trans({}, 'Admin.Design.Feature') }}
+      </h3>
+
+      <div class="card-block row">
+        <div class="card-text">
+
+          <div class="form-group row">
+            <label class="form-control-label">
+              {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}
+            </label>
+            <div class="col-sm">
+              {{ form_errors(translateMailsBodyForm.language) }}
+              {{ form_widget(translateMailsBodyForm.language) }}
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">
+            <i class="material-icons">email</i>
+            <span>{{ 'Translate emails'|trans({}, 'Admin.Actions') }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+    {{ form_end(translateMailsBodyForm) }}
+  </div>
+</div>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/index.html.twig
@@ -39,9 +39,9 @@
   }}
 
   {{
-  include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig', {
-    'generateMailsForm': generateMailsForm
-  })
+    include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig', {
+      'generateMailsForm': generateMailsForm
+    })
   }}
 
   {{

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
@@ -26,7 +26,7 @@
 {% trans_default_domain 'Admin.International.Feature' %}
 
 {% block modify_translations %}
-  {{ form_start(modifyTranslationsForm, {method: 'get', action: path('_admin_international_translations_modify')}) }}
+  {{ form_start(modifyTranslationsForm, {method: 'get', action: path('admin_international_translations_modify')}) }}
 
   <div class="card">
     <h3 class="card-header">

--- a/src/PrestaShopBundle/Translation/Provider/MailsBodyProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/MailsBodyProvider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop and Contributors
+ * 2007-2019 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *

--- a/src/PrestaShopBundle/Translation/Provider/MailsBodyProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/MailsBodyProvider.php
@@ -1,5 +1,6 @@
-{#**
- * 2007-2019 PrestaShop SA and Contributors
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -21,32 +22,44 @@
  * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
- *#}
+ */
 
-{% extends '@PrestaShop/Admin/layout.html.twig' %}
+namespace PrestaShopBundle\Translation\Provider;
 
-{% block content %}
-  {{
-    include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig', {
-      'mailThemeConfigurationForm': mailThemeConfigurationForm
-    })
-  }}
+/**
+ * Translation provider specific to email subjects.
+ */
+class MailsBodyProvider extends AbstractProvider implements UseDefaultCatalogueInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains()
+    {
+        return ['EmailsBody*'];
+    }
 
-  {{
-    include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig', {
-      'generateMailsForm': generateMailsForm
-    })
-  }}
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return ['#EmailsBody*#'];
+    }
 
-  {{
-  include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig', {
-    'generateMailsForm': generateMailsForm
-  })
-  }}
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        return 'mails_body';
+    }
 
-  {{
-    include('@PrestaShop/Admin/Improve/Design/MailTheme/Blocks/list_mail_themes.html.twig', {
-      'mailThemes': mailThemes
-    })
-  }}
-{% endblock %}
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultResourceDirectory()
+    {
+        return $this->resourceDirectory . DIRECTORY_SEPARATOR . 'default';
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add translation provider to allow modifying body contents, add a form in Email Theme page to access this edition
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15474
| How to test?  | Go to `Design > Email Theme` page in the "Translate Emails" page select a language and start editing some texts. Check that the modifications are update in the mails previews, then re-generate emails and tests the modifications in real condition.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14809)
<!-- Reviewable:end -->
