### PR TITLE
Hide bad vouchers that should not be displayed to customers

### DIFF
--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -184,7 +184,7 @@ class DiscountControllerCore extends FrontController
     {
         $voucher['voucher_date'] = Tools::displayDate($voucher['date_to'], null, false);
 
-        if ($voucher['minimum_amount'] === 0) {
+        if ((int) $voucher['minimum_amount'] === 0) {
             $voucher['voucher_minimal'] = $this->trans('None', array(), 'Shop.Theme.Global');
         } else {
             $voucher['voucher_minimal'] = Tools::displayPrice(

--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * 2007-2019 PrestaShop SA and Contributors
  *
@@ -58,27 +59,26 @@ class DiscountControllerCore extends FrontController
     public function getTemplateVarCartRules()
     {
         $cart_rules = [];
+        $customerId = $this->context->customer->id;
+        $languageId = $this->context->language->id;
 
         $vouchers = CartRule::getCustomerCartRules(
-            $this->context->language->id,
-            $this->context->customer->id,
+            $languageId,
+            $customerId,
             true,
             false
         );
 
         foreach ($vouchers as $key => $voucher) {
-            $cart_rules[$key] = $voucher;
-            $cart_rules[$key]['voucher_date'] = Tools::displayDate($voucher['date_to'], null, false);
-            $cart_rules[$key]['voucher_minimal'] = ($voucher['minimum_amount'] > 0) ? Tools::displayPrice($voucher['minimum_amount'], (int) $voucher['minimum_amount_currency']) : $this->trans('None', array(), 'Shop.Theme.Global');
-            $cart_rules[$key]['voucher_cumulable'] = $this->getCombinableVoucherTranslation($voucher);
+            $voucherCustomerId = (int) $voucher['id_customer'];
+            $voucherIsRestrictedToASingleCustomer = ($voucherCustomerId !== 0);
 
-            $cartRuleValue = $this->accumulateCartRuleValue($voucher);
-
-            if (0 === count($cartRuleValue)) {
-                $cart_rules[$key]['value'] = '-';
-            } else {
-                $cart_rules[$key]['value'] = implode(' + ', $cartRuleValue);
+            if ($voucherIsRestrictedToASingleCustomer && $customerId !== $voucherCustomerId) {
+                continue;
             }
+
+            $cart_rule = $this->buildCartRuleFromVoucher($voucher);
+            $cart_rules[$key] = $cart_rule;
         }
 
         return $cart_rules;
@@ -141,7 +141,7 @@ class DiscountControllerCore extends FrontController
     }
 
     /**
-     * @param $voucher
+     * @param array $voucher
      *
      * @return array
      */
@@ -173,5 +173,37 @@ class DiscountControllerCore extends FrontController
         }
 
         return $cartRuleValue;
+    }
+
+    /**
+     * @param array $voucher
+     *
+     * @return array
+     */
+    protected function buildCartRuleFromVoucher($voucher)
+    {
+        $cart_rule = $voucher;
+        $cart_rule['voucher_date'] = Tools::displayDate($voucher['date_to'], null, false);
+
+        if ($voucher['minimum_amount'] > 0) {
+            $cart_rule['voucher_minimal'] = Tools::displayPrice(
+                $voucher['minimum_amount'],
+                (int) $voucher['minimum_amount_currency']
+            );
+        } else {
+            $cart_rule['voucher_minimal'] = $this->trans('None', array(), 'Shop.Theme.Global');
+        }
+
+        $cart_rule['voucher_cumulable'] = $this->getCombinableVoucherTranslation($voucher);
+
+        $cartRuleValues = $this->accumulateCartRuleValue($voucher);
+
+        if (0 === count($cartRuleValues)) {
+            $cart_rule['value'] = '-';
+        } else {
+            $cart_rule['value'] = implode(' + ', $cartRuleValues);
+        }
+
+        return $cart_rule;
     }
 }

--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -180,30 +180,29 @@ class DiscountControllerCore extends FrontController
      *
      * @return array
      */
-    protected function buildCartRuleFromVoucher($voucher)
+    protected function buildCartRuleFromVoucher(array $voucher): array
     {
-        $cart_rule = $voucher;
-        $cart_rule['voucher_date'] = Tools::displayDate($voucher['date_to'], null, false);
+        $voucher['voucher_date'] = Tools::displayDate($voucher['date_to'], null, false);
 
-        if ($voucher['minimum_amount'] > 0) {
-            $cart_rule['voucher_minimal'] = Tools::displayPrice(
+        if ($voucher['minimum_amount'] === 0) {
+            $voucher['voucher_minimal'] = $this->trans('None', array(), 'Shop.Theme.Global');
+        } else {
+            $voucher['voucher_minimal'] = Tools::displayPrice(
                 $voucher['minimum_amount'],
                 (int) $voucher['minimum_amount_currency']
             );
-        } else {
-            $cart_rule['voucher_minimal'] = $this->trans('None', array(), 'Shop.Theme.Global');
         }
 
-        $cart_rule['voucher_cumulable'] = $this->getCombinableVoucherTranslation($voucher);
+        $voucher['voucher_cumulable'] = $this->getCombinableVoucherTranslation($voucher);
 
         $cartRuleValues = $this->accumulateCartRuleValue($voucher);
 
         if (0 === count($cartRuleValues)) {
-            $cart_rule['value'] = '-';
+            $voucher['value'] = '-';
         } else {
-            $cart_rule['value'] = implode(' + ', $cartRuleValues);
+            $voucher['value'] = implode(' + ', $cartRuleValues);
         }
 
-        return $cart_rule;
+        return $voucher;
     }
 }

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -444,7 +444,13 @@ class CartPresenter implements PresenterInterface
             $vouchers['added']
         ));
 
-        $discounts = array_filter($discounts, function ($discount) use ($cartRulesIds) {
+        $discounts = array_filter($discounts, function ($discount) use ($cartRulesIds, $cart) {
+            $voucherCustomerId = (int) $discount['id_customer'];
+            $voucherIsRestrictedToASingleCustomer = ($voucherCustomerId !== 0);
+            if ($voucherIsRestrictedToASingleCustomer && $cart->id_customer !== $voucherCustomerId) {
+                return false;
+            }
+
             return !array_key_exists($discount['id_cart_rule'], $cartRulesIds);
         });
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Hides bad vouchers that should not be displayed to customer. Port of https://github.com/PrestaShop/PrestaShop/pull/8701
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Customer can see all vouchers #13002. It hides the bad vouchers, but the bad data is still in database, just hidden.
| How to test?  | See ticket. Bad vouchers (= vouchers that should not be visible) are not visible anymore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15903)
<!-- Reviewable:end -->
