### PR TITLE
Remove useless legacy files and templates from 1.7.6

### DIFF
--- a/admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cms/helpers/form/form.tpl
@@ -23,10 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-{**
- * @deprecated since 1.7.6, to be removed in the next minor
- *}
-
 {extends file="helpers/form/form.tpl"}
 {block name="input"}
 	{if $input.name == "link_rewrite"}

--- a/admin-dev/themes/default/template/controllers/cms_categories/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cms_categories/helpers/form/form.tpl
@@ -23,10 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-{**
- * @deprecated since 1.7.6, to be removed in the next minor
- *}
-
 {extends file="helpers/form/form.tpl"}
 {block name="input"}
 	{if $input.name == "link_rewrite"}

--- a/admin-dev/themes/default/template/controllers/cms_content/content.tpl
+++ b/admin-dev/themes/default/template/controllers/cms_content/content.tpl
@@ -23,10 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-{**
- * @deprecated since 1.7.6, to be removed in the next minor
- *}
-
 {if isset($cms_breadcrumb)}
 	<ul class="breadcrumb cat_bar">
 		{$cms_breadcrumb}

--- a/admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl
@@ -23,10 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-{**
- * @deprecated since 1.7.6, to be removed in the next minor
- *}
-
 {extends file="helpers/view/view.tpl"}
 
 {block name="override_tpl"}

--- a/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
@@ -23,10 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-{**
- * @deprecated since 1.7.6, to be removed in the next minor
- *}
-
 <div class="leadin">{block name="leadin"}{/block}</div>
 
 <form action="{$url_submit|escape:'html':'UTF-8'}" id="{$table}_form" method="post" class="form-horizontal">

--- a/admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl
@@ -23,10 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-{**
- * @deprecated since 1.7.6, to be removed in the next minor
- *}
-
 <script type="text/javascript">
 	var come_from = 'AdminModulesPositions';
 </script>

--- a/admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl
@@ -23,10 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-{**
- * @deprecated since 1.7.6, to be removed in the next minor
- *}
-
 {extends file="helpers/form/form.tpl"}
 
 {block name="after"}

--- a/admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/helpers/view/view.tpl
@@ -23,10 +23,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-{**
- * @deprecated since 1.7.6, to be removed in the next minor
- *}
-
 {extends file="helpers/view/view.tpl"}
 
 {block name="override_tpl"}

--- a/admin-dev/themes/default/template/controllers/request_sql/list_action_export.tpl
+++ b/admin-dev/themes/default/template/controllers/request_sql/list_action_export.tpl
@@ -22,11 +22,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-
-{**
- * @deprecated since 1.7.6, to be removed in the next minor
- *}
-
 <a href="{$href|escape:'html':'UTF-8'}" title="{$action}" class="btn btn-default">
 	<i class="icon-cloud-upload"></i> {$action}
 </a>


### PR DESCRIPTION
Reverts https://github.com/PrestaShop/PrestaShop/pull/13956

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | These files are supposed to be useless now since these pages have beeb migrated
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | yes, it deprecates some legacy template and controller files
| Fixed ticket? | 
| How to test?  | This PR is supposed to break nothing 😅 

This PR re-applies:
- https://github.com/PrestaShop/PrestaShop/pull/13910
- https://github.com/PrestaShop/PrestaShop/pull/13852
- https://github.com/PrestaShop/PrestaShop/pull/13850
- https://github.com/PrestaShop/PrestaShop/pull/13849
- https://github.com/PrestaShop/PrestaShop/pull/13847

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14868)
<!-- Reviewable:end -->
