### PR TITLE
Migrate Merchandise returns for Orders view

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
@@ -42,6 +42,7 @@
     </li>
     <li class="nav-item">
       <a class="nav-link" id="orderReturnsTab" data-toggle="tab" href="#orderReturnsTabContent" role="tab" aria-controls="orderReturnsTabContent" aria-expanded="true" aria-selected="false">
+        <i class="material-icons">replay</i>
         {{ 'Merchandise returns'|trans({}, 'Admin.Orderscustomers.Feature') }} ({{ orderForViewing.returns.orderReturns|length }})
       </a>
     </li>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/merchandise_returns.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/merchandise_returns.html.twig
@@ -23,33 +23,41 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% if orderForViewing.returns.orderReturns is not empty %}
-  <table class="table">
-    <thead>
+{% if not orderForViewing.virtual %}
+  {% if orderForViewing.returns.orderReturns is not empty %}
+    <table class="table">
+      <thead>
       <tr>
         <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
         <th>{{ 'Type'|trans({}, 'Admin.Global') }}</th>
         <th>{{ 'Carrier'|trans({}, 'Admin.Shipping.Feature') }}</th>
         <th>{{ 'Tracking number'|trans({}, 'Admin.Shipping.Feature') }}</th>
       </tr>
-    </thead>
-    <tbody>
-    {% for return in orderForViewing.returns.orderReturns %}
-      <tr>
-      <td>{{ return.date|date('Y-m-d H:i:s') }}</td>
-      <td>{{ return.type }}</td>
-      <td>{{ return.stateName }}</td>
-      <td>
-        {% if return.trackingNumber and return.trackingUrl %}
-          <a href="{{ return.trackingUrl }}">{{ return.trackingNumber }}</a>
-        {% elseif return.trackingNumber %}
-          {{ return.trackingNumber }}
-        {% endif %}
-      </td>
-    </tr>
-    {% endfor %}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+      {% for return in orderForViewing.returns.orderReturns %}
+        <tr>
+          <td>{{ return.date|date('Y-m-d H:i:s') }}</td>
+          <td>{{ return.type }}</td>
+          <td>{{ return.stateName }}</td>
+          <td class="text-right">
+            {% if return.trackingNumber and return.trackingUrl %}
+              <a href="{{ return.trackingUrl }}">{{ return.trackingNumber }}</a>
+            {% elseif return.trackingNumber %}
+              {{ return.trackingNumber }}
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="text-center mb-0">{{ 'No merchandise returned yet'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
+  {% endif %}
+
+  {% if orderForViewing.shipping.carrierModuleInfo %}
+    {{ orderForViewing.shipping.carrierModuleInfo|raw }}
+  {% endif %}
 {% else %}
-  <p class="text-center mb-0">{{ 'No merchandise returned yet'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
+  <p class="text-center mb-0">{{ 'Merchandise returns are not applicable for virtual orders'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
 {% endif %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Migrates Merchandise returns for Orders view
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #15825 
| How to test?  | :warning: Rebuild assets :warning: Merchandise returns block should work the same as in legacy page.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16084)
<!-- Reviewable:end -->
