### PR TITLE
Fix error SQL in getRecurseCategory method

### DIFF
--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -197,7 +197,7 @@ class CMSCategoryCore extends ObjectModel
 				JOIN `' . _DB_PREFIX_ . 'cms_lang` cl ON c.`id_cms` = cl.`id_cms`
 				WHERE `id_cms_category` = ' . (int) $current . ($active ? ' AND c.`active` = 1' : '') . ' 
 				AND cl.`id_shop` = ' . (int) Context::getContext()->shop->id . ' 
-				AND cl.`id_lang` = ' . (int) $id_lang . ') 
+				AND cl.`id_lang` = ' . (int) $id_lang . ' 
 				GROUP BY c.id_cms
 				ORDER BY c.`position`';
 

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -195,7 +195,7 @@ class CMSCategoryCore extends ObjectModel
 				FROM `' . _DB_PREFIX_ . 'cms` c
 				' . Shop::addSqlAssociation('cms', 'c') . '
 				JOIN `' . _DB_PREFIX_ . 'cms_lang` cl ON c.`id_cms` = cl.`id_cms`
-				WHERE `id_cms_category` = ' . (int)$current . ($active ? ' AND c.`active` = 1' : '') . ' 
+				WHERE `id_cms_category` = ' . (int) $current . ($active ? ' AND c.`active` = 1' : '') . ' 
 				AND cl.`id_shop` = '. (int) Context::getContext()->shop->id . ' 
 				AND cl.`id_lang` = ' . (int) $id_lang . ') 
 				GROUP BY c.id_cms

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -191,7 +191,7 @@ class CMSCategoryCore extends ObjectModel
             $category['children'][] = CMSCategory::getRecurseCategory($id_lang, $row['id_cms_category'], $active, $links);
         }
 
-		$sql = 'SELECT c.`id_cms`, cl.`meta_title`, cl.`link_rewrite`
+        $sql = 'SELECT c.`id_cms`, cl.`meta_title`, cl.`link_rewrite`
 				FROM `' . _DB_PREFIX_ . 'cms` c
 				' . Shop::addSqlAssociation('cms', 'c') . '
 				JOIN `' . _DB_PREFIX_ . 'cms_lang` cl ON c.`id_cms` = cl.`id_cms`

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -196,7 +196,7 @@ class CMSCategoryCore extends ObjectModel
 				' . Shop::addSqlAssociation('cms', 'c') . '
 				JOIN `' . _DB_PREFIX_ . 'cms_lang` cl ON c.`id_cms` = cl.`id_cms`
 				WHERE `id_cms_category` = ' . (int) $current . ($active ? ' AND c.`active` = 1' : '') . ' 
-				AND cl.`id_shop` = '. (int) Context::getContext()->shop->id . ' 
+				AND cl.`id_shop` = ' . (int) Context::getContext()->shop->id . ' 
 				AND cl.`id_lang` = ' . (int) $id_lang . ') 
 				GROUP BY c.id_cms
 				ORDER BY c.`position`';

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -191,14 +191,16 @@ class CMSCategoryCore extends ObjectModel
             $category['children'][] = CMSCategory::getRecurseCategory($id_lang, $row['id_cms_category'], $active, $links);
         }
 
-        $sql = 'SELECT c.`id_cms`, cl.`meta_title`, cl.`link_rewrite`
+		$sql = 'SELECT c.`id_cms`, cl.`meta_title`, cl.`link_rewrite`
 				FROM `' . _DB_PREFIX_ . 'cms` c
 				' . Shop::addSqlAssociation('cms', 'c') . '
 				JOIN `' . _DB_PREFIX_ . 'cms_lang` cl ON c.`id_cms` = cl.`id_cms`
-				WHERE `id_cms_category` = ' . (int) $current . '
-				AND cl.`id_lang` = ' . (int) $id_lang . ($active ? ' AND c.`active` = 1' : '') . '
+				WHERE `id_cms_category` = ' . (int)$current . ($active ? ' AND c.`active` = 1' : '') . ' 
+				AND cl.`id_shop` = '. (int) Context::getContext()->shop->id . ' 
+				AND cl.`id_lang` = ' . (int) $id_lang . ') 
 				GROUP BY c.id_cms
 				ORDER BY c.`position`';
+
         $category['cms'] = Db::getInstance()->executeS($sql);
         if ($links == 1) {
             $category['link'] = $link->getCMSCategoryLink($current, $category['link_rewrite']);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix error SQL in getRecurseCategory method
| Type?         | bug fix 
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14366
| How to test?  | Try to create a CMS category + CMS page with multistore enabled and without. Try to display the sitemap page in FO. Try to generate and display sitemap.xml through Google sitemap module
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15926)
<!-- Reviewable:end -->
