### PR TITLE
Fix wrong hook names

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -786,30 +786,15 @@
       <title>Manage Administration Page form fields</title>
       <description>This hook adds, update or remove fields of the Administration Page form</description>
     </hook>
-    <hook id="actionAdministrationPageFormSave">
-      <name>actionAdministrationPageFormSave</name>
-      <title>Processing Administration page form</title>
-      <description>This hook is called when the Administration Page form is processed</description>
-    </hook>
     <hook id="actionPerformancePageForm">
       <name>actionPerformancePageForm</name>
       <title>Manage Performance Page form fields</title>
       <description>This hook adds, update or remove fields of the Performance Page form</description>
     </hook>
-    <hook id="actionPerformancePageFormSave">
-      <name>actionPerformancePageFormSave</name>
-      <title>Processing Performance page form</title>
-      <description>This hook is called when the Performance Page form is processed</description>
-    </hook>
     <hook id="actionMaintenancePageForm">
       <name>actionMaintenancePageForm</name>
       <title>Manage Maintenance Page form fields</title>
       <description>This hook adds, update or remove fields of the Maintenance Page form</description>
-    </hook>
-    <hook id="actionMaintenancePageFormSave">
-      <name>actionMaintenancePageFormSave</name>
-      <title>Processing Maintenance page form</title>
-      <description>This hook is called when the Maintenance Page form is processed</description>
     </hook>
     <hook id="actionWebserviceKeyGridPresenterModifier">
       <name>actionWebserviceKeyGridPresenterModifier</name>

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -842,3 +842,22 @@ VALUES (NULL, 'actionOrderMessageFormBuilderModifier', 'Modify order message ide
        (NULL, 'actionCreditSlipGridPresenterModifier', 'Modify credit slip grid template data',
         'This hook allows to modify data which is about to be used in template for credit slip grid', '1')
 ;
+
+/* Update wrong hook names */
+UPDATE `PREFIX_hook_module` AS hm
+INNER JOIN `PREFIX_hook` AS hfrom ON hm.id_hook = hfrom.id_hook AND hfrom.name = 'actionAdministrationPageFormSave'
+INNER JOIN `PREFIX_hook` AS hto ON hto.name = 'actionAdministrationPageSave'
+SET hm.id_hook = hto.id_hook;
+DELETE FROM `PREFIX_hook` WHERE name = 'actionAdministrationPageFormSave';
+
+UPDATE `PREFIX_hook_module` AS hm
+INNER JOIN `PREFIX_hook` AS hfrom ON hm.id_hook = hfrom.id_hook AND hfrom.name = 'actionMaintenancePageFormSave'
+INNER JOIN `PREFIX_hook` AS hto ON hto.name = 'actionMaintenancePageSave'
+SET hm.id_hook = hto.id_hook;
+DELETE FROM `PREFIX_hook` WHERE name = 'actionMaintenancePageFormSave';
+
+UPDATE `PREFIX_hook_module` AS hm
+INNER JOIN `PREFIX_hook` AS hfrom ON hm.id_hook = hfrom.id_hook AND hfrom.name = 'actionPerformancePageFormSave'
+INNER JOIN `PREFIX_hook` AS hto ON hto.name = 'actionPerformancePageSave'
+SET hm.id_hook = hto.id_hook;
+DELETE FROM `PREFIX_hook` WHERE name = 'actionPerformancePageFormSave';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In 1.7.4 we introduced new form hooks. The names used in documentation were wrong. See below for more.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Update your shop to 1.7.7.0, verify in database that hook names have been changed.

## More information

Updated hooked names in `PREFIX_hook_module`:

- `actionAdministrationPageFormSave` -> `actionAdministrationPageSave`
- `actionMaintenancePageFormSave` -> `actionMaintenancePageSave`
- `actionPerformancePageFormSave` -> `actionPerformancePageSave`

The hooks were created for 1.7.4.0 as `action<Name>FormSave` in #8368. They were later normalized to `action<Name>Save` in #8908, still delivered with 1.7.4.0, but the fixtures were never updated appropriately.

Related devdocs PR: https://github.com/PrestaShop/docs/pull/280

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15049)
<!-- Reviewable:end -->
