### PR TITLE
Use empty legacy action parameter

### DIFF
--- a/src/Adapter/Routing/LegacyHelperLinkBuilder.php
+++ b/src/Adapter/Routing/LegacyHelperLinkBuilder.php
@@ -87,12 +87,15 @@ class LegacyHelperLinkBuilder implements EntityLinkBuilderInterface
     {
         unset($parameters['current_index']);
         $actionParameter = $action . $entity;
+
+        /**
+         * Legacy actions are displayed with empty value (e.g ?controller=ProductAdminController&updateproduct&id_product=1)
+         * Some modules don't just check that the parameter is set but also that it is empty...
+         * The closest thing we have with http_build_query is controller=ProductAdminController&updateproduct=&id_product=1
+         */
         $parameters = array_merge(
-            $parameters,
-            //Legacy actions are displayed with empty value (e.g ?controller=ProductAdminController&updateproduct&id_product=1)
-            //Some modules don't just check that the parameter is set but also that it is empty...
-            //The closest thing we have with http_build_query is controller=ProductAdminController&updateproduct=&id_product=1
-            [$actionParameter => '']
+            [$actionParameter => ''],
+            $parameters
         );
 
         return $parameters;

--- a/src/Adapter/Routing/LegacyHelperLinkBuilder.php
+++ b/src/Adapter/Routing/LegacyHelperLinkBuilder.php
@@ -86,10 +86,13 @@ class LegacyHelperLinkBuilder implements EntityLinkBuilderInterface
     private function buildActionParameters($action, $entity, array $parameters)
     {
         unset($parameters['current_index']);
-        $viewAction = $action . $entity;
+        $actionParameter = $action . $entity;
         $parameters = array_merge(
             $parameters,
-            [$viewAction => 1]
+            //Legacy actions are displayed with empty value (e.g ?controller=ProductAdminController&updateproduct&id_product=1)
+            //Some modules don't just check that the parameter is set but also that it is empty...
+            //The closest thing we have with http_build_query is controller=ProductAdminController&updateproduct=&id_product=1
+            [$actionParameter => '']
         );
 
         return $parameters;

--- a/tests/Unit/Adapter/Routing/LegacyHelperLinkBuilderTest.php
+++ b/tests/Unit/Adapter/Routing/LegacyHelperLinkBuilderTest.php
@@ -35,20 +35,20 @@ class LegacyHelperLinkBuilderTest extends TestCase
     {
         $builder = new LegacyHelperLinkBuilder();
         $viewLink = $builder->getViewLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts']);
-        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&viewproduct=1', $viewLink);
+        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&viewproduct=', $viewLink);
 
         $viewLink = $builder->getViewLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts', 'token' => 'toto']);
-        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&token=toto&viewproduct=1', $viewLink);
+        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&token=toto&viewproduct=', $viewLink);
     }
 
     public function testBuildEditLink()
     {
         $builder = new LegacyHelperLinkBuilder();
         $editLink = $builder->getEditLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts']);
-        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&updateproduct=1', $editLink);
+        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&updateproduct=', $editLink);
 
         $editLink = $builder->getEditLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts', 'token' => 'toto']);
-        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&token=toto&updateproduct=1', $editLink);
+        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&token=toto&updateproduct=', $editLink);
     }
 
     /**

--- a/tests/Unit/Adapter/Routing/LegacyHelperLinkBuilderTest.php
+++ b/tests/Unit/Adapter/Routing/LegacyHelperLinkBuilderTest.php
@@ -35,20 +35,26 @@ class LegacyHelperLinkBuilderTest extends TestCase
     {
         $builder = new LegacyHelperLinkBuilder();
         $viewLink = $builder->getViewLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts']);
-        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&viewproduct=', $viewLink);
+        $this->assertEquals('index.php?controller=AdminProducts&viewproduct=&id_product=42', $viewLink);
 
         $viewLink = $builder->getViewLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts', 'token' => 'toto']);
-        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&token=toto&viewproduct=', $viewLink);
+        $this->assertEquals('index.php?controller=AdminProducts&viewproduct=&id_product=42&token=toto', $viewLink);
+
+        $viewLink = $builder->getViewLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts', 'viewproduct' => 'on']);
+        $this->assertEquals('index.php?controller=AdminProducts&viewproduct=on&id_product=42', $viewLink);
     }
 
     public function testBuildEditLink()
     {
         $builder = new LegacyHelperLinkBuilder();
         $editLink = $builder->getEditLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts']);
-        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&updateproduct=', $editLink);
+        $this->assertEquals('index.php?controller=AdminProducts&updateproduct=&id_product=42', $editLink);
 
         $editLink = $builder->getEditLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts', 'token' => 'toto']);
-        $this->assertEquals('index.php?controller=AdminProducts&id_product=42&token=toto&updateproduct=', $editLink);
+        $this->assertEquals('index.php?controller=AdminProducts&updateproduct=&id_product=42&token=toto', $editLink);
+
+        $viewLink = $builder->getEditLink('product', ['id_product' => 42, 'current_index' => 'index.php?controller=AdminProducts', 'updateproduct' => 'enabled']);
+        $this->assertEquals('index.php?controller=AdminProducts&updateproduct=enabled&id_product=42', $viewLink);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | When building legacy urls the action needs to remain empty. The previous used value (1 or `true`) didn't work because in some modules check that the parameter is present AND that it's empty
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #15559
| How to test?  | See the video in the issue, try to edit a link in `ps_mainmenu` module without this PR the module shows you a form to edit but can't handle it

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15658)
<!-- Reviewable:end -->
