### PR TITLE
Avoid error when trying to translate an invalid module

### DIFF
--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -32,6 +32,8 @@ use PrestaShopBundle\Service\TranslationService;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Module;
+use Exception;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class TranslationRouteFinder finds the correct route for translations.
@@ -72,20 +74,28 @@ class TranslationRouteFinder
      * @var ModuleRepositoryInterface
      */
     private $moduleRepository;
+    
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
 
     /**
      * @param TranslationService $translationService
      * @param Link $link
      * @param ModuleRepositoryInterface $moduleRepository
+     * @param TranslatorInterface $translator
      */
     public function __construct(
         TranslationService $translationService,
         Link $link,
-        ModuleRepositoryInterface $moduleRepository
+        ModuleRepositoryInterface $moduleRepository,
+        TranslatorInterface $translator
     ) {
         $this->translationService = $translationService;
         $this->link = $link;
         $this->moduleRepository = $moduleRepository;
+        $this->translator = $translator;
     }
 
     /**
@@ -204,10 +214,10 @@ class TranslationRouteFinder
     private function isModuleUsingNewTranslationSystem($moduleName)
     {
         $module = $this->moduleRepository->getInstanceByName($moduleName);
-        if ($module instanceof Module) {
-            return $module->isUsingNewTranslationSystem();
+        if (!($module instanceof Module)) {
+            throw new Exception($this->translator->trans('Invalid module : %s', array($moduleName),'Admin.International.Notification'));
         }
 
-        return false;
+        return $module->isUsingNewTranslationSystem();
     }
 }

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -215,7 +215,7 @@ class TranslationRouteFinder
     {
         $module = $this->moduleRepository->getInstanceByName($moduleName);
         if (!($module instanceof Module)) {
-            throw new Exception($this->translator->trans('Invalid module : %s', array($moduleName),'Admin.International.Notification'));
+            throw new Exception($this->translator->trans('Invalid module : %s', array($moduleName), 'Admin.International.Notification'));
         }
 
         return $module->isUsingNewTranslationSystem();

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -31,9 +31,9 @@ use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepositoryInterface;
 use PrestaShopBundle\Service\TranslationService;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Translation\TranslatorInterface;
 use Module;
 use Exception;
-use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class TranslationRouteFinder finds the correct route for translations.
@@ -214,6 +214,7 @@ class TranslationRouteFinder
     private function isModuleUsingNewTranslationSystem($moduleName)
     {
         $module = $this->moduleRepository->getInstanceByName($moduleName);
+        
         if (!($module instanceof Module)) {
             throw new Exception($this->translator->trans('Invalid module : %s', array($moduleName), 'Admin.International.Notification'));
         }

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -74,7 +74,7 @@ class TranslationRouteFinder
      * @var ModuleRepositoryInterface
      */
     private $moduleRepository;
-    
+
     /**
      * @var TranslatorInterface
      */
@@ -214,7 +214,7 @@ class TranslationRouteFinder
     private function isModuleUsingNewTranslationSystem($moduleName)
     {
         $module = $this->moduleRepository->getInstanceByName($moduleName);
-        
+
         if (!($module instanceof Module)) {
             throw new Exception($this->translator->trans('Invalid module : %s', array($moduleName), 'Admin.International.Notification'));
         }

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -31,9 +31,8 @@ use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepositoryInterface;
 use PrestaShopBundle\Service\TranslationService;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\PropertyAccess\PropertyAccess;
-use Symfony\Component\Translation\TranslatorInterface;
+use PrestaShopBundle\Exception\InvalidModuleException;
 use Module;
-use Exception;
 
 /**
  * Class TranslationRouteFinder finds the correct route for translations.
@@ -76,26 +75,18 @@ class TranslationRouteFinder
     private $moduleRepository;
 
     /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
      * @param TranslationService $translationService
      * @param Link $link
      * @param ModuleRepositoryInterface $moduleRepository
-     * @param TranslatorInterface $translator
      */
     public function __construct(
         TranslationService $translationService,
         Link $link,
-        ModuleRepositoryInterface $moduleRepository,
-        TranslatorInterface $translator
+        ModuleRepositoryInterface $moduleRepository
     ) {
         $this->translationService = $translationService;
         $this->link = $link;
         $this->moduleRepository = $moduleRepository;
-        $this->translator = $translator;
     }
 
     /**
@@ -216,7 +207,7 @@ class TranslationRouteFinder
         $module = $this->moduleRepository->getInstanceByName($moduleName);
 
         if (!($module instanceof Module)) {
-            throw new Exception($this->translator->trans('Invalid module : %s', array($moduleName), 'Admin.International.Notification'));
+            throw new InvalidModuleException($moduleName);
         }
 
         return $module->isUsingNewTranslationSystem();

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -209,6 +209,5 @@ class TranslationRouteFinder
         }
 
         return false;
-        }
     }
 }

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepositoryInterface;
 use PrestaShopBundle\Service\TranslationService;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Validate;
 
 /**
  * Class TranslationRouteFinder finds the correct route for translations.
@@ -203,7 +204,11 @@ class TranslationRouteFinder
     private function isModuleUsingNewTranslationSystem($moduleName)
     {
         $module = $this->moduleRepository->getInstanceByName($moduleName);
-
-        return $module->isUsingNewTranslationSystem();
+        
+        if (Validate::isLoadedObject($module)){
+            return $module->isUsingNewTranslationSystem();
+        }else {
+            return false;
+        }
     }
 }

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepositoryInterface;
 use PrestaShopBundle\Service\TranslationService;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\PropertyAccess\PropertyAccess;
-use Validate;
+use Module;
 
 /**
  * Class TranslationRouteFinder finds the correct route for translations.

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -206,7 +206,7 @@ class TranslationRouteFinder
         $module = $this->moduleRepository->getInstanceByName($moduleName);
         if (Validate::isLoadedObject($module)) {
             return $module->isUsingNewTranslationSystem();
-        } else {
+        }
             return false;
         }
     }

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -204,7 +204,7 @@ class TranslationRouteFinder
     private function isModuleUsingNewTranslationSystem($moduleName)
     {
         $module = $this->moduleRepository->getInstanceByName($moduleName);
-        if (Validate::isLoadedObject($module)) {
+        if ($module instanceof Module) {
             return $module->isUsingNewTranslationSystem();
         }
 

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -207,7 +207,8 @@ class TranslationRouteFinder
         if (Validate::isLoadedObject($module)) {
             return $module->isUsingNewTranslationSystem();
         }
-            return false;
+
+        return false;
         }
     }
 }

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -204,7 +204,6 @@ class TranslationRouteFinder
     private function isModuleUsingNewTranslationSystem($moduleName)
     {
         $module = $this->moduleRepository->getInstanceByName($moduleName);
-        
         if (Validate::isLoadedObject($module)) {
             return $module->isUsingNewTranslationSystem();
         } else {

--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -205,9 +205,9 @@ class TranslationRouteFinder
     {
         $module = $this->moduleRepository->getInstanceByName($moduleName);
         
-        if (Validate::isLoadedObject($module)){
+        if (Validate::isLoadedObject($module)) {
             return $module->isUsingNewTranslationSystem();
-        }else {
+        } else {
             return false;
         }
     }

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -129,7 +129,7 @@ class TranslationsController extends FrameworkBundleAdminController
             $route = $routeFinder->findRoute($request->query);
             $routeParameters = $routeFinder->findRouteParameters($request->query);
         } catch (InvalidModuleException $e) {
-            $this->addFlash('error',$this->trans('An error has occurred, this module does not exist: %s', 'Admin.International.Notification',array($e->getMessage())));
+            $this->addFlash('error', $this->trans('An error has occurred, this module does not exist: %s', 'Admin.International.Notification',array($e->getMessage())));
 
             return $this->redirectToRoute('admin_international_translations_show_settings');
         }

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -33,6 +33,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use PrestaShopBundle\Exception\InvalidModuleException;
 
 /**
  * Admin controller for the International pages.
@@ -123,9 +124,15 @@ class TranslationsController extends FrameworkBundleAdminController
      */
     public function modifyTranslationsAction(Request $request)
     {
-        $routeFinder = $this->get('prestashop.adapter.translation_route_finder');
-        $route = $routeFinder->findRoute($request->query);
-        $routeParameters = $routeFinder->findRouteParameters($request->query);
+        try {
+            $routeFinder = $this->get('prestashop.adapter.translation_route_finder');
+            $route = $routeFinder->findRoute($request->query);
+            $routeParameters = $routeFinder->findRouteParameters($request->query);
+        } catch (InvalidModuleException $e) {
+            $this->addFlash('error',$this->trans('An error has occurred, this module does not exist: %s', 'Admin.International.Notification',array($e->getMessage())));
+
+            return $this->redirectToRoute('admin_international_translations_show_settings');
+        }
 
         // If route parameters are empty we are redirecting to a legacy route
         return empty($routeParameters) ? $this->redirect($route) : $this->redirectToRoute($route, $routeParameters);

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -129,7 +129,7 @@ class TranslationsController extends FrameworkBundleAdminController
             $route = $routeFinder->findRoute($request->query);
             $routeParameters = $routeFinder->findRouteParameters($request->query);
         } catch (InvalidModuleException $e) {
-            $this->addFlash('error', $this->trans('An error has occurred, this module does not exist: %s', 'Admin.International.Notification',array($e->getMessage())));
+            $this->addFlash('error', $this->trans('An error has occurred, this module does not exist: %s', 'Admin.International.Notification', array($e->getMessage())));
 
             return $this->redirectToRoute('admin_international_translations_show_settings');
         }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -116,7 +116,6 @@ services:
             - '@prestashop.service.translation'
             - '@=service("prestashop.adapter.legacy.context").getContext().link'
             - '@prestashop.core.admin.module.repository'
-            - '@translator'
 
     prestashop.adapter.shop.shop_url:
         class: 'PrestaShop\PrestaShop\Adapter\Shop\ShopUrlDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -116,6 +116,7 @@ services:
             - '@prestashop.service.translation'
             - '@=service("prestashop.adapter.legacy.context").getContext().link'
             - '@prestashop.core.admin.module.repository'
+            - '@translator'
 
     prestashop.adapter.shop.shop_url:
         class: 'PrestaShop\PrestaShop\Adapter\Shop\ShopUrlDataProvider'


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Check to avoid the error: : ```Fatal Error: Call to a member function isUsingNewTranslationSystem() on null```  when translating your modules ! This can happen if you have modules that have been removed, installed, or disabled incorrectly..
| Type?         | bug fix 
| Category?     |  CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | https://drive.google.com/file/d/1-QJ-4eJg1BiiNuSddXZ0U4AmvBC3jAJ4/view

### How to reproduce ?
https://drive.google.com/file/d/1-QJ-4eJg1BiiNuSddXZ0U4AmvBC3jAJ4/view

### How to test the PR ?
Check that you no longer have the fatal error, but a cleaner error message indicating that the module concerned is invalid

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15871)
<!-- Reviewable:end -->
