### PR TITLE
Fix error when deleting order cart rule

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -800,10 +800,10 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
         $currency = new Currency($order->id_currency);
         $discounts = $order->getCartRules();
         $discountsForViewing = [];
-
+        dump($discounts);
         foreach ($discounts as $discount) {
             $discountsForViewing[] = new OrderDiscountForViewing(
-                (int) $discount['id_cart_rule'],
+                (int) $discount['id_order_cart_rule'],
                 $discount['name'],
                 (float) $discount['value'],
                 Tools::displayPrice($discount['value'], $currency)

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -800,7 +800,7 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
         $currency = new Currency($order->id_currency);
         $discounts = $order->getCartRules();
         $discountsForViewing = [];
-        dump($discounts);
+
         foreach ($discounts as $discount) {
             $discountsForViewing[] = new OrderDiscountForViewing(
                 (int) $discount['id_order_cart_rule'],

--- a/src/Core/Domain/Order/QueryResult/OrderDiscountForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderDiscountForViewing.php
@@ -31,7 +31,7 @@ class OrderDiscountForViewing
     /**
      * @var int
      */
-    private $cartRuleId;
+    private $orderCartRuleId;
 
     /**
      * @var string
@@ -49,12 +49,12 @@ class OrderDiscountForViewing
     private $amountRaw;
 
     public function __construct(
-        int $cartRuleId,
+        int $orderCartRuleId,
         string $name,
         float $amountRaw,
         string $amountFormatted
     ) {
-        $this->cartRuleId = $cartRuleId;
+        $this->orderCartRuleId = $orderCartRuleId;
         $this->name = $name;
         $this->amountFormatted = $amountFormatted;
         $this->amountRaw = $amountRaw;
@@ -63,9 +63,9 @@ class OrderDiscountForViewing
     /**
      * @return int
      */
-    public function getCartRuleId(): int
+    public function getOrderCartRuleId(): int
     {
-        return $this->cartRuleId;
+        return $this->orderCartRuleId;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -151,7 +151,7 @@
                 {{ discount.amountFormatted }}
               </td>
               <td class="text-right">
-                <form action="{{ path('admin_orders_remove_cart_rule', {'orderId': orderForViewing.id, 'orderCartRuleId': discount.cartRuleId}) }}" method="post">
+                <form action="{{ path('admin_orders_remove_cart_rule', {'orderId': orderForViewing.id, 'orderCartRuleId': discount.orderCartRuleId}) }}" method="post">
                   <button type="submit"
                           class="ml-2 tooltip-link btn btn-text"
                           data-toggle="pstooltip"


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix error when deleting order cart rule in new order page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #13890 
| How to test?  | :warning: Rebuild assets :warning: Access `/admin-dev/index.php/sell/orders/orders/1/view` and try to delete cart rule, it should work without any errors.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16222)
<!-- Reviewable:end -->
