### PR TITLE
Use cover photo in listing instead of default combination

### DIFF
--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -29,12 +29,14 @@
     <div class="thumbnail-container">
       {block name='product_thumbnail'}
         {if $product.cover}
-          <a href="{$product.url}" class="thumbnail product-thumbnail">
+          {assign var='coverImage' value=Product::getCover($product->id)}
+          {assign var='coverImageId' value="{$product->id}-{$coverImage.id_image}"}
+          <a href="{$product.canonical_url}" class="thumbnail product-thumbnail">
             <img
-              src="{$product.cover.bySize.home_default.url}"
+              src="{$link->getImageLink($product.link_rewrite, $coverImageId)}"
               alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
               data-full-size-image-url="{$product.cover.large.url}"
-            />
+              />
           </a>
         {else}
           <a href="{$product.url}" class="thumbnail product-thumbnail">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Use cover photo in listing instead of default combination
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12241 
| How to test?  | Follow ticket instruction.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15748)
<!-- Reviewable:end -->
