### PR TITLE
Remove unnecessary require_once config.inc

### DIFF
--- a/src/PrestaShopBundle/Command/GenerateMailTemplatesCommand.php
+++ b/src/PrestaShopBundle/Command/GenerateMailTemplatesCommand.php
@@ -96,7 +96,6 @@ class GenerateMailTemplatesCommand extends ContainerAwareCommand
      */
     private function initContext()
     {
-        require_once $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
         /** @var LegacyContext $legacyContext */
         $legacyContext = $this->getContainer()->get('prestashop.adapter.legacy.context');
         //We need to have an employee or the module hooks don't work

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -83,7 +83,6 @@ class ModuleCommand extends ContainerAwareCommand
         $this->translator = $this->getContainer()->get('translator');
         $this->input = $input;
         $this->output = $output;
-        require $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
         /** @var LegacyContext $legacyContext */
         $legacyContext = $this->getContainer()->get('prestashop.adapter.legacy.context');
         //We need to have an employee or the module hooks don't work

--- a/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
+++ b/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
@@ -51,8 +51,6 @@ final class ThemeEnablerCommand extends ContainerAwareCommand
      */
     protected function init(InputInterface $input, OutputInterface $output)
     {
-        require $this->getContainer()->get('kernel')->getRootDir() . '/../config/config.inc.php';
-
         Context::getContext()->employee = new Employee();
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | A notice _PS_SSL_PORT_ already defined when you install a module in command line. Backport of #16072
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Try to install a module in command line, example of command: `php bin/console prestashop:module install welcome`. See discussion in https://github.com/PrestaShop/PrestaShop/pull/16072

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16258)
<!-- Reviewable:end -->
