### PR TITLE
Update ProductLazyArray.php

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -622,9 +622,9 @@ class ProductLazyArray extends AbstractLazyArray
         $this->product['discount_amount_to_display'] = null;
 
         if ($settings->include_taxes) {
-            $price = $regular_price = $product['price'];
+            $price = $regular_price = (isset($product['price_amount']) ? $product['price_amount'] : $product['price']);
         } else {
-            $price = $regular_price = $product['price_tax_exc'];
+            $price = $regular_price = (isset($product['price_amount']) ? $product['price_amount'] : $product['price_tax_exc']);
         }
 
         if ($product['specific_prices']) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | any 1.7 version
| Description?  | $price should be a numeric value here because later it assigned to price_amount. However $product['price'] that comes from CartPresenter already formatted in CartPresenter::presentProduct and $product['price_amount'] is set correctly. When it comes not from a cart (product page) $product['price_amount'] is not set, but $product['price'] is still not formatted.
| Type?         | bug fix 
| Category?     | FO / BO 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15307)
<!-- Reviewable:end -->
