### PR TITLE
Webservice is letting create customers with same email #12844

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -151,7 +151,7 @@ class CustomerCore extends ObjectModel
 
     protected $webserviceParameters = array(
         'objectMethods' => array(
-            'add' => 'addWs'
+            'add' => 'addWs',
         ),
         'fields' => array(
             'id_default_group' => array('xlink_resource' => 'groups'),
@@ -239,9 +239,9 @@ class CustomerCore extends ObjectModel
      */
     public function addWs($autodate = true, $null_values = false)
     {
-        if (CustomerCore::customerExists($this->email)) {
+        if (self::customerExists($this->email)) {
             //Customer already exist... update
-            $customer = Customer::getByEmail($this->email);
+            $customer = self::getByEmail($this->email);
             $this->id = $customer->id;
             return $this->update($null_values);
         } else {

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -150,6 +150,9 @@ class CustomerCore extends ObjectModel
     public $reset_password_validity;
 
     protected $webserviceParameters = array(
+        'objectMethods' => array(
+            'add' => 'addWs'
+        ),
         'fields' => array(
             'id_default_group' => array('xlink_resource' => 'groups'),
             'id_lang' => array('xlink_resource' => 'languages'),
@@ -222,7 +225,31 @@ class CustomerCore extends ObjectModel
         $this->id_default_group = (int) Configuration::get('PS_CUSTOMER_GROUP');
         parent::__construct($id);
     }
-
+    
+    /**
+     * Add customer or update if customer already exist
+     *
+     * @param bool $autoDate Automatically set `date_upd` and `date_add` columns
+     * @param bool $nullValues Whether we want to use NULL values instead of empty quotes values
+     *
+     * @return bool Indicates whether the Customer has been successfully added
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    public function addWs($autodate = true, $null_values = false)
+    {
+        if (CustomerCore::customerExists($this->email)) {
+            //Customer already exist... update
+            $customer = Customer::getByEmail($this->email);
+            $this->id = $customer->id;
+            return $this->update($null_values);
+        } else {
+            //Customer not exist... add
+            return $this->add($autodate, $null_values);
+        }
+    }
+    
     /**
      * Adds current Customer as a new Object to the database.
      *


### PR DESCRIPTION
…l to validate this email already exist or not

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We can create several times the same user with api
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? |  #12844
| How to test?  | Send several same xml api request with the same email

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14952)
<!-- Reviewable:end -->
