### PR TITLE
Fix ajax spinner not disappearing after Ajax is done

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -750,21 +750,24 @@ $(document).ready(function()
       return copyMeta2friendlyURL()
   });
 
-  $('#ajax_running').ajaxStart(function() {
-    ajax_running_timeout = setTimeout(function() {showAjaxOverlay()}, 1000);
-  });
-
-  $('#ajax_running').ajaxStop(function() {
-    var element = $(this)
-    setTimeout(function(){element.hide()}, 1000);
-    clearTimeout(ajax_running_timeout);
-  });
-
-  $('#ajax_running').ajaxError(function() {
-    var element = $(this)
-    setTimeout(function(){element.hide()}, 1000);
-    clearTimeout(ajax_running_timeout);
-  });
+  $(document)
+    .ajaxStart(function() {
+      ajax_running_timeout = setTimeout(function() {
+        showAjaxOverlay()
+      }, 1000);
+    })
+    .ajaxStop(function() {
+      setTimeout(function() {
+        $('#ajax_running').hide()
+      }, 1000);
+      clearTimeout(ajax_running_timeout);
+    })
+    .ajaxError(function() {
+      setTimeout(function() {
+        $('#ajax_running').hide()
+      }, 1000);
+      clearTimeout(ajax_running_timeout);
+    });
 
   bindTabModuleListAction();
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This fixes a regression in develop where the ajax spinner icon wouldn't stop spinning after the dashboard is loaded
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Open up the dashboard, the spinner icon at the top left corner of the screen should disappear after a couple seconds.

This bug was a regression due to the jQuery version being upgraded. As noted in [this page](https://api.jquery.com/ajaxStart/):

> As of jQuery 1.9, all the handlers for the jQuery global Ajax events, including those added with the .ajaxStart() method, must be attached to document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16285)
<!-- Reviewable:end -->
