### PR TITLE
Add check for required fields in BO > Country > Address format

### DIFF
--- a/admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl
@@ -32,7 +32,7 @@
 					<textarea id="ordered_fields" name="address_layout" style="height:150px;">{$input.address_layout}</textarea>
 				</div>
 				<div class="col-lg-8">
-					{l s='Required fields for the address (click for more details):' d='Admin.International.Feature'}
+					{l s='Some countries require different elements than others. Click on the button below to get the valid default address format for this country.' d='Admin.International.Feature'}
 					{$input.display_valid_fields}
 				</div>
 			</div>

--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressException;
 
 /**
  * Class AddressFormatCore.
@@ -263,11 +264,13 @@ class AddressFormatCore extends ObjectModel
     /**
      * Given a field name, get the name of the tab in which the field name can be found.
      * For ex: Country:name => the tab is 'Country'.
-     * There should be only one separator in the string, otherwise return false.
+     * There should be only one separator in the string, otherwise throw an exception.
      *
      * @param string $field
      *
      * @return bool|string
+     *
+     * @throws AddressException
      */
     private function getFieldTabName($field)
     {
@@ -282,7 +285,7 @@ class AddressFormatCore extends ObjectModel
             return $fieldTab[0];
         }
 
-        return false;
+        throw new AddressException('Address format field is not valid');
     }
 
     /**

--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -253,7 +253,7 @@ class AddressFormatCore extends ObjectModel
         foreach (self::getFieldsRequired() as $requiredField) {
             if (!in_array($requiredField, $fieldList)) {
                 $this->_errorFormatList[] = $this->trans(
-                    'The field %s is required (in the "%s" tab).',
+                    'The field %s is required (in the %s tab).',
                     array($requiredField, $this->getFieldTabName($requiredField)),
                     'Admin.Notifications.Error');
             }

--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -253,7 +253,7 @@ class AddressFormatCore extends ObjectModel
         foreach (self::getFieldsRequired() as $requiredField) {
             if (!in_array($requiredField, $fieldList)) {
                 $this->_errorFormatList[] = $this->trans(
-                    'The field %s is required (in the %s tab).',
+                    'The %s field (in tab %s) is required.',
                     array($requiredField, $this->getFieldTabName($requiredField)),
                     'Admin.Notifications.Error');
             }

--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -252,9 +252,37 @@ class AddressFormatCore extends ObjectModel
     {
         foreach (self::getFieldsRequired() as $requiredField) {
             if (!in_array($requiredField, $fieldList)) {
-                $this->_errorFormatList[] = $this->trans('The field %s is required.', array($requiredField), 'Admin.Notifications.Error');
+                $this->_errorFormatList[] = $this->trans(
+                    'The field %s is required (in the "%s" tab).',
+                    array($requiredField, $this->getFieldTabName($requiredField)),
+                    'Admin.Notifications.Error');
             }
         }
+    }
+
+    /**
+     * Given a field name, get the name of the tab in which the field name can be found.
+     * For ex: Country:name => the tab is 'Country'.
+     * There should be only one separator in the string, otherwise return false.
+     *
+     * @param string $field
+     *
+     * @return bool|string
+     */
+    private function getFieldTabName($field)
+    {
+        if (strpos($field, ':') === false) {
+            // When there is no ':' separator, the field is in the Address tab
+            return 'Address';
+        }
+
+        $fieldTab = explode(':', $field);
+        if (count($fieldTab) === 2) {
+            // The part preceding the ':' separator is the name of the tab in which there is the required field
+            return $fieldTab[0];
+        }
+
+        return false;
     }
 
     /**

--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -236,9 +236,25 @@ class AddressFormatCore extends ObjectModel
                     }
                 }
             }
+            $this->checkRequiredFields($usedKeyList);
         }
 
         return (count($this->_errorFormatList)) ? false : true;
+    }
+
+    /**
+     * Checks that all required fields exist in a given fields list.
+     * Fills _errorFormatList array in case of absence of a required field.
+     *
+     * @param array $fieldList
+     */
+    protected function checkRequiredFields($fieldList)
+    {
+        foreach (self::getFieldsRequired() as $requiredField) {
+            if (!in_array($requiredField, $fieldList)) {
+                $this->_errorFormatList[] = $this->trans('The field %s is required.', array($requiredField), 'Admin.Notifications.Error');
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When editing the address format for a country, check that all required address fields are present. This prevents the address form in the frontend from throwing an exception because of missing required fields. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9812
| How to test?  | In BO > International > Zones geo > Country, change address format, remove a required field (for ex: firstname, lastname, or Country:name), you should see an error message stating that this field is required.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15428)
<!-- Reviewable:end -->
