### PR TITLE
Remove google plus from login footer

### DIFF
--- a/admin-dev/themes/default/template/controllers/login/content.tpl
+++ b/admin-dev/themes/default/template/controllers/login/content.tpl
@@ -181,9 +181,6 @@
 			<a class="link-social link-github _blank" href="https://www.prestashop.com/github" title="Github">
 				<i class="icon-github"></i>
 			</a>
-			<a class="link-social link-google _blank" href="https://plus.google.com/+prestashop/" title="Google">
-				<i class="icon-google-plus"></i>
-			</a>
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove link to google plus from login template (google plus is dead)
| Type?         |  improvement 
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16040 
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16041)
<!-- Reviewable:end -->
