### PR TITLE
Cart rule bug: exclude discounted products on CartRule with a selection of product

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1206,7 +1206,19 @@ class CartRuleCore extends ObjectModel
                 $selected_products = $this->checkProductRestrictionsFromCart($context->cart, true);
                 if (is_array($selected_products)) {
                     foreach ($package_products as $product) {
-                        if ((in_array($product['id_product'] . '-' . $product['id_product_attribute'], $selected_products)
+if (
+    (
+        in_array($product['id_product'] . '-' . $product['id_product_attribute'], $selected_products)
+        || in_array($product['id_product'] . '-0', $selected_products)
+    )
+    && (
+        (
+            $this->reduction_exclude_special
+            && !$product['reduction_applies']
+        )
+        || !$this->reduction_exclude_special
+    )
+) {
                             || in_array($product['id_product'] . '-0', $selected_products))
                             && (($this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
                             $price = $product['price'];

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1206,21 +1206,9 @@ class CartRuleCore extends ObjectModel
                 $selected_products = $this->checkProductRestrictionsFromCart($context->cart, true);
                 if (is_array($selected_products)) {
                     foreach ($package_products as $product) {
-if (
-    (
-        in_array($product['id_product'] . '-' . $product['id_product_attribute'], $selected_products)
-        || in_array($product['id_product'] . '-0', $selected_products)
-    )
-    && (
-        (
-            $this->reduction_exclude_special
-            && !$product['reduction_applies']
-        )
-        || !$this->reduction_exclude_special
-    )
-) {
-                            || in_array($product['id_product'] . '-0', $selected_products))
-                            && (($this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
+                        if ((in_array($product['id_product'].'-'.$product['id_product_attribute'], $selected_products)
+                            || in_array($product['id_product'].'-0', $selected_products))
+                            && (((bool)$this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
                             $price = $product['price'];
                             if ($use_tax) {
                                 $infos = Product::getTaxesInformations($product, $context);

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1206,8 +1206,8 @@ class CartRuleCore extends ObjectModel
                 $selected_products = $this->checkProductRestrictionsFromCart($context->cart, true);
                 if (is_array($selected_products)) {
                     foreach ($package_products as $product) {
-                        if (in_array($product['id_product'] . '-' . $product['id_product_attribute'], $selected_products)
-                            || in_array($product['id_product'] . '-0', $selected_products)
+                        if ((in_array($product['id_product'] . '-' . $product['id_product_attribute'], $selected_products)
+                            || in_array($product['id_product'] . '-0', $selected_products))
                             && (($this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
                             $price = $product['price'];
                             if ($use_tax) {

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1206,9 +1206,9 @@ class CartRuleCore extends ObjectModel
                 $selected_products = $this->checkProductRestrictionsFromCart($context->cart, true);
                 if (is_array($selected_products)) {
                     foreach ($package_products as $product) {
-                        if ((in_array($product['id_product'].'-'.$product['id_product_attribute'], $selected_products)
-                            || in_array($product['id_product'].'-0', $selected_products))
-                            && (((bool)$this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
+                        if ((in_array($product['id_product'] . '-' . $product['id_product_attribute'], $selected_products)
+                            || in_array($product['id_product'] . '-0', $selected_products))
+                            && (($this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
                             $price = $product['price'];
                             if ($use_tax) {
                                 $infos = Product::getTaxesInformations($product, $context);


### PR DESCRIPTION
Questions | Answers
-- | --
Branch? | 1.7.6.x
Description? | The cart rules with selection of products and which excludes products with reduction allows products with reduction.
Type? | bug fix
Category? | FO
BC breaks? | no
Deprecations? | no
Fixed ticket? | #14407
How to test? | Create a cart rule (%) with a selection of products of which one or   more already have a reduction and select exclude the products in promotion.<br>![Panier](https://user-images.githubusercontent.com/20644112/64971699-55f90800-d8a8-11e9-90f2-14569530f924.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15566)
<!-- Reviewable:end -->
