### PR TITLE
Fix swap-select values not being submitted in generated AdminController forms

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -899,6 +899,7 @@ $(document).ready(function()
   });
 
   $('.swap-container').each(function() {
+    var swap_container = this;
     /** make sure that all the swap id is present in the dom to prevent mistake **/
     if (typeof $('.addSwap', this) !== undefined && typeof $(".removeSwap", this) !== undefined &&
       typeof $('.selectedSwap', this) !== undefined && typeof $('.availableSwap', this) !== undefined)
@@ -907,7 +908,7 @@ $(document).ready(function()
       bindSwapButton('remove', 'selected', 'available', this);
 
       $('button:submit').click(function() {
-        bindSwapSave(this);
+        bindSwapSave(swap_container);
       });
     }
   });


### PR DESCRIPTION
The context variable is used inside bindSwapSave(context) function to find the selected values.

Previously the variable passed to the function was referring to the button inside the .click() function.

Now new variable "swap_container" is passed which refers to the found swap container.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes swap-select values not being submitted in generated AdminController forms.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Install my test module from git: https://github.com/L3RAZ/PS-swap-module , press "Configure" and a form should appear. When swap columns are changed and the form submitted, the saved columns should remain. When submitting the form for a second time without moving any columns then no selected values are submitted. This PR solves the issue when saving the form without changing the swap values.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16045)
<!-- Reviewable:end -->
