### PR TITLE
Fix Monitoring grids data for multishop

### DIFF
--- a/src/Core/Grid/Query/Monitoring/AbstractProductQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/AbstractProductQueryBuilder.php
@@ -127,6 +127,10 @@ abstract class AbstractProductQueryBuilder extends AbstractDoctrineQueryBuilder
                 'p.id_product = ps.id_product AND ps.id_shop = p.id_shop_default'
         );
 
+        if ($isSingleShopContext) {
+            $qb->andWhere('ps.id_shop = :context_shop_id');
+        }
+
         $this->applyFilters($qb, $searchCriteria->getFilters());
 
         return $qb;

--- a/src/Core/Grid/Query/Monitoring/AbstractProductQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/AbstractProductQueryBuilder.php
@@ -28,7 +28,6 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query\Monitoring;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShop\PrestaShop\Core\Grid\Query\AbstractDoctrineQueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicator;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
@@ -70,18 +69,12 @@ abstract class AbstractProductQueryBuilder extends AbstractDoctrineQueryBuilder
     protected $multistoreContextChecker;
 
     /**
-     * @var FeatureInterface
-     */
-    protected $multistoreFeature;
-
-    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicator $searchCriteriaApplicator
      * @param int $contextLangId
      * @param int $contextShopId
      * @param MultistoreContextCheckerInterface $multistoreContextChecker
-     * @param FeatureInterface $multistoreFeature
      */
     public function __construct(
         Connection $connection,
@@ -89,15 +82,13 @@ abstract class AbstractProductQueryBuilder extends AbstractDoctrineQueryBuilder
         $contextLangId,
         $contextShopId,
         DoctrineSearchCriteriaApplicator $searchCriteriaApplicator,
-        MultistoreContextCheckerInterface $multistoreContextChecker,
-        FeatureInterface $multistoreFeature
+        MultistoreContextCheckerInterface $multistoreContextChecker
     ) {
         parent::__construct($connection, $dbPrefix);
         $this->contextLangId = $contextLangId;
         $this->contextShopId = $contextShopId;
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
         $this->multistoreContextChecker = $multistoreContextChecker;
-        $this->multistoreFeature = $multistoreFeature;
     }
 
     /**
@@ -109,8 +100,7 @@ abstract class AbstractProductQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     protected function getProductsCommonQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        $isSingleShopContext = $this->multistoreFeature->isUsed() &&
-            $this->multistoreContextChecker->isSingleShopContext();
+        $isSingleShopContext = $this->multistoreContextChecker->isSingleShopContext();
 
         $qb = $this->connection
             ->createQueryBuilder()
@@ -136,10 +126,6 @@ abstract class AbstractProductQueryBuilder extends AbstractDoctrineQueryBuilder
                 'p.id_product = ps.id_product AND ps.id_shop = :context_shop_id' :
                 'p.id_product = ps.id_product AND ps.id_shop = p.id_shop_default'
         );
-
-        if ($isSingleShopContext) {
-            $qb->andWhere('ps.id_shop = :context_shop_id');
-        }
 
         $this->applyFilters($qb, $searchCriteria->getFilters());
 

--- a/src/Core/Grid/Query/Monitoring/DisabledProductQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/DisabledProductQueryBuilder.php
@@ -71,6 +71,11 @@ final class DisabledProductQueryBuilder extends AbstractProductQueryBuilder
         $qb = $this->getProductsCommonQueryBuilder($searchCriteria);
         $qb->andWhere('ps.active = 0');
 
+        if ($this->multistoreContextChecker->isSingleShopContext()) {
+            $qb->andWhere('ps.id_shop = :context_shop_id')
+                ->setParameter('context_shop_id', $this->contextShopId);
+        }
+
         return $qb;
     }
 }

--- a/src/Core/Grid/Query/Monitoring/EmptyCategoryQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/EmptyCategoryQueryBuilder.php
@@ -28,7 +28,6 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query\Monitoring;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShop\PrestaShop\Core\Grid\Query\AbstractDoctrineQueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineSearchCriteriaApplicator;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
@@ -60,11 +59,6 @@ final class EmptyCategoryQueryBuilder extends AbstractDoctrineQueryBuilder
     private $multistoreContextChecker;
 
     /**
-     * @var FeatureInterface
-     */
-    private $multistoreFeature;
-
-    /**
      * @var int
      */
     private $rootCategoryId;
@@ -76,7 +70,6 @@ final class EmptyCategoryQueryBuilder extends AbstractDoctrineQueryBuilder
      * @param int $contextLangId
      * @param int $contextShopId
      * @param MultistoreContextCheckerInterface $multistoreContextChecker
-     * @param FeatureInterface $multistoreFeature
      * @param $rootCategoryId
      */
     public function __construct(
@@ -86,7 +79,6 @@ final class EmptyCategoryQueryBuilder extends AbstractDoctrineQueryBuilder
         $contextShopId,
         DoctrineSearchCriteriaApplicator $searchCriteriaApplicator,
         MultistoreContextCheckerInterface $multistoreContextChecker,
-        FeatureInterface $multistoreFeature,
         $rootCategoryId
     ) {
         parent::__construct($connection, $dbPrefix);
@@ -94,7 +86,6 @@ final class EmptyCategoryQueryBuilder extends AbstractDoctrineQueryBuilder
         $this->contextShopId = $contextShopId;
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
         $this->multistoreContextChecker = $multistoreContextChecker;
-        $this->multistoreFeature = $multistoreFeature;
         $this->rootCategoryId = $rootCategoryId;
     }
 
@@ -133,8 +124,7 @@ final class EmptyCategoryQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     private function getQueryBuilder(array $filters)
     {
-        $isSingleShopContext = $this->multistoreFeature->isUsed() &&
-            $this->multistoreContextChecker->isSingleShopContext();
+        $isSingleShopContext = $this->multistoreContextChecker->isSingleShopContext();
 
         $qb = $this->connection
             ->createQueryBuilder()

--- a/src/Core/Grid/Query/Monitoring/NoQtyProductWithCombinationQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/NoQtyProductWithCombinationQueryBuilder.php
@@ -73,16 +73,19 @@ final class NoQtyProductWithCombinationQueryBuilder extends AbstractProductQuery
         $attrSubQuery = $this->connection->createQueryBuilder()
             ->select(1)
             ->from($this->dbPrefix . 'product_attribute', 'pa')
-            ->andWhere('pa.id_product = p.id_product')
-        ;
+            ->andWhere('pa.id_product = p.id_product');
 
-        $subQuery = $this->connection->createQueryBuilder();
-        $subQuery->select('1')
+        $subQuery = $this->connection->createQueryBuilder()->select(1);
+        $subQuery
             ->from($this->dbPrefix . 'stock_available', 'stock')
             ->andWhere('p.id_product = stock.id_product')
             ->andWhere('EXISTS(' . $attrSubQuery->getSQL() . ')')
-            ->andWhere('IFNULL(stock.quantity, 0) <= 0')
-        ;
+            ->andWhere('IFNULL(stock.quantity, 0) <= 0');
+
+        if ($this->multistoreContextChecker->isSingleShopContext()) {
+            $attrSubQuery->andWhere('stock.id_shop = :context_shop_id')
+                ->setParameter('context_shop_id', $this->contextShopId);
+        }
 
         $qb->andWhere('EXISTS(' . $subQuery->getSQL() . ')');
 

--- a/src/Core/Grid/Query/Monitoring/NoQtyProductWithoutCombinationQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/NoQtyProductWithoutCombinationQueryBuilder.php
@@ -73,16 +73,19 @@ final class NoQtyProductWithoutCombinationQueryBuilder extends AbstractProductQu
         $attrSubQuery = $this->connection->createQueryBuilder()
             ->select(1)
             ->from($this->dbPrefix . 'product_attribute', 'pa')
-            ->andWhere('pa.id_product = p.id_product')
-        ;
+            ->andWhere('pa.id_product = p.id_product');
 
         $subQuery = $this->connection->createQueryBuilder();
-        $subQuery->select('1')
+        $subQuery->select(1)
             ->from($this->dbPrefix . 'stock_available', 'stock')
             ->andWhere('p.id_product = stock.id_product')
             ->andWhere('NOT EXISTS(' . $attrSubQuery->getSQL() . ')')
-            ->andWhere('IFNULL(stock.quantity, 0) <= 0')
-        ;
+            ->andWhere('IFNULL(stock.quantity, 0) <= 0');
+
+        if ($this->multistoreContextChecker->isSingleShopContext()) {
+            $subQuery->andWhere('stock.id_shop = :context_shop_id')
+                ->setParameter('context_shop_id', $this->contextShopId);
+        }
 
         $qb->andWhere('EXISTS(' . $subQuery->getSQL() . ')');
 

--- a/src/Core/Grid/Query/Monitoring/ProductWithoutDescriptionQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/ProductWithoutDescriptionQueryBuilder.php
@@ -69,8 +69,8 @@ final class ProductWithoutDescriptionQueryBuilder extends AbstractProductQueryBu
     private function getQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getProductsCommonQueryBuilder($searchCriteria);
-        $qb->andWhere('pl.description = ""')
-            ->andWhere('pl.description_short = ""');
+        $qb->andWhere('pl.description IS NULL OR pl.description = ""')
+            ->andWhere('pl.description_short IS NULL OR pl.description_short = ""');
 
         return $qb;
     }

--- a/src/Core/Grid/Query/Monitoring/ProductWithoutImageQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/ProductWithoutImageQueryBuilder.php
@@ -69,18 +69,16 @@ final class ProductWithoutImageQueryBuilder extends AbstractProductQueryBuilder
     private function getQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getProductsCommonQueryBuilder($searchCriteria);
-        $imageSubQuery = $this->connection->createQueryBuilder()->select(1);
+
+        $imageSubQuery = $this->connection->createQueryBuilder()
+            ->select(1)
+            ->from($this->dbPrefix . 'image_shop', 'img')
+            ->andWhere('p.id_product = img.id_product');
 
         if ($this->multistoreContextChecker->isSingleShopContext()) {
-            $imageSubQuery
-                ->from($this->dbPrefix . 'image', 'img')
-                ->andWhere('p.id_product = img.id_product');
+            $imageSubQuery->andWhere('img.id_shop = :context_shop_id');
         } else {
-            $imageSubQuery
-                ->from($this->dbPrefix . 'image_shop', 'img')
-                ->andWhere('p.id_product = img.id_product')
-                ->andWhere('img.id_shop = :context_shop_id')
-                ->setParameter('context_shop_id', $this->contextShopId);
+            $imageSubQuery->andWhere('img.id_shop = p.id_shop_default');
         }
 
         $qb->andWhere('NOT EXISTS(' . $imageSubQuery->getSQL() . ')');

--- a/src/Core/Grid/Query/Monitoring/ProductWithoutImageQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/ProductWithoutImageQueryBuilder.php
@@ -69,12 +69,19 @@ final class ProductWithoutImageQueryBuilder extends AbstractProductQueryBuilder
     private function getQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getProductsCommonQueryBuilder($searchCriteria);
+        $imageSubQuery = $this->connection->createQueryBuilder()->select(1);
 
-        $imageSubQuery = $this->connection->createQueryBuilder()
-            ->select(1)
-            ->from($this->dbPrefix . 'image', 'img')
-            ->andWhere('p.id_product = img.id_product')
-        ;
+        if ($this->multistoreContextChecker->isSingleShopContext()) {
+            $imageSubQuery
+                ->from($this->dbPrefix . 'image', 'img')
+                ->andWhere('p.id_product = img.id_product');
+        } else {
+            $imageSubQuery
+                ->from($this->dbPrefix . 'image_shop', 'img')
+                ->andWhere('p.id_product = img.id_product')
+                ->andWhere('img.id_shop = :context_shop_id')
+                ->setParameter('context_shop_id', $this->contextShopId);
+        }
 
         $qb->andWhere('NOT EXISTS(' . $imageSubQuery->getSQL() . ')');
 

--- a/src/Core/Grid/Query/Monitoring/ProductWithoutPriceQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/ProductWithoutPriceQueryBuilder.php
@@ -75,6 +75,11 @@ final class ProductWithoutPriceQueryBuilder extends AbstractProductQueryBuilder
             ->from($this->dbPrefix . 'specific_price', 'sp')
             ->andWhere('p.id_product = sp.id_product');
 
+        if ($this->multistoreContextChecker->isSingleShopContext()) {
+            $specPriceSubQuery->andWhere('sp.id_shop = :context_shop_id')
+                ->setParameter('context_shop_id', $this->contextShopId);
+        }
+
         $qb->andWhere('p.price = 0')
             ->andWhere('p.wholesale_price = 0')
             ->andWhere('NOT EXISTS(' . $specPriceSubQuery->getSQL() . ')');

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -155,7 +155,6 @@ services:
         - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
         - '@prestashop.core.query.doctrine_search_criteria_applicator'
         - '@prestashop.adapter.shop.context'
-        - '@prestashop.adapter.feature.multistore'
         - "@=service('prestashop.adapter.legacy.configuration').get('PS_ROOT_CATEGORY')"
       public: true
 
@@ -167,7 +166,6 @@ services:
         - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
         - '@prestashop.core.query.doctrine_search_criteria_applicator'
         - '@prestashop.adapter.shop.context'
-        - '@prestashop.adapter.feature.multistore'
       public: true
 
     prestashop.core.grid.query_builder.monitoring.no_qty_product_with_combination:


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When multiple shops exists, but context is single shop - most of migrated Monitoring lists where not considering the shop context id when getting data.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #10552
| How to test?  | Use `/admin-dev/index.php/sell/catalog/monitoring` to see migrated monitoring page. When multiple shops are available, select one of them and make sure that all monitoring grids are showing data just for that shop. When All shops are enabled, grids should contain data for default shop. :warning: Actions like edit/delete are not migrated within this PR, because it is highly coupled with product page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/14991)
<!-- Reviewable:end -->
