### PR TITLE
Fix bad combination dropdown in cart rule

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -497,6 +497,8 @@ $(document).ready(function() {
 			callback: function(text) { combinable_filter('#cart_rule_select_2', text, 'selected'); }
 		});
 	}
+  
+  displayProductAttributes();  
 });
 
 


### PR DESCRIPTION
When you load a cart rule with a gift product and the gift product search found more than 1 product, all the combination dropdowns are visible.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you load a cart rule with a gift product and the gift product search found more than 1 product, all the combination dropdowns are visible.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15529
| How to test?  | Create a product with name and reference "AAA" with 2 combinations. Create a product with name and reference "AAAA" with 2 combinations. Create a cart rule with "AAA" as gift product. Save the rule. Edit again the cart rule and you will see 2 dropdowns, one with "AAA" combinations and another with "AAAA" combinations.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15546)
<!-- Reviewable:end -->
