### PR TITLE
Allow CLDR to display deleted/inactive currencies

### DIFF
--- a/app/config/set_parameters.php
+++ b/app/config/set_parameters.php
@@ -62,7 +62,7 @@ if ($container instanceof \Symfony\Component\DependencyInjection\Container) {
 
     // Parameter used only in dev and test env
     $envParameter = getenv('DISABLE_DEBUG_TOOLBAR');
-    if (!isset($parameters['use_debug_toolbar']) || false !== $envParameter) {
+    if (!isset($parameters['parameters']['use_debug_toolbar']) || false !== $envParameter) {
         $container->setParameter('use_debug_toolbar', !$envParameter);
     }
 }

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -402,18 +402,20 @@ class CurrencyCore extends ObjectModel
      * @param bool $active If true only active are returned
      * @param bool $groupBy Group by id_currency
      * @param bool $currentShopOnly If true returns only currencies associated to current shop
+     * @param bool $filterDeleted It true filter deleted currencies
      *
      * @return array Currency data from database
      *
      * @throws PrestaShopDatabaseException
      */
-    public static function findAll($active = true, $groupBy = false, $currentShopOnly = true)
+    public static function findAll($active = true, $groupBy = false, $currentShopOnly = true, $filterDeleted = true)
     {
         $currencies = Db::getInstance()->executeS('
             SELECT *
             FROM `' . _DB_PREFIX_ . 'currency` c
             ' . ($currentShopOnly ? Shop::addSqlAssociation('currency', 'c') : '') . '
-                WHERE `deleted` = 0' .
+                WHERE 1' .
+                ($filterDeleted ? ' AND c.`deleted` = 0' : '') .
                 ($active ? ' AND c.`active` = 1' : '') .
                 ($groupBy ? ' GROUP BY c.`id_currency`' : '') .
                 ' ORDER BY `iso_code` ASC');
@@ -800,7 +802,7 @@ class CurrencyCore extends ObjectModel
         $symbolsByLang = $namesByLang = [];
         foreach ($languages as $languageData) {
             $language = new Language($languageData['id_lang']);
-            if ($language->locale === '') {
+            if (empty($language->locale)) {
                 // Language doesn't have locale we can't install this language
                 continue;
             }

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -428,9 +428,9 @@ class CurrencyCore extends ObjectModel
      *
      * @throws PrestaShopDatabaseException
      */
-    public static function findAllInDatabase()
+    public static function findAllInstalled()
     {
-        $currencies = Db::getInstance()->executeS(
+        $currencies = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
             'SELECT * FROM `' . _DB_PREFIX_ . 'currency` c ORDER BY `iso_code` ASC'
         );
 
@@ -590,14 +590,14 @@ class CurrencyCore extends ObjectModel
      *
      * @param string $isoCode ISO code
      * @param int $idShop Shop ID
-     * @param bool $noCache
+     * @param bool $forceRefreshCache [default=false] Set to TRUE to forcefully refresh any currently cached results
      *
      * @return int Currency ID
      */
-    public static function getIdByIsoCode($isoCode, $idShop = 0, $noCache = false)
+    public static function getIdByIsoCode($isoCode, $idShop = 0, $forceRefreshCache = false)
     {
         $cacheId = 'Currency::getIdByIsoCode_' . pSQL($isoCode) . '-' . (int) $idShop;
-        if ($noCache || !Cache::isStored($cacheId)) {
+        if ($forceRefreshCache || !Cache::isStored($cacheId)) {
             $query = Currency::getIdByQuery($idShop);
             $query->where('iso_code = \'' . pSQL($isoCode) . '\'');
 

--- a/install-dev/upgrade/php/ps_1761_update_currencies.php
+++ b/install-dev/upgrade/php/ps_1761_update_currencies.php
@@ -60,7 +60,7 @@ function ps_1761_update_currencies()
         $cldrCurrency = $cldrLocale->getCurrency($currency->iso_code);
         if (!empty($cldrCurrency)) {
             $currency->precision = (int) $cldrCurrency->getDecimalDigits();
-            $currency->numeric_iso_code = (int) $cldrCurrency->getNumericIsoCode();
+            $currency->numeric_iso_code = $cldrCurrency->getNumericIsoCode();
         }
         $currency->save();
     }

--- a/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
@@ -86,6 +86,7 @@ final class AddCurrencyHandler extends AbstractCurrencyHandler implements AddCur
             if (!empty($cldrCurrency)) {
                 // The currency may not be declared in the locale, eg with custom iso code
                 $entity->precision = (int) $cldrCurrency->getDecimalDigits();
+                $entity->numeric_iso_code = (int) $cldrCurrency->getNumericIsoCode();
             }
 
             $entity->refreshLocalizedCurrencyData(Language::getLanguages(), $this->localeRepoCLDR);

--- a/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AddCurrencyHandler.php
@@ -86,7 +86,7 @@ final class AddCurrencyHandler extends AbstractCurrencyHandler implements AddCur
             if (!empty($cldrCurrency)) {
                 // The currency may not be declared in the locale, eg with custom iso code
                 $entity->precision = (int) $cldrCurrency->getDecimalDigits();
-                $entity->numeric_iso_code = (int) $cldrCurrency->getNumericIsoCode();
+                $entity->numeric_iso_code = $cldrCurrency->getNumericIsoCode();
             }
 
             $entity->refreshLocalizedCurrencyData(Language::getLanguages(), $this->localeRepoCLDR);

--- a/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
@@ -268,7 +268,7 @@ final class EditCurrencyHandler extends AbstractCurrencyHandler implements EditC
                 $langIds = Language::getLanguages(true, false, true);
                 $entity->name = [];
                 $entity->symbol = [];
-                $entity->numeric_iso_code = $currency->getNumericIsoCode();
+                $entity->numeric_iso_code = (int) $currency->getNumericIsoCode();
 
                 foreach ($langIds as $langId) {
                     $entity->name[$langId] = $currency->getDisplayName();

--- a/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
@@ -268,7 +268,7 @@ final class EditCurrencyHandler extends AbstractCurrencyHandler implements EditC
                 $langIds = Language::getLanguages(true, false, true);
                 $entity->name = [];
                 $entity->symbol = [];
-                $entity->numeric_iso_code = (int) $currency->getNumericIsoCode();
+                $entity->numeric_iso_code = $currency->getNumericIsoCode();
 
                 foreach ($langIds as $langId) {
                     $entity->name[$langId] = $currency->getDisplayName();

--- a/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/EditCurrencyHandler.php
@@ -268,6 +268,7 @@ final class EditCurrencyHandler extends AbstractCurrencyHandler implements EditC
                 $langIds = Language::getLanguages(true, false, true);
                 $entity->name = [];
                 $entity->symbol = [];
+                $entity->numeric_iso_code = $currency->getNumericIsoCode();
 
                 foreach ($langIds as $langId) {
                     $entity->name[$langId] = $currency->getDisplayName();

--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -31,7 +31,6 @@ use Exception;
 use Language;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
-use PrestaShopException;
 
 /**
  * This class will provide data from DB / ORM about Currency.
@@ -51,6 +50,10 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     /** @var Currency */
     private $defaultCurrency;
 
+    /**
+     * @param ConfigurationInterface $configuration
+     * @param int $shopId
+     */
     public function __construct(ConfigurationInterface $configuration, $shopId)
     {
         $this->configuration = $configuration;
@@ -58,9 +61,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     }
 
     /**
-     * Return available currencies.
-     *
-     * @return array Currencies
+     * {@inheritdoc}
      */
     public function getCurrencies($object = false, $active = true, $group_by = false)
     {
@@ -70,22 +71,21 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function findAll($currentShopOnly = true, $filterDeleted = true)
+    public function findAll($currentShopOnly = true)
     {
-        return Currency::findAll(false, false, $currentShopOnly, $filterDeleted);
+        return Currency::findAll(true, false, $currentShopOnly);
     }
 
     /**
-     * Get a Currency entity instance by ISO code.
-     *
-     * @param string $isoCode
-     *                        An ISO 4217 currency code
-     * @param int|false|null $idLang
-     *                               Set this parameter if you want the currency in a specific language.
-     *                               If null or false, default language will be used
-     *
-     * @return currency|null
-     *                       The asked Currency object, or null if not found
+     * {@inheritdoc}
+     */
+    public function findAllInDatabase()
+    {
+        return Currency::findAllInDatabase();
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function getCurrencyByIsoCode($isoCode, $idLang = null)
     {
@@ -102,15 +102,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     }
 
     /**
-     * Get a Currency entity instance by ISO code.
-     *
-     * @param string $isoCode
-     *                        An ISO 4217 currency code
-     * @param string $locale
-     *                       The locale to use for localized data
-     *
-     * @return currency|null
-     *                       The asked Currency object, or null if not found
+     * {@inheritdoc}
      */
     public function getCurrencyByIsoCodeAndLocale($isoCode, $locale)
     {
@@ -120,17 +112,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     }
 
     /**
-     * Get a Currency entity instance.
-     * If the passed ISO code is known, this Currency entity will be loaded with known data.
-     *
-     * @param string $isoCode
-     *                        An ISO 4217 currency code
-     * @param int|null $idLang
-     *                         Set this parameter if you want the currency in a specific language.
-     *                         If null, default language will be used
-     *
-     * @return currency
-     *                  The asked Currency object, loaded with relevant data if passed ISO code is known
+     * {@inheritdoc}
      */
     public function getCurrencyByIsoCodeOrCreate($isoCode, $idLang = null)
     {
@@ -147,16 +129,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     }
 
     /**
-     * Persists a Currency entity into DB.
-     * If this entity already exists in DB (has a known currency_id), it will be updated.
-     *
-     * @param Currency $currencyEntity
-     *                                 Currency object model to save
-     *
-     * @throws PrestaShopException
-     *                             If something wrong happened with DB when saving $currencyEntity
-     * @throws Exception
-     *                   If an unexpected result is retrieved when saving $currencyEntity
+     * {@inheritdoc}
      */
     public function saveCurrency(Currency $currencyEntity)
     {
@@ -166,11 +139,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     }
 
     /**
-     * Gets a legacy Currency instance by ID.
-     *
-     * @param int $currencyId
-     *
-     * @return Currency
+     * {@inheritdoc}
      */
     public function getCurrencyById($currencyId)
     {
@@ -178,7 +147,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     }
 
     /**
-     * Get Default currency Iso code.
+     * {@inheritdoc}
      */
     public function getDefaultCurrencyIsoCode()
     {

--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -79,9 +79,9 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function findAllInDatabase()
+    public function findAllInstalled()
     {
-        return Currency::findAllInDatabase();
+        return Currency::findAllInstalled();
     }
 
     /**

--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -70,9 +70,9 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function findAll($currentShopOnly = true)
+    public function findAll($currentShopOnly = true, $filterDeleted = true)
     {
-        return Currency::findAll(false, false, $currentShopOnly);
+        return Currency::findAll(false, false, $currentShopOnly, $filterDeleted);
     }
 
     /**

--- a/src/Core/Currency/CurrencyDataProviderInterface.php
+++ b/src/Core/Currency/CurrencyDataProviderInterface.php
@@ -56,11 +56,11 @@ interface CurrencyDataProviderInterface
     public function findAll($currentShopOnly = true);
 
     /**
-     * Return raw currencies data from the database (regardless of their active or deleted status).
+     * Return raw data of all installed currencies in the database (regardless of their active or soft deleted status).
      *
-     * @return array[] Currencies in database
+     * @return array[] Currencies installed in database
      */
-    public function findAllInDatabase();
+    public function findAllInstalled();
 
     /**
      * Get a Currency entity instance by ISO code.

--- a/src/Core/Currency/CurrencyDataProviderInterface.php
+++ b/src/Core/Currency/CurrencyDataProviderInterface.php
@@ -50,10 +50,11 @@ interface CurrencyDataProviderInterface
      * Return raw currencies data from the database.
      *
      * @param bool $currentShopOnly If true returns only currencies associated to current shop
+     * @param bool $filterDeleted If true deleted currencies are filtered
      *
      * @return array[] Installed currencies
      */
-    public function findAll($currentShopOnly = true);
+    public function findAll($currentShopOnly = true, $filterDeleted = true);
 
     /**
      * Get a Currency entity instance by ISO code.

--- a/src/Core/Currency/CurrencyDataProviderInterface.php
+++ b/src/Core/Currency/CurrencyDataProviderInterface.php
@@ -47,14 +47,20 @@ interface CurrencyDataProviderInterface
     public function getCurrencies($object = false, $active = true, $group_by = false);
 
     /**
-     * Return raw currencies data from the database.
+     * Return raw currencies data from the database (not deleted + active currencies).
      *
      * @param bool $currentShopOnly If true returns only currencies associated to current shop
-     * @param bool $filterDeleted If true deleted currencies are filtered
      *
-     * @return array[] Installed currencies
+     * @return array[] Available currencies
      */
-    public function findAll($currentShopOnly = true, $filterDeleted = true);
+    public function findAll($currentShopOnly = true);
+
+    /**
+     * Return raw currencies data from the database (regardless of their active or deleted status).
+     *
+     * @return array[] Currencies in database
+     */
+    public function findAllInDatabase();
 
     /**
      * Get a Currency entity instance by ISO code.

--- a/src/Core/Localization/Currency/CurrencyDataSource.php
+++ b/src/Core/Localization/Currency/CurrencyDataSource.php
@@ -92,9 +92,9 @@ class CurrencyDataSource implements DataSourceInterface
     /**
      * {@inheritdoc}
      */
-    public function getAllCurrenciesDataInDatabase($localeCode)
+    public function getAllInstalledCurrenciesData($localeCode)
     {
-        return $this->formatCurrenciesData($this->installedDataLayer->getAllCurrencyCodesInDatabase(), $localeCode);
+        return $this->formatCurrenciesData($this->installedDataLayer->getAllInstalledCurrencyIsoCodes(), $localeCode);
     }
 
     /**

--- a/src/Core/Localization/Currency/CurrencyDataSource.php
+++ b/src/Core/Localization/Currency/CurrencyDataSource.php
@@ -92,9 +92,9 @@ class CurrencyDataSource implements DataSourceInterface
     /**
      * {@inheritdoc}
      */
-    public function getAllCurrenciesData($localeCode)
+    public function getAllCurrenciesDataInDatabase($localeCode)
     {
-        return $this->formatCurrenciesData($this->installedDataLayer->getAvailableCurrencyCodes(), $localeCode);
+        return $this->formatCurrenciesData($this->installedDataLayer->getAllCurrencyCodesInDatabase(), $localeCode);
     }
 
     /**
@@ -103,7 +103,7 @@ class CurrencyDataSource implements DataSourceInterface
      *
      * @return array
      */
-    protected function formatCurrenciesData(array $currencyCodes, $localeCode)
+    private function formatCurrenciesData(array $currencyCodes, $localeCode)
     {
         $currenciesData = [];
         foreach ($currencyCodes as $currencyCode) {

--- a/src/Core/Localization/Currency/CurrencyDataSource.php
+++ b/src/Core/Localization/Currency/CurrencyDataSource.php
@@ -60,13 +60,7 @@ class CurrencyDataSource implements DataSourceInterface
     }
 
     /**
-     * Get complete currency data by currency code, in a given language.
-     *
-     * @param LocalizedCurrencyId $localizedCurrencyId
-     *                                                 The currency data identifier (currency code + locale code)
-     *
-     * @return CurrencyData
-     *                      The currency data
+     * {@inheritdoc}
      */
     public function getLocalizedCurrencyData(LocalizedCurrencyId $localizedCurrencyId)
     {
@@ -88,17 +82,29 @@ class CurrencyDataSource implements DataSourceInterface
     }
 
     /**
-     * Get all the available (installed + active) currencies' data.
-     *
-     * @param string $localeCode
-     *                           IETF tag. Data will be translated in this language
-     *
-     * @return CurrencyData[]
-     *                        The available currencies' data
+     * {@inheritdoc}
      */
     public function getAvailableCurrenciesData($localeCode)
     {
-        $currencyCodes = $this->installedDataLayer->getAvailableCurrencyCodes();
+        return $this->formatCurrenciesData($this->installedDataLayer->getAvailableCurrencyCodes(), $localeCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllCurrenciesData($localeCode)
+    {
+        return $this->formatCurrenciesData($this->installedDataLayer->getAvailableCurrencyCodes(), $localeCode);
+    }
+
+    /**
+     * @param array $currencyCodes
+     * @param string $localeCode
+     *
+     * @return array
+     */
+    protected function formatCurrenciesData(array $currencyCodes, $localeCode)
+    {
         $currenciesData = [];
         foreach ($currencyCodes as $currencyCode) {
             $currenciesData[] = $this->getLocalizedCurrencyData(new LocalizedCurrencyId($currencyCode, $localeCode));

--- a/src/Core/Localization/Currency/DataLayer/CurrencyDatabase.php
+++ b/src/Core/Localization/Currency/DataLayer/CurrencyDatabase.php
@@ -121,6 +121,9 @@ class CurrencyDatabase extends AbstractDataLayer implements CurrencyDataLayerInt
      */
     protected function doWrite($currencyDataId, $currencyData)
     {
-        // Nothing.
+        // We should not save anything in this layer. The CLDR or its Repository nor any of its layers
+        // should modify the database. This could override customization added by the user with default
+        // CLDR values. Any changes on the database must be managed through the backoffice and the appropriate
+        // commands/handlers
     }
 }

--- a/src/Core/Localization/Currency/DataLayer/CurrencyDatabase.php
+++ b/src/Core/Localization/Currency/DataLayer/CurrencyDatabase.php
@@ -27,7 +27,6 @@
 
 namespace PrestaShop\PrestaShop\Core\Localization\Currency\DataLayer;
 
-use Exception;
 use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
 use PrestaShop\PrestaShop\Core\Data\Layer\AbstractDataLayer;
 use PrestaShop\PrestaShop\Core\Data\Layer\DataLayerException;
@@ -122,23 +121,6 @@ class CurrencyDatabase extends AbstractDataLayer implements CurrencyDataLayerInt
      */
     protected function doWrite($currencyDataId, $currencyData)
     {
-        if (!$currencyDataId instanceof LocalizedCurrencyId) {
-            throw new LocalizationException('First parameter must be an instance of ' . LocalizedCurrencyId::class);
-        }
-
-        $currencyCode = $currencyDataId->getCurrencyCode();
-        $currencyEntity = $this->dataProvider->getCurrencyByIsoCodeOrCreate($currencyCode, $currencyDataId->getLocaleCode());
-
-        $currencyEntity->iso_code = $currencyData->getIsoCode();
-        $currencyEntity->name = $currencyData->getNames()[$currencyDataId->getLocaleCode()];
-        $currencyEntity->numeric_iso_code = $currencyData->getNumericIsoCode();
-        $currencyEntity->symbol = $currencyData->getSymbols()[$currencyDataId->getLocaleCode()];
-        $currencyEntity->precision = $currencyData->getPrecision();
-
-        try {
-            $this->dataProvider->saveCurrency($currencyEntity);
-        } catch (Exception $e) {
-            throw new DataLayerException('Unable to persist data in DB data layer', 0, $e);
-        }
+        // Nothing.
     }
 }

--- a/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
+++ b/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
@@ -77,9 +77,9 @@ class CurrencyInstalled
     public function getAvailableCurrencyCodes()
     {
         $currencies = $this->dataProvider->findAll(false, true);
-        $currencyIds = array_column($currencies, 'iso_code');
+        $currencyIsoCodes = array_column($currencies, 'iso_code');
 
-        return $currencyIds;
+        return $currencyIsoCodes;
     }
 
     /**
@@ -90,8 +90,8 @@ class CurrencyInstalled
     public function getAllCurrencyCodes()
     {
         $currencies = $this->dataProvider->findAll(false, false);
-        $currencyIds = array_column($currencies, 'iso_code');
+        $currencyIsoCodes = array_column($currencies, 'iso_code');
 
-        return $currencyIds;
+        return $currencyIsoCodes;
     }
 }

--- a/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
+++ b/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
@@ -76,7 +76,20 @@ class CurrencyInstalled
      */
     public function getAvailableCurrencyCodes()
     {
-        $currencies = $this->dataProvider->findAll(false);
+        $currencies = $this->dataProvider->findAll(false, true);
+        $currencyIds = array_column($currencies, 'iso_code');
+
+        return $currencyIds;
+    }
+
+    /**
+     * Get all the available currencies' ISO codes (installed in database no matter if it's deleted or active).
+     *
+     * @return string[]
+     */
+    public function getAllCurrencyCodes()
+    {
+        $currencies = $this->dataProvider->findAll(false, false);
         $currencyIds = array_column($currencies, 'iso_code');
 
         return $currencyIds;

--- a/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
+++ b/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
@@ -87,9 +87,9 @@ class CurrencyInstalled
      *
      * @return string[]
      */
-    public function getAllCurrencyCodesInDatabase()
+    public function getAllInstalledCurrencyIsoCodes()
     {
-        $currencies = $this->dataProvider->findAllInDatabase();
+        $currencies = $this->dataProvider->findAllInstalled();
         $currencyIsoCodes = array_column($currencies, 'iso_code');
 
         return $currencyIsoCodes;

--- a/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
+++ b/src/Core/Localization/Currency/DataLayer/CurrencyInstalled.php
@@ -76,20 +76,20 @@ class CurrencyInstalled
      */
     public function getAvailableCurrencyCodes()
     {
-        $currencies = $this->dataProvider->findAll(false, true);
+        $currencies = $this->dataProvider->findAll();
         $currencyIsoCodes = array_column($currencies, 'iso_code');
 
         return $currencyIsoCodes;
     }
 
     /**
-     * Get all the available currencies' ISO codes (installed in database no matter if it's deleted or active).
+     * Get all the available currencies' ISO codes (present in database no matter if it's deleted or active).
      *
      * @return string[]
      */
-    public function getAllCurrencyCodes()
+    public function getAllCurrencyCodesInDatabase()
     {
-        $currencies = $this->dataProvider->findAll(false, false);
+        $currencies = $this->dataProvider->findAllInDatabase();
         $currencyIsoCodes = array_column($currencies, 'iso_code');
 
         return $currencyIsoCodes;

--- a/src/Core/Localization/Currency/DataSourceInterface.php
+++ b/src/Core/Localization/Currency/DataSourceInterface.php
@@ -65,4 +65,15 @@ interface DataSourceInterface
      *                        The available currencies' data
      */
     public function getAvailableCurrenciesData($localeCode);
+
+    /**
+     * Get all the available currencies' data (installed in database no matter if it's deleted or active).
+     *
+     * @param string $localeCode
+     *                           Data will be translated in this language
+     *
+     * @return CurrencyData[]
+     *                        The available currencies' data
+     */
+    public function getAllCurrenciesData($localeCode);
 }

--- a/src/Core/Localization/Currency/DataSourceInterface.php
+++ b/src/Core/Localization/Currency/DataSourceInterface.php
@@ -67,13 +67,13 @@ interface DataSourceInterface
     public function getAvailableCurrenciesData($localeCode);
 
     /**
-     * Get all the available currencies' data (installed in database no matter if it's deleted or active).
+     * Get all the database currencies' data (present in database no matter if it's deleted or active).
      *
      * @param string $localeCode
      *                           Data will be translated in this language
      *
      * @return CurrencyData[]
-     *                        The available currencies' data
+     *                        The database currencies' data
      */
-    public function getAllCurrenciesData($localeCode);
+    public function getAllCurrenciesDataInDatabase($localeCode);
 }

--- a/src/Core/Localization/Currency/DataSourceInterface.php
+++ b/src/Core/Localization/Currency/DataSourceInterface.php
@@ -67,13 +67,13 @@ interface DataSourceInterface
     public function getAvailableCurrenciesData($localeCode);
 
     /**
-     * Get all the database currencies' data (present in database no matter if it's deleted or active).
+     * Get all installed currencies' data in database (regardless of their active or soft deleted status).
      *
      * @param string $localeCode
      *                           Data will be translated in this language
      *
      * @return CurrencyData[]
-     *                        The database currencies' data
+     *                        The installed currencies' database data
      */
-    public function getAllCurrenciesDataInDatabase($localeCode);
+    public function getAllInstalledCurrenciesData($localeCode);
 }

--- a/src/Core/Localization/Currency/Repository.php
+++ b/src/Core/Localization/Currency/Repository.php
@@ -80,19 +80,29 @@ class Repository implements CurrencyRepositoryInterface
     }
 
     /**
-     * Get all the available currencies (installed + active).
-     *
-     * @param string $localeCode
-     *                           IETF tag. Data will be translated in this language
-     *
-     * @return CurrencyCollection
-     *                            The available currencies
+     * {@inheritdoc}
      */
     public function getAvailableCurrencies($localeCode)
     {
-        $currencies = new CurrencyCollection();
-        $currenciesData = $this->dataSource->getAvailableCurrenciesData($localeCode);
+        return $this->formatCurrencies($this->dataSource->getAvailableCurrenciesData($localeCode));
+    }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllCurrencies($localeCode)
+    {
+        return $this->formatCurrencies($this->dataSource->getAllCurrenciesData($localeCode));
+    }
+
+    /**
+     * @param array $currenciesData
+     *
+     * @return CurrencyCollection
+     */
+    private function formatCurrencies(array $currenciesData)
+    {
+        $currencies = new CurrencyCollection();
         foreach ($currenciesData as $currencyDatum) {
             $currencies->add(new Currency(
                 $currencyDatum->isActive(),

--- a/src/Core/Localization/Currency/Repository.php
+++ b/src/Core/Localization/Currency/Repository.php
@@ -90,9 +90,9 @@ class Repository implements CurrencyRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getAllCurrencies($localeCode)
+    public function getAllCurrenciesInDatabase($localeCode)
     {
-        return $this->formatCurrencies($this->dataSource->getAllCurrenciesData($localeCode));
+        return $this->formatCurrencies($this->dataSource->getAllCurrenciesDataInDatabase($localeCode));
     }
 
     /**
@@ -103,6 +103,7 @@ class Repository implements CurrencyRepositoryInterface
     private function formatCurrencies(array $currenciesData)
     {
         $currencies = new CurrencyCollection();
+        /** @var CurrencyData $currencyDatum */
         foreach ($currenciesData as $currencyDatum) {
             $currencies->add(new Currency(
                 $currencyDatum->isActive(),

--- a/src/Core/Localization/Currency/Repository.php
+++ b/src/Core/Localization/Currency/Repository.php
@@ -90,9 +90,9 @@ class Repository implements CurrencyRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getAllCurrenciesInDatabase($localeCode)
+    public function getAllInstalledCurrencies($localeCode)
     {
-        return $this->formatCurrencies($this->dataSource->getAllCurrenciesDataInDatabase($localeCode));
+        return $this->formatCurrencies($this->dataSource->getAllInstalledCurrenciesData($localeCode));
     }
 
     /**

--- a/src/Core/Localization/Currency/RepositoryInterface.php
+++ b/src/Core/Localization/Currency/RepositoryInterface.php
@@ -69,5 +69,5 @@ interface RepositoryInterface
      * @return CurrencyCollection
      *                            The available currencies
      */
-    public function getAllCurrencies($localeCode);
+    public function getAllCurrenciesInDatabase($localeCode);
 }

--- a/src/Core/Localization/Currency/RepositoryInterface.php
+++ b/src/Core/Localization/Currency/RepositoryInterface.php
@@ -61,13 +61,13 @@ interface RepositoryInterface
     public function getAvailableCurrencies($localeCode);
 
     /**
-     * Get all the available currencies (installed in database no matter if it's deleted or active).
+     * Get all the installed currencies in database (regardless of their active or soft deleted status).
      *
      * @param string $localeCode
      *                           IETF tag. Data will be translated in this language
      *
      * @return CurrencyCollection
-     *                            The available currencies
+     *                            The installed currencies in database
      */
-    public function getAllCurrenciesInDatabase($localeCode);
+    public function getAllInstalledCurrencies($localeCode);
 }

--- a/src/Core/Localization/Currency/RepositoryInterface.php
+++ b/src/Core/Localization/Currency/RepositoryInterface.php
@@ -59,4 +59,15 @@ interface RepositoryInterface
      *                            The available currencies
      */
     public function getAvailableCurrencies($localeCode);
+
+    /**
+     * Get all the available currencies (installed in database no matter if it's deleted or active).
+     *
+     * @param string $localeCode
+     *                           IETF tag. Data will be translated in this language
+     *
+     * @return CurrencyCollection
+     *                            The available currencies
+     */
+    public function getAllCurrencies($localeCode);
 }

--- a/src/Core/Localization/Locale/Repository.php
+++ b/src/Core/Localization/Locale/Repository.php
@@ -204,7 +204,7 @@ class Repository implements RepositoryInterface
             throw new LocalizationException('CLDR locale not found for locale code "' . $localeCode . '"');
         }
 
-        $currencies = $this->currencyRepository->getAllCurrencies($localeCode);
+        $currencies = $this->currencyRepository->getAllCurrenciesInDatabase($localeCode);
 
         $priceSpecifications = new PriceSpecificationMap();
         foreach ($currencies as $currency) {

--- a/src/Core/Localization/Locale/Repository.php
+++ b/src/Core/Localization/Locale/Repository.php
@@ -204,7 +204,7 @@ class Repository implements RepositoryInterface
             throw new LocalizationException('CLDR locale not found for locale code "' . $localeCode . '"');
         }
 
-        $currencies = $this->currencyRepository->getAllCurrenciesInDatabase($localeCode);
+        $currencies = $this->currencyRepository->getAllInstalledCurrencies($localeCode);
 
         $priceSpecifications = new PriceSpecificationMap();
         foreach ($currencies as $currency) {

--- a/src/Core/Localization/Locale/Repository.php
+++ b/src/Core/Localization/Locale/Repository.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Localization\Locale;
 
 use PrestaShop\Decimal\Operation\Rounding;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository as CldrLocaleRepository;
-use PrestaShop\PrestaShop\Core\Localization\Currency\Repository as CurrencyRepository;
+use PrestaShop\PrestaShop\Core\Localization\Currency\RepositoryInterface as CurrencyRepositoryInterface;
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Number\Formatter as NumberFormatter;
@@ -62,7 +62,7 @@ class Repository implements RepositoryInterface
     /**
      * Repository used to retrieve Currency objects.
      *
-     * @var CurrencyRepository
+     * @var CurrencyRepositoryInterface
      */
     protected $currencyRepository;
 
@@ -121,7 +121,7 @@ class Repository implements RepositoryInterface
 
     public function __construct(
         CldrLocaleRepository $cldrLocaleRepository,
-        CurrencyRepository $currencyRepository,
+        CurrencyRepositoryInterface $currencyRepository,
         $roundingMode = Rounding::ROUND_HALF_UP,
         $numberingSystem = Locale::NUMBERING_SYSTEM_LATIN,
         $currencyDisplayType = PriceSpecification::CURRENCY_DISPLAY_SYMBOL,
@@ -204,7 +204,7 @@ class Repository implements RepositoryInterface
             throw new LocalizationException('CLDR locale not found for locale code "' . $localeCode . '"');
         }
 
-        $currencies = $this->currencyRepository->getAvailableCurrencies($localeCode);
+        $currencies = $this->currencyRepository->getAllCurrencies($localeCode);
 
         $priceSpecifications = new PriceSpecificationMap();
         foreach ($currencies as $currency) {

--- a/tests-legacy/Unit/Core/Localization/DataLayer/CurrencyDatabaseTest.php
+++ b/tests-legacy/Unit/Core/Localization/DataLayer/CurrencyDatabaseTest.php
@@ -121,7 +121,7 @@ class CurrencyDatabaseTest extends TestCase
     {
         $someCurrencyData = new CurrencyData();
 
-        $this->fakeDataProvider->expects($this->once())
+        $this->fakeDataProvider->expects($this->never())
             ->method('saveCurrency')
             ->with($this->isInstanceOf(Currency::class));
 

--- a/tests/Integration/Behaviour/Features/Context/CLDRFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CLDRFeatureContext.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context;
+
+use PrestaShop\PrestaShop\Core\Localization\Locale\RepositoryInterface;
+use RuntimeException;
+
+class CLDRFeatureContext extends AbstractPrestaShopFeatureContext
+{
+    /**
+     * @Then display a price of :price :currencyIsoCode with locale :locale should look like :expectedPrice
+     */
+    public function assertDisplayPrice($price, $currencyIsoCode, $locale, $expectedPrice)
+    {
+        /** @var RepositoryInterface $localeRepository */
+        $localeRepository = CommonFeatureContext::getContainer()->get('prestashop.core.localization.locale.repository');
+        $locale = $localeRepository->getLocale($locale);
+        $displayedPrice = $locale->formatPrice($price, $currencyIsoCode);
+
+        if ($expectedPrice !== $displayedPrice) {
+            throw new RuntimeException(sprintf(
+                'Displayed price is "%s" but "%s" was expected',
+                $displayedPrice,
+                $expectedPrice
+            ));
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/CLDRFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CLDRFeatureContext.php
@@ -32,7 +32,7 @@ use RuntimeException;
 class CLDRFeatureContext extends AbstractPrestaShopFeatureContext
 {
     /**
-     * @Then display a price of :price :currencyIsoCode with locale :locale should look like :expectedPrice
+     * @Then a price of :price using :currencyIsoCode in locale :locale should look like :expectedPrice
      */
     public function assertDisplayPrice($price, $currencyIsoCode, $locale, $expectedPrice)
     {

--- a/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
@@ -71,7 +71,10 @@ class CurrencyFeatureContext extends AbstractPrestaShopFeatureContext
      */
     public function createCurrencyWithIsoCode($reference, $isoCode)
     {
-        //Currency::getIdByIsoCode only returns not deleted currency so we check the storage to avoid duplicate contents
+        /*
+         * Currency::getIdByIsoCode only returns not deleted currency so we check the storage to avoid
+         * duplicate contents, if it matches the expected iso code then we do nothing
+         */
         if (SharedStorage::getStorage()->exists($reference)) {
             /** @var Currency $currency */
             $currency = SharedStorage::getStorage()->get($reference);

--- a/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
@@ -67,7 +67,7 @@ class CurrencyFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @Given currency :reference with isoCode :isoCode exists
+     * @Given currency :reference with ISO code :isoCode exists
      */
     public function createCurrencyWithIsoCode($reference, $isoCode)
     {
@@ -161,7 +161,7 @@ class CurrencyFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @Then there should be :expectedCount currencies of :currencyIsoCode
+     * @Given database contains :expectedCount rows of currency :currencyIsoCode
      */
     public function countCurrencies($expectedCount, $currencyIsoCode)
     {

--- a/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
@@ -67,11 +67,42 @@ class CurrencyFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given currency :reference with isoCode :isoCode exists
+     */
+    public function createCurrencyWithIsoCode($reference, $isoCode)
+    {
+        //Currency::getIdByIsoCode only returns not deleted currency so we check the storage to avoid duplicate contents
+        if (SharedStorage::getStorage()->exists($reference)) {
+            /** @var Currency $currency */
+            $currency = SharedStorage::getStorage()->get($reference);
+            if ($currency->iso_code == $isoCode) {
+                return;
+            }
+        }
+
+        $currencyId = Currency::getIdByIsoCode($isoCode, 0, true);
+
+        if (!$currencyId) {
+            $currency = new Currency();
+            $currency->name = $isoCode;
+            $currency->iso_code = $isoCode;
+            $currency->active = 1;
+            $currency->deleted = 0;
+            $currency->conversion_rate = 1;
+            $currency->add();
+        } else {
+            $currency = new Currency($currencyId);
+        }
+
+        SharedStorage::getStorage()->set($reference, $currency);
+    }
+
+    /**
      * @Given /^there is a currency named "(.+)" with iso code "(.+)" and exchange rate of (\d+\.\d+)$/
      */
     public function thereIsACurrency($currencyName, $currencyIsoCode, $changeRate)
     {
-        $currencyId = Currency::getIdByIsoCode($currencyIsoCode);
+        $currencyId = Currency::getIdByIsoCode($currencyIsoCode, 0, true);
         // soft delete here...
         if (!$currencyId) {
             $currency = new Currency();

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain;
+
+use Behat\Behat\Context\Context;
+use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
+use ObjectModel;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use RuntimeException;
+use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\SharedStorage;
+
+abstract class AbstractDomainFeatureContext implements Context
+{
+    /**
+     * @var \Exception|null
+     */
+    protected $lastException;
+
+    /**
+     * @BeforeSuite
+     */
+    public static function prepare(BeforeSuiteScope $scope)
+    {
+        // Disable legacy object model cache to prevent conflicts between scenarios.
+        ObjectModel::disableCache();
+    }
+
+    /**
+     * @return CommandBusInterface
+     */
+    protected function getCommandBus()
+    {
+        return CommonFeatureContext::getContainer()->get('prestashop.core.command_bus');
+    }
+
+    /**
+     * @return CommandBusInterface
+     */
+    protected function getQueryBus()
+    {
+        return CommonFeatureContext::getContainer()->get('prestashop.core.query_bus');
+    }
+
+    /**
+     * @return SharedStorage
+     */
+    protected function getSharedStorage()
+    {
+        return SharedStorage::getStorage();
+    }
+
+    /**
+     * @param string $expectedError
+     * @param int|null $errorCode
+     */
+    protected function assertLastErrorIs($expectedError, $errorCode = null)
+    {
+        if (!$this->lastException instanceof $expectedError) {
+            throw new RuntimeException(sprintf(
+                'Last error should be "%s", but got "%s"',
+                $expectedError,
+                $this->lastException ? get_class($this->lastException) : 'null'
+            ));
+        }
+        if (null !== $errorCode && $this->lastException->getCode() !== $errorCode) {
+            throw new RuntimeException(sprintf(
+                'Last error should have code "%s", but has "%s"',
+                $errorCode,
+                $this->lastException ? $this->lastException->getCode() : 'null'
+            ));
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain;
+
+use Behat\Gherkin\Node\TableNode;
+use Currency;
+use DbQuery;
+use Db;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Command\AddCurrencyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Command\DeleteCurrencyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Command\EditCurrencyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Command\ToggleCurrencyStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CannotDeleteDefaultCurrencyException;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CannotDisableDefaultCurrencyException;
+use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use RuntimeException;
+use Tests\Integration\Behaviour\Features\Context\SharedStorage;
+
+class CurrencyFeatureContext extends AbstractDomainFeatureContext
+{
+    /**
+     * @When I add new currency :reference with following properties:
+     */
+    public function addCurrency($reference, TableNode $node)
+    {
+        $data = $node->getRowsHash();
+        /** @var \Shop $shop */
+        $shop = SharedStorage::getStorage()->get($data['shop_association']);
+
+        $command = new AddCurrencyCommand(
+            $data['iso_code'],
+            (float) $data['exchange_rate'],
+            (bool) $data['is_enabled']
+        );
+
+        $command->setShopIds([
+            (int) $shop->id,
+        ]);
+
+        try {
+            $this->lastException = null;
+            /** @var CurrencyId $currencyId */
+            $currencyId = $this->getCommandBus()->handle($command);
+
+            SharedStorage::getStorage()->set($reference, new Currency($currencyId->getValue()));
+        } catch (CoreException $e) {
+            $this->lastException = $e;
+        }
+    }
+
+    /**
+     * @When I edit currency :reference with following properties:
+     */
+    public function editCurrency($reference, TableNode $node)
+    {
+        $data = $node->getRowsHash();
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($reference);
+
+        $command = new EditCurrencyCommand((int) $currency->id);
+
+        if (isset($data['iso_code'])) {
+            $command->setIsoCode($data['iso_code']);
+        }
+
+        if (isset($data['exchange_rate'])) {
+            $command->setExchangeRate((float) $data['exchange_rate']);
+        }
+
+        if (isset($data['is_enabled'])) {
+            $command->setIsEnabled((bool) $data['is_enabled']);
+        }
+
+        if (isset($data['shop_association'])) {
+            $command->setShopIds([(int) $data['shop_association']]);
+        }
+
+        try {
+            $this->lastException = null;
+            $this->getCommandBus()->handle($command);
+
+            SharedStorage::getStorage()->set($reference, new Currency($currency->id));
+        } catch (CoreException $e) {
+            $this->lastException = $e;
+        }
+    }
+
+    /**
+     * @When I disable currency ":currencyReference"
+     */
+    public function disableCurrency($reference)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($reference);
+
+        try {
+            $this->lastException = null;
+            $this->getCommandBus()->handle(new ToggleCurrencyStatusCommand((int) $currency->id));
+        } catch (CannotDisableDefaultCurrencyException $e) {
+            $this->lastException = $e;
+        }
+    }
+
+    /**
+     * @When I delete currency ":currencyReference"
+     */
+    public function deleteCurrency($reference)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($reference);
+
+        try {
+            $this->lastException = null;
+            $this->getCommandBus()->handle(new DeleteCurrencyCommand((int) $currency->id));
+        } catch (CannotDeleteDefaultCurrencyException $e) {
+            $this->lastException = $e;
+        }
+    }
+
+    /**
+     * @Then currency :reference should be :isoCode
+     */
+    public function assertCurrencyIsoCode($reference, $isoCode)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($reference);
+
+        if ($currency->iso_code !== $isoCode) {
+            throw new RuntimeException(sprintf(
+                'Currency "%s" has "%s" iso code, but "%s" was expected.',
+                $reference,
+                $currency->iso_code,
+                $isoCode
+            ));
+        }
+    }
+
+    /**
+     * @Then /^currency "(.*)" should have status (enabled|disabled)$/
+     */
+    public function assertCurrencyStatus($reference, $status)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($reference);
+        $expectedStatus = $status === 'enabled';
+
+        if ($currency->active != $expectedStatus) {
+            throw new RuntimeException(sprintf(
+                'Currency "%s" has status "%s", but "%s" was expected.',
+                $reference,
+                $currency->active,
+                $expectedStatus
+            ));
+        }
+    }
+
+    /**
+     * @Then currency :reference exchange rate should be :exchangeRate
+     */
+    public function assertCurrencyExchangeRate($reference, $exchangeRate)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($reference);
+
+        if ((float) $currency->conversion_rate != (float) $exchangeRate) {
+            throw new RuntimeException(sprintf(
+                'Currency "%s" has "%s" exchange rate, but "%s" was expected.',
+                $reference,
+                $currency->conversion_rate,
+                $exchangeRate
+            ));
+        }
+    }
+
+    /**
+     * @Then currency :reference precision should be :precision
+     */
+    public function assertCurrencyPrecision($reference, $precision)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($reference);
+
+        if ((int) $currency->precision != (int) $precision) {
+            throw new RuntimeException(sprintf(
+                'Currency "%s" has "%s" precision, but "%s" was expected.',
+                $reference,
+                $currency->precision,
+                $precision
+            ));
+        }
+    }
+
+    /**
+     * @Then currency :currencyReference should be available in shop :shopReference
+     */
+    public function assertCurrencyIsAvailableInShop($currencyReference, $shopReference)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($currencyReference);
+        /** @var \Shop $shop */
+        $shop = SharedStorage::getStorage()->get($shopReference);
+
+        if (!in_array($shop->id, $currency->getAssociatedShops())) {
+            throw new RuntimeException(sprintf(
+                'Currency "%s" is not associated with "%s" shop',
+                $currencyReference,
+                $shopReference
+            ));
+        }
+    }
+
+    /**
+     * @Given currency with :isoCode has been deleted
+     */
+    public function assertCurrencyHasBeenDeleted($isoCode)
+    {
+        $query = new DbQuery();
+        $query->select('c.id_currency');
+        $query->from('currency', 'c');
+        $query->where('deleted = 1');
+        $query->where('iso_code = \'' . pSQL($isoCode) . '\'');
+
+        $currencyId = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query->build());
+
+        if (!$currencyId) {
+            throw new RuntimeException(sprintf('Currency with ISO Code "%s" should be deleted in database', $isoCode));
+        }
+    }
+
+    /**
+     * @Then currency :reference numeric iso code should be :numericIsoCode
+     */
+    public function assertCurrencyNumericIsoCode($reference, $numericIsoCode)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($reference);
+
+        if ('valid' === $numericIsoCode) {
+            if ((int) $currency->numeric_iso_code <= 0) {
+                throw new RuntimeException(sprintf(
+                    'Currency "%s" has invalid numeric iso code "%s".',
+                    $reference,
+                    $currency->numeric_iso_code
+                ));
+            }
+        } elseif ((int) $currency->numeric_iso_code !== (int) $numericIsoCode) {
+            throw new RuntimeException(sprintf(
+                'Currency "%s" has "%s" numeric iso code, but "%s" was expected.',
+                $reference,
+                $currency->numeric_iso_code,
+                $numericIsoCode
+            ));
+        }
+    }
+
+    /**
+     * @Then currency :reference name should be :name
+     */
+    public function assertCurrencyName($reference, $name)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($reference);
+
+        if ($currency->name !== $name) {
+            throw new RuntimeException(sprintf(
+                'Currency "%s" has "%s" name, but "%s" was expected.',
+                $reference,
+                $currency->name,
+                $name
+            ));
+        }
+    }
+
+    /**
+     * @Then currency :reference symbol should be :symbol
+     */
+    public function assertCurrencySymbol($reference, $symbol)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($reference);
+
+        if ($currency->symbol !== $symbol) {
+            throw new RuntimeException(sprintf(
+                'Currency "%s" has "%s" symbol, but "%s" was expected.',
+                $reference,
+                $currency->symbol,
+                $symbol
+            ));
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
@@ -253,6 +253,24 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Given currency with :isoCode has been deactivated
+     */
+    public function assertCurrencyHasBeenDeactivated($isoCode)
+    {
+        $query = new DbQuery();
+        $query->select('c.id_currency');
+        $query->from('currency', 'c');
+        $query->where('active = 0');
+        $query->where('iso_code = \'' . pSQL($isoCode) . '\'');
+
+        $currencyId = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query->build());
+
+        if (!$currencyId) {
+            throw new RuntimeException(sprintf('Currency with ISO Code "%s" should be deleted in database', $isoCode));
+        }
+    }
+
+    /**
      * @Then currency :reference numeric iso code should be :numericIsoCode
      */
     public function assertCurrencyNumericIsoCode($reference, $numericIsoCode)

--- a/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
@@ -266,7 +266,7 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
         $currencyId = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query->build());
 
         if (!$currencyId) {
-            throw new RuntimeException(sprintf('Currency with ISO Code "%s" should be deleted in database', $isoCode));
+            throw new RuntimeException(sprintf('Currency with ISO Code "%s" should be deactivated in database', $isoCode));
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context;
+
+use Behat\Gherkin\Node\TableNode;
+use Language;
+use RuntimeException;
+
+class LanguageFeatureContext extends AbstractPrestaShopFeatureContext
+{
+    /**
+     * @Given I add a new language :reference with following properties:
+     */
+    public function addLocale($reference, TableNode $node)
+    {
+        $data = $node->getRowsHash();
+        $language = new Language();
+        $language->name = $data['name'];
+        $language->iso_code = $data['iso_code'];
+        $language->language_code = $data['language_code'];
+        $language->locale = $data['locale'];
+        $language->date_format_lite = $data['date_format_lite'];
+        $language->date_format_full = $data['date_format_full'];
+        $language->is_rtl = (bool) $data['is_rtl'];
+        $language->add();
+
+        SharedStorage::getStorage()->set($reference, $language);
+    }
+
+    /**
+     * @Then language :reference should be :locale
+     */
+    public function assertLanguageLocale($reference, $locale)
+    {
+        /** @var Language $language */
+        $language = SharedStorage::getStorage()->get($reference);
+
+        if ($language->locale !== $locale) {
+            throw new RuntimeException(sprintf(
+                'Currency "%s" has "%s" iso code, but "%s" was expected.',
+                $reference,
+                $language->locale,
+                $locale
+            ));
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
@@ -26,27 +26,30 @@
 
 namespace Tests\Integration\Behaviour\Features\Context;
 
-use Behat\Gherkin\Node\TableNode;
 use Language;
 use RuntimeException;
 
 class LanguageFeatureContext extends AbstractPrestaShopFeatureContext
 {
     /**
-     * @Given I add a new language :reference with following properties:
+     * @Given language :reference with locale :locale exists
      */
-    public function addLocale($reference, TableNode $node)
+    public function createLanguageWithLocale($reference, $locale)
     {
-        $data = $node->getRowsHash();
-        $language = new Language();
-        $language->name = $data['name'];
-        $language->iso_code = $data['iso_code'];
-        $language->language_code = $data['language_code'];
-        $language->locale = $data['locale'];
-        $language->date_format_lite = $data['date_format_lite'];
-        $language->date_format_full = $data['date_format_full'];
-        $language->is_rtl = (bool) $data['is_rtl'];
-        $language->add();
+        $languageId = Language::getIdByLocale($locale, true);
+
+        if (false === $languageId) {
+            $language = new Language();
+            $language->locale = $locale;
+            $language->active = true;
+            $language->name = $locale;
+            $language->is_rtl = false;
+            $language->language_code = strtolower($locale);
+            $language->iso_code = substr($locale, 0, strpos($locale, '-'));
+            $language->add();
+        } else {
+            $language = new Language($languageId);
+        }
 
         SharedStorage::getStorage()->set($reference, $language);
     }

--- a/tests/Integration/Behaviour/Features/Context/SharedStorage.php
+++ b/tests/Integration/Behaviour/Features/Context/SharedStorage.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context;
+
+use RuntimeException;
+
+/**
+ * Shared storage to use between behat contexts
+ */
+class SharedStorage
+{
+    /**
+     * @var self
+     */
+    protected static $instance;
+
+    /**
+     * @var array
+     */
+    private $storage = [];
+
+    /**
+     * Used for accessing latest resource.
+     *
+     * @var string|null
+     */
+    private $latestKey;
+
+    /**
+     * @return self
+     */
+    public static function getStorage()
+    {
+        if (!isset(self::$instance)) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function get($key)
+    {
+        if (!$this->exists($key)) {
+            throw new RuntimeException(sprintf('Item with key "%s" does not exist', $key));
+        }
+
+        return $this->storage[$key];
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getWithDefault($key, $default)
+    {
+        if (!isset($this->storage[$key])) {
+            return $default;
+        }
+
+        return $this->storage[$key];
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $resource
+     */
+    public function set($key, $resource)
+    {
+        $this->storage[$key] = $resource;
+        $this->latestKey = $key;
+    }
+
+    /**
+     * @param $key
+     *
+     * @return bool
+     */
+    public function exists($key)
+    {
+        return isset($this->storage[$key]);
+    }
+
+    /**
+     * @param string $key
+     */
+    public function clear($key)
+    {
+        if ($this->exists($key)) {
+            unset($this->storage[$key]);
+        }
+    }
+
+    /**
+     * Get the resource that was the latest one to be set into the storage.
+     *
+     * @return mixed
+     */
+    public function getLatestResource()
+    {
+        if (!array_key_exists($this->latestKey, $this->storage)) {
+            throw new RuntimeException(
+                sprintf('Latest resource with key "%s" does not exist.', $this->latestKey)
+            );
+        }
+
+        return $this->storage[$this->latestKey];
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context;
+
+use RuntimeException;
+use Shop;
+
+class ShopFeatureContext extends AbstractPrestaShopFeatureContext
+{
+    /**
+     * @Given shop :reference with name :shopName exists
+     */
+    public function shopWithNameExists($reference, $shopName)
+    {
+        $shopId = Shop::getIdByName($shopName);
+
+        if (false === $shopId) {
+            throw new RuntimeException(sprintf('Shop with name "%s" does not exist', $shopName));
+        }
+
+        SharedStorage::getStorage()->set($reference, new Shop($shopId));
+    }
+}

--- a/tests/Integration/Behaviour/Features/Scenario/CLDR/cldr.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CLDR/cldr.feature
@@ -6,32 +6,32 @@ Feature: CLDR display for prices
   # caches the locale which contains the price specifications of all currencies available at the time they were created.
   Background:
     Given shop "shop1" with name "test_shop" exists
-    Given language "language1" with locale "en-US" exists
-    Given language "language2" with locale "fr-FR" exists
-    Given currency "currency1" with isoCode "USD" exists
-    Given currency "currency2" with isoCode "EUR" exists
-    Given currency "currency3" with isoCode "AUD" exists
-    And I delete currency "currency2"
-    And I disable currency "currency3"
+      And language "language1" with locale "en-US" exists
+      And language "language2" with locale "fr-FR" exists
+      And currency "currency1" with ISO code "USD" exists
+      And currency "currency2" with ISO code "EUR" exists
+      And currency "currency3" with ISO code "AUD" exists
+    When I delete currency "currency2"
+      And I disable currency "currency3"
 
   Scenario: Display USD
-    Then display a price of 14789.5426 "USD" with locale "en-US" should look like "$14,789.54"
-    Then display a price of 14789.5426 "USD" with locale "fr-FR" should look like "14 789,54 $"
+    Then a price of 14789.5426 using "USD" in locale "en-US" should look like "$14,789.54"
+      And a price of 14789.5426 using "USD" in locale "fr-FR" should look like "14 789,54 $"
 
   Scenario: Display a deleted EUR currency
-    And there should be 1 currencies of "EUR"
-    And currency with "EUR" has been deleted
-    Then display a price of 14789.5426 "EUR" with locale "en-US" should look like "€14,789.54"
-    And display a price of 14789.5426 "EUR" with locale "fr-FR" should look like "14 789,54 €"
-    # Check that the CLDR doesn't add the currency in database
-    And there should be 1 currencies of "EUR"
+    Given database contains 1 rows of currency "EUR"
+      And currency with "EUR" has been deleted
+    Then a price of 14789.5426 using "EUR" in locale "en-US" should look like "€14,789.54"
+      And a price of 14789.5426 using "EUR" in locale "fr-FR" should look like "14 789,54 €"
+      # Check that the CLDR doesn't add the currency in database
+      And database contains 1 rows of currency "EUR"
 
   Scenario: Display a disabled currency
-    And there should be 1 currencies of "AUD"
-    And currency with "AUD" has been deactivated
+    Given database contains 1 rows of currency "AUD"
+      And currency with "AUD" has been deactivated
     # We use narrow symbols that's why australian dollar is displayed with $ and not A$
-    Then display a price of 14789.5426 "AUD" with locale "en-US" should look like "$14,789.54"
-    And display a price of 14789.5426 "AUD" with locale "fr-FR" should look like "14 789,54 $"
-    # Check that the CLDR doesn't add the currency in database
-    And there should be 1 currencies of "AUD"
+    Then a price of 14789.5426 using "AUD" in locale "en-US" should look like "$14,789.54"
+      And a price of 14789.5426 using "AUD" in locale "fr-FR" should look like "14 789,54 $"
+      # Check that the CLDR doesn't add the currency in database
+      And database contains 1 rows of currency "AUD"
 

--- a/tests/Integration/Behaviour/Features/Scenario/CLDR/cldr.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CLDR/cldr.feature
@@ -1,0 +1,58 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cldr
+@reset-database-before-feature
+Feature: CLDR display for prices
+
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+
+  Scenario: Display EUR
+    When I add a new language "language1" with following properties:
+      | name             | English (US) |
+      | iso_code         | en           |
+      | language_code    | en-us        |
+      | locale           | en-US        |
+      | date_format_lite | m/d/Y        |
+      | date_format_full | m/d/Y H:i:s  |
+      | is_rtl           | 0            |
+    And I add a new language "language2" with following properties:
+      | name             | French       |
+      | iso_code         | fr           |
+      | language_code    | fr-fr        |
+      | locale           | fr-FR        |
+      | date_format_lite | d/m/Y        |
+      | date_format_full | d/m/Y H:i:s  |
+      | is_rtl           | 0            |
+    And I add new currency "currency1" with following properties:
+      | iso_code         | EUR           |
+      | exchange_rate    | 0.63          |
+      | is_enabled       | 1             |
+      | shop_association | shop1         |
+    Then language "language1" should be "en-US"
+    Then language "language2" should be "fr-FR"
+    And currency "currency1" should be "EUR"
+    And display a price of 14789.5426 "EUR" with locale "en-US" should look like "€14,789.54"
+    And display a price of 14789.5426 "EUR" with locale "fr-FR" should look like "14 789,54 €"
+
+  Scenario: Display a deleted currency
+    Given language "language1" should be "en-US"
+    And currency "currency1" should be "EUR"
+    And there should be 1 currencies of "EUR"
+    And display a price of 14789.5426 "EUR" with locale "en-US" should look like "€14,789.54"
+    When I delete currency "currency1"
+    Then display a price of 14789.5426 "EUR" with locale "en-US" should look like "€14,789.54"
+    # Check that the CLDR doesn't add the currency in database
+    And there should be 1 currencies of "EUR"
+
+  Scenario: Display a disabled currency
+    Given language "language1" should be "en-US"
+    And I add new currency "currency1" with following properties:
+      | iso_code         | USD           |
+      | exchange_rate    | 0.89          |
+      | is_enabled       | 1             |
+      | shop_association | shop1         |
+    And there should be 1 currencies of "USD"
+    And display a price of 14789.5426 "USD" with locale "en-US" should look like "$14,789.54"
+    When I disable currency "currency1"
+    Then display a price of 14789.5426 "USD" with locale "en-US" should look like "$14,789.54"
+    # Check that the CLDR doesn't add the currency in database
+    And there should be 1 currencies of "USD"

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
@@ -1,0 +1,36 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s currency
+@reset-database-before-feature
+Feature: Currency Management
+  PrestaShop allows BO users to manage currencies
+  As a BO user
+  I must be able to create, edit and delete currencies in my shop
+
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+
+  Scenario: Adding and editing currency
+    When I add new currency "currency1" with following properties:
+      | iso_code         | EUR       |
+      | exchange_rate    | 0.88      |
+      | is_enabled       | 1         |
+      | shop_association | shop1     |
+    Then currency "currency1" should be "EUR"
+    And currency "currency1" exchange rate should be 0.88
+    And currency "currency1" numeric iso code should be 978
+    And currency "currency1" name should be "Euro"
+    And currency "currency1" symbol should be "€"
+    And currency "currency1" should have status enabled
+    And currency "currency1" should be available in shop "shop1"
+    And there should be 1 currencies of "EUR"
+    When I edit currency "currency1" with following properties:
+      | iso_code         | EUR       |
+      | exchange_rate    | 1.0       |
+      | is_enabled       | 0         |
+      | shop_association | shop1     |
+    Then currency "currency1" should be "EUR"
+    And currency "currency1" exchange rate should be 1
+    And currency "currency1" numeric iso code should be 978
+    And currency "currency1" name should be "Euro"
+    And currency "currency1" symbol should be "€"
+    And currency "currency1" precision should be 2
+    And currency "currency1" should have status disabled

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -28,3 +28,21 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\OrderFeatureContext
+        currency:
+          paths:
+            features: Features/Scenario/Currency
+          contexts:
+            - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
+        cldr:
+            paths:
+                features: Features/Scenario/CLDR
+            contexts:
+                - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CLDRFeatureContext


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Allow CLDR to display delete currencies by fetching any currency in database regardless of its `deleted` or `active` status, and add a few behat tests for CLDR and currencies This required to add a few methods to existing interfaces thus creating a BC break But since these interfaces should mainly be used by the core for now it is relatively safe
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #15376<br>Fixes #15486
| How to test?  | See issues' contents for details, but mainly create orders and suppliers with prices in EUR the change the default currency and delete the EUR currency Then you should have an exception in Orders page and Suppliers page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15643)
<!-- Reviewable:end -->
