### PR TITLE
Fix prices display in new order page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -191,14 +191,12 @@
               </div>
             {% endif %}
 
-            {% if orderForViewing.prices.shippingPriceRaw %}
-              <div class="col-sm text-center">
-                <p class="text-muted mb-0"><strong>{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</strong></p>
-                <strong>{{ orderForViewing.prices.shippingPriceFormatted }}</strong>
-              </div>
-            {% endif %}
+            <div class="col-sm text-center">
+              <p class="text-muted mb-0"><strong>{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</strong></p>
+              <strong>{{ orderForViewing.prices.shippingPriceFormatted }}</strong>
+            </div>
 
-            {% if orderForViewing.taxIncluded %}
+            {% if not orderForViewing.taxIncluded %}
               <div class="col-sm text-center">
                 <p class="text-muted mb-0"><strong>{{ 'Taxes'|trans({}, 'Admin.Global') }}</strong></p>
                 <strong>{{ orderForViewing.prices.taxesAmountFormatted }}</strong>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix prices display in new order page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Part of #13890 
| How to test?  | :warning: Rebuild assets :warning: Prices displayed in new page here https://prnt.sc/pql5b1 should be exactly the same as in legacy page here https://prnt.sc/pql4iv

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16225)
<!-- Reviewable:end -->
