### PR TITLE
Properly cleanup the customization table if no more customized_data

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4179,14 +4179,14 @@ class CartCore extends ObjectModel
         );
 
         $hasRemainingCustomData = Db::getInstance()->getValue(
-            'SELECT 1 FROM `'._DB_PREFIX_.'customized_data`
-            WHERE `id_customization` = '.(int)$cust_data['id_customization']
+            'SELECT 1 FROM `' . _DB_PREFIX_ . 'customized_data`
+            WHERE `id_customization` = ' . (int) $cust_data['id_customization']
         );
 
         if (!$hasRemainingCustomData) {
             $result &= Db::getInstance()->execute(
-                'DELETE FROM `'._DB_PREFIX_.'customization` 
-            WHERE `id_customization` = '.(int)$cust_data['id_customization']
+                'DELETE FROM `' . _DB_PREFIX_ . 'customization` 
+            WHERE `id_customization` = ' . (int) $cust_data['id_customization']
             );
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4178,6 +4178,18 @@ class CartCore extends ObjectModel
             AND `index` = ' . (int) $index
         );
 
+        $hasRemainingCustomData = Db::getInstance()->getValue(
+            'SELECT 1 FROM `'._DB_PREFIX_.'customized_data`
+            WHERE `id_customization` = '.(int)$cust_data['id_customization']
+        );
+
+        if (!$hasRemainingCustomData) {
+            $result &= Db::getInstance()->execute(
+                'DELETE FROM `'._DB_PREFIX_.'customization` 
+            WHERE `id_customization` = '.(int)$cust_data['id_customization']
+            );
+        }
+
         return $result;
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Properly cleanup the customization table when customized_data is deleted
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #15624 
| How to test?  | Add a customization to a product, remove the customization, put the product into your cart. Without the fix, you'll not be able to remove the product from the cart because will still have an id_customization associated, but no more customized_data

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15625)
<!-- Reviewable:end -->
