### PR TITLE
Migrate Customer block of Order view page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
+++ b/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
@@ -27,4 +27,6 @@ export default {
   orderPaymentDetailsBtn: '.js-payment-details-btn',
   privateNoteToggleBtn: '.js-private-note-toggle-btn',
   privateNoteBlock: '.js-private-note-block',
+  privateNoteInput: '#private_note_note',
+  privateNoteSubmitBtn: '.js-private-note-btn',
 };

--- a/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
+++ b/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
@@ -25,4 +25,6 @@
 
 export default {
   orderPaymentDetailsBtn: '.js-payment-details-btn',
+  privateNoteToggleBtn: '.js-private-note-toggle-btn',
+  privateNoteBlock: '.js-private-note-block',
 };

--- a/admin-dev/themes/new-theme/js/pages/order/view.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view.js
@@ -66,7 +66,7 @@ $(() => {
 
     $(OrderViewPageMap.privateNoteInput).on('input', (event) => {
       const note = $(event.currentTarget).val();
-      $submitBtn.attr('disabled', !note);
+      $submitBtn.prop('disabled', !note);
     });
   }
 });

--- a/admin-dev/themes/new-theme/js/pages/order/view.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view.js
@@ -29,6 +29,7 @@ const $ = window.$;
 
 $(() => {
   handlePaymentDetailsToggle();
+  handlePrivateNoteChange();
 
   $(OrderViewPageMap.privateNoteToggleBtn).on('click', (event) => {
     event.preventDefault();
@@ -44,7 +45,6 @@ $(() => {
   }
 
   function togglePrivateNoteBlock() {
-    //debugger;
     const $block = $(OrderViewPageMap.privateNoteBlock);
     const $btn = $(OrderViewPageMap.privateNoteToggleBtn);
     const isPrivateNoteOpened = $btn.hasClass('is-opened');
@@ -59,5 +59,19 @@ $(() => {
 
     const $icon = $btn.find('.material-icons');
     $icon.text(isPrivateNoteOpened ? 'add' : 'remove');
+  }
+
+  function handlePrivateNoteChange() {
+    const $submitBtn = $(OrderViewPageMap.privateNoteSubmitBtn);
+
+    $(OrderViewPageMap.privateNoteInput).on('input', (event) => {
+      const note = $(event.currentTarget).val();
+
+      if (note) {
+        $submitBtn.attr('disabled', false);
+      } else {
+        $submitBtn.attr('disabled', true);
+      }
+    });
   }
 });

--- a/admin-dev/themes/new-theme/js/pages/order/view.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view.js
@@ -66,12 +66,7 @@ $(() => {
 
     $(OrderViewPageMap.privateNoteInput).on('input', (event) => {
       const note = $(event.currentTarget).val();
-
-      if (note) {
-        $submitBtn.attr('disabled', false);
-      } else {
-        $submitBtn.attr('disabled', true);
-      }
+      $submitBtn.attr('disabled', !note);
     });
   }
 });

--- a/admin-dev/themes/new-theme/js/pages/order/view.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view.js
@@ -30,11 +30,34 @@ const $ = window.$;
 $(() => {
   handlePaymentDetailsToggle();
 
+  $(OrderViewPageMap.privateNoteToggleBtn).on('click', (event) => {
+    event.preventDefault();
+    togglePrivateNoteBlock();
+  });
+
   function handlePaymentDetailsToggle() {
     $(OrderViewPageMap.orderPaymentDetailsBtn).on('click', (event) => {
       const $paymentDetailRow = $(event.currentTarget).closest('tr').next(':first');
 
       $paymentDetailRow.toggleClass('d-none');
     });
+  }
+
+  function togglePrivateNoteBlock() {
+    //debugger;
+    const $block = $(OrderViewPageMap.privateNoteBlock);
+    const $btn = $(OrderViewPageMap.privateNoteToggleBtn);
+    const isPrivateNoteOpened = $btn.hasClass('is-opened');
+
+    if (isPrivateNoteOpened) {
+      $btn.removeClass('is-opened');
+      $block.addClass('d-none');
+    } else {
+      $btn.addClass('is-opened');
+      $block.removeClass('d-none');
+    }
+
+    const $icon = $btn.find('.material-icons');
+    $icon.text(isPrivateNoteOpened ? 'add' : 'remove');
   }
 });

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -191,7 +191,8 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
             $customer->email,
             new DateTimeImmutable($customer->date_add),
             Tools::displayPrice(Tools::ps_round(Tools::convertPrice($customerStats['total_orders'], $order->id_currency), PS_ROUND_HALF_UP), (int) $order->id_currency),
-            $customerStats['nb_orders']
+            $customerStats['nb_orders'],
+            $customer->note
         );
     }
 

--- a/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
@@ -173,7 +173,7 @@ class OrderCustomerForViewing
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPrivateNote(): ?string
     {

--- a/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
@@ -71,6 +71,11 @@ class OrderCustomerForViewing
     private $validOrdersPlaced;
 
     /**
+     * @var string
+     */
+    private $privateNote;
+
+    /**
      * @param int $id
      * @param string $firstName
      * @param string $lastName
@@ -79,6 +84,7 @@ class OrderCustomerForViewing
      * @param DateTimeImmutable $accountRegistrationDate
      * @param string $totalSpentSinceRegistration
      * @param int $validOrdersPlaced
+     * @param string|null $privateNote
      */
     public function __construct(
         int $id,
@@ -88,7 +94,8 @@ class OrderCustomerForViewing
         string $email,
         DateTimeImmutable $accountRegistrationDate,
         string $totalSpentSinceRegistration,
-        int $validOrdersPlaced
+        int $validOrdersPlaced,
+        ?string $privateNote
     ) {
         $this->id = $id;
         $this->firstName = $firstName;
@@ -98,6 +105,7 @@ class OrderCustomerForViewing
         $this->accountRegistrationDate = $accountRegistrationDate;
         $this->totalSpentSinceRegistration = $totalSpentSinceRegistration;
         $this->validOrdersPlaced = $validOrdersPlaced;
+        $this->privateNote = $privateNote;
     }
 
     /**
@@ -162,5 +170,13 @@ class OrderCustomerForViewing
     public function getValidOrdersPlaced(): int
     {
         return $this->validOrdersPlaced;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrivateNote(): ?string
+    {
+        return $this->privateNote;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -45,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderGridDefinitionFactor
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Form\Admin\Sell\Customer\PrivateNoteType;
 use PrestaShopBundle\Form\Admin\Sell\Order\AddOrderCartRuleType;
 use PrestaShopBundle\Form\Admin\Sell\Order\ChangeOrderCurrencyType;
 use PrestaShopBundle\Form\Admin\Sell\Order\ChangeOrdersStatusType;
@@ -255,6 +256,9 @@ class OrderController extends FrameworkBundleAdminController
         $changeOrderCurrencyForm = $this->createForm(ChangeOrderCurrencyType::class, [], [
             'current_currency_id' => $orderForViewing->getCurrencyId(),
         ]);
+        $privateNoteForm = $this->createForm(PrivateNoteType::class, [
+            'note' => $orderForViewing->getCustomer()->getPrivateNote(),
+        ]);
 
         return $this->render('@PrestaShop/Admin/Sell/Order/Order/view.html.twig', [
             'showContentHeader' => false,
@@ -263,6 +267,7 @@ class OrderController extends FrameworkBundleAdminController
             'updateOrderStatusForm' => $updateOrderStatusForm->createView(),
             'addOrderPaymentForm' => $addOrderPaymentForm->createView(),
             'changeOrderCurrencyForm' => $changeOrderCurrencyForm->createView(),
+            'privateNoteForm' => $privateNoteForm->createView(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -204,7 +204,10 @@
             </div>
 
             <div class="mt-2 text-right">
-              <button type="submit" class="btn btn-primary btn-sm js-private-note-btn">
+              <button type="submit"
+                      class="btn btn-primary btn-sm js-private-note-btn"
+                      {% if orderForViewing.customer.privateNote is empty %}disabled{% endif %}
+              >
                 {{ 'Save'|trans({}, 'Admin.Actions') }}
               </button>
             </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -92,7 +92,8 @@
               'addaddress': 1,
               'address_type': 1,
               'id_order': orderForViewing.id,
-              'id_address': orderForViewing.shippingAddress.addressId
+              'id_address': orderForViewing.shippingAddress.addressId,
+              'back': path('admin_orders_view', {'orderId': orderForViewing.id})
             }) }}"
                class="float-right tooltip-link"
                data-toggle="pstooltip"
@@ -133,7 +134,8 @@
               'addaddress': 1,
               'address_type': 2,
               'id_order': orderForViewing.id,
-              'id_address': orderForViewing.invoiceAddress.addressId
+              'id_address': orderForViewing.invoiceAddress.addressId,
+              'back': path('admin_orders_view', {'orderId': orderForViewing.id})
             }) }}"
                class="float-right tooltip-link"
                data-toggle="pstooltip"

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -43,7 +43,7 @@
           </h2>
         </div>
         <div class="col-md-6 text-right">
-          <a href="{{ path('admin_customers_view', {'customerId': orderForViewing.customer.id }) }}" class="">
+          <a href="{{ path('admin_customers_view', {'customerId': orderForViewing.customer.id }) }}">
             {{ 'View full details'|trans({}, 'Admin.Actions') }}
           </a>
         </div>
@@ -87,7 +87,13 @@
           <p>
             <strong>{{ 'Shipping address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
 
-            <a href="#"
+            <a href="{{ getAdminLink('AdminAddresses', true, {
+              'realedit': 1,
+              'addaddress': 1,
+              'address_type': 1,
+              'id_order': orderForViewing.id,
+              'id_address': orderForViewing.shippingAddress.addressId
+            }) }}"
                class="float-right tooltip-link"
                data-toggle="pstooltip"
                data-placement="top"
@@ -122,7 +128,13 @@
           <p>
             <strong>{{ 'Invoice address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
 
-            <a href="#"
+            <a href="{{ getAdminLink('AdminAddresses', true, {
+              'realedit': 1,
+              'addaddress': 1,
+              'address_type': 2,
+              'id_order': orderForViewing.id,
+              'id_address': orderForViewing.invoiceAddress.addressId
+            }) }}"
                class="float-right tooltip-link"
                data-toggle="pstooltip"
                data-placement="top"

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -177,14 +177,38 @@
           </h3>
         </div>
         <div class="col-md-6 text-right">
+          {% set isPrivateNoteOpen = not orderForViewing.customer.privateNote is empty %}
+
           <a href="#"
-             class="float-right tooltip-link"
-             data-toggle="pstooltip"
-             data-placement="top"
-             data-original-title="{{ 'Add'|trans({}, 'Admin.Actions') }}"
+             class="float-right tooltip-link js-private-note-toggle-btn {% if isPrivateNoteOpen %}is-opened{% endif %}"
           >
-            <i class="material-icons">add</i>
+            {% if isPrivateNoteOpen %}
+              <i class="material-icons">remove</i>
+            {% else %}
+              <i class="material-icons">add</i>
+            {% endif %}
           </a>
+        </div>
+
+        <div class="col-md-12 mt-3 js-private-note-block {% if not isPrivateNoteOpen %}d-none{% endif %}">
+          {{ form_start(privateNoteForm, {
+            'action': path('admin_customers_set_private_note', {
+              'customerId': orderForViewing.customer.id,
+              'back': path('admin_orders_view', {'orderId': orderForViewing.id})
+            })
+          }) }}
+
+          {{ form_widget(privateNoteForm.note) }}
+            <div class="d-none">
+              {{ form_rest(privateNoteForm) }}
+            </div>
+
+            <div class="mt-2 text-right">
+              <button type="submit" class="btn btn-primary btn-sm js-private-note-btn">
+                {{ 'Save'|trans({}, 'Admin.Actions') }}
+              </button>
+            </div>
+          {{ form_end(privateNoteForm) }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Migrates Customer block of new Order view page.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #15821 
| How to test?  | :warning: Build assets before testing :warning: This PR does not add drop-down to these buttons (see https://prnt.sc/pk2y8a ), it will be done in another PR. Access `/admin-dev/index.php/sell/orders/orders/1/view` to see new Customer block.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15955)
<!-- Reviewable:end -->
