### PR TITLE
Remove constraint on siret in CustomerType

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -202,12 +202,6 @@ class CustomerType extends AbstractType
                 ])
                 ->add('siret_code', TextType::class, [
                     'required' => false,
-                    'constraints' => [
-                        new Type([
-                            'type' => 'numeric',
-                            'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
-                        ]),
-                    ],
                 ])
                 ->add('ape_code', TextType::class, [
                     'required' => false,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fix error when adding a siret with a non numeric character in customer form
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16167
| How to test?  | In BO > Customer > Add a customer: fill siret field with this value: **12345678-K**, you should be able to save your modification. Please check that the SIRET input is still working in a relevant manner with B2B mode.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16172)
<!-- Reviewable:end -->
