### PR TITLE
Fix Search customer in specific group

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -186,6 +186,10 @@ class AdminGroupsControllerCore extends AdminController
             if (isset($_POST['submitReset' . $this->list_id])) {
                 $this->processResetFilters();
             }
+
+            if (Tools::isSubmit('submitFilter')) {
+                self::$currentIndex .= '&id_group=' . (int) Tools::getValue('id_group') . '&viewgroup';
+            }
         } else {
             $this->list_id = 'group';
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Navigate to a customer group that has more than one customer, then try to search with a name. On click "Search" you have to redirect to a list of groups ...not having search results. Going back to the list of customers in the same group, search filter works OK, reset button same work.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9825
| How to test?  | Navigate to a customer group that has more than one customer, then try to search with a name. On click "Search" => Ok ( Same test with reset)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14977)
<!-- Reviewable:end -->
