### PR TITLE
Improve wording on order confirmation email

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -615,7 +615,7 @@ abstract class PaymentModuleCore extends Module
                             '{order_name}' => $order->getUniqReference(),
                             '{date}' => Tools::displayDate(date('Y-m-d H:i:s'), null, 1),
                             '{carrier}' => ($virtual_product || !isset($carrier->name)) ? $this->trans('No carrier', array(), 'Admin.Payment.Notification') : $carrier->name,
-                            '{payment}' => Tools::substr($order->payment, 0, 255),
+                            '{payment}' => Tools::substr($order->payment, 0, 255) . ($order->hasBeenPaid() ? '' : '&nbsp;' . $this->trans('(waiting for validation)', array(), 'Emails.Body')),
                             '{products}' => $product_list_html,
                             '{products_txt}' => $product_list_txt,
                             '{discounts}' => $cart_rules_list_html,

--- a/mails/themes/modern/core/order_conf.html.twig
+++ b/mails/themes/modern/core/order_conf.html.twig
@@ -50,7 +50,7 @@
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:25px;word-break:break-word;">
                                         <div style="font-family:Open sans, arial, sans-serif;font-size:16px;line-height:25px;text-align:left;color:#363A41;">
-                                          {{ 'Thank you for shopping on [1]{shop_name}[/1]!'|trans({'[1]': '<span class="label">', '[/1]': '</span>'}, 'Emails.Body', locale)|raw }}
+                                          {{ 'Thank you for your order on [1]{shop_name}[/1]!'|trans({'[1]': '<span class="label">', '[/1]': '</span>'}, 'Emails.Body', locale)|raw }}
                                         </div>
                                       </td>
                                     </tr>
@@ -379,7 +379,7 @@
                                   </tr>
                                   <tr class="order_summary">
                                     <td bgcolor="#FDFDFD" colspan="3" align="right">
-                                      {{ 'Total paid'|trans({}, 'Emails.Body', locale)|raw }}
+                                      {{ 'Total'|trans({}, 'Emails.Body', locale)|raw }}
                                     </td>
                                     <td bgcolor="#FDFDFD" colspan="3"> {total_paid} </td>
                                   </tr>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Change wording to handle the case when payment validation is waiting
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15940
| How to test?  | Order a product and chose check/bank wire as payment method and then check your confirmation mail

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16063)
<!-- Reviewable:end -->
