### PR TITLE
Fix association of payment methods with delivery module

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -170,7 +170,7 @@ abstract class PaymentModuleCore extends Module
             $shops = Shop::getShops(true, null, true);
         }
 
-        $carriers = Carrier::getCarriers((int) Context::getContext()->language->id, false, false, false, null, null);
+        $carriers = Carrier::getCarriers((int) Context::getContext()->language->id, false, false, false, null, Carrier::ALL_CARRIERS);
         $carrier_ids = array();
         foreach ($carriers as $carrier) {
             $carrier_ids[] = $carrier['id_reference'];

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -170,7 +170,7 @@ abstract class PaymentModuleCore extends Module
             $shops = Shop::getShops(true, null, true);
         }
 
-        $carriers = Carrier::getCarriers((int) Context::getContext()->language->id);
+        $carriers = Carrier::getCarriers((int) Context::getContext()->language->id, false, false, false, null, null);
         $carrier_ids = array();
         foreach ($carriers as $carrier) {
             $carrier_ids[] = $carrier['id_reference'];


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | if you install a delivery module and then install a payment module, the new payment method will not contact that delivery module.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15852
| How to test?  | Default $modules_filters is only carriers, not modules

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15799)
<!-- Reviewable:end -->
