### PR TITLE
Keep BO from using two different translators in parallel 

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShopBundle\Translation\Loader\SqlTranslationLoader;
 use PrestaShopBundle\Translation\TranslatorComponent as Translator;
@@ -370,10 +371,16 @@ class ContextCore
             return $this->translator;
         }
 
-        $translator = $this->getTranslatorFromLocale($this->language->locale);
-        $this->translator = $translator;
+        $sfContainer = SymfonyContainer::getInstance();
 
-        return $translator;
+        if (null === $sfContainer) {
+            // symfony's container isn't available in front office, so we load and configure the translator component
+            $this->translator = $this->getTranslatorFromLocale($this->language->locale);
+        } else {
+            $this->translator = $sfContainer->get('translator');
+        }
+
+        return $this->translator;
     }
 
     /**

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -365,7 +365,7 @@ class ContextCore
     /**
      * @return Translator
      */
-    public function getTranslator()
+    public function getTranslator($needComponentTranslator = false)
     {
         if (null !== $this->translator) {
             return $this->translator;
@@ -373,11 +373,12 @@ class ContextCore
 
         $sfContainer = SymfonyContainer::getInstance();
 
-        if (null === $sfContainer) {
+        if ($needComponentTranslator || null === $sfContainer) {
             // symfony's container isn't available in front office, so we load and configure the translator component
             $this->translator = $this->getTranslatorFromLocale($this->language->locale);
         } else {
             $this->translator = $sfContainer->get('translator');
+            $this->translator->setLocale($this->language->locale);
         }
 
         return $this->translator;

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -363,9 +363,14 @@ class ContextCore
     }
 
     /**
+     * Returns a translator depending on service container availability and if the method
+     * is called by the installer or not.
+     *
+     * @param bool $isInstaller Set to true if the method is called by the installer
+     *
      * @return Translator
      */
-    public function getTranslator($needComponentTranslator = false)
+    public function getTranslator($isInstaller = false)
     {
         if (null !== $this->translator) {
             return $this->translator;
@@ -373,11 +378,13 @@ class ContextCore
 
         $sfContainer = SymfonyContainer::getInstance();
 
-        if ($needComponentTranslator || null === $sfContainer) {
+        if ($isInstaller || null === $sfContainer) {
             // symfony's container isn't available in front office, so we load and configure the translator component
             $this->translator = $this->getTranslatorFromLocale($this->language->locale);
         } else {
             $this->translator = $sfContainer->get('translator');
+            // We need to set the locale here because in legacy BO pages, the translator is used
+            // before the TranslatorListener does its job of setting the locale according to the Request object
             $this->translator->setLocale($this->language->locale);
         }
 

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -180,6 +180,10 @@ abstract class ControllerCore
             define('_PS_BASE_URL_SSL_', Tools::getShopDomainSsl(true));
         }
 
+        if (null === $this->getContainer()) {
+            $this->container = $this->buildContainer();
+        }
+
         $localeRepo = $this->get(self::SERVICE_LOCALE_REPOSITORY);
         $this->context->currentLocale = $localeRepo->getLocale(
             $this->context->language->getLocale()
@@ -225,9 +229,6 @@ abstract class ControllerCore
         }
         if (null === $this->display_footer) {
             $this->display_footer = true;
-        }
-        if (null === $this->getContainer()) {
-            $this->container = $this->buildContainer();
         }
         $this->context = Context::getContext();
         $this->context->controller = $this;

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -180,9 +180,6 @@ abstract class ControllerCore
             define('_PS_BASE_URL_SSL_', Tools::getShopDomainSsl(true));
         }
 
-        if (null === $this->getContainer()) {
-            $this->container = $this->buildContainer();
-        }
         $localeRepo = $this->get(self::SERVICE_LOCALE_REPOSITORY);
         $this->context->currentLocale = $localeRepo->getLocale(
             $this->context->language->getLocale()
@@ -228,6 +225,9 @@ abstract class ControllerCore
         }
         if (null === $this->display_footer) {
             $this->display_footer = true;
+        }
+        if (null === $this->getContainer()) {
+            $this->container = $this->buildContainer();
         }
         $this->context = Context::getContext();
         $this->context->controller = $this;

--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -143,7 +143,7 @@ class InstallControllerHttp
             $this->session->lang ?: false
         );
 
-        $this->translator = Context::getContext()->getTranslator();
+        $this->translator = Context::getContext()->getTranslator(true);
 
         if (isset($this->session->lang)) {
             $lang = $this->session->lang;

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -108,6 +108,11 @@ services:
         tags:
             - {name: translation.loader, alias: db}
 
+    prestashop.translation.sql_loader:
+        class: PrestaShopBundle\Translation\Loader\SqlTranslationLoader
+        tags:
+            - {name: translation.loader, alias: db}
+
     prestashop.translation.legacy_file_reader:
         class: PrestaShopBundle\Translation\Loader\LegacyFileReader
         arguments:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fix translation issues, read below
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14932
| How to test?  | Check that translation is still working, especially translations coming from database in modules.

First, you should read this PR from @eternoendless 
https://github.com/PrestaShop/PrestaShop/pull/14845

His PR renames translation test modules, allows underscores in translation domain name, and adds useful comments to understand the two translators.

From there, this PR adds a few things, the main goal being that wether we are in FO or BO, we always use **only one translator**, either the translator component or the one from frameworkbundle. Also make it so that we still have the translation part in symfony's debug toolbar, and that the database translations are still working in modules.

- make frameworkbundle's translator load SQL translations with yaml service configuration
- fix timing issue in controllerCore (service container was called after the first call to the translator) . (edit: removed due to issue with php 5.6)  
- Fetch the right translator depending on the availability or not of the symfony service container
- Make it possible to specify which translator you need

I carefully checked that the component translator is never called in back office, and that the framework bundle translator is never called in front office.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14966)
<!-- Reviewable:end -->
