### PR TITLE
Add management of an env var to disable debug toolbar in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ php:
 env:
   global:
     - SYMFONY_DEPRECATIONS_HELPER=disabled
+    - DISABLE_DEBUG_TOOLBAR=1
   matrix:
     - PRESTASHOP_TEST_TYPE=unit
     - PRESTASHOP_TEST_TYPE=integration

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -8,7 +8,7 @@ framework:
     profiler: { only_exceptions: false }
 
 web_profiler:
-    toolbar: true
+    toolbar: '%use_debug_toolbar%'
     intercept_redirects: false
 
 monolog:

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -13,7 +13,7 @@ framework:
         collect: false
 
 web_profiler:
-    toolbar: false
+    toolbar: '%use_debug_toolbar%'
     intercept_redirects: true
 
 swiftmailer:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -23,3 +23,5 @@ parameters:
     ps_cache_enable: false
     ps_creation_date: ~
     locale: en-US
+
+    use_debug_toolbar: true

--- a/app/config/set_parameters.php
+++ b/app/config/set_parameters.php
@@ -59,5 +59,10 @@ if ($container instanceof \Symfony\Component\DependencyInjection\Container) {
     }
 
     $container->setParameter('cache.driver', extension_loaded('apc') ? 'apc': 'array');
+
+    // Parameter used only in dev and test env
+    if (false !== ($envParameter = getenv('DISABLE_DEBUG_TOOLBAR'))) {
+        $container->setParameter('use_debug_toolbar', !$envParameter);
+    }
 }
 

--- a/tests-legacy/parameters.yml.travis
+++ b/tests-legacy/parameters.yml.travis
@@ -23,3 +23,5 @@ parameters:
     locale: en-US
     cookie_key: ThisTokenIsNotSoSecretChangeIt
     cookie_iv: ThisTokenIsNotSoSecretChangeIt
+
+    use_debug_toolbar: false


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Add management of an env var `DISABLE_DEBUG_TOOLBAR` to disable debug toolbar in travis tests
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Wait for build to go green

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15895)
<!-- Reviewable:end -->
