### PR TITLE
Fix breadcrumb SEO

### DIFF
--- a/themes/classic/templates/_partials/breadcrumb.tpl
+++ b/themes/classic/templates/_partials/breadcrumb.tpl
@@ -27,16 +27,16 @@
     {block name='breadcrumb'}
       {foreach from=$breadcrumb.links item=path name=breadcrumb}
         {block name='breadcrumb_item'}
-          <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-              {if not $smarty.foreach.breadcrumb.last}
-                <a itemprop="item" href="{$path.url}">
-              {/if}
-                <span itemprop="name">{$path.title}</span>
-              {if not $smarty.foreach.breadcrumb.last}
-                </a>
-              {/if}
-            <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
-          </li>
+          {if not $smarty.foreach.breadcrumb.last}
+            <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+              <a itemprop="item" href="{$path.url}"><span itemprop="name">{$path.title}</span></a>
+              <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
+            </li>
+          {else}
+            <li>
+              <span>{$path.title}</span>
+            </li>
+          {/if}
         {/block}
       {/foreach}
     {/block}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The PullRequest https://github.com/PrestaShop/PrestaShop/pull/14710 causes structured data to no longer be valid.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13083 (Already closed) & #15368 
| How to test?  | Go to any page having a breadcrumb in front office (category, product, etc), and check that the last breadcrumb element is not clickable. In addition, Check structured data with the Google tool https://search.google.com/structured-data/testing-tool

FIXED ERROR:
![image](https://user-images.githubusercontent.com/194784/64120993-ed853380-cd9d-11e9-8adb-69191d803efb.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15368)
<!-- Reviewable:end -->
