### PR TITLE
Remove reference to non existent css file

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -288,11 +288,6 @@
 
 {% endblock %}
 
-{% block stylesheets %}
-  {{ parent() }}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_page.css') }}">
-{% endblock %}
-
 {% block javascripts %}
   {{ parent() }}
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Removed reference to `product_page.css` that doesn't exist (the contents from the scss file is already included in the main css file).
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Load the product page (in the back-office) in Chrome or equivalent looking at the "network" tab in the developer tools. Without the PR, there's a 404 on product_page.css. With this PR, this file is no longer requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15325)
<!-- Reviewable:end -->
