### PR TITLE
Fixed the bad discount amount for specific prices

### DIFF
--- a/classes/product/SpecificPriceFormatter.php
+++ b/classes/product/SpecificPriceFormatter.php
@@ -91,7 +91,7 @@ class SpecificPriceFormatterCore
             // The price may be directly set
 
             /** @var float $currentPriceDefaultCurrency current price with taxes in default currency */
-            if (Product::$_taxCalculationMethod == PS_TAX_INC) {
+            if ($this->isTaxIncluded) {
                 $currentPriceDefaultCurrency = ($this->specificPrice['price'] * (1 + $tax_rate / 100)) + (float)$ecotax_amount;
             } else {
                 $currentPriceDefaultCurrency = $this->specificPrice['price'] + (float)$ecotax_amount;
@@ -103,10 +103,10 @@ class SpecificPriceFormatterCore
             $currentPriceCurrentCurrency = \Tools::convertPrice($currentPriceDefaultCurrency, $this->currency, true);
 
             if ($this->specificPrice['reduction_type'] == 'amount') {
-                if (!$this->specificPrice['reduction_tax'] && Product::$_taxCalculationMethod == PS_TAX_INC) {
+                if (!$this->specificPrice['reduction_tax'] && $this->isTaxIncluded) {
                     $this->specificPrice['reduction'] = $this->specificPrice['reduction'] * (1 + $tax_rate / 100);
                 }
-                if (Product::$_taxCalculationMethod == PS_TAX_INC) {
+                if ($this->isTaxIncluded) {
                     $currentPriceCurrentCurrency -= $this->specificPrice['reduction'];
                     $this->specificPrice['reduction_with_tax'] = $this->specificPrice['reduction'];
                 } else {

--- a/classes/product/SpecificPriceFormatter.php
+++ b/classes/product/SpecificPriceFormatter.php
@@ -90,11 +90,11 @@ class SpecificPriceFormatterCore
         if ($this->specificPrice['price'] >= 0) {
             // The price may be directly set
 
-            /** @var float $currentPriceDefaultCurrency current price with taxes in default currency */
+            /* @var float $currentPriceDefaultCurrency current price with taxes in default currency */
             if ($this->isTaxIncluded) {
-                $currentPriceDefaultCurrency = ($this->specificPrice['price'] * (1 + $tax_rate / 100)) + (float)$ecotax_amount;
+                $currentPriceDefaultCurrency = ($this->specificPrice['price'] * (1 + $tax_rate / 100)) + (float) $ecotax_amount;
             } else {
-                $currentPriceDefaultCurrency = $this->specificPrice['price'] + (float)$ecotax_amount;
+                $currentPriceDefaultCurrency = $this->specificPrice['price'] + (float) $ecotax_amount;
             }
 
             // Since this price is set in default currency,

--- a/tests-legacy/Unit/Classes/Product/SpecificPriceFormatterTest.php
+++ b/tests-legacy/Unit/Classes/Product/SpecificPriceFormatterTest.php
@@ -149,6 +149,60 @@ class SpecificPriceFormatterTest extends SymfonyIntegrationTestCase
                 'nextQuantity' => -1,
             ),
         );
+
+        $specificPricesWithoutReductionTax = array(
+            0 => array(
+                'id_specific_price' => '10',
+                'id_specific_price_rule' => '0',
+                'id_cart' => '0',
+                'id_product' => '10',
+                'id_shop' => '1',
+                'id_shop_group' => '0',
+                'id_currency' => '0',
+                'id_country' => '0',
+                'id_group' => '0',
+                'id_customer' => '0',
+                'id_product_attribute' => '0',
+                'price' => '8.000000',
+                'from_quantity' => '10',
+                'reduction' => 0,
+                'reduction_tax' => '0',
+                'reduction_type' => 'amount',
+                'from' => '0000-00-00 00:00:00',
+                'to' => '0000-00-00 00:00:00',
+                'score' => '48',
+                'quantity' => '10',
+                'reduction_with_tax' => 0,
+                'nextQuantity' => -1,
+            ),
+        );
+
+        $specificPricesWithoutReductionTaxWithReduction = array(
+            0 => array(
+                'id_specific_price' => '11',
+                'id_specific_price_rule' => '0',
+                'id_cart' => '0',
+                'id_product' => '10',
+                'id_shop' => '1',
+                'id_shop_group' => '0',
+                'id_currency' => '0',
+                'id_country' => '0',
+                'id_group' => '0',
+                'id_customer' => '0',
+                'id_product_attribute' => '0',
+                'price' => '11.350000',
+                'from_quantity' => '3',
+                'reduction' => 2,
+                'reduction_tax' => '0',
+                'reduction_type' => 'amount',
+                'from' => '0000-00-00 00:00:00',
+                'to' => '0000-00-00 00:00:00',
+                'score' => '48',
+                'quantity' => '3',
+                'reduction_with_tax' => 0,
+                'nextQuantity' => -1,
+            ),
+        );
         $currencyEur = array(
             'conversion_rate' => 1.0,
             'sign' => '€',
@@ -242,6 +296,34 @@ class SpecificPriceFormatterTest extends SymfonyIntegrationTestCase
                     array(
                         'discount' => 9.00,
                         'save' => 135.00,
+                    ),
+                ),
+            ),
+            'EUR to EUR, with taxes, without reduction tax' => array(
+                'price' => 12.30,
+                'tax_rate' => 23,
+                'ecotax_amount' => 0,
+                'currency' => $currencyEur,
+                'specific_prices' => $specificPricesWithoutReductionTax,
+                'isTaxIncluded' => true,
+                'expected' => array(
+                    array(
+                        'discount' => 2.46,
+                        'save' => 24.60,
+                    ),
+                ),
+            ),
+            'EUR to EUR, with taxes, without reduction tax, with reduction' => array(
+                'price' => 15.48,
+                'tax_rate' => 20,
+                'ecotax_amount' => 0,
+                'currency' => $currencyEur,
+                'specific_prices' => $specificPricesWithoutReductionTaxWithReduction,
+                'isTaxIncluded' => true,
+                'expected' => array(
+                    array(
+                        'discount' => 4.26,
+                        'save' => 12.78,
                     ),
                 ),
             ),


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Bad discount display when specific price is configured with new product price and discount in FO; Bad discount amount when specific price by quantity is configured tax excl and prices are displayed tax incl in FO
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15835, Fixes #15866
| How to test?  | The description of testing attached in issues (many things)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16138)
<!-- Reviewable:end -->
