### PR TITLE
Set emailsubscription input required

### DIFF
--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -49,6 +49,7 @@
                 value="{$value}"
                 placeholder="{l s='Your email address' d='Shop.Forms.Labels'}"
                 aria-labelledby="block-newsletter-label"
+                required
               >
             </div>
             <input type="hidden" name="blockHookName" value="{$hookName}" />


### PR DESCRIPTION
Because there is no reason to subscribe to empty mail address.
Prevents accidental clicks or page reloading to show error.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Because there is no reason to subscribe to empty mail address. Prevents accidental clicks or page reloading to show error.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Before: Subscribe with email "" → page reload → error message.<br />After:  Subscribe with email "" → browser shows that the email is missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15916)
<!-- Reviewable:end -->
