### PR TITLE
Fix Cannot use object of type ParameterBag as array

### DIFF
--- a/src/Adapter/Security/Admin.php
+++ b/src/Adapter/Security/Admin.php
@@ -88,7 +88,7 @@ class Admin
 
         // in case of exception handler sub request, avoid infinite redirection
         if ($event->getRequestType() === HttpKernelInterface::SUB_REQUEST
-            && isset($event->getRequest()->attributes['exception'])
+            && $event->getRequest()->attributes->has('exception')
         ) {
             return true;
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I got an exception when saving a product: Cannot use object of type ParameterBag as array and I have fixed it using ParameterBag "has" method.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15815
| How to test?  | if it exists, Run this file unit test.

```
[Tue Oct 01 14:45:05.873957 2019] [php7:error] [pid 15296] [client 172.19.0.2:47756] script '/var/www/html/admin/themes/new-theme/public/index.php' not found or unable to stat, referer: https://myshop.com/admin/index.php/sell/catalog/products/9018?_token=Tl8ItvVRfaL46AdjUjhk5F52XFRuJjsQPfPQPS7X9FY
[Tue Oct 01 14:45:15.704399 2019] [php7:error] [pid 19] [client 172.19.0.2:47768] PHP Fatal error:  Uncaught Symfony\\Component\\Debug\\Exception\\FatalThrowableError: Cannot use object of type Symfony\\Component\\HttpFoundation\\ParameterBag as array in /var/www/html/src/Adapter/Security/Admin.php:91
Stack trace:
#0 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php(212): PrestaShop\\PrestaShop\\Adapter\\Security\\Admin->onKernelRequest(Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent), 'kernel.request', Object(Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher))
#1 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php(44): Symfony\\Component\\EventDispatcher\\EventDispatcher->doDispatch(Array, 'kernel.request', Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent))
#2 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(127): Symfony\\Component\\EventDispatcher\\EventDispatcher->dispatch('kernel.request', Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent))
#3 /var/www/h in /var/www/html/src/Adapter/Security/Admin.php on line 91, referer: https://myshop.com/admin/index.php/sell/catalog/products/9018?_token=Tl8ItvVRfaL46AdjUjhk5F52XFRuJjsQPfPQPS7X9FY
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15805)
<!-- Reviewable:end -->
