### PR TITLE
Fix abstract service declaration

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/adapter/cms_page_category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cms_page_category.yml
@@ -6,6 +6,7 @@ services:
 
     prestashop.adapter.cms_page_category.command_handler.abstract_cms_page_category_handler:
         class: PrestaShop\PrestaShop\Adapter\CMS\PageCategory\CommandHandler\AbstractCmsPageCategoryHandler
+        abstract: true
         arguments:
           - '@validator'
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -18,6 +18,7 @@ services:
 
   prestashop.adapter.supplier.command_handler.abstract_delete_supplier_handler:
     class: PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\AbstractDeleteSupplierHandler
+    abstract: true
     arguments:
       - '@prestashop.adapter.supplier.supplier_order_validator'
       - '@prestashop.adapter.supplier.provider.supplier_address'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | There were to services based on abstract classes which were missing the "abstract" annotation
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | nothing to test

kudos to @mickaelandrieu for pointing it out

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15132)
<!-- Reviewable:end -->
