### PR TITLE
Inline styles should be loaded from project root

### DIFF
--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -137,7 +137,7 @@ class StylesheetManagerCore extends AbstractAssetManager
         foreach ($this->list['inline'] as &$item) {
             $item['content'] =
                 '/* ---- ' . $item['id'] . ' @ ' . $item['path'] . ' ---- */' . "\r\n" .
-                file_get_contents($item['path']);
+                file_get_contents("." . $item['path']);
         }
     }
 }


### PR DESCRIPTION
Right now inline styles are not loaded because they can not be found. 

They are trying to load from the file system root not the presta shop root. 

eg

```
 file_get_contents(/themes/mytheme/assets/css/Inline.css): failed to open stream: No such file or directory in /var/www/html/classes/assets/StylesheetManager.php on line 134
```

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.6.x / 1.6.1.x
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc.
| Type?         | bug fix / improvement / new feature / refacto / critical
| Category?     | FO / BO / CO / IN / WS / TE
| BC breaks?    | Does it break backward compatibility? yes/no
| Deprecations? | Does it deprecate an existing feature? yes/no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15008)
<!-- Reviewable:end -->
