### PR TITLE
Set Demo mode only if undefined

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -42,7 +42,9 @@ if (_PS_MODE_DEV_ === true) {
 if (!defined('_PS_DEBUG_PROFILING_')) {
     define('_PS_DEBUG_PROFILING_', false);
 }
-define('_PS_MODE_DEMO_', false);
+if (!defined('_PS_MODE_DEMO_')) {
+    define('_PS_MODE_DEMO_', false);
+}
 
 $currentDir = dirname(__FILE__);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Avoid PHP Notices caused by a defined constant, as given at the bottom of this description.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | Nope
| How to test?  | Basically, the way the demo works should remain the same. However, if another script (like https://github.com/PrestaShop/docker/blob/master/base/config_files/defines_custom.inc.php) sets the value, we should not have any more notices.

```
[Thu Oct 31 12:09:13.688334 2019] [php7:notice] [pid 20] [client 172.18.0.3:52676] PHP Notice:  Constant _PS_MODE_DEMO_ already defined in /var/www/html/config/defines.inc.php on line 45
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16237)
<!-- Reviewable:end -->
