### PR TITLE
Fix for new product feature indexation

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -889,6 +889,7 @@ class AdminProductsControllerCore extends AdminController
                         }
                     }
                 }
+	            Search::indexation(false, $id_product);
             }
         } else {
             $this->errors[] = $this->trans('A product must be created before adding features.', array(), 'Admin.Catalog.Notification');

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -889,6 +889,7 @@ class AdminProductsControllerCore extends AdminController
                         }
                     }
                 }
+                // additional indexation fixes issue where Search::getFeatures is run before new values are saved
 	            Search::indexation(false, $id_product);
             }
         } else {

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -890,7 +890,7 @@ class AdminProductsControllerCore extends AdminController
                     }
                 }
                 // additional indexation fixes issue where Search::getFeatures is run before new values are saved
-	            Search::indexation(false, $id_product);
+                Search::indexation(false, $id_product);
             }
         } else {
             $this->errors[] = $this->trans('A product must be created before adding features.', array(), 'Admin.Catalog.Notification');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | getFeatures method is run before new custom values are saved in classes/Search.php @ 658 so these values aren't added to the the search index on the first time save. Added indexation method call straight after the feature is recorded to the DB.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15018 
| How to test?  | Add feature to the product and enter a custom value: http://bit.ly/2KymFk9 <br> Save product <br> In database open ps_search_word, order by id_word, scroll to the bottom and should see saved value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15035)
<!-- Reviewable:end -->
