### PR TITLE
Fix E2E dockerfile as npm is not anymore in the nodejs package

### DIFF
--- a/tests/E2E/.docker/Dockerfile
+++ b/tests/E2E/.docker/Dockerfile
@@ -18,8 +18,7 @@ RUN rm -rf /var/lib/apt/lists/*
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update
-RUN apt-get install -y nodejs
-RUN npm i npm@latest -g
+RUN apt-get install -y nodejs npm
 
 # Repository update
 WORKDIR /var/www/html/tests/E2E


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Npm is not anymore in the nodejs package.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| How to test?  | No need QA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15848)
<!-- Reviewable:end -->
