### PR TITLE
Make id_order available everywhere where order_name is available

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1135,7 +1135,7 @@ abstract class PaymentModuleCore extends Module
                         '{voucher_num}' => $voucher->code,
                         '{firstname}' => $this->context->customer->firstname,
                         '{lastname}' => $this->context->customer->lastname,
-                        '{id_order}' => $order->reference,
+                        '{id_order}' => $order->id,
                         '{order_name}' => $order->getUniqReference(),
                     );
                     Mail::Send(

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -613,6 +613,7 @@ abstract class PaymentModuleCore extends Module
                             '{invoice_phone}' => ($invoice->phone) ? $invoice->phone : $invoice->phone_mobile,
                             '{invoice_other}' => $invoice->other,
                             '{order_name}' => $order->getUniqReference(),
+                            '{id_order}' => $order->id,
                             '{date}' => Tools::displayDate(date('Y-m-d H:i:s'), null, 1),
                             '{carrier}' => ($virtual_product || !isset($carrier->name)) ? $this->trans('No carrier', array(), 'Admin.Payment.Notification') : $carrier->name,
                             '{payment}' => Tools::substr($order->payment, 0, 255),

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -229,6 +229,7 @@ final class MailPreviewVariablesBuilder
             )),
             '{date}' => Tools::displayDate($order->date_add, null, 1),
             '{order_name}' => $order->getUniqReference(),
+            '{id_order}' => $order->id,
             '{payment}' => Tools::substr($order->payment, 0, 255),
             '{total_products}' => count($order->getProducts()),
             '{total_discounts}' => $this->locale->formatPrice($order->total_discounts, $this->context->currency->iso_code),


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Make {id_order} available everywhere where {order_name} is available
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13964
| How to test?  | replace `{order_name}` with `{id_order}` in `order_conf` mail template, buy any product on the store and look at the confirmation mail

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16213)
<!-- Reviewable:end -->
