### PR TITLE
Change wording in FO when there is specific price by quantity

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1535,8 +1535,8 @@ class FrontControllerCore extends Controller
             'quantity_discount' => array(
                 'type' => ($quantity_discount_price) ? 'price' : 'discount',
                 'label' => ($quantity_discount_price)
-                    ? $this->getTranslator()->trans('Price', array(), 'Shop.Theme.Catalog')
-                    : $this->getTranslator()->trans('Discount', array(), 'Shop.Theme.Catalog'),
+                    ? $this->getTranslator()->trans('Unit price', array(), 'Shop.Theme.Catalog')
+                    : $this->getTranslator()->trans('Unit discount', array(), 'Shop.Theme.Catalog'),
             ),
             'voucher_enabled' => (int) CartRule::isFeatureActive(),
             'return_enabled' => (int) Configuration::get('PS_ORDER_RETURN'),

--- a/themes/classic/templates/catalog/_partials/product-discounts.tpl
+++ b/themes/classic/templates/catalog/_partials/product-discounts.tpl
@@ -39,7 +39,7 @@
           <tr data-discount-type="{$quantity_discount.reduction_type}" data-discount="{$quantity_discount.real_value}" data-discount-quantity="{$quantity_discount.quantity}">
             <td>{$quantity_discount.quantity}</td>
             <td>{$quantity_discount.discount}</td>
-            <td>{l s='Up to %discount%' d='Shop.Theme.Catalog' sprintf=['%discount%' => $quantity_discount.save]}</td>
+            <td>{$quantity_discount.save}</td>
           </tr>
         {/foreach}
         </tbody>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This change the wording when there is volume discounts
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15817
| How to test?  | 1. Edit a product (Catalog > Products)<br>2. Click on price tab<br>3. Click on add a specific price<br>4.  Fill "Starting at" and "Apply a discount of" fields<br>5. See the product in FO

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16069)
<!-- Reviewable:end -->
