### PR TITLE
Fix quicksearch results missing the category name

### DIFF
--- a/src/Core/Filter/FrontEndObject/SearchResultProductFilter.php
+++ b/src/Core/Filter/FrontEndObject/SearchResultProductFilter.php
@@ -40,6 +40,7 @@ class SearchResultProductFilter extends HashMapWhitelistFilter
             'active',
             'add_to_cart_url',
             'canonical_url',
+            'category_name',
             'cover',
             'description_short',
             'discount_amount',


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This should fix https://github.com/PrestaShop/PrestaShop/issues/9767 . The reason the search box does not work correctly (even in the live demo at http://demo.prestashop.com !) is that the category_name attribute is filtered in ProductListingFrontController using the SearchResultProductFilter. 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9767 
| How to test?  | Use the default search box, see the categories are missing (all items starting with ">"). Apply fix, they should appear again.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15352)
<!-- Reviewable:end -->
