### PR TITLE
Get locale from Context current locale instead of repository in OrderDetailLazyArray

### DIFF
--- a/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
@@ -29,12 +29,11 @@ namespace PrestaShop\PrestaShop\Adapter\Presenter\Order;
 use Cart;
 use Configuration;
 use Context;
+use Currency;
 use HistoryController;
 use Order;
-use PrestaShop\PrestaShop\Adapter\ContainerFinder;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
-use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use PrestaShopException;
 use Tools;
@@ -63,32 +62,16 @@ class OrderDetailLazyArray extends AbstractLazyArray
 
     /**
      * OrderDetailLazyArray constructor.
+     *
+     * @param Order $order
      */
     public function __construct(Order $order)
     {
         $this->order = $order;
         $this->context = Context::getContext();
         $this->translator = Context::getContext()->getTranslator();
-        $this->locale = $this->getCldrLocaleRepository()->getLocale(
-            $this->context->language->getLocale()
-        );
+        $this->locale = $this->context->getCurrentLocale();
         parent::__construct();
-    }
-
-    /**
-     * @return LocaleRepository
-     *
-     * @throws \Exception
-     */
-    protected function getCldrLocaleRepository()
-    {
-        $containerFinder = new ContainerFinder($this->context);
-        $container = $containerFinder->getContainer();
-
-        /** @var LocaleRepository $localeRepoCLDR */
-        $localeRepoCLDR = $container->get('prestashop.core.localization.cldr.locale_repository');
-
-        return $localeRepoCLDR;
     }
 
     /**
@@ -249,7 +232,7 @@ class OrderDetailLazyArray extends AbstractLazyArray
                     (!$order->getTaxCalculationMethod()) ? $shipping['shipping_cost_tax_excl']
                         : $shipping['shipping_cost_tax_incl'];
                 $orderShipping[$shippingId]['shipping_cost'] =
-                    ($shippingCost > 0) ? $this->locale->formatPrice($shippingCost, (\Currency::getIsoCodeById((int) $order->id_currency)))
+                    ($shippingCost > 0) ? $this->locale->formatPrice($shippingCost, (Currency::getIsoCodeById((int) $order->id_currency)))
                         : $this->translator->trans('Free', array(), 'Shop.Theme.Checkout');
 
                 $tracking_line = '-';


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes error in front office
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16080
| How to test?  | 1. Go to FO and login<br>2. Make sure you have at least one order placed<br>3. Go to your account and open "Order history"<br>4. Click "Details" on any order and see error at the bottom of the page.<br>... and see that no errors appear in the page
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16085)
<!-- Reviewable:end -->
