### PR TITLE
Prevent uninstall of Product Comments module

### DIFF
--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -164,7 +164,6 @@ namespace PrestaShopBundle\Install {
             'blockstore',
             'blocktags',
             'blockwishlist',
-            'productcomments',
             'productpaymentlogos',
             'sendtoafriend',
             'themeconfigurator',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Product Comments module (v4.0.0) gets uninstalled while upgrading Prestashop.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14850)
<!-- Reviewable:end -->
