### PR TITLE
[WIP] Fixed the displayed discount when adding product (linked to a coupon) to an existing order in BO

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1153,7 +1153,7 @@ class OrderCore extends ObjectModel
      *
      * @param int $id_cart Cart id
      *
-     * @return OrderCore|null
+     * @return Order|null
      *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1153,13 +1153,16 @@ class OrderCore extends ObjectModel
      *
      * @param int $id_cart Cart id
      *
-     * @return OrderCore
+     * @return OrderCore|null
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      */
     public static function getByCartId($id_cart)
     {
         $id_order = (int) self::getIdByCartId((int) $id_cart);
 
-        return ($id_order > 0) ? new self($id_order) : null;
+        return ($id_order > 0) ? new static($id_order) : null;
     }
 
     /**

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2078,7 +2078,15 @@ class AdminOrdersControllerCore extends AdminController
         }
     }
 
-    public function ajaxProcessAddProductOnOrder()
+    /**
+     * Add product on an order
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws SmartyException
+     * @throws \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
+     */
+    public function displayAjaxAddProductOnOrder()
     {
         // Load object
         $order = new Order((int) Tools::getValue('id_order'));
@@ -2093,7 +2101,9 @@ class AdminOrdersControllerCore extends AdminController
         $invoice_informations = $_POST['add_invoice'] ?? [];
 
         $result = $this->addProductToOrder($order, $product_informations, $invoice_informations, Tools::getValue('add_product_warehouse'));
-        die(json_encode(array(
+
+        header('Content-Type: application/json');
+        $this->ajaxRender(json_encode([
             'result' => true,
             'view' => $this->createTemplate('_product_line.tpl')->fetch(),
             'can_edit' => $this->access('add'),
@@ -2103,7 +2113,7 @@ class AdminOrdersControllerCore extends AdminController
             'shipping_html' => $this->createTemplate('_shipping.tpl')->fetch(),
             'discount_form_html' => $this->createTemplate('_discount_form.tpl')->fetch(),
             'refresh' => $result['refresh'],
-        )));
+        ]));
     }
 
     /**

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2080,11 +2080,6 @@ class AdminOrdersControllerCore extends AdminController
 
     /**
      * Add product on an order
-     *
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     * @throws SmartyException
-     * @throws \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
      */
     public function displayAjaxAddProductOnOrder()
     {
@@ -2123,10 +2118,6 @@ class AdminOrdersControllerCore extends AdminController
      * @param bool $warehouseId
      *
      * @return array
-     *
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     * @throws \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
      */
     protected function addProductToOrder(Order $order, array $product_informations, array $invoice_informations = [], $warehouseId = false)
     {

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2089,8 +2089,38 @@ class AdminOrdersControllerCore extends AdminController
             ]));
         }
 
-        $old_cart_rules = Context::getContext()->cart->getCartRules();
+        $product_informations = $_POST['add_product'];
+        $invoice_informations = $_POST['add_invoice'] ?? [];
 
+        $result = $this->addProductToOrder($order, $product_informations, $invoice_informations, Tools::getValue('add_product_warehouse'));
+        die(json_encode(array(
+            'result' => true,
+            'view' => $this->createTemplate('_product_line.tpl')->fetch(),
+            'can_edit' => $this->access('add'),
+            'order' => $order,
+            'invoices' => $result['invoice_array'],
+            'documents_html' => $this->createTemplate('_documents.tpl')->fetch(),
+            'shipping_html' => $this->createTemplate('_shipping.tpl')->fetch(),
+            'discount_form_html' => $this->createTemplate('_discount_form.tpl')->fetch(),
+            'refresh' => $result['refresh'],
+        )));
+    }
+
+    /**
+     * @param Order $order
+     * @param array $product_informations
+     * @param array $invoice_informations
+     * @param bool $warehouseId
+     *
+     * @return array
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws \PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException
+     */
+    protected function addProductToOrder(Order $order, array $product_informations, array $invoice_informations = [], $warehouseId = false)
+    {
+        $old_cart_rules = Context::getContext()->cart->getCartRules();
         if ($order->hasBeenShipped()) {
             die(json_encode([
                 'result' => false,
@@ -2098,12 +2128,6 @@ class AdminOrdersControllerCore extends AdminController
             ]));
         }
 
-        $product_informations = $_POST['add_product'];
-        if (isset($_POST['add_invoice'])) {
-            $invoice_informations = $_POST['add_invoice'];
-        } else {
-            $invoice_informations = [];
-        }
         $product = new Product($product_informations['product_id'], false, $order->id_lang);
         if (!Validate::isLoadedObject($product)) {
             die(json_encode([
@@ -2293,7 +2317,7 @@ class AdminOrdersControllerCore extends AdminController
 
         // Create Order detail information
         $order_detail = new OrderDetail();
-        $order_detail->createList($order, $cart, $order->getCurrentOrderState(), $cart->getProducts(), (isset($order_invoice) ? $order_invoice->id : 0), $use_taxes, (int) Tools::getValue('add_product_warehouse'));
+        $order_detail->createList($order, $cart, $order->getCurrentOrderState(), $cart->getProducts(), (isset($order_invoice) ? $order_invoice->id : 0), $use_taxes, (int) $warehouseId);
 
         // update totals amount of order
         $order->total_products += (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
@@ -2369,6 +2393,7 @@ class AdminOrdersControllerCore extends AdminController
             $invoice_array[] = $invoice;
         }
 
+        /** @var Order $order */
         $order = $order->refreshShippingCost();
 
         // Assign to smarty informations in order to show the new product line
@@ -2403,34 +2428,22 @@ class AdminOrdersControllerCore extends AdminController
             $order_cart_rule = new OrderCartRule();
             $order_cart_rule->id_order = $order->id;
             $order_cart_rule->id_cart_rule = $cart_rule['id_cart_rule'];
-            $order_cart_rule->id_order_invoice = $order_invoice->id;
+            if ($order->hasInvoice()) {
+                $order_cart_rule->id_order_invoice = $order_invoice->id;
+            }
             $order_cart_rule->name = $cart_rule['name'];
             $order_cart_rule->value = $values['tax_incl'];
             $order_cart_rule->value_tax_excl = $values['tax_excl'];
             $res &= $order_cart_rule->add();
-
-            $order->total_discounts += $order_cart_rule->value;
-            $order->total_discounts_tax_incl += $order_cart_rule->value;
-            $order->total_discounts_tax_excl += $order_cart_rule->value_tax_excl;
-            $order->total_paid -= $order_cart_rule->value;
-            $order->total_paid_tax_incl -= $order_cart_rule->value;
-            $order->total_paid_tax_excl -= $order_cart_rule->value_tax_excl;
         }
 
         // Update Order
         $res &= $order->update();
 
-        die(json_encode([
-            'result' => true,
-            'view' => $this->createTemplate('_product_line.tpl')->fetch(),
-            'can_edit' => $this->access('add'),
-            'order' => $order,
-            'invoices' => $invoice_array,
-            'documents_html' => $this->createTemplate('_documents.tpl')->fetch(),
-            'shipping_html' => $this->createTemplate('_shipping.tpl')->fetch(),
-            'discount_form_html' => $this->createTemplate('_discount_form.tpl')->fetch(),
+        return [
+            'invoice_array' => $invoice_array,
             'refresh' => $refresh,
-        ]));
+        ];
     }
 
     public function sendChangedNotification(Order $order = null)

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -87,10 +87,9 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
     {
         $order = $this->getOrderObject($command->getOrderId());
 
+        $oldCartRules = [];
         if ($this->context->cart !== null) {
             $oldCartRules = $this->context->cart->getCartRules();
-        } else {
-            $oldCartRules = [];
         }
 
         $this->assertOrderWasNotShipped($order);
@@ -179,10 +178,9 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         sort($oldCartRules);
         sort($newCartRules);
 
+        $result = [];
         if (!empty($newCartRules) && !empty($oldCartRules)) {
             $result = array_diff($newCartRules, $oldCartRules);
-        } else {
-            $result = [];
         }
 
         foreach ($result as $cartRule) {

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -26,15 +26,35 @@
 
 namespace Tests\Integration\Behaviour\Features\Context;
 
+use Address;
 use AppKernel;
+use Attribute;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Carrier;
+use Cart;
+use CartRule;
 use Configuration;
 use Context;
+use Currency;
+use Customer;
 use Exception;
 use LegacyTests\Unit\Core\Cart\CartToOrder\PaymentModuleFake;
 use Order;
+use OrderCarrier;
 use OrderCartRule;
+use OrderDetail;
+use OrderInvoice;
+use OrderReturn;
+use OrderSlip;
+use Product;
 use RuntimeException;
+use Shop;
+use SpecificPrice;
+use StockAvailable;
+use Tools;
+use Validate;
+use Warehouse;
+use WarehouseProductLocation;
 
 class OrderFeatureContext extends AbstractPrestaShopFeatureContext
 {
@@ -105,36 +125,351 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
         $order = $this->getCurrentCartOrder();
         $this->productFeatureContext->checkProductWithNameExists($productName);
         $product = $this->productFeatureContext->getProductWithName($productName);
-        // need to disable some behaviour to avoid mocking the world !
-        $adminOrderController = new class() extends \AdminOrdersControllerCore {
-            public function access($action, $disable = false)
-            {
-                return true;
-            }
-
-            public function createTemplate($tpl_name)
-            {
-                return new class() {
-                    public function fetch()
-                    {
-                        return true;
-                    }
-                };
-            }
-        };
-        // expected arguments from ajax call
-        $productData = [
+        $this->addProductToOrder($order, [
             'product_id' => $product->id,
             'product_price_tax_excl' => $priceTaxExcl,
             'product_price_tax_incl' => $priceTaxIncl,
             'product_quantity' => $quantity,
-        ];
-        $reflection = new \ReflectionClass(\AdminOrdersControllerCore::class);
-        $method = $reflection->getMethod('addProductToOrder');
-        $method->setAccessible(true);
-        $method->invokeArgs($adminOrderController, [$order, $productData]);
+        ]);
         // restore correct cart since previous method has overridden it
         Context::getContext()->cart = $cart;
+    }
+
+    /**
+     * Duplicate from AdminOrderController::addProductToOrder
+     * @param Order $order
+     * @param array $product_informations
+     * @param array $invoice_informations
+     * @param bool $warehouseId
+     * @return array
+     */
+    protected function addProductToOrder(Order $order, array $product_informations, array $invoice_informations = [], $warehouseId = false)
+    {
+        $old_cart_rules = Context::getContext()->cart->getCartRules();
+        if ($order->hasBeenShipped()) {
+            die(json_encode(array(
+                'result' => false,
+                'error' => $this->trans('You cannot add products to delivered orders.', array(), 'Admin.Orderscustomers.Notification'),
+            )));
+        }
+
+        $product = new Product($product_informations['product_id'], false, $order->id_lang);
+        if (!Validate::isLoadedObject($product)) {
+            die(json_encode(array(
+                'result' => false,
+                'error' => $this->trans('The product object cannot be loaded.', array(), 'Admin.Orderscustomers.Notification'),
+            )));
+        }
+
+        if (isset($product_informations['product_attribute_id']) && $product_informations['product_attribute_id']) {
+            $combination = new Combination($product_informations['product_attribute_id']);
+            if (!Validate::isLoadedObject($combination)) {
+                die(json_encode(array(
+                    'result' => false,
+                    'error' => $this->trans('The combination object cannot be loaded.', array(), 'Admin.Orderscustomers.Notification'),
+                )));
+            }
+        }
+
+        // Total method
+        $total_method = Cart::BOTH_WITHOUT_SHIPPING;
+
+        // Create new cart
+        $cart = new Cart();
+        $cart->id_shop_group = $order->id_shop_group;
+        $cart->id_shop = $order->id_shop;
+        $cart->id_customer = $order->id_customer;
+        $cart->id_carrier = $order->id_carrier;
+        $cart->id_address_delivery = $order->id_address_delivery;
+        $cart->id_address_invoice = $order->id_address_invoice;
+        $cart->id_currency = $order->id_currency;
+        $cart->id_lang = $order->id_lang;
+        $cart->secure_key = $order->secure_key;
+
+        // Save new cart
+        $cart->add();
+
+        // Save context (in order to apply cart rule)
+        Context::getContext()->cart = $cart;
+        Context::getContext()->customer = new Customer($order->id_customer);
+
+        // always add taxes even if there are not displayed to the customer
+        $use_taxes = true;
+
+        $initial_product_price_tax_incl = Product::getPriceStatic(
+            $product->id,
+            $use_taxes,
+            isset($combination) ? $combination->id : null,
+            2,
+            null,
+            false,
+            true,
+            1,
+            false,
+            $order->id_customer,
+            $cart->id,
+            $order->{Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop)}
+        );
+
+        // Creating specific price if needed
+        if ($product_informations['product_price_tax_incl'] != $initial_product_price_tax_incl) {
+            $specific_price = new SpecificPrice();
+            $specific_price->id_shop = 0;
+            $specific_price->id_shop_group = 0;
+            $specific_price->id_currency = 0;
+            $specific_price->id_country = 0;
+            $specific_price->id_group = 0;
+            $specific_price->id_customer = $order->id_customer;
+            $specific_price->id_product = $product->id;
+            if (isset($combination)) {
+                $specific_price->id_product_attribute = $combination->id;
+            } else {
+                $specific_price->id_product_attribute = 0;
+            }
+            $specific_price->price = $product_informations['product_price_tax_excl'];
+            $specific_price->from_quantity = 1;
+            $specific_price->reduction = 0;
+            $specific_price->reduction_type = 'amount';
+            $specific_price->reduction_tax = 0;
+            $specific_price->from = '0000-00-00 00:00:00';
+            $specific_price->to = '0000-00-00 00:00:00';
+            $specific_price->add();
+        }
+
+        // Add product to cart
+        $update_quantity = $cart->updateQty(
+            $product_informations['product_quantity'],
+            $product->id,
+            isset($product_informations['product_attribute_id']) ? $product_informations['product_attribute_id'] : null,
+            isset($combination) ? $combination->id : null,
+            'up',
+            0,
+            new Shop($cart->id_shop)
+        );
+
+        if ($update_quantity < 0) {
+            // If product has attribute, minimal quantity is set with minimal quantity of attribute
+            $minimal_quantity = ($product_informations['product_attribute_id']) ? Attribute::getAttributeMinimalQty($product_informations['product_attribute_id']) : $product->minimal_quantity;
+            die(json_encode(array('error' => $this->trans('You must add %d minimum quantity', array('%d' => $minimal_quantity), 'Admin.Orderscustomers.Notification'))));
+        } elseif (!$update_quantity) {
+            die(json_encode(array('error' => $this->trans('You already have the maximum quantity available for this product.', array(), 'Admin.Orderscustomers.Notification'))));
+        }
+
+        // If order is valid, we can create a new invoice or edit an existing invoice
+        if ($order->hasInvoice()) {
+            $order_invoice = new OrderInvoice($product_informations['invoice']);
+            // Create new invoice
+            if ($order_invoice->id == 0) {
+                // If we create a new invoice, we calculate shipping cost
+                $total_method = Cart::BOTH;
+                // Create Cart rule in order to make free shipping
+                if (isset($invoice_informations['free_shipping']) && $invoice_informations['free_shipping']) {
+                    $cart_rule = new CartRule();
+                    $cart_rule->id_customer = $order->id_customer;
+                    $cart_rule->name = array(
+                        Configuration::get('PS_LANG_DEFAULT') => $this->trans('[Generated] CartRule for Free Shipping', array(), 'Admin.Orderscustomers.Notification'),
+                    );
+                    $cart_rule->date_from = date('Y-m-d H:i:s', time());
+                    $cart_rule->date_to = date('Y-m-d H:i:s', time() + 24 * 3600);
+                    $cart_rule->quantity = 1;
+                    $cart_rule->quantity_per_user = 1;
+                    $cart_rule->minimum_amount_currency = $order->id_currency;
+                    $cart_rule->reduction_currency = $order->id_currency;
+                    $cart_rule->free_shipping = true;
+                    $cart_rule->active = 1;
+                    $cart_rule->add();
+
+                    // Add cart rule to cart and in order
+                    $cart->addCartRule($cart_rule->id);
+                    $values = array(
+                        'tax_incl' => $cart_rule->getContextualValue(true),
+                        'tax_excl' => $cart_rule->getContextualValue(false),
+                    );
+                    $order->addCartRule($cart_rule->id, $cart_rule->name[Configuration::get('PS_LANG_DEFAULT')], $values);
+                }
+
+                $order_invoice->id_order = $order->id;
+                if ($order_invoice->number) {
+                    Configuration::updateValue('PS_INVOICE_START_NUMBER', false, false, null, $order->id_shop);
+                } else {
+                    $order_invoice->number = Order::getLastInvoiceNumber() + 1;
+                }
+
+
+                $invoice_address = new Address((int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop)});
+                $carrier = new Carrier((int) $order->id_carrier);
+                $tax_calculator = $carrier->getTaxCalculator($invoice_address);
+
+                $order_invoice->total_paid_tax_excl = Tools::ps_round((float) $cart->getOrderTotal(false, $total_method), 2);
+                $order_invoice->total_paid_tax_incl = Tools::ps_round((float) $cart->getOrderTotal($use_taxes, $total_method), 2);
+                $order_invoice->total_products = (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
+                $order_invoice->total_products_wt = (float) $cart->getOrderTotal($use_taxes, Cart::ONLY_PRODUCTS);
+                $order_invoice->total_shipping_tax_excl = (float) $cart->getTotalShippingCost(null, false);
+                $order_invoice->total_shipping_tax_incl = (float) $cart->getTotalShippingCost();
+
+                $order_invoice->total_wrapping_tax_excl = abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING));
+                $order_invoice->total_wrapping_tax_incl = abs($cart->getOrderTotal($use_taxes, Cart::ONLY_WRAPPING));
+                $order_invoice->shipping_tax_computation_method = (int) $tax_calculator->computation_method;
+
+                // Update current order field, only shipping because other field is updated later
+                $order->total_shipping += $order_invoice->total_shipping_tax_incl;
+                $order->total_shipping_tax_excl += $order_invoice->total_shipping_tax_excl;
+                $order->total_shipping_tax_incl += ($use_taxes) ? $order_invoice->total_shipping_tax_incl : $order_invoice->total_shipping_tax_excl;
+
+                $order->total_wrapping += abs($cart->getOrderTotal($use_taxes, Cart::ONLY_WRAPPING));
+                $order->total_wrapping_tax_excl += abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING));
+                $order->total_wrapping_tax_incl += abs($cart->getOrderTotal($use_taxes, Cart::ONLY_WRAPPING));
+                $order_invoice->add();
+
+                $order_invoice->saveCarrierTaxCalculator($tax_calculator->getTaxesAmount($order_invoice->total_shipping_tax_excl));
+
+                $order_carrier = new OrderCarrier();
+                $order_carrier->id_order = (int) $order->id;
+                $order_carrier->id_carrier = (int) $order->id_carrier;
+                $order_carrier->id_order_invoice = (int) $order_invoice->id;
+                $order_carrier->weight = (float) $cart->getTotalWeight();
+                $order_carrier->shipping_cost_tax_excl = (float) $order_invoice->total_shipping_tax_excl;
+                $order_carrier->shipping_cost_tax_incl = ($use_taxes) ? (float) $order_invoice->total_shipping_tax_incl : (float) $order_invoice->total_shipping_tax_excl;
+                $order_carrier->add();
+            } else {
+                // Update current invoice
+                $order_invoice->total_paid_tax_excl += Tools::ps_round((float) ($cart->getOrderTotal(false, $total_method)), 2);
+                $order_invoice->total_paid_tax_incl += Tools::ps_round((float) ($cart->getOrderTotal($use_taxes, $total_method)), 2);
+                $order_invoice->total_products += (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
+                $order_invoice->total_products_wt += (float) $cart->getOrderTotal($use_taxes, Cart::ONLY_PRODUCTS);
+                $order_invoice->update();
+            }
+        }
+
+        // Create Order detail information
+        $order_detail = new OrderDetail();
+        $order_detail->createList($order, $cart, $order->getCurrentOrderState(), $cart->getProducts(), (isset($order_invoice) ? $order_invoice->id : 0), $use_taxes, (int) $warehouseId);
+
+        // update totals amount of order
+        $order->total_products += (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
+        $order->total_products_wt += (float) $cart->getOrderTotal($use_taxes, Cart::ONLY_PRODUCTS);
+
+        $order->total_paid += Tools::ps_round((float) ($cart->getOrderTotal(true, $total_method)), 2);
+        $order->total_paid_tax_excl += Tools::ps_round((float) ($cart->getOrderTotal(false, $total_method)), 2);
+        $order->total_paid_tax_incl += Tools::ps_round((float) ($cart->getOrderTotal($use_taxes, $total_method)), 2);
+
+        if (isset($order_invoice) && Validate::isLoadedObject($order_invoice)) {
+            $order->total_shipping = $order_invoice->total_shipping_tax_incl;
+            $order->total_shipping_tax_incl = $order_invoice->total_shipping_tax_incl;
+            $order->total_shipping_tax_excl = $order_invoice->total_shipping_tax_excl;
+        }
+        // discount
+        $order->total_discounts += (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS));
+        $order->total_discounts_tax_excl += (float) abs($cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS));
+        $order->total_discounts_tax_incl += (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS));
+
+        // Save changes of order
+        $order->update();
+
+        StockAvailable::synchronize($product->id);
+
+        // Update weight SUM
+        $order_carrier = new OrderCarrier((int) $order->getIdOrderCarrier());
+        if (Validate::isLoadedObject($order_carrier)) {
+            $order_carrier->weight = (float) $order->getTotalWeight();
+            if ($order_carrier->update()) {
+                $order->weight = sprintf('%.3f ' . Configuration::get('PS_WEIGHT_UNIT'), $order_carrier->weight);
+            }
+        }
+
+        // Update Tax lines
+        $order_detail->updateTaxAmount($order);
+
+        // Delete specific price if exists
+        if (isset($specific_price)) {
+            $specific_price->delete();
+        }
+
+        $products = $this->getProducts($order);
+
+        // Get the last product
+        $product = end($products);
+        $resume = OrderSlip::getProductSlipResume((int) $product['id_order_detail']);
+        $product['quantity_refundable'] = $product['product_quantity'] - $resume['product_quantity'];
+        $product['amount_refundable'] = $product['total_price_tax_excl'] - $resume['amount_tax_excl'];
+        $product['amount_refund'] = Tools::displayPrice($resume['amount_tax_incl']);
+        $product['return_history'] = OrderReturn::getProductReturnDetail((int) $product['id_order_detail']);
+        $product['refund_history'] = OrderSlip::getProductSlipDetail((int) $product['id_order_detail']);
+        if ($product['id_warehouse'] != 0) {
+            $warehouse = new Warehouse((int) $product['id_warehouse']);
+            $product['warehouse_name'] = $warehouse->name;
+            $warehouse_location = WarehouseProductLocation::getProductLocation($product['product_id'], $product['product_attribute_id'], $product['id_warehouse']);
+            if (!empty($warehouse_location)) {
+                $product['warehouse_location'] = $warehouse_location;
+            } else {
+                $product['warehouse_location'] = false;
+            }
+        } else {
+            $product['warehouse_name'] = '--';
+            $product['warehouse_location'] = false;
+        }
+
+        // Get invoices collection
+        $invoice_collection = $order->getInvoicesCollection();
+
+        $invoice_array = array();
+        foreach ($invoice_collection as $invoice) {
+            /* @var OrderInvoice $invoice */
+            $invoice->name = $invoice->getInvoiceNumberFormatted(Context::getContext()->language->id, (int) $order->id_shop);
+            $invoice_array[] = $invoice;
+        }
+
+        /** @var Order $order */
+        $order = $order->refreshShippingCost();
+
+        // Assign to smarty informations in order to show the new product line
+        $this->context->smarty->assign(array(
+            'product' => $product,
+            'order' => $order,
+            'currency' => new Currency($order->id_currency),
+            'can_edit' => $this->access('edit'),
+            'invoices_collection' => $invoice_collection,
+            'current_id_lang' => Context::getContext()->language->id,
+            'link' => Context::getContext()->link,
+            'current_index' => self::$currentIndex,
+            'display_warehouse' => (int) Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT'),
+        ));
+
+        $this->sendChangedNotification($order);
+        $new_cart_rules = Context::getContext()->cart->getCartRules();
+        sort($old_cart_rules);
+        sort($new_cart_rules);
+        $result = array_diff($new_cart_rules, $old_cart_rules);
+        $refresh = false;
+
+        $res = true;
+        foreach ($result as $cart_rule) {
+            $refresh = true;
+            // Create OrderCartRule
+            $rule = new CartRule($cart_rule['id_cart_rule']);
+            $values = array(
+                'tax_incl' => $rule->getContextualValue(true),
+                'tax_excl' => $rule->getContextualValue(false),
+            );
+            $order_cart_rule = new OrderCartRule();
+            $order_cart_rule->id_order = $order->id;
+            $order_cart_rule->id_cart_rule = $cart_rule['id_cart_rule'];
+            if ($order->hasInvoice()) {
+                $order_cart_rule->id_order_invoice = $order_invoice->id;
+            }
+            $order_cart_rule->name = $cart_rule['name'];
+            $order_cart_rule->value = $values['tax_incl'];
+            $order_cart_rule->value_tax_excl = $values['tax_excl'];
+            $res &= $order_cart_rule->add();
+        }
+
+        // Update Order
+        $res &= $order->update();
+
+        return [
+            'invoice_array' => $invoice_array,
+            'refresh' => $refresh,
+        ];
     }
 
     /**
@@ -280,17 +615,19 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
 
     /**
      * @Then order :reference should have :paymentModuleName payment method
+     *
+     * @param string $reference
+     * @param string $paymentModuleName
      */
-    public function createdOrderShouldHavePaymentMethod($reference, $paymentModuleName)
+    public function createdOrderShouldHavePaymentMethod(string $reference, string $paymentModuleName)
     {
-        $order = SharedStorage::getStorage()->get($reference);
+        $orderId = SharedStorage::getStorage()->get($reference);
 
+        $order = new Order($orderId);
+
+        // todo: think about a way to get paymentModuleName from domain classes
         if ($order->module !== $paymentModuleName) {
-            throw new Exception(sprintf(
-                'Order should have "%s" payment method, but has "%s" instead.',
-                $paymentModuleName,
-                $order->payment
-            ));
+            throw new RuntimeException(sprintf('Order should have "%s" payment method, but has "%s" instead.', $paymentModuleName, $order->payment));
         }
     }
 
@@ -400,23 +737,5 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
             $order->delete();
         }
         $this->orders = [];
-    }
-
-    /**
-     * @Then order :reference should have :paymentModuleName payment method
-     *
-     * @param string $reference
-     * @param string $paymentModuleName
-     */
-    public function createdOrderShouldHavePaymentMethod(string $reference, string $paymentModuleName)
-    {
-        $orderId = SharedStorage::getStorage()->get($reference);
-
-        $order = new Order($orderId);
-
-        // todo: think about a way to get paymentModuleName from domain classes
-        if ($order->module !== $paymentModuleName) {
-            throw new RuntimeException(sprintf('Order should have "%s" payment method, but has "%s" instead.', $paymentModuleName, $order->payment));
-        }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -26,38 +26,18 @@
 
 namespace Tests\Integration\Behaviour\Features\Context;
 
-use Address;
 use AppKernel;
-use Attribute;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Carrier;
-use Cart;
-use CartRule;
 use Configuration;
 use Context;
-use Currency;
-use Customer;
 use Exception;
-use Hook;
-use ImageManager;
 use LegacyTests\Unit\Core\Cart\CartToOrder\PaymentModuleFake;
 use Order;
-use OrderCarrier;
 use OrderCartRule;
-use OrderDetail;
 use OrderInvoice;
-use OrderReturn;
-use OrderSlip;
-use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\AddProductToOrderCommand;
 use Product;
 use RuntimeException;
-use Shop;
-use SpecificPrice;
-use StockAvailable;
-use Tools;
-use Validate;
-use Warehouse;
-use WarehouseProductLocation;
 
 class OrderFeatureContext extends AbstractPrestaShopFeatureContext
 {
@@ -121,6 +101,11 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
 
     /**
      * @When /^(\d+) items? of product "(.+)" are added in my cart order, with prices (\d+\.\d+) tax excluded and (\d+\.\d+) tax included$/
+     *
+     * @param int $quantity
+     * @param string $productName
+     * @param float $priceTaxExcl
+     * @param float $priceTaxIncl
      */
     public function addProductInCartOrder($quantity, $productName, $priceTaxExcl, $priceTaxIncl)
     {
@@ -150,352 +135,29 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
      */
     protected function addProductToOrder(Order $order, array $product_informations, array $invoice_informations = [], $warehouseId = false)
     {
-        /** @var Locale $locale */
-        $locale = CommonFeatureContext::getContainer()->get('prestashop.core.localization.locale.context_locale');
-
-        $old_cart_rules = Context::getContext()->cart->getCartRules();
-        if ($order->hasBeenShipped()) {
-            die(json_encode(array(
-                'result' => false,
-                'error' => $this->trans('You cannot add products to delivered orders.', array(), 'Admin.Orderscustomers.Notification'),
-            )));
-        }
-
-        $product = new Product($product_informations['product_id'], false, $order->id_lang);
-        if (!Validate::isLoadedObject($product)) {
-            die(json_encode(array(
-                'result' => false,
-                'error' => $this->trans('The product object cannot be loaded.', array(), 'Admin.Orderscustomers.Notification'),
-            )));
-        }
-
-        if (isset($product_informations['product_attribute_id']) && $product_informations['product_attribute_id']) {
-            $combination = new Combination($product_informations['product_attribute_id']);
-            if (!Validate::isLoadedObject($combination)) {
-                die(json_encode(array(
-                    'result' => false,
-                    'error' => $this->trans('The combination object cannot be loaded.', array(), 'Admin.Orderscustomers.Notification'),
-                )));
-            }
-        }
-
-        // Total method
-        $total_method = Cart::BOTH_WITHOUT_SHIPPING;
-
-        // Create new cart
-        $cart = new Cart();
-        $cart->id_shop_group = $order->id_shop_group;
-        $cart->id_shop = $order->id_shop;
-        $cart->id_customer = $order->id_customer;
-        $cart->id_carrier = $order->id_carrier;
-        $cart->id_address_delivery = $order->id_address_delivery;
-        $cart->id_address_invoice = $order->id_address_invoice;
-        $cart->id_currency = $order->id_currency;
-        $cart->id_lang = $order->id_lang;
-        $cart->secure_key = $order->secure_key;
-
-        // Save new cart
-        $cart->add();
-
-        // Save context (in order to apply cart rule)
-        Context::getContext()->cart = $cart;
-        Context::getContext()->customer = new Customer($order->id_customer);
-
-        // always add taxes even if there are not displayed to the customer
-        $use_taxes = true;
-
-        $initial_product_price_tax_incl = Product::getPriceStatic(
-            $product->id,
-            $use_taxes,
-            isset($combination) ? $combination->id : null,
-            2,
-            null,
-            false,
-            true,
-            1,
-            false,
-            $order->id_customer,
-            $cart->id,
-            $order->{Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop)}
-        );
-
-        // Creating specific price if needed
-        if ($product_informations['product_price_tax_incl'] != $initial_product_price_tax_incl) {
-            $specific_price = new SpecificPrice();
-            $specific_price->id_shop = 0;
-            $specific_price->id_shop_group = 0;
-            $specific_price->id_currency = 0;
-            $specific_price->id_country = 0;
-            $specific_price->id_group = 0;
-            $specific_price->id_customer = $order->id_customer;
-            $specific_price->id_product = $product->id;
-            if (isset($combination)) {
-                $specific_price->id_product_attribute = $combination->id;
-            } else {
-                $specific_price->id_product_attribute = 0;
-            }
-            $specific_price->price = $product_informations['product_price_tax_excl'];
-            $specific_price->from_quantity = 1;
-            $specific_price->reduction = 0;
-            $specific_price->reduction_type = 'amount';
-            $specific_price->reduction_tax = 0;
-            $specific_price->from = '0000-00-00 00:00:00';
-            $specific_price->to = '0000-00-00 00:00:00';
-            $specific_price->add();
-        }
-
-        // Add product to cart
-        $update_quantity = $cart->updateQty(
-            $product_informations['product_quantity'],
-            $product->id,
-            isset($product_informations['product_attribute_id']) ? $product_informations['product_attribute_id'] : null,
-            isset($combination) ? $combination->id : null,
-            'up',
-            0,
-            new Shop($cart->id_shop)
-        );
-
-        if ($update_quantity < 0) {
-            // If product has attribute, minimal quantity is set with minimal quantity of attribute
-            $minimal_quantity = ($product_informations['product_attribute_id']) ? Attribute::getAttributeMinimalQty($product_informations['product_attribute_id']) : $product->minimal_quantity;
-            die(json_encode(array('error' => $this->trans('You must add %d minimum quantity', array('%d' => $minimal_quantity), 'Admin.Orderscustomers.Notification'))));
-        } elseif (!$update_quantity) {
-            die(json_encode(array('error' => $this->trans('You already have the maximum quantity available for this product.', array(), 'Admin.Orderscustomers.Notification'))));
-        }
-
-        // If order is valid, we can create a new invoice or edit an existing invoice
+        $commandBus = CommonFeatureContext::getContainer()->get('prestashop.core.command_bus');
         if ($order->hasInvoice()) {
             $order_invoice = new OrderInvoice($product_informations['invoice']);
-            // Create new invoice
-            if ($order_invoice->id == 0) {
-                // If we create a new invoice, we calculate shipping cost
-                $total_method = Cart::BOTH;
-                // Create Cart rule in order to make free shipping
-                if (isset($invoice_informations['free_shipping']) && $invoice_informations['free_shipping']) {
-                    $cart_rule = new CartRule();
-                    $cart_rule->id_customer = $order->id_customer;
-                    $cart_rule->name = array(
-                        Configuration::get('PS_LANG_DEFAULT') => $this->trans('[Generated] CartRule for Free Shipping', array(), 'Admin.Orderscustomers.Notification'),
-                    );
-                    $cart_rule->date_from = date('Y-m-d H:i:s', time());
-                    $cart_rule->date_to = date('Y-m-d H:i:s', time() + 24 * 3600);
-                    $cart_rule->quantity = 1;
-                    $cart_rule->quantity_per_user = 1;
-                    $cart_rule->minimum_amount_currency = $order->id_currency;
-                    $cart_rule->reduction_currency = $order->id_currency;
-                    $cart_rule->free_shipping = true;
-                    $cart_rule->active = 1;
-                    $cart_rule->add();
-
-                    // Add cart rule to cart and in order
-                    $cart->addCartRule($cart_rule->id);
-                    $values = array(
-                        'tax_incl' => $cart_rule->getContextualValue(true),
-                        'tax_excl' => $cart_rule->getContextualValue(false),
-                    );
-                    $order->addCartRule($cart_rule->id, $cart_rule->name[Configuration::get('PS_LANG_DEFAULT')], $values);
-                }
-
-                $order_invoice->id_order = $order->id;
-                if ($order_invoice->number) {
-                    Configuration::updateValue('PS_INVOICE_START_NUMBER', false, false, null, $order->id_shop);
-                } else {
-                    $order_invoice->number = Order::getLastInvoiceNumber() + 1;
-                }
-
-                $invoice_address = new Address((int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop)});
-                $carrier = new Carrier((int) $order->id_carrier);
-                $tax_calculator = $carrier->getTaxCalculator($invoice_address);
-
-                $order_invoice->total_paid_tax_excl = Tools::ps_round((float) $cart->getOrderTotal(false, $total_method), 2);
-                $order_invoice->total_paid_tax_incl = Tools::ps_round((float) $cart->getOrderTotal($use_taxes, $total_method), 2);
-                $order_invoice->total_products = (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
-                $order_invoice->total_products_wt = (float) $cart->getOrderTotal($use_taxes, Cart::ONLY_PRODUCTS);
-                $order_invoice->total_shipping_tax_excl = (float) $cart->getTotalShippingCost(null, false);
-                $order_invoice->total_shipping_tax_incl = (float) $cart->getTotalShippingCost();
-
-                $order_invoice->total_wrapping_tax_excl = abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING));
-                $order_invoice->total_wrapping_tax_incl = abs($cart->getOrderTotal($use_taxes, Cart::ONLY_WRAPPING));
-                $order_invoice->shipping_tax_computation_method = (int) $tax_calculator->computation_method;
-
-                // Update current order field, only shipping because other field is updated later
-                $order->total_shipping += $order_invoice->total_shipping_tax_incl;
-                $order->total_shipping_tax_excl += $order_invoice->total_shipping_tax_excl;
-                $order->total_shipping_tax_incl += ($use_taxes) ? $order_invoice->total_shipping_tax_incl : $order_invoice->total_shipping_tax_excl;
-
-                $order->total_wrapping += abs($cart->getOrderTotal($use_taxes, Cart::ONLY_WRAPPING));
-                $order->total_wrapping_tax_excl += abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING));
-                $order->total_wrapping_tax_incl += abs($cart->getOrderTotal($use_taxes, Cart::ONLY_WRAPPING));
-                $order_invoice->add();
-
-                $order_invoice->saveCarrierTaxCalculator($tax_calculator->getTaxesAmount($order_invoice->total_shipping_tax_excl));
-
-                $order_carrier = new OrderCarrier();
-                $order_carrier->id_order = (int) $order->id;
-                $order_carrier->id_carrier = (int) $order->id_carrier;
-                $order_carrier->id_order_invoice = (int) $order_invoice->id;
-                $order_carrier->weight = (float) $cart->getTotalWeight();
-                $order_carrier->shipping_cost_tax_excl = (float) $order_invoice->total_shipping_tax_excl;
-                $order_carrier->shipping_cost_tax_incl = ($use_taxes) ? (float) $order_invoice->total_shipping_tax_incl : (float) $order_invoice->total_shipping_tax_excl;
-                $order_carrier->add();
-            } else {
-                // Update current invoice
-                $order_invoice->total_paid_tax_excl += Tools::ps_round((float) ($cart->getOrderTotal(false, $total_method)), 2);
-                $order_invoice->total_paid_tax_incl += Tools::ps_round((float) ($cart->getOrderTotal($use_taxes, $total_method)), 2);
-                $order_invoice->total_products += (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
-                $order_invoice->total_products_wt += (float) $cart->getOrderTotal($use_taxes, Cart::ONLY_PRODUCTS);
-                $order_invoice->update();
-            }
-        }
-
-        // Create Order detail information
-        $order_detail = new OrderDetail();
-        $order_detail->createList($order, $cart, $order->getCurrentOrderState(), $cart->getProducts(), (isset($order_invoice) ? $order_invoice->id : 0), $use_taxes, (int) $warehouseId);
-
-        // update totals amount of order
-        $order->total_products += (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
-        $order->total_products_wt += (float) $cart->getOrderTotal($use_taxes, Cart::ONLY_PRODUCTS);
-
-        $order->total_paid += Tools::ps_round((float) ($cart->getOrderTotal(true, $total_method)), 2);
-        $order->total_paid_tax_excl += Tools::ps_round((float) ($cart->getOrderTotal(false, $total_method)), 2);
-        $order->total_paid_tax_incl += Tools::ps_round((float) ($cart->getOrderTotal($use_taxes, $total_method)), 2);
-
-        if (isset($order_invoice) && Validate::isLoadedObject($order_invoice)) {
-            $order->total_shipping = $order_invoice->total_shipping_tax_incl;
-            $order->total_shipping_tax_incl = $order_invoice->total_shipping_tax_incl;
-            $order->total_shipping_tax_excl = $order_invoice->total_shipping_tax_excl;
-        }
-        // discount
-        $order->total_discounts += (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS));
-        $order->total_discounts_tax_excl += (float) abs($cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS));
-        $order->total_discounts_tax_incl += (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS));
-
-        // Save changes of order
-        $order->update();
-
-        StockAvailable::synchronize($product->id);
-
-        // Update weight SUM
-        $order_carrier = new OrderCarrier((int) $order->getIdOrderCarrier());
-        if (Validate::isLoadedObject($order_carrier)) {
-            $order_carrier->weight = (float) $order->getTotalWeight();
-            if ($order_carrier->update()) {
-                $order->weight = sprintf('%.3f ' . Configuration::get('PS_WEIGHT_UNIT'), $order_carrier->weight);
-            }
-        }
-
-        // Update Tax lines
-        $order_detail->updateTaxAmount($order);
-
-        // Delete specific price if exists
-        if (isset($specific_price)) {
-            $specific_price->delete();
-        }
-
-        // Replace $this->getProducts($order);
-        $products = $order->getProducts();
-        foreach ($products as &$product) {
-            if ($product['image'] != null) {
-                $name = 'product_mini_' . (int) $product['product_id'] . (isset($product['product_attribute_id']) ? '_' . (int) $product['product_attribute_id'] : '') . '.jpg';
-                // generate image cache, only for back office
-                $product['image_tag'] = ImageManager::thumbnail(_PS_IMG_DIR_ . 'p/' . $product['image']->getExistingImgPath() . '.jpg', $name, 45, 'jpg');
-                if (file_exists(_PS_TMP_IMG_DIR_ . $name)) {
-                    $product['image_size'] = getimagesize(_PS_TMP_IMG_DIR_ . $name);
-                } else {
-                    $product['image_size'] = false;
-                }
-            }
-        }
-        ksort($products);
-
-        // Get the last product
-        $product = end($products);
-        $resume = OrderSlip::getProductSlipResume((int) $product['id_order_detail']);
-        $product['quantity_refundable'] = $product['product_quantity'] - $resume['product_quantity'];
-        $product['amount_refundable'] = $product['total_price_tax_excl'] - $resume['amount_tax_excl'];
-        $product['amount_refund'] = !is_null($resume['amount_tax_incl']) ? $locale->formatPrice($resume['amount_tax_incl'], Context::getContext()->currency->iso_code) : null;
-        $product['return_history'] = OrderReturn::getProductReturnDetail((int) $product['id_order_detail']);
-        $product['refund_history'] = OrderSlip::getProductSlipDetail((int) $product['id_order_detail']);
-        if ($product['id_warehouse'] != 0) {
-            $warehouse = new Warehouse((int) $product['id_warehouse']);
-            $product['warehouse_name'] = $warehouse->name;
-            $warehouse_location = WarehouseProductLocation::getProductLocation($product['product_id'], $product['product_attribute_id'], $product['id_warehouse']);
-            if (!empty($warehouse_location)) {
-                $product['warehouse_location'] = $warehouse_location;
-            } else {
-                $product['warehouse_location'] = false;
-            }
+            $commandBus->handle(AddProductToOrderCommand::toExistingInvoice(
+                $order->id,
+                $order_invoice->id,
+                $product_informations['product_id'],
+                $product_informations['product_attribute_id'] ?? 0,
+                $product_informations['product_price_tax_incl'],
+                $product_informations['product_price_tax_excl'],
+                $product_informations['product_quantity']
+            ));
         } else {
-            $product['warehouse_name'] = '--';
-            $product['warehouse_location'] = false;
+            $commandBus->handle(AddProductToOrderCommand::withNewInvoice(
+                $order->id,
+                $product_informations['product_id'],
+                $product_informations['product_attribute_id'] ?? 0,
+                $product_informations['product_price_tax_incl'],
+                $product_informations['product_price_tax_excl'],
+                $product_informations['product_quantity'],
+                $invoice_informations['free_shipping'] ?? false
+            ));
         }
-
-        // Get invoices collection
-        $invoice_collection = $order->getInvoicesCollection();
-
-        $invoice_array = array();
-        foreach ($invoice_collection as $invoice) {
-            /* @var OrderInvoice $invoice */
-            $invoice->name = $invoice->getInvoiceNumberFormatted(Context::getContext()->language->id, (int) $order->id_shop);
-            $invoice_array[] = $invoice;
-        }
-
-        /** @var Order $order */
-        $order = $order->refreshShippingCost();
-
-        // Assign to smarty informations in order to show the new product line
-        Context::getContext()->smarty->assign(array(
-            'product' => $product,
-            'order' => $order,
-            'currency' => new Currency($order->id_currency),
-            // 'can_edit' => $this->access('edit'),
-            'invoices_collection' => $invoice_collection,
-            'current_id_lang' => Context::getContext()->language->id,
-            'link' => Context::getContext()->link,
-            // 'current_index' => self::$currentIndex,
-            'display_warehouse' => (int) Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT'),
-        ));
-
-        // Replace $this->sendChangedNotification($order);
-        if (null === $order) {
-            $order = new Order(Tools::getValue('id_order'));
-        }
-        Hook::exec('actionOrderEdited', array('order' => $order));
-
-        $new_cart_rules = Context::getContext()->cart->getCartRules();
-        sort($old_cart_rules);
-        sort($new_cart_rules);
-        $result = array_diff($new_cart_rules, $old_cart_rules);
-        $refresh = false;
-
-        $res = true;
-        foreach ($result as $cart_rule) {
-            $refresh = true;
-            // Create OrderCartRule
-            $rule = new CartRule($cart_rule['id_cart_rule']);
-            $values = array(
-                'tax_incl' => $rule->getContextualValue(true),
-                'tax_excl' => $rule->getContextualValue(false),
-            );
-            $order_cart_rule = new OrderCartRule();
-            $order_cart_rule->id_order = $order->id;
-            $order_cart_rule->id_cart_rule = $cart_rule['id_cart_rule'];
-            if ($order->hasInvoice()) {
-                $order_cart_rule->id_order_invoice = $order_invoice->id;
-            }
-            $order_cart_rule->name = $cart_rule['name'];
-            $order_cart_rule->value = $values['tax_incl'];
-            $order_cart_rule->value_tax_excl = $values['tax_excl'];
-            $res &= $order_cart_rule->add();
-        }
-
-        // Update Order
-        $res &= $order->update();
-
-        return [
-            'invoice_array' => $invoice_array,
-            'refresh' => $refresh,
-        ];
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -137,10 +137,12 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
 
     /**
      * Duplicate from AdminOrderController::addProductToOrder
+     *
      * @param Order $order
      * @param array $product_informations
      * @param array $invoice_informations
      * @param bool $warehouseId
+     *
      * @return array
      */
     protected function addProductToOrder(Order $order, array $product_informations, array $invoice_informations = [], $warehouseId = false)
@@ -294,7 +296,6 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
                 } else {
                     $order_invoice->number = Order::getLastInvoiceNumber() + 1;
                 }
-
 
                 $invoice_address = new Address((int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop)});
                 $carrier = new Carrier((int) $order->id_carrier);

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -439,7 +439,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
         $order = $order->refreshShippingCost();
 
         // Assign to smarty informations in order to show the new product line
-        $this->context->smarty->assign(array(
+        Context::getContext()->smarty->assign(array(
             'product' => $product,
             'order' => $order,
             'currency' => new Currency($order->id_currency),

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -48,6 +48,7 @@ use OrderDetail;
 use OrderInvoice;
 use OrderReturn;
 use OrderSlip;
+use PrestaShop\PrestaShop\Core\Localization\Locale;
 use Product;
 use RuntimeException;
 use Shop;
@@ -149,6 +150,9 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
      */
     protected function addProductToOrder(Order $order, array $product_informations, array $invoice_informations = [], $warehouseId = false)
     {
+        /** @var Locale $locale */
+        $locale = CommonFeatureContext::getContainer()->get('prestashop.core.localization.locale.context_locale');
+
         $old_cart_rules = Context::getContext()->cart->getCartRules();
         if ($order->hasBeenShipped()) {
             die(json_encode(array(
@@ -409,7 +413,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
         $resume = OrderSlip::getProductSlipResume((int) $product['id_order_detail']);
         $product['quantity_refundable'] = $product['product_quantity'] - $resume['product_quantity'];
         $product['amount_refundable'] = $product['total_price_tax_excl'] - $resume['amount_tax_excl'];
-        $product['amount_refund'] = Tools::displayPrice($resume['amount_tax_incl']);
+        $product['amount_refund'] = !is_null($resume['amount_tax_incl']) ? $locale->formatPrice($resume['amount_tax_incl'], Context::getContext()->currency->iso_code) : null;
         $product['return_history'] = OrderReturn::getProductReturnDetail((int) $product['id_order_detail']);
         $product['refund_history'] = OrderSlip::getProductSlipDetail((int) $product['id_order_detail']);
         if ($product['id_warehouse'] != 0) {

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -443,7 +443,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
             'product' => $product,
             'order' => $order,
             'currency' => new Currency($order->id_currency),
-            'can_edit' => $this->access('edit'),
+            'can_edit' => true, // $this->access('edit'),
             'invoices_collection' => $invoice_collection,
             'current_id_lang' => Context::getContext()->language->id,
             'link' => Context::getContext()->link,

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -29,6 +29,7 @@ namespace Tests\Integration\Behaviour\Features\Context;
 use AppKernel;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Configuration;
+use Context;
 use Exception;
 use LegacyTests\Unit\Core\Cart\CartToOrder\PaymentModuleFake;
 use Order;

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -38,6 +38,7 @@ use Context;
 use Currency;
 use Customer;
 use Exception;
+use ImageManager;
 use LegacyTests\Unit\Core\Cart\CartToOrder\PaymentModuleFake;
 use Order;
 use OrderCarrier;
@@ -386,7 +387,21 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
             $specific_price->delete();
         }
 
-        $products = $this->getProducts($order);
+        // Replace $this->getProducts($order);
+        $products = $order->getProducts();
+        foreach ($products as &$product) {
+            if ($product['image'] != null) {
+                $name = 'product_mini_' . (int) $product['product_id'] . (isset($product['product_attribute_id']) ? '_' . (int) $product['product_attribute_id'] : '') . '.jpg';
+                // generate image cache, only for back office
+                $product['image_tag'] = ImageManager::thumbnail(_PS_IMG_DIR_ . 'p/' . $product['image']->getExistingImgPath() . '.jpg', $name, 45, 'jpg');
+                if (file_exists(_PS_TMP_IMG_DIR_ . $name)) {
+                    $product['image_size'] = getimagesize(_PS_TMP_IMG_DIR_ . $name);
+                } else {
+                    $product['image_size'] = false;
+                }
+            }
+        }
+        ksort($products);
 
         // Get the last product
         $product = end($products);

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -38,6 +38,7 @@ use Context;
 use Currency;
 use Customer;
 use Exception;
+use Hook;
 use ImageManager;
 use LegacyTests\Unit\Core\Cart\CartToOrder\PaymentModuleFake;
 use Order;
@@ -443,15 +444,20 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
             'product' => $product,
             'order' => $order,
             'currency' => new Currency($order->id_currency),
-            'can_edit' => true, // $this->access('edit'),
+            // 'can_edit' => $this->access('edit'),
             'invoices_collection' => $invoice_collection,
             'current_id_lang' => Context::getContext()->language->id,
             'link' => Context::getContext()->link,
-            'current_index' => self::$currentIndex,
+            // 'current_index' => self::$currentIndex,
             'display_warehouse' => (int) Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT'),
         ));
 
-        $this->sendChangedNotification($order);
+        // Replace $this->sendChangedNotification($order);
+        if (null === $order) {
+            $order = new Order(Tools::getValue('id_order'));
+        }
+        Hook::exec('actionOrderEdited', array('order' => $order));
+
         $new_cart_rules = Context::getContext()->cart->getCartRules();
         sort($old_cart_rules);
         sort($new_cart_rules);

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -113,51 +113,32 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
         $order = $this->getCurrentCartOrder();
         $this->productFeatureContext->checkProductWithNameExists($productName);
         $product = $this->productFeatureContext->getProductWithName($productName);
-        $this->addProductToOrder($order, [
-            'product_id' => $product->id,
-            'product_price_tax_excl' => $priceTaxExcl,
-            'product_price_tax_incl' => $priceTaxIncl,
-            'product_quantity' => $quantity,
-        ]);
-        // restore correct cart since previous method has overridden it
-        Context::getContext()->cart = $cart;
-    }
 
-    /**
-     * Duplicate from AdminOrderController::addProductToOrder
-     *
-     * @param Order $order
-     * @param array $product_informations
-     * @param array $invoice_informations
-     * @param bool $warehouseId
-     *
-     * @return array
-     */
-    protected function addProductToOrder(Order $order, array $product_informations, array $invoice_informations = [], $warehouseId = false)
-    {
         $commandBus = CommonFeatureContext::getContainer()->get('prestashop.core.command_bus');
         if ($order->hasInvoice()) {
-            $order_invoice = new OrderInvoice($product_informations['invoice']);
+            $order_invoice = end($order->getInvoicesCollection()->getResults());
             $commandBus->handle(AddProductToOrderCommand::toExistingInvoice(
                 $order->id,
                 $order_invoice->id,
-                (int) $product_informations['product_id'],
-                $product_informations['product_attribute_id'] ?? 0,
-                $product_informations['product_price_tax_incl'],
-                $product_informations['product_price_tax_excl'],
-                $product_informations['product_quantity']
+                (int) $product->id,
+                0,
+                $priceTaxIncl,
+                $priceTaxExcl,
+                $quantity
             ));
         } else {
             $commandBus->handle(AddProductToOrderCommand::withNewInvoice(
                 $order->id,
-                (int) $product_informations['product_id'],
-                $product_informations['product_attribute_id'] ?? 0,
-                $product_informations['product_price_tax_incl'],
-                $product_informations['product_price_tax_excl'],
-                $product_informations['product_quantity'],
-                $invoice_informations['free_shipping'] ?? false
+                (int) $product->id,
+                0,
+                $priceTaxIncl,
+                $priceTaxExcl,
+                $quantity,
+                false
             ));
         }
+        // restore correct cart since previous method has overridden it
+        Context::getContext()->cart = $cart;
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -55,7 +55,6 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
         $this->productFeatureContext = $scope->getEnvironment()->getContext(ProductFeatureContext::class);
     }
 
-
     /**
      * @When /^I validate my cart using payment module (fake)$/
      */
@@ -111,6 +110,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
             {
                 return true;
             }
+
             public function createTemplate($tpl_name)
             {
                 return new class() {
@@ -225,6 +225,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
             );
         }
     }
+
     /**
      * @Then order :reference should have :quantity products in total
      */

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -34,7 +34,6 @@ use Exception;
 use LegacyTests\Unit\Core\Cart\CartToOrder\PaymentModuleFake;
 use Order;
 use OrderCartRule;
-use OrderInvoice;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\AddProductToOrderCommand;
 use Product;
 use RuntimeException;

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -141,7 +141,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
             $commandBus->handle(AddProductToOrderCommand::toExistingInvoice(
                 $order->id,
                 $order_invoice->id,
-                $product_informations['product_id'],
+                (int) $product_informations['product_id'],
                 $product_informations['product_attribute_id'] ?? 0,
                 $product_informations['product_price_tax_incl'],
                 $product_informations['product_price_tax_excl'],
@@ -150,7 +150,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
         } else {
             $commandBus->handle(AddProductToOrderCommand::withNewInvoice(
                 $order->id,
-                $product_informations['product_id'],
+                (int) $product_informations['product_id'],
                 $product_informations['product_attribute_id'] ?? 0,
                 $product_informations['product_price_tax_incl'],
                 $product_informations['product_price_tax_excl'],

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product.feature
@@ -1,0 +1,37 @@
+@reset-database-before-feature
+Feature: Check cart to order data copy
+  As a BO user
+  I must be able to add products in existing order
+
+  Scenario: 1 product in cart
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given product "product2" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
+    Then current cart order total for products should be 87.97 tax included
+    Then current cart order total for products should be 84.59 tax excluded
+    Then current cart order total discount should be 0.0 tax included
+    Then current cart order total discount should be 0.0 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded
+    Then current cart order should have no discount

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product.feature
@@ -28,8 +28,8 @@ Feature: Check cart to order data copy
     When I select carrier "carrier1" in my cart
     When I validate my cart using payment module fake
     When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
-    Then current cart order total for products should be 87.97 tax included
-    Then current cart order total for products should be 84.59 tax excluded
+    Then current cart order total for products should be 87.971520 tax included
+    Then current cart order total for products should be 84.588000 tax excluded
     Then current cart order total discount should be 0.0 tax included
     Then current cart order total discount should be 0.0 tax excluded
     Then current cart order shipping fees should be 7.0 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product_with_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product_with_cart_rule.feature
@@ -1,0 +1,106 @@
+@reset-database-before-feature
+Feature: Check cart to order data copy
+  As a BO user
+  I must be able to add products in existing order, calculation must be done correctly with cart rule
+
+  Scenario: 1 product in cart, add new product from order with restricted amount discount exceeding product price
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given product "product2" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    Given there is a cart rule named "cartrule5" that applies an amount discount of 500.0 with priority 5, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule5" is restricted to product "product2"
+    When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
+    Then current cart order total for products should be 87.97 tax included
+    Then current cart order total for products should be 84.59 tax excluded
+    Then current cart order total discount should be 67.37 tax included
+    Then current cart order total discount should be 64.78 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded
+
+  Scenario: 1 product in cart, add new product from order with restricted amount discount
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given product "product2" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    Given there is a cart rule named "cartrule5" that applies an amount discount of 5.0 with priority 5, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule5" is restricted to product "product2"
+    When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
+    Then current cart order total for products should be 87.97 tax included
+    Then current cart order total for products should be 84.59 tax excluded
+    Then current cart order total discount should be 5.2 tax included
+    Then current cart order total discount should be 5.0 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded
+
+  Scenario: 1 product in cart, add new product from order with restricted percent discount
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given product "product2" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    Given there is a cart rule named "cartrule5" that applies a percent discount of 15.0% with priority 5, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule5" is restricted to product "product2"
+    When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
+    Then current cart order total for products should be 87.97 tax included
+    Then current cart order total for products should be 84.59 tax excluded
+    Then current cart order total discount should be 10.11 tax included
+    Then current cart order total discount should be 9.72 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product_with_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/order_add_product_with_cart_rule.feature
@@ -30,10 +30,10 @@ Feature: Check cart to order data copy
     Given there is a cart rule named "cartrule5" that applies an amount discount of 500.0 with priority 5, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule5" is restricted to product "product2"
     When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
-    Then current cart order total for products should be 87.97 tax included
-    Then current cart order total for products should be 84.59 tax excluded
-    Then current cart order total discount should be 67.37 tax included
-    Then current cart order total discount should be 64.78 tax excluded
+    Then current cart order total for products should be 87.971520 tax included
+    Then current cart order total for products should be 84.588000 tax excluded
+    Then current cart order total discount should be 67.367040 tax included
+    Then current cart order total discount should be 64.776000 tax excluded
     Then current cart order shipping fees should be 7.0 tax included
     Then current cart order shipping fees should be 7.0 tax excluded
 
@@ -64,8 +64,8 @@ Feature: Check cart to order data copy
     Given there is a cart rule named "cartrule5" that applies an amount discount of 5.0 with priority 5, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule5" is restricted to product "product2"
     When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
-    Then current cart order total for products should be 87.97 tax included
-    Then current cart order total for products should be 84.59 tax excluded
+    Then current cart order total for products should be 87.971520 tax included
+    Then current cart order total for products should be 84.588000 tax excluded
     Then current cart order total discount should be 5.2 tax included
     Then current cart order total discount should be 5.0 tax excluded
     Then current cart order shipping fees should be 7.0 tax included
@@ -98,9 +98,9 @@ Feature: Check cart to order data copy
     Given there is a cart rule named "cartrule5" that applies a percent discount of 15.0% with priority 5, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule5" is restricted to product "product2"
     When 2 items of product "product2" are added in my cart order, with prices 32.388 tax excluded and 32.388 tax included
-    Then current cart order total for products should be 87.97 tax included
-    Then current cart order total for products should be 84.59 tax excluded
-    Then current cart order total discount should be 10.11 tax included
-    Then current cart order total discount should be 9.72 tax excluded
+    Then current cart order total for products should be 87.971520 tax included
+    Then current cart order total for products should be 84.588000 tax excluded
+    Then current cart order total discount should be 10.105056 tax included
+    Then current cart order total discount should be 9.716400 tax excluded
     Then current cart order shipping fees should be 7.0 tax included
     Then current cart order shipping fees should be 7.0 tax excluded


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a coupon was linked to a product, and when we add this product to an existing order, the discount calculation was bad.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13880 
| How to test?  | [Test Scenario from @khouloudbelguith](https://github.com/PrestaShop/PrestaShop/issues/13880#issuecomment-494353896)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15364)
<!-- Reviewable:end -->
