### PR TITLE
Unable to create new supplier when VAT identification number is mandatory

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -948,6 +948,11 @@
 				}
 			{/if}
 
+			dniRequired();
+			$('#id_country').change(function() {
+				dniRequired();
+			});
+
 			if ($(".datepicker").length > 0)
 				$(".datepicker").datepicker({
 					prevText: '',
@@ -977,7 +982,8 @@
 			$(".textarea-autosize").autosize();
 			{/if}
 		});
-	state_token = '{getAdminToken tab='AdminStates'}';
+		state_token = '{getAdminToken tab='AdminStates'}';
+		address_token = '{getAdminToken tab='AdminAddresses'}';
 	{block name="script"}{/block}
 	</script>
 {/if}

--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -949,9 +949,7 @@
 			{/if}
 
 			dniRequired();
-			$('#id_country').change(function() {
-				dniRequired();
-			});
+			$('#id_country').change(dniRequired);
 
 			if ($(".datepicker").length > 0)
 				$(".datepicker").datepicker({

--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -67,7 +67,7 @@
 					<div class="form-wrapper">
 					{foreach $field as $input}
 						{block name="input_row"}
-						<div class="form-group{if isset($input.form_group_class)} {$input.form_group_class}{/if}{if $input.type == 'hidden'} hide{/if}"{if $input.name == 'id_state'} id="contains_states"{if !$contains_states} style="display:none;"{/if}{/if}{if isset($tabs) && isset($input.tab)} data-tab-id="{$input.tab}"{/if}>
+						<div class="form-group{if isset($input.form_group_class)} {$input.form_group_class}{/if}{if $input.type == 'hidden'} hide{/if}"{if $input.name == 'id_state'} id="contains_states"{if !$contains_states} style="display:none;"{/if}{/if}{if $input.name == 'dni'} id="contains_dni"{if !$contains_dni} style="display:none;"{/if}{/if}{if isset($tabs) && isset($input.tab)} data-tab-id="{$input.tab}"{/if}>
 						{if $input.type == 'hidden'}
 							<input type="hidden" name="{$input.name}" id="{$input.name}" value="{$fields_value[$input.name]|escape:'html':'UTF-8'}" />
 						{else}

--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -67,7 +67,7 @@
 					<div class="form-wrapper">
 					{foreach $field as $input}
 						{block name="input_row"}
-						<div class="form-group{if isset($input.form_group_class)} {$input.form_group_class}{/if}{if $input.type == 'hidden'} hide{/if}"{if $input.name == 'id_state'} id="contains_states"{if !$contains_states} style="display:none;"{/if}{/if}{if $input.name == 'dni'} id="contains_dni"{if !$contains_dni} style="display:none;"{/if}{/if}{if isset($tabs) && isset($input.tab)} data-tab-id="{$input.tab}"{/if}>
+						<div class="form-group{if isset($input.form_group_class)} {$input.form_group_class}{/if}{if $input.type == 'hidden'} hide{/if}"{if $input.name == 'id_state'} id="contains_states"{if !$contains_states} style="display:none;"{/if}{/if}{if $input.name == 'dni'} id="dni_required"{if !$dni_required} style="display:none;"{/if}{/if}{if isset($tabs) && isset($input.tab)} data-tab-id="{$input.tab}"{/if}>
 						{if $input.type == 'hidden'}
 							<input type="hidden" name="{$input.name}" id="{$input.name}" value="{$fields_value[$input.name]|escape:'html':'UTF-8'}" />
 						{else}

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -347,12 +347,7 @@ class AddressCore extends ObjectModel
         }
 
         // Special validation for dni, check if the country needs it
-        $result = (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
-			SELECT c.`need_identification_number`
-			FROM `' . _DB_PREFIX_ . 'country` c
-			WHERE c.`id_country` = ' . (int) $this->id_country);
-
-        if ($result && Tools::isEmpty($value)) {
+        if (static::containsDni((int) $this->id_country) && Tools::isEmpty($value)) {
             if ($human_errors) {
                 return $this->trans(
                     'The %s field is required.',
@@ -369,6 +364,23 @@ class AddressCore extends ObjectModel
         }
 
         return true;
+    }
+
+    /**
+     * Request to check if DNI field is required
+     * depending on the current selected country.
+     *
+     * @param int $idCountry
+     *
+     * @return bool
+     */
+    public static function containsDni($idCountry)
+    {
+        return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+            'SELECT c.`need_identification_number` ' .
+            'FROM `' . _DB_PREFIX_ . 'country` c ' .
+            'WHERE c.`id_country` = ' . (int) $idCountry
+        );
     }
 
     /**

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -347,7 +347,7 @@ class AddressCore extends ObjectModel
         }
 
         // Special validation for dni, check if the country needs it
-        if (static::containsDni((int) $this->id_country) && Tools::isEmpty($value)) {
+        if (static::dniRequired((int) $this->id_country) && Tools::isEmpty($value)) {
             if ($human_errors) {
                 return $this->trans(
                     'The %s field is required.',
@@ -374,7 +374,7 @@ class AddressCore extends ObjectModel
      *
      * @return bool
      */
-    public static function containsDni($idCountry)
+    public static function dniRequired($idCountry)
     {
         return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
             'SELECT c.`need_identification_number` ' .

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -271,6 +271,7 @@ class HelperFormCore extends Helper
             'module_dir' => _MODULE_DIR_,
             'base_url' => $this->context->shop->getBaseURL(),
             'contains_states' => (isset($this->fields_value['id_country'], $this->fields_value['id_state'])) ? Country::containsStates($this->fields_value['id_country']) : null,
+            'contains_dni' => (isset($this->fields_value['id_country'], $this->fields_value['dni'])) ? Address::containsDni($this->fields_value['id_country']) : null,
             'show_cancel_button' => $this->show_cancel_button,
             'back_url' => $this->back_url,
         ));

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -271,7 +271,7 @@ class HelperFormCore extends Helper
             'module_dir' => _MODULE_DIR_,
             'base_url' => $this->context->shop->getBaseURL(),
             'contains_states' => (isset($this->fields_value['id_country'], $this->fields_value['id_state'])) ? Country::containsStates($this->fields_value['id_country']) : null,
-            'contains_dni' => (isset($this->fields_value['id_country'], $this->fields_value['dni'])) ? Address::containsDni($this->fields_value['id_country']) : null,
+            'dni_required' => (isset($this->fields_value['id_country'], $this->fields_value['dni'])) ? Address::dniRequired($this->fields_value['id_country']) : null,
             'show_cancel_button' => $this->show_cancel_button,
             'back_url' => $this->back_url,
         ));

--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -517,6 +517,11 @@ class AdminAddressesControllerCore extends AdminController
                 echo json_encode(array('infos' => pSQL($customer['firstname']) . '_' . pSQL($customer['lastname']) . '_' . pSQL($customer['company'])));
             }
         }
+
+        if (Tools::isSubmit('contains_dni')) {
+            echo json_encode(['contains_dni' => Address::containsDni((int) Tools::getValue('id_country'))]);
+        }
+
         die;
     }
 

--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -518,8 +518,8 @@ class AdminAddressesControllerCore extends AdminController
             }
         }
 
-        if (Tools::isSubmit('contains_dni')) {
-            echo json_encode(['contains_dni' => Address::containsDni((int) Tools::getValue('id_country'))]);
+        if (Tools::isSubmit('dni_required')) {
+            echo json_encode(['dni_required' => Address::dniRequired((int) Tools::getValue('id_country'))]);
         }
 
         die;

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -323,6 +323,7 @@ class AdminSuppliersControllerCore extends AdminController
                 'city' => $address->city,
                 'id_country' => $address->id_country,
                 'id_state' => $address->id_state,
+                'dni' => $address->dni,
             );
         } else {
             $this->fields_value = array(

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -237,6 +237,7 @@ class AdminSuppliersControllerCore extends AdminController
                     'name' => 'dni',
                     'maxlength' => 16,
                     'col' => 4,
+                    'required' => true, // Only required in case of specifics countries
                 ),
                 array(
                     'type' => 'file',

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -232,6 +232,13 @@ class AdminSuppliersControllerCore extends AdminController
                     ),
                 ),
                 array(
+                    'type' => 'text',
+                    'label' => $this->trans('DNI', array(), 'Admin.Global'),
+                    'name' => 'dni',
+                    'maxlength' => 16,
+                    'col' => 4,
+                ),
+                array(
                     'type' => 'file',
                     'label' => $this->trans('Logo', array(), 'Admin.Global'),
                     'name' => 'logo',
@@ -485,8 +492,23 @@ class AdminSuppliersControllerCore extends AdminController
             $address->id_country = Tools::getValue('id_country', null);
             $address->id_state = Tools::getValue('id_state', null);
             $address->city = Tools::getValue('city', null);
+            $address->dni = Tools::getValue('dni', null);
 
             $validation = $address->validateController();
+
+            /*
+             * Make sure dni is checked without raising an exception.
+             * This field is mandatory for some countries.
+             */
+            if ($address->validateField('dni', $address->dni) !== true) {
+                $validation['dni'] = $this->trans(
+                    '%s is invalid.',
+                    array(
+                        '<b>dni</b>',
+                    ),
+                    'Admin.Notifications.Error'
+                );
+            }
 
             // checks address validity
             if (count($validation) > 0) {

--- a/js/admin.js
+++ b/js/admin.js
@@ -1381,6 +1381,20 @@ function ajaxStates(id_state_selected)
     }
   });
 
+  $.ajax({
+    url: 'index.php',
+    dataType: 'json',
+    cache: false,
+    data: 'token=' + state_token + '&ajax=1&contains_dni=1&tab=AdminAddresses&id_country=' + $('#id_country').val(),
+    success: function(resp) {
+      if (resp && resp.contains_dni) {
+        $("#contains_dni").fadeIn();
+      } else {
+        $("#contains_dni").fadeOut();
+      }
+    }
+  });
+
   if (module_dir && vat_number)
   {
     $.ajax({

--- a/js/admin.js
+++ b/js/admin.js
@@ -1385,12 +1385,12 @@ function ajaxStates(id_state_selected)
     url: 'index.php',
     dataType: 'json',
     cache: false,
-    data: 'token=' + state_token + '&ajax=1&contains_dni=1&tab=AdminAddresses&id_country=' + $('#id_country').val(),
+    data: 'token=' + state_token + '&ajax=1&dni_required=1&tab=AdminAddresses&id_country=' + $('#id_country').val(),
     success: function(resp) {
-      if (resp && resp.contains_dni) {
-        $("#contains_dni").fadeIn();
+      if (resp && resp.dni_required) {
+        $("#dni_required").fadeIn();
       } else {
-        $("#contains_dni").fadeOut();
+        $("#dni_required").fadeOut();
       }
     }
   });

--- a/js/admin.js
+++ b/js/admin.js
@@ -1381,20 +1381,6 @@ function ajaxStates(id_state_selected)
     }
   });
 
-  $.ajax({
-    url: 'index.php',
-    dataType: 'json',
-    cache: false,
-    data: 'token=' + state_token + '&ajax=1&dni_required=1&tab=AdminAddresses&id_country=' + $('#id_country').val(),
-    success: function(resp) {
-      if (resp && resp.dni_required) {
-        $("#dni_required").fadeIn();
-      } else {
-        $("#dni_required").fadeOut();
-      }
-    }
-  });
-
   if (module_dir && vat_number)
   {
     $.ajax({
@@ -1409,6 +1395,22 @@ function ajaxStates(id_state_selected)
       }
     });
   }
+}
+
+function dniRequired() {
+  $.ajax({
+    url: 'index.php',
+    dataType: 'json',
+    cache: false,
+    data: 'token=' + address_token + '&ajax=1&dni_required=1&tab=AdminAddresses&id_country=' + $('#id_country').val(),
+    success: function(resp) {
+      if (resp && resp.dni_required) {
+        $("#dni_required").fadeIn();
+      } else {
+        $("#dni_required").fadeOut();
+      }
+    }
+  });
 }
 
 function check_for_all_accesses(tabsize, tabnumber)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Some countries such as Spain or Argentina require to have a Documento Nacional de Identidad (National Identity Document also named DNI). Add the capability to check if the country needs a DNI during the supplier process.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15622 
| How to test?  | You should be able to add and edit Supplier with or without DNI field. (Spain has DNI).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15685)
<!-- Reviewable:end -->
