### PR TITLE
Fix create account sitemap link

### DIFF
--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -132,7 +132,7 @@ class SitemapControllerCore extends FrontController
         $links[] = array(
             'id' => 'register-page',
             'label' => $this->trans('Create new account', array(), 'Shop.Theme.Global'),
-            'url' => $this->context->link->getPageLink('authentication'),
+            'url' => $this->context->link->getPageLink('authentication', null, null, array('create_account' => 1)),
         );
 
         return $links;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix "create new account" link on sitemap page, where is would take the user to the login form instead of the registration form.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14818
| How to test?  | Go on the sitemap page, verify that clicking on "create new account" takes you to the registration form.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14819)
<!-- Reviewable:end -->
