### PR TITLE
Fix supplier display after import

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2110,6 +2110,7 @@ class AdminImportControllerCore extends AdminController
                 $product_supplier->id_supplier = (int) $product->id_supplier;
                 $product_supplier->product_supplier_price_te = $product->wholesale_price;
                 $product_supplier->product_supplier_reference = $product->supplier_reference;
+                $product_supplier->id_currency = Currency::getDefaultCurrency()->id;
                 $product_supplier->save();
             }
 

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -400,7 +400,8 @@ class AdminSuppliersControllerCore extends AdminController
                     0
                 );
                 $products[$i]->product_supplier_reference = $product_infos['product_supplier_reference'];
-                $products[$i]->product_supplier_price_te = Tools::displayPrice($product_infos['product_supplier_price_te'], new Currency($product_infos['id_currency']));
+                $currencyId = $product_infos['id_currency'] ?: Currency::getDefaultCurrency()->id;
+                $products[$i]->product_supplier_price_te = Tools::displayPrice($product_infos['product_supplier_price_te'], new Currency($currencyId));
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fix supplier display in case its currency is 0, fix import to set the default currency on insertion
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/14908
| How to test?  | Go to Advanced Parameters > Import, import the product csv example which includes Apple as a supplier, go to suppliers list and click on View on one of the supplier

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15036)
<!-- Reviewable:end -->
