### PR TITLE
Set value for list total automatically in HelperList generation

### DIFF
--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -182,7 +182,7 @@ class HelperListCore extends Helper
 
         $this->orderWay = preg_replace('/^([a-z _]*!)/Ui', '', $this->orderWay);
 
-        if($this->listTotal == 0 && is_array($list) && count($list) > 0) {
+        if ($this->listTotal == 0 && is_array($list) && count($list) > 0) {
             $this->listTotal = count($list);
         }        
         

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -182,6 +182,10 @@ class HelperListCore extends Helper
 
         $this->orderWay = preg_replace('/^([a-z _]*!)/Ui', '', $this->orderWay);
 
+        if($this->listTotal == 0 && is_array($list) && count($list) > 0) {
+            $this->listTotal = count($list);
+        }        
+        
         $this->tpl->assign(array(
             'header' => $this->displayListHeader(), // Display list header (filtering, pagination and column names)
             'content' => $this->displayListContent(), // Show the content of the table


### PR DESCRIPTION

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | As the rows are defined by the function parameter $list anyway, we can use it to calculate and display the list total - no need to set this value outside when using the HelperList in this case.
| Type?         | improvement 
| Category?     | BO 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Create and display a helper list - number of list entries should be visible without settting it

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15887)
<!-- Reviewable:end -->
