### PR TITLE
Cart rules mustn't be auto added automatically in some cases

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2124,9 +2124,9 @@ class CartCore extends ObjectModel
         if ($withShipping || $type == Cart::ONLY_DISCOUNTS) {
             $cartRules = $this->getCartRules(CartRule::FILTER_ACTION_ALL);
         } else {
-            $cartRules = $this->getCartRules(CartRule::FILTER_ACTION_REDUCTION);
+            $cartRules = $this->getCartRules(CartRule::FILTER_ACTION_REDUCTION, false);
             // Cart Rules array are merged manually in order to avoid doubles
-            foreach ($this->getCartRules(CartRule::FILTER_ACTION_GIFT) as $cartRuleCandidate) {
+            foreach ($this->getCartRules(CartRule::FILTER_ACTION_GIFT, false) as $cartRuleCandidate) {
                 $alreadyAddedCartRule = false;
                 foreach ($cartRules as $cartRule) {
                     if ($cartRuleCandidate['id_cart_rule'] == $cartRule['id_cart_rule']) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1951,7 +1951,7 @@ class CartCore extends ObjectModel
 
         // CART CALCULATION
         $cartRules = array();
-        if (in_array($type, [Cart::BOTH, Cart::ONLY_DISCOUNTS])) {
+        if (in_array($type, [Cart::BOTH, Cart::BOTH_WITHOUT_SHIPPING, Cart::ONLY_DISCOUNTS])) {
             $cartRules = $this->getTotalCalculationCartRules($type, $type == Cart::BOTH);
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1951,9 +1951,10 @@ class CartCore extends ObjectModel
 
         // CART CALCULATION
         $cartRules = array();
-        if (in_array($type, [Cart::BOTH, Cart::BOTH_WITHOUT_SHIPPING, Cart::ONLY_DISCOUNTS])) {
+        if (in_array($type, [Cart::BOTH, Cart::ONLY_DISCOUNTS])) {
             $cartRules = $this->getTotalCalculationCartRules($type, $type == Cart::BOTH);
         }
+
         $calculator = $this->newCalculator($products, $cartRules, $id_carrier);
         $computePrecision = $this->configuration->get('_PS_PRICE_COMPUTE_PRECISION_');
         switch ($type) {

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -26,12 +26,12 @@
 
 namespace Tests\Integration\Behaviour\Features\Context;
 
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Cache;
 use CartRule;
 use Configuration;
 use DateInterval;
 use DateTime;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Db;
 
 class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
@@ -59,6 +59,11 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     protected $customerFeatureContext;
 
     /**
+     * @var CategoryFeatureContext
+     */
+    protected $categoryFeatureContext;
+
+    /**
      * This hook can be used to perform a database cleaning of added objects
      *
      * @AfterScenario
@@ -77,6 +82,7 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
         $this->productFeatureContext = $scope->getEnvironment()->getContext(ProductFeatureContext::class);
         $this->carrierFeatureContext = $scope->getEnvironment()->getContext(CarrierFeatureContext::class);
         $this->customerFeatureContext = $scope->getEnvironment()->getContext(CustomerFeatureContext::class);
+        $this->categoryFeatureContext = $scope->getEnvironment()->getContext(CategoryFeatureContext::class);
     }
 
     /**
@@ -121,6 +127,33 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
         $cartRule->active = 1;
         $cartRule->add();
         $this->cartRules[$cartRuleName] = $cartRule;
+    }
+
+    /**
+     * @Given /^cart rule "(.+?)" is restricted to the category "(.+?)" with a quantity of (\d+)$/
+     */
+    public function cartRuleWithProductRuleRestriction($cartRuleName, $categoryName)
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->categoryFeatureContext->checkCategoryWithNameExists($categoryName);
+        $category = $this->categoryFeatureContext->getCategoryWithName($categoryName);
+
+        Db::getInstance()->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_product_rule_group` (`id_cart_rule`, `quantity`) ' .
+            'VALUES (' . (int) $this->cartRules[$cartRuleName]->id . ', 1)'
+        );
+        $idProductRuleGroup = Db::getInstance()->Insert_ID();
+
+        Db::getInstance()->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_product_rule` (`id_product_rule_group`, `type`) ' .
+            'VALUES (' . (int) $idProductRuleGroup . ', "categories")'
+        );
+        $idProductRule = Db::getInstance()->Insert_ID();
+
+        Db::getInstance()->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_product_rule_value` (`id_product_rule`, `id_item`) ' .
+            'VALUES (' . (int) $idProductRuleGroup . ', '. $category->id . ')'
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -152,7 +152,7 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
 
         Db::getInstance()->execute(
             'INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_product_rule_value` (`id_product_rule`, `id_item`) ' .
-            'VALUES (' . (int) $idProductRuleGroup . ', '. $category->id . ')'
+            'VALUES (' . (int) $idProductRuleGroup . ', ' . $category->id . ')'
         );
     }
 

--- a/tests/Integration/Behaviour/Features/Context/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CategoryFeatureContext.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context;
+
+use Context;
+use Category;
+use Tools;
+
+class CategoryFeatureContext extends AbstractPrestaShopFeatureContext
+{
+    use CartAwareTrait;
+
+    /**
+     * @var Category[]
+     */
+    protected $categories = [];
+
+    /**
+     * @Given /^there is a category named "(.+)"$/
+     */
+    public function createCategory($categoryName)
+    {
+        $idLang = (int) Context::getContext()->language->id;
+        $category = new Category();
+        $category->name = [$idLang => $categoryName];
+        $category->link_rewrite = [$idLang => Tools::link_rewrite($categoryName)];
+        $category->add();
+        $this->categories[$categoryName] = $category;
+    }
+
+    /**
+     * @param $categoryName
+     */
+    public function checkCategoryWithNameExists($categoryName)
+    {
+        $this->checkFixtureExists($this->categories, 'Category', $categoryName);
+    }
+
+    /**
+     * @param $categoryName
+     *
+     * @return Category
+     */
+    public function getCategoryWithName($categoryName)
+    {
+        return $this->categories[$categoryName];
+    }
+
+    /**
+     * @AfterScenario
+     */
+    public function cleanCategoryFixtures()
+    {
+        foreach ($this->categories as $category) {
+            $category->delete();
+        }
+
+        $this->categories = [];
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CustomerFeatureContext.php
@@ -70,7 +70,7 @@ class CustomerFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @param $productName
+     * @param $customerName
      *
      * @return Customer
      */

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -26,6 +26,7 @@
 
 namespace Tests\Integration\Behaviour\Features\Context;
 
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Cart;
 use Combination;
 use Configuration;
@@ -58,6 +59,17 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
      * @var CustomizationField[][]
      */
     protected $customizationFields = [];
+
+    /**
+     * @var CategoryFeatureContext
+     */
+    protected $categoryFeatureContext;
+
+    /** @BeforeScenario */
+    public function before(BeforeScenarioScope $scope)
+    {
+        $this->categoryFeatureContext = $scope->getEnvironment()->getContext(CategoryFeatureContext::class);
+    }
 
     /* PRODUCTS */
 
@@ -579,10 +591,25 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     /**
      * @Given /^product "(.+)" is virtual$/
      */
-    public function productWithNameProductisVirtual($productName)
+    public function productWithNameProductIsVirtual($productName)
     {
         $this->checkProductWithNameExists($productName);
         $this->products[$productName]->is_virtual = 1;
+        $this->products[$productName]->save();
+    }
+
+    /**
+     * @Given /^product "(.+?)" is in category "(.+?)"$/
+     */
+    public function productWithNameProductInInCategory($productName, $categoryName)
+    {
+        $this->checkProductWithNameExists($productName);
+        $this->categoryFeatureContext->checkCategoryWithNameExists($categoryName);
+
+        $category = $this->categoryFeatureContext->getCategoryWithName($categoryName);
+
+        $this->products[$productName]->id_category_default = $category->id_category;
+        $this->products[$productName]->addToCategories([$category->id]);
         $this->products[$productName]->save();
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_multiple.feature
@@ -61,3 +61,18 @@ Feature: Cart rule (amount) calculation with multiple cart rules
     When I use the discount "cartrule6"
     Then my cart total should be 147.4 tax included
     Then my cart total using previous calculation method should be 147.4 tax included
+
+  Scenario: One product in my cart, one cart rule for free shipping and one for free gift
+    Given I have an empty default cart
+    Given there is a category named "Awesome"
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product8" with a price of 12.345 and 1000 items in stock
+    Given product "product8" is in category "Awesome"
+    Given there is a cart rule named "cartrule-free-shipping" that applies an amount discount of 0.0 with priority 1, quantity of 1 and quantity per user 1
+    Given cart rule "cartrule-free-shipping" offers free shipping
+    Given there is a cart rule named "cartrule-free-gift" that applies an amount discount of 10.0 with priority 1, quantity of 1 and quantity per user 1
+    Given cart rule "cartrule-free-gift" is restricted to the category "Awesome" with a quantity of 1
+    Given cart rule "cartrule-free-gift" is restricted to product "product8"
+    When I add 1 item of product "product8" in my cart
+    Then my cart total should be 2.4 tax included
+    Then my cart total using previous calculation method should be 2.4 tax included

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -26,4 +26,5 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\SpecificPriceRuleFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CarrierFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\OrderFeatureContext


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Cart rules mustn't be auto added automatically during getTotalCalculationCartRules. The calculation here make the function recursive and going to an infinite loop :man_facepalming: 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15574 
| How to test?  | Follow ticket instruction.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15691)
<!-- Reviewable:end -->
