### PR TITLE
Fix bug keeping users from choosing a carrier before cart order completion

### DIFF
--- a/classes/form/CustomerAddressPersister.php
+++ b/classes/form/CustomerAddressPersister.php
@@ -65,10 +65,7 @@ class CustomerAddressPersisterCore
         $address->id_customer = $this->customer->id;
 
         if ($address->isUsed()) {
-            $old_address = new Address($address->id);
-            $address->id = $address->id_address = null;
-
-            return $address->save() && $old_address->delete();
+            return $this->updateUsedAddress($address);
         }
 
         return $address->save();
@@ -97,5 +94,29 @@ class CustomerAddressPersisterCore
         }
 
         return $ok;
+    }
+
+    /**
+     * When an address has already been used in a placed order, it is not edited directly,
+     * instead it is set to "deleted" (but kept in database) and a new address
+     * is created.
+     *
+     * @param Address $address
+     *
+     * @return bool
+     */
+    private function updateUsedAddress(Address $address)
+    {
+        $old_address = new Address($address->id);
+        $address->id = $address->id_address = null;
+
+        if ($address->save() && $old_address->delete()) {
+            // a new address was created, we must update current cart
+            $this->cart->updateAddressId($old_address->id, $address->id);
+
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
- Update current cart's id_address_devivery when the update of an address resulted in the creation of a new address (hence changing the address id)

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix bug that kept user from choosing a carrier
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9932
| How to test?  | See issue #9932, and check that you can choose a carrier once you've completed all the reproduction steps.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15399)
<!-- Reviewable:end -->
