### PR TITLE
Fix not being able to remove automatically applied cart rule

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -486,6 +486,7 @@ class CartPresenter implements PresenterInterface
         foreach ($cartVouchers as $cartVoucher) {
             $vouchers[$cartVoucher['id_cart_rule']]['id_cart_rule'] = $cartVoucher['id_cart_rule'];
             $vouchers[$cartVoucher['id_cart_rule']]['name'] = $cartVoucher['name'];
+            $vouchers[$cartVoucher['id_cart_rule']]['code'] = $cartVoucher['code'];
             $vouchers[$cartVoucher['id_cart_rule']]['reduction_percent'] = $cartVoucher['reduction_percent'];
             $vouchers[$cartVoucher['id_cart_rule']]['reduction_currency'] = $cartVoucher['reduction_currency'];
 

--- a/themes/classic/templates/checkout/_partials/cart-voucher.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-voucher.tpl
@@ -34,7 +34,9 @@
                   <span class="label">{$voucher.name}</span>
                   <div class="float-xs-right">
                     <span>{$voucher.reduction_formatted}</span>
-                    <a href="{$voucher.delete_url}" data-link-action="remove-voucher"><i class="material-icons">&#xE872;</i></a>
+                      {if !empty($voucher.code)}
+                        <a href="{$voucher.delete_url}" data-link-action="remove-voucher"><i class="material-icons">&#xE872;</i></a>
+                      {/if}
                   </div>
                 </li>
               {/foreach}

--- a/themes/classic/templates/checkout/_partials/cart-voucher.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-voucher.tpl
@@ -34,7 +34,7 @@
                   <span class="label">{$voucher.name}</span>
                   <div class="float-xs-right">
                     <span>{$voucher.reduction_formatted}</span>
-                      {if !empty($voucher.code)}
+                      {if !empty($voucher.code) && $voucher.code != '0'}
                         <a href="{$voucher.delete_url}" data-link-action="remove-voucher"><i class="material-icons">&#xE872;</i></a>
                       {/if}
                   </div>

--- a/themes/classic/templates/checkout/_partials/cart-voucher.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-voucher.tpl
@@ -34,7 +34,7 @@
                   <span class="label">{$voucher.name}</span>
                   <div class="float-xs-right">
                     <span>{$voucher.reduction_formatted}</span>
-                      {if !empty($voucher.code) && $voucher.code != '0'}
+                      {if !empty($voucher.code) || $voucher.code == '0'}
                         <a href="{$voucher.delete_url}" data-link-action="remove-voucher"><i class="material-icons">&#xE872;</i></a>
                       {/if}
                   </div>

--- a/themes/classic/templates/checkout/_partials/cart-voucher.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-voucher.tpl
@@ -34,7 +34,7 @@
                   <span class="label">{$voucher.name}</span>
                   <div class="float-xs-right">
                     <span>{$voucher.reduction_formatted}</span>
-                      {if !empty($voucher.code) || $voucher.code == '0'}
+                      {if isset($voucher.code) && $voucher.code !== ''}
                         <a href="{$voucher.delete_url}" data-link-action="remove-voucher"><i class="material-icons">&#xE872;</i></a>
                       {/if}
                   </div>


### PR DESCRIPTION
Avoid to show trash icon if cart rule is automatically applied (voucher code is empty)

| Questions     | Answers
| -------------| -------------------------------------------------------
| Branch?        | develop 
| Description? | Fix 
| Type?            | bug fix
| Category?     | FO
| BC breaks?   | no
| Deprecations? | no
| Fixed ticket? | Fixes #12608
| How to test?  | Create a cart rule with empty code (like described in the issue #12608)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15314)
<!-- Reviewable:end -->
