### PR TITLE
Fix permanent redirection in installer

### DIFF
--- a/install-dev/theme/views/header.php
+++ b/install-dev/theme/views/header.php
@@ -18,7 +18,7 @@
 	<script type="text/javascript" src="../js/jquery/jquery-1.11.0.min.js"></script>
 	<script type="text/javascript" src="../js/jquery/plugins/jquery.chosen.js"></script>
 	<script type="text/javascript" src="theme/js/install.js"></script>
-	<script type="text/javascript" src="//www.prestashop.com/js/user-assistance.js"></script>
+	<script type="text/javascript" src="https://www.prestashop.com/js/user-assistance.js"></script>
 	<?php if (file_exists(_PS_INSTALL_PATH_.'theme/js/'.self::$steps->current()->getName().'.js')): ?>
 		<script type="text/javascript" src="theme/js/<?php echo self::$steps->current()->getName() ?>.js"></script>
 	<?php endif; ?>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I've detected permanent redirection on an HTTP call to one of our internal service.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Open developer tools in your favorite web browser and start a new installation of PrestaShop. In each step, you can confirm that no 301 HTTP calls are done.

### Before

![before](https://user-images.githubusercontent.com/1247388/63171060-0b7f3400-c03b-11e9-9c22-a8beb489804f.png)

### After

![after](https://user-images.githubusercontent.com/1247388/63171075-1639c900-c03b-11e9-956e-b0a7d5d00b67.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15131)
<!-- Reviewable:end -->
