### PR TITLE
Fixed {firstname} typo in order customer comment mail in 1.7.6.x

### DIFF
--- a/mails/themes/modern/core/order_customer_comment.html.twig
+++ b/mails/themes/modern/core/order_customer_comment.html.twig
@@ -250,7 +250,7 @@
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                         <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">
-                                          <span style=" font-size:16px" class="label">{{ 'Customer:'|trans({}, 'Emails.Body', locale)|raw }}</span> {firstrname} {lastname} ({email}) </div>
+                                          <span style=" font-size:16px" class="label">{{ 'Customer:'|trans({}, 'Emails.Body', locale)|raw }}</span> {firstname} {lastname} ({email}) </div>
                                       </td>
                                     </tr>
                                   </table>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc.
| Type?         | bug fix
| Category?     | FO 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/14906
| How to test?  | Just got to FO order details page and send a message to admin for the order. Admin can see this error in the mail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14945)
<!-- Reviewable:end -->
