### PR TITLE
Delete supplier's address only if no other shops use it

### DIFF
--- a/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/AbstractDeleteSupplierHandler.php
@@ -117,7 +117,7 @@ abstract class AbstractDeleteSupplierHandler
                 );
             }
 
-            if (false === $this->deleteSupplierAddress($supplierId)) {
+            if (1 >= count($entity->getAssociatedShops()) && false === $this->deleteSupplierAddress($supplierId)) {
                 throw new CannotDeleteSupplierAddressException(
                     sprintf(
                         'Unable to set deleted flag for supplier with id "%s" address',


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Do not delete supplier's address if it's used for another shop
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14762
| How to test?  | 1. Create two shops<br>2. Go to Brands & Supplier<br>3. Create a supplier for all shops<br>4. Then delete this supplier for shop A<br>5. Edit the supplier in shop B

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16123)
<!-- Reviewable:end -->
