### PR TITLE
Define use_debug_toolbar even if it's not set in parameters.php

### DIFF
--- a/app/config/set_parameters.php
+++ b/app/config/set_parameters.php
@@ -61,8 +61,8 @@ if ($container instanceof \Symfony\Component\DependencyInjection\Container) {
     $container->setParameter('cache.driver', extension_loaded('apc') ? 'apc': 'array');
 
     // Parameter used only in dev and test env
-    if (false !== ($envParameter = getenv('DISABLE_DEBUG_TOOLBAR'))) {
+    $envParameter = getenv('DISABLE_DEBUG_TOOLBAR');
+    if (!isset($parameters['use_debug_toolbar']) || false !== $envParameter) {
         $container->setParameter('use_debug_toolbar', !$envParameter);
     }
 }
-


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | If the parameter `use_debug_toolbar`is not set in parameters.php, set it depending on env `DISABLE_DEBUG_TOOLBAR`.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Remove in your parameters.php the key `use_debug_toolbar` you shouldn't have any warning on the page.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15917)
<!-- Reviewable:end -->
