### PR TITLE
Fix incorrect last visit date in the customer grid

### DIFF
--- a/src/Core/Grid/Query/CustomerQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerQueryBuilder.php
@@ -158,11 +158,11 @@ final class CustomerQueryBuilder extends AbstractDoctrineQueryBuilder
     private function appendLastVisitQuery(QueryBuilder $queryBuilder)
     {
         $lastVisitQueryBuilder = $this->connection->createQueryBuilder()
-            ->select('c.date_add')
+            ->select('con.date_add')
             ->from($this->dbPrefix . 'guest', 'g')
             ->leftJoin('g', $this->dbPrefix . 'connections', 'con', 'con.id_guest = g.id_guest')
             ->where('g.id_customer = c.id_customer')
-            ->orderBy('c.date_add', 'DESC')
+            ->orderBy('con.date_add', 'DESC')
             ->setMaxResults(1);
 
         $queryBuilder->addSelect('(' . $lastVisitQueryBuilder->getSQL() . ') as connect');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Last visit date was incorrect, it used the date_add from the customer table while it should use the connections table.
| Type?         | bug fix
| BC breaks?    | no
| Category | BO
| Deprecations? | no
| How to test?  | In the customer table, try login back in on the frontend and you will not see the last visit date change, with this fix you will.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15005)
<!-- Reviewable:end -->
