### PR TITLE
Update order status colors

### DIFF
--- a/install-dev/data/xml/order_state.xml
+++ b/install-dev/data/xml/order_state.xml
@@ -15,43 +15,43 @@
     <field name="pdf_invoice"/>
   </fields>
   <entities>
-    <order_state id="Awaiting_cheque_payment" invoice="0" send_email="1" color="#4169E1" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Awaiting_cheque_payment" invoice="0" send_email="1" color="#34219E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name>ps_checkpayment</module_name>
     </order_state>
-    <order_state id="Payment_accepted" invoice="1" send_email="1" color="#32CD32" unremovable="1" hidden="0" logable="1" delivery="0" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="1">
+    <order_state id="Payment_accepted" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="1" delivery="0" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="1">
       <module_name/>
     </order_state>
-    <order_state id="Preparation_in_progress" invoice="1" send_email="1" color="#FF8C00" unremovable="1" hidden="0" logable="1" delivery="1" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Preparation_in_progress" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="1" delivery="1" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Shipped" invoice="1" send_email="1" color="#8A2BE2" unremovable="1" hidden="0" logable="1" delivery="1" shipped="1" paid="1" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Shipped" invoice="1" send_email="1" color="#2ECC71" unremovable="1" hidden="0" logable="1" delivery="1" shipped="1" paid="1" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Delivered" invoice="1" send_email="0" color="#108510" unremovable="1" hidden="0" logable="1" delivery="1" shipped="1" paid="1" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Delivered" invoice="1" send_email="0" color="#2ECC71" unremovable="1" hidden="0" logable="1" delivery="1" shipped="1" paid="1" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Canceled" invoice="0" send_email="1" color="#DC143C" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Canceled" invoice="0" send_email="1" color="#2C3E50" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Refund" invoice="1" send_email="1" color="#ec2e15" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Refund" invoice="1" send_email="1" color="#2ECC71" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Payment_error" invoice="0" send_email="1" color="#8f0621" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Payment_error" invoice="0" send_email="1" color="#E74C3C" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="On_backorder_paid" invoice="1" send_email="1" color="#FF69B4" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="On_backorder_paid" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Awaiting_bank_wire_payment" invoice="0" send_email="1" color="#4169E1" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Awaiting_bank_wire_payment" invoice="0" send_email="1" color="#34219E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name>ps_wirepayment</module_name>
     </order_state>
-    <order_state id="Payment_remotely_accepted" invoice="1" send_email="1" color="#32CD32" unremovable="1" hidden="0" logable="1" delivery="0" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="Payment_remotely_accepted" invoice="1" send_email="1" color="#3498D8" unremovable="1" hidden="0" logable="1" delivery="0" shipped="0" paid="1" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="On_backorder_unpaid" invoice="0" send_email="1" color="#FF69B4" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
+    <order_state id="On_backorder_unpaid" invoice="0" send_email="1" color="#34219E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0" pdf_delivery="0" pdf_invoice="0">
       <module_name/>
     </order_state>
-    <order_state id="Awaiting_cod_validation" invoice="0" send_email="0" color="#4169E1" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0">
+    <order_state id="Awaiting_cod_validation" invoice="0" send_email="0" color="#34219E" unremovable="1" hidden="0" logable="0" delivery="0" shipped="0" paid="0">
       <module_name>ps_cashondelivery</module_name>
     </order_state>
   </entities>

--- a/install-dev/upgrade/php/ps_1770_update_order_status_colors.php
+++ b/install-dev/upgrade/php/ps_1770_update_order_status_colors.php
@@ -59,8 +59,24 @@ function ps_1770_update_order_status_colors() {
     foreach ($statusColorMap as $color => $statuses) {
         foreach ($statuses as $statusId) {
             Db::getInstance()->execute(
-                'UPDATE `'._DB_PREFIX_.'order_state` SET `color` = ' . pSQL($color) . ' WHERE `id_order_state` = ' . (int) $statusId
+                'UPDATE `'._DB_PREFIX_.'order_state` SET `color` = "' . pSQL($color) . '" WHERE `id_order_state` = ' . (int) $statusId
             );
         }
+    }
+
+    // Some of the statuses can be deduced by their parameters, this allows to update the modules status colors
+    $statusColorConditions = [
+        OrderStatusColor::ACCEPTED_PAYMENT => ['paid' => 1, 'shipped' => 0],
+        OrderStatusColor::COMPLETED => ['paid' => 1, 'shipped' => 1],
+        OrderStatusColor::AWAITING_PAYMENT => ['color' => '#4169E1'], // Former color of awaiting payment
+    ];
+    foreach ($statusColorConditions as $color => $conditions) {
+        $whereCondition = ' WHERE 1';
+        foreach ($conditions as $field => $expectedValue) {
+            $whereCondition .= ' AND `' . $field . '` = "' . pSQL($expectedValue) . '"';
+        }
+        Db::getInstance()->execute(
+            'UPDATE `'._DB_PREFIX_.'order_state` SET `color` = "' . pSQL($color) . '"' . $whereCondition
+        );
     }
 }

--- a/install-dev/upgrade/php/ps_1770_update_order_status_colors.php
+++ b/install-dev/upgrade/php/ps_1770_update_order_status_colors.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+use PrestaShop\PrestaShop\Core\Domain\Order\Status\OrderStatusColor;
+
+/**
+ * Updates order status colors according to new color schema
+ */
+function ps_1770_update_order_status_colors() {
+    $statusColorMap = [
+        OrderStatusColor::AWAITING_PAYMENT => Configuration::getMultiple([
+            'PS_OS_CHEQUE',
+            'PS_OS_BANKWIRE',
+            'PS_OS_OUTOFSTOCK_UNPAID',
+            'PS_OS_COD_VALIDATION',
+        ]),
+        OrderStatusColor::ACCEPTED_PAYMENT => Configuration::getMultiple([
+            'PS_OS_PAYMENT',
+            'PS_OS_PREPARATION',
+            'PS_OS_OUTOFSTOCK_PAID',
+            'PS_OS_WS_PAYMENT',
+        ]),
+        OrderStatusColor::COMPLETED => Configuration::getMultiple([
+            'PS_OS_SHIPPING',
+            'PS_OS_DELIVERED',
+            'PS_OS_REFUND',
+        ]),
+        OrderStatusColor::ERROR => Configuration::getMultiple([
+            'PS_OS_ERROR',
+        ]),
+        OrderStatusColor::SPECIAL => Configuration::getMultiple([
+            'PS_OS_CANCELED',
+        ]),
+    ];
+
+    foreach ($statusColorMap as $color => $statuses) {
+        foreach ($statuses as $statusId) {
+            Db::getInstance()->execute(
+                'UPDATE `'._DB_PREFIX_.'order_state` SET `color` = ' . pSQL($color) . ' WHERE `id_order_state` = ' . (int) $statusId
+            );
+        }
+    }
+}

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -13,7 +13,7 @@ ALTER TABLE `PREFIX_product_attribute` ADD `mpn` VARCHAR(40) NULL AFTER `upc`;
 ALTER TABLE `PREFIX_product` ADD `mpn` VARCHAR(40) NULL AFTER `upc`;
 
 /* Delete price display precision configuration */
-DELETE FROM `PREFIX_configuration` WHERE name = 'PS_PRICE_DISPLAY_PRECISION';
+DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_PRICE_DISPLAY_PRECISION';
 
 /* Set optin field value to 0 in employee table */
 ALTER TABLE `PREFIX_employee` MODIFY COLUMN `optin` tinyint(1) unsigned DEFAULT NULL;

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -516,3 +516,5 @@ ALTER TABLE `PREFIX_zone_shop` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_
 /* Doctrine update happens too late to update the new enabled field, so we preset everything here */
 ALTER TABLE `PREFIX_tab` ADD enabled TINYINT(1) NOT NULL;
 /* PHP:ps_1770_preset_tab_enabled(); */;
+
+/* PHP:ps_1770_update_order_status_colors(); */;

--- a/src/Core/Domain/Order/Status/OrderStatusColor.php
+++ b/src/Core/Domain/Order/Status/OrderStatusColor.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\Status;
+
+/**
+ * Defines colors for order statuses
+ */
+class OrderStatusColor
+{
+    /**
+     * Used for statuses that are waiting for customer actions.
+     * Example statuses: Awaiting bank wire payment, Awaiting check payment, On backorder (not paid).
+     */
+    public const AWAITING_PAYMENT = '#34219E';
+
+    /**
+     * Used for statuses when further merchant action is required.
+     * Example statuses: Processing in progress, On backorder (paid), Payment accepted.
+     */
+    public const ACCEPTED_PAYMENT = '#3498D8';
+
+    /**
+     * Used for statuses when no actions are required anymore.
+     * Example statuses: Shipped, Refunded, Delivered.
+     */
+    public const COMPLETED = '#2ECC71';
+
+    /**
+     * Used for error statuses.
+     * Example statuses: Payment error.
+     */
+    public const ERROR = '#E74C3C';
+
+    /**
+     * Used for statuses with special cases.
+     * Example statuses: Canceled.
+     */
+    public const SPECIAL = '#2C3E50';
+
+    /**
+     * Class is not meant to be initialized.
+     */
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | See ticket.
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/15228
| How to test?  | After installing/upgrading PS, order colors should change. You must use the last version of autoupgrade 4.10.0

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16104)
<!-- Reviewable:end -->
