### PR TITLE
Fix duplicate products with attributes and suppliers

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4342,7 +4342,7 @@ class ProductCore extends ObjectModel
                 unset($row3['id_product_supplier']);
                 $row3['id_product'] = $id_product_new;
                 $row3['id_product_attribute'] = $id_product_attribute_new;
-                $return &= Db::getInstance()->insert('product_supplier', $row3);
+                $return &= Db::getInstance()->insert('product_supplier', $row3, false, true, Db::INSERT_IGNORE);
             }
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In some case of products with attributes and suppliers the duplication of suppliers for attribute return an SQL error of duplicate entry.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | 1. Install a PrestaShop with default catalog on develop branch<br>2. Create a supplier and activate it.<br>3. Edit the first product - it sould be with attributes (for instance) and add a supplier on options tab. Save it.<br>4. On the list of product, clic on verticlal "..." at the end of the line and select "Duplicate".<br>5. You sould see on debug mode following errors<br /><br />Duplicate entry '22-41-1' for key 'id_product'<br />INSERT INTO `ps_product_supplier` (`id_product`, `id_product_attribute`, `id_supplier`, `product_supplier_reference`, `product_supplier_price_te`, `id_currency`) VALUES ('22', '41', '1', '', '0.000000', '1')

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15093)
<!-- Reviewable:end -->
