### PR TITLE
Remove unneccessary slash on Home category breadcrumb

### DIFF
--- a/themes/classic/templates/_partials/breadcrumb.tpl
+++ b/themes/classic/templates/_partials/breadcrumb.tpl
@@ -32,7 +32,7 @@
               <a itemprop="item" href="{$path.url}"><span itemprop="name">{$path.title}</span></a>
               <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
             </li>
-          {else}
+          {elseif isset($path.title)}
             <li>
               <span>{$path.title}</span>
             </li>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  |  Fixes issue #15302
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes issue #15302
| How to test?  | Open home category.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15632)
<!-- Reviewable:end -->
