### PR TITLE
Fix wrong breadcrumb on home category

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -233,7 +233,7 @@ class CategoryControllerCore extends ProductListingFrontController
             }
         }
 
-        if (!$this->category->is_root_category) {
+        if ($this->category->id_parent != 0 && !$this->category->is_root_category) {
             $breadcrumb['links'][] = $this->getCategoryPath($this->category);
         }
 

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -233,7 +233,9 @@ class CategoryControllerCore extends ProductListingFrontController
             }
         }
 
-        $breadcrumb['links'][] = $this->getCategoryPath($this->category);
+        if (!$this->category->is_root_category) {
+            $breadcrumb['links'][] = $this->getCategoryPath($this->category);
+        }
 
         return $breadcrumb;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Breadcrumb computation is wrong on home category
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #15641 
| How to test?  | Go on the home category, and check breadcrumb is the source. It should only contains 1 entry + "count":1. Without the fix it generates invalid breadcrumb, which could be annoying when using google rich snippets

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15642)
<!-- Reviewable:end -->
