### PR TITLE
Remove require config.inc.php on all commands and fix a notice

### DIFF
--- a/src/PrestaShopBundle/Command/AppendConfigurationFileHooksListCommand.php
+++ b/src/PrestaShopBundle/Command/AppendConfigurationFileHooksListCommand.php
@@ -91,7 +91,6 @@ class AppendConfigurationFileHooksListCommand extends ContainerAwareCommand
      */
     private function initContext()
     {
-        require_once $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
         /** @var LegacyContext $legacyContext */
         $legacyContext = $this->getContainer()->get('prestashop.adapter.legacy.context');
         //We need to have an employee or the listing hooks don't work

--- a/src/PrestaShopBundle/Command/AppendHooksListForSqlUpgradeFileCommand.php
+++ b/src/PrestaShopBundle/Command/AppendHooksListForSqlUpgradeFileCommand.php
@@ -113,8 +113,6 @@ class AppendHooksListForSqlUpgradeFileCommand extends ContainerAwareCommand
      */
     private function initContext()
     {
-        require_once $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
-
         /** @var LegacyContext $legacyContext */
         $legacyContext = $this->getContainer()->get('prestashop.adapter.legacy.context');
         //We need to have an employee or the listing hooks don't work

--- a/src/PrestaShopBundle/Command/GenerateMailTemplatesCommand.php
+++ b/src/PrestaShopBundle/Command/GenerateMailTemplatesCommand.php
@@ -96,7 +96,6 @@ class GenerateMailTemplatesCommand extends ContainerAwareCommand
      */
     private function initContext()
     {
-        require_once $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
         /** @var LegacyContext $legacyContext */
         $legacyContext = $this->getContainer()->get('prestashop.adapter.legacy.context');
         //We need to have an employee or the module hooks don't work

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -83,7 +83,6 @@ class ModuleCommand extends ContainerAwareCommand
         $this->translator = $this->getContainer()->get('translator');
         $this->input = $input;
         $this->output = $output;
-        require_once $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
         /** @var LegacyContext $legacyContext */
         $legacyContext = $this->getContainer()->get('prestashop.adapter.legacy.context');
         //We need to have an employee or the module hooks don't work

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -83,7 +83,7 @@ class ModuleCommand extends ContainerAwareCommand
         $this->translator = $this->getContainer()->get('translator');
         $this->input = $input;
         $this->output = $output;
-        require $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
+        require_once $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
         /** @var LegacyContext $legacyContext */
         $legacyContext = $this->getContainer()->get('prestashop.adapter.legacy.context');
         //We need to have an employee or the module hooks don't work

--- a/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
+++ b/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
@@ -51,8 +51,6 @@ final class ThemeEnablerCommand extends ContainerAwareCommand
      */
     protected function init(InputInterface $input, OutputInterface $output)
     {
-        require $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
-
         Context::getContext()->employee = new Employee();
     }
 


### PR DESCRIPTION

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | A notice _PS_SSL_PORT_ already defined when you install a module in command line. See also our discussion #15515 https://github.com/PrestaShop/PrestaShop/pull/15515#issuecomment-536637885 You say : "we make sure we use require_once to avoid this if other scripts make good usage of require_once too" but that not the case.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | nc
| How to test?  | Just try to install a module in command line, example of command: `php bin/console prestashop:module install welcome`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16072)
<!-- Reviewable:end -->
