### PR TITLE
Fix error when loading theme that includes a translations directory but no translations

### DIFF
--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -34,13 +34,14 @@ use PrestaShop\PrestaShop\Core\Addon\Theme\Exception\ThemeAlreadyExistsException
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\FailedToEnableThemeModuleException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeConstraintException;
+use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem as PsFileSystem;
 use PrestaShop\PrestaShop\Core\Module\HookConfigurator;
 use PrestaShop\PrestaShop\Core\Image\ImageTypeRepository;
 use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShopBundle\Service\TranslationService;
-use PrestaShopBundle\Translation\Provider\TranslationFinderTrait;
+use PrestaShopBundle\Translation\Provider\TranslationFinder;
 use PrestaShopLogger;
 use Shop;
 use Symfony\Component\Filesystem\Filesystem;
@@ -556,14 +557,21 @@ class ThemeManager implements AddonManagerInterface
                 continue;
             }
 
-            // construct a new catalog for this lang and import in database if key and message are different
-            $messageCatalog = $this->translationFinder->getCatalogueFromPaths($translationFolder . $locale, $locale);
+            try {
+                // construct a new catalog for this lang and import in database if key and message are different
+                $messageCatalog = $this->translationFinder->getCatalogueFromPaths(
+                    $translationFolder . $locale,
+                    $locale
+                );
 
-            // get all default domain from catalog
-            $allDomains = $this->getDefaultDomains($locale, $themeProvider);
+                // get all default domain from catalog
+                $allDomains = $this->getDefaultDomains($locale, $themeProvider);
 
-            // do the import
-            $this->handleImport($translationService, $messageCatalog, $allDomains, $lang, $locale, $themeName);
+                // do the import
+                $this->handleImport($translationService, $messageCatalog, $allDomains, $lang, $locale, $themeName);
+            } catch (FileNotFoundException $e) {
+                // if the directory is there but there are no files, do nothing
+            }
         }
     }
 

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -119,8 +119,7 @@ class ThemeManager implements AddonManagerInterface
      */
     public function uninstall($name)
     {
-        if (!$this->employee->can('delete', 'AdminThemes')
-            && $this->isThemeUsed($name)) {
+        if (!$this->employee->can('delete', 'AdminThemes')) {
             return false;
         }
 

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -45,6 +45,7 @@ use PrestaShopLogger;
 use Shop;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Yaml\Parser;
@@ -52,16 +53,61 @@ use Tools;
 
 class ThemeManager implements AddonManagerInterface
 {
-    use TranslationFinderTrait;
-
+    /**
+     * @var HookConfigurator
+     */
     private $hookConfigurator;
+
+    /**
+     * @var Shop
+     */
     private $shop;
+
+    /**
+     * @var Employee
+     */
     private $employee;
+
+    /**
+     * @var ThemeValidator
+     */
     private $themeValidator;
+
+    /**
+     * @var ConfigurationInterface
+     */
     private $appConfiguration;
+
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
+
+    /**
+     * @var Finder
+     */
     private $finder;
+
+    /**
+     * @var ThemeRepository
+     */
     private $themeRepository;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var ImageTypeRepository
+     */
+    private $imageTypeRepository;
+
+    /**
+     * @var TranslationFinder
+     */
+    private $translationFinder;
+
 
     public function __construct(
         Shop $shop,
@@ -75,6 +121,7 @@ class ThemeManager implements AddonManagerInterface
         ThemeRepository $themeRepository,
         ImageTypeRepository $imageTypeRepository
     ) {
+        $this->translationFinder = new TranslationFinder();
         $this->shop = $shop;
         $this->appConfiguration = $configuration;
         $this->themeValidator = $themeValidator;
@@ -353,6 +400,7 @@ class ThemeManager implements AddonManagerInterface
      */
     private function installFromZip($source)
     {
+        /** @var Finder $finderClass */
         $finderClass = get_class($this->finder);
         $this->finder = $finderClass::create();
 
@@ -411,7 +459,7 @@ class ThemeManager implements AddonManagerInterface
             $module_dirs = $this->finder->directories()
                                         ->in($modules_parent_dir)
                                         ->depth('== 0');
-
+            /** @var SplFileInfo $dir */
             foreach (iterator_to_array($module_dirs) as $dir) {
                 $destination = $module_root_dir . basename($dir->getFileName());
                 if (!$this->filesystem->exists($destination)) {
@@ -509,7 +557,7 @@ class ThemeManager implements AddonManagerInterface
             }
 
             // construct a new catalog for this lang and import in database if key and message are different
-            $messageCatalog = $this->getCatalogueFromPaths($translationFolder . $locale, $locale);
+            $messageCatalog = $this->translationFinder->getCatalogueFromPaths($translationFolder . $locale, $locale);
 
             // get all default domain from catalog
             $allDomains = $this->getDefaultDomains($locale, $themeProvider);

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -109,7 +109,6 @@ class ThemeManager implements AddonManagerInterface
      */
     private $translationFinder;
 
-
     public function __construct(
         Shop $shop,
         ConfigurationInterface $configuration,

--- a/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
@@ -119,8 +119,8 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
      * Get the PrestaShop locale from real locale.
      *
      * @return string The PrestaShop locale
-     * @deprecated since 1.7.6, to be removed in the next major
      *
+     * @deprecated since 1.7.6, to be removed in the next major
      */
     public function getPrestaShopLocale()
     {
@@ -267,7 +267,7 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    public abstract function getDefaultResourceDirectory();
+    abstract public function getDefaultResourceDirectory();
 }

--- a/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
@@ -34,8 +34,6 @@ use Symfony\Component\Translation\MessageCatalogue;
 
 abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInterface, DatabaseCatalogueInterface
 {
-    use TranslationFinderTrait;
-
     const DEFAULT_LOCALE = 'en-US';
 
     /**
@@ -120,9 +118,9 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
     /**
      * Get the PrestaShop locale from real locale.
      *
+     * @return string The PrestaShop locale
      * @deprecated since 1.7.6, to be removed in the next major
      *
-     * @return string The PrestaShop locale
      */
     public function getPrestaShopLocale()
     {
@@ -252,5 +250,19 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
         }
 
         return $messageCatalogue;
+    }
+
+    /**
+     * @param array $paths a list of paths when we can look for translations
+     * @param string $locale the Symfony (not the PrestaShop one) locale
+     * @param string|null $pattern a regular expression
+     *
+     * @return MessageCatalogue
+     *
+     * @throws FileNotFoundException
+     */
+    public function getCatalogueFromPaths($paths, $locale, $pattern = null)
+    {
+        return (new TranslationFinder())->getCatalogueFromPaths($paths, $locale, $pattern);
     }
 }

--- a/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
@@ -265,4 +265,9 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
     {
         return (new TranslationFinder())->getCatalogueFromPaths($paths, $locale, $pattern);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public abstract function getDefaultResourceDirectory();
 }

--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
@@ -39,9 +39,11 @@ use Symfony\Component\Translation\MessageCatalogueInterface;
  */
 class TranslationFinder
 {
+    const ERR_NO_FILES_IN_DIRECTORY = 1;
+    const ERR_DIRECTORY_NOT_FOUND = 2;
 
     /**
-     * @param array $paths a list of paths when we can look for translations
+     * @param string|array $paths a list of paths when we can look for translations
      * @param string $locale the Symfony (not the PrestaShop one) locale
      * @param string|null $pattern a regular expression
      *
@@ -67,13 +69,13 @@ class TranslationFinder
                     'Could not crawl for translation files: %s',
                     $e->getMessage()
                 ),
-                0,
+                self::ERR_DIRECTORY_NOT_FOUND,
                 $e
             );
         }
 
         if (count($translationFiles) === 0) {
-            throw new FileNotFoundException('There is no translation file available.');
+            throw new FileNotFoundException('There are no translation file available.', self::ERR_NO_FILES_IN_DIRECTORY);
         }
 
         /** @var SplFileInfo $file */

--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation\Provider;
+
+use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+/**
+ * Helper used to build a MessageCataloguer from xliff files
+ */
+class TranslationFinder
+{
+
+    /**
+     * @param array $paths a list of paths when we can look for translations
+     * @param string $locale the Symfony (not the PrestaShop one) locale
+     * @param string|null $pattern a regular expression
+     *
+     * @return MessageCatalogue
+     *
+     * @throws FileNotFoundException
+     */
+    public function getCatalogueFromPaths($paths, $locale, $pattern = null)
+    {
+        $messageCatalogue = new MessageCatalogue($locale);
+        $xliffFileLoader = new XliffFileLoader();
+        $finder = new Finder();
+
+        if (null !== $pattern) {
+            $finder->name($pattern);
+        }
+
+        try {
+            $translationFiles = $finder->files()->notName('index.php')->in($paths);
+        } catch (\InvalidArgumentException $e) {
+            throw new FileNotFoundException(
+                sprintf(
+                    'Could not crawl for translation files: %s',
+                    $e->getMessage()
+                ),
+                0,
+                $e
+            );
+        }
+
+        if (count($translationFiles) === 0) {
+            throw new FileNotFoundException('There is no translation file available.');
+        }
+
+        /** @var SplFileInfo $file */
+        foreach ($translationFiles as $file) {
+            if ('xlf' === $file->getExtension()) {
+                if (strpos($file->getBasename('.xlf'), $locale) !== false) {
+                    $domain = $file->getBasename('.xlf');
+                } else {
+                    $domain = $file->getBasename('.xlf') . '.' . $locale;
+                }
+
+                $fileCatalogue = $xliffFileLoader->load($file->getPathname(), $locale, $domain);
+                $messageCatalogue->addCatalogue(
+                    $this->removeTrailingLocaleFromDomains($fileCatalogue)
+                );
+            }
+        }
+
+        return $messageCatalogue;
+    }
+
+    /**
+     * @param MessageCatalogueInterface $catalogue
+     *
+     * @return MessageCatalogue
+     */
+    private function removeTrailingLocaleFromDomains(MessageCatalogueInterface $catalogue)
+    {
+        $messages = $catalogue->all();
+        $locale = $catalogue->getLocale();
+        $localeSuffix = '.' . $locale;
+        $suffixLength = strlen($localeSuffix);
+
+        foreach ($catalogue->getDomains() as $domain) {
+            if (substr($domain, -$suffixLength) === $localeSuffix) {
+                $cleanDomain = substr($domain, 0, -$suffixLength);
+                $messages[$cleanDomain] = $messages[$domain];
+                unset($messages[$domain]);
+            }
+        }
+
+        return new MessageCatalogue($locale, $messages);
+    }
+}

--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinderTrait.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinderTrait.php
@@ -27,14 +27,12 @@
 namespace PrestaShopBundle\Translation\Provider;
 
 use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
-use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\MessageCatalogue;
-use Symfony\Component\Translation\MessageCatalogueInterface;
 
 /**
  * Helper used to retrieve a Symfony Catalogue object.
+ *
+ * @deprecated use TraslationFinder instead
  */
 trait TranslationFinderTrait
 {
@@ -46,73 +44,18 @@ trait TranslationFinderTrait
      * @return MessageCatalogue
      *
      * @throws FileNotFoundException
+     *
+     * @deprecated use TraslationFinder::getCatalogueFromPaths() instead
+     *
      */
     public function getCatalogueFromPaths($paths, $locale, $pattern = null)
     {
-        $messageCatalogue = new MessageCatalogue($locale);
-        $xliffFileLoader = new XliffFileLoader();
-        $finder = new Finder();
 
-        if (null !== $pattern) {
-            $finder->name($pattern);
-        }
+        @trigger_error(
+            __FUNCTION__ . 'is deprecated since version 1.7.6.1 Use TranslationFinder::getCatalogueFromPaths() instead.',
+            E_USER_DEPRECATED
+        );
 
-        try {
-            $translationFiles = $finder->files()->notName('index.php')->in($paths);
-        } catch (\InvalidArgumentException $e) {
-            throw new FileNotFoundException(
-                sprintf(
-                    'Could not crawl for translation files: %s',
-                    $e->getMessage()
-                ),
-                0,
-                $e
-            );
-        }
-
-        if (count($translationFiles) === 0) {
-            throw new FileNotFoundException('There is no translation file available.');
-        }
-
-        /** @var SplFileInfo $file */
-        foreach ($translationFiles as $file) {
-            if ('xlf' === $file->getExtension()) {
-                if (strpos($file->getBasename('.xlf'), $locale) !== false) {
-                    $domain = $file->getBasename('.xlf');
-                } else {
-                    $domain = $file->getBasename('.xlf') . '.' . $locale;
-                }
-
-                $fileCatalogue = $xliffFileLoader->load($file->getPathname(), $locale, $domain);
-                $messageCatalogue->addCatalogue(
-                    $this->removeTrailingLocaleFromDomains($fileCatalogue)
-                );
-            }
-        }
-
-        return $messageCatalogue;
-    }
-
-    /**
-     * @param MessageCatalogueInterface $catalogue
-     *
-     * @return MessageCatalogue
-     */
-    private function removeTrailingLocaleFromDomains(MessageCatalogueInterface $catalogue)
-    {
-        $messages = $catalogue->all();
-        $locale = $catalogue->getLocale();
-        $localeSuffix = '.' . $locale;
-        $suffixLength = strlen($localeSuffix);
-
-        foreach ($catalogue->getDomains() as $domain) {
-            if (substr($domain, -$suffixLength) === $localeSuffix) {
-                $cleanDomain = substr($domain, 0, -$suffixLength);
-                $messages[$cleanDomain] = $messages[$domain];
-                unset($messages[$domain]);
-            }
-        }
-
-        return new MessageCatalogue($locale, $messages);
+        return (new TranslationFinder())->getCatalogueFromPaths($paths, $locale, $pattern);
     }
 }

--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinderTrait.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinderTrait.php
@@ -46,11 +46,9 @@ trait TranslationFinderTrait
      * @throws FileNotFoundException
      *
      * @deprecated use TraslationFinder::getCatalogueFromPaths() instead
-     *
      */
     public function getCatalogueFromPaths($paths, $locale, $pattern = null)
     {
-
         @trigger_error(
             __FUNCTION__ . 'is deprecated since version 1.7.6.1 Use TranslationFinder::getCatalogueFromPaths() instead.',
             E_USER_DEPRECATED


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | When loading a theme, ThemeManager will try to load its translations if the `translations` directory is present. But if it's present AND empty it would throw an exception.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | Yes, `TranslationFinderTrait` has been extracted into a class of its own, `TranslationFinder`.
| Fixed ticket? | Fixes #14960
| How to test?  | Create a theme that is not named `classic`, make sure there's a `translations` directory in it with nothing inside. Zip it and try to import it into PS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14938)
<!-- Reviewable:end -->
