### PR TITLE
Disallow showing bad cart to FO user

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3999,6 +3999,7 @@ class CartCore extends ObjectModel
                 WHERE NOT EXISTS (SELECT 1 FROM ' . _DB_PREFIX_ . 'orders o WHERE o.`id_cart` = c.`id_cart`
                                     AND o.`id_customer` = ' . (int) $id_customer . ')
                 AND c.`id_customer` = ' . (int) $id_customer . '
+                AND c.`id_guest` != 0
                     ' . Shop::addSqlRestriction(Shop::SHARE_ORDER, 'c') . '
                 ORDER BY c.`date_upd` DESC';
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When "add a product to order" is used from the BO (on order page), a fake Cart is generated, probably because of https://github.com/PrestaShop/PrestaShop/issues/14131. This PR avoids the FO user to be mistakenly showed this cart when "Re-display cart at login" option is enabled. It's a port of 1.6 PR https://github.com/PrestaShop/PrestaShop/pull/8315
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/15521
| How to test?  | See ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15533)
<!-- Reviewable:end -->
