### PR TITLE
Fix html being displayed in download virtual product text mail

### DIFF
--- a/mails/_partials/download_product_virtual_products.tpl
+++ b/mails/_partials/download_product_virtual_products.tpl
@@ -1,0 +1,29 @@
+{**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+<ul>
+{foreach $list as $product}
+  <li><a href="{$product.url}">{$product.text}</a></li>
+{/foreach}
+</ul>

--- a/mails/_partials/download_product_virtual_products.txt
+++ b/mails/_partials/download_product_virtual_products.txt
@@ -1,0 +1,3 @@
+{foreach $list as $product}
+  [{$product.text}]({$product.url})
+{/foreach}

--- a/mails/themes/classic/core/download_product.html.twig
+++ b/mails/themes/classic/core/download_product.html.twig
@@ -24,11 +24,16 @@
               <p style="border-bottom:1px solid #D6D4D4;">
                 {{ 'Product(s) now available for download'|trans({}, 'Emails.Body', locale)|raw }}
               </p>
-            
+
 {% endif %}
             <span>
               {{ 'You have [1]{nbProducts}[/1] product(s) now available for download using the following link(s):'|trans({'[1]': '<span><strong>', '[/1]': '</strong></span>'}, 'Emails.Body', locale)|raw }}<br/><br/>
-              {virtualProducts}
+              {% if templateType == 'html' %}
+                {virtualProducts}
+              {% endif %}
+              {% if templateType == 'txt' %}
+                {virtualProductsTxt}
+              {% endif %}
             </span>
           </font>
         </td>

--- a/mails/themes/modern/core/download_product.html.twig
+++ b/mails/themes/modern/core/download_product.html.twig
@@ -259,7 +259,14 @@
                                     </tr>
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                        <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;"> {virtualProducts} </div>
+                                        <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">
+                                          {% if templateType == 'html' %}
+{virtualProducts}
+{% endif %}
+                                          {% if templateType == 'txt' %}
+{virtualProductsTxt}
+{% endif %}
+                                        </div>
                                       </td>
                                     </tr>
                                   </table>

--- a/src/Adapter/MailTemplate/MailPartialTemplateRenderer.php
+++ b/src/Adapter/MailTemplate/MailPartialTemplateRenderer.php
@@ -55,10 +55,11 @@ class MailPartialTemplateRenderer
      * @param string $partialTemplateName template name with extension
      * @param LanguageInterface $language
      * @param array $variables sent to smarty as 'list'
+     * @param bool $cleanComments
      *
      * @return string
      */
-    public function render($partialTemplateName, LanguageInterface $language, array $variables = [])
+    public function render($partialTemplateName, LanguageInterface $language, array $variables = [], $cleanComments = false)
     {
         $potentialPaths = array(
             _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . $language->getIsoCode() . DIRECTORY_SEPARATOR . $partialTemplateName,
@@ -71,8 +72,12 @@ class MailPartialTemplateRenderer
         foreach ($potentialPaths as $path) {
             if (Tools::file_exists_cache($path)) {
                 $this->smarty->assign('list', $variables);
+                $content = $this->smarty->fetch($path);
+                if ($cleanComments) {
+                    $content = preg_replace('/\s?<!--.*?-->\s?/s', '', $content);
+                }
 
-                return $this->smarty->fetch($path);
+                return $content;
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | uses partial mail to render text/html list of downloadable virtual products in the download product mail
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10915
| How to test?  | Order a virtual product with a file and see the text mail sent

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16014)
<!-- Reviewable:end -->
