### PR TITLE
Set InnoDB as Default Engine on checkCreatePrivilege when installing PrestaShop

### DIFF
--- a/src/PrestaShopBundle/Install/Database.php
+++ b/src/PrestaShopBundle/Install/Database.php
@@ -72,12 +72,11 @@ class Database extends AbstractInstall
                     if (!Db::checkEncoding($server, $login, $password)) {
                         $errors[] = $this->translator->trans('Cannot convert database data to utf-8', [], 'Install') . $dbtype;
                     }
-
                     // Check if a table with same prefix already exists
                     if (!$clear && Db::hasTableWithSamePrefix($server, $login, $password, $database, $prefix)) {
                         $errors[] = $this->translator->trans('At least one table with same prefix was already found, please change your prefix or drop your database', [], 'Install');
                     }
-                    if (($create_error = Db::checkCreatePrivilege($server, $login, $password, $database, $prefix)) !== true) {
+                    if (($create_error = Db::checkCreatePrivilege($server, $login, $password, $database, $prefix, $this->getBestEngine($server, $database, $login, $password))) !== true) {
                         $errors[] = $this->translator->trans('Your database login does not have the privileges to create table on the database "%s". Ask your hosting provider:', ['%database%' => $database], 'Install');
                         if ($create_error != false) {
                             $errors[] = $create_error;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | InnoDB is the only supported engine for Second Generation instances on the Google Cloud Platform because it is more resistant to table corruption than other MySQL storage engines, such as MyISAM. At the moment the installation causes an error not allowing GCP users to install PrestaShop on the GCP SQL instances without getting too technical.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | 
| How to test?  | Install PrestaShop on a SQL server with only InnoDB available.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15493)
<!-- Reviewable:end -->
