### PR TITLE
Fix unit price calculation in cart, product listings and order_conf email

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -440,7 +440,7 @@ abstract class PaymentModuleCore extends Module
                         ];
 
                         if (isset($product['unit_price_ratio']) && $product['unit_price_ratio'] > 0) {
-                            if($product['id_product_attribute'] > 0) {
+                            if ($product['id_product_attribute'] > 0) {
                                 $combination = new Combination($product['id_product_attribute']);
                                 if (0 != $combination->unit_price_impact && 0 != $product['unit_price_ratio']) {
                                     $unitPrice = ($price / $product['unit_price_ratio']) + $combination->unit_price_impact;

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -433,15 +433,24 @@ abstract class PaymentModuleCore extends Module
                             'id_product' => $product['id_product'],
                             'reference' => $product['reference'],
                             'name' => $product['name'] . (isset($product['attributes']) ? ' - ' . $product['attributes'] : ''),
+                            'base_price' => Tools::displayPrice($product_price, $this->context->currency, false),
                             'price' => Tools::getContextLocale($this->context)->formatPrice($product_price * $product['quantity'], $this->context->currency->iso_code),
                             'quantity' => $product['quantity'],
                             'customization' => [],
                         ];
 
-                        if (isset($product['price']) && $product['price']) {
-                            $product_var_tpl['unit_price'] = Tools::getContextLocale($this->context)->formatPrice($product_price, $this->context->currency->iso_code);
-                            $product_var_tpl['unit_price_full'] = Tools::getContextLocale($this->context)->formatPrice($product_price, $this->context->currency->iso_code)
-                                . ' ' . $product['unity'];
+                        if (isset($product['unit_price_ratio']) && $product['unit_price_ratio'] > 0) {
+                            if($product['id_product_attribute'] > 0) {
+                                $combination = new Combination($product['id_product_attribute']);
+                                if (0 != $combination->unit_price_impact && 0 != $product['unit_price_ratio']) {
+                                    $unitPrice = ($price / $product['unit_price_ratio']) + $combination->unit_price_impact;
+                                    $product['unit_price_ratio'] = $price / $unitPrice;
+                                }
+                            }
+                            $product['unit_price'] = $product_price / $product['unit_price_ratio'];
+
+                            $product_var_tpl['unit_price'] = Tools::getContextLocale($this->context)->formatPrice($product['unit_price'], $this->context->currency->iso_code);
+                            $product_var_tpl['unit_price_full'] = $product_var_tpl['unit_price'] . ' ' . $product['unity'];
                         } else {
                             $product_var_tpl['unit_price'] = $product_var_tpl['unit_price_full'] = '';
                         }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5382,6 +5382,8 @@ class ProductCore extends ObjectModel
             $quantity = (int) $row['minimal_quantity'];
         }
 
+        $price_base_tax_exc = $row['price'];
+
         $row['price_tax_exc'] = Product::getPriceStatic(
             (int) $row['id_product'],
             false,
@@ -5558,15 +5560,19 @@ class ProductCore extends ObjectModel
             'context' => $context,
         ]);
 
-        $combination = new Combination($id_product_attribute);
+		$combination = new Combination($id_product_attribute);
 
         if (0 != $combination->unit_price_impact && 0 != $row['unit_price_ratio']) {
-            $unitPrice = ($row['price_tax_exc'] / $row['unit_price_ratio']) + $combination->unit_price_impact;
+            $unitPrice = ($price_base_tax_exc / $row['unit_price_ratio']) + $combination->unit_price_impact;
             $row['unit_price_ratio'] = $row['price_tax_exc'] / $unitPrice;
         }
 
         if (isset($row['unit_price_ratio'])) {
-            $row['unit_price'] = ($row['unit_price_ratio'] != 0 ? $row['price'] / $row['unit_price_ratio'] : 0);
+            if (self::$_taxCalculationMethod == PS_TAX_EXC) {
+                $row['unit_price'] = ($row['unit_price_ratio'] != 0 ? $row['price_tax_exc'] / $row['unit_price_ratio'] : 0);
+            } else {
+                $row['unit_price'] = ($row['unit_price_ratio'] != 0 ? $row['price'] / $row['unit_price_ratio'] : 0);
+            }
         } else {
             $row['unit_price'] = 0.0;
         }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5560,7 +5560,7 @@ class ProductCore extends ObjectModel
             'context' => $context,
         ]);
 
-		$combination = new Combination($id_product_attribute);
+        $combination = new Combination($id_product_attribute);
 
         if (0 != $combination->unit_price_impact && 0 != $row['unit_price_ratio']) {
             $unitPrice = ($price_base_tax_exc / $row['unit_price_ratio']) + $combination->unit_price_impact;

--- a/mails/_partials/order_conf_product_list.tpl
+++ b/mails/_partials/order_conf_product_list.tpl
@@ -64,7 +64,7 @@
 				<td width="5">&nbsp;</td>
 				<td align="right">
 					<font size="2" face="Open-sans, sans-serif" color="#555454">
-						{$product['unit_price']}
+						{$product['base_price']}
 					</font>
 				</td>
 				<td width="5">&nbsp;</td>

--- a/mails/_partials/order_conf_product_list.txt
+++ b/mails/_partials/order_conf_product_list.txt
@@ -3,7 +3,7 @@
 
 						{$product['name']}
 
-						{$product['price']}
+						{$product['base_price']}
 						{capture "productPriceBlock"}{hook h='displayProductPriceBlock' product=$product type="unit_price"}{/capture}{$smarty.capture.productPriceBlock|strip_tags|trim}
 
 						{$product['quantity']}

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -32,6 +32,7 @@ use Configuration;
 use Context;
 use Country;
 use Hook;
+use Combination;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
@@ -143,6 +144,8 @@ class CartPresenter implements PresenterInterface
                 $rawProduct[$field] = '';
             }
         }
+		
+		$price_tax_exc = $rawProduct['price'];
 
         if ($this->includeTaxes()) {
             $rawProduct['price_amount'] = $rawProduct['price_wt'];
@@ -153,6 +156,13 @@ class CartPresenter implements PresenterInterface
         }
 
         if ($rawProduct['price_amount'] && $rawProduct['unit_price_ratio'] > 0) {
+			if($rawProduct['id_product_attribute'] > 0) {
+				$combination = new Combination($rawProduct['id_product_attribute']);
+				if (0 != $combination->unit_price_impact && 0 != $rawProduct['unit_price_ratio']) {
+					$unitPrice = ($price_tax_exc / $rawProduct['unit_price_ratio']) + $combination->unit_price_impact;
+					$rawProduct['unit_price_ratio'] = $price_tax_exc / $unitPrice;
+				}
+			}
             $rawProduct['unit_price'] = $rawProduct['price_amount'] / $rawProduct['unit_price_ratio'];
         }
 

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -28,11 +28,11 @@ namespace PrestaShop\PrestaShop\Adapter\Presenter\Cart;
 
 use Cart;
 use CartRule;
+use Combination;
 use Configuration;
 use Context;
 use Country;
 use Hook;
-use Combination;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
@@ -144,7 +144,7 @@ class CartPresenter implements PresenterInterface
                 $rawProduct[$field] = '';
             }
         }
-        
+
         $price_tax_exc = $rawProduct['price'];
 
         if ($this->includeTaxes()) {

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -144,8 +144,8 @@ class CartPresenter implements PresenterInterface
                 $rawProduct[$field] = '';
             }
         }
-		
-		$price_tax_exc = $rawProduct['price'];
+        
+        $price_tax_exc = $rawProduct['price'];
 
         if ($this->includeTaxes()) {
             $rawProduct['price_amount'] = $rawProduct['price_wt'];
@@ -156,13 +156,13 @@ class CartPresenter implements PresenterInterface
         }
 
         if ($rawProduct['price_amount'] && $rawProduct['unit_price_ratio'] > 0) {
-			if($rawProduct['id_product_attribute'] > 0) {
-				$combination = new Combination($rawProduct['id_product_attribute']);
-				if (0 != $combination->unit_price_impact && 0 != $rawProduct['unit_price_ratio']) {
-					$unitPrice = ($price_tax_exc / $rawProduct['unit_price_ratio']) + $combination->unit_price_impact;
-					$rawProduct['unit_price_ratio'] = $price_tax_exc / $unitPrice;
-				}
-			}
+            if($rawProduct['id_product_attribute'] > 0) {
+                $combination = new Combination($rawProduct['id_product_attribute']);
+                if (0 != $combination->unit_price_impact && 0 != $rawProduct['unit_price_ratio']) {
+                    $unitPrice = ($price_tax_exc / $rawProduct['unit_price_ratio']) + $combination->unit_price_impact;
+                    $rawProduct['unit_price_ratio'] = $price_tax_exc / $unitPrice;
+                }
+            }
             $rawProduct['unit_price'] = $rawProduct['price_amount'] / $rawProduct['unit_price_ratio'];
         }
 

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -156,7 +156,7 @@ class CartPresenter implements PresenterInterface
         }
 
         if ($rawProduct['price_amount'] && $rawProduct['unit_price_ratio'] > 0) {
-            if($rawProduct['id_product_attribute'] > 0) {
+            if ($rawProduct['id_product_attribute'] > 0) {
                 $combination = new Combination($rawProduct['id_product_attribute']);
                 if (0 != $combination->unit_price_impact && 0 != $rawProduct['unit_price_ratio']) {
                     $unitPrice = ($price_tax_exc / $rawProduct['unit_price_ratio']) + $combination->unit_price_impact;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The unit price calculation used in Product#getProductProperties and called by the product listing system, is wrong. when taking the impact from combinations, it does not calculate the base unit price correctly using the base tax_exc price but instead the already influenced price with combination impact and adding the combination unit impact on top. Furthermore, no distinction of tax mode is in place for unit price calculation at this location.<br>In the cart there is no unit price impact for combination present at all, which we've added.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9603
| How to test?  | If you want to whip out excel and calculate unit prices for a complicated product with a few combinations and such, you can see this correction take place in the listing, provided you have ps_legalcompliance enabled with the show unit price in listing feature. For the cart change, this addition is rather intuitive.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15259)
<!-- Reviewable:end -->
