### PR TITLE
Fixed missing translation for tax label

### DIFF
--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -102,9 +102,9 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
             $priceFormatter = new PriceFormatter();
 
             if ($this->getIncludeTaxes() && $this->getDisplayTaxesLabel()) {
-                $taxLabel .= ' tax incl.';
+                $taxLabel .= $this->getTranslator()->trans('tax incl.', array(), 'Shop.Theme.Checkout');
             } elseif ($this->getDisplayTaxesLabel()) {
-                $taxLabel .= ' tax excl.';
+                $taxLabel .= $this->getTranslator()->trans('tax excl.', array(), 'Shop.Theme.Checkout');
             }
 
             return $this->getTranslator()->trans(


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed missing translation for tax label
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Do checkout with gift and see that tax incl. /tax excl. is translated

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15851)
<!-- Reviewable:end -->
