### PR TITLE
[WIP] Disable cache to fix bad delivery options computation

### DIFF
--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -72,7 +72,7 @@ class DeliveryOptionsFinderCore
 
     public function getDeliveryOptions()
     {
-        $delivery_option_list = $this->context->cart->getDeliveryOptionList();
+        $delivery_option_list = $this->context->cart->getDeliveryOptionList(null, true);
         $include_taxes = !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer) && (int) Configuration::get('PS_TAX');
         $display_taxes_label = (Configuration::get('PS_TAX') && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'));
 

--- a/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
@@ -40,14 +40,30 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
     protected $cart;
 
     /**
+     * @Then there is no delivery options available for my cart
+     */
+    public function noDeliveryOptions()
+    {
+        if ($this->getCurrentCart() === null) {
+            throw new \RuntimeException('No current cart, cannot check available delivery options');
+        }
+
+        $deliveryOptions = $this->getCurrentCart()->getDeliveryOptionList();
+
+        if (!empty($deliveryOptions)) {
+            throw new \RuntimeException('Expected no available delivery options, but there are some !');
+        }
+    }
+
+    /**
      * @Given /^I have an empty default cart$/
      */
     public function iHaveAnEmptyDefaultCart()
     {
         $cart = new CartOld();
-        $cart->id_lang = (int) Context::getContext()->language->id;
-        $cart->id_currency = (int) Context::getContext()->currency->id;
-        $cart->id_shop = (int) Context::getContext()->shop->id;
+        $cart->id_lang = (int)Context::getContext()->language->id;
+        $cart->id_currency = (int)Context::getContext()->currency->id;
+        $cart->id_shop = (int)Context::getContext()->shop->id;
         $cart->add(); // required, else we cannot get the content when calculating total
         Context::getContext()->cart = $cart;
     }
@@ -139,7 +155,7 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
     protected function expectsTotal($expectedTotal, $method, $withTax = true, $precisely = false)
     {
         $cart = $this->getCurrentCart();
-        $carrierId = (int) $cart->id_carrier <= 0 ? null : $cart->id_carrier;
+        $carrierId = (int)$cart->id_carrier <= 0 ? null : $cart->id_carrier;
         if ($method == 'v1') {
             $total = $cart->getOrderTotalV1($withTax, Cart::BOTH, null, $carrierId);
         } else {

--- a/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
@@ -42,16 +42,32 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
     /**
      * @Then there is no delivery options available for my cart
      */
-    public function noDeliveryOptions()
+    public function noDeliveryOptionsAvailable()
     {
         if ($this->getCurrentCart() === null) {
             throw new \RuntimeException('No current cart, cannot check available delivery options');
         }
 
-        $deliveryOptions = $this->getCurrentCart()->getDeliveryOptionList();
+        $deliveryOptions = $this->getCurrentCart()->getDeliveryOptionList(null, true);
 
         if (!empty($deliveryOptions)) {
             throw new \RuntimeException('Expected no available delivery options, but there are some !');
+        }
+    }
+
+    /**
+     * @Then there is delivery options available for my cart
+     */
+    public function deliveryOptionsAvailable()
+    {
+        if ($this->getCurrentCart() === null) {
+            throw new \RuntimeException('No current cart, cannot check available delivery options');
+        }
+
+        $deliveryOptions = $this->getCurrentCart()->getDeliveryOptionList(null, true);
+
+        if (empty($deliveryOptions)) {
+            throw new \RuntimeException('Expected no available delivery options, but there are none !');
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -174,6 +174,26 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^cart rule "(.+)" is disabled$/
+     */
+    public function cartRuleIsDisabled($cartRuleName)
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->cartRules[$cartRuleName]->active = 0;
+        $this->cartRules[$cartRuleName]->save();
+    }
+
+    /**
+     * @When /^I enable cart rule "(.+)"$/
+     */
+    public function enableCartRule($cartRuleName)
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->cartRules[$cartRuleName]->active = 1;
+        $this->cartRules[$cartRuleName]->save();
+    }
+
+    /**
      * @Given /^cart rule "(.+)" does not apply to already discounted products$/
      */
     public function cartRuleDoesNotApplyToDiscountedProduct($cartRuleName)

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -175,8 +175,9 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
 
     /**
      * @Given /^cart rule "(.+)" is disabled$/
+     * @When /^I disable cart rule "(.+)"$/
      */
-    public function cartRuleIsDisabled($cartRuleName)
+    public function disableCartRule($cartRuleName)
     {
         $this->checkCartRuleWithNameExists($cartRuleName);
         $this->cartRules[$cartRuleName]->active = 0;
@@ -184,6 +185,7 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^cart rule "(.+)" is enabled$/
      * @When /^I enable cart rule "(.+)"$/
      */
     public function enableCartRule($cartRuleName)

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
@@ -1,0 +1,42 @@
+@reset-database-before-feature
+Feature: Compute correct delivery options
+  As a customer
+  I should be provided relevant delivery options depending on my cart content and my customer profile
+
+  Scenario: Use 2 carts rules, 1 free-shipping and one global, no carriers are available
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    # Create free shipping cart rule
+    Given there is a cart rule named "free_shipping_1" that applies no discount with priority 1, quantity of 1000 and quantity per user 1000
+    Given cart rule "free_shipping_1" offers free shipping
+    Given cart rule "free_shipping_1" has a discount code "djbuch-12878"
+    # Standard cart rule, disabled
+    Given there is a cart rule named "bad_cart_rule" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
+    Given cart rule "bad_cart_rule" is disabled
+    # Standard location settings
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    # One standard carrier
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    # Checkout begins
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    # Use discount code
+    When I use the discount "free_shipping_1"
+    When I select address "address1" in my cart
+    # Enables standard cart rule
+    When I enable cart rule "bad_cart_rule"
+    When I select carrier "carrier1" in my cart
+    # Bad result T_T
+    Then there is no delivery options available for my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
@@ -34,9 +34,6 @@ Feature: Compute correct delivery options
     When I add 1 items of product "product1" in my cart
     # Use discount code
     When I use the discount "free_shipping_1"
-    When I select address "address1" in my cart
     # Enables standard cart rule
     When I enable cart rule "bad_cart_rule"
-    When I select carrier "carrier1" in my cart
-    # Bad result T_T
-    Then there is no delivery options available for my cart
+    Then there is delivery options available for my cart


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | It seems https://github.com/PrestaShop/PrestaShop/issues/11172 was due to bad static cache computation https://github.com/PrestaShop/PrestaShop/blob/develop/classes/Cart.php#L2617
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/11172
| How to test?  | Please check ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15472)
<!-- Reviewable:end -->
