### PR TITLE
Fix search returning too much products.

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -237,7 +237,7 @@ class SearchCore
             if (!empty($word) && strlen($word) >= (int) Configuration::get('PS_SEARCH_MINWORDLEN')) {
                 $sql_param_search = self::getSearchParamFromWord($word);
 
-                $intersect_array[] = 'SELECT DISTINCT si.id_product
+                $intersect_array[] = 'SELECT si.id_product
 					FROM ' . _DB_PREFIX_ . 'search_word sw
 					LEFT JOIN ' . _DB_PREFIX_ . 'search_index si ON sw.id_word = si.id_word
 					WHERE sw.id_lang = ' . (int) $id_lang . '
@@ -275,7 +275,7 @@ class SearchCore
         }
 
         $results = $db->executeS('
-		SELECT DISTINCT cp.`id_product`
+		SELECT cp.`id_product`
 		FROM `' . _DB_PREFIX_ . 'category_product` cp
 		' . (Group::isFeatureActive() ? 'INNER JOIN `' . _DB_PREFIX_ . 'category_group` cg ON cp.`id_category` = cg.`id_category`' : '') . '
 		INNER JOIN `' . _DB_PREFIX_ . 'category` c ON cp.`id_category` = c.`id_category`
@@ -291,17 +291,19 @@ class SearchCore
         foreach ($results as $row) {
             $eligible_products[] = $row['id_product'];
         }
-
-        $eligible_products2 = array();
         foreach ($intersect_array as $query) {
+            $eligible_products2 = array();
             foreach ($db->executeS($query, true, false) as $row) {
                 $eligible_products2[] = $row['id_product'];
             }
+
+            $eligible_products = array_intersect($eligible_products, $eligible_products2);
+            if (!count($eligible_products)) {
+                return ($ajax ? array() : array('total' => 0, 'result' => array()));
+            }
         }
-        $eligible_products = array_unique(array_intersect($eligible_products, array_unique($eligible_products2)));
-        if (!count($eligible_products)) {
-            return $ajax ? array() : array('total' => 0, 'result' => array());
-        }
+
+        $eligible_products = array_unique($eligible_products);
 
         $product_pool = '';
         foreach ($eligible_products as $id_product) {


### PR DESCRIPTION
Reverts a change that happened sometimes around 1.6.1.13 and fixes Prestashop search.



| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes #16019 and #14350.
| How to test?  | Search something as described in #16019

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16023)
<!-- Reviewable:end -->
