### PR TITLE
Apply free delivery voucher on Delievry step

### DIFF
--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2018 PrestaShop
+ * 2007-2019 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -16,15 +16,13 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to http://www.prestashop.com for more information.
+ * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2018 PrestaShop SA
+ * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
-
 use Symfony\Component\Translation\TranslatorInterface;
 
 class CheckoutAddressesStepCore extends AbstractCheckoutStep
@@ -69,27 +67,8 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
         if (array_key_exists('use_same_address', $requestParams)) {
             $this->use_same_address = (bool) $requestParams['use_same_address'];
             if (!$this->use_same_address) {
-                $this->step_is_current = true;
-            }
-        }
-
-        if (isset($requestParams['id_address_delivery'])) {
-            $id_address = $requestParams['id_address_delivery'];
-
-            if ($this->getCheckoutSession()->getIdAddressDelivery() != $id_address) {
                 $this->setCurrent(true);
-                $this->getCheckoutProcess()->invalidateAllStepsAfterCurrent();
             }
-
-            $this->getCheckoutSession()->setIdAddressDelivery($id_address);
-            if ($this->use_same_address) {
-                $this->getCheckoutSession()->setIdAddressInvoice($id_address);
-            }
-        }
-
-        if (isset($requestParams['id_address_invoice'])) {
-            $id_address = $requestParams['id_address_invoice'];
-            $this->getCheckoutSession()->setIdAddressInvoice($id_address);
         }
 
         if (isset($requestParams['cancelAddress'])) {
@@ -98,7 +77,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
                     $this->use_same_address = true;
                 }
             }
-            $this->step_is_current = true;
+            $this->setCurrent(true);
         }
 
         // Can't really hurt to set the firstname and lastname.
@@ -110,7 +89,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
         if (isset($requestParams['saveAddress'])) {
             $saved = $this->addressForm->fillWith($requestParams)->submit();
             if (!$saved) {
-                $this->step_is_current = true;
+                $this->setCurrent(true);
                 $this->getCheckoutProcess()->setHasErrors(true);
                 if ($requestParams['saveAddress'] === 'delivery') {
                     $this->show_delivery_address_form = true;
@@ -133,7 +112,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             }
         } elseif (isset($requestParams['newAddress'])) {
             // while a form is open, do not go to next step
-            $this->step_is_current = true;
+            $this->setCurrent(true);
             if ($requestParams['newAddress'] === 'delivery') {
                 $this->show_delivery_address_form = true;
             } else {
@@ -143,7 +122,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             $this->form_has_continue_button = $this->use_same_address;
         } elseif (isset($requestParams['editAddress'])) {
             // while a form is open, do not go to next step
-            $this->step_is_current = true;
+            $this->setCurrent(true);
             if ($requestParams['editAddress'] === 'delivery') {
                 $this->show_delivery_address_form = true;
             } else {
@@ -157,7 +136,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
                 Tools::getToken(true, $this->context)
             );
 
-            $deletionResult = (bool)$addressPersister->delete(
+            $deletionResult = (bool) $addressPersister->delete(
                 new Address((int) Tools::getValue('id_address'), $this->context->language->id),
                 Tools::getValue('token')
             );
@@ -180,11 +159,41 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             }
         }
 
-        if (!$this->step_is_complete) {
-            $this->step_is_complete = isset($requestParams['confirm-addresses']) &&
-                $this->getCheckoutSession()->getIdAddressInvoice() &&
-                $this->getCheckoutSession()->getIdAddressDelivery()
-            ;
+        if (isset($requestParams['confirm-addresses'])) {
+            if (isset($requestParams['id_address_delivery'])) {
+                $id_address = $requestParams['id_address_delivery'];
+
+                if (!Customer::customerHasAddress($this->getCheckoutSession()->getCustomer()->id, $id_address)) {
+                    $this->getCheckoutProcess()->setHasErrors(true);
+                } else {
+                    if ($this->getCheckoutSession()->getIdAddressDelivery() != $id_address) {
+                        $this->setCurrent(true);
+                        $this->getCheckoutProcess()->invalidateAllStepsAfterCurrent();
+                    }
+
+                    $this->getCheckoutSession()->setIdAddressDelivery($id_address);
+                    if ($this->use_same_address) {
+                        $this->getCheckoutSession()->setIdAddressInvoice($id_address);
+                    }
+                }
+            }
+
+            if (isset($requestParams['id_address_invoice'])) {
+                $id_address = $requestParams['id_address_invoice'];
+                if (!Customer::customerHasAddress($this->getCheckoutSession()->getCustomer()->id, $id_address)) {
+                    $this->getCheckoutProcess()->setHasErrors(true);
+                } else {
+                    $this->getCheckoutSession()->setIdAddressInvoice($id_address);
+                }
+            }
+
+            if (!$this->getCheckoutProcess()->hasErrors()) {
+                $this->setNextStepAsCurrent();
+                $this->setComplete(
+                    $this->getCheckoutSession()->getIdAddressInvoice() &&
+                    $this->getCheckoutSession()->getIdAddressDelivery()
+                );
+            }
         }
 
         $addresses_count = $this->getCheckoutSession()->getCustomerAddressesCount();
@@ -193,7 +202,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             $this->show_delivery_address_form = true;
         } elseif ($addresses_count < 2 && !$this->use_same_address) {
             $this->show_invoice_address_form = true;
-            $this->step_is_complete = false;
+            $this->setComplete(false);
         }
 
         if ($this->show_invoice_address_form) {
@@ -214,41 +223,41 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
 
     public function getTemplateParameters()
     {
-        $idAddressDelivery = (int)$this->getCheckoutSession()->getIdAddressDelivery();
-        $idAddressInvoice  = (int)$this->getCheckoutSession()->getIdAddressInvoice();
+        $idAddressDelivery = (int) $this->getCheckoutSession()->getIdAddressDelivery();
+        $idAddressInvoice = (int) $this->getCheckoutSession()->getIdAddressInvoice();
         $params = array(
-            'address_form'               => $this->addressForm->getProxy(),
-            'use_same_address'           => $this->use_same_address,
-            'use_different_address_url'  => $this->context->link->getPageLink(
+            'address_form' => $this->addressForm->getProxy(),
+            'use_same_address' => $this->use_same_address,
+            'use_different_address_url' => $this->context->link->getPageLink(
                 'order',
                 true,
                 null,
                 array('use_same_address' => 0)
             ),
-            'new_address_delivery_url'   => $this->context->link->getPageLink(
+            'new_address_delivery_url' => $this->context->link->getPageLink(
                 'order',
                 true,
                 null,
                 array('newAddress' => 'delivery')
             ),
-            'new_address_invoice_url'    => $this->context->link->getPageLink(
+            'new_address_invoice_url' => $this->context->link->getPageLink(
                 'order',
                 true,
                 null,
                 array('newAddress' => 'invoice')
             ),
-            'id_address_delivery'        => $idAddressDelivery,
-            'id_address_invoice'         => $idAddressInvoice,
+            'id_address_delivery' => $idAddressDelivery,
+            'id_address_invoice' => $idAddressInvoice,
             'show_delivery_address_form' => $this->show_delivery_address_form,
-            'show_invoice_address_form'  => $this->show_invoice_address_form,
-            'form_has_continue_button'   => $this->form_has_continue_button,
+            'show_invoice_address_form' => $this->show_invoice_address_form,
+            'form_has_continue_button' => $this->form_has_continue_button,
         );
 
         /** @var OrderControllerCore $controller */
         $controller = $this->context->controller;
         if (isset($controller)) {
-            $warnings         = $controller->checkoutWarning;
-            $addressWarning   = isset($warnings['address'])
+            $warnings = $controller->checkoutWarning;
+            $addressWarning = isset($warnings['address'])
                 ? $warnings['address']
                 : false;
             $invalidAddresses = isset($warnings['invalid_addresses'])
@@ -275,8 +284,8 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             $params = array_replace(
                 $params,
                 array(
-                    'not_valid_addresses' => implode(",", $invalidAddresses),
-                    'use_same_address'    => $this->use_same_address,
+                    'not_valid_addresses' => implode(',', $invalidAddresses),
+                    'use_same_address' => $this->use_same_address,
                 ),
                 $errors
             );
@@ -292,5 +301,20 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             $extraParams,
             $this->getTemplateParameters()
         );
+    }
+    
+    public function setComplete($step_is_complete)
+    {
+        if ($step_is_complete && $this->context->cart->id_carrier==0) {
+            $deliveryOptionSelected = $this->getCheckoutSession()->getSelectedDeliveryOption();
+            $id_address = $this->context->cart->id_address_delivery;
+
+            if ($deliveryOptionSelected) {
+                $this->getCheckoutSession()->setDeliveryOption(array(
+                    $id_address => $deliveryOptionSelected,
+                ));
+            }
+        }
+        return parent::setComplete($step_is_complete);
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x 
| Description?  | Free delivery voucher is applied only after CheckoutDeliveryStep or after customer click other but default carrier on this step. 
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15458
| How to test?  | Create two or more carriers. Create a voucher with free shipping option and select one of those carriers in the voucher settings. So this voucher should affect only one of those carriers. Create an order in FO, proccess it to the step Address, select Address, go to the next step. You expect to see that selected in voucher settings carrier is free and expect to appear the discount in the cart. It will happend if select other carrier and select the desired carrier agian or to proccess to the next step.
 
This is besause the carrier ID is not yet set. So I set the default carrier ID to cart right after the address step is complete.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15457)
<!-- Reviewable:end -->
