### PR TITLE
Fix duplicate retrieval of attributes color list

### DIFF
--- a/src/Adapter/Product/ProductColorsRetriever.php
+++ b/src/Adapter/Product/ProductColorsRetriever.php
@@ -40,6 +40,8 @@ class ProductColorsRetriever
      */
     public function getColoredVariants($id_product)
     {
-        return (is_array(Product::getAttributesColorList([$id_product]))) ? current(Product::getAttributesColorList([$id_product])) : null;
+        $attributesColorList = Product::getAttributesColorList([$id_product]);
+
+        return (is_array($attributesColorList)) ? current($attributesColorList) : null;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Prevent calling `Product::getAttributesColorList()` twice, which contain heavy SQL queries
| Type?         | refacto
| Category?         | CO
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15371)
<!-- Reviewable:end -->
