### PR TITLE
Fix missing wrapper in quickview displayProductAdditionalInfo hook

### DIFF
--- a/themes/classic/templates/catalog/_partials/quickview.tpl
+++ b/themes/classic/templates/catalog/_partials/quickview.tpl
@@ -72,7 +72,9 @@
       </div>
      </div>
      <div class="modal-footer">
-       {hook h='displayProductAdditionalInfo' product=$product}
+        <div class="product-additional-info">
+          {hook h='displayProductAdditionalInfo' product=$product}
+        </div>
     </div>
    </div>
  </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Attribute change on quick view page will not affect code in displayProductAdditionalInfo hook
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15287
| How to test?  | Described in issue page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15289)
<!-- Reviewable:end -->
