### PR TITLE
Remove useless checkbox in product options tab for attached files

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1156,15 +1156,6 @@ var attachmentProduct = (function() {
       var buttonSave = $('#form_step6_attachment_product_add');
       var buttonCancel = $('#form_step6_attachment_product_cancel');
 
-      /** check all attachments files */
-      $('#product-attachment-files-check').change(function() {
-        if ($(this).is(":checked")) {
-          $('#product-attachment-file input[type="checkbox"]').prop('checked', true);
-        } else {
-          $('#product-attachment-file input[type="checkbox"]').prop('checked', false);
-        }
-      });
-
       buttonCancel.click(function (){
         resetAttachmentForm();
       });

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -404,7 +404,7 @@
           <table id="product-attachment-file" class="table">
             <thead class="thead-default">
               <tr>
-                <th class="col-md-3"><input type="checkbox" id="product-attachment-files-check" /> {{ 'Title'|trans({}, 'Admin.Global') }}</th>
+                <th class="col-md-3">{{ 'Title'|trans({}, 'Admin.Global') }}</th>
                 <th class="col-md-6">{{ 'File name'|trans({}, 'Admin.Global') }}</th>
                 <th class="col-md-2">{{ 'Type'|trans({}, 'Admin.Catalog.Feature') }}</th>
               </tr>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove useless checkbox in product options tab for attached files
| Type?         | bug fix 
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9790
| How to test?  | Edit a product, go to options tab, add 2 attached files, verify there is no checkbox before "Title"

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16271)
<!-- Reviewable:end -->
