### PR TITLE
Re-enable port in shop domains

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -334,15 +334,13 @@ class ShopCore extends ObjectModel
             $host = Tools::getHttpHost(false, false, true);
             $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
 
-            $sql = 'SELECT s.id_shop, CONCAT(su.physical_uri, su.virtual_uri) AS uri, su.domain, su.main
-                    FROM ' . _DB_PREFIX_ . 'shop_url su
-                    LEFT JOIN ' . _DB_PREFIX_ . 'shop s ON (s.id_shop = su.id_shop)
-                    WHERE (su.domain = \'' . pSQL($host) . '\' OR su.domain_ssl = \'' . pSQL($host) . '\')
-                        AND s.active = 1
-                        AND s.deleted = 0
-                    ORDER BY LENGTH(CONCAT(su.physical_uri, su.virtual_uri)) DESC';
+            $result = self::findShopByHost($host);
 
-            $result = Db::getInstance()->executeS($sql);
+            // If could not find a matching, try with port
+            if (empty($result)) {
+                $host = Tools::getHttpHost(false, false, false);
+                $result = self::findShopByHost($host);
+            }
 
             $through = false;
             foreach ($result as $row) {
@@ -1321,5 +1319,27 @@ class ShopCore extends ObjectModel
             ($active ? ' AND entity.`active` = 1' : '') .
             ($delete ? ' AND entity.deleted = 0' : '')
         );
+    }
+
+    /**
+     * @param string $host
+     *
+     * @return array
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    private static function findShopByHost($host)
+    {
+        $sql = 'SELECT s.id_shop, CONCAT(su.physical_uri, su.virtual_uri) AS uri, su.domain, su.main
+                    FROM ' . _DB_PREFIX_ . 'shop_url su
+                    LEFT JOIN ' . _DB_PREFIX_ . 'shop s ON (s.id_shop = su.id_shop)
+                    WHERE (su.domain = \'' . pSQL($host) . '\' OR su.domain_ssl = \'' . pSQL($host) . '\')
+                        AND s.active = 1
+                        AND s.deleted = 0
+                    ORDER BY LENGTH(CONCAT(su.physical_uri, su.virtual_uri)) DESC';
+
+        $result = Db::getInstance()->executeS($sql);
+
+        return $result;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since https://github.com/PrestaShop/PrestaShop/pull/14089 was merged, you cannot use `mysite:myportnumber` (with a not-default port number) as a domain name although this can be useful. This PR re-enabled this as a fallback. The fact it is used as a fallback should make sure https://github.com/PrestaShop/PrestaShop/pull/14089 bugfix is still valid.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Install a shop using a not-standard port such as 8888 (default MAMP port) (so your domain should be `localhost:8888` and try to install and reach the FO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15446)
<!-- Reviewable:end -->
