### PR TITLE
Show value for free delivery voucher instead of empty percents

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -496,17 +496,18 @@ class CartPresenter implements PresenterInterface
                 $cartVoucher['reduction_amount'] = $cartVoucher['reduction_amount'] * (1 + $cartHasTax / 100);
             }
 
-            $vouchers[$cartVoucher['id_cart_rule']]['reduction_amount'] = $cartVoucher['reduction_amount'];
-
             if ((array_key_exists('gift_product', $cartVoucher) && $cartVoucher['gift_product']) ||
                     $cartVoucher['free_shipping']) {
                 $cartVoucher['reduction_amount'] = $cartVoucher['value_real'];
             }
+            
+            $vouchers[$cartVoucher['id_cart_rule']]['reduction_amount'] = $cartVoucher['reduction_amount'];
 
-            if (isset($cartVoucher['reduction_percent']) && $cartVoucher['reduction_amount'] == '0.00' &&
+            if (isset($cartVoucher['reduction_percent']) &&
+                    $cartVoucher['reduction_amount'] == '0.00' &&
                     !$cartVoucher['free_shipping']) {
                 $cartVoucher['reduction_formatted'] = $cartVoucher['reduction_percent'] . '%';
-            } elseif (isset($cartVoucher['reduction_amount']) && $cartVoucher['reduction_amount'] > 0) {
+            } else {
                 $value = $this->includeTaxes() ? $cartVoucher['reduction_amount'] : $cartVoucher['value_tax_exc'];
                 $currencyFrom = new \Currency($cartVoucher['reduction_currency']);
                 $currencyTo = new \Currency($cart->id_currency);

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -498,11 +498,13 @@ class CartPresenter implements PresenterInterface
 
             $vouchers[$cartVoucher['id_cart_rule']]['reduction_amount'] = $cartVoucher['reduction_amount'];
 
-            if (array_key_exists('gift_product', $cartVoucher) && $cartVoucher['gift_product']) {
+            if ((array_key_exists('gift_product', $cartVoucher) && $cartVoucher['gift_product']) ||
+                    $cartVoucher['free_shipping']) {
                 $cartVoucher['reduction_amount'] = $cartVoucher['value_real'];
             }
 
-            if (isset($cartVoucher['reduction_percent']) && $cartVoucher['reduction_amount'] == '0.00') {
+            if (isset($cartVoucher['reduction_percent']) && $cartVoucher['reduction_amount'] == '0.00' &&
+                    !$cartVoucher['free_shipping']) {
                 $cartVoucher['reduction_formatted'] = $cartVoucher['reduction_percent'] . '%';
             } elseif (isset($cartVoucher['reduction_amount']) && $cartVoucher['reduction_amount'] > 0) {
                 $value = $this->includeTaxes() ? $cartVoucher['reduction_amount'] : $cartVoucher['value_tax_exc'];


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When voucher with free delivery option is beeing applied to the cart it is shown as percent '0.0%'
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9702
| How to test?  | Create voucher with free delievery option. Create an order, proccess it, in the cart you will see the line: -0.00% Instead of shipping value.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

I had to create this PR instead of this one https://github.com/PrestaShop/PrestaShop/pull/15459 because I changed the wrong file there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15542)
<!-- Reviewable:end -->
