### PR TITLE
Use midnight for birthdate verification

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -638,7 +638,7 @@ class ValidateCore
             return false;
         }
 
-        return $d->getTimestamp() <= time();
+        return $d->setTime(0, 0, 0)->getTimestamp() <= time();
     }
 
     /**

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -254,7 +254,7 @@ class ValidateCoreTest extends TestCase
             array(true, '1991-04-19'),
             array(true, '2015-03-22'),
             array(true, '1945-07-25'),
-            array(false, '2020-03-19'),
+            array(false, '3000-03-19'),
             array(false, '1991-03-33'),
             array(false, '1991-15-19'),
             array(true, date('Y-m-d', strtotime('now'))),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In some weird cases, [this unit test would fail](https://travis-ci.com/PrestaShop/PrestaShop/jobs/245665968#L728) when using the current date. The best solution we've come up with is to compare birthdates using the date at midnight. 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Validated by unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15967)
<!-- Reviewable:end -->
