### PR TITLE
Fix ajax exception when search for a product in order creation page

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -631,7 +631,7 @@
 				action: "searchProducts",
 				id_cart: id_cart,
 				id_customer: id_customer,
-				id_currency: id_currency,
+				id_currency: $('#id_currency option:selected').val(),
 				product_search: $('#product').val()},
 			success : function(res)
 			{


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix the broken ajax product search in order creation page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16259
| How to test?  | See below:

**Steps to reproduce the behavior:**

- Install prestashop development mode (using /install-dev)
- Click on Sell > Orders > Create new
- Search and choose a customer
- Search for products (ex: 'mug')
- Products should be displayed in a select


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16266)
<!-- Reviewable:end -->
