### PR TITLE
Fix number of DL & expiration date being displayed in the download virtual product mail

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -136,16 +136,17 @@ class OrderHistoryCore extends ObjectModel
                 $customer = new Customer((int) $order->id_customer);
                 $links = array();
                 foreach ($assign as $product) {
-                    $text = Tools::htmlentitiesUTF8($product['name']);
+                    $complementaryText = array();
                     if (isset($product['deadline'])) {
-                        $text .= '&nbsp;' . $this->trans('expires on %s.', array($product['deadline']), 'Admin.Orderscustomers.Notification');
+                        $complementaryText[] = $this->trans('expires on %s.', array($product['deadline']), 'Admin.Orderscustomers.Notification');
                     }
                     if (isset($product['downloadable'])) {
-                        $text .= '&nbsp;' . $this->trans('downloadable %d time(s)', array((int) $product['downloadable']), 'Admin.Orderscustomers.Notification');
+                        $complementaryText[] = $this->trans('downloadable %d time(s)', array((int) $product['downloadable']), 'Admin.Orderscustomers.Notification');
                     }
                     $links[] = array(
-                        'text' => $text,
+                        'text' => Tools::htmlentitiesUTF8($product['name']),
                         'url' => $product['link'],
+                        'complementary_text' => implode(' ', $complementaryText),
                     );
                 }
 

--- a/mails/_partials/download_product_virtual_products.tpl
+++ b/mails/_partials/download_product_virtual_products.tpl
@@ -24,6 +24,6 @@
  *}
 <ul>
 {foreach $list as $product}
-  <li><a href="{$product.url}">{$product.text}</a></li>
+  <li><a href="{$product.url}">{$product.text}</a> {$product.complementary_text}</li>
 {/foreach}
 </ul>

--- a/mails/_partials/download_product_virtual_products.txt
+++ b/mails/_partials/download_product_virtual_products.txt
@@ -1,3 +1,3 @@
 {foreach $list as $product}
-  [{$product.text}]({$product.url})
+  [{$product.text}]({$product.url}) {$product.complementary_text}
 {/foreach}

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Employee\ContextEmployeeProviderInterface;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Address;
 use AddressFormat;
 use Carrier;
@@ -46,6 +47,8 @@ use Tools;
 final class MailPreviewVariablesBuilder
 {
     const ORDER_CONFIRMATION = 'order_conf';
+
+    const DOWNLOAD_PRODUCT = 'download_product';
 
     const EMAIL_ALERTS_MODULE = 'ps_emailalerts';
     const NEW_ORDER = 'new_order';
@@ -72,6 +75,11 @@ final class MailPreviewVariablesBuilder
     private $mailPartialTemplateRenderer;
 
     /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
      * MailPreviewVariablesBuilder constructor.
      *
      * @param ConfigurationInterface $configuration
@@ -79,13 +87,15 @@ final class MailPreviewVariablesBuilder
      * @param ContextEmployeeProviderInterface $employeeProvider
      * @param MailPartialTemplateRenderer $mailPartialTemplateRenderer
      * @param Locale $locale
+     * @param TranslatorInterface $translatorComponent
      */
     public function __construct(
         ConfigurationInterface $configuration,
         LegacyContext $legacyContext,
         ContextEmployeeProviderInterface $employeeProvider,
         MailPartialTemplateRenderer $mailPartialTemplateRenderer,
-        Locale $locale
+        Locale $locale,
+        TranslatorInterface $translatorComponent
     ) {
         $this->configuration = $configuration;
         $this->legacyContext = $legacyContext;
@@ -93,6 +103,7 @@ final class MailPreviewVariablesBuilder
         $this->employeeProvider = $employeeProvider;
         $this->mailPartialTemplateRenderer = $mailPartialTemplateRenderer;
         $this->locale = $locale;
+        $this->translator = $translatorComponent;
     }
 
     /**
@@ -137,6 +148,19 @@ final class MailPreviewVariablesBuilder
     }
 
     /**
+     * @param $id
+     * @param array $parameters
+     * @param null $domain
+     * @param null $local
+     *
+     * @return string
+     */
+    protected function trans($id, $parameters = [], $domain = null, $local = null)
+    {
+        return $this->translator->trans($id, $parameters, $domain, $local);
+    }
+
+    /**
      * @return array
      *
      * @throws \PrestaShopException
@@ -165,6 +189,15 @@ final class MailPreviewVariablesBuilder
                 '{products_txt}' => $productListTxt,
                 '{discounts}' => $cartRulesListHtml,
                 '{discounts_txt}' => $cartRulesListTxt,
+            ];
+        } elseif (self::DOWNLOAD_PRODUCT == $mailLayout->getName()) {
+            $virtualProductTemplateList = $this->getFakeVirtualProductList();
+            $virtualProductListTxt = $this->mailPartialTemplateRenderer->render('download_product_virtual_products.txt', $this->context->language, $virtualProductTemplateList);
+            $virtualProductListHtml = $this->mailPartialTemplateRenderer->render('download_product_virtual_products.tpl', $this->context->language, $virtualProductTemplateList);
+            $productVariables = [
+                '{nbProducts}' => count($virtualProductTemplateList),
+                '{virtualProducts}' => $virtualProductListHtml,
+                '{virtualProductsTxt}' => $virtualProductListTxt,
             ];
         } elseif (self::EMAIL_ALERTS_MODULE == $mailLayout->getModuleName() && self::NEW_ORDER == $mailLayout->getName()) {
             $productVariables = [
@@ -366,6 +399,28 @@ final class MailPreviewVariablesBuilder
         }
 
         return $productTemplateList;
+    }
+
+    /**
+     * @return array
+     */
+    private function getFakeVirtualProductList()
+    {
+        $products = Product::getProducts($this->context->language->getId(), 0, 2, 'id_product', 'ASC');
+        $results = [];
+
+        foreach ($products as $productData) {
+            $product = new Product($productData['id_product']);
+            $results[] = [
+                'text' => Product::getProductName($productData['id_product']),
+                'url' => $product->getLink(),
+                'complementary_text' => '',
+            ];
+        }
+        $results[1]['complementary_text'] = ' ' . $this->trans('expires on %s.', array(date('Y-m-d')), 'Admin.Orderscustomers.Notification');
+        $results[1]['complementary_text'] .= ' ' . $this->trans('downloadable %d time(s)', array(10), 'Admin.Orderscustomers.Notification');
+
+        return $results;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
@@ -29,3 +29,4 @@ services:
       - '@prestashop.adapter.data_provider.employee'
       - "@prestashop.adapter.mail_template.partial_template_renderer"
       - "@prestashop.core.localization.locale.context_locale"
+      - "@translator"


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This fixes #16014 that was merged to soon
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10915
| How to test?  | Order a virtual product with a file and see the text mail sent

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16049)
<!-- Reviewable:end -->
