### PR TITLE
Migrate Shipping block of new Order View page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
+++ b/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
@@ -42,4 +42,7 @@ export default {
   updateOrderStatusActionBtn: '#update_order_status_action_btn',
   updateOrderStatusActionInput: '#update_order_status_action_input',
   updateOrderStatusActionForm: '#update_order_status_action_form',
+  showOrderShippingUpdateModalBtn: '.js-update-shipping-btn',
+  updateOrderShippingTrackingNumberInput: '#update_order_shipping_tracking_number',
+  updateOrderShippingCurrentOrderCarrierIdInput: '#update_order_shipping_current_order_carrier_id',
 };

--- a/admin-dev/themes/new-theme/js/pages/order/order-shipping-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/order/order-shipping-manager.js
@@ -1,0 +1,36 @@
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+const $ = window.$;
+
+export default class OrderShippingManager {
+  constructor() {
+
+  }
+
+  _initOrderShippingUpdateEventHandler() {
+
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/order/order-shipping-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/order/order-shipping-manager.js
@@ -22,15 +22,21 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+import OrderViewPageMap from './OrderViewPageMap';
 
 const $ = window.$;
 
 export default class OrderShippingManager {
   constructor() {
-
+    this._initOrderShippingUpdateEventHandler();
   }
 
   _initOrderShippingUpdateEventHandler() {
+    $(OrderViewPageMap.showOrderShippingUpdateModalBtn).on('click', (event) => {
+      const $btn = $(event.currentTarget);
 
+      $(OrderViewPageMap.updateOrderShippingTrackingNumberInput).val($btn.data('order-tracking-number'));
+      $(OrderViewPageMap.updateOrderShippingCurrentOrderCarrierIdInput).val($btn.data('order-carrier-id'));
+    });
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/order/view.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view.js
@@ -24,6 +24,7 @@
  */
 
 import OrderViewPageMap from './OrderViewPageMap';
+import OrderShippingManager from './order-shipping-manager';
 
 const $ = window.$;
 
@@ -31,6 +32,8 @@ $(() => {
   const DISCOUNT_TYPE_AMOUNT = 'amount';
   const DISCOUNT_TYPE_PERCENT = 'percent';
   const DISCOUNT_TYPE_FREE_SHIPPING = 'free_shipping';
+
+  new OrderShippingManager();
 
   handlePaymentDetailsToggle();
   handlePrivateNoteChange();

--- a/src/Adapter/Form/ChoiceProvider/CarrierForOrderChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/CarrierForOrderChoiceProvider.php
@@ -55,7 +55,7 @@ final class CarrierForOrderChoiceProvider implements ConfigurableFormChoiceProvi
         foreach ($carriers as $carrier) {
             $delay = $carrier['delay'] ? sprintf(' (%s)', $carrier['delay']) : '';
 
-            $choices[$carrier['name'].$delay] = (int) $carrier['id_carrier'];
+            $choices[$carrier['name'] . $delay] = (int) $carrier['id_carrier'];
         }
 
         return $choices;

--- a/src/Adapter/Form/ChoiceProvider/CarrierForOrderChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/CarrierForOrderChoiceProvider.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
+
+use Address;
+use Carrier;
+use Cart;
+use Customer;
+use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @internal
+ */
+final class CarrierForOrderChoiceProvider implements ConfigurableFormChoiceProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getChoices(array $options): array
+    {
+        $options = $this->resolveOptions($options);
+
+        $cart = Cart::getCartByOrderId($options['order_id']);
+        $groups = Customer::getGroupsStatic((int) $cart->id_customer);
+        $address = new Address((int) $cart->id_address_delivery);
+
+        $carriers = Carrier::getCarriersForOrder(Address::getZoneById((int) $address->id), $groups, $cart);
+        $choices = [];
+
+        foreach ($carriers as $carrier) {
+            $delay = $carrier['delay'] ? sprintf(' (%s)', $carrier['delay']) : '';
+
+            $choices[$carrier['name'].$delay] = (int) $carrier['id_carrier'];
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    private function resolveOptions(array $options): array
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setRequired([
+            'order_id',
+        ]);
+        $resolver->setAllowedTypes('order_id', 'int');
+
+        return $resolver->resolve($options);
+    }
+}

--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\UpdateOrderShippingDetailsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\TransistEmailSendingException;
 use Validate;
 
 /**
@@ -87,7 +88,7 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
         //send mail only if tracking number is different AND not empty
         if (!empty($trackingNumber) && $oldTrackingNumber != $trackingNumber) {
             if (!$orderCarrier->sendInTransitEmail($order)) {
-                throw new OrderException('An error occurred while sending an email to the customer.');
+                throw new TransistEmailSendingException('An error occurred while sending an email to the customer.');
             }
 
             $customer = new Customer((int) $order->id_customer);

--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -52,7 +52,7 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
         $carrierId = $command->getNewCarrierId();
         $oldTrackingNumber = $order->shipping_number;
 
-        $orderCarrier = new OrderCarrier($order->getIdOrderCarrier());
+        $orderCarrier = new OrderCarrier($command->getCurrentOrderCarrierId());
         if (!Validate::isLoadedObject($orderCarrier)) {
             throw new OrderException('The order carrier ID is invalid.');
         }

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -601,7 +601,6 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
                     $price = Tools::displayPrice($item['shipping_cost_tax_excl'], $currency);
                 }
 
-
                 $trackingUrl = null;
                 $trackingNumber = $item['tracking_number'];
 

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -142,6 +142,7 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
         return new OrderForViewing(
             (int) $order->id,
             (int) $order->id_currency,
+            (int) $order->id_carrier,
             $order->reference,
             (bool) $order->isVirtual(),
             $taxMethod,

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -603,11 +603,10 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
 
 
                 $trackingUrl = null;
-                $trackingNumber = null;
+                $trackingNumber = $item['tracking_number'];
 
                 if ($item['url'] && $item['tracking_number']) {
                     $trackingUrl = str_replace('@', $item['tracking_number'], $item['url']);
-                    $trackingNumber = $item['tracking_number'];
                 }
 
                 $weight = sprintf('%.3f %s', $item['weight'], Configuration::get('PS_WEIGHT_UNIT'));

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -143,6 +143,7 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
             (int) $order->id,
             (int) $order->id_currency,
             $order->reference,
+            (bool) $order->isVirtual(),
             $taxMethod,
             $isTaxIncluded,
             (bool) $order->valid,
@@ -592,40 +593,44 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
             }
         }
 
-        foreach ($shipping as $item) {
-            if ($order->getTaxCalculationMethod() == PS_TAX_INC) {
-                $price = !empty($item['shipping_cost_tax_incl']) ? $this->locale->formatPrice($item['shipping_cost_tax_incl'], $currency->iso_code) : '';
-            } else {
-                $price = !empty($item['shipping_cost_tax_excl']) ? $this->locale->formatPrice($item['shipping_cost_tax_excl'], $currency->iso_code) : '';
+        if (!$order->isVirtual()) {
+            foreach ($shipping as $item) {
+                if ($order->getTaxCalculationMethod() == PS_TAX_INC) {
+                    $price = Tools::displayPrice($item['shipping_cost_tax_incl'], $currency);
+                } else {
+                    $price = Tools::displayPrice($item['shipping_cost_tax_excl'], $currency);
+                }
+
+
+                $trackingUrl = null;
+                $trackingNumber = null;
+
+                if ($item['url'] && $item['tracking_number']) {
+                    $trackingUrl = str_replace('@', $item['tracking_number'], $item['url']);
+                    $trackingNumber = $item['tracking_number'];
+                }
+
+                $weight = sprintf('%.3f %s', $item['weight'], Configuration::get('PS_WEIGHT_UNIT'));
+
+                $carriers[] = new OrderCarrierForViewing(
+                    (int) $item['id_order_carrier'],
+                    new DateTimeImmutable($item['date_add']),
+                    $item['carrier_name'],
+                    $weight,
+                    (int) $item['id_carrier'],
+                    $price,
+                    $trackingUrl,
+                    $trackingNumber,
+                    $item['can_edit']
+                );
             }
-
-            $trackingUrl = null;
-            $trackingNumber = null;
-
-            if ($item['url'] && $item['tracking_number']) {
-                $trackingUrl = str_replace('@', $item['tracking_number'], $item['url']);
-                $trackingNumber = $item['tracking_number'];
-            }
-
-            $weight = sprintf('%.3f %s', $item['weight'], Configuration::get('PS_WEIGHT_UNIT'));
-
-            $carriers[] = new OrderCarrierForViewing(
-                (int) $item['id_order_carrier'],
-                new DateTimeImmutable($item['date_add']),
-                $item['carrier_name'] ?? '',
-                $weight,
-                (int) $item['id_carrier'],
-                $price,
-                $trackingUrl,
-                $trackingNumber,
-                $item['can_edit']
-            );
         }
 
         return new OrderShippingForViewing(
             $carriers,
             (bool) $order->recyclable,
             (bool) $order->gift,
+            $order->gift_message,
             $carrierModuleInfo
         );
     }

--- a/src/Core/Domain/Order/Command/UpdateOrderShippingDetailsCommand.php
+++ b/src/Core/Domain/Order/Command/UpdateOrderShippingDetailsCommand.php
@@ -44,26 +44,33 @@ class UpdateOrderShippingDetailsCommand
     private $newCarrierId;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $trackingNumber;
 
     /**
+     * @var int
+     */
+    private $currentOrderCarrierId;
+
+    /**
      * @param int $orderId
+     * @param int $currentOrderCarrierId
      * @param int $newCarrierId
      * @param string $trackingNumber
      */
-    public function __construct($orderId, $newCarrierId, $trackingNumber = '')
+    public function __construct(int $orderId, int $currentOrderCarrierId, int $newCarrierId, ?string $trackingNumber = '')
     {
         $this->orderId = new OrderId($orderId);
         $this->newCarrierId = $newCarrierId;
         $this->trackingNumber = $trackingNumber;
+        $this->currentOrderCarrierId = $currentOrderCarrierId;
     }
 
     /**
      * @return OrderId
      */
-    public function getOrderId()
+    public function getOrderId(): OrderId
     {
         return $this->orderId;
     }
@@ -71,16 +78,24 @@ class UpdateOrderShippingDetailsCommand
     /**
      * @return int
      */
-    public function getNewCarrierId()
+    public function getNewCarrierId(): int
     {
         return $this->newCarrierId;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getShippingTrackingNumber()
+    public function getShippingTrackingNumber(): ?string
     {
         return $this->trackingNumber;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCurrentOrderCarrierId(): int
+    {
+        return $this->currentOrderCarrierId;
     }
 }

--- a/src/Core/Domain/Order/Exception/TransistEmailSendingException.php
+++ b/src/Core/Domain/Order/Exception/TransistEmailSendingException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\Exception;
+
+/**
+ * Thrown when when failed to send email to customer regarding order tracking
+ */
+class TransistEmailSendingException extends OrderException
+{
+}

--- a/src/Core/Domain/Order/QueryResult/OrderForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderForViewing.php
@@ -137,10 +137,16 @@ class OrderForViewing
      */
     private $createdAt;
 
+    /**
+     * @var bool
+     */
+    private $isVirtual;
+
     public function __construct(
         int $orderId,
         int $currencyId,
         string $reference,
+        bool $isVirtual,
         string $taxMethod,
         bool $isTaxIncluded,
         bool $isValid,
@@ -181,6 +187,7 @@ class OrderForViewing
         $this->hasInvoice = $hasInvoice;
         $this->discounts = $discounts;
         $this->createdAt = $createdAt;
+        $this->isVirtual = $isVirtual;
     }
 
     /**
@@ -349,5 +356,13 @@ class OrderForViewing
     public function getCreatedAt(): DateTimeImmutable
     {
         return $this->createdAt;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isVirtual(): bool
+    {
+        return $this->isVirtual;
     }
 }

--- a/src/Core/Domain/Order/QueryResult/OrderForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderForViewing.php
@@ -142,9 +142,15 @@ class OrderForViewing
      */
     private $isVirtual;
 
+    /**
+     * @var int
+     */
+    private $carrierId;
+
     public function __construct(
         int $orderId,
         int $currencyId,
+        int $carrierId,
         string $reference,
         bool $isVirtual,
         string $taxMethod,
@@ -188,6 +194,7 @@ class OrderForViewing
         $this->discounts = $discounts;
         $this->createdAt = $createdAt;
         $this->isVirtual = $isVirtual;
+        $this->carrierId = $carrierId;
     }
 
     /**
@@ -204,6 +211,14 @@ class OrderForViewing
     public function getCurrencyId(): int
     {
         return $this->currencyId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCarrierId(): int
+    {
+        return $this->carrierId;
     }
 
     /**

--- a/src/Core/Domain/Order/QueryResult/OrderShippingForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderShippingForViewing.php
@@ -49,15 +49,22 @@ class OrderShippingForViewing
     private $carrierModuleInfo;
 
     /**
+     * @var string|null
+     */
+    private $giftMessage;
+
+    /**
      * @param OrderCarrierForViewing[] $carriers
      * @param bool $isRecycledPackaging
      * @param bool $isGiftWrapping
+     * @param string|null $giftMessage
      * @param string|null $carrierModuleInfo
      */
     public function __construct(
         array $carriers,
         bool $isRecycledPackaging,
         bool $isGiftWrapping,
+        ?string $giftMessage,
         ?string $carrierModuleInfo
     ) {
         foreach ($carriers as $carrier) {
@@ -67,6 +74,7 @@ class OrderShippingForViewing
         $this->isRecycledPackaging = $isRecycledPackaging;
         $this->isGiftWrapping = $isGiftWrapping;
         $this->carrierModuleInfo = $carrierModuleInfo;
+        $this->giftMessage = $giftMessage;
     }
 
     /**
@@ -99,6 +107,14 @@ class OrderShippingForViewing
     public function getCarrierModuleInfo(): ?string
     {
         return $this->carrierModuleInfo;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getGiftMessage(): ?string
+    {
+        return $this->giftMessage;
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -278,7 +278,9 @@ class OrderController extends FrameworkBundleAdminController
         ]);
         $addProductToOrderForm = $this->createForm(AddProductToOrderType::class);
         $updateOrderProductForm = $this->createForm(UpdateProductInOrderType::class);
-        $updateOrderShippingForm = $this->createForm(UpdateOrderShippingType::class, [], [
+        $updateOrderShippingForm = $this->createForm(UpdateOrderShippingType::class, [
+            'new_carrier_id' => $orderForViewing->getCarrierId(),
+        ], [
             'order_id' => $orderId,
         ]);
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -58,6 +58,7 @@ use PrestaShopBundle\Form\Admin\Sell\Order\AddProductToOrderType;
 use PrestaShopBundle\Form\Admin\Sell\Order\ChangeOrderCurrencyType;
 use PrestaShopBundle\Form\Admin\Sell\Order\ChangeOrdersStatusType;
 use PrestaShopBundle\Form\Admin\Sell\Order\OrderPaymentType;
+use PrestaShopBundle\Form\Admin\Sell\Order\UpdateOrderShippingType;
 use PrestaShopBundle\Form\Admin\Sell\Order\UpdateOrderStatusType;
 use PrestaShopBundle\Form\Admin\Sell\Order\UpdateProductInOrderType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -276,6 +277,9 @@ class OrderController extends FrameworkBundleAdminController
         ]);
         $addProductToOrderForm = $this->createForm(AddProductToOrderType::class);
         $updateOrderProductForm = $this->createForm(UpdateProductInOrderType::class);
+        $updateOrderShippingForm = $this->createForm(UpdateOrderShippingType::class, [], [
+            'order_id' => $orderId,
+        ]);
 
         return $this->render('@PrestaShop/Admin/Sell/Order/Order/view.html.twig', [
             'showContentHeader' => true,
@@ -289,6 +293,23 @@ class OrderController extends FrameworkBundleAdminController
             'privateNoteForm' => $privateNoteForm->createView(),
             'addProductToOrderForm' => $addProductToOrderForm->createView(),
             'updateOrderProductForm' => $updateOrderProductForm->createView(),
+            'updateOrderShippingForm' => $updateOrderShippingForm->createView(),
+        ]);
+    }
+
+    /**
+     * @param int $orderId
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function updateShippingAction(int $orderId, Request $request): RedirectResponse
+    {
+
+        $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+
+        return $this->redirectToRoute('admin_orders_view', [
+            'orderId' => $orderId,
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotEditDeliveredOrderPr
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderEmailResendException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\TransistEmailSendingException;
 use PrestaShop\PrestaShop\Core\Domain\Order\OrderConstraints;
 use PrestaShop\PrestaShop\Core\Domain\Order\Payment\Command\AddPaymentCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand;
@@ -327,6 +328,14 @@ class OrderController extends FrameworkBundleAdminController
                 );
 
                 $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+            } catch (TransistEmailSendingException $e) {
+                $this->addFlash(
+                    'error',
+                    $this->trans(
+                        'An error occurred while sending an email to the customer.',
+                        'Admin.Orderscustomers.Notification'
+                    )
+                );
             } catch (Exception $e) {
                 $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
             }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -254,7 +254,7 @@ class OrderController extends FrameworkBundleAdminController
     {
         /** @var OrderForViewing $orderForViewing */
         $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
-        dump($orderForViewing);
+
         $addOrderCartRuleForm = $this->createForm(AddOrderCartRuleType::class, [], [
             'order_id' => $orderId,
         ]);

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -252,7 +252,7 @@ class OrderController extends FrameworkBundleAdminController
     {
         /** @var OrderForViewing $orderForViewing */
         $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
-
+        dump($orderForViewing);
         $addOrderCartRuleForm = $this->createForm(AddOrderCartRuleType::class, [], [
             'order_id' => $orderId,
         ]);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderShippingType.php
@@ -57,7 +57,7 @@ class UpdateOrderShippingType extends AbstractType
         $builder
             ->add('new_carrier_id', ChoiceType::class, [
                 'choices' => $this->carrierForOrderChoiceProvider->getChoices([
-                    'order_id' => $options['order_id']
+                    'order_id' => $options['order_id'],
                 ]),
             ])
             ->add('current_order_carrier_id', HiddenType::class)

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderShippingType.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Form\Admin\Sell\Order;
+
+use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class UpdateOrderShippingType extends AbstractType
+{
+    /**
+     * @var ConfigurableFormChoiceProviderInterface
+     */
+    private $carrierForOrderChoiceProvider;
+
+    /**
+     * @param ConfigurableFormChoiceProviderInterface $carrierForOrderChoiceProvider
+     */
+    public function __construct(ConfigurableFormChoiceProviderInterface $carrierForOrderChoiceProvider)
+    {
+        $this->carrierForOrderChoiceProvider = $carrierForOrderChoiceProvider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('new_carrier_id', ChoiceType::class, [
+                'choices' => $this->carrierForOrderChoiceProvider->getChoices([
+                    'order_id' => $options['order_id']
+                ]),
+            ])
+            ->add('current_order_carrier_id', HiddenType::class)
+            ->add('tracking_number', TextType::class, [
+                'required' => false,
+            ])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setRequired([
+                'order_id',
+            ])
+            ->setAllowedTypes('order_id', 'int')
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
@@ -154,3 +154,12 @@ admin_search_product_for_order_creation:
   methods: [GET]
   defaults:
     _controller: PrestaShopBundle:Admin/Sell/Order/Order:searchProducts
+
+admin_orders_update_shipping:
+  path: /{orderId}/shipping
+  methods: [POST]
+  defaults:
+    _controller: PrestaShopBundle:Admin/Sell/Order/Order:updateShipping
+    _legacy_controller: AdminOrders
+  requirements:
+    orderId: \d+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
@@ -51,3 +51,6 @@ services:
 
   prestashop.adapter.form.choice_provider.installed_payment_modules:
     class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\InstalledPaymentModulesChoiceProvider'
+
+  prestashop.adapter.form.choice.provider.carrier_for_order_choice_provider:
+    class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\CarrierForOrderChoiceProvider'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -964,3 +964,10 @@ services:
       public: true
       tags:
         - { name: form.type }
+
+    form.type.order.update_order_shipping:
+      class: 'PrestaShopBundle\Form\Admin\Sell\Order\UpdateOrderShippingType'
+      arguments:
+        - '@prestashop.adapter.form.choice.provider.carrier_for_order_choice_provider'
+      tags:
+        - { name: form.type }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
@@ -36,6 +36,14 @@
         </button>
       </div>
       <div class="modal-body">
+        {% if not 'PS_ORDER_RECALCULATE_SHIPPING'|configuration %}
+          <div class="alert alert-info" role="alert">
+            <p class="alert-text">
+              {{ 'Please note that carrier change will not recalculate your shipping costs, if you want to change this please visit Shop Parameters > Order Settings'|trans({}, 'Admin.Orderscustomers.Notification') }}
+            </p>
+          </div>
+        {% endif %}
+
         <div class="form-group">
           <label class="form-control-label" for="{{ updateOrderShippingForm.tracking_number.vars.id }}">
             {{ 'Tracking number'|trans({}, 'Admin.Shipping.Feature') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
@@ -1,0 +1,68 @@
+{#**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+<div class="modal fade" id="updateOrderShippingModal" tabindex="-1" role="dialog">
+  {{ form_start(updateOrderShippingForm) }}
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">{{ 'Edit shipping details'|trans({}, 'Admin.Orderscustomers.Feature') }}</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label class="form-control-label" for="{{ updateOrderShippingForm.tracking_number.vars.id }}">
+            {{ 'Tracking number'|trans({}, 'Admin.Shipping.Feature') }}
+          </label>
+
+          {{ form_widget(updateOrderShippingForm.tracking_number) }}
+        </div>
+
+        <div class="form-group">
+          <label class="form-control-label" for="{{ updateOrderShippingForm.new_carrier_id.vars.id }}">
+            {{ 'Carrier'|trans({}, 'Admin.Global') }}
+          </label>
+
+          {{ form_widget(updateOrderShippingForm.new_carrier_id) }}
+        </div>
+
+        <div class="d-none">
+          {{ form_rest(updateOrderShippingForm) }}
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
+          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+        </button>
+        <button type="submit" class="btn btn-primary">
+          {{ 'Update'|trans({}, 'Admin.Actions') }}
+        </button>
+      </div>
+    </div>
+  </div>
+  {{ form_end(updateOrderShippingForm) }}
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
@@ -24,7 +24,9 @@
  *#}
 
 <div class="modal fade" id="updateOrderShippingModal" tabindex="-1" role="dialog">
-  {{ form_start(updateOrderShippingForm) }}
+  {{ form_start(updateOrderShippingForm, {
+    'action': path('admin_orders_update_shipping', {'orderId': orderForViewing.id})
+  }) }}
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
@@ -37,7 +37,7 @@
     </li>
     <li class="nav-item">
       <a class="nav-link" id="orderShippingTab" data-toggle="tab" href="#orderShippingTabContent" role="tab" aria-controls="orderShippingTabContent" aria-expanded="true" aria-selected="false">
-        {{ 'Carriers'|trans({}, 'Admin.Orderscustomers.Feature') }} ({{ orderForViewing.shipping.carriers|length }})
+        {{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }} ({{ orderForViewing.shipping.carriers|length }})
       </a>
     </li>
     <li class="nav-item">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -45,8 +45,12 @@
           <td>{{ carrier.weight }}</td>
           <td>{{ carrier.price }}</td>
           <td>
-            {% if carrier.trackingNumber and carrier.trackingUrl %}
-              <a href="{{ carrier.trackingUrl }}">{{ carrier.trackingNumber }}</a>
+            {% if carrier.trackingNumber %}
+              {% if carrier.trackingUrl %}
+                <a href="{{ carrier.trackingUrl }}">{{ carrier.trackingNumber }}</a>
+              {% else %}
+                {{ carrier.trackingNumber }}
+              {% endif %}
             {% endif %}
           </td>
           <td class="text-right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -51,7 +51,11 @@
           </td>
           <td class="text-right">
             {% if carrier.canEdit %}
-              <a href="#">
+              <a href="#"
+                 data-toggle="modal"
+                 data-target="#updateOrderShippingModal"
+                 data-order-carrier-id="{{ carrier.orderCarrierId }}"
+              >
                 {{ 'Edit'|trans({}, 'Admin.Actions') }}
               </a>
             {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -52,9 +52,11 @@
           <td class="text-right">
             {% if carrier.canEdit %}
               <a href="#"
+                 class="js-update-shipping-btn"
                  data-toggle="modal"
                  data-target="#updateOrderShippingModal"
                  data-order-carrier-id="{{ carrier.orderCarrierId }}"
+                 data-order-tracking-number="{{ carrier.trackingNumber }}"
               >
                 {{ 'Edit'|trans({}, 'Admin.Actions') }}
               </a>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -23,57 +23,57 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-<table class="table">
-  <thead>
-    <tr>
-      <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
-      <th>&nbsp;</th>
-      <th>{{ 'Carrier'|trans({}, 'Admin.Shipping.Feature') }}</th>
-      <th>{{ 'Weight'|trans({}, 'Admin.Global') }}</th>
-      <th>{{ 'Shipping cost'|trans({}, 'Admin.Shipping.Feature') }}</th>
-      <th>{{ 'Tracking number'|trans({}, 'Admin.Shipping.Feature') }}</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for carrier in orderForViewing.shipping.carriers %}
+{% if not orderForViewing.virtual %}
+  <table class="table">
+    <thead>
       <tr>
-        <td>{{ carrier.date|date('Y-m-d') }}</td>
-        <td>&nbsp;</td>
-        <td>{{ carrier.name }}</td>
-        <td>{{ carrier.weight }}</td>
-        <td>{{ carrier.price }}</td>
-        <td>
-          {% if carrier.trackingNumber and carrier.trackingUrl %}
-            <a href="{{ carrier.trackingUrl }}">{{ carrier.trackingNumber }}</a>
-          {% endif %}
-        </td>
-        <td class="text-right">
-          {% if carrier.canEdit %}
-            <a href="#">
-              {{ 'Edit'|trans({}, 'Admin.Actions') }}
-            </a>
-          {% endif %}
-        </td>
+        <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
+        <th>&nbsp;</th>
+        <th>{{ 'Carrier'|trans({}, 'Admin.Shipping.Feature') }}</th>
+        <th>{{ 'Weight'|trans({}, 'Admin.Global') }}</th>
+        <th>{{ 'Shipping cost'|trans({}, 'Admin.Shipping.Feature') }}</th>
+        <th>{{ 'Tracking number'|trans({}, 'Admin.Shipping.Feature') }}</th>
+        <th></th>
       </tr>
-    {% endfor %}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {% for carrier in orderForViewing.shipping.carriers %}
+        <tr>
+          <td>{{ carrier.date|date('Y-m-d') }}</td>
+          <td>&nbsp;</td>
+          <td>{{ carrier.name }}</td>
+          <td>{{ carrier.weight }}</td>
+          <td>{{ carrier.price }}</td>
+          <td>
+            {% if carrier.trackingNumber and carrier.trackingUrl %}
+              <a href="{{ carrier.trackingUrl }}">{{ carrier.trackingNumber }}</a>
+            {% endif %}
+          </td>
+          <td class="text-right">
+            {% if carrier.canEdit %}
+              <a href="#">
+                {{ 'Edit'|trans({}, 'Admin.Actions') }}
+              </a>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 
-{% if orderForViewing.shipping.carrierModuleInfo %}
-  {{ orderForViewing.shipping.carrierModuleInfo|raw }}
-{% endif %}
+  {% if orderForViewing.shipping.carrierModuleInfo %}
+    {{ orderForViewing.shipping.carrierModuleInfo|raw }}
+  {% endif %}
 
-{% if orderForViewing.shipping.recycledPackaging %}
-  <span class="badge badge-success">{{ 'Recycled packaging'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
+  {% if orderForViewing.shipping.recycledPackaging %}
+    <span class="badge badge-success">{{ 'Recycled packaging'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
+  {% endif %}
+
+  {% if orderForViewing.shipping.giftWrapping %}
+    <span class="badge badge-success">{{ 'Gift wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
+  {% endif %}
 {% else %}
-  <span class="badge badge-secondary">
-    {{ 'Recycled packaging'|trans({}, 'Admin.Orderscustomers.Feature') }}
-  </span>
-{% endif %}
-
-{% if orderForViewing.shipping.giftWrapping %}
-  <span class="badge badge-success">{{ 'Gift wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
-{% else %}
-  <span class="badge badge-secondary">{{ 'Gift wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
+  <p class="text-center mb-0">
+    {{ 'Shipping does not apply to virtual orders'|trans({}, 'Admin.Orderscustomers.Feature') }}
+  </p>
 {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -55,6 +55,7 @@
   {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig' %}
   {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/add_product_modal.html.twig' %}
   {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/update_product_modal.html.twig' %}
+  {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Migrates Shipping block to new Order View page.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #15824 
| How to test?  | Shipping block should behave the same as in legacy.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16065)
<!-- Reviewable:end -->
