### PR TITLE
Improve getCategories function

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1282,7 +1282,7 @@ class ShopCore extends ObjectModel
         }
         $query->from('category_shop', 'cs');
         $query->leftJoin('category_lang', 'cl', 'cl.`id_category` = cs.`id_category` AND cl.`id_lang` = ' . (int) Context::getContext()->language->id);
-        $query->where('cs.`id_shop` = ' . (int) $id);
+        $query->where('cs.`id_shop` = ' . (int) $id . ' AND cl.`id_shop` = ' . (int) $id);
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
 
         if ($only_id) {


### PR DESCRIPTION


<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I needed to use getCategories in a module I'm creating but when I used getCategories, some categories appeared between 1 and 4 times (I'm working on a multishop). To not have this problem I just needed to add a condition : cl.id_shop (because, thanks to LEFT JOIN you made, you can select the language but you can't select the shop if you have the same category on many shops, this categories appears many times)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Does it break backward compatibility? yes/no
| Deprecations? | Does it deprecate an existing feature? yes/no
| Fixed ticket? | [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16035)
<!-- Reviewable:end -->
