### PR TITLE
Fix monitoring grids id configuration

### DIFF
--- a/src/Core/Grid/Data/Factory/EmptyCategoryGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/EmptyCategoryGridDataFactory.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Modifies records from database for empty_category grid
+ */
+final class EmptyCategoryGridDataFactory implements GridDataFactoryInterface
+{
+    /**
+     * @var GridDataFactoryInterface
+     */
+    private $doctrineEmptyCategoryDataFactory;
+
+    /**
+     * @param GridDataFactoryInterface $doctrineEmptyCategoryDataFactory
+     */
+    public function __construct(GridDataFactoryInterface $doctrineEmptyCategoryDataFactory)
+    {
+        $this->doctrineEmptyCategoryDataFactory = $doctrineEmptyCategoryDataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(SearchCriteriaInterface $searchCriteria)
+    {
+        $data = $this->doctrineEmptyCategoryDataFactory->getData($searchCriteria);
+
+        $records = $this->modifyRecords($data->getRecords()->all());
+
+        return new GridData(
+            new RecordCollection($records),
+            $data->getRecordsTotal(),
+            $data->getQuery()
+        );
+    }
+
+    /**
+     * Modify empty category records.
+     *
+     * @param array $records
+     *
+     * @return array
+     */
+    private function modifyRecords(array $records)
+    {
+        foreach ($records as $key => $record) {
+            $records[$key]['description'] = strip_tags(stripslashes($record['description']));
+        }
+
+        return $records;
+    }
+}

--- a/src/Core/Grid/Definition/Factory/Monitoring/EmptyCategoryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Monitoring/EmptyCategoryGridDefinitionFactory.php
@@ -91,7 +91,6 @@ final class EmptyCategoryGridDefinitionFactory extends AbstractGridDefinitionFac
                     ->setName($this->trans('Description', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'description',
-                        'sortable' => false,
                     ])
             )
             ->add(

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -155,7 +155,6 @@ services:
             - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
             - '@prestashop.core.query.doctrine_search_criteria_applicator'
             - '@prestashop.adapter.shop.context'
-            - '@prestashop.adapter.feature.multistore'
             - "@=service('prestashop.adapter.legacy.configuration').get('PS_ROOT_CATEGORY')"
         public: true
 

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -189,6 +189,11 @@ services:
             - '@prestashop.core.grid.query.doctrine_query_parser'
             - 'empty_category'
 
+    prestashop.core.grid.data.factory.empty_category_decorator:
+        class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\EmptyCategoryGridDataFactory'
+        arguments:
+            - '@prestashop.core.grid.data.factory.empty_category'
+
     prestashop.core.grid.data.factory.no_qty_product_with_combination:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -203,7 +203,7 @@ services:
             - '@prestashop.core.grid.query_builder.monitoring.no_qty_product_without_combination'
             - '@prestashop.core.hook.dispatcher'
             - '@prestashop.core.grid.query.doctrine_query_parser'
-            - 'no_qty_product_with_combination'
+            - 'no_qty_product_without_combination'
 
     prestashop.core.grid.data.factory.disabled_product:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
@@ -211,7 +211,7 @@ services:
             - '@prestashop.core.grid.query_builder.monitoring.disabled_product'
             - '@prestashop.core.hook.dispatcher'
             - '@prestashop.core.grid.query.doctrine_query_parser'
-            - 'no_qty_product_with_combination'
+            - 'disabled_product'
 
     prestashop.core.grid.data.factory.product_without_image:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
@@ -219,7 +219,7 @@ services:
             - '@prestashop.core.grid.query_builder.monitoring.product_without_image'
             - '@prestashop.core.hook.dispatcher'
             - '@prestashop.core.grid.query.doctrine_query_parser'
-            - 'no_qty_product_with_combination'
+            - 'product_without_image'
 
     prestashop.core.grid.data.factory.product_without_description:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
@@ -227,7 +227,7 @@ services:
             - '@prestashop.core.grid.query_builder.monitoring.product_without_description'
             - '@prestashop.core.hook.dispatcher'
             - '@prestashop.core.grid.query.doctrine_query_parser'
-            - 'no_qty_product_with_combination'
+            - 'product_without_description'
 
     prestashop.core.grid.data.factory.product_without_price:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
@@ -235,7 +235,7 @@ services:
             - '@prestashop.core.grid.query_builder.monitoring.product_without_price'
             - '@prestashop.core.hook.dispatcher'
             - '@prestashop.core.grid.query.doctrine_query_parser'
-            - 'no_qty_product_with_combination'
+            - 'product_without_price'
 
     prestashop.core.grid.data.factory.order:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -163,7 +163,7 @@ services:
         class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
         arguments:
             - '@prestashop.core.grid.definition.factory.monitoring.empty_category'
-            - '@prestashop.core.grid.data.factory.empty_category'
+            - '@prestashop.core.grid.data.factory.empty_category_decorator'
             - '@prestashop.core.grid.filter.form_factory'
             - '@prestashop.core.hook.dispatcher'
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Monitoring/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Monitoring/index.html.twig
@@ -30,6 +30,20 @@
     <div class="row">
       <div class="col">
         {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': emptyCategoryGrid} %}
+
+          {% block grid_panel_body %}
+            <div class="card-body">
+              <div class="alert alert-info">
+                <div class="alert-text">
+                  {{ 'An empty category is a category that has no product directly associated to it. An empty category may however contain products through its subcategories.'|trans({}, 'Admin.Catalog.Help') }}
+                </div>
+              </div>
+              {% block grid_view_block %}
+                {{ include('@PrestaShop/Admin/Common/Grid/grid.html.twig', {'grid': emptyCategoryGrid }) }}
+              {% endblock %}
+            </div>
+          {% endblock %}
+
           {% block grid_panel_extra_content %}
             {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig'
               with {'deleteCategoriesForm': deleteCategoryForm }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In `grid_data_factory.yaml` monitoring page grid definitions where configured with wrong id's. Also empty_category grid had one wrong argument injected, which was leading to error.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | partially https://github.com/PrestaShop/PrestaShop/issues/10552
| How to test?  | open `/admin-dev/index.php/sell/catalog/monitoring`, ensure that the page contains 7 lists. Each list should be filterable, sortable, paginatable independently from each other. The only action currently working is categories status toggling (other actions are not migrated).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15757)
<!-- Reviewable:end -->
