### PR TITLE
Update rtlfix to make BO category tree icons flip

### DIFF
--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -1,54 +1,57 @@
 .sidebar.sidebar-right {
-  -webkit-transform: translate(-100%, 0);
-  -moz-transform: translate(-100%, 0);
-  -ms-transform: translate(-100%, 0);
-  -o-transform: translate(-100%, 0);
-  transform: translate(-100%, 0);
+    -webkit-transform: translate(-100%, 0);
+    -moz-transform: translate(-100%, 0);
+    -ms-transform: translate(-100%, 0);
+    -o-transform: translate(-100%, 0);
+    transform: translate(-100%, 0);
 }
 
 /* fix logo position */
 .main-header > .logo {
-  background-position: right;
+    background-position: right;
 }
 
 /* fix profile menu position */
 .employee-dropdown .dropdown-menu {
-  right: auto !important;
-  left: .3em !important;
+    right: auto !important;
+    left: .3em !important;
 }
 
 /* fix select dropdown */
 .select2-container--open .select2-dropdown {
-  right: auto;
-  left: 0;
+    right: auto;
+    left: 0;
 }
 
 /* fix notification dropdown */
 .notification-center .dropdown-menu {
-  right: auto;
-  left: 85px !important;
+    right: auto;
+    left: 85px !important;
 }
 
 /* fix popover */
 .popover {
-  right: auto;
-  left: 5px;
-  margin-right: 0;
-  margin-left: 8px;
+    right: auto;
+    left: 5px;
+    margin-right: 0;
+    margin-left: 8px;
 }
 .popover .arrow {
-  left: -8px;
-  right: auto;
-  transform: scaleX(-1);
+    left: -8px;
+    right: auto;
+    transform: scaleX(-1);
 }
 
 /* fix stock quantity arrow direction */
 .stock-app .stock-overview .table .qty-update .material-icons {
-  transform: scaleX(-1);
+    transform: scaleX(-1);
 }
 
 /* Fixes image flipping for RTL language */
 .img-rtl {
-  -webkit-transform: scaleX(-1);
-  transform: scaleX(-1);
+    -webkit-transform: scaleX(-1);
+    transform: scaleX(-1);
+}
+.material-choice-tree-container ul.choice-tree .collapsed>.checkbox:before, .material-choice-tree-container ul.choice-tree .collapsed>.radio:before {
+    content: "\E5CB";
 }


### PR DESCRIPTION
Change content: "\E5CC"; to content: "\E5CB"; to make category tree icons flip horizontally on BO

<!--
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows with the necessary information.

                                           Check out our contribution guidelines to find out how to complete it:
                                           https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
-->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Update PrestaShop BO New theme RTLFIX file.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | (optional) If this PR fixes an [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Delete old .rtlfix file from admin-dev/themes/default/public/ directory and regenerate RTL styles from BO.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15497)
<!-- Reviewable:end -->
