### PR TITLE
Allow anonymous mode for AdminController

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2887,6 +2887,11 @@ class AdminControllerCore extends Controller
      */
     public function initShopContext()
     {
+        // Do not initialize context when the shop is not installed
+        if (defined('PS_INSTALLATION_IN_PROGRESS')) {
+            return;
+        }
+
         // Change shop context ?
         if (Shop::isFeatureActive() && Tools::getValue('setShopContext') !== false) {
             $this->context->cookie->shopContext = Tools::getValue('setShopContext');

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -247,6 +247,9 @@ class AdminControllerCore extends Controller
     /** @var HelperList */
     protected $helper;
 
+    /** @var bool */
+    private $allowAnonymous = false;
+
     /** @var int DELETE access level */
     const LEVEL_DELETE = 4;
 
@@ -770,7 +773,7 @@ class AdminControllerCore extends Controller
      */
     public function checkToken()
     {
-        if (TokenInUrls::isDisabled()) {
+        if (TokenInUrls::isDisabled() || $this->isAnonymousAllowed()) {
             return true;
         }
 
@@ -2794,7 +2797,17 @@ class AdminControllerCore extends Controller
                 $this->context->cookie->last_activity = time();
             }
         }
-        if ($this->controller_name != 'AdminLogin' && (!isset($this->context->employee) || !$this->context->employee->isLoggedBack())) {
+
+        if (
+            !$this->isAnonymousAllowed()
+            && (
+                $this->controller_name != 'AdminLogin'
+                && (
+                    !isset($this->context->employee)
+                    || !$this->context->employee->isLoggedBack()
+                )
+            )
+        ) {
             if (isset($this->context->employee)) {
                 $this->context->employee->logout();
             }
@@ -2804,6 +2817,7 @@ class AdminControllerCore extends Controller
             }
             Tools::redirectAdmin($this->context->link->getAdminLink('AdminLogin') . ((!isset($_GET['logout']) && $this->controller_name != 'AdminNotFound' && Tools::getValue('controller')) ? '&redirect=' . $this->controller_name : '') . ($email ? '&email=' . $email : ''));
         }
+
         // Set current index
         $current_index = 'index.php' . (($controller = Tools::getValue('controller')) ? '?controller=' . $controller : '');
         if ($back = Tools::getValue('back')) {
@@ -2873,10 +2887,6 @@ class AdminControllerCore extends Controller
      */
     public function initShopContext()
     {
-        if (!$this->context->employee->isLoggedBack()) {
-            return;
-        }
-
         // Change shop context ?
         if (Shop::isFeatureActive() && Tools::getValue('setShopContext') !== false) {
             $this->context->cookie->shopContext = Tools::getValue('setShopContext');
@@ -2888,13 +2898,13 @@ class AdminControllerCore extends Controller
             $this->redirect_after = $url['path'] . ($http_build_query ? '?' . $http_build_query : '');
         } elseif (!Shop::isFeatureActive()) {
             $this->context->cookie->shopContext = 's-' . (int) Configuration::get('PS_SHOP_DEFAULT');
-        } elseif (Shop::getTotalShops(false, null) < 2) {
+        } elseif (Shop::getTotalShops(false, null) < 2 && $this->context->employee->isLoggedBack()) {
             $this->context->cookie->shopContext = 's-' . (int) $this->context->employee->getDefaultShopID();
         }
 
-        $shop_id = '';
+        $shop_id = null;
         Shop::setContext(Shop::CONTEXT_ALL);
-        if ($this->context->cookie->shopContext) {
+        if ($this->context->cookie->shopContext && $this->context->employee->isLoggedBack()) {
             $split = explode('-', $this->context->cookie->shopContext);
             if (count($split) == 2) {
                 if ($split[0] == 'g') {
@@ -4826,5 +4836,27 @@ class AdminControllerCore extends Controller
             ['symbol' => $numberSpecification->getSymbolsByNumberingSystem(Locale::NUMBERING_SYSTEM_LATIN)->toArray()],
             $numberSpecification->toArray()
         );
+    }
+
+    /**
+     * Set if anonymous is allowed to run this controller
+     *
+     * @param bool $value
+     *
+     * @return bool
+     */
+    protected function setAllowAnonymous($value)
+    {
+        $this->allowAnonymous = (bool) $value;
+    }
+
+    /**
+     * Return if an anonymous is allowed to run this controller
+     *
+     * @return bool
+     */
+    protected function isAnonymousAllowed()
+    {
+        return $this->allowAnonymous;
     }
 }

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -34,26 +34,27 @@ class AdminSearchControllerCore extends AdminController
         parent::__construct();
     }
 
-    public function getTabSlug()
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
     {
-        return 'ROLE_MOD_TAB_ADMINSEARCHCONF_';
-    }
-
-    public function checkToken()
-    {
-        // Specific check for the ajax request 'searchCron'
-        if (Tools::isSubmit('action')
-            && 'searchCron' === Tools::getValue('action')
+        if ($this->isCronTask()
             && substr(
                 _COOKIE_KEY_,
                 static::TOKEN_CHECK_START_POS,
                 static::TOKEN_CHECK_LENGTH
             ) === Tools::getValue('token')
         ) {
-            return true;
+            $this->setAllowAnonymous(true);
         }
 
-        return parent::checkToken();
+        parent::init();
+    }
+
+    public function getTabSlug()
+    {
+        return 'ROLE_MOD_TAB_ADMINSEARCHCONF_';
     }
 
     public function postProcess()
@@ -510,5 +511,15 @@ class AdminSearchControllerCore extends AdminController
         if (Tools::getValue('redirect')) {
             Tools::redirectAdmin($_SERVER['HTTP_REFERER'] . '&conf=4');
         }
+    }
+
+    /**
+     * Check if a task is a cron task
+     *
+     * @return bool
+     */
+    protected function isCronTask()
+    {
+        return Tools::isSubmit('action') && 'searchCron' === Tools::getValue('action');
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Add `allowAnonymous` property in `AdminController` in order to execute cron.  
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15725 
| How to test?  | The cron script can be executable without having an employee connected.

Example:
```php
    /**
     * {@inheritdoc}
     */
    public function init()
    {
        if ($this->isCronTask()
            && substr(
                _COOKIE_KEY_,
                static::TOKEN_CHECK_START_POS,
                static::TOKEN_CHECK_LENGTH
            ) === Tools::getValue('token')
        ) {
            $this->isAnonymousAllowed(true);
        }

        parent::init();
    }

    /**
     * Check if a task is a cron task
     *
     * @return bool
     */
    protected function isCronTask()
    {
        return Tools::isSubmit('action') && 'searchCron' === Tools::getValue('action');
    }

```
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15855)
<!-- Reviewable:end -->
