### PR TITLE
Fix for product images in multishop BO

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -207,12 +207,14 @@ class ImageCore extends ObjectModel
      * @param int $idLang Language ID
      * @param int $idProduct Product ID
      * @param int $idProductAttribute Product Attribute ID
+     * @param int $idShop Shop ID
      *
      * @return array Images
      */
-    public static function getImages($idLang, $idProduct, $idProductAttribute = null)
+    public static function getImages($idLang, $idProduct, $idProductAttribute = null, $idShop = null)
     {
         $attributeFilter = ($idProductAttribute ? ' AND ai.`id_product_attribute` = ' . (int) $idProductAttribute : '');
+        $shopFilter = ($idShop ? ' AND ims.`id_shop` = ' . (int) $idShop : '');
         $sql = 'SELECT *
 			FROM `' . _DB_PREFIX_ . 'image` i
 			LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (i.`id_image` = il.`id_image`)';
@@ -221,7 +223,11 @@ class ImageCore extends ObjectModel
             $sql .= ' LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_image` ai ON (i.`id_image` = ai.`id_image`)';
         }
 
-        $sql .= ' WHERE i.`id_product` = ' . (int) $idProduct . ' AND il.`id_lang` = ' . (int) $idLang . $attributeFilter . '
+        if ($idShop) {
+            $sql .= ' LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` ims ON (i.`id_image` = ims.`id_image`)';
+        }
+
+        $sql .= ' WHERE i.`id_product` = ' . (int) $idProduct . ' AND il.`id_lang` = ' . (int) $idLang . $attributeFilter . $shopFilter . '
 			ORDER BY i.`position` ASC';
 
         return Db::getInstance()->executeS($sql);

--- a/src/Adapter/Product/ProductDataProvider.php
+++ b/src/Adapter/Product/ProductDataProvider.php
@@ -133,7 +133,7 @@ class ProductDataProvider
      */
     public function getImages($id_product, $id_lang)
     {
-        $id_shop = (int)Context::getContext()->shop->id;
+        $id_shop = (int) Context::getContext()->shop->id;
         $data = [];
         foreach (Image::getImages($id_lang, $id_product, null, $id_shop) as $image) {
             $data[] = $this->getImage($image['id_image']);

--- a/src/Adapter/Product/ProductDataProvider.php
+++ b/src/Adapter/Product/ProductDataProvider.php
@@ -133,8 +133,9 @@ class ProductDataProvider
      */
     public function getImages($id_product, $id_lang)
     {
+        $id_shop = (int)Context::getContext()->shop->id;
         $data = [];
-        foreach (Image::getImages($id_lang, $id_product) as $image) {
+        foreach (Image::getImages($id_lang, $id_product, null, $id_shop) as $image) {
             $data[] = $this->getImage($image['id_image']);
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix for product images in backoffice for multishop and give option for getting images by shop id
| Type?         | bug fix 
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes issue [#12061](https://github.com/PrestaShop/PrestaShop/issues/12061)
| How to test?  |  **1.** Go to a product in BO  **2**.  Select one of your multishops in the context. **3.** Upload a new image **4.** This image will only be shown on the selected shop that it was uploaded on (this is the expected behavior, before this PR it does not work, see ticket)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15909)
<!-- Reviewable:end -->
