### PR TITLE
Fix no carriers in checkout bad cart rules

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -756,8 +756,9 @@ class CartCore extends ObjectModel
 
             $givenAwayProductsIds = array();
 
-            if ($this->shouldSplitGiftProductsQuantity) {
-                $gifts = $this->getCartRules(CartRule::FILTER_ACTION_GIFT);
+            // Do not recalculate in case of refresh
+            if ($this->shouldSplitGiftProductsQuantity && !$refresh) {
+                $gifts = $this->getCartRules(CartRule::FILTER_ACTION_GIFT, false);
                 if (count($gifts) > 0) {
                     foreach ($gifts as $gift) {
                         foreach ($result as $rowIndex => $row) {
@@ -4214,7 +4215,7 @@ class CartCore extends ObjectModel
 
         if (!$hasRemainingCustomData) {
             $result &= Db::getInstance()->execute(
-                'DELETE FROM `' . _DB_PREFIX_ . 'customization` 
+                'DELETE FROM `' . _DB_PREFIX_ . 'customization`
             WHERE `id_customization` = ' . (int) $cust_data['id_customization']
             );
         }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -747,12 +747,13 @@ class CartCore extends ObjectModel
 
         if (empty($result)) {
             $this->_products = array();
+
             return array();
         }
 
         if ($fullInfos) {
             $cart_shop_context = Context::getContext()->cloneContext();
-            
+
             $givenAwayProductsIds = array();
 
             if ($this->shouldSplitGiftProductsQuantity) {
@@ -782,7 +783,7 @@ class CartCore extends ObjectModel
                     }
                 }
             }
-            
+
             $this->_products = array();
 
             foreach ($result as &$row) {

--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -106,11 +106,11 @@ final class AddOrderFromBackOfficeHandler implements AddOrderFromBackOfficeHandl
         $isDeliveryCountryDisabled = !Address::isCountryActiveById((int) $cart->id_address_delivery);
         $isInvoiceCountryDisabled = !Address::isCountryActiveById((int) $cart->id_address_invoice);
 
-        if ($isDeliveryCountryDisabled || $isInvoiceCountryDisabled) {
-            if ($isDeliveryCountryDisabled) {
-                throw new OrderException(sprintf('Delivery country for cart with id "%d" is disabled.', $cart->id));
-            }
+        if ($isDeliveryCountryDisabled) {
+            throw new OrderException(sprintf('Delivery country for cart with id "%d" is disabled.', $cart->id));
+        }
 
+        if ($isInvoiceCountryDisabled) {
             throw new OrderException(sprintf('Invoice country for cart with id "%d" is disabled.', $cart->id));
         }
     }

--- a/src/Core/Domain/Cart/Command/UpdateCartAddressesCommand.php
+++ b/src/Core/Domain/Cart/Command/UpdateCartAddressesCommand.php
@@ -50,9 +50,11 @@ class UpdateCartAddressesCommand
     /**
      * @param int $cartId
      */
-    public function __construct(int $cartId)
+    public function __construct(int $cartId, int $newDeliveryAddressId, int $newInvoiceAddressId)
     {
         $this->cartId = new CartId($cartId);
+        $this->setNewDeliveryAddressId($newDeliveryAddressId);
+        $this->setNewInvoiceAddressId($newInvoiceAddressId);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
@@ -56,6 +56,24 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Then there are available delivery options for my cart
+     *
+     * @todo: improve this to assert the content of delivery options
+     */
+    public function deliveryOptionsAreAvailable()
+    {
+        if ($this->getCurrentCart() === null) {
+            throw new \RuntimeException('No current cart, cannot check available delivery options');
+        }
+
+        $deliveryOptions = $this->getCurrentCart()->getDeliveryOptionList();
+
+        if (empty($deliveryOptions)) {
+            throw new \RuntimeException('Expected available delivery options, but there are none !');
+        }
+    }
+
+    /**
      * @Given /^I have an empty default cart$/
      */
     public function iHaveAnEmptyDefaultCart()

--- a/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
@@ -79,9 +79,9 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
     public function iHaveAnEmptyDefaultCart()
     {
         $cart = new CartOld();
-        $cart->id_lang = (int)Context::getContext()->language->id;
-        $cart->id_currency = (int)Context::getContext()->currency->id;
-        $cart->id_shop = (int)Context::getContext()->shop->id;
+        $cart->id_lang = (int) Context::getContext()->language->id;
+        $cart->id_currency = (int) Context::getContext()->currency->id;
+        $cart->id_shop = (int) Context::getContext()->shop->id;
         $cart->add(); // required, else we cannot get the content when calculating total
         Context::getContext()->cart = $cart;
     }
@@ -173,7 +173,7 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
     protected function expectsTotal($expectedTotal, $method, $withTax = true, $precisely = false)
     {
         $cart = $this->getCurrentCart();
-        $carrierId = (int)$cart->id_carrier <= 0 ? null : $cart->id_carrier;
+        $carrierId = (int) $cart->id_carrier <= 0 ? null : $cart->id_carrier;
         if ($method == 'v1') {
             $total = $cart->getOrderTotalV1($withTax, Cart::BOTH, null, $carrierId);
         } else {

--- a/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
@@ -40,14 +40,30 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
     protected $cart;
 
     /**
+     * @Then there is no delivery options available for my cart
+     */
+    public function noDeliveryOptions()
+    {
+        if ($this->getCurrentCart() === null) {
+            throw new \RuntimeException('No current cart, cannot check available delivery options');
+        }
+
+        $deliveryOptions = $this->getCurrentCart()->getDeliveryOptionList();
+
+        if (!empty($deliveryOptions)) {
+            throw new \RuntimeException('Expected no available delivery options, but there are some !');
+        }
+    }
+
+    /**
      * @Given /^I have an empty default cart$/
      */
     public function iHaveAnEmptyDefaultCart()
     {
         $cart = new CartOld();
-        $cart->id_lang = (int) Context::getContext()->language->id;
-        $cart->id_currency = (int) Context::getContext()->currency->id;
-        $cart->id_shop = (int) Context::getContext()->shop->id;
+        $cart->id_lang = (int)Context::getContext()->language->id;
+        $cart->id_currency = (int)Context::getContext()->currency->id;
+        $cart->id_shop = (int)Context::getContext()->shop->id;
         $cart->add(); // required, else we cannot get the content when calculating total
         Context::getContext()->cart = $cart;
     }
@@ -139,7 +155,7 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
     protected function expectsTotal($expectedTotal, $method, $withTax = true, $precisely = false)
     {
         $cart = $this->getCurrentCart();
-        $carrierId = (int) $cart->id_carrier <= 0 ? null : $cart->id_carrier;
+        $carrierId = (int)$cart->id_carrier <= 0 ? null : $cart->id_carrier;
         if ($method == 'v1') {
             $total = $cart->getOrderTotalV1($withTax, Cart::BOTH, null, $carrierId);
         } else {

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -207,6 +207,26 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^cart rule "(.+)" is disabled$/
+     */
+    public function cartRuleIsDisabled($cartRuleName)
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->cartRules[$cartRuleName]->active = 0;
+        $this->cartRules[$cartRuleName]->save();
+    }
+
+    /**
+     * @When /^I enable cart rule "(.+)"$/
+     */
+    public function enableCartRule($cartRuleName)
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->cartRules[$cartRuleName]->active = 1;
+        $this->cartRules[$cartRuleName]->save();
+    }
+
+    /**
      * @Given /^cart rule "(.+)" does not apply to already discounted products$/
      */
     public function cartRuleDoesNotApplyToDiscountedProduct($cartRuleName)

--- a/tests/Integration/Behaviour/Features/Context/CountryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CountryFeatureContext.php
@@ -61,6 +61,7 @@ class CountryFeatureContext extends AbstractPrestaShopFeatureContext
 
     /**
      * @param $countryIsoCode
+     *
      * @throws \RuntimeException
      */
     public function checkCountryWithIsoCodeExists($countryIsoCode)

--- a/tests/Integration/Behaviour/Features/Context/CountryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CountryFeatureContext.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context;
+
+use Country;
+use RuntimeException;
+
+class CountryFeatureContext extends AbstractPrestaShopFeatureContext
+{
+    /**
+     * @Given country :countryIsoCode is enabled
+     */
+    public function enableCountry($countryIsoCode)
+    {
+        $this->checkCountryWithIsoCodeExists($countryIsoCode);
+        /** @var Country $country */
+        $countryId = Country::getByIso($countryIsoCode);
+
+        $country = new Country($countryId);
+        $country->active = 1;
+        $country->save();
+    }
+
+    /**
+     * @Given country :countryIsoCode is disabled
+     */
+    public function disableCountry($countryIsoCode)
+    {
+        $this->checkCountryWithIsoCodeExists($countryIsoCode);
+        /** @var Country $country */
+        $countryId = Country::getByIso($countryIsoCode);
+
+        $country = new Country($countryId);
+        $country->active = 0;
+        $country->save();
+    }
+
+    /**
+     * @param $countryIsoCode
+     * @throws \RuntimeException
+     */
+    public function checkCountryWithIsoCodeExists($countryIsoCode)
+    {
+        $country = Country::getByIso($countryIsoCode);
+
+        if (false === $country) {
+            throw new RuntimeException(sprintf('No country with ISO Code "%s"', $countryIsoCode));
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -44,7 +44,7 @@ use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 class CartFeatureContext extends AbstractDomainFeatureContext
 {
     /**
-     * @given the current currency is :currencyIsoCode
+     * @Given the current currency is :currencyIsoCode
      */
     public function addCurrencyToContext($currencyIsoCode)
     {

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -63,6 +63,8 @@ class CartFeatureContext extends AbstractDomainFeatureContext
      */
     public function createEmptyCartForCustomer($cartReference, $customerReference)
     {
+        // Clear static cache each time you create a cart
+        Cart::resetStaticCache();
         $customer = SharedStorage::getStorage()->get($customerReference);
 
         /** @var CartId $cartId */

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
@@ -1,0 +1,42 @@
+@reset-database-before-feature
+Feature: Compute correct delivery options
+  As a customer
+  I should be provided relevant delivery options depending on my cart content and my customer profile
+
+  Scenario: Use 2 carts rules, 1 free-shipping and one global, no carriers are available
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    # Create free shipping cart rule
+    Given there is a cart rule named "free_shipping_1" that applies no discount with priority 1, quantity of 1000 and quantity per user 1000
+    Given cart rule "free_shipping_1" offers free shipping
+    Given cart rule "free_shipping_1" has a discount code "djbuch-12878"
+    # Standard cart rule, disabled
+    Given there is a cart rule named "bad_cart_rule" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
+    Given cart rule "bad_cart_rule" is disabled
+    # Standard location settings
+    Given there is a zone named "zone1"
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country"country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    # One standard carrier
+    Given there is a carrier named "carrier1"
+    Given carrier "carrier1" ships to all groups
+    Given carrier "carrier1" applies shipping fees of 5.0 in zone "zone1" for price between 0 and 10000
+    # Checkout begins
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    # Use discount code
+    When I use the discount "free_shipping_1"
+    When I select address "address1" in my cart
+    # Enables standard cart rule
+    When I enable cart rule "bad_cart_rule"
+    When I select carrier "carrier1" in my cart
+    # Bad result T_T
+    Then there is no delivery options available for my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
@@ -38,5 +38,4 @@ Feature: Compute correct delivery options
     # Enables standard cart rule
     When I enable cart rule "bad_cart_rule"
     When I select carrier "carrier1" in my cart
-    # Bad result T_T
-    Then there is no delivery options available for my cart
+    Then there are available delivery options for my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_order_from_bo.feature
@@ -12,14 +12,14 @@ Feature: Add Order from Back Office
     Given I am logged in as "test@prestashop.com" employee
     And the current currency is "USD"
     And country "US" is enabled
-    And there is customer "customer1" with email "pub@prestashop.com"
-    And customer "customer1" has address in "US" country
+    And there is customer "customer_for_free_shipping" with email "pub@prestashop.com"
+    And customer "customer_for_free_shipping" has address in "US" country
     And the module "dummy_payment" is installed
-    When I create an empty cart "dummy_cart" for customer "customer1"
+    When I create an empty cart "dummy_cart" for customer "customer_for_free_shipping"
     And I add 2 products with reference "demo_13" to the cart "dummy_cart"
-    And I select "US" address as delivery and invoice address for customer "customer1" in cart "dummy_cart"
+    And I select "US" address as delivery and invoice address for customer "customer_for_free_shipping" in cart "dummy_cart"
     And I set Free shipping to the cart "dummy_cart"
-    And I add order "order1" from cart "dummy_cart" with "dummy_payment" payment method and "Payment accepted" order status
-    Then order "order1" should have 2 products in total
-    And order "order1" should have free shipping
-    And order "order1" should have "dummy_payment" payment method
+    And I add order "bo_order_for_free_shipping" from cart "dummy_cart" with "dummy_payment" payment method and "Payment accepted" order status
+    Then order "bo_order_for_free_shipping" should have 2 products in total
+    And order "bo_order_for_free_shipping" should have free shipping
+    And order "bo_order_for_free_shipping" should have "dummy_payment" payment method

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_order_from_bo.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order
 @reset-database-before-feature
+  @aaa
 Feature: Add Order from Back Office
   PrestaShop allows BO users to add new orders in the Sell > Orders > Add new Order page
   As a BO user
@@ -10,7 +11,8 @@ Feature: Add Order from Back Office
 
   Scenario: Add order from Back Office with free shipping
     Given I am logged in as "test@prestashop.com" employee
-    Given The current currency is "EUR"
+    Given the current currency is "USD"
+    And country "US" is enabled
     And there is customer "customer1" with email "pub@prestashop.com"
     And customer "customer1" has address in "US" country
     And the module "dummy_payment" is installed

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_order_from_bo.feature
@@ -1,6 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order
 @reset-database-before-feature
-  @aaa
 Feature: Add Order from Back Office
   PrestaShop allows BO users to add new orders in the Sell > Orders > Add new Order page
   As a BO user
@@ -11,16 +10,16 @@ Feature: Add Order from Back Office
 
   Scenario: Add order from Back Office with free shipping
     Given I am logged in as "test@prestashop.com" employee
-    Given the current currency is "USD"
+    And the current currency is "USD"
     And country "US" is enabled
     And there is customer "customer1" with email "pub@prestashop.com"
     And customer "customer1" has address in "US" country
     And the module "dummy_payment" is installed
-    When I create an empty cart "cart1" for customer "customer1"
-    And I add 2 products with reference "demo_13" to the cart "cart1"
-    And I select "US" address as delivery and invoice address for customer "customer1" in cart "cart1"
-    And I set Free shipping to the cart "cart1"
-    And I add order "order1" from cart "cart1" with "dummy_payment" payment method and "Payment accepted" order status
+    When I create an empty cart "dummy_cart" for customer "customer1"
+    And I add 2 products with reference "demo_13" to the cart "dummy_cart"
+    And I select "US" address as delivery and invoice address for customer "customer1" in cart "dummy_cart"
+    And I set Free shipping to the cart "dummy_cart"
+    And I add order "order1" from cart "dummy_cart" with "dummy_payment" payment method and "Payment accepted" order status
     Then order "order1" should have 2 products in total
     And order "order1" should have free shipping
     And order "order1" should have "dummy_payment" payment method

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -58,6 +58,9 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CarrierFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
+
         currency:
             paths:
                 features: Features/Scenario/Currency


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Port of https://github.com/PrestaShop/PrestaShop/pull/12878, fix no carrier available in checkout with free shipping cart rule
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/11172
| How to test?  |

-  Create cart rule without code 
- In the condition Tab "Minimum amount 100 EUR & Shipping included 
- In the actions tab, apply any action => Free shipping
- Go to FO, add to cart a product which price = 70 EUR < 100 EUR (must be < 100 EUR) => so the cart rule is not applied
- Complete your order => in step 3: SHIPPING METHOD => Unfortunately, there are no carriers available for your delivery address.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16087)
<!-- Reviewable:end -->
