### PR TITLE
Update Turkish currency sign

### DIFF
--- a/localization/tr.xml
+++ b/localization/tr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <localizationPack name="Turkey" version="1.0">
 	<currencies>
-		<currency name="Lira" iso_code="TRY" iso_code_num="949" sign="TL" blank="1" conversion_rate="1.97638" format="2" decimals="1" />
+		<currency name="Lira" iso_code="TRY" iso_code_num="949" sign="₺" blank="1" conversion_rate="1.97638" format="2" decimals="1" />
 	</currencies>
 	<languages>
 		<language iso_code="tr" />


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Update localization packs data, add the right currency sign - feedback from the Turkish ambassador ([here](https://docs.google.com/spreadsheets/d/1QvBo1q_ddSZU3wcawGN_oZVeutY-CB5eJaYfky6HXys/edit?usp=sharing))
| Type?         | improvement
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | It is part of this [EPIC](https://github.com/PrestaShop/PrestaShop/issues/15829).
| Test? | Install PrestaShop in Turkish and you should have `₺` as a currency symbol.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16020)
<!-- Reviewable:end -->
