### PR TITLE
Check mimum quantity for products in the basket order

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4914,6 +4914,23 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * Checks that all products in cart have minimal required quantities
+     *
+     * @return bool
+     */
+    public function checkAllProductsHaveMinimalQuantities()
+    {
+        $productList = $this->getProducts(true);
+        foreach ($productList as $product) {
+            if ($product['minimal_quantity'] > $product['cart_quantity']) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Execute hook displayCarrierList (extraCarrier) and merge them into the $array.
      *
      * @deprecated since 1.7.6.0.

--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -46,8 +46,9 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
         $cart = $this->getCheckoutSession()->getCart();
         $allProductsInStock = $cart->isAllProductsInStock();
         $allProductsExist = $cart->checkAllProductsAreStillAvailableInThisState();
+        $allProductsHaveMinimalQuantity = $cart->checkAllProductsHaveMinimalQuantities();
 
-        if ($allProductsInStock !== true || $allProductsExist !== true) {
+        if ($allProductsInStock !== true || $allProductsExist !== true || $allProductsHaveMinimalQuantity !== true) {
             $cartShowUrl = $this->context->link->getPageLink(
                 'cart',
                 null,

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -98,7 +98,8 @@ class CartControllerCore extends FrontController
             Tools::redirect('index.php');
         }
 
-        // check that minimal quantity conditions are respected for each product in the cart
+        /* check that minimal quantity conditions are respected for each product in the cart
+         (this is to be applied only on page load, not for ajax calls) */
         if (!Tools::getValue('ajax')) {
             $this->checkCartProductsMinimalQuantities();
         }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -492,7 +492,17 @@ class CartControllerCore extends FrontController
                     false,
                     true
                 );
-                $update_quantity = $this->updateCartProductQuantity((int) $this->qty, (int) $this->id_product);
+                $update_quantity = $this->context->cart->updateQty(
+                    $this->qty,
+                    $this->id_product,
+                    $this->id_product_attribute,
+                    $this->customization_id,
+                    Tools::getValue('op', 'up'),
+                    $this->id_address_delivery,
+                    null,
+                    true,
+                    true
+                );
                 if ($update_quantity < 0) {
                     // If product has attribute, minimal quantity is set with minimal quantity of attribute
                     $minimal_quantity = ($this->id_product_attribute)
@@ -659,35 +669,7 @@ class CartControllerCore extends FrontController
                         'Shop.Notifications.Error',
                     )
                 );
-                // increase cart's product quantity up to minimal quantity
-                $addedQuantity = (int) $product['minimal_quantity'] - (int) $product['cart_quantity'];
-                $this->updateCartProductQuantity($addedQuantity, (int) $product['id_product']);
             }
         }
-    }
-
-    /**
-     * Wrapper for the cart's updateQty method, not to repeat the long list of parameters
-     * at each use of the method.
-     * It increases the quantity for a product in the cart.
-     *
-     * @param int $addedQuantity
-     * @param int $productId
-     *
-     * @return bool Whether the quantity has been successfully updated
-     */
-    private function updateCartProductQuantity(int $addedQuantity, int $productId)
-    {
-        return $this->context->cart->updateQty(
-            $addedQuantity,
-            $productId,
-            $this->id_product_attribute,
-            $this->customization_id,
-            Tools::getValue('op', 'up'),
-            $this->id_address_delivery,
-            null,
-            true,
-            true
-        );
     }
 }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -99,7 +99,9 @@ class CartControllerCore extends FrontController
         }
 
         // check that minimal quantity conditions are respected for each product in the cart
-        $this->checkCartProductsMinimalQuantities();
+        if (!Tools::getValue('ajax')) {
+            $this->checkCartProductsMinimalQuantities();
+        }
         $presenter = new CartPresenter();
         $presented_cart = $presenter->present($this->context->cart, $shouldSeparateGifts = true);
 
@@ -666,8 +668,8 @@ class CartControllerCore extends FrontController
                     array(
                         '%product%' => $product['name'],
                         '%quantity%' => $product['minimal_quantity'],
-                        'Shop.Notifications.Error',
-                    )
+                    ),
+                    'Shop.Notifications.Error'
                 );
             }
         }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -98,7 +98,7 @@ class CartControllerCore extends FrontController
             Tools::redirect('index.php');
         }
 
-        /**
+        /*
          * Check that minimal quantity conditions are respected for each product in the cart
          * (this is to be applied only on page load, not for ajax calls)
          */

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -98,8 +98,10 @@ class CartControllerCore extends FrontController
             Tools::redirect('index.php');
         }
 
-        /* check that minimal quantity conditions are respected for each product in the cart
-         (this is to be applied only on page load, not for ajax calls) */
+        /**
+         * Check that minimal quantity conditions are respected for each product in the cart
+         * (this is to be applied only on page load, not for ajax calls)
+         */
         if (!Tools::getValue('ajax')) {
             $this->checkCartProductsMinimalQuantities();
         }

--- a/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -129,7 +129,6 @@
                 type="number"
                 value="{$product.quantity}"
                 name="product-quantity-spin"
-                min="{$product.minimal_quantity}"
               />
             {/if}
           </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes bug occuring when someone adds a product on a single, someone in the BO changes the minimal quantity, and later the FO user refreshes his basket page.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14909
| How to test?  | See the referenced issue, but to sum up: 

1/ In FO, add a product in your basket (quantity: one)
2/ In BO, increase the minimum quantity for this product (ex: 10)
3/ Refresh the basket page
Expected result: 
- You get an error message warning you about the minimum quantity
- If you don't refresh but click on "order" (commander) directly, it will redirect you back to the basket page, with the same error message


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15872)
<!-- Reviewable:end -->
