### PR TITLE
Remove useless and buggy identifier computation

### DIFF
--- a/src/Adapter/Routing/AdminLinkBuilder.php
+++ b/src/Adapter/Routing/AdminLinkBuilder.php
@@ -90,12 +90,13 @@ class AdminLinkBuilder implements EntityLinkBuilderInterface
      */
     private function buildActionParameters($action, $entity, array $parameters)
     {
+        unset($parameters['current_index']);
+        unset($parameters['token']);
         $editAction = $action . $entity;
-        $entityId = 'id_' . $entity;
 
         return array_merge(
             $parameters,
-            [$entityId => $parameters[$entityId], $editAction => 1]
+            [$editAction => 1]
         );
     }
 

--- a/src/Adapter/Routing/LegacyHelperLinkBuilder.php
+++ b/src/Adapter/Routing/LegacyHelperLinkBuilder.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Routing;
 
+use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Routing\EntityLinkBuilderInterface;
 
 /**
@@ -36,10 +37,19 @@ use PrestaShop\PrestaShop\Core\Routing\EntityLinkBuilderInterface;
 class LegacyHelperLinkBuilder implements EntityLinkBuilderInterface
 {
     /**
-     * {@inheritdoc}
+     * @param string $entity
+     * @param array $parameters
+     *
+     * @return string
+     *
+     * @throws InvalidArgumentException
      */
     public function getViewLink($entity, array $parameters)
     {
+        if (!isset($parameters['current_index'])) {
+            throw new InvalidArgumentException('Missing parameter current_index to build legacy link');
+        }
+
         $currentIndex = $parameters['current_index'];
         $parameters = $this->buildActionParameters('view', $entity, $parameters);
 
@@ -47,10 +57,19 @@ class LegacyHelperLinkBuilder implements EntityLinkBuilderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $entity
+     * @param array $parameters
+     *
+     * @return string
+     *
+     * @throws InvalidArgumentException
      */
     public function getEditLink($entity, array $parameters)
     {
+        if (!isset($parameters['current_index'])) {
+            throw new InvalidArgumentException('Missing parameter current_index to build legacy link');
+        }
+
         $currentIndex = $parameters['current_index'];
         $parameters = $this->buildActionParameters('update', $entity, $parameters);
 
@@ -68,10 +87,9 @@ class LegacyHelperLinkBuilder implements EntityLinkBuilderInterface
     {
         unset($parameters['current_index']);
         $viewAction = $action . $entity;
-        $entityId = 'id_' . $entity;
         $parameters = array_merge(
             $parameters,
-            [$entityId => $parameters[$entityId], $viewAction => 1]
+            [$viewAction => 1]
         );
 
         return $parameters;

--- a/tests/Unit/Adapter/Routing/AdminLinkBuilderTest.php
+++ b/tests/Unit/Adapter/Routing/AdminLinkBuilderTest.php
@@ -89,8 +89,15 @@ class AdminLinkBuilderTest extends TestCase
 
     public function testCleanTokenInLink()
     {
-        $builder = new AdminLinkBuilder($this->getLinkMock(), ['product' => 'AdminProducts', 'token' => 'toto']);
-        $editLink = $builder->getEditLink('product', ['id_product' => 42]);
+        $builder = new AdminLinkBuilder($this->getLinkMock(), ['product' => 'AdminProducts']);
+        $editLink = $builder->getEditLink('product', ['id_product' => 42, 'token' => 'toto']);
+        $this->assertEquals('?controller=AdminProducts&id_product=42&updateproduct=1', $editLink);
+    }
+
+    public function testCleanCurrentIndex()
+    {
+        $builder = new AdminLinkBuilder($this->getLinkMock(), ['product' => 'AdminProducts']);
+        $editLink = $builder->getEditLink('product', ['id_product' => 42, 'current_index' => '/admin-dev/index.php/sell/customers/?_token=mYY9DFadRSfPTsJR-XXHHMQl_MXOCTZQ8n2bVlbeUMA']);
         $this->assertEquals('?controller=AdminProducts&id_product=42&updateproduct=1', $editLink);
     }
 

--- a/tests/Unit/Adapter/Routing/LegacyHelperLinkBuilderTest.php
+++ b/tests/Unit/Adapter/Routing/LegacyHelperLinkBuilderTest.php
@@ -36,12 +36,38 @@ class LegacyHelperLinkBuilderTest extends TestCase
         $builder = new LegacyHelperLinkBuilder();
         $viewLink = $builder->getViewLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts']);
         $this->assertEquals('index.php?controller=AdminProducts&id_product=42&viewproduct=1', $viewLink);
+
+        $viewLink = $builder->getViewLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts', 'token' => 'toto']);
+        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&token=toto&viewproduct=1', $viewLink);
     }
 
     public function testBuildEditLink()
     {
         $builder = new LegacyHelperLinkBuilder();
-        $viewLink = $builder->getEditLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts']);
-        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&updateproduct=1', $viewLink);
+        $editLink = $builder->getEditLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts']);
+        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&updateproduct=1', $editLink);
+
+        $editLink = $builder->getEditLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts', 'token' => 'toto']);
+        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&token=toto&updateproduct=1', $editLink);
+    }
+
+    /**
+     * @expectedException \PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Missing parameter current_index to build legacy link
+     */
+    public function testViewLinkWithoutCurrentLinkFails()
+    {
+        $builder = new LegacyHelperLinkBuilder();
+        $builder->getViewLink('product', ['id_product' => 42]);
+    }
+
+    /**
+     * @expectedException \PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Missing parameter current_index to build legacy link
+     */
+    public function testEditLinkWithoutCurrentLinkFails()
+    {
+        $builder = new LegacyHelperLinkBuilder();
+        $builder->getEditLink('product', ['id_product' => 42]);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | The new `LegacyHelperLinkBuilder` (introduced in https://github.com/PrestaShop/PrestaShop/pull/14721) causes an error warning when the expected parameter was not present, besides this computation was useless as it expected the parameter to be present
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15333 and fixes #15318
| How to test?  | You can check the fix by using the product comments module or ps_emailsubscription module (known bugs, but probably other modules had troubles). You also need to check that the quick search is still valid

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15382)
<!-- Reviewable:end -->
