### PR TITLE
Update Cart.php

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1712,7 +1712,7 @@ class CartCore extends ObjectModel
                 WHERE `id_cart` = ' . (int) $this->id . '
                 AND `id_product` = ' . (int) $id_product . '
                 AND `id_customization` = ' . (int) $id_customization .
-                (int) $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
+                ((int) $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
             );
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1712,7 +1712,7 @@ class CartCore extends ObjectModel
                 WHERE `id_cart` = ' . (int) $this->id . '
                 AND `id_product` = ' . (int) $id_product . '
                 AND `id_customization` = ' . (int) $id_customization .
-                (Int) $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
+                (int) $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
             );
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1712,7 +1712,7 @@ class CartCore extends ObjectModel
                 WHERE `id_cart` = ' . (int) $this->id . '
                 AND `id_product` = ' . (int) $id_product . '
                 AND `id_customization` = ' . (int) $id_customization .
-                ($id_product_attribute != null ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
+                (Int) $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
             );
         }
 
@@ -1723,7 +1723,7 @@ class CartCore extends ObjectModel
                 SET `quantity` = ' . (int) $preservedGifts[(int) $id_product . '-' . (int) $id_product_attribute] . '
                 WHERE `id_cart` = ' . (int) $this->id . '
                 AND `id_product` = ' . (int) $id_product .
-                ($id_product_attribute != null ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
+                ((int) $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
             );
         }
 
@@ -1732,7 +1732,7 @@ class CartCore extends ObjectModel
         DELETE FROM `' . _DB_PREFIX_ . 'cart_product`
         WHERE `id_product` = ' . (int) $id_product . '
         AND `id_customization` = ' . (int) $id_customization .
-            (null !== $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '') . '
+            ((int) $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '') . '
         AND `id_cart` = ' . (int) $this->id . '
         ' . ((int) $id_address_delivery ? 'AND `id_address_delivery` = ' . (int) $id_address_delivery : ''));
 


### PR DESCRIPTION
Default value for $id_product_attribute in deleteProduct method was changed from null to 0. Strict comparison $id_product_attribute !== null is not working with zero. Changed comparison with null to (int).

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | any configuration
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15323)
<!-- Reviewable:end -->
