### PR TITLE
Apply free delivery voucher on Delievery step

### DIFF
--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -302,4 +302,19 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             $this->getTemplateParameters()
         );
     }
+    
+    public function setComplete($step_is_complete)
+    {
+        if ($step_is_complete && $this->context->cart->id_carrier == 0) {
+            $deliveryOptionSelected = $this->getCheckoutSession()->getSelectedDeliveryOption();
+            $id_address = $this->context->cart->id_address_delivery;
+
+            if ($deliveryOptionSelected) {
+                $this->getCheckoutSession()->setDeliveryOption(array(
+                    $id_address => $deliveryOptionSelected,
+                ));
+            }
+        }
+        return parent::setComplete($step_is_complete);
+    }
 }

--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -308,15 +308,17 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
     public function setComplete($step_is_complete)
     {
         if ($step_is_complete &&
-                $this->context->cart->id_carrier == 0 &&
-                ($deliveryOptionSelected =
-                    $this->getCheckoutSession()->getSelectedDeliveryOption())) {
-            $id_address = $this->context->cart->id_address_delivery;
-            $this->getCheckoutSession()->setDeliveryOption(
-                array(
-                    $id_address => $deliveryOptionSelected
-                )
-            );
+                $this->context->cart->id_carrier == 0) {
+            $deliveryOptionSelected =
+                    $this->getCheckoutSession()->getSelectedDeliveryOption();
+            if ($deliveryOptionSelected) {
+                $id_address = $this->context->cart->id_address_delivery;
+                $this->getCheckoutSession()->setDeliveryOption(
+                    array(
+                        $id_address => $deliveryOptionSelected
+                    )
+                );
+            }
         }
         
         return parent::setComplete($step_is_complete);

--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -81,10 +81,12 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
         }
 
         // Can't really hurt to set the firstname and lastname.
-        $this->addressForm->fillWith(array(
+        $this->addressForm->fillWith(
+            array(
             'firstname' => $this->getCheckoutSession()->getCustomer()->firstname,
             'lastname' => $this->getCheckoutSession()->getCustomer()->lastname,
-        ));
+            )
+        );
 
         if (isset($requestParams['saveAddress'])) {
             $saved = $this->addressForm->fillWith($requestParams)->submit();
@@ -305,15 +307,16 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
     
     public function setComplete($step_is_complete)
     {
-        if ($step_is_complete && $this->context->cart->id_carrier == 0) {
-            $deliveryOptionSelected = $this->getCheckoutSession()->getSelectedDeliveryOption();
+        if ($step_is_complete &&
+                $this->context->cart->id_carrier == 0 &&
+                ($deliveryOptionSelected =
+                    $this->getCheckoutSession()->getSelectedDeliveryOption())) {
             $id_address = $this->context->cart->id_address_delivery;
-
-            if ($deliveryOptionSelected) {
-                $this->getCheckoutSession()->setDeliveryOption(array(
-                    $id_address => $deliveryOptionSelected,
-                ));
-            }
+            $this->getCheckoutSession()->setDeliveryOption(
+                array(
+                    $id_address => $deliveryOptionSelected
+                )
+            );
         }
         
         return parent::setComplete($step_is_complete);

--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -315,6 +315,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
                 ));
             }
         }
+        
         return parent::setComplete($step_is_complete);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Free delivery voucher is applied only after CheckoutDeliveryStep or after customer click other but default carrier on this step.improvement
| Type?         |  improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15458 
| How to test?  | Create two or more carriers. Create a voucher with free shipping option and select one of those carriers in the voucher settings. So this voucher should affect only one of those carriers. Create an order in FO, proccess it to the step Address, select Address, go to the next step. You expect to see that selected in voucher settings carrier is free and expect to appear the discount in the cart. It will happend if select other carrier and select the desired carrier agian or to proccess to the next step.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

This is besause the carrier ID is not yet set. So I set the default carrier ID to cart right after the address step is complete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15544)
<!-- Reviewable:end -->
