### PR TITLE
Add missing placeholder in the Private Note textarea

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/PrivateNoteType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/PrivateNoteType.php
@@ -29,12 +29,28 @@ namespace PrestaShopBundle\Form\Admin\Sell\Customer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class PrivateNoteType is used to add private notes about customer.
  */
 class PrivateNoteType extends AbstractType
 {
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * PrivateNoteType constructor.
+     *
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -44,6 +60,9 @@ class PrivateNoteType extends AbstractType
             ->add('note', TextareaType::class, [
                 'required' => false,
                 'empty_data' => '',
+                'attr' => [
+                    'placeholder' => $this->translator->trans('Add a note on this customer. It will only be visible to you.', [], 'Admin.Orderscustomers.Feature'),
+                ],
             ]);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -907,6 +907,13 @@ services:
         tags:
             - { name: form.type }
 
+    form.type.sell.customer.private_note:
+      class: 'PrestaShopBundle\Form\Admin\Sell\Customer\PrivateNoteType'
+      arguments:
+          - "@translator"
+      tags:
+          - { name: form.type }
+
     form.type.order.add_order_cart_rule:
       class: 'PrestaShopBundle\Form\Admin\Sell\Order\AddOrderCartRuleType'
       arguments:


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This adds a missing placeholder in the "Private note" textarea
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16024
| How to test?  | See #15955 and take a look at the field "Private note"

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16114)
<!-- Reviewable:end -->
