### PR TITLE
Order payment duplicated depending on order state configuration

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -372,7 +372,7 @@ class OrderHistoryCore extends ObjectModel
 
             foreach ($invoices as $invoice) {
                 /** @var OrderInvoice $invoice */
-                if ((int)$invoice->number > 0) {
+                if ((int) $invoice->number > 0) {
                     $rest_paid = $invoice->getRestPaid();
                     if ($rest_paid > 0) {
                         $payment = new OrderPayment();

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -372,32 +372,34 @@ class OrderHistoryCore extends ObjectModel
 
             foreach ($invoices as $invoice) {
                 /** @var OrderInvoice $invoice */
-                $rest_paid = $invoice->getRestPaid();
-                if ($rest_paid > 0) {
-                    $payment = new OrderPayment();
-                    $payment->order_reference = Tools::substr($order->reference, 0, 9);
-                    $payment->id_currency = $order->id_currency;
-                    $payment->amount = $rest_paid;
+                if ((int)$invoice->number > 0) {
+                    $rest_paid = $invoice->getRestPaid();
+                    if ($rest_paid > 0) {
+                        $payment = new OrderPayment();
+                        $payment->order_reference = Tools::substr($order->reference, 0, 9);
+                        $payment->id_currency = $order->id_currency;
+                        $payment->amount = $rest_paid;
 
-                    if ($order->total_paid != 0) {
-                        $payment->payment_method = $payment_method->displayName;
-                    } else {
-                        $payment->payment_method = null;
+                        if ($order->total_paid != 0) {
+                            $payment->payment_method = $payment_method->displayName;
+                        } else {
+                            $payment->payment_method = null;
+                        }
+
+                        // Update total_paid_real value for backward compatibility reasons
+                        if ($payment->id_currency == $order->id_currency) {
+                            $order->total_paid_real += $payment->amount;
+                        } else {
+                            $order->total_paid_real += Tools::ps_round(Tools::convertPrice($payment->amount, $payment->id_currency, false), 2);
+                        }
+                        $order->save();
+
+                        $payment->conversion_rate = ($order ? $order->conversion_rate : 1);
+                        $payment->save();
+                        Db::getInstance()->execute('
+                        INSERT INTO `' . _DB_PREFIX_ . 'order_invoice_payment` (`id_order_invoice`, `id_order_payment`, `id_order`)
+                        VALUES(' . (int) $invoice->id . ', ' . (int) $payment->id . ', ' . (int) $order->id . ')');
                     }
-
-                    // Update total_paid_real value for backward compatibility reasons
-                    if ($payment->id_currency == $order->id_currency) {
-                        $order->total_paid_real += $payment->amount;
-                    } else {
-                        $order->total_paid_real += Tools::ps_round(Tools::convertPrice($payment->amount, $payment->id_currency, false), 2);
-                    }
-                    $order->save();
-
-                    $payment->conversion_rate = ($order ? $order->conversion_rate : 1);
-                    $payment->save();
-                    Db::getInstance()->execute('
-                    INSERT INTO `' . _DB_PREFIX_ . 'order_invoice_payment` (`id_order_invoice`, `id_order_payment`, `id_order`)
-                    VALUES(' . (int) $invoice->id . ', ' . (int) $payment->id . ', ' . (int) $order->id . ')');
                 }
             }
         }

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -79,7 +79,7 @@ class OrderHistoryCore extends ObjectModel
      * @param int/object $id_order
      * @param bool $use_existing_payment
      */
-    public function changeIdOrderState($new_order_state, $id_order, $use_existing_payment = false)
+    public function changeIdOrderState($new_order_state, $id_order, $use_existing_payment = true)
     {
         if (!$new_order_state || !$id_order) {
             return;
@@ -372,9 +372,6 @@ class OrderHistoryCore extends ObjectModel
 
             foreach ($invoices as $invoice) {
                 /** @var OrderInvoice $invoice */
-                if (0 == (int) $invoice->number) {
-                    continue;
-                }
                 $rest_paid = $invoice->getRestPaid();
                 if ($rest_paid > 0) {
                     $payment = new OrderPayment();


### PR DESCRIPTION
Only add a new payment if it is a real invoice and missing payment info.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Bug fix for #12588
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |Fixes #12588
| How to test?  | See details under the ticket.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15322)
<!-- Reviewable:end -->
