### PR TITLE
Fix one column row without colspan

### DIFF
--- a/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
@@ -126,7 +126,7 @@
         {/if}
         {if $subtotals.tax.label !== null}
           <tr class="sub taxes">
-            <td><span class="label">{l s='%label%:' sprintf=['%label%' => $subtotals.tax.label] d='Shop.Theme.Global'}</span>&nbsp;<span class="value">{$subtotals.tax.value}</span></td>
+            <td colspan="2"><span class="label">{l s='%label%:' sprintf=['%label%' => $subtotals.tax.label] d='Shop.Theme.Global'}</span>&nbsp;<span class="value">{$subtotals.tax.value}</span></td>
           </tr>
         {/if}
       </table>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | All `<tr>` have 2 `<td>` except the last one, giving a bad table structure.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Check that the order confirmation table is correctly displayed when the modified row is displayed `$subtotals.tax.label !== null`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15276)
<!-- Reviewable:end -->
