### PR TITLE
Fix travis e2e test build with bad dpkg version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ addons:
   chrome: stable
   apt:
     packages:
+      - dpkg
       - apache2
       - postfix
       - libapache2-mod-fastcgi


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fix travis e2e test build with bad dpkg version
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/15579
| How to test?  | Travis should be green

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15581)
<!-- Reviewable:end -->
