### PR TITLE
Enable modules to know the current checkout process step

### DIFF
--- a/classes/checkout/CheckoutProcess.php
+++ b/classes/checkout/CheckoutProcess.php
@@ -215,4 +215,20 @@ class CheckoutProcessCore implements RenderableInterface
 
         return $this;
     }
+
+    /**
+     * @return CheckoutStepInterface
+     *
+     * @throws \RuntimeException if no current step is found
+     */
+    public function getCurrentStep()
+    {
+        foreach ($this->getSteps() as $step) {
+            if ($step->isCurrent()) {
+                return $step;
+            }
+        }
+
+        throw new \RuntimeException('There should be at least one current step');
+    }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Enable modules to know the current checkout process step
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | No QA necessary I think 🤔

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15176)
<!-- Reviewable:end -->
