### PR TITLE
Use Xenial instead of old Trusty distrib for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - $HOME/.composer/cache
 
 sudo: required
-dist: trusty
+dist: xenial
 
 php:
   - 7.1


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Use Xenial instead of old Trusty distrib for Travis. This should prevent outdated package errors
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/15582
| How to test?  | Travis should be green

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15583)
<!-- Reviewable:end -->
