### PR TITLE
Make sure the keys used for translation are case sensitive

### DIFF
--- a/src/PrestaShopBundle/Entity/Translation.php
+++ b/src/PrestaShopBundle/Entity/Translation.php
@@ -60,7 +60,7 @@ class Translation
     /**
      * @var string
      *
-     * @ORM\Column(name="`key`", type="text", length=65500)
+     * @ORM\Column(name="`key`", type="binary", length=65500)
      */
     private $key;
 

--- a/src/PrestaShopBundle/Entity/Translation.php
+++ b/src/PrestaShopBundle/Entity/Translation.php
@@ -60,7 +60,7 @@ class Translation
     /**
      * @var string
      *
-     * @ORM\Column(name="`key`", type="binary", length=8000)
+     * @ORM\Column(name="`key`", type="text", length=8000, options={"collation":"utf8_bin"})
      */
     private $key;
 

--- a/src/PrestaShopBundle/Entity/Translation.php
+++ b/src/PrestaShopBundle/Entity/Translation.php
@@ -60,7 +60,7 @@ class Translation
     /**
      * @var string
      *
-     * @ORM\Column(name="`key`", type="binary", length=65500)
+     * @ORM\Column(name="`key`", type="binary", length=8000)
      */
     private $key;
 


### PR DESCRIPTION
This allows to handle "Order" & "order" keys properly for example

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | International / Translation BO is not able to properly update translation keys with the same name, but different case
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #15510 / #10701 
| How to test?  | See the related ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15511)
<!-- Reviewable:end -->
