### PR TITLE
Test - Improve quick view product

### DIFF
--- a/tests/puppeteer/pages/FO/home.js
+++ b/tests/puppeteer/pages/FO/home.js
@@ -46,6 +46,8 @@ module.exports = class Home extends FOBasePage {
     await this.page.hover(this.productImg.replace('%NUMBER', id));
     let displayed = false;
     /* eslint-disable no-await-in-loop */
+    // Only way to detect if element is displayed is to get value of computed style 'product description' after hover
+    // and compare it with value 'block'
     for (let i = 0; i < 10 && !displayed; i++) {
       displayed = await this.page.evaluate(
         selector => window.getComputedStyle(document.querySelector(selector), ':after')

--- a/tests/puppeteer/pages/FO/home.js
+++ b/tests/puppeteer/pages/FO/home.js
@@ -45,15 +45,16 @@ module.exports = class Home extends FOBasePage {
   async quickViewProduct(id) {
     await this.page.hover(this.productImg.replace('%NUMBER', id));
     let displayed = false;
-    for (let i=0; i<10 && !displayed; i++) {
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < 10 && !displayed; i++) {
       displayed = await this.page.evaluate(
-        (selector) =>
-        window.getComputedStyle(document.querySelector(selector), ':after')
+        selector => window.getComputedStyle(document.querySelector(selector), ':after')
           .getPropertyValue('display') === 'block',
         this.productDescriptionDiv.replace('%NUMBER', id),
       );
       await this.page.waitFor(100);
     }
+    /* eslint-enable no-await-in-loop */
     await Promise.all([
       this.page.waitForSelector(this.quickViewModalDiv, {visible: true}),
       this.page.$eval(this.productQuickViewLink.replace('%NUMBER', id), el => el.click()),

--- a/tests/puppeteer/pages/FO/home.js
+++ b/tests/puppeteer/pages/FO/home.js
@@ -9,6 +9,7 @@ module.exports = class Home extends FOBasePage {
     this.homePageSection = 'section#content.page-home';
     this.productArticle = '#content .products div:nth-child(%NUMBER) article';
     this.productImg = `${this.productArticle} img`;
+    this.productDescriptionDiv = `${this.productArticle} div.product-description`;
     this.productQuickViewLink = `${this.productArticle} a.quick-view`;
     this.allProductLink = '#content a.all-product-link';
     this.totalProducts = '#js-product-list-top .total-products > p';
@@ -42,12 +43,19 @@ module.exports = class Home extends FOBasePage {
    * @return {Promise<void>}
    */
   async quickViewProduct(id) {
+    await this.page.hover(this.productImg.replace('%NUMBER', id));
+    let displayed = false;
+    for (let i=0; i<10 && !displayed; i++) {
+      displayed = await this.page.evaluate(
+        (selector) =>
+        window.getComputedStyle(document.querySelector(selector), ':after')
+          .getPropertyValue('display') === 'block',
+        this.productDescriptionDiv.replace('%NUMBER', id),
+      );
+      await this.page.waitFor(100);
+    }
     await Promise.all([
-      this.page.waitForSelector(`${this.productQuickViewLink.replace('%NUMBER', id)}`),
-      this.page.hover(this.productImg.replace('%NUMBER', id)),
-    ]);
-    await Promise.all([
-      this.page.waitForSelector(this.quickViewModalDiv),
+      this.page.waitForSelector(this.quickViewModalDiv, {visible: true}),
       this.page.$eval(this.productQuickViewLink.replace('%NUMBER', id), el => el.click()),
     ]);
   }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Resolve problem at sanity that happens one in 10 times, by adding waiting for property element to have some value after hover product
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | (Run this command many times to be sure) <br> `URL_FO=SHOP_URL TEST_PATH="sanity/06_checkoutFO/*" npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15984)
<!-- Reviewable:end -->
