### PR TITLE
After modifying a product by webservice, the product position in the categories changes, even if we will use current position.

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6157,6 +6157,7 @@ class ProductCore extends ObjectModel
             return false;
         }
 
+        // result is indexed by recordset order and not position. positions start at index 1 so we need an empty element
         array_unshift($result, null);
         foreach ($result as &$value) {
             $value = $value['id_product'];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | After modifying a product by webservice, the product position in the categories changes, even if we will use current position.<br>the function getWsPositionInCategory does not return correct values, bad syntax.<br>The function setWsPositionInCategory makes a change even if the wrong parameter is entered, missing return.<br>When creating a new product, the position in the category is never 0, but always starts from 1.<br>Unfortunately, the array of values from the sql function is indexing from 0, so I add an item to the top of the list to move the index to 1
| Type?         | bug fix 
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | you have to make a modification a product with the webservice, <position_in_category notFilterable="true"><![CDATA[1]]></position_in_category>

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15286)
<!-- Reviewable:end -->
