### PR TITLE
Make CLDR Specification\Number immutable

### DIFF
--- a/src/Core/Localization/Locale/Repository.php
+++ b/src/Core/Localization/Locale/Repository.php
@@ -214,9 +214,9 @@ class Repository implements RepositoryInterface
                 $cldrLocale,
                 $currency,
                 $this->numberGroupingUsed,
-                $this->currencyDisplayType
+                $this->currencyDisplayType,
+                (int) $currency->getDecimalPrecision()
             );
-            $thisPriceSpecification->setMaxFractionDigits((int) $currency->getDecimalPrecision());
 
             // Add the spec to the collection
             $priceSpecifications->add(

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -100,7 +100,8 @@ class Factory
         CldrLocaleInterface $cldrLocale,
         Currency $currency,
         $numberGroupingUsed,
-        $currencyDisplayType
+        $currencyDisplayType,
+        ?int $maxFractionDigits = null
     ) {
         $currencyPattern = $cldrLocale->getCurrencyPattern();
         $numbersSymbols = $cldrLocale->getAllNumberSymbols();
@@ -111,7 +112,7 @@ class Factory
             $positivePattern,
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
-            $this->getMaxFractionDigits($positivePattern),
+            $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
             $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Number.php
+++ b/src/Core/Localization/Specification/Number.php
@@ -325,13 +325,15 @@ class Number implements NumberInterface
     }
 
     /**
-     * @deprecated https://github.com/PrestaShop/PrestaShop/issues/13168
+     * @deprecated
      *
      * @param int $maxFractionDigits
+     *
+     * @throws LocalizationException
      */
     public function setMaxFractionDigits($maxFractionDigits)
     {
-        $this->maxFractionDigits = $maxFractionDigits;
+        throw new LocalizationException('Class Number is immutable. Please define maxFractionDigits from the constructor.');
     }
 
     /**

--- a/src/Core/Localization/Specification/Number.php
+++ b/src/Core/Localization/Specification/Number.php
@@ -325,18 +325,6 @@ class Number implements NumberInterface
     }
 
     /**
-     * @deprecated
-     *
-     * @param int $maxFractionDigits
-     *
-     * @throws LocalizationException
-     */
-    public function setMaxFractionDigits($maxFractionDigits)
-    {
-        throw new LocalizationException('Class Number is immutable. Please define maxFractionDigits from the constructor.');
-    }
-
-    /**
      * To array function
      *
      * @return array

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -180,6 +180,7 @@ class FactoryTest extends TestCase
             true,
             $maxFractionDigits
         );
+        $expected['maxFractionDigits'] = $maxFractionDigits;
         $this->assertEquals(
             $expected,
             $specification->toArray()

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -143,6 +143,48 @@ class FactoryTest extends TestCase
             $expected,
             $specification->toArray()
         );
+        $this->assertEquals($specification->getMaxFractionDigits(), $expected['maxFractionDigits']);
+    }
+
+    /**
+     * Given a valid CLDR locale
+     * Given a Max Fractions digts to display in a number's decimal
+     * Given a boolean to define if we should group digits in a number's integer part
+     * Given an integer to specify max fraction digits
+     * Then calling buildPriceSpecification() should return an NumberSpecification
+     *
+     * @dataProvider getPriceData
+     */
+    public function testBuildPriceSpecificationWithM($data, $expected)
+    {
+        $maxFractionDigits = 3;
+        $specification = $this->factory->buildPriceSpecification(
+            $data[0],
+            $this->createLocale(
+                ...$data
+            ),
+            new Currency(
+                null,
+                null,
+                'EUR',
+                '978',
+                [
+                    $data[0] => '€',
+                ],
+                '2',
+                [
+                    $data[0] => 'Euro',
+                ]
+            ),
+            3,
+            true,
+            $maxFractionDigits
+        );
+        $this->assertEquals(
+            $expected,
+            $specification->toArray()
+        );
+        $this->assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
     }
 
     public function getPriceData()

--- a/tests-legacy/Unit/Core/Localization/Specification/NumberTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/NumberTest.php
@@ -27,6 +27,7 @@
 namespace LegacyTests\Unit\Core\Localization\Specification;
 
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Number as NumberSpecification;
 use PrestaShop\PrestaShop\Core\Localization\Specification\NumberSymbolList;
 
@@ -110,8 +111,22 @@ class NumberTest extends TestCase
      */
     public function testGetSymbolsByNumberingSystemWithInvalidParameter()
     {
-        $this->expectException(\PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException::class);
+        $this->expectException(LocalizationException::class);
 
         $this->latinNumberSpec->getSymbolsByNumberingSystem('foobar');
+    }
+
+    /**
+     * Given a valid Number specification
+     * When defining max fraction digits from the method setMaxFractionDigits
+     * Then an exception souhd be raised
+     *
+     */
+    public function testSetMaxFractionDigits()
+    {
+        $this->expectException(LocalizationException::class);
+        $this->expectExceptionMessage('Class Number is immutable. Please define maxFractionDigits from the constructor.');
+
+        $this->latinNumberSpec->setMaxFractionDigits(2);
     }
 }

--- a/tests-legacy/Unit/Core/Localization/Specification/NumberTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/NumberTest.php
@@ -115,18 +115,4 @@ class NumberTest extends TestCase
 
         $this->latinNumberSpec->getSymbolsByNumberingSystem('foobar');
     }
-
-    /**
-     * Given a valid Number specification
-     * When defining max fraction digits from the method setMaxFractionDigits
-     * Then an exception souhd be raised
-     *
-     */
-    public function testSetMaxFractionDigits()
-    {
-        $this->expectException(LocalizationException::class);
-        $this->expectExceptionMessage('Class Number is immutable. Please define maxFractionDigits from the constructor.');
-
-        $this->latinNumberSpec->setMaxFractionDigits(2);
-    }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Current CLDR implementation uses Specification\Number::setMaxFractionDigits() to override cldr specification precision with customized currency one
| Type?         | improvement
| Category?     | CO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #13168
| How to test?  | 

**BC Break :** Class PrestaShop\PrestaShop\Core\Localization\Specification\Number is now final

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15755)
<!-- Reviewable:end -->
