### PR TITLE
Fix missing invoice logo

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -136,7 +136,7 @@ abstract class HTMLTemplateCore
             $width *= $ratio;
         }
 
-        if (_MEDIA_SERVER_1_ || _MEDIA_SERVER_2_ || _MEDIA_SERVER_3_ !== '') {
+        if ('' !== _MEDIA_SERVER_1_ || _MEDIA_SERVER_2_ || _MEDIA_SERVER_3_) {
             $logo_path = Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . _PS_IMG_ . $logo;
         } else {
             $logo_path = _PS_IMG_ . $logo;

--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -136,8 +136,14 @@ abstract class HTMLTemplateCore
             $width *= $ratio;
         }
 
+        if (_MEDIA_SERVER_1_ || _MEDIA_SERVER_2_ || _MEDIA_SERVER_3_ !== '') {
+            $logo_path = Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . _PS_IMG_ . $logo;
+        } else {
+            $logo_path = _PS_IMG_ . $logo;
+        }
+
         $this->smarty->assign(array(
-            'logo_path' => Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . _PS_IMG_ . $logo,
+            'logo_path' => $logo_path,
             'img_ps_dir' => Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . _PS_IMG_,
             'img_update_time' => Configuration::get('PS_IMG_UPDATE_TIME'),
             'date' => $this->date,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Logo on invoice was missing if SSL was activated in BO. Use URI instead of URL fix the issue.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/15088
| How to test?  | Enable SSL in BO. Then generate an invoice. Without this PR the logo is missing. With this PR the logo is showed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15089)
<!-- Reviewable:end -->
