### PR TITLE
Prioritize customer search by id when saving an address

### DIFF
--- a/controllers/admin/AdminAddressesController.php
+++ b/controllers/admin/AdminAddressesController.php
@@ -368,20 +368,20 @@ class AdminAddressesControllerCore extends AdminController
         }
 
         // Transform e-mail in id_customer for parent processing
-        if (Validate::isEmail(Tools::getValue('email'))) {
+        if ($id_customer = Tools::getValue('id_customer')) {
+            $customer = new Customer((int) $id_customer);
+            if (Validate::isLoadedObject($customer)) {
+                $_POST['id_customer'] = $customer->id;
+            } else {
+                $this->errors[] = $this->trans('This customer ID is not recognized.', array(), 'Admin.Orderscustomers.Notification');
+            }
+        } elseif (Validate::isEmail(Tools::getValue('email'))) {
             $customer = new Customer();
             $customer->getByEmail(Tools::getValue('email'), null, false);
             if (Validate::isLoadedObject($customer)) {
                 $_POST['id_customer'] = $customer->id;
             } else {
                 $this->errors[] = $this->trans('This email address is not registered.', array(), 'Admin.Orderscustomers.Notification');
-            }
-        } elseif ($id_customer = Tools::getValue('id_customer')) {
-            $customer = new Customer((int) $id_customer);
-            if (Validate::isLoadedObject($customer)) {
-                $_POST['id_customer'] = $customer->id;
-            } else {
-                $this->errors[] = $this->trans('This customer ID is not recognized.', array(), 'Admin.Orderscustomers.Notification');
             }
         } else {
             $this->errors[] = $this->trans('This email address is not valid. Please use an address like bob@example.com.', array(), 'Admin.Orderscustomers.Notification');


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When creating a new address from an order in the BackOffice, the address is assigned to the wrong user
| Type?         | bug fix 
| Category?     |  BO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16116 
| How to test?  | 1. Create few guest or non-guest accounts (with the same email address).<br>2. Start creating a new order from the Backoffice<br>3. Select the last account you have created<br>4. Create a new address for this user<br>Error: the address will be assigned to the first from previously created account

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16074)
<!-- Reviewable:end -->
