### PR TITLE
Fix missing currency in behat test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -199,7 +199,7 @@
             "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/old-controllers.xml"
         ],
         "integration-behaviour-tests": [
-            "@php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml"
+            "@php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml --no-snippets --strict"
         ],
         "create-release": "@php tools/build/CreateRelease.php",
         "git-hook-install": "@php .github/contrib/install.php",

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -29,6 +29,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 use Cart;
 use Configuration;
 use Context;
+use Currency;
 use Country;
 use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\CreateEmptyCustomerCartCommand;
@@ -42,6 +43,21 @@ use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 
 class CartFeatureContext extends AbstractDomainFeatureContext
 {
+    /**
+     * @given the current currency is :currencyIsoCode
+     */
+    public function addCurrencyToContext($currencyIsoCode)
+    {
+        $currency = new Currency();
+        $currency->name = $currencyIsoCode;
+        $currency->precision = 2;
+        $currency->iso_code = $currencyIsoCode;
+        $currency->active = 1;
+        $currency->conversion_rate = 1;
+
+        Context::getContext()->currency = $currency;
+    }
+
     /**
      * @When I create an empty cart :cartReference for customer :customerReference
      */

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
@@ -90,7 +90,7 @@ Feature: Cart calculation with currencies
     Given currency "currency2" is the current one
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
-    Then my cart total should be 83 tax included
+    Then my cart total should be 83.0 tax included
     Then my cart total using previous calculation method should be 83 tax included
 
   Scenario: 3 products in cart, several quantities

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
@@ -91,7 +91,7 @@ Feature: Cart calculation with currencies
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
     Then my cart total should be 83.0 tax included
-    Then my cart total using previous calculation method should be 83 tax included
+    Then my cart total using previous calculation method should be 83.0 tax included
 
   Scenario: 3 products in cart, several quantities
     Given I have an empty default cart

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_order_from_bo.feature
@@ -10,6 +10,7 @@ Feature: Add Order from Back Office
 
   Scenario: Add order from Back Office with free shipping
     Given I am logged in as "test@prestashop.com" employee
+    Given The current currency is "EUR"
     And there is customer "customer1" with email "pub@prestashop.com"
     And customer "customer1" has address in "US" country
     And the module "dummy_payment" is installed


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix failing behat test by adding a missing currency to the context
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Travis must be green.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15912)
<!-- Reviewable:end -->
