### PR TITLE
Update Greek tax rates

### DIFF
--- a/localization/gr.xml
+++ b/localization/gr.xml
@@ -7,40 +7,37 @@
     <language iso_code="el"/>
   </languages>
   <taxes>
-    <tax id="1" name="ΦΠΑ GR 23%" rate="23" eu-tax-group="virtual"/>
+    <tax id="1" name="ΦΠΑ GR 24%" rate="24" eu-tax-group="virtual"/>
     <tax id="2" name="ΦΠΑ GR 13%" rate="13"/>
-    <tax id="3" name="ΦΠΑ GR 6.5%" rate="6.5"/>
-    <tax id="4" name="ΦΠΑ GR 16%" rate="16"/>
-    <tax id="5" name="ΦΠΑ GR 8%" rate="8"/>
-    <tax id="6" name="ΦΠΑ GR 4%" rate="4"/>
-    <tax id="7" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="8" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="9" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="10" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="11" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="12" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="20" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="21" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="22" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="23" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="24" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="30" name="TVA RO 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="31" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="32" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="33" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <taxRulesGroup name="GR Standard Rate (23%)">
+    <tax id="3" name="ΦΠΑ GR 6%" rate="6"/>
+    <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <taxRulesGroup name="GR Standard Rate (24%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
       <taxRule iso_code_country="cz" id_tax="1"/>
@@ -98,7 +95,7 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="GR Super Reduced Rate (6.5%)">
+    <taxRulesGroup name="GR Super Reduced Rate (6%)">
       <taxRule iso_code_country="be" id_tax="3"/>
       <taxRule iso_code_country="bg" id_tax="3"/>
       <taxRule iso_code_country="cz" id_tax="3"/>
@@ -126,93 +123,6 @@
       <taxRule iso_code_country="fi" id_tax="3"/>
       <taxRule iso_code_country="se" id_tax="3"/>
       <taxRule iso_code_country="uk" id_tax="3"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="GR islands Standard Rate (16%)">
-      <taxRule iso_code_country="be" id_tax="4"/>
-      <taxRule iso_code_country="bg" id_tax="4"/>
-      <taxRule iso_code_country="cz" id_tax="4"/>
-      <taxRule iso_code_country="dk" id_tax="4"/>
-      <taxRule iso_code_country="de" id_tax="4"/>
-      <taxRule iso_code_country="ee" id_tax="4"/>
-      <taxRule iso_code_country="gr" id_tax="4"/>
-      <taxRule iso_code_country="es" id_tax="4"/>
-      <taxRule iso_code_country="fr" id_tax="4"/>
-      <taxRule iso_code_country="ie" id_tax="4"/>
-      <taxRule iso_code_country="it" id_tax="4"/>
-      <taxRule iso_code_country="cy" id_tax="4"/>
-      <taxRule iso_code_country="lv" id_tax="4"/>
-      <taxRule iso_code_country="lt" id_tax="4"/>
-      <taxRule iso_code_country="lu" id_tax="4"/>
-      <taxRule iso_code_country="hu" id_tax="4"/>
-      <taxRule iso_code_country="mt" id_tax="4"/>
-      <taxRule iso_code_country="nl" id_tax="4"/>
-      <taxRule iso_code_country="at" id_tax="4"/>
-      <taxRule iso_code_country="pl" id_tax="4"/>
-      <taxRule iso_code_country="pt" id_tax="4"/>
-      <taxRule iso_code_country="ro" id_tax="4"/>
-      <taxRule iso_code_country="si" id_tax="4"/>
-      <taxRule iso_code_country="sk" id_tax="4"/>
-      <taxRule iso_code_country="fi" id_tax="4"/>
-      <taxRule iso_code_country="se" id_tax="4"/>
-      <taxRule iso_code_country="uk" id_tax="4"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="GR islands Reduced Rate (8%)">
-      <taxRule iso_code_country="be" id_tax="5"/>
-      <taxRule iso_code_country="bg" id_tax="5"/>
-      <taxRule iso_code_country="cz" id_tax="5"/>
-      <taxRule iso_code_country="dk" id_tax="5"/>
-      <taxRule iso_code_country="de" id_tax="5"/>
-      <taxRule iso_code_country="ee" id_tax="5"/>
-      <taxRule iso_code_country="gr" id_tax="5"/>
-      <taxRule iso_code_country="es" id_tax="5"/>
-      <taxRule iso_code_country="fr" id_tax="5"/>
-      <taxRule iso_code_country="ie" id_tax="5"/>
-      <taxRule iso_code_country="it" id_tax="5"/>
-      <taxRule iso_code_country="cy" id_tax="5"/>
-      <taxRule iso_code_country="lv" id_tax="5"/>
-      <taxRule iso_code_country="lt" id_tax="5"/>
-      <taxRule iso_code_country="lu" id_tax="5"/>
-      <taxRule iso_code_country="hu" id_tax="5"/>
-      <taxRule iso_code_country="mt" id_tax="5"/>
-      <taxRule iso_code_country="nl" id_tax="5"/>
-      <taxRule iso_code_country="at" id_tax="5"/>
-      <taxRule iso_code_country="pl" id_tax="5"/>
-      <taxRule iso_code_country="pt" id_tax="5"/>
-      <taxRule iso_code_country="ro" id_tax="5"/>
-      <taxRule iso_code_country="si" id_tax="5"/>
-      <taxRule iso_code_country="sk" id_tax="5"/>
-      <taxRule iso_code_country="fi" id_tax="5"/>
-      <taxRule iso_code_country="se" id_tax="5"/>
-      <taxRule iso_code_country="uk" id_tax="5"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="GR islands Super Reduced Rate (4%)">
-      <taxRule iso_code_country="be" id_tax="6"/>
-      <taxRule iso_code_country="bg" id_tax="6"/>
-      <taxRule iso_code_country="cz" id_tax="6"/>
-      <taxRule iso_code_country="dk" id_tax="6"/>
-      <taxRule iso_code_country="de" id_tax="6"/>
-      <taxRule iso_code_country="ee" id_tax="6"/>
-      <taxRule iso_code_country="gr" id_tax="6"/>
-      <taxRule iso_code_country="es" id_tax="6"/>
-      <taxRule iso_code_country="fr" id_tax="6"/>
-      <taxRule iso_code_country="ie" id_tax="6"/>
-      <taxRule iso_code_country="it" id_tax="6"/>
-      <taxRule iso_code_country="cy" id_tax="6"/>
-      <taxRule iso_code_country="lv" id_tax="6"/>
-      <taxRule iso_code_country="lt" id_tax="6"/>
-      <taxRule iso_code_country="lu" id_tax="6"/>
-      <taxRule iso_code_country="hu" id_tax="6"/>
-      <taxRule iso_code_country="mt" id_tax="6"/>
-      <taxRule iso_code_country="nl" id_tax="6"/>
-      <taxRule iso_code_country="at" id_tax="6"/>
-      <taxRule iso_code_country="pl" id_tax="6"/>
-      <taxRule iso_code_country="pt" id_tax="6"/>
-      <taxRule iso_code_country="ro" id_tax="6"/>
-      <taxRule iso_code_country="si" id_tax="6"/>
-      <taxRule iso_code_country="sk" id_tax="6"/>
-      <taxRule iso_code_country="fi" id_tax="6"/>
-      <taxRule iso_code_country="se" id_tax="6"/>
-      <taxRule iso_code_country="uk" id_tax="6"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="gr" id_tax="1"/>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Update localization packs data, add the right tax rates - feedback from the Turkish ambassador ([here](https://docs.google.com/spreadsheets/d/1QvBo1q_ddSZU3wcawGN_oZVeutY-CB5eJaYfky6HXys/edit?usp=sharing))
| Type?         | improvement
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | It is part of this [EPIC](https://github.com/PrestaShop/PrestaShop/issues/15829).
| Test? | Install PrestaShop in Greek and you should have 3 taxes in the International section of the back office, matching 24%, 13%, and 6%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16055)
<!-- Reviewable:end -->
