### PR TITLE
Disable old selenium tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ matrix:
   include:
     - php: 7.2
       env: EXTRA_DEPS=phpHigh  PRESTASHOP_TEST_TYPE=unit
-    - php: 7.2
-      env: PRESTASHOP_TEST_TYPE=e2e EXTRA_TESTS=functional
     - stage: deploy
       php: 7.2
       before_install: skip
@@ -56,7 +54,7 @@ matrix:
         on:
           all_branches: true
   exclude:
-    - php: 7.2 # Replaced with additional tests
+    - php: 5.6 # Only run e2e on php 7.2
       env: PRESTASHOP_TEST_TYPE=e2e
   allow_failures:
     - php: 7.2

--- a/tests/check_e2e.sh
+++ b/tests/check_e2e.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
-bash travis-scripts/run-selenium-tests;
-SELENIUM=$?
-
-# run-functional-tests must run before starter theme
 bash travis-scripts/run-functional-tests;
 FUNCTIONAL=$?
 
-if [[ "$SELENIUM" == "0" && "$FUNCTIONAL" == "0" ]]; then
+if [[ "$FUNCTIONAL" == "0" ]]; then
   echo -e "\e[92mE2E TESTS OK"
   exit 0;
 else

--- a/travis-scripts/run-functional-tests
+++ b/travis-scripts/run-functional-tests
@@ -4,13 +4,24 @@ PROJECT_PATH=$(cd "$( dirname "$0" )/../" && pwd)
 
 bash $PROJECT_PATH/travis-scripts/install-prestashop
 
-echo "* Installing functional tests ...";
+echo "* Installing functional tests...";
 
-cd $PROJECT_PATH/tests/E2E && npm install
+pushd $PROJECT_PATH/tests/E2E
+npm install --silent
 
-echo "* Running functional tests ...";
+echo "* Preparing environment...";
 
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_10.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :10 -ac -screen 0 1600x1200x16
 
+DISPLAY=:10 npm start-selenium &> /dev/null &
+
+sleep 5
+
+echo "* Running functional tests ...";
+
 npm test -- --MODULE=ps_legalcompliance
-exit $?
+status=$?
+
+popd
+
+exit $status

--- a/travis-scripts/run-functional-tests
+++ b/travis-scripts/run-functional-tests
@@ -9,5 +9,8 @@ echo "* Installing functional tests ...";
 cd $PROJECT_PATH/tests/E2E && npm install
 
 echo "* Running functional tests ...";
+
+/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_10.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :10 -ac -screen 0 1600x1200x16
+
 npm test -- --MODULE=ps_legalcompliance
 exit $?

--- a/travis-scripts/run-functional-tests
+++ b/travis-scripts/run-functional-tests
@@ -22,6 +22,7 @@ echo "* Running functional tests ...";
 npm test --verbose -- --MODULE=ps_legalcompliance
 status=$?
 
+
 popd
 
 exit $status

--- a/travis-scripts/run-functional-tests
+++ b/travis-scripts/run-functional-tests
@@ -2,10 +2,6 @@
 
 PROJECT_PATH=$(cd "$( dirname "$0" )/../" && pwd)
 
-if [[ $EXTRA_TESTS != *"functional"* ]]; then
-  exit 0
-fi
-
 bash $PROJECT_PATH/travis-scripts/install-prestashop
 
 echo "* Installing functional tests ...";

--- a/travis-scripts/run-functional-tests
+++ b/travis-scripts/run-functional-tests
@@ -19,7 +19,7 @@ sleep 5
 
 echo "* Running functional tests ...";
 
-npm test -- --MODULE=ps_legalcompliance
+npm test --verbose -- --MODULE=ps_legalcompliance
 status=$?
 
 popd


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Disable old selenium tests that are always failing and will be removed anyway
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Tests should be green

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15530)
<!-- Reviewable:end -->
