### PR TITLE
Remove Github checks for PHP 5.6

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,14 +1,8 @@
 workflow "Code Quality" {
   on = "push"
   resolves = [
-    "PHP 5.6 Syntax check",
     "PHP 7.2 Syntax check",
   ]
-}
-
-action "PHP 5.6 Syntax check" {
-  uses = "docker://prestashop/github-action-php-lint:5.6"
-  args = "! -path \"./vendor/*\" ! -path \"./tools/*\" ! -path \"./modules/*\""
 }
 
 action "PHP 7.2 Syntax check" {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Removed invalid check for PHP 5.6 syntax, because that version is no longer supported
| Type?         | bug fix
| Category?     | PM
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Checks pass

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15127)
<!-- Reviewable:end -->
