### PR TITLE
Increase maximum hook length to 191 characters

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -62,7 +62,7 @@ class HookCore extends ObjectModel
         'table' => 'hook',
         'primary' => 'id_hook',
         'fields' => array(
-            'name' => array('type' => self::TYPE_STRING, 'validate' => 'isHookName', 'required' => true, 'size' => 255),
+            'name' => array('type' => self::TYPE_STRING, 'validate' => 'isHookName', 'required' => true, 'size' => 191),
             'title' => array('type' => self::TYPE_STRING, 'validate' => 'isGenericName'),
             'description' => array('type' => self::TYPE_HTML, 'validate' => 'isCleanHtml'),
             'position' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -62,7 +62,7 @@ class HookCore extends ObjectModel
         'table' => 'hook',
         'primary' => 'id_hook',
         'fields' => array(
-            'name' => array('type' => self::TYPE_STRING, 'validate' => 'isHookName', 'required' => true, 'size' => 64),
+            'name' => array('type' => self::TYPE_STRING, 'validate' => 'isHookName', 'required' => true, 'size' => 255),
             'title' => array('type' => self::TYPE_STRING, 'validate' => 'isGenericName'),
             'description' => array('type' => self::TYPE_HTML, 'validate' => 'isCleanHtml'),
             'position' => array('type' => self::TYPE_BOOL, 'validate' => 'isBool'),

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -979,7 +979,7 @@ CREATE TABLE `PREFIX_guest` (
 /* Store hook description */
 CREATE TABLE `PREFIX_hook` (
   `id_hook` int(10) unsigned NOT NULL auto_increment,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(191) NOT NULL,
   `title` varchar(255) NOT NULL,
   `description` text,
   `position` tinyint(1) NOT NULL DEFAULT '1',
@@ -990,8 +990,8 @@ CREATE TABLE `PREFIX_hook` (
 /* Hook alias name */
 CREATE TABLE `PREFIX_hook_alias` (
   `id_hook_alias` int(10) unsigned NOT NULL auto_increment,
-  `alias` varchar(255) NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `alias` varchar(191) NOT NULL,
+  `name` varchar(191) NOT NULL,
   PRIMARY KEY (`id_hook_alias`),
   UNIQUE KEY `alias` (`alias`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -979,8 +979,8 @@ CREATE TABLE `PREFIX_guest` (
 /* Store hook description */
 CREATE TABLE `PREFIX_hook` (
   `id_hook` int(10) unsigned NOT NULL auto_increment,
-  `name` varchar(64) NOT NULL,
-  `title` varchar(64) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `title` varchar(255) NOT NULL,
   `description` text,
   `position` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id_hook`),
@@ -990,8 +990,8 @@ CREATE TABLE `PREFIX_hook` (
 /* Hook alias name */
 CREATE TABLE `PREFIX_hook_alias` (
   `id_hook_alias` int(10) unsigned NOT NULL auto_increment,
-  `alias` varchar(64) NOT NULL,
-  `name` varchar(64) NOT NULL,
+  `alias` varchar(255) NOT NULL,
+  `name` varchar(255) NOT NULL,
   PRIMARY KEY (`id_hook_alias`),
   UNIQUE KEY `alias` (`alias`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -14,7 +14,7 @@ ALTER TABLE `PREFIX_product_attribute` ADD `mpn` VARCHAR(40) NULL AFTER `upc`;
 ALTER TABLE `PREFIX_product` ADD `mpn` VARCHAR(40) NULL AFTER `upc`;
 
 /* Delete price display precision configuration */
-DELETE `PREFIX_configuration` WHERE name = 'PS_PRICE_DISPLAY_PRECISION';
+DELETE FROM `PREFIX_configuration` WHERE name = 'PS_PRICE_DISPLAY_PRECISION';
 
 /* Set optin field value to 0 in employee table */
 ALTER TABLE `PREFIX_employee` MODIFY COLUMN `optin` tinyint(1) unsigned DEFAULT NULL;

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -20,7 +20,7 @@ DELETE FROM `PREFIX_configuration` WHERE name = 'PS_PRICE_DISPLAY_PRECISION';
 ALTER TABLE `PREFIX_employee` MODIFY COLUMN `optin` tinyint(1) unsigned DEFAULT NULL;
 
 /* Increase column size */
-ALTER TABLE `PREFIX_hook` CHANGE `name` `name` VARCHAR(255) NOT NULL;
+ALTER TABLE `PREFIX_hook` CHANGE `name` `name` VARCHAR(191) NOT NULL;
 ALTER TABLE `PREFIX_hook` CHANGE `title` `title` VARCHAR(255) NOT NULL;
-ALTER TABLE `PREFIX_hook_alias` CHANGE `name` `name` VARCHAR(255) NOT NULL;
-ALTER TABLE `PREFIX_hook_alias` CHANGE `alias` `alias` VARCHAR(255) NOT NULL;
+ALTER TABLE `PREFIX_hook_alias` CHANGE `name` `name` VARCHAR(191) NOT NULL;
+ALTER TABLE `PREFIX_hook_alias` CHANGE `alias` `alias` VARCHAR(191) NOT NULL;

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -18,3 +18,9 @@ DELETE FROM `PREFIX_configuration` WHERE name = 'PS_PRICE_DISPLAY_PRECISION';
 
 /* Set optin field value to 0 in employee table */
 ALTER TABLE `PREFIX_employee` MODIFY COLUMN `optin` tinyint(1) unsigned DEFAULT NULL;
+
+/* Increase column size */
+ALTER TABLE `PREFIX_hook` CHANGE `name` `name` VARCHAR(255) NOT NULL;
+ALTER TABLE `PREFIX_hook` CHANGE `title` `title` VARCHAR(255) NOT NULL;
+ALTER TABLE `PREFIX_hook_alias` CHANGE `name` `name` VARCHAR(255) NOT NULL;
+ALTER TABLE `PREFIX_hook_alias` CHANGE `alias` `alias` VARCHAR(255) NOT NULL;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Hook names were unnecessarily fixed at a maximum of 64 characters, which could be especially problematic for hooks whose names are dynamically generated (see fixed issue). This change simply increases that limit to 191 (maximum allowed by utf8mb4).
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16169
| How to test?  | Install or update PS, then install a module that simply registers a hook like this: `$this->registerHook('actionBeforeAjaxDieOrderControllerdisplayAjaxselectDeliveryOption')`

This PR also fixes an invalid SQL statement in the update script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16176)
<!-- Reviewable:end -->
