### PR TITLE
LC_CTYPE turkish

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -148,7 +148,7 @@ $context->country = $default_country;
 $locale = strtolower(Configuration::get('PS_LOCALE_LANGUAGE')).'_'.strtoupper(Configuration::get('PS_LOCALE_COUNTRY'));
 /* Please do not use LC_ALL here http://www.php.net/manual/fr/function.setlocale.php#25041 */
 setlocale(LC_COLLATE, $locale.'.UTF-8', $locale.'.utf8');
-setlocale(LC_CTYPE, $locale.'.UTF-8', $locale.'.utf8');
+setlocale(LC_CTYPE, 'en_US.UTF-8', 'en_US.utf8');
 setlocale(LC_TIME, $locale.'.UTF-8', $locale.'.utf8');
 setlocale(LC_NUMERIC, 'en_US.UTF-8', 'en_US.utf8');
 

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -4670,7 +4670,7 @@ class AdminImportControllerCore extends AdminController
     {
         $iso_lang = trim(Tools::getValue('iso_lang'));
         setlocale(LC_COLLATE, strtolower($iso_lang) . '_' . strtoupper($iso_lang) . '.UTF-8');
-        setlocale(LC_CTYPE, strtolower($iso_lang) . '_' . strtoupper($iso_lang) . '.UTF-8');
+        setlocale(LC_CTYPE, 'en_US.UTF-8', 'en_US.utf8');
     }
 
     protected function addProductWarning($product_name, $product_id = null, $message = '')


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If setlocale is set to LC_CTYPE variable tr_TR, some of the Turkish characters are different from the en_US definition of PHP's strtolower method.<br><br>**For example:**<br>echo strtolower ('Instance'); // en_US: **i**nstance,<br>echo strtolower ('Instance'); // tr_TR: **ı**nstance<br><br>This character change affects the autoloader configuration of some vendor packages. Smarty for example.<br><br>This definition causes Smarty-like Vendor packages to fail to find the classes the autoloaders want to load.<br><br>en_US -> Smarty_Internal_Undefined -> smarty_**i**nternal_undefined.php<br>tr_TR -> Smarty_Internal_Undefined -> smarty_**ı**nternal_undefined.php
| Type?         | bug fix
| Category?     |  CO
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes #16745
| How to test?  | You can try installation in Turkish language, you can try csv product import in Turkish language or you can try Upgrade via One Click Upgrade module in Turkish language.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/15991)
<!-- Reviewable:end -->
