### PR TITLE
Wrong combinaison reference in customer account order history

### DIFF
--- a/themes/classic/templates/customer/_partials/order-detail-no-return.tpl
+++ b/themes/classic/templates/customer/_partials/order-detail-no-return.tpl
@@ -41,8 +41,8 @@
                 {$product.name}
               </a>
             </strong><br/>
-            {if $product.reference}
-              {l s='Reference' d='Shop.Theme.Catalog'}: {$product.reference}<br/>
+            {if $product.product_reference}
+              {l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}<br/>
             {/if}
             {if $product.customizations}
               {foreach from=$product.customizations item="customization"}
@@ -122,8 +122,8 @@
         <div class="row">
           <div class="col-sm-5 desc">
             <div class="name">{$product.name}</div>
-            {if $product.reference}
-              <div class="ref">{l s='Reference' d='Shop.Theme.Catalog'}: {$product.reference}</div>
+            {if $product.product_reference}
+              <div class="ref">{l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}</div>
             {/if}
             {if $product.customizations}
               {foreach $product.customizations as $customization}

--- a/themes/classic/templates/customer/_partials/order-detail-return.tpl
+++ b/themes/classic/templates/customer/_partials/order-detail-return.tpl
@@ -54,8 +54,8 @@
             </td>
             <td>
               <strong>{$product.name}</strong><br/>
-              {if $product.reference}
-                {l s='Reference' d='Shop.Theme.Catalog'}: {$product.reference}<br/>
+              {if $product.product_reference}
+                {l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}<br/>
               {/if}
               {if $product.customizations}
                 {foreach from=$product.customizations item="customization"}
@@ -171,8 +171,8 @@
               <div class="row">
                 <div class="col-sm-5 desc">
                   <div class="name">{$product.name}</div>
-                  {if $product.reference}
-                    <div class="ref">{l s='Reference' d='Shop.Theme.Catalog'}: {$product.reference}</div>
+                  {if $product.product_reference}
+                    <div class="ref">{l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}</div>
                   {/if}
                   {if $product.customizations}
                     {foreach $product.customizations as $customization}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Wrong combinaison reference in customer account order history
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/15717
| How to test?  | After purchasing a product (combinaison), go to the order history on your customer account, in the list of products you will find that the reference shows for the combinaison is that of the parent product. See here https://github.com/PrestaShop/PrestaShop/issues/15717

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15706)
<!-- Reviewable:end -->
