### PR TITLE
Do not allow to put item in cart if available quantity is 0

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -225,7 +225,7 @@ class PackCore extends Product
     }
 
     /**
-     * Returns the available quantity of a given pack.
+     * Returns the available quantity of a given pack (this method already have decreased products in cart).
      *
      * @param int $id_product Product id
      * @param int $id_product_attribute Product attribute id (optional)

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3712,6 +3712,7 @@ class ProductCore extends ObjectModel
         Cart $cart = null,
         $idCustomization = null
     ) {
+        // pack usecase: Pack::getQuantity() returns the pack quantity after cart quantities have been removed from stock
         if (Pack::isPack((int) $idProduct)) {
             return Pack::getQuantity($idProduct, $idProductAttribute, $cacheIsPack, $cart, $idCustomization);
         }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -562,7 +562,13 @@ class CartControllerCore extends FrontController
     }
 
     /**
-     * Check product quantity availability.
+     * Check product quantity availability to acknowledge whether
+     * an availability error should be raised.
+     *
+     * If shop has been configured to oversell, answer is no.
+     * If there is no items available (no stock), answer is yes.
+     * If there is items available, but the Cart already contains more than the quantity,
+     * answer is yes.
      *
      * @param Product $product
      * @param int $qtyToCheck
@@ -578,8 +584,18 @@ class CartControllerCore extends FrontController
             return false;
         }
 
-        // product quantity is the available quantity after decreasing products in cart
-        $productQuantity = Product::getQuantity(
+        // Check if this product is out-of-stock
+        $availableProductQuantity = StockAvailable::getQuantityAvailableByProduct(
+            $this->id_product,
+            $this->id_product_attribute
+        );
+        if ($availableProductQuantity <= 0) {
+            return true;
+        }
+
+        // Check if this product is out-of-stock after cart quantities have been removed from stock
+        // Be aware that Product::getQuantity() returns the available quantity after decreasing products in cart
+        $productQuantityAvailableAfterCartItemsHaveBeenRemovedFromStock = Product::getQuantity(
             $this->id_product,
             $this->id_product_attribute,
             null,
@@ -587,7 +603,7 @@ class CartControllerCore extends FrontController
             $this->customization_id
         );
 
-        return $productQuantity < 0;
+        return $productQuantityAvailableAfterCartItemsHaveBeenRemovedFromStock < 0;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If available stock quantity is 0, refuse to add cart to product
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13374
| How to test?  | See ticket, be careful about different "out of stock" behaviors (see screenshot below). Plase check with products, products with combinations and packs.

Different "out of stock" behaviors:
<img src="https://user-images.githubusercontent.com/3830050/64821490-3f566680-d5b3-11e9-9863-e0642f6d898f.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15623)
<!-- Reviewable:end -->
