### PR TITLE
Fix error preventing to translate backoffice wordings when using a theme other than classic

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -67,7 +67,7 @@ class TranslationController extends ApiController
 
             $locale = $request->attributes->get('locale');
             $domain = $request->attributes->get('domain');
-            $theme = $request->attributes->get('theme', $this->getSelectedTheme());
+            $theme = $request->attributes->get('theme');
             $module = $request->query->get('module');
             $search = $request->query->get('search');
 
@@ -171,7 +171,7 @@ class TranslationController extends ApiController
             $response = [];
             foreach ($translations as $translation) {
                 if (empty($translation['theme'])) {
-                    $translation['theme'] = $this->getSelectedTheme();
+                    $translation['theme'] = null;
                 }
 
                 try {
@@ -314,8 +314,8 @@ class TranslationController extends ApiController
      */
     private function getNormalTree($lang, $type, $selected, $search = null)
     {
-        $treeBuilder = new TreeBuilder($this->translationService->langToLocale($lang), $this->getSelectedTheme());
-        $catalogue = $this->translationService->getTranslationsCatalogue($lang, $type, $this->getSelectedTheme(), $search);
+        $treeBuilder = new TreeBuilder($this->translationService->langToLocale($lang), $selected);
+        $catalogue = $this->translationService->getTranslationsCatalogue($lang, $type, $selected, $search);
 
         return $this->getCleanTree($treeBuilder, $catalogue, $type, $selected, $search);
     }

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -30,6 +30,7 @@ use Exception;
 use PrestaShopBundle\Entity\Translation;
 use PrestaShopBundle\Translation\Constraints\PassVsprintf;
 use PrestaShopBundle\Translation\Provider\UseModuleInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Validator\Validation;
 
 class TranslationService
@@ -111,19 +112,16 @@ class TranslationService
     {
         $factory = $this->container->get('ps.translations_factory');
 
-        if ($selected !== 'classic' && $this->requiresThemeTranslationsFactory($selected, $type)) {
-            $factory = $this->container->get('ps.theme_translations_factory');
-        }
-
-        $locale = $this->langToLocale($lang);
-
         if ($this->requiresThemeTranslationsFactory($selected, $type)) {
             if ('classic' === $selected) {
                 $type = 'front';
             } else {
                 $type = $selected;
+                $factory = $this->container->get('ps.theme_translations_factory');
             }
         }
+
+        $locale = $this->langToLocale($lang);
 
         return $factory->createTranslationsArray($type, $locale, $selected, $search);
     }

--- a/src/PrestaShopBundle/Translation/Loader/DatabaseTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/DatabaseTranslationLoader.php
@@ -55,6 +55,13 @@ class DatabaseTranslationLoader implements LoaderInterface
     public function load($resource, $locale, $domain = 'messages', $theme = null)
     {
         static $langs = array();
+        $catalogue = new MessageCatalogue($locale);
+
+        // do not try and load translations for a locale that cannot be saved to DB anyway
+        if ($locale === 'default') {
+            return $catalogue;
+        }
+
         if (!array_key_exists($locale, $langs)) {
             $langs[$locale] = $this->entityManager
                 ->getRepository('PrestaShopBundle:Lang')
@@ -75,8 +82,6 @@ class DatabaseTranslationLoader implements LoaderInterface
         $translations = $queryBuilder
             ->getQuery()
             ->getResult();
-
-        $catalogue = new MessageCatalogue($locale);
 
         /** @var Translation $translation */
         foreach ($translations as $translation) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | This PR fixes an issue making it impossible to translate BO wordings if the current theme is anything other than "classic". Read below for more.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14733
| How to test?  | See issue + test translating at least a wording in BO, FO, classic theme and custom theme.

## More information about this bug

Before this fix, back office translations would be pulled from the current FO theme as well, and any saved translation would also be attached to that theme, even if the wording didn't belong to the FO. This issue would render the translation of backoffice wordings impossible when using a theme other than "classic" (which has a custom behavior compared to any other theme since its wordings are included in the core). 

The problem is related to how the theme translation section works when dealing with themes: it analyzes the theme's code looking for wordings, extracts them into a xliff catalogue in cache, then reads it to build the form. This extraction ONLY happens when working with theme translations. So what happened here was that when requested to load the backoffice translations, it would try to load the theme translations for some reason, and since its xliff catalogue hadn't been extracted, it raised an exception.

This PR reverts changes in #13088 that introduced the forced theme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14962)
<!-- Reviewable:end -->
