### PR TITLE
Disable Customer group selection checkbox when single customer is set…

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -105,14 +105,22 @@ var restrictions = new Array('country', 'carrier', 'group', 'cart_rule', 'shop')
 for (i in restrictions)
 {
 	toggleCartRuleFilter($('#' + restrictions[i] + '_restriction'));
-	$('#' + restrictions[i] + '_restriction').click(function() {toggleCartRuleFilter(this);});
+	$('#' + restrictions[i] + '_restriction').change(function() {toggleCartRuleFilter(this);});
 	$('#' + restrictions[i] + '_select_remove').click(function() {removeCartRuleOption(this);});
 	$('#' + restrictions[i] + '_select_add').click(function() {addCartRuleOption(this);});
 }
 
 toggleCartRuleFilter($('#product_restriction'));
 
-$('#product_restriction').click(function() {
+$('#group_restriction').change(function() {
+  $('#customerFilter').prop('disabled', $(this).prop('checked'));
+}).change();
+
+$('#customerFilter').on('change keyup', function() {
+    $('#group_restriction').prop('disabled', $(this).val() !== '');
+}).change();
+
+$('#product_restriction').change(function() {
 	toggleCartRuleFilter(this);
 
 	if ($(this).prop('checked'))
@@ -497,8 +505,8 @@ $(document).ready(function() {
 			callback: function(text) { combinable_filter('#cart_rule_select_2', text, 'selected'); }
 		});
 	}
-  
-  displayProductAttributes();  
+
+  displayProductAttributes();
 });
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Disable Customer group selection checkbox when single customer is set and disable single customer field when Customer group selection is checked
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15938
| How to test?  | In Sell > Catalog > Discounts, add a new Cart Rule, in conditions, set a single customer: Customer group selection checkbox should be disabled. Remove single customer, check Customer group selection: single customer field should be disabled

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16088)
<!-- Reviewable:end -->
