### PR TITLE
Do not allow to put item in cart if available quantity is 0

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -587,7 +587,7 @@ class CartControllerCore extends FrontController
             $this->customization_id
         );
 
-        return $productQuantity < 0;
+        return $productQuantity <= 0;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If available quantity is 0, do not add cart to product
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13374
| How to test?  | See ticket, be careful about different "out of stock" behaviors (see screenshot below)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15517)
<!-- Reviewable:end -->
