### PR TITLE
[On pause] Migrates rendering of Basic settings for Product form

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -54,6 +54,7 @@ module.exports = {
     webservice: './js/pages/webservice',
     error: './js/pages/error',
     monitoring: './js/pages/monitoring',
+    product_form: './js/pages/product/form',
   },
   output: {
     path: path.resolve(__dirname, '../public'),

--- a/admin-dev/themes/new-theme/js/pages/product/components/product-type-change-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/product/components/product-type-change-handler.js
@@ -1,0 +1,57 @@
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+import ProductFormPageMap from './../form-page-map';
+import ProductType from './../product-type';
+
+const $ = window.$;
+
+export default function productTypeChangeHandler() {
+  const $productTypeSelect = $(ProductFormPageMap.productTypeSelect);
+
+  handleProductWithCombinationSelectionDisplay();
+
+  $productTypeSelect.on('change', () => handleProductWithCombinationSelectionDisplay());
+
+  function handleProductWithCombinationSelectionDisplay() {
+    const selectedProductType = parseInt($productTypeSelect.val(), 10);
+
+    if (selectedProductType === ProductType.STANDARD_PRODUCT) {
+      showProductWithCombinationSelection();
+
+      return;
+    }
+
+    hideProductWithCombinationsSelection();
+  }
+
+  function showProductWithCombinationSelection() {
+    $(ProductFormPageMap.productWithCombinationsSelectionBlock).removeClass('d-none');
+  }
+
+  function hideProductWithCombinationsSelection() {
+    $(ProductFormPageMap.productWithCombinationsSelectionBlock).addClass('d-none');
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/product/form-page-map.js
+++ b/admin-dev/themes/new-theme/js/pages/product/form-page-map.js
@@ -1,0 +1,29 @@
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+export default {
+  productTypeSelect: '#product_type',
+  productWithCombinationsSelectionBlock: '#product_with_combinations_selection_block',
+};

--- a/admin-dev/themes/new-theme/js/pages/product/form.js
+++ b/admin-dev/themes/new-theme/js/pages/product/form.js
@@ -1,0 +1,32 @@
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+import productTypeChangeHandler from './components/product-type-change-handler';
+
+const $ = window.$;
+
+$(() => {
+  productTypeChangeHandler();
+});

--- a/admin-dev/themes/new-theme/js/pages/product/form.js
+++ b/admin-dev/themes/new-theme/js/pages/product/form.js
@@ -24,9 +24,12 @@
  */
 
 import productTypeChangeHandler from './components/product-type-change-handler';
+import TranslatableInput from '../../components/translatable-input';
 
 const $ = window.$;
 
 $(() => {
   productTypeChangeHandler();
+
+  new TranslatableInput();
 });

--- a/admin-dev/themes/new-theme/js/pages/product/product-type.js
+++ b/admin-dev/themes/new-theme/js/pages/product/product-type.js
@@ -1,0 +1,30 @@
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+export default {
+  STANDARD_PRODUCT: 0,
+  PACK_OF_PRODUCTS: 1,
+  VIRTUAL_PRODUCT: 2,
+};

--- a/admin-dev/themes/new-theme/scss/pages/_product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_product_page.scss
@@ -28,6 +28,10 @@
     }
   }
 
+  #product_type {
+    width: 80%;
+  }
+
   .table-fixed {
     table-layout: fixed;
     border: 0;

--- a/admin-dev/themes/new-theme/scss/pages/_product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_product_page.scss
@@ -175,9 +175,7 @@
   }
 
   .summary-description-container {
-    overflow: hidden; // fixes horizontal scrolling on the product page
     .nav-tabs {
-      overflow: hidden; // fixes tab borders bleeding into the tab content
 
       &.bordered {
         .nav-link {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ProductController.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
+
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Form\Admin\Sell\Product\ProductType;
+use Symfony\Component\HttpFoundation\Response;
+
+class ProductController extends FrameworkBundleAdminController
+{
+    public function addAction(): Response
+    {
+        $form = $this->createForm(ProductType::class);
+
+        return $this->render('@PrestaShop/Admin/Sell/Catalog/Products/add.html.twig', [
+            'showContentHeader' => false,
+            'isCombinationFeatureActive' => $this->get('prestashop.adapter.combination_feature')->isActive(),
+            'productForm' => $form->createView(),
+        ]);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicSettingsTabType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicSettingsTabType.php
@@ -33,7 +33,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class BasicSettingsType extends AbstractType
+class BasicSettingsTabType extends AbstractType
 {
     /**
      * @var TranslatorInterface
@@ -52,11 +52,12 @@ class BasicSettingsType extends AbstractType
                 'expanded' => true,
                 'multiple' => false,
                 'choices' => [
-                    $this->translator->trans('Yes', [], 'Admin.Global') => true,
-                    $this->translator->trans('No', [], 'Admin.Global') => false,
+                    $this->translator->trans('Simple product', [], 'Admin.Catalog.Feature') => 0,
+                    $this->translator->trans('Product with combinations', [], 'Admin.Catalog.Feature') => 1,
                 ],
                 'required' => true,
                 'choice_translation_domain' => false,
+                'empty_data' => 0,
             ])
             ->add('reference', TextType::class, [
                 'required' => false,
@@ -64,7 +65,7 @@ class BasicSettingsType extends AbstractType
             ->add('quantity', NumberType::class, [
                 'required' => false,
             ])
-            ->add('price', PriceType::class, [
+            ->add('price', ProductPriceType::class, [
                 'required' => false,
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicSettingsTabType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicSettingsTabType.php
@@ -26,9 +26,11 @@
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -48,6 +50,17 @@ class BasicSettingsTabType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
+            ->add('short_description', TranslatableType::class, [
+                'type' => TextareaType::class,
+                'options' => [
+                    'attr' => [
+                        'placeholder' => $this->translator->trans('The summary is a short sentence describing your product.<br />It will appears at the top of your shop\'s product page, in product lists, and in search engines\' results page (so it\'s important for SEO). To give more details about your product, use the "Description" tab.', [], 'Admin.Catalog.Help'),
+                    ],
+                ],
+            ])
+            ->add('description', TranslatableType::class, [
+                'type' => TextareaType::class,
+            ])
             ->add('with_combinations', ChoiceType::class, [
                 'expanded' => true,
                 'multiple' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicSettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicSettingsType.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class BasicSettingsType extends AbstractType
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('with_combinations', ChoiceType::class, [
+                'expanded' => true,
+                'multiple' => false,
+                'choices' => [
+                    $this->translator->trans('Yes', [], 'Admin.Global') => true,
+                    $this->translator->trans('No', [], 'Admin.Global') => false,
+                ],
+                'required' => true,
+                'choice_translation_domain' => false,
+            ])
+            ->add('reference', TextType::class, [
+                'required' => false,
+            ])
+            ->add('quantity', NumberType::class, [
+                'required' => false,
+            ])
+            ->add('price', PriceType::class, [
+                'required' => false,
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/PriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/PriceType.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class PriceType extends AbstractType
+{
+    /**
+     * @var FormChoiceProviderInterface
+     */
+    private $taxRuleGroupChoiceProvider;
+
+    public function __construct(FormChoiceProviderInterface $taxRuleGroupChoiceProvider)
+    {
+        $this->taxRuleGroupChoiceProvider = $taxRuleGroupChoiceProvider;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('price_tax_excluded', MoneyType::class, [
+                'divisor' => 6,
+                'required' => false,
+            ])
+            ->add('price_tax_included', MoneyType::class, [
+                'divisor' => 6,
+                'required' => false,
+            ])
+            ->add('tax_rule_group_id', ChoiceType::class, [
+                'choices' => $this->taxRuleGroupChoiceProvider->getChoices(),
+                'required' => false,
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductPriceType.php
@@ -58,6 +58,11 @@ class ProductPriceType extends AbstractType
             ->add('tax_rule_group_id', ChoiceType::class, [
                 'choices' => $this->taxRuleGroupChoiceProvider->getChoices(),
                 'required' => false,
+                'placeholder' => false,
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductPriceType.php
@@ -32,7 +32,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class PriceType extends AbstractType
+class ProductPriceType extends AbstractType
 {
     /**
      * @var FormChoiceProviderInterface

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -47,7 +47,13 @@ class ProductType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('name', TranslatableType::class)
+            ->add('name', TranslatableType::class, [
+                'options' => [
+                    'attr' => [
+                        'placeholder' => $this->translator->trans('Enter your product name', [], 'Admin.Catalog.Help'),
+                    ],
+                ],
+            ])
             ->add('type', ChoiceType::class, [
                 'expanded' => false,
                 'multiple' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -46,6 +47,7 @@ class ProductType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
+            ->add('name', TranslatableType::class)
             ->add('type', ChoiceType::class, [
                 'expanded' => false,
                 'multiple' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class ProductType extends AbstractType
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('type', ChoiceType::class, [
+                'expanded' => false,
+                'multiple' => false,
+                'choices' => [
+                    // @todo: define product types as constants
+                    $this->translator->trans('Standard product', [], 'Admin.Catalog.Feature') => 0,
+                    $this->translator->trans('Pack of products', [], 'Admin.Catalog.Feature') => 1,
+                    $this->translator->trans('Virtual product', [], 'Admin.Catalog.Feature') => 2,
+                ],
+            ])
+            ->add('basic_settings', BasicSettingsType::class)
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -56,7 +56,7 @@ class ProductType extends AbstractType
                     $this->translator->trans('Virtual product', [], 'Admin.Catalog.Feature') => 2,
                 ],
             ])
-            ->add('basic_settings', BasicSettingsType::class)
+            ->add('basic_settings', BasicSettingsTabType::class)
         ;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/products.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/products.yml
@@ -1,3 +1,7 @@
+_products_v2:
+  resource: "products_v2.yml"
+  prefix: /v2/
+
 _product:
     resource: "product.yml"
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/products_v2.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/products_v2.yml
@@ -3,5 +3,4 @@ admin_products_add:
   methods: [GET]
   defaults:
     _controller: PrestaShopBundle:Admin/Sell/Catalog/Product:add
-
-
+    _legacy_controller: AdminProducts

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/products_v2.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products/products_v2.yml
@@ -1,0 +1,7 @@
+admin_products_add:
+  path: /new
+  methods: [GET]
+  defaults:
+    _controller: PrestaShopBundle:Admin/Sell/Catalog/Product:add
+
+

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type/product.yml
@@ -1,0 +1,25 @@
+services:
+  _defaults:
+    public: true
+
+  form.type.product:
+    class: PrestaShopBundle\Form\Admin\Sell\Product\ProductType
+    arguments:
+      - '@translator'
+    tags:
+      - { name: form.type }
+
+  form.type.product.product_price:
+    class: PrestaShopBundle\Form\Admin\Sell\Product\ProductPriceType
+    arguments:
+      - '@prestashop.core.form.choice_provider.tax_rule_group_choice_provider'
+    tags:
+      - { name: form.type }
+
+  form.type.product.basic_settings_tab:
+    class: PrestaShopBundle\Form\Admin\Sell\Product\BasicSettingsTabType
+    arguments:
+      - '@translator'
+    tags:
+      - { name: form.type }
+

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/basic_settings_tab.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/basic_settings_tab.html.twig
@@ -1,0 +1,121 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+<div role="tabpanel" class="form-contenttab tab-pane active" id="product_basic_settings_tab_content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-9">
+        {# RIGHT SIDE #}
+      </div>
+
+      <div class="col-md-3">
+        {% if isCombinationFeatureActive %}
+          <div class="form-group mb-3">
+            <h2>
+              {{ 'Combinations'|trans({}, 'Admin.Catalog.Feature') }}
+              <span class="help-box"
+                    data-toggle="popover"
+                    data-content="{{ 'Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?'|trans({}, 'Admin.Catalog.Help') }}">
+              </span>
+            </h2>
+            {{ form_widget(productForm.basic_settings.with_combinations) }}
+            <div id="product_type_combinations_shortcut">
+                <span class="small font-secondary">
+                  {{ "Advanced settings in [1][2]Combinations[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').tab(\'show\');" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+                </span>
+            </div>
+          </div>
+        {% endif %}
+
+        <div class="form-group mb-4">
+          <h2>
+            {{ 'Reference'|trans({}, 'Admin.Catalog.Feature') }}
+            <span class="help-box"
+                  data-toggle="popover"
+                  data-content="{{ 'Your reference code for this product. Allowed special characters: .-_#\.'|trans({}, 'Admin.Catalog.Help') }}" >
+            </span>
+          </h2>
+          <div class="row">
+            <div class="col-xl-12 col-lg-12">
+              {{ form_widget(productForm.basic_settings.reference) }}
+            </div>
+          </div>
+        </div>
+
+        {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+          <div class="form-group mb-4">
+            <h2>
+              {{ 'Quantity'|trans({}, 'Admin.Catalog.Feature') }}
+              <span class="help-box"
+                    data-toggle="popover"
+                    data-content="{{ 'How many products should be available for sale?'|trans({}, 'Admin.Catalog.Help') }}" >
+              </span>
+            </h2>
+            <div class="row">
+              <div class="col-xl-6 col-lg-12">
+                {{ form_widget(productForm.basic_settings.quantity) }}
+              </div>
+            </div>
+            <span class="small font-secondary">
+              {{ 'Advanced settings in [1][2]Quantities[/1]'|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').tab(\'show\');" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+            </span>
+          </div>
+        {% endif %}
+
+        <div class="form-group mb-4">
+          <h2>
+            {{ 'Price'|trans({}, 'Admin.Global') }}
+            <span class="help-box"
+                  data-toggle="popover"
+                  data-content="{{ 'This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.'|trans({}, 'Admin.Catalog.Help') }}" >
+            </span>
+          </h2>
+          <div class="row">
+            <div class="col-md-6">
+              <label class="form-control-label">{{ "Tax excluded"|trans({}, 'Admin.Catalog.Feature') }}</label>
+              {{ form_widget(productForm.basic_settings.price.price_tax_excluded) }}
+            </div>
+
+            <div class="col-md-6 col-offset-md-1">
+              <label class="form-control-label">{{ "Tax included"|trans({}, 'Admin.Catalog.Feature') }}</label>
+              {{ form_widget(productForm.basic_settings.price.price_tax_included) }}
+            </div>
+
+            <div class="col-md-12 mt-1">
+              <label class="form-control-label">{{ "Tax rule"|trans({}, 'Admin.Catalog.Feature') }}</label>
+              {{ form_widget(productForm.basic_settings.price.tax_rule_group_id) }}
+            </div>
+
+            <div class="col-md-12">
+              <span class="small font-secondary">
+                {{ 'Advanced settings in [1][2]Pricing[/1]'|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step2" onclick="$(\'a[href=\\\'#step2\\\']\').tab(\'show\');" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/basic_settings_tab.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/basic_settings_tab.html.twig
@@ -27,12 +27,27 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-md-9">
-        {# RIGHT SIDE #}
+
+        <div class="summary-description-container">
+          <ul class="nav nav-tabs bordered">
+            <li id="tab_description_short" class="nav-item"><a href="#description_short" data-toggle="tab" class="nav-link description-tab active">{{ 'Summary'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+            <li id="tab_description" class="nav-item"><a href="#description" data-toggle="tab" class="nav-link description-tab">{{ 'Description'|trans({}, 'Admin.Global') }}</a></li>
+          </ul>
+
+          <div class="tab-content">
+            <div class="tab-pane panel panel-default active" id="description_short">
+              {{ form_widget(productForm.basic_settings.short_description) }}
+            </div>
+            <div class="tab-pane panel panel-default" id="description">
+              {{ form_widget(productForm.basic_settings.description) }}
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="col-md-3">
         {% if isCombinationFeatureActive %}
-          <div class="form-group mb-3">
+          <div class="form-group mb-3" id="product_with_combinations_selection_block">
             <h2>
               {{ 'Combinations'|trans({}, 'Admin.Catalog.Feature') }}
               <span class="help-box"

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/combinations_tab.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/combinations_tab.html.twig
@@ -1,0 +1,7 @@
+<div role="tabpanel" class="form-contenttab tab-pane" id="product_combinations_tab_content">
+  <div class="container-fluid">
+    <div class="row">
+      COMBINATIONS
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/options_tab.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/options_tab.html.twig
@@ -1,0 +1,7 @@
+<div role="tabpanel" class="form-contenttab tab-pane" id="product_options_tab_content">
+  <div class="container-fluid">
+    <div class="row">
+      OPTIONS
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/pricing_tab.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/pricing_tab.html.twig
@@ -1,0 +1,7 @@
+<div role="tabpanel" class="form-contenttab tab-pane" id="product_pricing_tab_content">
+  <div class="container-fluid">
+    <div class="row">
+      PRICING
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/quantities_tab.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/quantities_tab.html.twig
@@ -1,0 +1,7 @@
+<div role="tabpanel" class="form-contenttab tab-pane" id="product_quantities_tab_content">
+  <div class="container-fluid">
+    <div class="row">
+      QUANTITIES
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/seo_tab.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/seo_tab.html.twig
@@ -1,0 +1,7 @@
+<div role="tabpanel" class="form-contenttab tab-pane" id="product_seo_tab_content">
+  <div class="container-fluid">
+    <div class="row">
+      SEO
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/shipping_tab.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/shipping_tab.html.twig
@@ -1,0 +1,7 @@
+<div role="tabpanel" class="form-contenttab tab-pane" id="product_shipping_tab_content">
+  <div class="container-fluid">
+    <div class="row">
+      SHIPPING
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/virtual_product_tab.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/Tab/virtual_product_tab.html.twig
@@ -1,0 +1,7 @@
+<div role="tabpanel" class="form-contenttab tab-pane" id="product_virtual_product_tab_content">
+  <div class="container-fluid">
+    <div class="row">
+      VIRTUAL PRODUCT
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/header.html.twig
@@ -25,8 +25,51 @@
 <div class="product-header col-md-12">
   <div class="row justify-content-md-center">
     <div class="col-xxl-10">
-      <div class="row"></div>
-      <div class="row"></div>
+      <div class="row">
+        <div class="col-md-7 big-input">
+          {{ form_widget(productForm.name) }}
+        </div>
+
+        <div class="col-sm-7 col-md-2">
+          {{ form_widget(productForm.type) }}
+          <span class="help-box pull-xs-right"
+                data-toggle="popover"
+                data-content="{{ "Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, physical product?"|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </div>
+
+        <div class="toolbar col-sm-3 col-md-2 text-md-right">
+          <a class="toolbar-button btn-sales" href="#" target="_blank" title="{{ 'Sales'|trans({}, 'Admin.Global') }}"
+             id="product_form_go_to_sales">
+            <i class="material-icons">assessment</i>
+            <span class="title">{{ 'Sales'|trans({}, 'Admin.Global') }}</span>
+          </a>
+
+          <a
+            class="toolbar-button btn-quicknav btn-sidebar"
+            href="#"
+            title="{{ 'Quick navigation'|trans({}, 'Admin.Global') }}"
+            data-toggle="sidebar"
+            data-target="#right-sidebar"
+            data-url="{{ path('admin_product_list', {limit: 'last', offset: 'last', view: 'quicknav'}) }}"
+            id="product_form_open_quicknav"
+          >
+            <i class="material-icons">list</i>
+            <span class="title">{{ 'Product list'|trans({}, 'Admin.Catalog.Feature') }}</span>
+          </a>
+
+          <a class="toolbar-button btn-help btn-sidebar" href="#"
+             title="{{ 'Help'|trans({}, 'Admin.Global') }}"
+             data-toggle="sidebar"
+             data-target="#right-sidebar"
+             data-url="#"
+             id="product_form_open_help"
+          >
+            <i class="material-icons">help</i>
+            <span class="title">{{ 'Help'|trans({}, 'Admin.Global') }}</span>
+          </a>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/header.html.twig
@@ -1,0 +1,32 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+<div class="product-header col-md-12">
+  <div class="row justify-content-md-center">
+    <div class="col-xxl-10">
+      <div class="row"></div>
+      <div class="row"></div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/tabs.html.twig
@@ -33,11 +33,37 @@
         {{ 'Basic settings'|trans({}, 'Admin.Catalog.Feature') }}
       </a>
     </li>
-    <li id="tab_step3" class="nav-item"><a href="#step3" role="tab" data-toggle="tab" class="nav-link">{{ 'Quantities'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
-    <li id="tab_step4" class="nav-item"><a href="#step4" role="tab" data-toggle="tab" class="nav-link">{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
-    <li id="tab_step2" class="nav-item"><a href="#step2" role="tab" data-toggle="tab" class="nav-link">{{ 'Pricing'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
-    <li id="tab_step5" class="nav-item"><a href="#step5" role="tab" data-toggle="tab" class="nav-link">{{ 'SEO'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
-    <li id="tab_step6" class="nav-item"><a href="#step6" role="tab" data-toggle="tab" class="nav-link">{{ 'Options'|trans({}, 'Admin.Global') }}</a></li>
+    <li id="product_combinations_tab" class="nav-item">
+      <a href="#product_combinations_tab_content" role="tab" data-toggle="tab" class="nav-link">
+        {{ 'Combinations'|trans({}, 'Admin.Catalog.Feature') }}
+      </a>
+    </li>
+    <li id="product_quantities_tab" class="nav-item">
+      <a href="#product_quantities_tab_content" role="tab" data-toggle="tab" class="nav-link">
+        {{ 'Quantities'|trans({}, 'Admin.Catalog.Feature') }}
+      </a>
+    </li>
+    <li id="product_shipping_tab" class="nav-item">
+      <a href="#product_shipping_tab_content" role="tab" data-toggle="tab" class="nav-link">
+        {{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}
+      </a>
+    </li>
+    <li id="product_pricing_tab" class="nav-item">
+      <a href="#product_pricing_tab_content" role="tab" data-toggle="tab" class="nav-link">
+        {{ 'Pricing'|trans({}, 'Admin.Catalog.Feature') }}
+      </a>
+    </li>
+    <li id="product_seo_tab" class="nav-item">
+      <a href="#product_seo_tab_content" role="tab" data-toggle="tab" class="nav-link">
+        {{ 'SEO'|trans({}, 'Admin.Catalog.Feature') }}
+      </a>
+    </li>
+    <li id="product_options_tab" class="nav-item">
+      <a href="#product_options_tab_content" role="tab" data-toggle="tab" class="nav-link">
+        {{ 'Options'|trans({}, 'Admin.Global') }}
+      </a>
+    </li>
+
     {% if hookcount('displayAdminProductsExtra') > 0 %}
       <li id="tab_hooks" class="nav-item"><a href="#hooks" role="tab" data-toggle="tab" class="nav-link">{{ 'Modules'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
     {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/Blocks/tabs.html.twig
@@ -1,0 +1,49 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+<div class="tabs js-tabs">
+  <div class="arrow d-xl-none js-arrow left-arrow float-left">
+    <i class="material-icons hide">chevron_left</i>
+  </div>
+
+  <ul class="nav nav-tabs js-nav-tabs" id="form-nav" role="tablist">
+    <li id="basic_settings_tab" class="nav-item">
+      <a href="#product_basic_settings_tab_content" role="tab" data-toggle="tab" class="nav-link active">
+        {{ 'Basic settings'|trans({}, 'Admin.Catalog.Feature') }}
+      </a>
+    </li>
+    <li id="tab_step3" class="nav-item"><a href="#step3" role="tab" data-toggle="tab" class="nav-link">{{ 'Quantities'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    <li id="tab_step4" class="nav-item"><a href="#step4" role="tab" data-toggle="tab" class="nav-link">{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    <li id="tab_step2" class="nav-item"><a href="#step2" role="tab" data-toggle="tab" class="nav-link">{{ 'Pricing'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    <li id="tab_step5" class="nav-item"><a href="#step5" role="tab" data-toggle="tab" class="nav-link">{{ 'SEO'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    <li id="tab_step6" class="nav-item"><a href="#step6" role="tab" data-toggle="tab" class="nav-link">{{ 'Options'|trans({}, 'Admin.Global') }}</a></li>
+    {% if hookcount('displayAdminProductsExtra') > 0 %}
+      <li id="tab_hooks" class="nav-item"><a href="#hooks" role="tab" data-toggle="tab" class="nav-link">{{ 'Modules'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    {% endif %}
+  </ul>
+
+  <div class="arrow d-xl-none js-arrow right-arrow visible float-right">
+    <i class="material-icons hide">chevron_right</i>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/add.html.twig
@@ -1,0 +1,50 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  {{ form_start(productForm, {'attr': {'class': 'product-page row justify-content-md-center'}}) }}
+
+    {% block product_header %}
+      {% include '@PrestaShop/Admin/Sell/Catalog/Products/Blocks/header.html.twig' %}
+    {% endblock %}
+
+    <div class="col-xxl-10">
+      {% include '@PrestaShop/Admin/Sell/Catalog/Products/Blocks/tabs.html.twig' %}
+
+      <div class="tab-content">
+        {% block product_basic_settings_tab_content %}
+          {% include '@PrestaShop/Admin/Sell/Catalog/Products/Blocks/Tab/basic_settings_tab.html.twig' %}
+        {% endblock %}
+      </div>
+    </div>
+
+    <div class="d-none">
+      {{ form_rest(productForm) }}
+    </div>
+
+  {{ form_end(productForm) }}
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Products/add.html.twig
@@ -39,12 +39,38 @@
         {% block product_basic_settings_tab_content %}
           {% include '@PrestaShop/Admin/Sell/Catalog/Products/Blocks/Tab/basic_settings_tab.html.twig' %}
         {% endblock %}
+
+        {% block product_combinations_tab_content %}
+          {% include '@PrestaShop/Admin/Sell/Catalog/Products/Blocks/Tab/combinations_tab.html.twig' %}
+        {% endblock %}
+
+        {% block product_quantities_tab_content %}
+          {% include '@PrestaShop/Admin/Sell/Catalog/Products/Blocks/Tab/quantities_tab.html.twig' %}
+        {% endblock %}
+
+        {% block product_shipping_tab_content %}
+          {% include '@PrestaShop/Admin/Sell/Catalog/Products/Blocks/Tab/shipping_tab.html.twig' %}
+        {% endblock %}
+
+        {% block product_pricing_tab_content %}
+          {% include '@PrestaShop/Admin/Sell/Catalog/Products/Blocks/Tab/pricing_tab.html.twig' %}
+        {% endblock %}
+
+        {% block product_seo_tab_content %}
+          {% include '@PrestaShop/Admin/Sell/Catalog/Products/Blocks/Tab/seo_tab.html.twig' %}
+        {% endblock %}
+
+        {% block product_options_tab_content %}
+          {% include '@PrestaShop/Admin/Sell/Catalog/Products/Blocks/Tab/options_tab.html.twig' %}
+        {% endblock %}
       </div>
     </div>
 
-    <div class="d-none">
-      {{ form_rest(productForm) }}
-    </div>
-
   {{ form_end(productForm) }}
+{% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+
+  <script src="{{ asset('themes/new-theme/public/product_form.bundle.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR migrates rendering of Basic settings tab in product form in Back Office without any product saving logic.
| Type?         | refacto
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially https://github.com/PrestaShop/PrestaShop/issues/14763
| How to test?  | I don't think it's needed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14898)
<!-- Reviewable:end -->
