### PR TITLE
BO: Fix admin controller's render list identifier notice issue

### DIFF
--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -875,6 +875,7 @@ class HelperListCore extends Helper
     {
         $parameters = [
             $this->identifier => $id,
+            'id_'.$this->table => $id,
             'current_index' => $this->currentIndex,
             'token' => $token != null ? $token : $this->token,
         ];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Getting notice on admin controller's render list in with edit/view when URL have identifier, when debug mode enabled.
| Type?         | bug fix 
| Category?     |BO
| BC breaks?    | Does it break backward compatibility? yes
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes #15333
| How to test?  | Check the issue page. its described there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15341)
<!-- Reviewable:end -->
