### PR TITLE
SqlTranslator must throw a NotFoundResourceException

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -12,8 +12,7 @@ use Symfony\Component\Debug\Debug;
 
 set_time_limit(0);
 
-require __DIR__.'/../vendor/autoload.php';
-require_once __DIR__.'/../autoload.php';
+require_once __DIR__ . '/../config/config.inc.php';
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');

--- a/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
@@ -28,11 +28,11 @@
 namespace PrestaShopBundle\Translation\Loader;
 
 use Db;
-use Exception;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
 
 class SqlTranslationLoader implements LoaderInterface
 {
@@ -71,7 +71,7 @@ class SqlTranslationLoader implements LoaderInterface
         }
 
         if (empty($localeResults[$locale])) {
-            throw new Exception(sprintf('Language not found in database: %s', $locale));
+            throw new NotFoundResourceException(sprintf('Language not found in database: %s', $locale));
         }
 
         $selectTranslationsQuery = '


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | The throwing exception isn't the good one if we check the documentation: https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Translation/Loader/LoaderInterface.php#L34<br>In case another exception is thrown, it crashs the application, whereas with the NotFoundResourceException, it's properly catch and the Translator knows what to do.<br>Missing const in console mode (DB_SERVER, DB_USER, etc), the config.inc.php must be included in console context.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15324 
| How to test?  | `./bin/console cache:warmup --env=prod` must work

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15515)
<!-- Reviewable:end -->
