### PR TITLE
Webservices shouldn't display warning when running with fpm or Nginx

### DIFF
--- a/src/Core/Webservice/ServerRequirementsChecker.php
+++ b/src/Core/Webservice/ServerRequirementsChecker.php
@@ -117,8 +117,16 @@ final class ServerRequirementsChecker implements ServerRequirementsCheckerInterf
     {
         $issues = [];
 
+        if (!$this->phpExtensionChecker->loaded('SimpleXML')) {
+            $issues[] = self::ISSUE_EXT_SIMPLEXML_NOT_AVAILABLE;
+        }
+
+        if (false === $this->configuration->getBoolean('PS_SSL_ENABLED')) {
+            $issues[] = self::ISSUE_HTTPS_NOT_AVAILABLE;
+        }
+
         if (false === strpos($this->hostingInformation->getServerInformation()['version'], 'Apache')) {
-            $issues[] = self::ISSUE_NOT_APACHE_SERVER;
+            return $issues;
         }
 
         if (function_exists('apache_get_modules')) {
@@ -135,14 +143,6 @@ final class ServerRequirementsChecker implements ServerRequirementsCheckerInterf
             $issues[] = self::ISSUE_CANNOT_CHECK_APACHE_MODULES;
         }
 
-        if (!$this->phpExtensionChecker->loaded('SimpleXML')) {
-            $issues[] = self::ISSUE_EXT_SIMPLEXML_NOT_AVAILABLE;
-        }
-
-        if (false === $this->configuration->getBoolean('PS_SSL_ENABLED')) {
-            $issues[] = self::ISSUE_HTTPS_NOT_AVAILABLE;
-        }
-
         return $issues;
     }
 
@@ -152,11 +152,6 @@ final class ServerRequirementsChecker implements ServerRequirementsCheckerInterf
     private function getWarningMessages()
     {
         return [
-            self::ISSUE_NOT_APACHE_SERVER => $this->translator->trans(
-                'To avoid operating problems, please use an Apache server.',
-                [],
-                'Admin.Advparameters.Notification'
-            ),
             self::ISSUE_CANNOT_CHECK_APACHE_MODULES => $this->translator->trans(
                 'Please activate the \'mod_auth_basic\' Apache module to allow authentication of PrestaShop\'s webservice.',
                 [],

--- a/src/Core/Webservice/ServerRequirementsChecker.php
+++ b/src/Core/Webservice/ServerRequirementsChecker.php
@@ -37,8 +37,6 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 final class ServerRequirementsChecker implements ServerRequirementsCheckerInterface
 {
-    const ISSUE_NOT_APACHE_SERVER = 'not_apache_server';
-    const ISSUE_CANNOT_CHECK_APACHE_MODULES = 'cannot_check_apache_modules';
     const ISSUE_APACHE_MOD_AUTH_BASIC_NOT_AVAILABLE = 'issue_apache_mod_auth_basic_not_available';
     const ISSUE_APACHE_MOD_AUTH_REWRITE_NOT_AVAILABLE = 'issue_apache_mod_auth_rewrite_not_available';
     const ISSUE_EXT_SIMPLEXML_NOT_AVAILABLE = 'issue_ext_simplexml_not_available';
@@ -139,8 +137,6 @@ final class ServerRequirementsChecker implements ServerRequirementsCheckerInterf
             if (false === in_array('mod_rewrite', $apache_modules)) {
                 $issues[] = self::ISSUE_APACHE_MOD_AUTH_REWRITE_NOT_AVAILABLE;
             }
-        } else {
-            $issues[] = self::ISSUE_CANNOT_CHECK_APACHE_MODULES;
         }
 
         return $issues;
@@ -152,11 +148,6 @@ final class ServerRequirementsChecker implements ServerRequirementsCheckerInterf
     private function getWarningMessages()
     {
         return [
-            self::ISSUE_CANNOT_CHECK_APACHE_MODULES => $this->translator->trans(
-                'Please activate the \'mod_auth_basic\' Apache module to allow authentication of PrestaShop\'s webservice.',
-                [],
-                'Admin.Advparameters.Notification'
-            ),
             self::ISSUE_APACHE_MOD_AUTH_BASIC_NOT_AVAILABLE => $this->translator->trans(
                 'Please activate the \'mod_rewrite\' Apache module to allow the PrestaShop webservice.',
                 [],

--- a/tests/Unit/Core/Webservice/ServerRequirementsCheckerTest.php
+++ b/tests/Unit/Core/Webservice/ServerRequirementsCheckerTest.php
@@ -67,28 +67,6 @@ class ServerRequirementsCheckerTest extends TestCase
         $this->mockedPhpExtensionChecker = $this->createMock(PhpExtensionCheckerInterface::class);
     }
 
-    public function testErrorIsReturnedWhenNonApacheWebServerIsUsed()
-    {
-        $this->mockedHostingInformation
-            ->method('getServerInformation')
-            ->willReturn(['version' => 'nginx']);
-
-        $errors = $this->createNewServerRequirementsChecker()->checkForErrors();
-
-        $this->assertContains('To avoid operating problems, please use an Apache server.', $errors);
-    }
-
-    public function testNoErrorsAreReturnedWhenUsingApacheWebServer()
-    {
-        $this->mockedHostingInformation
-            ->method('getServerInformation')
-            ->willReturn(['version' => 'Apache/2.4.29 (Ubuntu)']);
-
-        $errors = $this->createNewServerRequirementsChecker()->checkForErrors();
-
-        $this->assertNotContains('To avoid operating problems, please use an Apache server.', $errors);
-    }
-
     public function testNoErrorsAreReturnedWhenSslIsEnabled()
     {
         $this->mockedConfiguration


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | We shouldn't display Apache warning if the php service is running under fpm or Nginx. Apache is not mandatory to run this kind of service.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15385 
| How to test?  | Follow ticket instructions.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15731)
<!-- Reviewable:end -->
