### PR TITLE
Handle multistore customers sharing in customers listing at group level

### DIFF
--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -73,6 +73,23 @@ class Context implements MultistoreContextCheckerInterface, ShopContextInterface
     }
 
     /**
+     * Return the result of getContextListShopID() for customers usecase
+     * This handles the "multishop sharing customer" feature setting
+     *
+     * @return array
+     */
+    public function getContextListShopIDUsingCustomerSharingSettings()
+    {
+        $groupSettings = Shop::getGroupFromShop(Shop::getContextShopID(), false);
+
+        if ($groupSettings['share_customer']) {
+            return Shop::getContextListShopID(Shop::SHARE_CUSTOMER);
+        } else {
+            return Shop::getContextListShopID();
+        }
+    }
+
+    /**
      * Get if it's a GroupShop context.
      *
      * @return bool

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -66,7 +66,7 @@ services:
         arguments:
             - '@prestashop.core.query.doctrine_search_criteria_applicator'
             - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
-            - '@=service("prestashop.adapter.shop.context").getContextListShopID()'
+            - '@=service("prestashop.adapter.shop.context").getContextListShopIDUsingCustomerSharingSettings()'
         public: true
 
     prestashop.core.grid.quer_.builder.language:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Handle multistore customers sharing in customers listing at group level
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/16043
| How to test?  | Please see issue, and check multistore behavior for Customers listing. Please also check if "customers sharing" setting is working fine when disabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16047)
<!-- Reviewable:end -->
