### PR TITLE
Fix "Call to a member function formatPrice() on null" fatal error

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3794,7 +3794,7 @@ class CartCore extends ObjectModel
 
             if ($product['reduction_type'] == 'amount') {
                 $reduction = (!Product::getTaxCalculationMethod() ? (float) $product['price_wt'] : (float) $product['price']) - (float) $product['price_without_quantity_discount'];
-                $product['reduction_formatted'] = $context->getCurrentLocale()->formatPrice($reduction, $context->currency->iso_code);
+                $product['reduction_formatted'] = Tools::getContextLocale($context)->formatPrice($reduction, $context->currency->iso_code);
             }
         }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3676,12 +3676,12 @@ class ProductCore extends ObjectModel
         $currency = $params['currency'];
         $currency = is_object($currency) ? $currency->iso_code : Currency::getIsoCodeById((int) $currency);
 
-        return Context::getContext()->getCurrentLocale()->formatPrice($params['price'], $currency);
+        return Tools::getContextLocale(Context::getContext())->formatPrice($params['price'], $currency);
     }
 
     public static function displayWtPrice($params, &$smarty)
     {
-        return Context::getContext()->getCurrentLocale()->formatPrice($params['p'], Context::getContext()->currency->iso_code);
+        return Tools::getContextLocale(Context::getContext())->formatPrice($params['p'], Context::getContext()->currency->iso_code);
     }
 
     /**
@@ -3697,7 +3697,7 @@ class ProductCore extends ObjectModel
         $currency = $params['currency'];
         $currency = is_object($currency) ? $currency->iso_code : Currency::getIsoCodeById((int) $currency);
 
-        return Context::getContext()->getCurrentLocale()->formatPrice($params['price'], $currency);
+        return !is_null($params['price']) ? Tools::getContextLocale(Context::getContext())->formatPrice($params['price'], $currency) : null;
     }
 
     /**
@@ -5632,7 +5632,7 @@ class ProductCore extends ObjectModel
     {
         $context = Context::getContext();
 
-        return $context->getCurrentLocale()->formatPrice(Pack::noPackPrice((int) $this->id), $context->currency->iso_code);
+        return Tools::getContextLocale($context)->formatPrice(Pack::noPackPrice((int) $this->id), $context->currency->iso_code);
     }
 
     public function checkAccess($id_customer)


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed "Call to a member function formatPrice() on null" on some pages
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16068
| How to test?  | 1. Go to BO > Customer<br>2. Try to edit a Customer & save
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16071)
<!-- Reviewable:end -->
