### PR TITLE
Fix inability to order product variant out of stock for product accepting orders

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -955,7 +955,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     private function tryToGetAvailableIdProductAttribute($checkedIdProductAttribute)
     {
-        if (!Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
+        if (!Product::isAvailableWhenOutOfStock($this->product->out_of_stock) && Configuration::get('PS_DISP_UNAVAILABLE_ATTR') == 0) {
             $availableProductAttributes = $this->product->getAttributeCombinations();
             if (!Product::isAvailableWhenOutOfStock($this->product->out_of_stock)) {
                 $availableProductAttributes = array_filter(

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -955,6 +955,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     private function tryToGetAvailableIdProductAttribute($checkedIdProductAttribute)
     {
+        // wash attributes list (if some attributes are unavailable and only if allowed to wash them), just like in assignAttributesGroups()
         if (!Product::isAvailableWhenOutOfStock($this->product->out_of_stock) && Configuration::get('PS_DISP_UNAVAILABLE_ATTR') == 0) {
             $availableProductAttributes = $this->product->getAttributeCombinations();
             if (!Product::isAvailableWhenOutOfStock($this->product->out_of_stock)) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Products that accept orders without stock do not function properly if some variants have stock and others don't. The variant selection always jumps to the variant with stock available, even if all variants would accept orders. The applied fix copies the same condition as from further down in the ProductController, where variants are filtered in order to be displayed. The same logic must apply here.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | This fixes the work started in #13670
| How to test?  | Have a product accepting orders without stock with some variants with stock and some without. The ajax selection will always deselect the variant without stock prior to this fix

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16016)
<!-- Reviewable:end -->
