### PR TITLE
Check if customized product image exists before trying to delete it

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1803,7 +1803,7 @@ class CartCore extends ObjectModel
                 WHERE `id_customization` = ' . (int) $id_customization);
 
             // Delete customization picture if necessary
-            if (isset($cust_data['type']) && $cust_data['type'] == Product::CUSTOMIZE_FILE) {
+            if (isset($cust_data['type']) && $cust_data['type'] == Product::CUSTOMIZE_FILE && file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'])) {
                 $result &= (@unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) && @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small'));
             }
 
@@ -4169,7 +4169,7 @@ class CartCore extends ObjectModel
         );
 
         // Delete customization picture if necessary
-        if ($cust_data['type'] == Product::CUSTOMIZE_FILE) {
+        if ($cust_data['type'] == Product::CUSTOMIZE_FILE && file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'])) {
             $result &= (@unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) && @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small'));
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1803,7 +1803,10 @@ class CartCore extends ObjectModel
                 WHERE `id_customization` = ' . (int) $id_customization);
 
             // Delete customization picture if necessary
-            if (isset($cust_data['type']) && $cust_data['type'] == Product::CUSTOMIZE_FILE && file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'])) {
+            if (isset($cust_data['type']) && $cust_data['type'] == Product::CUSTOMIZE_FILE) {
+               $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value']) ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) : true;
+               $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') : true;
+           }
                 $result &= (@unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) && @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small'));
             }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1804,10 +1804,8 @@ class CartCore extends ObjectModel
 
             // Delete customization picture if necessary
             if (isset($cust_data['type']) && $cust_data['type'] == Product::CUSTOMIZE_FILE) {
-               $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value']) ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) : true;
-               $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') : true;
-           }
-                $result &= (@unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) && @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small'));
+                $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value']) ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) : true;
+                $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') : true;
             }
 
             $result &= Db::getInstance()->execute(
@@ -4175,8 +4173,6 @@ class CartCore extends ObjectModel
         if (isset($cust_data['type']) && $cust_data['type'] == Product::CUSTOMIZE_FILE) {
             $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value']) ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) : true;
             $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') : true;
-        }
-            $result &= (@unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) && @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small'));
         }
 
         $result &= Db::getInstance()->execute(

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4172,7 +4172,10 @@ class CartCore extends ObjectModel
         );
 
         // Delete customization picture if necessary
-        if ($cust_data['type'] == Product::CUSTOMIZE_FILE && file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'])) {
+        if (isset($cust_data['type']) && $cust_data['type'] == Product::CUSTOMIZE_FILE) {
+            $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value']) ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) : true;
+            $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') : true;
+        }
             $result &= (@unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) && @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small'));
         }
 


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  |  If customized product image doesn't exists, false is returned and the product cannot be deleted from the cart.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes #15986
| How to test?  | Cf my issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15987)
<!-- Reviewable:end -->
