### PR TITLE
Fix of new customer message

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -516,7 +516,7 @@ abstract class PaymentModuleCore extends Module
                         $customer_message->id_customer_thread = $customer_thread->id;
                         $customer_message->id_employee = 0;
                         $customer_message->message = $update_message->message;
-                        $customer_message->private = 1;
+                        $customer_message->private = 0;
 
                         if (!$customer_message->add()) {
                             $this->errors[] = $this->trans('An error occurred while saving message', array(), 'Admin.Payment.Notification');


### PR DESCRIPTION
 Unfortunately, the customer does not see in his detailed order his first order message he wrote at the time of the order. When a message is created, it is set to private?!

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | set to private = 0
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9769 
| How to test?  | Add a message when completing an order

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15614)
<!-- Reviewable:end -->
