### PR TITLE
Migrate order action and status block

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_button.scss
+++ b/admin-dev/themes/new-theme/scss/components/_button.scss
@@ -1,5 +1,6 @@
 .btn {
   &.btn-action {
+    color: black;
     background-color: white;
     border-radius: 4px;
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -562,7 +562,17 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
             );
         }
 
-        return new OrderDocumentsForViewing($documentsForViewing);
+        $canGenerateInvoice = Configuration::get('PS_INVOICE') &&
+            count($order->getInvoicesCollection()) &&
+            $order->invoice_number;
+
+        $canGenerateDeliverySlip = (bool) $order->delivery_number;
+
+        return new OrderDocumentsForViewing(
+            $canGenerateInvoice,
+            $canGenerateDeliverySlip,
+            $documentsForViewing
+        );
     }
 
     private function getOrderShipping(Order $order): OrderShippingForViewing

--- a/src/Core/Domain/Order/QueryResult/OrderCarrierForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderCarrierForViewing.php
@@ -78,10 +78,10 @@ class OrderCarrierForViewing
     /**
      * @param int $orderCarrierId
      * @param DateTimeImmutable $date
-     * @param string $name
+     * @param string $name Carrier name or null in case of virtual order
      * @param string $weight
      * @param int $carrierId
-     * @param string $price
+     * @param string $price Price or null in case of virtual order
      * @param string|null $trackingUrl
      * @param string|null $trackingNumber
      * @param bool $canEdit
@@ -89,10 +89,10 @@ class OrderCarrierForViewing
     public function __construct(
         int $orderCarrierId,
         DateTimeImmutable $date,
-        string $name,
+        ?string $name,
         string $weight,
         int $carrierId,
-        string $price,
+        ?string $price,
         ?string $trackingUrl,
         ?string $trackingNumber,
         bool $canEdit
@@ -127,7 +127,7 @@ class OrderCarrierForViewing
     /**
      * @return string
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -143,7 +143,7 @@ class OrderCarrierForViewing
     /**
      * @return string
      */
-    public function getPrice(): string
+    public function getPrice(): ?string
     {
         return $this->price;
     }

--- a/src/Core/Domain/Order/QueryResult/OrderDocumentsForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderDocumentsForViewing.php
@@ -34,13 +34,28 @@ class OrderDocumentsForViewing
     private $documents = [];
 
     /**
+     * @var bool
+     */
+    private $canGenerateInvoice;
+
+    /**
+     * @var bool
+     */
+    private $canGenerateDeliverySlip;
+
+    /**
+     * @param bool $canGenerateInvoice
+     * @param bool $canGenerateDeliverySlip
      * @param OrderDocumentForViewing[] $documents
      */
-    public function __construct(array $documents)
+    public function __construct(bool $canGenerateInvoice, bool $canGenerateDeliverySlip, array $documents)
     {
         foreach ($documents as $document) {
             $this->add($document);
         }
+
+        $this->canGenerateInvoice = $canGenerateInvoice;
+        $this->canGenerateDeliverySlip = $canGenerateDeliverySlip;
     }
 
     /**
@@ -49,6 +64,22 @@ class OrderDocumentsForViewing
     public function getDocuments(): array
     {
         return $this->documents;
+    }
+
+    /**
+     * @return bool
+     */
+    public function canGenerateInvoice(): bool
+    {
+        return $this->canGenerateInvoice;
+    }
+
+    /**
+     * @return bool
+     */
+    public function canGenerateDeliverySlip(): bool
+    {
+        return $this->canGenerateDeliverySlip;
     }
 
     private function add(OrderDocumentForViewing $document): void

--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -105,3 +105,10 @@ services:
         - '@=service("prestashop.user_provider").getUsername()'
       tags:
         - { name: twig.extension }
+
+    prestashop.bundle.twig.extension.localization_extension:
+      class: 'PrestaShopBundle\Twig\Extension\LocalizationExtension'
+      arguments:
+        - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
+      tags:
+        - { name: twig.extension }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/history.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/history.html.twig
@@ -40,7 +40,7 @@
         {% endif %}
       </td>
       <td class="text-right">
-        {{ status.createdAt.format('Y-m-d H:i:s') }}
+        {{ status.createdAt|date_format_full }}
       </td>
       <td class="text-right">
         {% if status.withEmail %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig
@@ -47,4 +47,26 @@
       {{ form_rest(updateOrderStatusActionBarForm) }}
     </div>
   {{ form_end(updateOrderStatusActionBarForm) }}
+
+  {% if orderForViewing.documents.canGenerateInvoice %}
+    <form class="form-inline d-inline-block form-horizontal ml-2">
+      <div class="input-group">
+        <a href="{{ path('admin_orders_generate_invoice_pdf', {'orderId': orderForViewing.id}) }}" class="btn btn-action">
+          <i class="material-icons">receipt</i>
+          {{ 'View invoice'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        </a>
+      </div>
+    </form>
+  {% endif %}
+
+  {% if orderForViewing.documents.canGenerateDeliverySlip %}
+    <form class="form-inline d-inline-block form-horizontal ml-2">
+      <div class="input-group">
+        <a href="{{ path('admin_orders_generate_delivery_slip_pdf', {'orderId': orderForViewing.id}) }}" class="btn btn-action">
+          <i class="material-icons">local_shipping</i>
+          {{ 'View delivery slip'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        </a>
+      </div>
+    </form>
+  {% endif %}
 </div>

--- a/src/PrestaShopBundle/Twig/Extension/LocalizationExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/LocalizationExtension.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Twig\Extension;
+
+use DateTime;
+use DateTimeInterface;
+use Twig\Extension\AbstractExtension;
+use Twig_SimpleFilter;
+
+class LocalizationExtension extends AbstractExtension
+{
+    /**
+     * @var string
+     */
+    private $dateFormatFull;
+
+    /**
+     * @param string $contextDateFormatFull
+     */
+    public function __construct(string $contextDateFormatFull)
+    {
+        $this->dateFormatFull = $contextDateFormatFull;
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            new Twig_SimpleFilter('date_format_full', [$this, 'dateFormatFull']),
+        ];
+    }
+
+    public function dateFormatFull($date): string
+    {
+        if (!$date instanceof DateTimeInterface) {
+            $date = new DateTime($date);
+        }
+
+        return $date->format($this->dateFormatFull);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Migrates "Update status", "View invoice" and "View delivery slip" actions. In addition, whole "Status" block should behave the same as legacy.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially #15818 and fully #15822
| How to test?  | :warning: Rebuild assets :warning: "Update status", "View invoice" and "View delivery slip" actions should behave the same as in legacy page. In addition, whole "Status" block should behave the same as legacy as well.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16022)
<!-- Reviewable:end -->
