### PR TITLE
Change computation price total of product custom on order detail confirmation

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5194,9 +5194,9 @@ class ProductCore extends ObjectModel
                 $product_update['customizationQuantityReturned'] = $customization_quantity_returned;
 
                 if ($customization_quantity) {
-                    $product_update['total_wt'] = $price_wt * ($product_quantity - $customization_quantity);
+                    $product_update['total_wt'] = $price_wt * $product_quantity;
                     $product_update['total_customization_wt'] = $price_wt * $customization_quantity;
-                    $product_update['total'] = $price * ($product_quantity - $customization_quantity);
+                    $product_update['total'] = $price * $product_quantity;
                     $product_update['total_customization'] = $price * $customization_quantity;
                 }
             }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5168,12 +5168,6 @@ class ProductCore extends ObjectModel
                 $product_attribute_id = isset($product_update['id_product_attribute']) ? (int) $product_update['id_product_attribute'] : (int) $product_update['product_attribute_id'];
                 $id_address_delivery = (int) $product_update['id_address_delivery'];
                 $product_quantity = isset($product_update['cart_quantity']) ? (int) $product_update['cart_quantity'] : (int) $product_update['product_quantity'];
-                $price = isset($product_update['price']) ? $product_update['price'] : $product_update['product_price'];
-                if (isset($product_update['price_wt']) && $product_update['price_wt']) {
-                    $price_wt = $product_update['price_wt'];
-                } else {
-                    $price_wt = $price * (1 + ((isset($product_update['tax_rate']) ? $product_update['tax_rate'] : $product_update['rate']) * 0.01));
-                }
 
                 if (!isset($customized_datas[$product_id][$product_attribute_id][$id_address_delivery])) {
                     $id_address_delivery = 0;
@@ -5194,10 +5188,10 @@ class ProductCore extends ObjectModel
                 $product_update['customizationQuantityReturned'] = $customization_quantity_returned;
 
                 if ($customization_quantity) {
-                    $product_update['total_wt'] = $price_wt * $product_quantity;
-                    $product_update['total_customization_wt'] = $price_wt * $customization_quantity;
-                    $product_update['total'] = $price * $product_quantity;
-                    $product_update['total_customization'] = $price * $customization_quantity;
+                    $product_update['total_wt'] = $product_update['unit_price_tax_incl'] * $product_quantity ;
+                    $product_update['total_customization_wt'] = $product_update['unit_price_tax_incl'] * $customization_quantity;
+                    $product_update['total'] = $product_update['unit_price_tax_excl'] * $product_quantity;
+                    $product_update['total_customization'] = $product_update['unit_price_tax_excl'] * $customization_quantity;
                 }
             }
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Bad price total display for custom products on detail order
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10912 
| How to test?  | Select a customizable product. Add this product to your cart. Confirm your cart. The total price for the customize product is not correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15171)
<!-- Reviewable:end -->
