### PR TITLE
CLDR has access to all currencies regardless of the current shop

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -399,14 +399,20 @@ class CurrencyCore extends ObjectModel
     /**
      * Retrieve all currencies data from the database.
      *
+     * @param bool $active If true only active are returned
+     * @param bool $groupBy Group by id_currency
+     * @param bool $currentShopOnly If true returns only currencies associated to current shop
+     *
      * @return array Currency data from database
+     *
+     * @throws PrestaShopDatabaseException
      */
-    public static function findAll($active = true, $groupBy = false, $filterShop = true)
+    public static function findAll($active = true, $groupBy = false, $currentShopOnly = true)
     {
         $currencies = Db::getInstance()->executeS('
             SELECT *
             FROM `' . _DB_PREFIX_ . 'currency` c
-            ' . ($filterShop ? Shop::addSqlAssociation('currency', 'c') : '') . '
+            ' . ($currentShopOnly ? Shop::addSqlAssociation('currency', 'c') : '') . '
                 WHERE `deleted` = 0' .
                 ($active ? ' AND c.`active` = 1' : '') .
                 ($groupBy ? ' GROUP BY c.`id_currency`' : '') .

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -189,9 +189,9 @@ class CurrencyCore extends ObjectModel
             }
 
             if (is_array($this->name)) {
-                $this->name = ucfirst($this->name[$idLang]);
+                $this->name = Tools::ucfirst($this->name[$idLang]);
             } else {
-                $this->name = ucfirst($this->name);
+                $this->name = Tools::ucfirst($this->name);
             }
 
             $this->iso_code_num = $this->numeric_iso_code;
@@ -356,6 +356,27 @@ class CurrencyCore extends ObjectModel
             ->where('c.`active` = 1');
 
         return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+    }
+
+    /**
+     * Returns the name of the currency (using the translated name base on the id_lang
+     * provided on creation). This method is useful when $this->name contains an array
+     * but you still need to get its name as a string.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        if (is_string($this->name)) {
+            return $this->name;
+        }
+
+        $id_lang = $this->id_lang;
+        if ($id_lang === null) {
+            $id_lang = Configuration::get('PS_LANG_DEFAULT');
+        }
+
+        return Tools::ucfirst($this->name[$id_lang]);
     }
 
     /**

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -401,12 +401,12 @@ class CurrencyCore extends ObjectModel
      *
      * @return array Currency data from database
      */
-    public static function findAll($active = true, $groupBy = false)
+    public static function findAll($active = true, $groupBy = false, $filterShop = true)
     {
         $currencies = Db::getInstance()->executeS('
             SELECT *
             FROM `' . _DB_PREFIX_ . 'currency` c
-            ' . Shop::addSqlAssociation('currency', 'c') . '
+            ' . ($filterShop ? Shop::addSqlAssociation('currency', 'c') : '') . '
                 WHERE `deleted` = 0' .
                 ($active ? ' AND c.`active` = 1' : '') .
                 ($groupBy ? ' GROUP BY c.`id_currency`' : '') .

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1705,11 +1705,6 @@ class AdminOrdersControllerCore extends AdminController
         if (!Validate::isLoadedObject($order)) {
             $this->errors[] = $this->trans('The order cannot be found within your database.', array(), 'Admin.Orderscustomers.Notification');
         }
-        if (!in_array($order->id_shop, Shop::getContextListShopID())) {
-            $this->errors[] = $this->trans('The order is not accessible in the current shop context.', array(), 'Admin.Orderscustomers.Notification');
-
-            return '';
-        }
 
         $customer = new Customer($order->id_customer);
         $carrier = new Carrier($order->id_carrier);

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1705,6 +1705,11 @@ class AdminOrdersControllerCore extends AdminController
         if (!Validate::isLoadedObject($order)) {
             $this->errors[] = $this->trans('The order cannot be found within your database.', array(), 'Admin.Orderscustomers.Notification');
         }
+        if (!in_array($order->id_shop, Shop::getContextListShopID())) {
+            $this->errors[] = $this->trans('The order is not accessible in the current shop context.', array(), 'Admin.Orderscustomers.Notification');
+
+            return '';
+        }
 
         $customer = new Customer($order->id_customer);
         $carrier = new Carrier($order->id_carrier);

--- a/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
@@ -226,7 +226,7 @@ final class EditCurrencyHandler extends AbstractCurrencyHandler implements EditC
             if (!in_array($shopId, $shopIds)) {
                 $shop = new Shop($shopId);
                 throw new DefaultCurrencyInMultiShopException(
-                    $currency->name,
+                    $currency->getName(),
                     $shop->name,
                     sprintf(
                         'Currency with id %s cannot be unassigned from shop with id %s because its the default currency.',
@@ -240,7 +240,7 @@ final class EditCurrencyHandler extends AbstractCurrencyHandler implements EditC
             if (!$currency->active) {
                 $shop = new Shop($shopId);
                 throw new DefaultCurrencyInMultiShopException(
-                    $currency->name,
+                    $currency->getName(),
                     $shop->name,
                     sprintf(
                         'Currency with id %s cannot be disabled from shop with id %s because its the default currency.',

--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -70,17 +70,9 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function findAll()
+    public function findAll($currentShopOnly = true)
     {
-        return Currency::findAll(false);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function findAllAvailable()
-    {
-        return Currency::findAll(false, false, false);
+        return Currency::findAll(false, false, $currentShopOnly);
     }
 
     /**

--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -76,6 +76,14 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function findAllAvailable()
+    {
+        return Currency::findAll(false, false, false);
+    }
+
+    /**
      * Get a Currency entity instance by ISO code.
      *
      * @param string $isoCode

--- a/src/Core/Currency/CurrencyDataProviderInterface.php
+++ b/src/Core/Currency/CurrencyDataProviderInterface.php
@@ -47,11 +47,18 @@ interface CurrencyDataProviderInterface
     public function getCurrencies($object = false, $active = true, $group_by = false);
 
     /**
-     * Return raw currencies data from the database reated to the current shop.
+     * Return raw currencies data from the database related to the current shop.
      *
      * @return array Installed currencies
      */
     public function findAll();
+
+    /**
+     * Return raw currencies data from the database regardless of the current shop.
+     *
+     * @return array
+     */
+    public function findAllAvailable();
 
     /**
      * Get a Currency entity instance by ISO code.

--- a/src/Core/Currency/CurrencyDataProviderInterface.php
+++ b/src/Core/Currency/CurrencyDataProviderInterface.php
@@ -47,18 +47,13 @@ interface CurrencyDataProviderInterface
     public function getCurrencies($object = false, $active = true, $group_by = false);
 
     /**
-     * Return raw currencies data from the database related to the current shop.
+     * Return raw currencies data from the database.
      *
-     * @return array Installed currencies
-     */
-    public function findAll();
-
-    /**
-     * Return raw currencies data from the database regardless of the current shop.
+     * @param bool $currentShopOnly If true returns only currencies associated to current shop
      *
-     * @return array
+     * @return array[] Installed currencies
      */
-    public function findAllAvailable();
+    public function findAll($currentShopOnly = true);
 
     /**
      * Get a Currency entity instance by ISO code.

--- a/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
+++ b/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
@@ -76,7 +76,7 @@ class CurrencyInstalled
      */
     public function getAvailableCurrencyCodes()
     {
-        $currencies = $this->dataProvider->findAll();
+        $currencies = $this->dataProvider->findAllAvailable();
         $currencyIds = array_column($currencies, 'iso_code');
 
         return $currencyIds;

--- a/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
+++ b/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
@@ -76,7 +76,7 @@ class CurrencyInstalled
      */
     public function getAvailableCurrencyCodes()
     {
-        $currencies = $this->dataProvider->findAllAvailable();
+        $currencies = $this->dataProvider->findAll(false);
         $currencyIds = array_column($currencies, 'iso_code');
 
         return $currencyIds;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | The CLDR used to get the currencies list related to the current shop, which caused errors in some specific contexts where orders are shared between shops, the CLDR could not display an unknown currency So from now on it can display any currency installed regardless of the shop context BUT this required to add a new method in the `CurrencyDataProviderInterface` which is a BC break as we change the interface
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/14595 and https://github.com/PrestaShop/PrestaShop/issues/15144
| How to test?  | See the issues which describes precisely at the end how to reproduce the bug (two shops with their own currencies), then try to access an order from Shop B in Shop A context, the order will be correctly displayed When you try to export orders it will also work BUT we need to check that in the front office we only display the expected currencies (one per shop)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15173)
<!-- Reviewable:end -->
