### PR TITLE
Allow users to edit address alias during checkout

### DIFF
--- a/themes/classic/templates/checkout/_partials/address-form.tpl
+++ b/themes/classic/templates/checkout/_partials/address-form.tpl
@@ -1,8 +1,8 @@
 {extends file='customer/_partials/address-form.tpl'}
 
 {block name='form_field'}
-  {if $field.name eq "alias"}
-    {* we don't ask for alias here *}
+  {if $field.name eq "alias" and $customer.is_guest}
+    {* we don't ask for alias here if customer is not registered *}
   {else}
     {$smarty.block.parent}
   {/if}


### PR DESCRIPTION
Registered users can edit adress alias during checkout. With current behaviour if they add several addresses right from the checkout they get a bunch of "My address" which can confuse users.There is an issue open for this #9913.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When registered users add adresses from the checkout steps, they don't see the field for editing the alias for the address, and they accumulate "My address" which is the default alias. With this fix they see the alias field as an optional that they can edit or not.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Don't think so.
| Deprecations? | Don't think so... sorry.
| Fixed ticket? | Fixes #9913
| How to test?  | Try to add addresses from the checkout phase bot as a guest and you should't see the alias field and as a registered user and you should see the alias field as an option.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15216)
<!-- Reviewable:end -->
