### PR TITLE
You can order even when no carrier is available for any of the products in the cart.

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2415,6 +2415,9 @@ class CartCore extends ObjectModel
                 }
             }
 
+            if(empty($product['carrier_list']))
+                return array();
+
             if (!isset($grouped_by_warehouse[$product['id_address_delivery']]['in_stock'][$id_warehouse])) {
                 $grouped_by_warehouse[$product['id_address_delivery']]['in_stock'][$id_warehouse] = array();
                 $grouped_by_warehouse[$product['id_address_delivery']]['out_of_stock'][$id_warehouse] = array();

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2415,8 +2415,9 @@ class CartCore extends ObjectModel
                 }
             }
 
-            if(empty($product['carrier_list']))
+            if (!$product['is_virtual'] && empty($product['carrier_list'])) {
                 return array();
+            }
 
             if (!isset($grouped_by_warehouse[$product['id_address_delivery']]['in_stock'][$id_warehouse])) {
                 $grouped_by_warehouse[$product['id_address_delivery']]['in_stock'][$id_warehouse] = array();
@@ -2436,10 +2437,6 @@ class CartCore extends ObjectModel
                     $product['cart_quantity'] -= $out_stock_part;
                     $grouped_by_warehouse[$product['id_address_delivery']]['out_of_stock'][$id_warehouse][] = $product_bis;
                 }
-            }
-
-            if (empty($product['carrier_list'])) {
-                $product['carrier_list'] = array(0 => 0);
             }
 
             $grouped_by_warehouse[$product['id_address_delivery']][$key][$id_warehouse][] = $product;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Ability to place an order despite the unavailability of carriers for certain products in the cart.
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ----.
| How to test?  | Create two products, and associate one of the products with a disabled carrier for example (or a carrier not available in the country where you want to be delivered) and the other product you associate with an available carrier. On the front, add both products to the basket. In the order process in the delivery step, you will find that despite the effect that carriers lack for one of the products you can still place your order. On the other hand, in the back office, at the level of the invoice you will miss information concerning the delivery of the products in question.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15698)
<!-- Reviewable:end -->
