### PR TITLE
Add tax information in combination table

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
@@ -85,8 +85,8 @@
             </th>
             <th></th>
             <th>{{ 'Combinations'|trans({}, 'Admin.Catalog.Feature') }}</th>
-            <th>{{ 'Impact on price'|trans({}, 'Admin.Catalog.Feature') }}</th>
-            <th>{{ 'Final price'|trans({}, 'Admin.Catalog.Feature') }}</th>
+            <th>{{ 'Impact on price (tax excl.)'|trans({}, 'Admin.Catalog.Feature') }}</th>
+            <th>{{ 'Final price (tax excl.)'|trans({}, 'Admin.Catalog.Feature') }}</th>
             {% if 'PS_STOCK_MANAGEMENT'|configuration %}
                 <th>{{ 'Quantity'|trans({}, 'Admin.Catalog.Feature') }}</th>
             {% endif %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Add tax information in combinations table
| Type?         | improvement 
| Category?     |  BO 
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes #16223
| How to test?  | Edit a product and click and combinations tab

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16224)
<!-- Reviewable:end -->
