### PR TITLE
Fixes issue Undefined index _route

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -118,7 +118,7 @@ class CommonController extends FrameworkBundleAdminController
                 unset($callerParameters[$k]);
             }
         }
-        $routeName = $request->attributes->get('caller_route', ($callerParameters + ['_route' => false])['_route']);
+        $routeName = $request->attributes->get('caller_route', ($callerParameters + array('_route' => false))['_route']);
         $nextPageUrl = (!$routeName || ($offset + $limit >= $total)) ? false : $this->generateUrl($routeName, array_merge(
             $callerParameters,
             array(

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -118,7 +118,7 @@ class CommonController extends FrameworkBundleAdminController
                 unset($callerParameters[$k]);
             }
         }
-        $routeName = $request->attributes->get('caller_route', $request->attributes->get('caller_parameters', ['_route' => false])['_route']);
+        $routeName = $request->attributes->get('caller_route', ($callerParameters + ['_route' => false])['_route']);
         $nextPageUrl = (!$routeName || ($offset + $limit >= $total)) ? false : $this->generateUrl($routeName, array_merge(
             $callerParameters,
             array(

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -118,7 +118,9 @@ class CommonController extends FrameworkBundleAdminController
                 unset($callerParameters[$k]);
             }
         }
-        $routeName = $request->attributes->get('caller_route', ($callerParameters + array('_route' => false))['_route']);
+        
+        $callerParameters += array('_route' => false);
+        $routeName = $request->attributes->get('caller_route', $callerParameters['_route']);
         $nextPageUrl = (!$routeName || ($offset + $limit >= $total)) ? false : $this->generateUrl($routeName, array_merge(
             $callerParameters,
             array(

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -118,7 +118,6 @@ class CommonController extends FrameworkBundleAdminController
                 unset($callerParameters[$k]);
             }
         }
-        
         $callerParameters += array('_route' => false);
         $routeName = $request->attributes->get('caller_route', $callerParameters['_route']);
         $nextPageUrl = (!$routeName || ($offset + $limit >= $total)) ? false : $this->generateUrl($routeName, array_merge(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Descripton?| not sure why _route is expected to be part of caller parameters but it's not, the route is actually in the caller_route parameter, so we first merge parameters with defaults array to make sure _route key is set. + will not overwrite params with the same name
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes issue #14663
| How to test ? | Please check pagination BO pages not migrated to Symfony is working


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15906)
<!-- Reviewable:end -->
