### PR TITLE
Fix how discounts are displayed in cart summary when using vouchers

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -582,7 +582,7 @@ class CartPresenter implements PresenterInterface
                 $cartVoucher['reduction_formatted'] = $this->translator->trans(
                     'Free shipping',
                     [],
-                    'Admin.Orderscustomers.Feature'
+                    'Admin.Shipping.Feature'
                 );
             } else {
                 // In all other cases, the value displayed should be the total of applied reductions for the current voucher

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -628,14 +628,6 @@ class CartPresenter implements PresenterInterface
         return isset($cartVoucher['reduction_percent'])
             && $cartVoucher['reduction_percent'] > 0
             && $cartVoucher['reduction_amount'] == '0.00';
-            isset($cartVoucher['reduction_percent'])
-            && $cartVoucher['reduction_percent'] > 0
-            && $cartVoucher['reduction_amount'] == '0.00'
-        ) {
-            return true;
-        }
-
-        return false;
     }
 
     /**

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -625,7 +625,9 @@ class CartPresenter implements PresenterInterface
      */
     private function cartVoucherHasPercentReduction($cartVoucher)
     {
-        if (
+        return isset($cartVoucher['reduction_percent'])
+            && $cartVoucher['reduction_percent'] > 0
+            && $cartVoucher['reduction_amount'] == '0.00';
             isset($cartVoucher['reduction_percent'])
             && $cartVoucher['reduction_percent'] > 0
             && $cartVoucher['reduction_amount'] == '0.00'

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -615,7 +615,7 @@ class CartPresenter implements PresenterInterface
      */
     private function cartVoucherHasFreeShipping($cartVoucher)
     {
-        return isset($cartVoucher['free_shipping']) && $cartVoucher['free_shipping'];
+        return !empty($cartVoucher['free_shipping']);
     }
 
     /**

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -546,7 +546,9 @@ class CartPresenter implements PresenterInterface
                 $cartVoucher['reduction_amount'] = $cartVoucher['value_real'];
             }
 
-            if (isset($cartVoucher['reduction_percent']) && $cartVoucher['reduction_amount'] == '0.00') {
+            if (isset($cartVoucher['free_shipping']) && $cartVoucher['free_shipping']) {
+                $cartVoucher['reduction_formatted'] = $this->priceFormatter->convertAndFormat($cart->getTotalShippingCost(null, $this->includeTaxes()));
+            } elseif (isset($cartVoucher['reduction_percent']) && $cartVoucher['reduction_amount'] == '0.00') {
                 $cartVoucher['reduction_formatted'] = $cartVoucher['reduction_percent'] . '%';
             } elseif (isset($cartVoucher['reduction_amount']) && $cartVoucher['reduction_amount'] > 0) {
                 $value = $this->includeTaxes() ? $cartVoucher['reduction_amount'] : $cartVoucher['value_tax_exc'];

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -580,7 +580,7 @@ class CartPresenter implements PresenterInterface
             // when a voucher has only a shipping reduction, the value displayed must be "Free Shipping"
             if ($freeShippingOnly) {
                 $cartVoucher['reduction_formatted'] = $this->translator->trans(
-                    'Free Shipping',
+                    'Free shipping',
                     [],
                     'Admin.Orderscustomers.Feature'
                 );

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -557,7 +557,7 @@ class CartPresenter implements PresenterInterface
                 $freeShippingOnly = true;
             }
             if ($this->cartVoucherHasPercentReduction($cartVoucher)) {
-                $productsTotalExcludingTax = $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
+                $productsTotalExcludingTax = $cart->getOrderTotal($this->includeTaxes(), Cart::ONLY_PRODUCTS);
                 $percentageReduction = ($productsTotalExcludingTax / 100) * $cartVoucher['reduction_percent'];
                 $freeShippingOnly = false;
             } elseif ($this->cartVoucherHasAmountReduction($cartVoucher)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | See below for display rules
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9702
| How to test?  | See below

On the cart summary, where reductions are displayed, here are the rules that should be respected:

- Cart rule with free shipping only: Display free shipping instead of 0,00%  
- Cart rule with free shipping + discount (amount or %): Display price of the carrier + Discount amount added  
- Cart rule with % discount: Display the discount amount (not the percentage)
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16235)
<!-- Reviewable:end -->
