### PR TITLE
Update tax rates for several countries

### DIFF
--- a/localization/ar.xml
+++ b/localization/ar.xml
@@ -8,16 +8,16 @@
 		<language iso_code="es" />
 	</languages>
 	<taxes>
-		<tax id="1" name="IVA AR 21%" rate="21" />
-        <tax id="2" name="IVA AR 10.5%" rate="10.5" />
-		
-		<taxRulesGroup name="AR Standard rate (21%)">
-            <taxRule iso_code_country="ar" id_tax="1" />
-        </taxRulesGroup>
-        
-		<taxRulesGroup name="AR Reduced rate (10.5%)">
-            <taxRule iso_code_country="ar" id_tax="2" />
-        </taxRulesGroup>
+    <tax id="1" name="IVA AR 21%" rate="21"/>
+    <tax id="2" name="IVA AR 10.5%" rate="10.5"/>
+
+    <taxRulesGroup name="AR Standard rate (21%)">
+      <taxRule iso_code_country="ar" id_tax="1"/>
+    </taxRulesGroup>
+
+    <taxRulesGroup name="AR Reduced rate (10.5%)">
+      <taxRule iso_code_country="ar" id_tax="2"/>
+    </taxRulesGroup>
 	</taxes>
 	<units>
 		<unit type="weight" value="kg" />

--- a/localization/at.xml
+++ b/localization/at.xml
@@ -9,35 +9,35 @@
   <taxes>
     <tax id="1" name="USt. AT 20%" rate="20" eu-tax-group="virtual"/>
     <tax id="2" name="USt. AT 10%" rate="10"/>
-    <tax id="3" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="4" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="5" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="6" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="7" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="8" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="9" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="10" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="11" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="12" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="20" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="21" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="22" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="23" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="24" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="30" name="USt. AT 13%" rate="13"/>
-    <tax id="31" name="USt. AT 0%" rate="0"/>
+    <tax id="3" name="USt. AT 13%" rate="13"/>
+    <tax id="4" name="USt. AT 0%" rate="0"/>
+    <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="31" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="AT Standard rate (20%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
@@ -68,33 +68,33 @@
       <taxRule iso_code_country="uk" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="AT Reduced Rate (13%)">
-      <taxRule iso_code_country="be" id_tax="30"/>
-      <taxRule iso_code_country="bg" id_tax="30"/>
-      <taxRule iso_code_country="cz" id_tax="30"/>
-      <taxRule iso_code_country="dk" id_tax="30"/>
-      <taxRule iso_code_country="de" id_tax="30"/>
-      <taxRule iso_code_country="ee" id_tax="30"/>
-      <taxRule iso_code_country="gr" id_tax="30"/>
-      <taxRule iso_code_country="es" id_tax="30"/>
-      <taxRule iso_code_country="fr" id_tax="30"/>
-      <taxRule iso_code_country="ie" id_tax="30"/>
-      <taxRule iso_code_country="it" id_tax="30"/>
-      <taxRule iso_code_country="cy" id_tax="30"/>
-      <taxRule iso_code_country="lv" id_tax="30"/>
-      <taxRule iso_code_country="lt" id_tax="30"/>
-      <taxRule iso_code_country="lu" id_tax="30"/>
-      <taxRule iso_code_country="hu" id_tax="30"/>
-      <taxRule iso_code_country="mt" id_tax="30"/>
-      <taxRule iso_code_country="nl" id_tax="30"/>
-      <taxRule iso_code_country="at" id_tax="30"/>
-      <taxRule iso_code_country="pl" id_tax="30"/>
-      <taxRule iso_code_country="pt" id_tax="30"/>
-      <taxRule iso_code_country="ro" id_tax="30"/>
-      <taxRule iso_code_country="si" id_tax="30"/>
-      <taxRule iso_code_country="sk" id_tax="30"/>
-      <taxRule iso_code_country="fi" id_tax="30"/>
-      <taxRule iso_code_country="se" id_tax="30"/>
-      <taxRule iso_code_country="uk" id_tax="30"/>
+      <taxRule iso_code_country="be" id_tax="3"/>
+      <taxRule iso_code_country="bg" id_tax="3"/>
+      <taxRule iso_code_country="cz" id_tax="3"/>
+      <taxRule iso_code_country="dk" id_tax="3"/>
+      <taxRule iso_code_country="de" id_tax="3"/>
+      <taxRule iso_code_country="ee" id_tax="3"/>
+      <taxRule iso_code_country="gr" id_tax="3"/>
+      <taxRule iso_code_country="es" id_tax="3"/>
+      <taxRule iso_code_country="fr" id_tax="3"/>
+      <taxRule iso_code_country="ie" id_tax="3"/>
+      <taxRule iso_code_country="it" id_tax="3"/>
+      <taxRule iso_code_country="cy" id_tax="3"/>
+      <taxRule iso_code_country="lv" id_tax="3"/>
+      <taxRule iso_code_country="lt" id_tax="3"/>
+      <taxRule iso_code_country="lu" id_tax="3"/>
+      <taxRule iso_code_country="hu" id_tax="3"/>
+      <taxRule iso_code_country="mt" id_tax="3"/>
+      <taxRule iso_code_country="nl" id_tax="3"/>
+      <taxRule iso_code_country="at" id_tax="3"/>
+      <taxRule iso_code_country="pl" id_tax="3"/>
+      <taxRule iso_code_country="pt" id_tax="3"/>
+      <taxRule iso_code_country="ro" id_tax="3"/>
+      <taxRule iso_code_country="si" id_tax="3"/>
+      <taxRule iso_code_country="sk" id_tax="3"/>
+      <taxRule iso_code_country="fi" id_tax="3"/>
+      <taxRule iso_code_country="se" id_tax="3"/>
+      <taxRule iso_code_country="uk" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="AT Reduced Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -154,76 +154,76 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
+    <taxRulesGroup name="AT Zero Rate (0%)">
+      <taxRule iso_code_country="be" id_tax="4"/>
+      <taxRule iso_code_country="bg" id_tax="4"/>
+      <taxRule iso_code_country="cz" id_tax="4"/>
+      <taxRule iso_code_country="dk" id_tax="4"/>
+      <taxRule iso_code_country="de" id_tax="4"/>
+      <taxRule iso_code_country="ee" id_tax="4"/>
+      <taxRule iso_code_country="gr" id_tax="4"/>
+      <taxRule iso_code_country="es" id_tax="4"/>
+      <taxRule iso_code_country="fr" id_tax="4"/>
+      <taxRule iso_code_country="ie" id_tax="4"/>
+      <taxRule iso_code_country="it" id_tax="4"/>
+      <taxRule iso_code_country="cy" id_tax="4"/>
+      <taxRule iso_code_country="lv" id_tax="4"/>
+      <taxRule iso_code_country="lt" id_tax="4"/>
+      <taxRule iso_code_country="lu" id_tax="4"/>
+      <taxRule iso_code_country="hu" id_tax="4"/>
+      <taxRule iso_code_country="mt" id_tax="4"/>
+      <taxRule iso_code_country="nl" id_tax="4"/>
+      <taxRule iso_code_country="at" id_tax="4"/>
+      <taxRule iso_code_country="pl" id_tax="4"/>
+      <taxRule iso_code_country="pt" id_tax="4"/>
+      <taxRule iso_code_country="ro" id_tax="4"/>
+      <taxRule iso_code_country="si" id_tax="4"/>
+      <taxRule iso_code_country="sk" id_tax="4"/>
+      <taxRule iso_code_country="fi" id_tax="4"/>
+      <taxRule iso_code_country="se" id_tax="4"/>
+      <taxRule iso_code_country="uk" id_tax="4"/>
+    </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="at" id_tax="1"/>
-      <taxRule iso_code_country="be" id_tax="3"/>
-      <taxRule iso_code_country="bg" id_tax="4"/>
-      <taxRule iso_code_country="cy" id_tax="5"/>
-      <taxRule iso_code_country="cz" id_tax="6"/>
-      <taxRule iso_code_country="de" id_tax="7"/>
-      <taxRule iso_code_country="dk" id_tax="8"/>
-      <taxRule iso_code_country="ee" id_tax="9"/>
-      <taxRule iso_code_country="es" id_tax="10"/>
-      <taxRule iso_code_country="fi" id_tax="11"/>
-      <taxRule iso_code_country="fr" id_tax="12"/>
-      <taxRule iso_code_country="gb" id_tax="13"/>
-      <taxRule iso_code_country="gr" id_tax="14"/>
-      <taxRule iso_code_country="hr" id_tax="15"/>
-      <taxRule iso_code_country="hu" id_tax="16"/>
-      <taxRule iso_code_country="ie" id_tax="17"/>
-      <taxRule iso_code_country="it" id_tax="18"/>
-      <taxRule iso_code_country="lt" id_tax="19"/>
-      <taxRule iso_code_country="lu" id_tax="20"/>
-      <taxRule iso_code_country="lv" id_tax="21"/>
-      <taxRule iso_code_country="mt" id_tax="22"/>
-      <taxRule iso_code_country="nl" id_tax="23"/>
-      <taxRule iso_code_country="pl" id_tax="24"/>
-      <taxRule iso_code_country="pt" id_tax="25"/>
-      <taxRule iso_code_country="ro" id_tax="26"/>
-      <taxRule iso_code_country="se" id_tax="27"/>
-      <taxRule iso_code_country="si" id_tax="28"/>
-      <taxRule iso_code_country="sk" id_tax="29"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="AT Zero Rate (0%)">
-      <taxRule iso_code_country="be" id_tax="31"/>
-      <taxRule iso_code_country="bg" id_tax="31"/>
-      <taxRule iso_code_country="cz" id_tax="31"/>
-      <taxRule iso_code_country="dk" id_tax="31"/>
-      <taxRule iso_code_country="de" id_tax="31"/>
-      <taxRule iso_code_country="ee" id_tax="31"/>
-      <taxRule iso_code_country="gr" id_tax="31"/>
-      <taxRule iso_code_country="es" id_tax="31"/>
-      <taxRule iso_code_country="fr" id_tax="31"/>
-      <taxRule iso_code_country="ie" id_tax="31"/>
-      <taxRule iso_code_country="it" id_tax="31"/>
-      <taxRule iso_code_country="cy" id_tax="31"/>
-      <taxRule iso_code_country="lv" id_tax="31"/>
-      <taxRule iso_code_country="lt" id_tax="31"/>
-      <taxRule iso_code_country="lu" id_tax="31"/>
-      <taxRule iso_code_country="hu" id_tax="31"/>
-      <taxRule iso_code_country="mt" id_tax="31"/>
-      <taxRule iso_code_country="nl" id_tax="31"/>
-      <taxRule iso_code_country="at" id_tax="31"/>
-      <taxRule iso_code_country="pl" id_tax="31"/>
-      <taxRule iso_code_country="pt" id_tax="31"/>
-      <taxRule iso_code_country="ro" id_tax="31"/>
-      <taxRule iso_code_country="si" id_tax="31"/>
+      <taxRule iso_code_country="be" id_tax="5"/>
+      <taxRule iso_code_country="bg" id_tax="6"/>
+      <taxRule iso_code_country="cy" id_tax="7"/>
+      <taxRule iso_code_country="cz" id_tax="8"/>
+      <taxRule iso_code_country="de" id_tax="9"/>
+      <taxRule iso_code_country="dk" id_tax="10"/>
+      <taxRule iso_code_country="ee" id_tax="11"/>
+      <taxRule iso_code_country="es" id_tax="12"/>
+      <taxRule iso_code_country="fi" id_tax="13"/>
+      <taxRule iso_code_country="fr" id_tax="14"/>
+      <taxRule iso_code_country="gb" id_tax="15"/>
+      <taxRule iso_code_country="gr" id_tax="16"/>
+      <taxRule iso_code_country="hr" id_tax="17"/>
+      <taxRule iso_code_country="hu" id_tax="18"/>
+      <taxRule iso_code_country="ie" id_tax="19"/>
+      <taxRule iso_code_country="it" id_tax="20"/>
+      <taxRule iso_code_country="lt" id_tax="21"/>
+      <taxRule iso_code_country="lu" id_tax="22"/>
+      <taxRule iso_code_country="lv" id_tax="23"/>
+      <taxRule iso_code_country="mt" id_tax="24"/>
+      <taxRule iso_code_country="nl" id_tax="25"/>
+      <taxRule iso_code_country="pl" id_tax="26"/>
+      <taxRule iso_code_country="pt" id_tax="27"/>
+      <taxRule iso_code_country="ro" id_tax="28"/>
+      <taxRule iso_code_country="se" id_tax="29"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
       <taxRule iso_code_country="sk" id_tax="31"/>
-      <taxRule iso_code_country="fi" id_tax="31"/>
-      <taxRule iso_code_country="se" id_tax="31"/>
-      <taxRule iso_code_country="uk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
   <states>
-    <state name="Burgenland" iso_code="AT-1" country="AT" zone="Europe" tax_behavior="0" />
-    <state name="Kärnten" iso_code="AT-2" country="AT" zone="Europe" tax_behavior="0" />
-    <state name="Niederösterreich" iso_code="AT-3" country="AT" zone="Europe" tax_behavior="0" />
-    <state name="Oberösterreich" iso_code="AT-4" country="AT" zone="Europe" tax_behavior="0" />
-    <state name="Salzburg" iso_code="AT-5" country="AT" zone="Europe" tax_behavior="0" />
-    <state name="Steiermark" iso_code="AT-6" country="AT" zone="Europe" tax_behavior="0" />
-    <state name="Tirol" iso_code="AT-7" country="AT" zone="Europe" tax_behavior="0" />
-    <state name="Vorarlberg" iso_code="AT-8" country="AT" zone="Europe" tax_behavior="0" />
-    <state name="Wien" iso_code="AT-9" country="AT" zone="Europe" tax_behavior="0" />
+    <state name="Burgenland" iso_code="AT-1" country="AT" zone="Europe" tax_behavior="0"/>
+    <state name="Kärnten" iso_code="AT-2" country="AT" zone="Europe" tax_behavior="0"/>
+    <state name="Niederösterreich" iso_code="AT-3" country="AT" zone="Europe" tax_behavior="0"/>
+    <state name="Oberösterreich" iso_code="AT-4" country="AT" zone="Europe" tax_behavior="0"/>
+    <state name="Salzburg" iso_code="AT-5" country="AT" zone="Europe" tax_behavior="0"/>
+    <state name="Steiermark" iso_code="AT-6" country="AT" zone="Europe" tax_behavior="0"/>
+    <state name="Tirol" iso_code="AT-7" country="AT" zone="Europe" tax_behavior="0"/>
+    <state name="Vorarlberg" iso_code="AT-8" country="AT" zone="Europe" tax_behavior="0"/>
+    <state name="Wien" iso_code="AT-9" country="AT" zone="Europe" tax_behavior="0"/>
   </states>
   <units>
     <unit type="weight" value="kg"/>

--- a/localization/at.xml
+++ b/localization/at.xml
@@ -36,6 +36,8 @@
     <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="USt. AT 13%" rate="13"/>
+    <tax id="31" name="USt. AT 0%" rate="0"/>
     <taxRulesGroup name="AT Standard rate (20%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
@@ -64,6 +66,35 @@
       <taxRule iso_code_country="fi" id_tax="1"/>
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="uk" id_tax="1"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="AT Reduced Rate (13%)">
+      <taxRule iso_code_country="be" id_tax="30"/>
+      <taxRule iso_code_country="bg" id_tax="30"/>
+      <taxRule iso_code_country="cz" id_tax="30"/>
+      <taxRule iso_code_country="dk" id_tax="30"/>
+      <taxRule iso_code_country="de" id_tax="30"/>
+      <taxRule iso_code_country="ee" id_tax="30"/>
+      <taxRule iso_code_country="gr" id_tax="30"/>
+      <taxRule iso_code_country="es" id_tax="30"/>
+      <taxRule iso_code_country="fr" id_tax="30"/>
+      <taxRule iso_code_country="ie" id_tax="30"/>
+      <taxRule iso_code_country="it" id_tax="30"/>
+      <taxRule iso_code_country="cy" id_tax="30"/>
+      <taxRule iso_code_country="lv" id_tax="30"/>
+      <taxRule iso_code_country="lt" id_tax="30"/>
+      <taxRule iso_code_country="lu" id_tax="30"/>
+      <taxRule iso_code_country="hu" id_tax="30"/>
+      <taxRule iso_code_country="mt" id_tax="30"/>
+      <taxRule iso_code_country="nl" id_tax="30"/>
+      <taxRule iso_code_country="at" id_tax="30"/>
+      <taxRule iso_code_country="pl" id_tax="30"/>
+      <taxRule iso_code_country="pt" id_tax="30"/>
+      <taxRule iso_code_country="ro" id_tax="30"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="30"/>
+      <taxRule iso_code_country="fi" id_tax="30"/>
+      <taxRule iso_code_country="se" id_tax="30"/>
+      <taxRule iso_code_country="uk" id_tax="30"/>
     </taxRulesGroup>
     <taxRulesGroup name="AT Reduced Rate (10%)">
       <taxRule iso_code_country="be" id_tax="2"/>
@@ -152,6 +183,35 @@
       <taxRule iso_code_country="se" id_tax="27"/>
       <taxRule iso_code_country="si" id_tax="28"/>
       <taxRule iso_code_country="sk" id_tax="29"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="AT Zero Rate (0%)">
+      <taxRule iso_code_country="be" id_tax="31"/>
+      <taxRule iso_code_country="bg" id_tax="31"/>
+      <taxRule iso_code_country="cz" id_tax="31"/>
+      <taxRule iso_code_country="dk" id_tax="31"/>
+      <taxRule iso_code_country="de" id_tax="31"/>
+      <taxRule iso_code_country="ee" id_tax="31"/>
+      <taxRule iso_code_country="gr" id_tax="31"/>
+      <taxRule iso_code_country="es" id_tax="31"/>
+      <taxRule iso_code_country="fr" id_tax="31"/>
+      <taxRule iso_code_country="ie" id_tax="31"/>
+      <taxRule iso_code_country="it" id_tax="31"/>
+      <taxRule iso_code_country="cy" id_tax="31"/>
+      <taxRule iso_code_country="lv" id_tax="31"/>
+      <taxRule iso_code_country="lt" id_tax="31"/>
+      <taxRule iso_code_country="lu" id_tax="31"/>
+      <taxRule iso_code_country="hu" id_tax="31"/>
+      <taxRule iso_code_country="mt" id_tax="31"/>
+      <taxRule iso_code_country="nl" id_tax="31"/>
+      <taxRule iso_code_country="at" id_tax="31"/>
+      <taxRule iso_code_country="pl" id_tax="31"/>
+      <taxRule iso_code_country="pt" id_tax="31"/>
+      <taxRule iso_code_country="ro" id_tax="31"/>
+      <taxRule iso_code_country="si" id_tax="31"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
+      <taxRule iso_code_country="fi" id_tax="31"/>
+      <taxRule iso_code_country="se" id_tax="31"/>
+      <taxRule iso_code_country="uk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
   <states>

--- a/localization/be.xml
+++ b/localization/be.xml
@@ -23,7 +23,7 @@
     <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -35,7 +35,7 @@
     <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/bg.xml
+++ b/localization/bg.xml
@@ -8,7 +8,8 @@
   </languages>
   <taxes>
     <tax id="1" name="ДДС BG 20%" rate="20" eu-tax-group="virtual"/>
-    <tax id="2" name="ДДС BG 7%" rate="7"/>
+    <tax id="2" name="ДДС BG 9%" rate="9"/>
+    <tax id="30" name="ДДС BG 0%" rate="0"/>
     <tax id="3" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="4" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -65,7 +66,7 @@
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="uk" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="BG Reduced Rate (7%)">
+    <taxRulesGroup name="BG Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>
@@ -94,63 +95,34 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="BG Foodstuff Rate (20%)">
-      <taxRule iso_code_country="be" id_tax="1"/>
-      <taxRule iso_code_country="bg" id_tax="1"/>
-      <taxRule iso_code_country="cz" id_tax="1"/>
-      <taxRule iso_code_country="dk" id_tax="1"/>
-      <taxRule iso_code_country="de" id_tax="1"/>
-      <taxRule iso_code_country="ee" id_tax="1"/>
-      <taxRule iso_code_country="gr" id_tax="1"/>
-      <taxRule iso_code_country="es" id_tax="1"/>
-      <taxRule iso_code_country="fr" id_tax="1"/>
-      <taxRule iso_code_country="ie" id_tax="1"/>
-      <taxRule iso_code_country="it" id_tax="1"/>
-      <taxRule iso_code_country="cy" id_tax="1"/>
-      <taxRule iso_code_country="lv" id_tax="1"/>
-      <taxRule iso_code_country="lt" id_tax="1"/>
-      <taxRule iso_code_country="lu" id_tax="1"/>
-      <taxRule iso_code_country="hu" id_tax="1"/>
-      <taxRule iso_code_country="mt" id_tax="1"/>
-      <taxRule iso_code_country="nl" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="1"/>
-      <taxRule iso_code_country="pl" id_tax="1"/>
-      <taxRule iso_code_country="pt" id_tax="1"/>
-      <taxRule iso_code_country="ro" id_tax="1"/>
-      <taxRule iso_code_country="si" id_tax="1"/>
-      <taxRule iso_code_country="sk" id_tax="1"/>
-      <taxRule iso_code_country="fi" id_tax="1"/>
-      <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="BG Books Rate (20%)">
-      <taxRule iso_code_country="be" id_tax="1"/>
-      <taxRule iso_code_country="bg" id_tax="1"/>
-      <taxRule iso_code_country="cz" id_tax="1"/>
-      <taxRule iso_code_country="dk" id_tax="1"/>
-      <taxRule iso_code_country="de" id_tax="1"/>
-      <taxRule iso_code_country="ee" id_tax="1"/>
-      <taxRule iso_code_country="gr" id_tax="1"/>
-      <taxRule iso_code_country="es" id_tax="1"/>
-      <taxRule iso_code_country="fr" id_tax="1"/>
-      <taxRule iso_code_country="ie" id_tax="1"/>
-      <taxRule iso_code_country="it" id_tax="1"/>
-      <taxRule iso_code_country="cy" id_tax="1"/>
-      <taxRule iso_code_country="lv" id_tax="1"/>
-      <taxRule iso_code_country="lt" id_tax="1"/>
-      <taxRule iso_code_country="lu" id_tax="1"/>
-      <taxRule iso_code_country="hu" id_tax="1"/>
-      <taxRule iso_code_country="mt" id_tax="1"/>
-      <taxRule iso_code_country="nl" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="1"/>
-      <taxRule iso_code_country="pl" id_tax="1"/>
-      <taxRule iso_code_country="pt" id_tax="1"/>
-      <taxRule iso_code_country="ro" id_tax="1"/>
-      <taxRule iso_code_country="si" id_tax="1"/>
-      <taxRule iso_code_country="sk" id_tax="1"/>
-      <taxRule iso_code_country="fi" id_tax="1"/>
-      <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+    <taxRulesGroup name="BG Zero Rate (0%)">
+      <taxRule iso_code_country="be" id_tax="30"/>
+      <taxRule iso_code_country="bg" id_tax="30"/>
+      <taxRule iso_code_country="cz" id_tax="30"/>
+      <taxRule iso_code_country="dk" id_tax="30"/>
+      <taxRule iso_code_country="de" id_tax="30"/>
+      <taxRule iso_code_country="ee" id_tax="30"/>
+      <taxRule iso_code_country="gr" id_tax="30"/>
+      <taxRule iso_code_country="es" id_tax="30"/>
+      <taxRule iso_code_country="fr" id_tax="30"/>
+      <taxRule iso_code_country="ie" id_tax="30"/>
+      <taxRule iso_code_country="it" id_tax="30"/>
+      <taxRule iso_code_country="cy" id_tax="30"/>
+      <taxRule iso_code_country="lv" id_tax="30"/>
+      <taxRule iso_code_country="lt" id_tax="30"/>
+      <taxRule iso_code_country="lu" id_tax="30"/>
+      <taxRule iso_code_country="hu" id_tax="30"/>
+      <taxRule iso_code_country="mt" id_tax="30"/>
+      <taxRule iso_code_country="nl" id_tax="30"/>
+      <taxRule iso_code_country="at" id_tax="30"/>
+      <taxRule iso_code_country="pl" id_tax="30"/>
+      <taxRule iso_code_country="pt" id_tax="30"/>
+      <taxRule iso_code_country="ro" id_tax="30"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="30"/>
+      <taxRule iso_code_country="fi" id_tax="30"/>
+      <taxRule iso_code_country="se" id_tax="30"/>
+      <taxRule iso_code_country="uk" id_tax="30"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="bg" id_tax="1"/>

--- a/localization/bg.xml
+++ b/localization/bg.xml
@@ -9,34 +9,34 @@
   <taxes>
     <tax id="1" name="ДДС BG 20%" rate="20" eu-tax-group="virtual"/>
     <tax id="2" name="ДДС BG 9%" rate="9"/>
-    <tax id="30" name="ДДС BG 0%" rate="0"/>
-    <tax id="3" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="4" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="5" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="6" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="7" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="8" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="9" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="10" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="11" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="12" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="20" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="21" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="22" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="23" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="24" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="3" name="ДДС BG 0%" rate="0"/>
+    <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="BG Standard Rate (20%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
@@ -96,63 +96,63 @@
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="BG Zero Rate (0%)">
-      <taxRule iso_code_country="be" id_tax="30"/>
-      <taxRule iso_code_country="bg" id_tax="30"/>
-      <taxRule iso_code_country="cz" id_tax="30"/>
-      <taxRule iso_code_country="dk" id_tax="30"/>
-      <taxRule iso_code_country="de" id_tax="30"/>
-      <taxRule iso_code_country="ee" id_tax="30"/>
-      <taxRule iso_code_country="gr" id_tax="30"/>
-      <taxRule iso_code_country="es" id_tax="30"/>
-      <taxRule iso_code_country="fr" id_tax="30"/>
-      <taxRule iso_code_country="ie" id_tax="30"/>
-      <taxRule iso_code_country="it" id_tax="30"/>
-      <taxRule iso_code_country="cy" id_tax="30"/>
-      <taxRule iso_code_country="lv" id_tax="30"/>
-      <taxRule iso_code_country="lt" id_tax="30"/>
-      <taxRule iso_code_country="lu" id_tax="30"/>
-      <taxRule iso_code_country="hu" id_tax="30"/>
-      <taxRule iso_code_country="mt" id_tax="30"/>
-      <taxRule iso_code_country="nl" id_tax="30"/>
-      <taxRule iso_code_country="at" id_tax="30"/>
-      <taxRule iso_code_country="pl" id_tax="30"/>
-      <taxRule iso_code_country="pt" id_tax="30"/>
-      <taxRule iso_code_country="ro" id_tax="30"/>
-      <taxRule iso_code_country="si" id_tax="30"/>
-      <taxRule iso_code_country="sk" id_tax="30"/>
-      <taxRule iso_code_country="fi" id_tax="30"/>
-      <taxRule iso_code_country="se" id_tax="30"/>
-      <taxRule iso_code_country="uk" id_tax="30"/>
+      <taxRule iso_code_country="be" id_tax="3"/>
+      <taxRule iso_code_country="bg" id_tax="3"/>
+      <taxRule iso_code_country="cz" id_tax="3"/>
+      <taxRule iso_code_country="dk" id_tax="3"/>
+      <taxRule iso_code_country="de" id_tax="3"/>
+      <taxRule iso_code_country="ee" id_tax="3"/>
+      <taxRule iso_code_country="gr" id_tax="3"/>
+      <taxRule iso_code_country="es" id_tax="3"/>
+      <taxRule iso_code_country="fr" id_tax="3"/>
+      <taxRule iso_code_country="ie" id_tax="3"/>
+      <taxRule iso_code_country="it" id_tax="3"/>
+      <taxRule iso_code_country="cy" id_tax="3"/>
+      <taxRule iso_code_country="lv" id_tax="3"/>
+      <taxRule iso_code_country="lt" id_tax="3"/>
+      <taxRule iso_code_country="lu" id_tax="3"/>
+      <taxRule iso_code_country="hu" id_tax="3"/>
+      <taxRule iso_code_country="mt" id_tax="3"/>
+      <taxRule iso_code_country="nl" id_tax="3"/>
+      <taxRule iso_code_country="at" id_tax="3"/>
+      <taxRule iso_code_country="pl" id_tax="3"/>
+      <taxRule iso_code_country="pt" id_tax="3"/>
+      <taxRule iso_code_country="ro" id_tax="3"/>
+      <taxRule iso_code_country="si" id_tax="3"/>
+      <taxRule iso_code_country="sk" id_tax="3"/>
+      <taxRule iso_code_country="fi" id_tax="3"/>
+      <taxRule iso_code_country="se" id_tax="3"/>
+      <taxRule iso_code_country="uk" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="bg" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="3"/>
-      <taxRule iso_code_country="be" id_tax="4"/>
-      <taxRule iso_code_country="cy" id_tax="5"/>
-      <taxRule iso_code_country="cz" id_tax="6"/>
-      <taxRule iso_code_country="de" id_tax="7"/>
-      <taxRule iso_code_country="dk" id_tax="8"/>
-      <taxRule iso_code_country="ee" id_tax="9"/>
-      <taxRule iso_code_country="es" id_tax="10"/>
-      <taxRule iso_code_country="fi" id_tax="11"/>
-      <taxRule iso_code_country="fr" id_tax="12"/>
-      <taxRule iso_code_country="gb" id_tax="13"/>
-      <taxRule iso_code_country="gr" id_tax="14"/>
-      <taxRule iso_code_country="hr" id_tax="15"/>
-      <taxRule iso_code_country="hu" id_tax="16"/>
-      <taxRule iso_code_country="ie" id_tax="17"/>
-      <taxRule iso_code_country="it" id_tax="18"/>
-      <taxRule iso_code_country="lt" id_tax="19"/>
-      <taxRule iso_code_country="lu" id_tax="20"/>
-      <taxRule iso_code_country="lv" id_tax="21"/>
-      <taxRule iso_code_country="mt" id_tax="22"/>
-      <taxRule iso_code_country="nl" id_tax="23"/>
-      <taxRule iso_code_country="pl" id_tax="24"/>
-      <taxRule iso_code_country="pt" id_tax="25"/>
-      <taxRule iso_code_country="ro" id_tax="26"/>
-      <taxRule iso_code_country="se" id_tax="27"/>
-      <taxRule iso_code_country="si" id_tax="28"/>
-      <taxRule iso_code_country="sk" id_tax="29"/>
+      <taxRule iso_code_country="at" id_tax="4"/>
+      <taxRule iso_code_country="be" id_tax="5"/>
+      <taxRule iso_code_country="cy" id_tax="6"/>
+      <taxRule iso_code_country="cz" id_tax="7"/>
+      <taxRule iso_code_country="de" id_tax="8"/>
+      <taxRule iso_code_country="dk" id_tax="9"/>
+      <taxRule iso_code_country="ee" id_tax="10"/>
+      <taxRule iso_code_country="es" id_tax="11"/>
+      <taxRule iso_code_country="fi" id_tax="12"/>
+      <taxRule iso_code_country="fr" id_tax="13"/>
+      <taxRule iso_code_country="gb" id_tax="14"/>
+      <taxRule iso_code_country="gr" id_tax="15"/>
+      <taxRule iso_code_country="hr" id_tax="16"/>
+      <taxRule iso_code_country="hu" id_tax="17"/>
+      <taxRule iso_code_country="ie" id_tax="18"/>
+      <taxRule iso_code_country="it" id_tax="19"/>
+      <taxRule iso_code_country="lt" id_tax="20"/>
+      <taxRule iso_code_country="lu" id_tax="21"/>
+      <taxRule iso_code_country="lv" id_tax="22"/>
+      <taxRule iso_code_country="mt" id_tax="23"/>
+      <taxRule iso_code_country="nl" id_tax="24"/>
+      <taxRule iso_code_country="pl" id_tax="25"/>
+      <taxRule iso_code_country="pt" id_tax="26"/>
+      <taxRule iso_code_country="ro" id_tax="27"/>
+      <taxRule iso_code_country="se" id_tax="28"/>
+      <taxRule iso_code_country="si" id_tax="29"/>
+      <taxRule iso_code_country="sk" id_tax="30"/>
     </taxRulesGroup>
   </taxes>
   <units>

--- a/localization/by.xml
+++ b/localization/by.xml
@@ -7,18 +7,10 @@
     <language iso_code="ru"/>
   </languages>
   <taxes>
+    <tax id="1" name="&#x41F;&#x414;&#x412; 20%" rate="20"/>
     <taxRulesGroup name="&#x41F;&#x414;&#x412; 20%">
-      <taxRule iso_code_country="by" behavior="0" id_tax="65"/>
+      <taxRule iso_code_country="by" behavior="0" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="&#x41F;&#x414;&#x412; 10%">
-      <taxRule iso_code_country="by" behavior="0" id_tax="66"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="&#x41F;&#x414;&#x412; 0.5%">
-      <taxRule iso_code_country="by" behavior="0" id_tax="67"/>
-    </taxRulesGroup>
-    <tax id="65" name="&#x41F;&#x414;&#x412; 20%" rate="20.000"/>
-    <tax id="66" name="&#x41F;&#x414;&#x412; 10%" rate="10.000"/>
-    <tax id="67" name="&#x41F;&#x414;&#x412; 0.5%" rate="0.500"/>
   </taxes>
   <units>
     <unit type="weight" value="kg"/>

--- a/localization/cn.xml
+++ b/localization/cn.xml
@@ -8,26 +8,21 @@
 		<language iso_code="zh" />
 	</languages>
 	<taxes>
-		<tax id="1" name="增值税 CN 17%" rate="17" />
-		<tax id="2" name="增值税 CN 13%" rate="13" />
-		<tax id="3" name="增值税 CN 6%" rate="6" />
-		<tax id="4" name="增值税 CN 3%" rate="3" />
+    <tax id="1" name="增值税 CN 13%" rate="13"/>
+    <tax id="2" name="增值税 CN 9%" rate="9"/>
+    <tax id="3" name="增值税 CN 6%" rate="6"/>
 
-		<taxRulesGroup name="CN Standard Rate (17%)">
-			<taxRule iso_code_country="cn" id_tax="1" />
-		</taxRulesGroup>
+    <taxRulesGroup name="CN Standard Rate (13%)">
+      <taxRule iso_code_country="cn" id_tax="1"/>
+    </taxRulesGroup>
 
-		<taxRulesGroup name="CN Reduced Rate (13%)">
-			<taxRule iso_code_country="cn" id_tax="2" />
-		</taxRulesGroup>
+    <taxRulesGroup name="CN Standard Rate (9%)">
+      <taxRule iso_code_country="cn" id_tax="2"/>
+    </taxRulesGroup>
 
-        <taxRulesGroup name="CN Super Reduced Rate (6%)">
-			<taxRule iso_code_country="cn" id_tax="3" />
-		</taxRulesGroup>
-
-		<taxRulesGroup name="CN Super Reduced Rate (3%)">
-			<taxRule iso_code_country="cn" id_tax="4" />
-		</taxRulesGroup>
+    <taxRulesGroup name="CN Standard Rate (6%)">
+      <taxRule iso_code_country="cn" id_tax="3"/>
+    </taxRulesGroup>
 	</taxes>
 	<states>
 		<state name="Beijing" iso_code="11" country="CN" zone="Asia" tax_behavior="0" />

--- a/localization/cy.xml
+++ b/localization/cy.xml
@@ -22,7 +22,7 @@
     <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -34,7 +34,7 @@
     <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/cz.xml
+++ b/localization/cz.xml
@@ -21,7 +21,7 @@
     <tax id="11" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="12" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="15" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -33,7 +33,7 @@
     <tax id="23" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="24" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/de.xml
+++ b/localization/de.xml
@@ -20,7 +20,7 @@
     <tax id="11" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="12" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="15" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -32,7 +32,7 @@
     <tax id="23" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="24" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/dk.xml
+++ b/localization/dk.xml
@@ -19,7 +19,7 @@
     <tax id="10" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="11" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="12" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="14" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="15" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -31,7 +31,7 @@
     <tax id="22" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="23" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="24" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="27" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -96,11 +96,11 @@
     </taxRulesGroup>
   </taxes>
   <states>
-    <state name="Hovedstaden" iso_code="DK-84" country="DK" zone="Europe" tax_behavior="0" />
-    <state name="Midtjylland" iso_code="DK-82" country="DK" zone="Europe" tax_behavior="0" />
-    <state name="Nordjylland" iso_code="DK-81" country="DK" zone="Europe" tax_behavior="0" />
-    <state name="Sjælland" iso_code="DK-85" country="DK" zone="Europe" tax_behavior="0" />
-    <state name="Syddanmark" iso_code="DK-83" country="DK" zone="Europe" tax_behavior="0" />
+    <state name="Hovedstaden" iso_code="DK-84" country="DK" zone="Europe" tax_behavior="0"/>
+    <state name="Midtjylland" iso_code="DK-82" country="DK" zone="Europe" tax_behavior="0"/>
+    <state name="Nordjylland" iso_code="DK-81" country="DK" zone="Europe" tax_behavior="0"/>
+    <state name="Sjælland" iso_code="DK-85" country="DK" zone="Europe" tax_behavior="0"/>
+    <state name="Syddanmark" iso_code="DK-83" country="DK" zone="Europe" tax_behavior="0"/>
   </states>
   <units>
     <unit type="weight" value="kg"/>

--- a/localization/ee.xml
+++ b/localization/ee.xml
@@ -20,7 +20,7 @@
     <tax id="11" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="12" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="15" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -32,7 +32,7 @@
     <tax id="23" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="24" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/es.xml
+++ b/localization/es.xml
@@ -24,7 +24,7 @@
     <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -36,7 +36,7 @@
     <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/fi.xml
+++ b/localization/fi.xml
@@ -21,7 +21,7 @@
     <tax id="12" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -33,7 +33,7 @@
     <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/fr.xml
+++ b/localization/fr.xml
@@ -31,7 +31,7 @@
     <tax id="13" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="14" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="15" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="19" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -43,7 +43,7 @@
     <tax id="25" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="27" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="31" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/gb.xml
+++ b/localization/gb.xml
@@ -20,7 +20,7 @@
     <tax id="11" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="15" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -32,7 +32,7 @@
     <tax id="23" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="24" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/gr.xml
+++ b/localization/gr.xml
@@ -33,7 +33,7 @@
     <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -126,33 +126,33 @@
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="gr" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="7"/>
-      <taxRule iso_code_country="be" id_tax="8"/>
-      <taxRule iso_code_country="bg" id_tax="9"/>
-      <taxRule iso_code_country="cy" id_tax="10"/>
-      <taxRule iso_code_country="cz" id_tax="11"/>
-      <taxRule iso_code_country="de" id_tax="12"/>
-      <taxRule iso_code_country="dk" id_tax="13"/>
-      <taxRule iso_code_country="ee" id_tax="14"/>
-      <taxRule iso_code_country="es" id_tax="15"/>
-      <taxRule iso_code_country="fi" id_tax="16"/>
-      <taxRule iso_code_country="fr" id_tax="17"/>
-      <taxRule iso_code_country="gb" id_tax="18"/>
-      <taxRule iso_code_country="hr" id_tax="19"/>
-      <taxRule iso_code_country="hu" id_tax="20"/>
-      <taxRule iso_code_country="ie" id_tax="21"/>
-      <taxRule iso_code_country="it" id_tax="22"/>
-      <taxRule iso_code_country="lt" id_tax="23"/>
-      <taxRule iso_code_country="lu" id_tax="24"/>
-      <taxRule iso_code_country="lv" id_tax="25"/>
-      <taxRule iso_code_country="mt" id_tax="26"/>
-      <taxRule iso_code_country="nl" id_tax="27"/>
-      <taxRule iso_code_country="pl" id_tax="28"/>
-      <taxRule iso_code_country="pt" id_tax="29"/>
-      <taxRule iso_code_country="ro" id_tax="30"/>
-      <taxRule iso_code_country="se" id_tax="31"/>
-      <taxRule iso_code_country="si" id_tax="32"/>
-      <taxRule iso_code_country="sk" id_tax="33"/>
+      <taxRule iso_code_country="at" id_tax="4"/>
+      <taxRule iso_code_country="be" id_tax="5"/>
+      <taxRule iso_code_country="bg" id_tax="6"/>
+      <taxRule iso_code_country="cy" id_tax="7"/>
+      <taxRule iso_code_country="cz" id_tax="8"/>
+      <taxRule iso_code_country="de" id_tax="9"/>
+      <taxRule iso_code_country="dk" id_tax="10"/>
+      <taxRule iso_code_country="ee" id_tax="11"/>
+      <taxRule iso_code_country="es" id_tax="12"/>
+      <taxRule iso_code_country="fi" id_tax="13"/>
+      <taxRule iso_code_country="fr" id_tax="14"/>
+      <taxRule iso_code_country="gb" id_tax="15"/>
+      <taxRule iso_code_country="hr" id_tax="16"/>
+      <taxRule iso_code_country="hu" id_tax="17"/>
+      <taxRule iso_code_country="ie" id_tax="18"/>
+      <taxRule iso_code_country="it" id_tax="19"/>
+      <taxRule iso_code_country="lt" id_tax="20"/>
+      <taxRule iso_code_country="lu" id_tax="21"/>
+      <taxRule iso_code_country="lv" id_tax="22"/>
+      <taxRule iso_code_country="mt" id_tax="23"/>
+      <taxRule iso_code_country="nl" id_tax="24"/>
+      <taxRule iso_code_country="pl" id_tax="25"/>
+      <taxRule iso_code_country="pt" id_tax="26"/>
+      <taxRule iso_code_country="ro" id_tax="27"/>
+      <taxRule iso_code_country="se" id_tax="28"/>
+      <taxRule iso_code_country="si" id_tax="29"/>
+      <taxRule iso_code_country="sk" id_tax="30"/>
     </taxRulesGroup>
   </taxes>
   <units>

--- a/localization/hr.xml
+++ b/localization/hr.xml
@@ -11,33 +11,33 @@
     <tax id="2" name="Croatia PDV 13%" rate="13.000"/>
     <tax id="3" name="Croatia PDV 5%" rate="5.000"/>
     <tax id="4" name="Croatia PDV 0%" rate="0"/>
-    <tax id="82" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="83" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="84" name="&#x414;&#x414;&#x421; BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="85" name="&#x3A6;&#x3A0;&#x391; CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="86" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="87" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="88" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="89" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="90" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="91" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="92" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="93" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="94" name="&#x3A6;&#x3A0;&#x391; GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="95" name="&#xC1;FA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="96" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="97" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="98" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="99" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="100" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="101" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="102" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="103" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="104" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="105" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="106" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="107" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="108" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="5" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="&#x414;&#x414;&#x421; BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="&#x3A6;&#x3A0;&#x391; CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="&#x3A6;&#x3A0;&#x391; GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="&#xC1;FA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="31" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="Croatia Standard Rate 25%">
       <taxRule iso_code_country="hr" behavior="0" id_tax="1"/>
     </taxRulesGroup>
@@ -52,33 +52,33 @@
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="hr" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="82"/>
-      <taxRule iso_code_country="be" id_tax="83"/>
-      <taxRule iso_code_country="bg" id_tax="84"/>
-      <taxRule iso_code_country="cy" id_tax="85"/>
-      <taxRule iso_code_country="cz" id_tax="86"/>
-      <taxRule iso_code_country="de" id_tax="87"/>
-      <taxRule iso_code_country="dk" id_tax="88"/>
-      <taxRule iso_code_country="ee" id_tax="89"/>
-      <taxRule iso_code_country="es" id_tax="90"/>
-      <taxRule iso_code_country="fi" id_tax="91"/>
-      <taxRule iso_code_country="fr" id_tax="92"/>
-      <taxRule iso_code_country="gb" id_tax="93"/>
-      <taxRule iso_code_country="gr" id_tax="94"/>
-      <taxRule iso_code_country="hu" id_tax="95"/>
-      <taxRule iso_code_country="ie" id_tax="96"/>
-      <taxRule iso_code_country="it" id_tax="97"/>
-      <taxRule iso_code_country="lt" id_tax="98"/>
-      <taxRule iso_code_country="lu" id_tax="99"/>
-      <taxRule iso_code_country="lv" id_tax="100"/>
-      <taxRule iso_code_country="mt" id_tax="101"/>
-      <taxRule iso_code_country="nl" id_tax="102"/>
-      <taxRule iso_code_country="pl" id_tax="103"/>
-      <taxRule iso_code_country="pt" id_tax="104"/>
-      <taxRule iso_code_country="ro" id_tax="105"/>
-      <taxRule iso_code_country="se" id_tax="106"/>
-      <taxRule iso_code_country="si" id_tax="107"/>
-      <taxRule iso_code_country="sk" id_tax="108"/>
+      <taxRule iso_code_country="at" id_tax="5"/>
+      <taxRule iso_code_country="be" id_tax="6"/>
+      <taxRule iso_code_country="bg" id_tax="7"/>
+      <taxRule iso_code_country="cy" id_tax="8"/>
+      <taxRule iso_code_country="cz" id_tax="9"/>
+      <taxRule iso_code_country="de" id_tax="10"/>
+      <taxRule iso_code_country="dk" id_tax="11"/>
+      <taxRule iso_code_country="ee" id_tax="12"/>
+      <taxRule iso_code_country="es" id_tax="13"/>
+      <taxRule iso_code_country="fi" id_tax="14"/>
+      <taxRule iso_code_country="fr" id_tax="15"/>
+      <taxRule iso_code_country="gb" id_tax="16"/>
+      <taxRule iso_code_country="gr" id_tax="17"/>
+      <taxRule iso_code_country="hu" id_tax="18"/>
+      <taxRule iso_code_country="ie" id_tax="19"/>
+      <taxRule iso_code_country="it" id_tax="20"/>
+      <taxRule iso_code_country="lt" id_tax="21"/>
+      <taxRule iso_code_country="lu" id_tax="22"/>
+      <taxRule iso_code_country="lv" id_tax="23"/>
+      <taxRule iso_code_country="mt" id_tax="24"/>
+      <taxRule iso_code_country="nl" id_tax="25"/>
+      <taxRule iso_code_country="pl" id_tax="26"/>
+      <taxRule iso_code_country="pt" id_tax="27"/>
+      <taxRule iso_code_country="ro" id_tax="28"/>
+      <taxRule iso_code_country="se" id_tax="29"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
   <units>

--- a/localization/hr.xml
+++ b/localization/hr.xml
@@ -7,6 +7,10 @@
     <language iso_code="hr"/>
   </languages>
   <taxes>
+    <tax id="1" name="Croatia PDV 25%" rate="25.000" eu-tax-group="virtual"/>
+    <tax id="2" name="Croatia PDV 13%" rate="13.000"/>
+    <tax id="3" name="Croatia PDV 5%" rate="5.000"/>
+    <tax id="4" name="Croatia PDV 0%" rate="0"/>
     <tax id="82" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="83" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="84" name="&#x414;&#x414;&#x421; BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -34,20 +38,20 @@
     <tax id="106" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="107" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="108" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <taxRulesGroup name="Croatia PDV 5%">
-      <taxRule iso_code_country="hr" behavior="0" id_tax="81"/>
+    <taxRulesGroup name="Croatia Standard Rate 25%">
+      <taxRule iso_code_country="hr" behavior="0" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="Croatia PDV 25%">
-      <taxRule iso_code_country="hr" behavior="0" id_tax="79"/>
+    <taxRulesGroup name="Croatia Reduced Rate 13%">
+      <taxRule iso_code_country="hr" behavior="0" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="Croatia PDV 10%">
-      <taxRule iso_code_country="hr" behavior="0" id_tax="80"/>
+    <taxRulesGroup name="Croatia Reduced Rate 5%">
+      <taxRule iso_code_country="hr" behavior="0" id_tax="3"/>
     </taxRulesGroup>
-    <tax id="79" name="Croatia PDV 25%" rate="25.000" eu-tax-group="virtual"/>
-    <tax id="80" name="Croatia PDV 10%" rate="10.000"/>
-    <tax id="81" name="Croatia PDV 5%" rate="5.000"/>
+    <taxRulesGroup name="Croatia Zero Rate 0%">
+      <taxRule iso_code_country="hr" behavior="0" id_tax="4"/>
+    </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
-      <taxRule iso_code_country="hr" id_tax="79"/>
+      <taxRule iso_code_country="hr" id_tax="1"/>
       <taxRule iso_code_country="at" id_tax="82"/>
       <taxRule iso_code_country="be" id_tax="83"/>
       <taxRule iso_code_country="bg" id_tax="84"/>

--- a/localization/hu.xml
+++ b/localization/hu.xml
@@ -22,7 +22,7 @@
     <tax id="13" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="14" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="15" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="19" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -33,7 +33,7 @@
     <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/ie.xml
+++ b/localization/ie.xml
@@ -23,7 +23,7 @@
     <tax id="14" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="15" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="19" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="20" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -34,7 +34,7 @@
     <tax id="25" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="27" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="31" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/it.xml
+++ b/localization/it.xml
@@ -9,36 +9,36 @@
   <taxes>
     <tax id="1" name="IVA IT 22%" rate="22" eu-tax-group="virtual"/>
     <tax id="2" name="IVA IT 10%" rate="10"/>
-    <tax id="31" name="IVA IT 5%" rate="5"/>
-    <tax id="3" name="IVA IT 4%" rate="4"/>
-    <tax id="32" name="IVA IT 0%" rate="0"/>
-    <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="7" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="8" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="9" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="10" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="11" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="12" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="20" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="21" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="22" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="23" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="3" name="IVA IT 5%" rate="5"/>
+    <tax id="4" name="IVA IT 4%" rate="4"/>
+    <tax id="5" name="IVA IT 0%" rate="0"/>
+    <tax id="6" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="31" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="32" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="IT Standard Rate (22%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
@@ -98,35 +98,6 @@
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="IT Reduced Rate (5%)">
-      <taxRule iso_code_country="be" id_tax="31"/>
-      <taxRule iso_code_country="bg" id_tax="31"/>
-      <taxRule iso_code_country="cz" id_tax="31"/>
-      <taxRule iso_code_country="dk" id_tax="31"/>
-      <taxRule iso_code_country="de" id_tax="31"/>
-      <taxRule iso_code_country="ee" id_tax="31"/>
-      <taxRule iso_code_country="gr" id_tax="31"/>
-      <taxRule iso_code_country="es" id_tax="31"/>
-      <taxRule iso_code_country="fr" id_tax="31"/>
-      <taxRule iso_code_country="ie" id_tax="31"/>
-      <taxRule iso_code_country="it" id_tax="31"/>
-      <taxRule iso_code_country="cy" id_tax="31"/>
-      <taxRule iso_code_country="lv" id_tax="31"/>
-      <taxRule iso_code_country="lt" id_tax="31"/>
-      <taxRule iso_code_country="lu" id_tax="31"/>
-      <taxRule iso_code_country="hu" id_tax="31"/>
-      <taxRule iso_code_country="mt" id_tax="31"/>
-      <taxRule iso_code_country="nl" id_tax="31"/>
-      <taxRule iso_code_country="at" id_tax="31"/>
-      <taxRule iso_code_country="pl" id_tax="31"/>
-      <taxRule iso_code_country="pt" id_tax="31"/>
-      <taxRule iso_code_country="ro" id_tax="31"/>
-      <taxRule iso_code_country="si" id_tax="31"/>
-      <taxRule iso_code_country="sk" id_tax="31"/>
-      <taxRule iso_code_country="fi" id_tax="31"/>
-      <taxRule iso_code_country="se" id_tax="31"/>
-      <taxRule iso_code_country="uk" id_tax="31"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="IT Reduced Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
       <taxRule iso_code_country="bg" id_tax="3"/>
       <taxRule iso_code_country="cz" id_tax="3"/>
@@ -155,64 +126,93 @@
       <taxRule iso_code_country="se" id_tax="3"/>
       <taxRule iso_code_country="uk" id_tax="3"/>
     </taxRulesGroup>
+    <taxRulesGroup name="IT Reduced Rate (4%)">
+      <taxRule iso_code_country="be" id_tax="4"/>
+      <taxRule iso_code_country="bg" id_tax="4"/>
+      <taxRule iso_code_country="cz" id_tax="4"/>
+      <taxRule iso_code_country="dk" id_tax="4"/>
+      <taxRule iso_code_country="de" id_tax="4"/>
+      <taxRule iso_code_country="ee" id_tax="4"/>
+      <taxRule iso_code_country="gr" id_tax="4"/>
+      <taxRule iso_code_country="es" id_tax="4"/>
+      <taxRule iso_code_country="fr" id_tax="4"/>
+      <taxRule iso_code_country="ie" id_tax="4"/>
+      <taxRule iso_code_country="it" id_tax="4"/>
+      <taxRule iso_code_country="cy" id_tax="4"/>
+      <taxRule iso_code_country="lv" id_tax="4"/>
+      <taxRule iso_code_country="lt" id_tax="4"/>
+      <taxRule iso_code_country="lu" id_tax="4"/>
+      <taxRule iso_code_country="hu" id_tax="4"/>
+      <taxRule iso_code_country="mt" id_tax="4"/>
+      <taxRule iso_code_country="nl" id_tax="4"/>
+      <taxRule iso_code_country="at" id_tax="4"/>
+      <taxRule iso_code_country="pl" id_tax="4"/>
+      <taxRule iso_code_country="pt" id_tax="4"/>
+      <taxRule iso_code_country="ro" id_tax="4"/>
+      <taxRule iso_code_country="si" id_tax="4"/>
+      <taxRule iso_code_country="sk" id_tax="4"/>
+      <taxRule iso_code_country="fi" id_tax="4"/>
+      <taxRule iso_code_country="se" id_tax="4"/>
+      <taxRule iso_code_country="uk" id_tax="4"/>
+    </taxRulesGroup>
     <taxRulesGroup name="IT Zero Rate (0%)">
-      <taxRule iso_code_country="be" id_tax="32"/>
-      <taxRule iso_code_country="bg" id_tax="32"/>
-      <taxRule iso_code_country="cz" id_tax="32"/>
-      <taxRule iso_code_country="dk" id_tax="32"/>
-      <taxRule iso_code_country="de" id_tax="32"/>
-      <taxRule iso_code_country="ee" id_tax="32"/>
-      <taxRule iso_code_country="gr" id_tax="32"/>
-      <taxRule iso_code_country="es" id_tax="32"/>
-      <taxRule iso_code_country="fr" id_tax="32"/>
-      <taxRule iso_code_country="ie" id_tax="32"/>
-      <taxRule iso_code_country="it" id_tax="32"/>
-      <taxRule iso_code_country="cy" id_tax="32"/>
-      <taxRule iso_code_country="lv" id_tax="32"/>
-      <taxRule iso_code_country="lt" id_tax="32"/>
-      <taxRule iso_code_country="lu" id_tax="32"/>
-      <taxRule iso_code_country="hu" id_tax="32"/>
-      <taxRule iso_code_country="mt" id_tax="32"/>
-      <taxRule iso_code_country="nl" id_tax="32"/>
-      <taxRule iso_code_country="at" id_tax="32"/>
-      <taxRule iso_code_country="pl" id_tax="32"/>
-      <taxRule iso_code_country="pt" id_tax="32"/>
-      <taxRule iso_code_country="ro" id_tax="32"/>
-      <taxRule iso_code_country="si" id_tax="32"/>
-      <taxRule iso_code_country="sk" id_tax="32"/>
-      <taxRule iso_code_country="fi" id_tax="32"/>
-      <taxRule iso_code_country="se" id_tax="32"/>
-      <taxRule iso_code_country="uk" id_tax="32"/>
+      <taxRule iso_code_country="be" id_tax="5"/>
+      <taxRule iso_code_country="bg" id_tax="5"/>
+      <taxRule iso_code_country="cz" id_tax="5"/>
+      <taxRule iso_code_country="dk" id_tax="5"/>
+      <taxRule iso_code_country="de" id_tax="5"/>
+      <taxRule iso_code_country="ee" id_tax="5"/>
+      <taxRule iso_code_country="gr" id_tax="5"/>
+      <taxRule iso_code_country="es" id_tax="5"/>
+      <taxRule iso_code_country="fr" id_tax="5"/>
+      <taxRule iso_code_country="ie" id_tax="5"/>
+      <taxRule iso_code_country="it" id_tax="5"/>
+      <taxRule iso_code_country="cy" id_tax="5"/>
+      <taxRule iso_code_country="lv" id_tax="5"/>
+      <taxRule iso_code_country="lt" id_tax="5"/>
+      <taxRule iso_code_country="lu" id_tax="5"/>
+      <taxRule iso_code_country="hu" id_tax="5"/>
+      <taxRule iso_code_country="mt" id_tax="5"/>
+      <taxRule iso_code_country="nl" id_tax="5"/>
+      <taxRule iso_code_country="at" id_tax="5"/>
+      <taxRule iso_code_country="pl" id_tax="5"/>
+      <taxRule iso_code_country="pt" id_tax="5"/>
+      <taxRule iso_code_country="ro" id_tax="5"/>
+      <taxRule iso_code_country="si" id_tax="5"/>
+      <taxRule iso_code_country="sk" id_tax="5"/>
+      <taxRule iso_code_country="fi" id_tax="5"/>
+      <taxRule iso_code_country="se" id_tax="5"/>
+      <taxRule iso_code_country="uk" id_tax="5"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="it" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="4"/>
-      <taxRule iso_code_country="be" id_tax="5"/>
-      <taxRule iso_code_country="bg" id_tax="6"/>
-      <taxRule iso_code_country="cy" id_tax="7"/>
-      <taxRule iso_code_country="cz" id_tax="8"/>
-      <taxRule iso_code_country="de" id_tax="9"/>
-      <taxRule iso_code_country="dk" id_tax="10"/>
-      <taxRule iso_code_country="ee" id_tax="11"/>
-      <taxRule iso_code_country="es" id_tax="12"/>
-      <taxRule iso_code_country="fi" id_tax="13"/>
-      <taxRule iso_code_country="fr" id_tax="14"/>
-      <taxRule iso_code_country="gb" id_tax="15"/>
-      <taxRule iso_code_country="gr" id_tax="16"/>
-      <taxRule iso_code_country="hr" id_tax="17"/>
-      <taxRule iso_code_country="hu" id_tax="18"/>
-      <taxRule iso_code_country="ie" id_tax="19"/>
-      <taxRule iso_code_country="lt" id_tax="20"/>
-      <taxRule iso_code_country="lu" id_tax="21"/>
-      <taxRule iso_code_country="lv" id_tax="22"/>
-      <taxRule iso_code_country="mt" id_tax="23"/>
-      <taxRule iso_code_country="nl" id_tax="24"/>
-      <taxRule iso_code_country="pl" id_tax="25"/>
-      <taxRule iso_code_country="pt" id_tax="26"/>
-      <taxRule iso_code_country="ro" id_tax="27"/>
-      <taxRule iso_code_country="se" id_tax="28"/>
-      <taxRule iso_code_country="si" id_tax="29"/>
-      <taxRule iso_code_country="sk" id_tax="30"/>
+      <taxRule iso_code_country="at" id_tax="6"/>
+      <taxRule iso_code_country="be" id_tax="7"/>
+      <taxRule iso_code_country="bg" id_tax="8"/>
+      <taxRule iso_code_country="cy" id_tax="9"/>
+      <taxRule iso_code_country="cz" id_tax="10"/>
+      <taxRule iso_code_country="de" id_tax="11"/>
+      <taxRule iso_code_country="dk" id_tax="12"/>
+      <taxRule iso_code_country="ee" id_tax="13"/>
+      <taxRule iso_code_country="es" id_tax="14"/>
+      <taxRule iso_code_country="fi" id_tax="15"/>
+      <taxRule iso_code_country="fr" id_tax="16"/>
+      <taxRule iso_code_country="gb" id_tax="17"/>
+      <taxRule iso_code_country="gr" id_tax="18"/>
+      <taxRule iso_code_country="hr" id_tax="19"/>
+      <taxRule iso_code_country="hu" id_tax="20"/>
+      <taxRule iso_code_country="ie" id_tax="21"/>
+      <taxRule iso_code_country="lt" id_tax="22"/>
+      <taxRule iso_code_country="lu" id_tax="23"/>
+      <taxRule iso_code_country="lv" id_tax="24"/>
+      <taxRule iso_code_country="mt" id_tax="25"/>
+      <taxRule iso_code_country="nl" id_tax="26"/>
+      <taxRule iso_code_country="pl" id_tax="27"/>
+      <taxRule iso_code_country="pt" id_tax="28"/>
+      <taxRule iso_code_country="ro" id_tax="29"/>
+      <taxRule iso_code_country="se" id_tax="30"/>
+      <taxRule iso_code_country="si" id_tax="31"/>
+      <taxRule iso_code_country="sk" id_tax="32"/>
     </taxRulesGroup>
   </taxes>
   <states>

--- a/localization/it.xml
+++ b/localization/it.xml
@@ -9,7 +9,9 @@
   <taxes>
     <tax id="1" name="IVA IT 22%" rate="22" eu-tax-group="virtual"/>
     <tax id="2" name="IVA IT 10%" rate="10"/>
+    <tax id="31" name="IVA IT 5%" rate="5"/>
     <tax id="3" name="IVA IT 4%" rate="4"/>
+    <tax id="32" name="IVA IT 0%" rate="0"/>
     <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -95,7 +97,36 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="IT Super Reduced Rate (4%)">
+    <taxRulesGroup name="IT Reduced Rate (5%)">
+      <taxRule iso_code_country="be" id_tax="31"/>
+      <taxRule iso_code_country="bg" id_tax="31"/>
+      <taxRule iso_code_country="cz" id_tax="31"/>
+      <taxRule iso_code_country="dk" id_tax="31"/>
+      <taxRule iso_code_country="de" id_tax="31"/>
+      <taxRule iso_code_country="ee" id_tax="31"/>
+      <taxRule iso_code_country="gr" id_tax="31"/>
+      <taxRule iso_code_country="es" id_tax="31"/>
+      <taxRule iso_code_country="fr" id_tax="31"/>
+      <taxRule iso_code_country="ie" id_tax="31"/>
+      <taxRule iso_code_country="it" id_tax="31"/>
+      <taxRule iso_code_country="cy" id_tax="31"/>
+      <taxRule iso_code_country="lv" id_tax="31"/>
+      <taxRule iso_code_country="lt" id_tax="31"/>
+      <taxRule iso_code_country="lu" id_tax="31"/>
+      <taxRule iso_code_country="hu" id_tax="31"/>
+      <taxRule iso_code_country="mt" id_tax="31"/>
+      <taxRule iso_code_country="nl" id_tax="31"/>
+      <taxRule iso_code_country="at" id_tax="31"/>
+      <taxRule iso_code_country="pl" id_tax="31"/>
+      <taxRule iso_code_country="pt" id_tax="31"/>
+      <taxRule iso_code_country="ro" id_tax="31"/>
+      <taxRule iso_code_country="si" id_tax="31"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
+      <taxRule iso_code_country="fi" id_tax="31"/>
+      <taxRule iso_code_country="se" id_tax="31"/>
+      <taxRule iso_code_country="uk" id_tax="31"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="IT Reduced Rate (4%)">
       <taxRule iso_code_country="be" id_tax="3"/>
       <taxRule iso_code_country="bg" id_tax="3"/>
       <taxRule iso_code_country="cz" id_tax="3"/>
@@ -124,63 +155,34 @@
       <taxRule iso_code_country="se" id_tax="3"/>
       <taxRule iso_code_country="uk" id_tax="3"/>
     </taxRulesGroup>
-    <taxRulesGroup name="IT Foodstuff Rate (4%)">
-      <taxRule iso_code_country="be" id_tax="3"/>
-      <taxRule iso_code_country="bg" id_tax="3"/>
-      <taxRule iso_code_country="cz" id_tax="3"/>
-      <taxRule iso_code_country="dk" id_tax="3"/>
-      <taxRule iso_code_country="de" id_tax="3"/>
-      <taxRule iso_code_country="ee" id_tax="3"/>
-      <taxRule iso_code_country="gr" id_tax="3"/>
-      <taxRule iso_code_country="es" id_tax="3"/>
-      <taxRule iso_code_country="fr" id_tax="3"/>
-      <taxRule iso_code_country="ie" id_tax="3"/>
-      <taxRule iso_code_country="it" id_tax="3"/>
-      <taxRule iso_code_country="cy" id_tax="3"/>
-      <taxRule iso_code_country="lv" id_tax="3"/>
-      <taxRule iso_code_country="lt" id_tax="3"/>
-      <taxRule iso_code_country="lu" id_tax="3"/>
-      <taxRule iso_code_country="hu" id_tax="3"/>
-      <taxRule iso_code_country="mt" id_tax="3"/>
-      <taxRule iso_code_country="nl" id_tax="3"/>
-      <taxRule iso_code_country="at" id_tax="3"/>
-      <taxRule iso_code_country="pl" id_tax="3"/>
-      <taxRule iso_code_country="pt" id_tax="3"/>
-      <taxRule iso_code_country="ro" id_tax="3"/>
-      <taxRule iso_code_country="si" id_tax="3"/>
-      <taxRule iso_code_country="sk" id_tax="3"/>
-      <taxRule iso_code_country="fi" id_tax="3"/>
-      <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="IT Books Rate (4%)">
-      <taxRule iso_code_country="be" id_tax="3"/>
-      <taxRule iso_code_country="bg" id_tax="3"/>
-      <taxRule iso_code_country="cz" id_tax="3"/>
-      <taxRule iso_code_country="dk" id_tax="3"/>
-      <taxRule iso_code_country="de" id_tax="3"/>
-      <taxRule iso_code_country="ee" id_tax="3"/>
-      <taxRule iso_code_country="gr" id_tax="3"/>
-      <taxRule iso_code_country="es" id_tax="3"/>
-      <taxRule iso_code_country="fr" id_tax="3"/>
-      <taxRule iso_code_country="ie" id_tax="3"/>
-      <taxRule iso_code_country="it" id_tax="3"/>
-      <taxRule iso_code_country="cy" id_tax="3"/>
-      <taxRule iso_code_country="lv" id_tax="3"/>
-      <taxRule iso_code_country="lt" id_tax="3"/>
-      <taxRule iso_code_country="lu" id_tax="3"/>
-      <taxRule iso_code_country="hu" id_tax="3"/>
-      <taxRule iso_code_country="mt" id_tax="3"/>
-      <taxRule iso_code_country="nl" id_tax="3"/>
-      <taxRule iso_code_country="at" id_tax="3"/>
-      <taxRule iso_code_country="pl" id_tax="3"/>
-      <taxRule iso_code_country="pt" id_tax="3"/>
-      <taxRule iso_code_country="ro" id_tax="3"/>
-      <taxRule iso_code_country="si" id_tax="3"/>
-      <taxRule iso_code_country="sk" id_tax="3"/>
-      <taxRule iso_code_country="fi" id_tax="3"/>
-      <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+    <taxRulesGroup name="IT Zero Rate (0%)">
+      <taxRule iso_code_country="be" id_tax="32"/>
+      <taxRule iso_code_country="bg" id_tax="32"/>
+      <taxRule iso_code_country="cz" id_tax="32"/>
+      <taxRule iso_code_country="dk" id_tax="32"/>
+      <taxRule iso_code_country="de" id_tax="32"/>
+      <taxRule iso_code_country="ee" id_tax="32"/>
+      <taxRule iso_code_country="gr" id_tax="32"/>
+      <taxRule iso_code_country="es" id_tax="32"/>
+      <taxRule iso_code_country="fr" id_tax="32"/>
+      <taxRule iso_code_country="ie" id_tax="32"/>
+      <taxRule iso_code_country="it" id_tax="32"/>
+      <taxRule iso_code_country="cy" id_tax="32"/>
+      <taxRule iso_code_country="lv" id_tax="32"/>
+      <taxRule iso_code_country="lt" id_tax="32"/>
+      <taxRule iso_code_country="lu" id_tax="32"/>
+      <taxRule iso_code_country="hu" id_tax="32"/>
+      <taxRule iso_code_country="mt" id_tax="32"/>
+      <taxRule iso_code_country="nl" id_tax="32"/>
+      <taxRule iso_code_country="at" id_tax="32"/>
+      <taxRule iso_code_country="pl" id_tax="32"/>
+      <taxRule iso_code_country="pt" id_tax="32"/>
+      <taxRule iso_code_country="ro" id_tax="32"/>
+      <taxRule iso_code_country="si" id_tax="32"/>
+      <taxRule iso_code_country="sk" id_tax="32"/>
+      <taxRule iso_code_country="fi" id_tax="32"/>
+      <taxRule iso_code_country="se" id_tax="32"/>
+      <taxRule iso_code_country="uk" id_tax="32"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="it" id_tax="1"/>

--- a/localization/lt.xml
+++ b/localization/lt.xml
@@ -1,223 +1,223 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <localizationPack name="Lithuania" version="1.0">
-	<currencies>
-		<currency name="Euro" iso_code="EUR" iso_code_num="978" sign="€" blank="1" conversion_rate="1.00" format="2" decimals="1"/>
-	</currencies>
-	<languages>
-		<language iso_code="lt"/>
-	</languages>
-	<taxes>
-		<tax id="1" name="PVM LT 21%" rate="21" eu-tax-group="virtual"/>
-		<tax id="2" name="PVM LT 9%" rate="9"/>
-		<tax id="3" name="PVM LT 5%" rate="5"/>
-		<tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="7" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="8" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="9" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="10" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="11" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="12" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="13" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="14" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="15" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="16" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="17" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="18" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="19" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="20" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="21" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="22" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="23" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="27" name="TVA RO 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-		<tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-		<taxRulesGroup name="LT Standard Rate (21%)">
-			<taxRule iso_code_country="be" id_tax="1"/>
-			<taxRule iso_code_country="bg" id_tax="1"/>
-			<taxRule iso_code_country="cz" id_tax="1"/>
-			<taxRule iso_code_country="dk" id_tax="1"/>
-			<taxRule iso_code_country="de" id_tax="1"/>
-			<taxRule iso_code_country="ee" id_tax="1"/>
-			<taxRule iso_code_country="gr" id_tax="1"/>
-			<taxRule iso_code_country="es" id_tax="1"/>
-			<taxRule iso_code_country="fr" id_tax="1"/>
-			<taxRule iso_code_country="ie" id_tax="1"/>
-			<taxRule iso_code_country="it" id_tax="1"/>
-			<taxRule iso_code_country="cy" id_tax="1"/>
-			<taxRule iso_code_country="lv" id_tax="1"/>
-			<taxRule iso_code_country="lt" id_tax="1"/>
-			<taxRule iso_code_country="lu" id_tax="1"/>
-			<taxRule iso_code_country="hu" id_tax="1"/>
-			<taxRule iso_code_country="mt" id_tax="1"/>
-			<taxRule iso_code_country="nl" id_tax="1"/>
-			<taxRule iso_code_country="at" id_tax="1"/>
-			<taxRule iso_code_country="pl" id_tax="1"/>
-			<taxRule iso_code_country="pt" id_tax="1"/>
-			<taxRule iso_code_country="ro" id_tax="1"/>
-			<taxRule iso_code_country="si" id_tax="1"/>
-			<taxRule iso_code_country="sk" id_tax="1"/>
-			<taxRule iso_code_country="fi" id_tax="1"/>
-			<taxRule iso_code_country="se" id_tax="1"/>
-			<taxRule iso_code_country="uk" id_tax="1"/>
-		</taxRulesGroup>
-		<taxRulesGroup name="LT Reduced Rate (9%)">
-			<taxRule iso_code_country="be" id_tax="2"/>
-			<taxRule iso_code_country="bg" id_tax="2"/>
-			<taxRule iso_code_country="cz" id_tax="2"/>
-			<taxRule iso_code_country="dk" id_tax="2"/>
-			<taxRule iso_code_country="de" id_tax="2"/>
-			<taxRule iso_code_country="ee" id_tax="2"/>
-			<taxRule iso_code_country="gr" id_tax="2"/>
-			<taxRule iso_code_country="es" id_tax="2"/>
-			<taxRule iso_code_country="fr" id_tax="2"/>
-			<taxRule iso_code_country="ie" id_tax="2"/>
-			<taxRule iso_code_country="it" id_tax="2"/>
-			<taxRule iso_code_country="cy" id_tax="2"/>
-			<taxRule iso_code_country="lv" id_tax="2"/>
-			<taxRule iso_code_country="lt" id_tax="2"/>
-			<taxRule iso_code_country="lu" id_tax="2"/>
-			<taxRule iso_code_country="hu" id_tax="2"/>
-			<taxRule iso_code_country="mt" id_tax="2"/>
-			<taxRule iso_code_country="nl" id_tax="2"/>
-			<taxRule iso_code_country="at" id_tax="2"/>
-			<taxRule iso_code_country="pl" id_tax="2"/>
-			<taxRule iso_code_country="pt" id_tax="2"/>
-			<taxRule iso_code_country="ro" id_tax="2"/>
-			<taxRule iso_code_country="si" id_tax="2"/>
-			<taxRule iso_code_country="sk" id_tax="2"/>
-			<taxRule iso_code_country="fi" id_tax="2"/>
-			<taxRule iso_code_country="se" id_tax="2"/>
-			<taxRule iso_code_country="uk" id_tax="2"/>
-		</taxRulesGroup>
-		<taxRulesGroup name="LT Super Reduced Rate (5%)">
-			<taxRule iso_code_country="be" id_tax="3"/>
-			<taxRule iso_code_country="bg" id_tax="3"/>
-			<taxRule iso_code_country="cz" id_tax="3"/>
-			<taxRule iso_code_country="dk" id_tax="3"/>
-			<taxRule iso_code_country="de" id_tax="3"/>
-			<taxRule iso_code_country="ee" id_tax="3"/>
-			<taxRule iso_code_country="gr" id_tax="3"/>
-			<taxRule iso_code_country="es" id_tax="3"/>
-			<taxRule iso_code_country="fr" id_tax="3"/>
-			<taxRule iso_code_country="ie" id_tax="3"/>
-			<taxRule iso_code_country="it" id_tax="3"/>
-			<taxRule iso_code_country="cy" id_tax="3"/>
-			<taxRule iso_code_country="lv" id_tax="3"/>
-			<taxRule iso_code_country="lt" id_tax="3"/>
-			<taxRule iso_code_country="lu" id_tax="3"/>
-			<taxRule iso_code_country="hu" id_tax="3"/>
-			<taxRule iso_code_country="mt" id_tax="3"/>
-			<taxRule iso_code_country="nl" id_tax="3"/>
-			<taxRule iso_code_country="at" id_tax="3"/>
-			<taxRule iso_code_country="pl" id_tax="3"/>
-			<taxRule iso_code_country="pt" id_tax="3"/>
-			<taxRule iso_code_country="ro" id_tax="3"/>
-			<taxRule iso_code_country="si" id_tax="3"/>
-			<taxRule iso_code_country="sk" id_tax="3"/>
-			<taxRule iso_code_country="fi" id_tax="3"/>
-			<taxRule iso_code_country="se" id_tax="3"/>
-			<taxRule iso_code_country="uk" id_tax="3"/>
-		</taxRulesGroup>
-		<taxRulesGroup name="LT Foodstuff Rate (21%)">
-			<taxRule iso_code_country="be" id_tax="1"/>
-			<taxRule iso_code_country="bg" id_tax="1"/>
-			<taxRule iso_code_country="cz" id_tax="1"/>
-			<taxRule iso_code_country="dk" id_tax="1"/>
-			<taxRule iso_code_country="de" id_tax="1"/>
-			<taxRule iso_code_country="ee" id_tax="1"/>
-			<taxRule iso_code_country="gr" id_tax="1"/>
-			<taxRule iso_code_country="es" id_tax="1"/>
-			<taxRule iso_code_country="fr" id_tax="1"/>
-			<taxRule iso_code_country="ie" id_tax="1"/>
-			<taxRule iso_code_country="it" id_tax="1"/>
-			<taxRule iso_code_country="cy" id_tax="1"/>
-			<taxRule iso_code_country="lv" id_tax="1"/>
-			<taxRule iso_code_country="lt" id_tax="1"/>
-			<taxRule iso_code_country="lu" id_tax="1"/>
-			<taxRule iso_code_country="hu" id_tax="1"/>
-			<taxRule iso_code_country="mt" id_tax="1"/>
-			<taxRule iso_code_country="nl" id_tax="1"/>
-			<taxRule iso_code_country="at" id_tax="1"/>
-			<taxRule iso_code_country="pl" id_tax="1"/>
-			<taxRule iso_code_country="pt" id_tax="1"/>
-			<taxRule iso_code_country="ro" id_tax="1"/>
-			<taxRule iso_code_country="si" id_tax="1"/>
-			<taxRule iso_code_country="sk" id_tax="1"/>
-			<taxRule iso_code_country="fi" id_tax="1"/>
-			<taxRule iso_code_country="se" id_tax="1"/>
-			<taxRule iso_code_country="uk" id_tax="1"/>
-		</taxRulesGroup>
-		<taxRulesGroup name="LT Books Rate (9%)">
-			<taxRule iso_code_country="be" id_tax="2"/>
-			<taxRule iso_code_country="bg" id_tax="2"/>
-			<taxRule iso_code_country="cz" id_tax="2"/>
-			<taxRule iso_code_country="dk" id_tax="2"/>
-			<taxRule iso_code_country="de" id_tax="2"/>
-			<taxRule iso_code_country="ee" id_tax="2"/>
-			<taxRule iso_code_country="gr" id_tax="2"/>
-			<taxRule iso_code_country="es" id_tax="2"/>
-			<taxRule iso_code_country="fr" id_tax="2"/>
-			<taxRule iso_code_country="ie" id_tax="2"/>
-			<taxRule iso_code_country="it" id_tax="2"/>
-			<taxRule iso_code_country="cy" id_tax="2"/>
-			<taxRule iso_code_country="lv" id_tax="2"/>
-			<taxRule iso_code_country="lt" id_tax="2"/>
-			<taxRule iso_code_country="lu" id_tax="2"/>
-			<taxRule iso_code_country="hu" id_tax="2"/>
-			<taxRule iso_code_country="mt" id_tax="2"/>
-			<taxRule iso_code_country="nl" id_tax="2"/>
-			<taxRule iso_code_country="at" id_tax="2"/>
-			<taxRule iso_code_country="pl" id_tax="2"/>
-			<taxRule iso_code_country="pt" id_tax="2"/>
-			<taxRule iso_code_country="ro" id_tax="2"/>
-			<taxRule iso_code_country="si" id_tax="2"/>
-			<taxRule iso_code_country="sk" id_tax="2"/>
-			<taxRule iso_code_country="fi" id_tax="2"/>
-			<taxRule iso_code_country="se" id_tax="2"/>
-			<taxRule iso_code_country="uk" id_tax="2"/>
-		</taxRulesGroup>
-		<taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
-			<taxRule iso_code_country="lt" id_tax="1"/>
-			<taxRule iso_code_country="at" id_tax="4"/>
-			<taxRule iso_code_country="be" id_tax="5"/>
-			<taxRule iso_code_country="bg" id_tax="6"/>
-			<taxRule iso_code_country="cy" id_tax="7"/>
-			<taxRule iso_code_country="cz" id_tax="8"/>
-			<taxRule iso_code_country="de" id_tax="9"/>
-			<taxRule iso_code_country="dk" id_tax="10"/>
-			<taxRule iso_code_country="ee" id_tax="11"/>
-			<taxRule iso_code_country="es" id_tax="12"/>
-			<taxRule iso_code_country="fi" id_tax="13"/>
-			<taxRule iso_code_country="fr" id_tax="14"/>
-			<taxRule iso_code_country="gb" id_tax="15"/>
-			<taxRule iso_code_country="gr" id_tax="16"/>
-			<taxRule iso_code_country="hr" id_tax="17"/>
-			<taxRule iso_code_country="hu" id_tax="18"/>
-			<taxRule iso_code_country="ie" id_tax="19"/>
-			<taxRule iso_code_country="it" id_tax="20"/>
-			<taxRule iso_code_country="lu" id_tax="21"/>
-			<taxRule iso_code_country="lv" id_tax="22"/>
-			<taxRule iso_code_country="mt" id_tax="23"/>
-			<taxRule iso_code_country="nl" id_tax="24"/>
-			<taxRule iso_code_country="pl" id_tax="25"/>
-			<taxRule iso_code_country="pt" id_tax="26"/>
-			<taxRule iso_code_country="ro" id_tax="27"/>
-			<taxRule iso_code_country="se" id_tax="28"/>
-			<taxRule iso_code_country="si" id_tax="29"/>
-			<taxRule iso_code_country="sk" id_tax="30"/>
-		</taxRulesGroup>
-	</taxes>
-	<units>
-		<unit type="weight" value="kg"/>
-		<unit type="volume" value="L"/>
-		<unit type="short_distance" value="cm"/>
-		<unit type="base_distance" value="m"/>
-		<unit type="long_distance" value="km"/>
-	</units>
+  <currencies>
+    <currency name="Euro" iso_code="EUR" iso_code_num="978" sign="€" blank="1" conversion_rate="1.00" format="2" decimals="1"/>
+  </currencies>
+  <languages>
+    <language iso_code="lt"/>
+  </languages>
+  <taxes>
+    <tax id="1" name="PVM LT 21%" rate="21" eu-tax-group="virtual"/>
+    <tax id="2" name="PVM LT 9%" rate="9"/>
+    <tax id="3" name="PVM LT 5%" rate="5"/>
+    <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <taxRulesGroup name="LT Standard Rate (21%)">
+      <taxRule iso_code_country="be" id_tax="1"/>
+      <taxRule iso_code_country="bg" id_tax="1"/>
+      <taxRule iso_code_country="cz" id_tax="1"/>
+      <taxRule iso_code_country="dk" id_tax="1"/>
+      <taxRule iso_code_country="de" id_tax="1"/>
+      <taxRule iso_code_country="ee" id_tax="1"/>
+      <taxRule iso_code_country="gr" id_tax="1"/>
+      <taxRule iso_code_country="es" id_tax="1"/>
+      <taxRule iso_code_country="fr" id_tax="1"/>
+      <taxRule iso_code_country="ie" id_tax="1"/>
+      <taxRule iso_code_country="it" id_tax="1"/>
+      <taxRule iso_code_country="cy" id_tax="1"/>
+      <taxRule iso_code_country="lv" id_tax="1"/>
+      <taxRule iso_code_country="lt" id_tax="1"/>
+      <taxRule iso_code_country="lu" id_tax="1"/>
+      <taxRule iso_code_country="hu" id_tax="1"/>
+      <taxRule iso_code_country="mt" id_tax="1"/>
+      <taxRule iso_code_country="nl" id_tax="1"/>
+      <taxRule iso_code_country="at" id_tax="1"/>
+      <taxRule iso_code_country="pl" id_tax="1"/>
+      <taxRule iso_code_country="pt" id_tax="1"/>
+      <taxRule iso_code_country="ro" id_tax="1"/>
+      <taxRule iso_code_country="si" id_tax="1"/>
+      <taxRule iso_code_country="sk" id_tax="1"/>
+      <taxRule iso_code_country="fi" id_tax="1"/>
+      <taxRule iso_code_country="se" id_tax="1"/>
+      <taxRule iso_code_country="uk" id_tax="1"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="LT Reduced Rate (9%)">
+      <taxRule iso_code_country="be" id_tax="2"/>
+      <taxRule iso_code_country="bg" id_tax="2"/>
+      <taxRule iso_code_country="cz" id_tax="2"/>
+      <taxRule iso_code_country="dk" id_tax="2"/>
+      <taxRule iso_code_country="de" id_tax="2"/>
+      <taxRule iso_code_country="ee" id_tax="2"/>
+      <taxRule iso_code_country="gr" id_tax="2"/>
+      <taxRule iso_code_country="es" id_tax="2"/>
+      <taxRule iso_code_country="fr" id_tax="2"/>
+      <taxRule iso_code_country="ie" id_tax="2"/>
+      <taxRule iso_code_country="it" id_tax="2"/>
+      <taxRule iso_code_country="cy" id_tax="2"/>
+      <taxRule iso_code_country="lv" id_tax="2"/>
+      <taxRule iso_code_country="lt" id_tax="2"/>
+      <taxRule iso_code_country="lu" id_tax="2"/>
+      <taxRule iso_code_country="hu" id_tax="2"/>
+      <taxRule iso_code_country="mt" id_tax="2"/>
+      <taxRule iso_code_country="nl" id_tax="2"/>
+      <taxRule iso_code_country="at" id_tax="2"/>
+      <taxRule iso_code_country="pl" id_tax="2"/>
+      <taxRule iso_code_country="pt" id_tax="2"/>
+      <taxRule iso_code_country="ro" id_tax="2"/>
+      <taxRule iso_code_country="si" id_tax="2"/>
+      <taxRule iso_code_country="sk" id_tax="2"/>
+      <taxRule iso_code_country="fi" id_tax="2"/>
+      <taxRule iso_code_country="se" id_tax="2"/>
+      <taxRule iso_code_country="uk" id_tax="2"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="LT Super Reduced Rate (5%)">
+      <taxRule iso_code_country="be" id_tax="3"/>
+      <taxRule iso_code_country="bg" id_tax="3"/>
+      <taxRule iso_code_country="cz" id_tax="3"/>
+      <taxRule iso_code_country="dk" id_tax="3"/>
+      <taxRule iso_code_country="de" id_tax="3"/>
+      <taxRule iso_code_country="ee" id_tax="3"/>
+      <taxRule iso_code_country="gr" id_tax="3"/>
+      <taxRule iso_code_country="es" id_tax="3"/>
+      <taxRule iso_code_country="fr" id_tax="3"/>
+      <taxRule iso_code_country="ie" id_tax="3"/>
+      <taxRule iso_code_country="it" id_tax="3"/>
+      <taxRule iso_code_country="cy" id_tax="3"/>
+      <taxRule iso_code_country="lv" id_tax="3"/>
+      <taxRule iso_code_country="lt" id_tax="3"/>
+      <taxRule iso_code_country="lu" id_tax="3"/>
+      <taxRule iso_code_country="hu" id_tax="3"/>
+      <taxRule iso_code_country="mt" id_tax="3"/>
+      <taxRule iso_code_country="nl" id_tax="3"/>
+      <taxRule iso_code_country="at" id_tax="3"/>
+      <taxRule iso_code_country="pl" id_tax="3"/>
+      <taxRule iso_code_country="pt" id_tax="3"/>
+      <taxRule iso_code_country="ro" id_tax="3"/>
+      <taxRule iso_code_country="si" id_tax="3"/>
+      <taxRule iso_code_country="sk" id_tax="3"/>
+      <taxRule iso_code_country="fi" id_tax="3"/>
+      <taxRule iso_code_country="se" id_tax="3"/>
+      <taxRule iso_code_country="uk" id_tax="3"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="LT Foodstuff Rate (21%)">
+      <taxRule iso_code_country="be" id_tax="1"/>
+      <taxRule iso_code_country="bg" id_tax="1"/>
+      <taxRule iso_code_country="cz" id_tax="1"/>
+      <taxRule iso_code_country="dk" id_tax="1"/>
+      <taxRule iso_code_country="de" id_tax="1"/>
+      <taxRule iso_code_country="ee" id_tax="1"/>
+      <taxRule iso_code_country="gr" id_tax="1"/>
+      <taxRule iso_code_country="es" id_tax="1"/>
+      <taxRule iso_code_country="fr" id_tax="1"/>
+      <taxRule iso_code_country="ie" id_tax="1"/>
+      <taxRule iso_code_country="it" id_tax="1"/>
+      <taxRule iso_code_country="cy" id_tax="1"/>
+      <taxRule iso_code_country="lv" id_tax="1"/>
+      <taxRule iso_code_country="lt" id_tax="1"/>
+      <taxRule iso_code_country="lu" id_tax="1"/>
+      <taxRule iso_code_country="hu" id_tax="1"/>
+      <taxRule iso_code_country="mt" id_tax="1"/>
+      <taxRule iso_code_country="nl" id_tax="1"/>
+      <taxRule iso_code_country="at" id_tax="1"/>
+      <taxRule iso_code_country="pl" id_tax="1"/>
+      <taxRule iso_code_country="pt" id_tax="1"/>
+      <taxRule iso_code_country="ro" id_tax="1"/>
+      <taxRule iso_code_country="si" id_tax="1"/>
+      <taxRule iso_code_country="sk" id_tax="1"/>
+      <taxRule iso_code_country="fi" id_tax="1"/>
+      <taxRule iso_code_country="se" id_tax="1"/>
+      <taxRule iso_code_country="uk" id_tax="1"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="LT Books Rate (9%)">
+      <taxRule iso_code_country="be" id_tax="2"/>
+      <taxRule iso_code_country="bg" id_tax="2"/>
+      <taxRule iso_code_country="cz" id_tax="2"/>
+      <taxRule iso_code_country="dk" id_tax="2"/>
+      <taxRule iso_code_country="de" id_tax="2"/>
+      <taxRule iso_code_country="ee" id_tax="2"/>
+      <taxRule iso_code_country="gr" id_tax="2"/>
+      <taxRule iso_code_country="es" id_tax="2"/>
+      <taxRule iso_code_country="fr" id_tax="2"/>
+      <taxRule iso_code_country="ie" id_tax="2"/>
+      <taxRule iso_code_country="it" id_tax="2"/>
+      <taxRule iso_code_country="cy" id_tax="2"/>
+      <taxRule iso_code_country="lv" id_tax="2"/>
+      <taxRule iso_code_country="lt" id_tax="2"/>
+      <taxRule iso_code_country="lu" id_tax="2"/>
+      <taxRule iso_code_country="hu" id_tax="2"/>
+      <taxRule iso_code_country="mt" id_tax="2"/>
+      <taxRule iso_code_country="nl" id_tax="2"/>
+      <taxRule iso_code_country="at" id_tax="2"/>
+      <taxRule iso_code_country="pl" id_tax="2"/>
+      <taxRule iso_code_country="pt" id_tax="2"/>
+      <taxRule iso_code_country="ro" id_tax="2"/>
+      <taxRule iso_code_country="si" id_tax="2"/>
+      <taxRule iso_code_country="sk" id_tax="2"/>
+      <taxRule iso_code_country="fi" id_tax="2"/>
+      <taxRule iso_code_country="se" id_tax="2"/>
+      <taxRule iso_code_country="uk" id_tax="2"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
+      <taxRule iso_code_country="lt" id_tax="1"/>
+      <taxRule iso_code_country="at" id_tax="4"/>
+      <taxRule iso_code_country="be" id_tax="5"/>
+      <taxRule iso_code_country="bg" id_tax="6"/>
+      <taxRule iso_code_country="cy" id_tax="7"/>
+      <taxRule iso_code_country="cz" id_tax="8"/>
+      <taxRule iso_code_country="de" id_tax="9"/>
+      <taxRule iso_code_country="dk" id_tax="10"/>
+      <taxRule iso_code_country="ee" id_tax="11"/>
+      <taxRule iso_code_country="es" id_tax="12"/>
+      <taxRule iso_code_country="fi" id_tax="13"/>
+      <taxRule iso_code_country="fr" id_tax="14"/>
+      <taxRule iso_code_country="gb" id_tax="15"/>
+      <taxRule iso_code_country="gr" id_tax="16"/>
+      <taxRule iso_code_country="hr" id_tax="17"/>
+      <taxRule iso_code_country="hu" id_tax="18"/>
+      <taxRule iso_code_country="ie" id_tax="19"/>
+      <taxRule iso_code_country="it" id_tax="20"/>
+      <taxRule iso_code_country="lu" id_tax="21"/>
+      <taxRule iso_code_country="lv" id_tax="22"/>
+      <taxRule iso_code_country="mt" id_tax="23"/>
+      <taxRule iso_code_country="nl" id_tax="24"/>
+      <taxRule iso_code_country="pl" id_tax="25"/>
+      <taxRule iso_code_country="pt" id_tax="26"/>
+      <taxRule iso_code_country="ro" id_tax="27"/>
+      <taxRule iso_code_country="se" id_tax="28"/>
+      <taxRule iso_code_country="si" id_tax="29"/>
+      <taxRule iso_code_country="sk" id_tax="30"/>
+    </taxRulesGroup>
+  </taxes>
+  <units>
+    <unit type="weight" value="kg"/>
+    <unit type="volume" value="L"/>
+    <unit type="short_distance" value="cm"/>
+    <unit type="base_distance" value="m"/>
+    <unit type="long_distance" value="km"/>
+  </units>
 </localizationPack>

--- a/localization/lu.xml
+++ b/localization/lu.xml
@@ -24,7 +24,7 @@
     <tax id="15" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="19" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="20" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="21" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -35,7 +35,7 @@
     <tax id="26" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="27" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="31" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="32" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/lv.xml
+++ b/localization/lv.xml
@@ -9,6 +9,8 @@
   <taxes>
     <tax id="1" name="PVN LV 21%" rate="21" eu-tax-group="virtual"/>
     <tax id="2" name="PVN LV 12%" rate="12"/>
+    <tax id="30" name="PVN LV 5%" rate="5"/>
+    <tax id="31" name="PVN LV 0%" rate="0"/>
     <tax id="3" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="4" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -94,63 +96,63 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="LV Foodstuff Rate (21%)">
-      <taxRule iso_code_country="be" id_tax="1"/>
-      <taxRule iso_code_country="bg" id_tax="1"/>
-      <taxRule iso_code_country="cz" id_tax="1"/>
-      <taxRule iso_code_country="dk" id_tax="1"/>
-      <taxRule iso_code_country="de" id_tax="1"/>
-      <taxRule iso_code_country="ee" id_tax="1"/>
-      <taxRule iso_code_country="gr" id_tax="1"/>
-      <taxRule iso_code_country="es" id_tax="1"/>
-      <taxRule iso_code_country="fr" id_tax="1"/>
-      <taxRule iso_code_country="ie" id_tax="1"/>
-      <taxRule iso_code_country="it" id_tax="1"/>
-      <taxRule iso_code_country="cy" id_tax="1"/>
-      <taxRule iso_code_country="lv" id_tax="1"/>
-      <taxRule iso_code_country="lt" id_tax="1"/>
-      <taxRule iso_code_country="lu" id_tax="1"/>
-      <taxRule iso_code_country="hu" id_tax="1"/>
-      <taxRule iso_code_country="mt" id_tax="1"/>
-      <taxRule iso_code_country="nl" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="1"/>
-      <taxRule iso_code_country="pl" id_tax="1"/>
-      <taxRule iso_code_country="pt" id_tax="1"/>
-      <taxRule iso_code_country="ro" id_tax="1"/>
-      <taxRule iso_code_country="si" id_tax="1"/>
-      <taxRule iso_code_country="sk" id_tax="1"/>
-      <taxRule iso_code_country="fi" id_tax="1"/>
-      <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
+    <taxRulesGroup name="LV Reduced Rate (5%)">
+      <taxRule iso_code_country="be" id_tax="30"/>
+      <taxRule iso_code_country="bg" id_tax="30"/>
+      <taxRule iso_code_country="cz" id_tax="30"/>
+      <taxRule iso_code_country="dk" id_tax="30"/>
+      <taxRule iso_code_country="de" id_tax="30"/>
+      <taxRule iso_code_country="ee" id_tax="30"/>
+      <taxRule iso_code_country="gr" id_tax="30"/>
+      <taxRule iso_code_country="es" id_tax="30"/>
+      <taxRule iso_code_country="fr" id_tax="30"/>
+      <taxRule iso_code_country="ie" id_tax="30"/>
+      <taxRule iso_code_country="it" id_tax="30"/>
+      <taxRule iso_code_country="cy" id_tax="30"/>
+      <taxRule iso_code_country="lv" id_tax="30"/>
+      <taxRule iso_code_country="lt" id_tax="30"/>
+      <taxRule iso_code_country="lu" id_tax="30"/>
+      <taxRule iso_code_country="hu" id_tax="30"/>
+      <taxRule iso_code_country="mt" id_tax="30"/>
+      <taxRule iso_code_country="nl" id_tax="30"/>
+      <taxRule iso_code_country="at" id_tax="30"/>
+      <taxRule iso_code_country="pl" id_tax="30"/>
+      <taxRule iso_code_country="pt" id_tax="30"/>
+      <taxRule iso_code_country="ro" id_tax="30"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="30"/>
+      <taxRule iso_code_country="fi" id_tax="30"/>
+      <taxRule iso_code_country="se" id_tax="30"/>
+      <taxRule iso_code_country="uk" id_tax="30"/>
     </taxRulesGroup>
-    <taxRulesGroup name="LV Books Rate (12%)">
-      <taxRule iso_code_country="be" id_tax="2"/>
-      <taxRule iso_code_country="bg" id_tax="2"/>
-      <taxRule iso_code_country="cz" id_tax="2"/>
-      <taxRule iso_code_country="dk" id_tax="2"/>
-      <taxRule iso_code_country="de" id_tax="2"/>
-      <taxRule iso_code_country="ee" id_tax="2"/>
-      <taxRule iso_code_country="gr" id_tax="2"/>
-      <taxRule iso_code_country="es" id_tax="2"/>
-      <taxRule iso_code_country="fr" id_tax="2"/>
-      <taxRule iso_code_country="ie" id_tax="2"/>
-      <taxRule iso_code_country="it" id_tax="2"/>
-      <taxRule iso_code_country="cy" id_tax="2"/>
-      <taxRule iso_code_country="lv" id_tax="2"/>
-      <taxRule iso_code_country="lt" id_tax="2"/>
-      <taxRule iso_code_country="lu" id_tax="2"/>
-      <taxRule iso_code_country="hu" id_tax="2"/>
-      <taxRule iso_code_country="mt" id_tax="2"/>
-      <taxRule iso_code_country="nl" id_tax="2"/>
-      <taxRule iso_code_country="at" id_tax="2"/>
-      <taxRule iso_code_country="pl" id_tax="2"/>
-      <taxRule iso_code_country="pt" id_tax="2"/>
-      <taxRule iso_code_country="ro" id_tax="2"/>
-      <taxRule iso_code_country="si" id_tax="2"/>
-      <taxRule iso_code_country="sk" id_tax="2"/>
-      <taxRule iso_code_country="fi" id_tax="2"/>
-      <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+    <taxRulesGroup name="LV Zero Rate (0%)">
+      <taxRule iso_code_country="be" id_tax="31"/>
+      <taxRule iso_code_country="bg" id_tax="31"/>
+      <taxRule iso_code_country="cz" id_tax="31"/>
+      <taxRule iso_code_country="dk" id_tax="31"/>
+      <taxRule iso_code_country="de" id_tax="31"/>
+      <taxRule iso_code_country="ee" id_tax="31"/>
+      <taxRule iso_code_country="gr" id_tax="31"/>
+      <taxRule iso_code_country="es" id_tax="31"/>
+      <taxRule iso_code_country="fr" id_tax="31"/>
+      <taxRule iso_code_country="ie" id_tax="31"/>
+      <taxRule iso_code_country="it" id_tax="31"/>
+      <taxRule iso_code_country="cy" id_tax="31"/>
+      <taxRule iso_code_country="lv" id_tax="31"/>
+      <taxRule iso_code_country="lt" id_tax="31"/>
+      <taxRule iso_code_country="lu" id_tax="31"/>
+      <taxRule iso_code_country="hu" id_tax="31"/>
+      <taxRule iso_code_country="mt" id_tax="31"/>
+      <taxRule iso_code_country="nl" id_tax="31"/>
+      <taxRule iso_code_country="at" id_tax="31"/>
+      <taxRule iso_code_country="pl" id_tax="31"/>
+      <taxRule iso_code_country="pt" id_tax="31"/>
+      <taxRule iso_code_country="ro" id_tax="31"/>
+      <taxRule iso_code_country="si" id_tax="31"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
+      <taxRule iso_code_country="fi" id_tax="31"/>
+      <taxRule iso_code_country="se" id_tax="31"/>
+      <taxRule iso_code_country="uk" id_tax="31"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="lv" id_tax="1"/>

--- a/localization/lv.xml
+++ b/localization/lv.xml
@@ -9,35 +9,35 @@
   <taxes>
     <tax id="1" name="PVN LV 21%" rate="21" eu-tax-group="virtual"/>
     <tax id="2" name="PVN LV 12%" rate="12"/>
-    <tax id="30" name="PVN LV 5%" rate="5"/>
-    <tax id="31" name="PVN LV 0%" rate="0"/>
-    <tax id="3" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="4" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="5" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="6" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="7" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="8" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="9" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="10" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="11" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="20" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="21" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="22" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="23" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="24" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="3" name="PVN LV 5%" rate="5"/>
+    <tax id="4" name="PVN LV 0%" rate="0"/>
+    <tax id="5" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="31" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="LV Standard Rate (21%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
@@ -97,92 +97,92 @@
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="LV Reduced Rate (5%)">
-      <taxRule iso_code_country="be" id_tax="30"/>
-      <taxRule iso_code_country="bg" id_tax="30"/>
-      <taxRule iso_code_country="cz" id_tax="30"/>
-      <taxRule iso_code_country="dk" id_tax="30"/>
-      <taxRule iso_code_country="de" id_tax="30"/>
-      <taxRule iso_code_country="ee" id_tax="30"/>
-      <taxRule iso_code_country="gr" id_tax="30"/>
-      <taxRule iso_code_country="es" id_tax="30"/>
-      <taxRule iso_code_country="fr" id_tax="30"/>
-      <taxRule iso_code_country="ie" id_tax="30"/>
-      <taxRule iso_code_country="it" id_tax="30"/>
-      <taxRule iso_code_country="cy" id_tax="30"/>
-      <taxRule iso_code_country="lv" id_tax="30"/>
-      <taxRule iso_code_country="lt" id_tax="30"/>
-      <taxRule iso_code_country="lu" id_tax="30"/>
-      <taxRule iso_code_country="hu" id_tax="30"/>
-      <taxRule iso_code_country="mt" id_tax="30"/>
-      <taxRule iso_code_country="nl" id_tax="30"/>
-      <taxRule iso_code_country="at" id_tax="30"/>
-      <taxRule iso_code_country="pl" id_tax="30"/>
-      <taxRule iso_code_country="pt" id_tax="30"/>
-      <taxRule iso_code_country="ro" id_tax="30"/>
-      <taxRule iso_code_country="si" id_tax="30"/>
-      <taxRule iso_code_country="sk" id_tax="30"/>
-      <taxRule iso_code_country="fi" id_tax="30"/>
-      <taxRule iso_code_country="se" id_tax="30"/>
-      <taxRule iso_code_country="uk" id_tax="30"/>
+      <taxRule iso_code_country="be" id_tax="3"/>
+      <taxRule iso_code_country="bg" id_tax="3"/>
+      <taxRule iso_code_country="cz" id_tax="3"/>
+      <taxRule iso_code_country="dk" id_tax="3"/>
+      <taxRule iso_code_country="de" id_tax="3"/>
+      <taxRule iso_code_country="ee" id_tax="3"/>
+      <taxRule iso_code_country="gr" id_tax="3"/>
+      <taxRule iso_code_country="es" id_tax="3"/>
+      <taxRule iso_code_country="fr" id_tax="3"/>
+      <taxRule iso_code_country="ie" id_tax="3"/>
+      <taxRule iso_code_country="it" id_tax="3"/>
+      <taxRule iso_code_country="cy" id_tax="3"/>
+      <taxRule iso_code_country="lv" id_tax="3"/>
+      <taxRule iso_code_country="lt" id_tax="3"/>
+      <taxRule iso_code_country="lu" id_tax="3"/>
+      <taxRule iso_code_country="hu" id_tax="3"/>
+      <taxRule iso_code_country="mt" id_tax="3"/>
+      <taxRule iso_code_country="nl" id_tax="3"/>
+      <taxRule iso_code_country="at" id_tax="3"/>
+      <taxRule iso_code_country="pl" id_tax="3"/>
+      <taxRule iso_code_country="pt" id_tax="3"/>
+      <taxRule iso_code_country="ro" id_tax="3"/>
+      <taxRule iso_code_country="si" id_tax="3"/>
+      <taxRule iso_code_country="sk" id_tax="3"/>
+      <taxRule iso_code_country="fi" id_tax="3"/>
+      <taxRule iso_code_country="se" id_tax="3"/>
+      <taxRule iso_code_country="uk" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="LV Zero Rate (0%)">
-      <taxRule iso_code_country="be" id_tax="31"/>
-      <taxRule iso_code_country="bg" id_tax="31"/>
-      <taxRule iso_code_country="cz" id_tax="31"/>
-      <taxRule iso_code_country="dk" id_tax="31"/>
-      <taxRule iso_code_country="de" id_tax="31"/>
-      <taxRule iso_code_country="ee" id_tax="31"/>
-      <taxRule iso_code_country="gr" id_tax="31"/>
-      <taxRule iso_code_country="es" id_tax="31"/>
-      <taxRule iso_code_country="fr" id_tax="31"/>
-      <taxRule iso_code_country="ie" id_tax="31"/>
-      <taxRule iso_code_country="it" id_tax="31"/>
-      <taxRule iso_code_country="cy" id_tax="31"/>
-      <taxRule iso_code_country="lv" id_tax="31"/>
-      <taxRule iso_code_country="lt" id_tax="31"/>
-      <taxRule iso_code_country="lu" id_tax="31"/>
-      <taxRule iso_code_country="hu" id_tax="31"/>
-      <taxRule iso_code_country="mt" id_tax="31"/>
-      <taxRule iso_code_country="nl" id_tax="31"/>
-      <taxRule iso_code_country="at" id_tax="31"/>
-      <taxRule iso_code_country="pl" id_tax="31"/>
-      <taxRule iso_code_country="pt" id_tax="31"/>
-      <taxRule iso_code_country="ro" id_tax="31"/>
-      <taxRule iso_code_country="si" id_tax="31"/>
-      <taxRule iso_code_country="sk" id_tax="31"/>
-      <taxRule iso_code_country="fi" id_tax="31"/>
-      <taxRule iso_code_country="se" id_tax="31"/>
-      <taxRule iso_code_country="uk" id_tax="31"/>
+      <taxRule iso_code_country="be" id_tax="4"/>
+      <taxRule iso_code_country="bg" id_tax="4"/>
+      <taxRule iso_code_country="cz" id_tax="4"/>
+      <taxRule iso_code_country="dk" id_tax="4"/>
+      <taxRule iso_code_country="de" id_tax="4"/>
+      <taxRule iso_code_country="ee" id_tax="4"/>
+      <taxRule iso_code_country="gr" id_tax="4"/>
+      <taxRule iso_code_country="es" id_tax="4"/>
+      <taxRule iso_code_country="fr" id_tax="4"/>
+      <taxRule iso_code_country="ie" id_tax="4"/>
+      <taxRule iso_code_country="it" id_tax="4"/>
+      <taxRule iso_code_country="cy" id_tax="4"/>
+      <taxRule iso_code_country="lv" id_tax="4"/>
+      <taxRule iso_code_country="lt" id_tax="4"/>
+      <taxRule iso_code_country="lu" id_tax="4"/>
+      <taxRule iso_code_country="hu" id_tax="4"/>
+      <taxRule iso_code_country="mt" id_tax="4"/>
+      <taxRule iso_code_country="nl" id_tax="4"/>
+      <taxRule iso_code_country="at" id_tax="4"/>
+      <taxRule iso_code_country="pl" id_tax="4"/>
+      <taxRule iso_code_country="pt" id_tax="4"/>
+      <taxRule iso_code_country="ro" id_tax="4"/>
+      <taxRule iso_code_country="si" id_tax="4"/>
+      <taxRule iso_code_country="sk" id_tax="4"/>
+      <taxRule iso_code_country="fi" id_tax="4"/>
+      <taxRule iso_code_country="se" id_tax="4"/>
+      <taxRule iso_code_country="uk" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="lv" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="3"/>
-      <taxRule iso_code_country="be" id_tax="4"/>
-      <taxRule iso_code_country="bg" id_tax="5"/>
-      <taxRule iso_code_country="cy" id_tax="6"/>
-      <taxRule iso_code_country="cz" id_tax="7"/>
-      <taxRule iso_code_country="de" id_tax="8"/>
-      <taxRule iso_code_country="dk" id_tax="9"/>
-      <taxRule iso_code_country="ee" id_tax="10"/>
-      <taxRule iso_code_country="es" id_tax="11"/>
-      <taxRule iso_code_country="fi" id_tax="12"/>
-      <taxRule iso_code_country="fr" id_tax="13"/>
-      <taxRule iso_code_country="gb" id_tax="14"/>
-      <taxRule iso_code_country="gr" id_tax="15"/>
-      <taxRule iso_code_country="hr" id_tax="16"/>
-      <taxRule iso_code_country="hu" id_tax="17"/>
-      <taxRule iso_code_country="ie" id_tax="18"/>
-      <taxRule iso_code_country="it" id_tax="19"/>
-      <taxRule iso_code_country="lt" id_tax="20"/>
-      <taxRule iso_code_country="lu" id_tax="21"/>
-      <taxRule iso_code_country="mt" id_tax="22"/>
-      <taxRule iso_code_country="nl" id_tax="23"/>
-      <taxRule iso_code_country="pl" id_tax="24"/>
-      <taxRule iso_code_country="pt" id_tax="25"/>
-      <taxRule iso_code_country="ro" id_tax="26"/>
-      <taxRule iso_code_country="se" id_tax="27"/>
-      <taxRule iso_code_country="si" id_tax="28"/>
-      <taxRule iso_code_country="sk" id_tax="29"/>
+      <taxRule iso_code_country="at" id_tax="5"/>
+      <taxRule iso_code_country="be" id_tax="6"/>
+      <taxRule iso_code_country="bg" id_tax="7"/>
+      <taxRule iso_code_country="cy" id_tax="8"/>
+      <taxRule iso_code_country="cz" id_tax="9"/>
+      <taxRule iso_code_country="de" id_tax="10"/>
+      <taxRule iso_code_country="dk" id_tax="11"/>
+      <taxRule iso_code_country="ee" id_tax="12"/>
+      <taxRule iso_code_country="es" id_tax="13"/>
+      <taxRule iso_code_country="fi" id_tax="14"/>
+      <taxRule iso_code_country="fr" id_tax="15"/>
+      <taxRule iso_code_country="gb" id_tax="16"/>
+      <taxRule iso_code_country="gr" id_tax="17"/>
+      <taxRule iso_code_country="hr" id_tax="18"/>
+      <taxRule iso_code_country="hu" id_tax="19"/>
+      <taxRule iso_code_country="ie" id_tax="20"/>
+      <taxRule iso_code_country="it" id_tax="21"/>
+      <taxRule iso_code_country="lt" id_tax="22"/>
+      <taxRule iso_code_country="lu" id_tax="23"/>
+      <taxRule iso_code_country="mt" id_tax="24"/>
+      <taxRule iso_code_country="nl" id_tax="25"/>
+      <taxRule iso_code_country="pl" id_tax="26"/>
+      <taxRule iso_code_country="pt" id_tax="27"/>
+      <taxRule iso_code_country="ro" id_tax="28"/>
+      <taxRule iso_code_country="se" id_tax="29"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
   <units>

--- a/localization/mt.xml
+++ b/localization/mt.xml
@@ -8,36 +8,36 @@
   </currencies>
   <taxes>
     <tax id="1" name="VAT MT 18%" rate="18" eu-tax-group="virtual"/>
-    <tax id="30" name="VAT MT 7%" rate="7"/>
-    <tax id="2" name="VAT MT 5%" rate="5"/>
-    <tax id="31" name="VAT MT 0%" rate="0"/>
-    <tax id="3" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="4" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="5" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="6" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="7" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="8" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="9" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="10" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="11" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="20" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="21" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="22" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="23" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="24" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="2" name="VAT MT 7%" rate="7"/>
+    <tax id="3" name="VAT MT 5%" rate="5"/>
+    <tax id="4" name="VAT MT 0%" rate="0"/>
+    <tax id="5" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="31" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="MT Standard Rate (18%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
@@ -68,35 +68,6 @@
       <taxRule iso_code_country="uk" id_tax="1"/>
     </taxRulesGroup>
     <taxRulesGroup name="MT Reduced Rate (7%)">
-      <taxRule iso_code_country="be" id_tax="30"/>
-      <taxRule iso_code_country="bg" id_tax="30"/>
-      <taxRule iso_code_country="cz" id_tax="30"/>
-      <taxRule iso_code_country="dk" id_tax="30"/>
-      <taxRule iso_code_country="de" id_tax="30"/>
-      <taxRule iso_code_country="ee" id_tax="30"/>
-      <taxRule iso_code_country="gr" id_tax="30"/>
-      <taxRule iso_code_country="es" id_tax="30"/>
-      <taxRule iso_code_country="fr" id_tax="30"/>
-      <taxRule iso_code_country="ie" id_tax="30"/>
-      <taxRule iso_code_country="it" id_tax="30"/>
-      <taxRule iso_code_country="cy" id_tax="30"/>
-      <taxRule iso_code_country="lv" id_tax="30"/>
-      <taxRule iso_code_country="lt" id_tax="30"/>
-      <taxRule iso_code_country="lu" id_tax="30"/>
-      <taxRule iso_code_country="hu" id_tax="30"/>
-      <taxRule iso_code_country="mt" id_tax="30"/>
-      <taxRule iso_code_country="nl" id_tax="30"/>
-      <taxRule iso_code_country="at" id_tax="30"/>
-      <taxRule iso_code_country="pl" id_tax="30"/>
-      <taxRule iso_code_country="pt" id_tax="30"/>
-      <taxRule iso_code_country="ro" id_tax="30"/>
-      <taxRule iso_code_country="si" id_tax="30"/>
-      <taxRule iso_code_country="sk" id_tax="30"/>
-      <taxRule iso_code_country="fi" id_tax="30"/>
-      <taxRule iso_code_country="se" id_tax="30"/>
-      <taxRule iso_code_country="uk" id_tax="30"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="MT Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>
@@ -125,64 +96,93 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
+    <taxRulesGroup name="MT Reduced Rate (5%)">
+      <taxRule iso_code_country="be" id_tax="3"/>
+      <taxRule iso_code_country="bg" id_tax="3"/>
+      <taxRule iso_code_country="cz" id_tax="3"/>
+      <taxRule iso_code_country="dk" id_tax="3"/>
+      <taxRule iso_code_country="de" id_tax="3"/>
+      <taxRule iso_code_country="ee" id_tax="3"/>
+      <taxRule iso_code_country="gr" id_tax="3"/>
+      <taxRule iso_code_country="es" id_tax="3"/>
+      <taxRule iso_code_country="fr" id_tax="3"/>
+      <taxRule iso_code_country="ie" id_tax="3"/>
+      <taxRule iso_code_country="it" id_tax="3"/>
+      <taxRule iso_code_country="cy" id_tax="3"/>
+      <taxRule iso_code_country="lv" id_tax="3"/>
+      <taxRule iso_code_country="lt" id_tax="3"/>
+      <taxRule iso_code_country="lu" id_tax="3"/>
+      <taxRule iso_code_country="hu" id_tax="3"/>
+      <taxRule iso_code_country="mt" id_tax="3"/>
+      <taxRule iso_code_country="nl" id_tax="3"/>
+      <taxRule iso_code_country="at" id_tax="3"/>
+      <taxRule iso_code_country="pl" id_tax="3"/>
+      <taxRule iso_code_country="pt" id_tax="3"/>
+      <taxRule iso_code_country="ro" id_tax="3"/>
+      <taxRule iso_code_country="si" id_tax="3"/>
+      <taxRule iso_code_country="sk" id_tax="3"/>
+      <taxRule iso_code_country="fi" id_tax="3"/>
+      <taxRule iso_code_country="se" id_tax="3"/>
+      <taxRule iso_code_country="uk" id_tax="3"/>
+    </taxRulesGroup>
     <taxRulesGroup name="MT Reduced Rate (0%)">
-      <taxRule iso_code_country="be" id_tax="31"/>
-      <taxRule iso_code_country="bg" id_tax="31"/>
-      <taxRule iso_code_country="cz" id_tax="31"/>
-      <taxRule iso_code_country="dk" id_tax="31"/>
-      <taxRule iso_code_country="de" id_tax="31"/>
-      <taxRule iso_code_country="ee" id_tax="31"/>
-      <taxRule iso_code_country="gr" id_tax="31"/>
-      <taxRule iso_code_country="es" id_tax="31"/>
-      <taxRule iso_code_country="fr" id_tax="31"/>
-      <taxRule iso_code_country="ie" id_tax="31"/>
-      <taxRule iso_code_country="it" id_tax="31"/>
-      <taxRule iso_code_country="cy" id_tax="31"/>
-      <taxRule iso_code_country="lv" id_tax="31"/>
-      <taxRule iso_code_country="lt" id_tax="31"/>
-      <taxRule iso_code_country="lu" id_tax="31"/>
-      <taxRule iso_code_country="hu" id_tax="31"/>
-      <taxRule iso_code_country="mt" id_tax="31"/>
-      <taxRule iso_code_country="nl" id_tax="31"/>
-      <taxRule iso_code_country="at" id_tax="31"/>
-      <taxRule iso_code_country="pl" id_tax="31"/>
-      <taxRule iso_code_country="pt" id_tax="31"/>
-      <taxRule iso_code_country="ro" id_tax="31"/>
-      <taxRule iso_code_country="si" id_tax="31"/>
-      <taxRule iso_code_country="sk" id_tax="31"/>
-      <taxRule iso_code_country="fi" id_tax="31"/>
-      <taxRule iso_code_country="se" id_tax="31"/>
-      <taxRule iso_code_country="uk" id_tax="31"/>
+      <taxRule iso_code_country="be" id_tax="4"/>
+      <taxRule iso_code_country="bg" id_tax="4"/>
+      <taxRule iso_code_country="cz" id_tax="4"/>
+      <taxRule iso_code_country="dk" id_tax="4"/>
+      <taxRule iso_code_country="de" id_tax="4"/>
+      <taxRule iso_code_country="ee" id_tax="4"/>
+      <taxRule iso_code_country="gr" id_tax="4"/>
+      <taxRule iso_code_country="es" id_tax="4"/>
+      <taxRule iso_code_country="fr" id_tax="4"/>
+      <taxRule iso_code_country="ie" id_tax="4"/>
+      <taxRule iso_code_country="it" id_tax="4"/>
+      <taxRule iso_code_country="cy" id_tax="4"/>
+      <taxRule iso_code_country="lv" id_tax="4"/>
+      <taxRule iso_code_country="lt" id_tax="4"/>
+      <taxRule iso_code_country="lu" id_tax="4"/>
+      <taxRule iso_code_country="hu" id_tax="4"/>
+      <taxRule iso_code_country="mt" id_tax="4"/>
+      <taxRule iso_code_country="nl" id_tax="4"/>
+      <taxRule iso_code_country="at" id_tax="4"/>
+      <taxRule iso_code_country="pl" id_tax="4"/>
+      <taxRule iso_code_country="pt" id_tax="4"/>
+      <taxRule iso_code_country="ro" id_tax="4"/>
+      <taxRule iso_code_country="si" id_tax="4"/>
+      <taxRule iso_code_country="sk" id_tax="4"/>
+      <taxRule iso_code_country="fi" id_tax="4"/>
+      <taxRule iso_code_country="se" id_tax="4"/>
+      <taxRule iso_code_country="uk" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="mt" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="3"/>
-      <taxRule iso_code_country="be" id_tax="4"/>
-      <taxRule iso_code_country="bg" id_tax="5"/>
-      <taxRule iso_code_country="cy" id_tax="6"/>
-      <taxRule iso_code_country="cz" id_tax="7"/>
-      <taxRule iso_code_country="de" id_tax="8"/>
-      <taxRule iso_code_country="dk" id_tax="9"/>
-      <taxRule iso_code_country="ee" id_tax="10"/>
-      <taxRule iso_code_country="es" id_tax="11"/>
-      <taxRule iso_code_country="fi" id_tax="12"/>
-      <taxRule iso_code_country="fr" id_tax="13"/>
-      <taxRule iso_code_country="gb" id_tax="14"/>
-      <taxRule iso_code_country="gr" id_tax="15"/>
-      <taxRule iso_code_country="hr" id_tax="16"/>
-      <taxRule iso_code_country="hu" id_tax="17"/>
-      <taxRule iso_code_country="ie" id_tax="18"/>
-      <taxRule iso_code_country="it" id_tax="19"/>
-      <taxRule iso_code_country="lt" id_tax="20"/>
-      <taxRule iso_code_country="lu" id_tax="21"/>
-      <taxRule iso_code_country="lv" id_tax="22"/>
-      <taxRule iso_code_country="nl" id_tax="23"/>
-      <taxRule iso_code_country="pl" id_tax="24"/>
-      <taxRule iso_code_country="pt" id_tax="25"/>
-      <taxRule iso_code_country="ro" id_tax="26"/>
-      <taxRule iso_code_country="se" id_tax="27"/>
-      <taxRule iso_code_country="si" id_tax="28"/>
-      <taxRule iso_code_country="sk" id_tax="29"/>
+      <taxRule iso_code_country="at" id_tax="5"/>
+      <taxRule iso_code_country="be" id_tax="6"/>
+      <taxRule iso_code_country="bg" id_tax="7"/>
+      <taxRule iso_code_country="cy" id_tax="8"/>
+      <taxRule iso_code_country="cz" id_tax="9"/>
+      <taxRule iso_code_country="de" id_tax="10"/>
+      <taxRule iso_code_country="dk" id_tax="11"/>
+      <taxRule iso_code_country="ee" id_tax="12"/>
+      <taxRule iso_code_country="es" id_tax="13"/>
+      <taxRule iso_code_country="fi" id_tax="14"/>
+      <taxRule iso_code_country="fr" id_tax="15"/>
+      <taxRule iso_code_country="gb" id_tax="16"/>
+      <taxRule iso_code_country="gr" id_tax="17"/>
+      <taxRule iso_code_country="hr" id_tax="18"/>
+      <taxRule iso_code_country="hu" id_tax="19"/>
+      <taxRule iso_code_country="ie" id_tax="20"/>
+      <taxRule iso_code_country="it" id_tax="21"/>
+      <taxRule iso_code_country="lt" id_tax="22"/>
+      <taxRule iso_code_country="lu" id_tax="23"/>
+      <taxRule iso_code_country="lv" id_tax="24"/>
+      <taxRule iso_code_country="nl" id_tax="25"/>
+      <taxRule iso_code_country="pl" id_tax="26"/>
+      <taxRule iso_code_country="pt" id_tax="27"/>
+      <taxRule iso_code_country="ro" id_tax="28"/>
+      <taxRule iso_code_country="se" id_tax="29"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
   <units>

--- a/localization/mt.xml
+++ b/localization/mt.xml
@@ -8,7 +8,9 @@
   </currencies>
   <taxes>
     <tax id="1" name="VAT MT 18%" rate="18" eu-tax-group="virtual"/>
+    <tax id="30" name="VAT MT 7%" rate="7"/>
     <tax id="2" name="VAT MT 5%" rate="5"/>
+    <tax id="31" name="VAT MT 0%" rate="0"/>
     <tax id="3" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="4" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -65,6 +67,35 @@
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="uk" id_tax="1"/>
     </taxRulesGroup>
+    <taxRulesGroup name="MT Reduced Rate (7%)">
+      <taxRule iso_code_country="be" id_tax="30"/>
+      <taxRule iso_code_country="bg" id_tax="30"/>
+      <taxRule iso_code_country="cz" id_tax="30"/>
+      <taxRule iso_code_country="dk" id_tax="30"/>
+      <taxRule iso_code_country="de" id_tax="30"/>
+      <taxRule iso_code_country="ee" id_tax="30"/>
+      <taxRule iso_code_country="gr" id_tax="30"/>
+      <taxRule iso_code_country="es" id_tax="30"/>
+      <taxRule iso_code_country="fr" id_tax="30"/>
+      <taxRule iso_code_country="ie" id_tax="30"/>
+      <taxRule iso_code_country="it" id_tax="30"/>
+      <taxRule iso_code_country="cy" id_tax="30"/>
+      <taxRule iso_code_country="lv" id_tax="30"/>
+      <taxRule iso_code_country="lt" id_tax="30"/>
+      <taxRule iso_code_country="lu" id_tax="30"/>
+      <taxRule iso_code_country="hu" id_tax="30"/>
+      <taxRule iso_code_country="mt" id_tax="30"/>
+      <taxRule iso_code_country="nl" id_tax="30"/>
+      <taxRule iso_code_country="at" id_tax="30"/>
+      <taxRule iso_code_country="pl" id_tax="30"/>
+      <taxRule iso_code_country="pt" id_tax="30"/>
+      <taxRule iso_code_country="ro" id_tax="30"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="30"/>
+      <taxRule iso_code_country="fi" id_tax="30"/>
+      <taxRule iso_code_country="se" id_tax="30"/>
+      <taxRule iso_code_country="uk" id_tax="30"/>
+    </taxRulesGroup>
     <taxRulesGroup name="MT Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
@@ -94,34 +125,34 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="MT Books Rate (5%)">
-      <taxRule iso_code_country="be" id_tax="2"/>
-      <taxRule iso_code_country="bg" id_tax="2"/>
-      <taxRule iso_code_country="cz" id_tax="2"/>
-      <taxRule iso_code_country="dk" id_tax="2"/>
-      <taxRule iso_code_country="de" id_tax="2"/>
-      <taxRule iso_code_country="ee" id_tax="2"/>
-      <taxRule iso_code_country="gr" id_tax="2"/>
-      <taxRule iso_code_country="es" id_tax="2"/>
-      <taxRule iso_code_country="fr" id_tax="2"/>
-      <taxRule iso_code_country="ie" id_tax="2"/>
-      <taxRule iso_code_country="it" id_tax="2"/>
-      <taxRule iso_code_country="cy" id_tax="2"/>
-      <taxRule iso_code_country="lv" id_tax="2"/>
-      <taxRule iso_code_country="lt" id_tax="2"/>
-      <taxRule iso_code_country="lu" id_tax="2"/>
-      <taxRule iso_code_country="hu" id_tax="2"/>
-      <taxRule iso_code_country="mt" id_tax="2"/>
-      <taxRule iso_code_country="nl" id_tax="2"/>
-      <taxRule iso_code_country="at" id_tax="2"/>
-      <taxRule iso_code_country="pl" id_tax="2"/>
-      <taxRule iso_code_country="pt" id_tax="2"/>
-      <taxRule iso_code_country="ro" id_tax="2"/>
-      <taxRule iso_code_country="si" id_tax="2"/>
-      <taxRule iso_code_country="sk" id_tax="2"/>
-      <taxRule iso_code_country="fi" id_tax="2"/>
-      <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+    <taxRulesGroup name="MT Reduced Rate (0%)">
+      <taxRule iso_code_country="be" id_tax="31"/>
+      <taxRule iso_code_country="bg" id_tax="31"/>
+      <taxRule iso_code_country="cz" id_tax="31"/>
+      <taxRule iso_code_country="dk" id_tax="31"/>
+      <taxRule iso_code_country="de" id_tax="31"/>
+      <taxRule iso_code_country="ee" id_tax="31"/>
+      <taxRule iso_code_country="gr" id_tax="31"/>
+      <taxRule iso_code_country="es" id_tax="31"/>
+      <taxRule iso_code_country="fr" id_tax="31"/>
+      <taxRule iso_code_country="ie" id_tax="31"/>
+      <taxRule iso_code_country="it" id_tax="31"/>
+      <taxRule iso_code_country="cy" id_tax="31"/>
+      <taxRule iso_code_country="lv" id_tax="31"/>
+      <taxRule iso_code_country="lt" id_tax="31"/>
+      <taxRule iso_code_country="lu" id_tax="31"/>
+      <taxRule iso_code_country="hu" id_tax="31"/>
+      <taxRule iso_code_country="mt" id_tax="31"/>
+      <taxRule iso_code_country="nl" id_tax="31"/>
+      <taxRule iso_code_country="at" id_tax="31"/>
+      <taxRule iso_code_country="pl" id_tax="31"/>
+      <taxRule iso_code_country="pt" id_tax="31"/>
+      <taxRule iso_code_country="ro" id_tax="31"/>
+      <taxRule iso_code_country="si" id_tax="31"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
+      <taxRule iso_code_country="fi" id_tax="31"/>
+      <taxRule iso_code_country="se" id_tax="31"/>
+      <taxRule iso_code_country="uk" id_tax="31"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="mt" id_tax="1"/>

--- a/localization/nl.xml
+++ b/localization/nl.xml
@@ -21,7 +21,7 @@
     <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -32,7 +32,7 @@
     <tax id="23" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="24" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -184,18 +184,18 @@
     </taxRulesGroup>
   </taxes>
   <states>
-    <state name="Drenthe" iso_code="NL-DR" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Flevoland" iso_code="NL-FL" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Fryslân" iso_code="NL-FR" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Gelderland" iso_code="NL-GE" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Groningen" iso_code="NL-GR" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Limburg" iso_code="NL-LI" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Noord-Brabant" iso_code="NL-NB" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Noord-Holland" iso_code="NL-NH" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Overijssel" iso_code="NL-OV" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Utrecht" iso_code="NL-UT" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Zeeland" iso_code="NL-ZE" country="NL" zone="Europe" tax_behavior="0" />
-    <state name="Zuid-Holland" iso_code="NL-ZH" country="NL" zone="Europe" tax_behavior="0" />
+    <state name="Drenthe" iso_code="NL-DR" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Flevoland" iso_code="NL-FL" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Fryslân" iso_code="NL-FR" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Gelderland" iso_code="NL-GE" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Groningen" iso_code="NL-GR" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Limburg" iso_code="NL-LI" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Noord-Brabant" iso_code="NL-NB" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Noord-Holland" iso_code="NL-NH" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Overijssel" iso_code="NL-OV" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Utrecht" iso_code="NL-UT" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Zeeland" iso_code="NL-ZE" country="NL" zone="Europe" tax_behavior="0"/>
+    <state name="Zuid-Holland" iso_code="NL-ZH" country="NL" zone="Europe" tax_behavior="0"/>
   </states>
   <units>
     <unit type="weight" value="kg"/>

--- a/localization/pa.xml
+++ b/localization/pa.xml
@@ -7,14 +7,22 @@
     <language iso_code="es"/>
   </languages>
   <taxes>
-    <taxRulesGroup name="ITBMS 7%">
-      <taxRule iso_code_country="pa" behavior="0" id_tax="74"/>
+    <tax id="1" name="ITBMS 15%" rate="15.000"/>
+    <tax id="2" name="ITBMS 10%" rate="10.000"/>
+    <tax id="3" name="ITBMS 7%" rate="7.000"/>
+    <tax id="4" name="ITBMS 0%" rate="0.000"/>
+    <taxRulesGroup name="ITBMS Higher Rate 15%">
+      <taxRule iso_code_country="pa" behavior="0" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="ITBMS 0%">
-      <taxRule iso_code_country="pa" behavior="0" id_tax="75"/>
+    <taxRulesGroup name="ITBMS Higher Rate 10%">
+      <taxRule iso_code_country="pa" behavior="0" id_tax="2"/>
     </taxRulesGroup>
-    <tax id="74" name="ITBMS 7%" rate="7.000"/>
-    <tax id="75" name="ITBMS 0%" rate="0.000"/>
+    <taxRulesGroup name="ITBMS Standard Rate 7%">
+      <taxRule iso_code_country="pa" behavior="0" id_tax="3"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="ITBMS Zero Rate 0%">
+      <taxRule iso_code_country="pa" behavior="0" id_tax="4"/>
+    </taxRulesGroup>
   </taxes>
   <units>
     <unit type="weight" value="kg"/>

--- a/localization/ph.xml
+++ b/localization/ph.xml
@@ -7,14 +7,18 @@
     <language iso_code="en"/>
   </languages>
   <taxes>
-    <taxRulesGroup name="RVAT 12%">
-      <taxRule iso_code_country="ph" behavior="0" id_tax="68"/>
+    <tax id="1" name="RVAT 18%" rate="18.000"/>
+    <tax id="2" name="RVAT 12%" rate="12.000"/>
+    <tax id="3" name="RVAT 0%" rate="0"/>
+    <taxRulesGroup name="RVAT Higher Rate 18%">
+      <taxRule iso_code_country="ph" behavior="0" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="RVAT 6%">
-      <taxRule iso_code_country="ph" behavior="0" id_tax="69"/>
+    <taxRulesGroup name="RVAT Standard Rate 12%">
+      <taxRule iso_code_country="ph" behavior="0" id_tax="2"/>
     </taxRulesGroup>
-    <tax id="68" name="RVAT 12%" rate="12.000"/>
-    <tax id="69" name="RVAT 6%" rate="6.000"/>
+    <taxRulesGroup name="RVAT Zero Rate 0%">
+      <taxRule iso_code_country="ph" behavior="0" id_tax="3"/>
+    </taxRulesGroup>
   </taxes>
   <units>
     <unit type="weight" value="kg"/>

--- a/localization/pl.xml
+++ b/localization/pl.xml
@@ -23,7 +23,7 @@
     <tax id="16" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="20" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="21" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="22" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -34,7 +34,7 @@
     <tax id="27" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="30" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="31" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="32" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="33" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/localization/pt.xml
+++ b/localization/pt.xml
@@ -10,34 +10,34 @@
     <tax id="1" name="IVA PT 23%" rate="23" eu-tax-group="virtual"/>
     <tax id="2" name="IVA PT 13%" rate="13"/>
     <tax id="3" name="IVA PT 6%" rate="6"/>
-    <tax id="31" name="IVA PT 0%" rate="0"/>
-    <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="7" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="8" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="9" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="10" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="11" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="12" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="20" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="21" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="22" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="23" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="24" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="4" name="IVA PT 0%" rate="0"/>
+    <tax id="5" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="31" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="PT Standard Rate (23%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
@@ -126,63 +126,63 @@
       <taxRule iso_code_country="uk" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="PT Zero Rate (0%)">
-      <taxRule iso_code_country="be" id_tax="31"/>
-      <taxRule iso_code_country="bg" id_tax="31"/>
-      <taxRule iso_code_country="cz" id_tax="31"/>
-      <taxRule iso_code_country="dk" id_tax="31"/>
-      <taxRule iso_code_country="de" id_tax="31"/>
-      <taxRule iso_code_country="ee" id_tax="31"/>
-      <taxRule iso_code_country="gr" id_tax="31"/>
-      <taxRule iso_code_country="es" id_tax="31"/>
-      <taxRule iso_code_country="fr" id_tax="31"/>
-      <taxRule iso_code_country="ie" id_tax="31"/>
-      <taxRule iso_code_country="it" id_tax="31"/>
-      <taxRule iso_code_country="cy" id_tax="31"/>
-      <taxRule iso_code_country="lv" id_tax="31"/>
-      <taxRule iso_code_country="lt" id_tax="31"/>
-      <taxRule iso_code_country="lu" id_tax="31"/>
-      <taxRule iso_code_country="hu" id_tax="31"/>
-      <taxRule iso_code_country="mt" id_tax="31"/>
-      <taxRule iso_code_country="nl" id_tax="31"/>
-      <taxRule iso_code_country="at" id_tax="31"/>
-      <taxRule iso_code_country="pl" id_tax="31"/>
-      <taxRule iso_code_country="pt" id_tax="31"/>
-      <taxRule iso_code_country="ro" id_tax="31"/>
-      <taxRule iso_code_country="si" id_tax="31"/>
-      <taxRule iso_code_country="sk" id_tax="31"/>
-      <taxRule iso_code_country="fi" id_tax="31"/>
-      <taxRule iso_code_country="se" id_tax="31"/>
-      <taxRule iso_code_country="uk" id_tax="31"/>
+      <taxRule iso_code_country="be" id_tax="4"/>
+      <taxRule iso_code_country="bg" id_tax="4"/>
+      <taxRule iso_code_country="cz" id_tax="4"/>
+      <taxRule iso_code_country="dk" id_tax="4"/>
+      <taxRule iso_code_country="de" id_tax="4"/>
+      <taxRule iso_code_country="ee" id_tax="4"/>
+      <taxRule iso_code_country="gr" id_tax="4"/>
+      <taxRule iso_code_country="es" id_tax="4"/>
+      <taxRule iso_code_country="fr" id_tax="4"/>
+      <taxRule iso_code_country="ie" id_tax="4"/>
+      <taxRule iso_code_country="it" id_tax="4"/>
+      <taxRule iso_code_country="cy" id_tax="4"/>
+      <taxRule iso_code_country="lv" id_tax="4"/>
+      <taxRule iso_code_country="lt" id_tax="4"/>
+      <taxRule iso_code_country="lu" id_tax="4"/>
+      <taxRule iso_code_country="hu" id_tax="4"/>
+      <taxRule iso_code_country="mt" id_tax="4"/>
+      <taxRule iso_code_country="nl" id_tax="4"/>
+      <taxRule iso_code_country="at" id_tax="4"/>
+      <taxRule iso_code_country="pl" id_tax="4"/>
+      <taxRule iso_code_country="pt" id_tax="4"/>
+      <taxRule iso_code_country="ro" id_tax="4"/>
+      <taxRule iso_code_country="si" id_tax="4"/>
+      <taxRule iso_code_country="sk" id_tax="4"/>
+      <taxRule iso_code_country="fi" id_tax="4"/>
+      <taxRule iso_code_country="se" id_tax="4"/>
+      <taxRule iso_code_country="uk" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="pt" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="4"/>
-      <taxRule iso_code_country="be" id_tax="5"/>
-      <taxRule iso_code_country="bg" id_tax="6"/>
-      <taxRule iso_code_country="cy" id_tax="7"/>
-      <taxRule iso_code_country="cz" id_tax="8"/>
-      <taxRule iso_code_country="de" id_tax="9"/>
-      <taxRule iso_code_country="dk" id_tax="10"/>
-      <taxRule iso_code_country="ee" id_tax="11"/>
-      <taxRule iso_code_country="es" id_tax="12"/>
-      <taxRule iso_code_country="fi" id_tax="13"/>
-      <taxRule iso_code_country="fr" id_tax="14"/>
-      <taxRule iso_code_country="gb" id_tax="15"/>
-      <taxRule iso_code_country="gr" id_tax="16"/>
-      <taxRule iso_code_country="hr" id_tax="17"/>
-      <taxRule iso_code_country="hu" id_tax="18"/>
-      <taxRule iso_code_country="ie" id_tax="19"/>
-      <taxRule iso_code_country="it" id_tax="20"/>
-      <taxRule iso_code_country="lt" id_tax="21"/>
-      <taxRule iso_code_country="lu" id_tax="22"/>
-      <taxRule iso_code_country="lv" id_tax="23"/>
-      <taxRule iso_code_country="mt" id_tax="24"/>
-      <taxRule iso_code_country="nl" id_tax="25"/>
-      <taxRule iso_code_country="pl" id_tax="26"/>
-      <taxRule iso_code_country="ro" id_tax="27"/>
-      <taxRule iso_code_country="se" id_tax="28"/>
-      <taxRule iso_code_country="si" id_tax="29"/>
-      <taxRule iso_code_country="sk" id_tax="30"/>
+      <taxRule iso_code_country="at" id_tax="5"/>
+      <taxRule iso_code_country="be" id_tax="6"/>
+      <taxRule iso_code_country="bg" id_tax="7"/>
+      <taxRule iso_code_country="cy" id_tax="8"/>
+      <taxRule iso_code_country="cz" id_tax="9"/>
+      <taxRule iso_code_country="de" id_tax="10"/>
+      <taxRule iso_code_country="dk" id_tax="11"/>
+      <taxRule iso_code_country="ee" id_tax="12"/>
+      <taxRule iso_code_country="es" id_tax="13"/>
+      <taxRule iso_code_country="fi" id_tax="14"/>
+      <taxRule iso_code_country="fr" id_tax="15"/>
+      <taxRule iso_code_country="gb" id_tax="16"/>
+      <taxRule iso_code_country="gr" id_tax="17"/>
+      <taxRule iso_code_country="hr" id_tax="18"/>
+      <taxRule iso_code_country="hu" id_tax="19"/>
+      <taxRule iso_code_country="ie" id_tax="20"/>
+      <taxRule iso_code_country="it" id_tax="21"/>
+      <taxRule iso_code_country="lt" id_tax="22"/>
+      <taxRule iso_code_country="lu" id_tax="23"/>
+      <taxRule iso_code_country="lv" id_tax="24"/>
+      <taxRule iso_code_country="mt" id_tax="25"/>
+      <taxRule iso_code_country="nl" id_tax="26"/>
+      <taxRule iso_code_country="pl" id_tax="27"/>
+      <taxRule iso_code_country="ro" id_tax="28"/>
+      <taxRule iso_code_country="se" id_tax="29"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
   <units>

--- a/localization/pt.xml
+++ b/localization/pt.xml
@@ -10,6 +10,7 @@
     <tax id="1" name="IVA PT 23%" rate="23" eu-tax-group="virtual"/>
     <tax id="2" name="IVA PT 13%" rate="13"/>
     <tax id="3" name="IVA PT 6%" rate="6"/>
+    <tax id="31" name="IVA PT 0%" rate="0"/>
     <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -124,63 +125,34 @@
       <taxRule iso_code_country="se" id_tax="3"/>
       <taxRule iso_code_country="uk" id_tax="3"/>
     </taxRulesGroup>
-    <taxRulesGroup name="PT Foodstuff Rate (6%)">
-      <taxRule iso_code_country="be" id_tax="3"/>
-      <taxRule iso_code_country="bg" id_tax="3"/>
-      <taxRule iso_code_country="cz" id_tax="3"/>
-      <taxRule iso_code_country="dk" id_tax="3"/>
-      <taxRule iso_code_country="de" id_tax="3"/>
-      <taxRule iso_code_country="ee" id_tax="3"/>
-      <taxRule iso_code_country="gr" id_tax="3"/>
-      <taxRule iso_code_country="es" id_tax="3"/>
-      <taxRule iso_code_country="fr" id_tax="3"/>
-      <taxRule iso_code_country="ie" id_tax="3"/>
-      <taxRule iso_code_country="it" id_tax="3"/>
-      <taxRule iso_code_country="cy" id_tax="3"/>
-      <taxRule iso_code_country="lv" id_tax="3"/>
-      <taxRule iso_code_country="lt" id_tax="3"/>
-      <taxRule iso_code_country="lu" id_tax="3"/>
-      <taxRule iso_code_country="hu" id_tax="3"/>
-      <taxRule iso_code_country="mt" id_tax="3"/>
-      <taxRule iso_code_country="nl" id_tax="3"/>
-      <taxRule iso_code_country="at" id_tax="3"/>
-      <taxRule iso_code_country="pl" id_tax="3"/>
-      <taxRule iso_code_country="pt" id_tax="3"/>
-      <taxRule iso_code_country="ro" id_tax="3"/>
-      <taxRule iso_code_country="si" id_tax="3"/>
-      <taxRule iso_code_country="sk" id_tax="3"/>
-      <taxRule iso_code_country="fi" id_tax="3"/>
-      <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="PT Books Rate (6%)">
-      <taxRule iso_code_country="be" id_tax="3"/>
-      <taxRule iso_code_country="bg" id_tax="3"/>
-      <taxRule iso_code_country="cz" id_tax="3"/>
-      <taxRule iso_code_country="dk" id_tax="3"/>
-      <taxRule iso_code_country="de" id_tax="3"/>
-      <taxRule iso_code_country="ee" id_tax="3"/>
-      <taxRule iso_code_country="gr" id_tax="3"/>
-      <taxRule iso_code_country="es" id_tax="3"/>
-      <taxRule iso_code_country="fr" id_tax="3"/>
-      <taxRule iso_code_country="ie" id_tax="3"/>
-      <taxRule iso_code_country="it" id_tax="3"/>
-      <taxRule iso_code_country="cy" id_tax="3"/>
-      <taxRule iso_code_country="lv" id_tax="3"/>
-      <taxRule iso_code_country="lt" id_tax="3"/>
-      <taxRule iso_code_country="lu" id_tax="3"/>
-      <taxRule iso_code_country="hu" id_tax="3"/>
-      <taxRule iso_code_country="mt" id_tax="3"/>
-      <taxRule iso_code_country="nl" id_tax="3"/>
-      <taxRule iso_code_country="at" id_tax="3"/>
-      <taxRule iso_code_country="pl" id_tax="3"/>
-      <taxRule iso_code_country="pt" id_tax="3"/>
-      <taxRule iso_code_country="ro" id_tax="3"/>
-      <taxRule iso_code_country="si" id_tax="3"/>
-      <taxRule iso_code_country="sk" id_tax="3"/>
-      <taxRule iso_code_country="fi" id_tax="3"/>
-      <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="uk" id_tax="3"/>
+    <taxRulesGroup name="PT Zero Rate (0%)">
+      <taxRule iso_code_country="be" id_tax="31"/>
+      <taxRule iso_code_country="bg" id_tax="31"/>
+      <taxRule iso_code_country="cz" id_tax="31"/>
+      <taxRule iso_code_country="dk" id_tax="31"/>
+      <taxRule iso_code_country="de" id_tax="31"/>
+      <taxRule iso_code_country="ee" id_tax="31"/>
+      <taxRule iso_code_country="gr" id_tax="31"/>
+      <taxRule iso_code_country="es" id_tax="31"/>
+      <taxRule iso_code_country="fr" id_tax="31"/>
+      <taxRule iso_code_country="ie" id_tax="31"/>
+      <taxRule iso_code_country="it" id_tax="31"/>
+      <taxRule iso_code_country="cy" id_tax="31"/>
+      <taxRule iso_code_country="lv" id_tax="31"/>
+      <taxRule iso_code_country="lt" id_tax="31"/>
+      <taxRule iso_code_country="lu" id_tax="31"/>
+      <taxRule iso_code_country="hu" id_tax="31"/>
+      <taxRule iso_code_country="mt" id_tax="31"/>
+      <taxRule iso_code_country="nl" id_tax="31"/>
+      <taxRule iso_code_country="at" id_tax="31"/>
+      <taxRule iso_code_country="pl" id_tax="31"/>
+      <taxRule iso_code_country="pt" id_tax="31"/>
+      <taxRule iso_code_country="ro" id_tax="31"/>
+      <taxRule iso_code_country="si" id_tax="31"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
+      <taxRule iso_code_country="fi" id_tax="31"/>
+      <taxRule iso_code_country="se" id_tax="31"/>
+      <taxRule iso_code_country="uk" id_tax="31"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="pt" id_tax="1"/>

--- a/localization/ro.xml
+++ b/localization/ro.xml
@@ -10,34 +10,34 @@
     <tax id="1" name="TVA RO 19%" rate="19" eu-tax-group="virtual"/>
     <tax id="2" name="TVA RO 9%" rate="9"/>
     <tax id="3" name="TVA RO 5%" rate="5"/>
-    <tax id="31" name="TVA RO 0%" rate="0"/>
-    <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="7" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="8" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="9" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="10" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="11" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="12" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="20" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="21" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="22" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="23" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="24" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="4" name="TVA RO 0%" rate="0"/>
+    <tax id="5" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="31" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="RO Standard Rate (19%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
@@ -126,63 +126,63 @@
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="RO Zero Rate (0%)">
-      <taxRule iso_code_country="be" id_tax="31"/>
-      <taxRule iso_code_country="bg" id_tax="31"/>
-      <taxRule iso_code_country="cz" id_tax="31"/>
-      <taxRule iso_code_country="dk" id_tax="31"/>
-      <taxRule iso_code_country="de" id_tax="31"/>
-      <taxRule iso_code_country="ee" id_tax="31"/>
-      <taxRule iso_code_country="gr" id_tax="31"/>
-      <taxRule iso_code_country="es" id_tax="31"/>
-      <taxRule iso_code_country="fr" id_tax="31"/>
-      <taxRule iso_code_country="ie" id_tax="31"/>
-      <taxRule iso_code_country="it" id_tax="31"/>
-      <taxRule iso_code_country="cy" id_tax="31"/>
-      <taxRule iso_code_country="lv" id_tax="31"/>
-      <taxRule iso_code_country="lt" id_tax="31"/>
-      <taxRule iso_code_country="lu" id_tax="31"/>
-      <taxRule iso_code_country="hu" id_tax="31"/>
-      <taxRule iso_code_country="mt" id_tax="31"/>
-      <taxRule iso_code_country="nl" id_tax="31"/>
-      <taxRule iso_code_country="at" id_tax="31"/>
-      <taxRule iso_code_country="pl" id_tax="31"/>
-      <taxRule iso_code_country="pt" id_tax="31"/>
-      <taxRule iso_code_country="ro" id_tax="31"/>
-      <taxRule iso_code_country="si" id_tax="31"/>
-      <taxRule iso_code_country="sk" id_tax="31"/>
-      <taxRule iso_code_country="fi" id_tax="31"/>
-      <taxRule iso_code_country="se" id_tax="31"/>
-      <taxRule iso_code_country="uk" id_tax="31"/>
+      <taxRule iso_code_country="be" id_tax="4"/>
+      <taxRule iso_code_country="bg" id_tax="4"/>
+      <taxRule iso_code_country="cz" id_tax="4"/>
+      <taxRule iso_code_country="dk" id_tax="4"/>
+      <taxRule iso_code_country="de" id_tax="4"/>
+      <taxRule iso_code_country="ee" id_tax="4"/>
+      <taxRule iso_code_country="gr" id_tax="4"/>
+      <taxRule iso_code_country="es" id_tax="4"/>
+      <taxRule iso_code_country="fr" id_tax="4"/>
+      <taxRule iso_code_country="ie" id_tax="4"/>
+      <taxRule iso_code_country="it" id_tax="4"/>
+      <taxRule iso_code_country="cy" id_tax="4"/>
+      <taxRule iso_code_country="lv" id_tax="4"/>
+      <taxRule iso_code_country="lt" id_tax="4"/>
+      <taxRule iso_code_country="lu" id_tax="4"/>
+      <taxRule iso_code_country="hu" id_tax="4"/>
+      <taxRule iso_code_country="mt" id_tax="4"/>
+      <taxRule iso_code_country="nl" id_tax="4"/>
+      <taxRule iso_code_country="at" id_tax="4"/>
+      <taxRule iso_code_country="pl" id_tax="4"/>
+      <taxRule iso_code_country="pt" id_tax="4"/>
+      <taxRule iso_code_country="ro" id_tax="4"/>
+      <taxRule iso_code_country="si" id_tax="4"/>
+      <taxRule iso_code_country="sk" id_tax="4"/>
+      <taxRule iso_code_country="fi" id_tax="4"/>
+      <taxRule iso_code_country="se" id_tax="4"/>
+      <taxRule iso_code_country="uk" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="ro" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="4"/>
-      <taxRule iso_code_country="be" id_tax="5"/>
-      <taxRule iso_code_country="bg" id_tax="6"/>
-      <taxRule iso_code_country="cy" id_tax="7"/>
-      <taxRule iso_code_country="cz" id_tax="8"/>
-      <taxRule iso_code_country="de" id_tax="9"/>
-      <taxRule iso_code_country="dk" id_tax="10"/>
-      <taxRule iso_code_country="ee" id_tax="11"/>
-      <taxRule iso_code_country="es" id_tax="12"/>
-      <taxRule iso_code_country="fi" id_tax="13"/>
-      <taxRule iso_code_country="fr" id_tax="14"/>
-      <taxRule iso_code_country="gb" id_tax="15"/>
-      <taxRule iso_code_country="gr" id_tax="16"/>
-      <taxRule iso_code_country="hr" id_tax="17"/>
-      <taxRule iso_code_country="hu" id_tax="18"/>
-      <taxRule iso_code_country="ie" id_tax="19"/>
-      <taxRule iso_code_country="it" id_tax="20"/>
-      <taxRule iso_code_country="lt" id_tax="21"/>
-      <taxRule iso_code_country="lu" id_tax="22"/>
-      <taxRule iso_code_country="lv" id_tax="23"/>
-      <taxRule iso_code_country="mt" id_tax="24"/>
-      <taxRule iso_code_country="nl" id_tax="25"/>
-      <taxRule iso_code_country="pl" id_tax="26"/>
-      <taxRule iso_code_country="pt" id_tax="27"/>
-      <taxRule iso_code_country="se" id_tax="28"/>
-      <taxRule iso_code_country="si" id_tax="29"/>
-      <taxRule iso_code_country="sk" id_tax="30"/>
+      <taxRule iso_code_country="at" id_tax="5"/>
+      <taxRule iso_code_country="be" id_tax="6"/>
+      <taxRule iso_code_country="bg" id_tax="7"/>
+      <taxRule iso_code_country="cy" id_tax="8"/>
+      <taxRule iso_code_country="cz" id_tax="9"/>
+      <taxRule iso_code_country="de" id_tax="10"/>
+      <taxRule iso_code_country="dk" id_tax="11"/>
+      <taxRule iso_code_country="ee" id_tax="12"/>
+      <taxRule iso_code_country="es" id_tax="13"/>
+      <taxRule iso_code_country="fi" id_tax="14"/>
+      <taxRule iso_code_country="fr" id_tax="15"/>
+      <taxRule iso_code_country="gb" id_tax="16"/>
+      <taxRule iso_code_country="gr" id_tax="17"/>
+      <taxRule iso_code_country="hr" id_tax="18"/>
+      <taxRule iso_code_country="hu" id_tax="19"/>
+      <taxRule iso_code_country="ie" id_tax="20"/>
+      <taxRule iso_code_country="it" id_tax="21"/>
+      <taxRule iso_code_country="lt" id_tax="22"/>
+      <taxRule iso_code_country="lu" id_tax="23"/>
+      <taxRule iso_code_country="lv" id_tax="24"/>
+      <taxRule iso_code_country="mt" id_tax="25"/>
+      <taxRule iso_code_country="nl" id_tax="26"/>
+      <taxRule iso_code_country="pl" id_tax="27"/>
+      <taxRule iso_code_country="pt" id_tax="28"/>
+      <taxRule iso_code_country="se" id_tax="29"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
   <states>

--- a/localization/ro.xml
+++ b/localization/ro.xml
@@ -7,9 +7,10 @@
     <language iso_code="ro"/>
   </languages>
   <taxes>
-    <tax id="1" name="TVA RO 20%" rate="20" eu-tax-group="virtual"/>
+    <tax id="1" name="TVA RO 19%" rate="19" eu-tax-group="virtual"/>
     <tax id="2" name="TVA RO 9%" rate="9"/>
     <tax id="3" name="TVA RO 5%" rate="5"/>
+    <tax id="31" name="TVA RO 0%" rate="0"/>
     <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -37,7 +38,7 @@
     <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <taxRulesGroup name="RO Standard Rate (24%)">
+    <taxRulesGroup name="RO Standard Rate (19%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
       <taxRule iso_code_country="cz" id_tax="1"/>
@@ -124,63 +125,34 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="uk" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="RO Foodstuff Rate (24%)">
-      <taxRule iso_code_country="be" id_tax="1"/>
-      <taxRule iso_code_country="bg" id_tax="1"/>
-      <taxRule iso_code_country="cz" id_tax="1"/>
-      <taxRule iso_code_country="dk" id_tax="1"/>
-      <taxRule iso_code_country="de" id_tax="1"/>
-      <taxRule iso_code_country="ee" id_tax="1"/>
-      <taxRule iso_code_country="gr" id_tax="1"/>
-      <taxRule iso_code_country="es" id_tax="1"/>
-      <taxRule iso_code_country="fr" id_tax="1"/>
-      <taxRule iso_code_country="ie" id_tax="1"/>
-      <taxRule iso_code_country="it" id_tax="1"/>
-      <taxRule iso_code_country="cy" id_tax="1"/>
-      <taxRule iso_code_country="lv" id_tax="1"/>
-      <taxRule iso_code_country="lt" id_tax="1"/>
-      <taxRule iso_code_country="lu" id_tax="1"/>
-      <taxRule iso_code_country="hu" id_tax="1"/>
-      <taxRule iso_code_country="mt" id_tax="1"/>
-      <taxRule iso_code_country="nl" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="1"/>
-      <taxRule iso_code_country="pl" id_tax="1"/>
-      <taxRule iso_code_country="pt" id_tax="1"/>
-      <taxRule iso_code_country="ro" id_tax="1"/>
-      <taxRule iso_code_country="si" id_tax="1"/>
-      <taxRule iso_code_country="sk" id_tax="1"/>
-      <taxRule iso_code_country="fi" id_tax="1"/>
-      <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="uk" id_tax="1"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="RO Books Rate (9%)">
-      <taxRule iso_code_country="be" id_tax="2"/>
-      <taxRule iso_code_country="bg" id_tax="2"/>
-      <taxRule iso_code_country="cz" id_tax="2"/>
-      <taxRule iso_code_country="dk" id_tax="2"/>
-      <taxRule iso_code_country="de" id_tax="2"/>
-      <taxRule iso_code_country="ee" id_tax="2"/>
-      <taxRule iso_code_country="gr" id_tax="2"/>
-      <taxRule iso_code_country="es" id_tax="2"/>
-      <taxRule iso_code_country="fr" id_tax="2"/>
-      <taxRule iso_code_country="ie" id_tax="2"/>
-      <taxRule iso_code_country="it" id_tax="2"/>
-      <taxRule iso_code_country="cy" id_tax="2"/>
-      <taxRule iso_code_country="lv" id_tax="2"/>
-      <taxRule iso_code_country="lt" id_tax="2"/>
-      <taxRule iso_code_country="lu" id_tax="2"/>
-      <taxRule iso_code_country="hu" id_tax="2"/>
-      <taxRule iso_code_country="mt" id_tax="2"/>
-      <taxRule iso_code_country="nl" id_tax="2"/>
-      <taxRule iso_code_country="at" id_tax="2"/>
-      <taxRule iso_code_country="pl" id_tax="2"/>
-      <taxRule iso_code_country="pt" id_tax="2"/>
-      <taxRule iso_code_country="ro" id_tax="2"/>
-      <taxRule iso_code_country="si" id_tax="2"/>
-      <taxRule iso_code_country="sk" id_tax="2"/>
-      <taxRule iso_code_country="fi" id_tax="2"/>
-      <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="uk" id_tax="2"/>
+    <taxRulesGroup name="RO Zero Rate (0%)">
+      <taxRule iso_code_country="be" id_tax="31"/>
+      <taxRule iso_code_country="bg" id_tax="31"/>
+      <taxRule iso_code_country="cz" id_tax="31"/>
+      <taxRule iso_code_country="dk" id_tax="31"/>
+      <taxRule iso_code_country="de" id_tax="31"/>
+      <taxRule iso_code_country="ee" id_tax="31"/>
+      <taxRule iso_code_country="gr" id_tax="31"/>
+      <taxRule iso_code_country="es" id_tax="31"/>
+      <taxRule iso_code_country="fr" id_tax="31"/>
+      <taxRule iso_code_country="ie" id_tax="31"/>
+      <taxRule iso_code_country="it" id_tax="31"/>
+      <taxRule iso_code_country="cy" id_tax="31"/>
+      <taxRule iso_code_country="lv" id_tax="31"/>
+      <taxRule iso_code_country="lt" id_tax="31"/>
+      <taxRule iso_code_country="lu" id_tax="31"/>
+      <taxRule iso_code_country="hu" id_tax="31"/>
+      <taxRule iso_code_country="mt" id_tax="31"/>
+      <taxRule iso_code_country="nl" id_tax="31"/>
+      <taxRule iso_code_country="at" id_tax="31"/>
+      <taxRule iso_code_country="pl" id_tax="31"/>
+      <taxRule iso_code_country="pt" id_tax="31"/>
+      <taxRule iso_code_country="ro" id_tax="31"/>
+      <taxRule iso_code_country="si" id_tax="31"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
+      <taxRule iso_code_country="fi" id_tax="31"/>
+      <taxRule iso_code_country="se" id_tax="31"/>
+      <taxRule iso_code_country="uk" id_tax="31"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="ro" id_tax="1"/>

--- a/localization/se.xml
+++ b/localization/se.xml
@@ -10,6 +10,7 @@
     <tax id="1" name="Moms SE 25%" rate="25" eu-tax-group="virtual"/>
     <tax id="2" name="Moms SE 12%" rate="12"/>
     <tax id="3" name="Moms SE 6%" rate="6"/>
+    <tax id="31" name="Moms SE 0%" rate="0"/>
     <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -46,8 +47,8 @@
     <taxRulesGroup name="SE Super Reduced Rate (6%)">
       <taxRule iso_code_country="se" id_tax="3"/>
     </taxRulesGroup>
-    <taxRulesGroup name="SE Reduced Rate within country (0%)">
-      <taxRule iso_code_country="se" id_tax="4"/>
+    <taxRulesGroup name="SE Zero Rate (0%)">
+      <taxRule iso_code_country="se" id_tax="31"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="se" id_tax="1"/>

--- a/localization/se.xml
+++ b/localization/se.xml
@@ -10,34 +10,34 @@
     <tax id="1" name="Moms SE 25%" rate="25" eu-tax-group="virtual"/>
     <tax id="2" name="Moms SE 12%" rate="12"/>
     <tax id="3" name="Moms SE 6%" rate="6"/>
-    <tax id="31" name="Moms SE 0%" rate="0"/>
-    <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="7" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="8" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="9" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="10" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="11" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="12" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="20" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="21" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="22" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="23" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="24" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="4" name="Moms SE 0%" rate="0"/>
+    <tax id="5" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="DPH CZ 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="31" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="SE Standard Rate (25%)">
       <taxRule iso_code_country="se" id_tax="1"/>
     </taxRulesGroup>
@@ -48,37 +48,37 @@
       <taxRule iso_code_country="se" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="SE Zero Rate (0%)">
-      <taxRule iso_code_country="se" id_tax="31"/>
+      <taxRule iso_code_country="se" id_tax="4"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="4"/>
-      <taxRule iso_code_country="be" id_tax="5"/>
-      <taxRule iso_code_country="bg" id_tax="6"/>
-      <taxRule iso_code_country="cy" id_tax="7"/>
-      <taxRule iso_code_country="cz" id_tax="8"/>
-      <taxRule iso_code_country="de" id_tax="9"/>
-      <taxRule iso_code_country="dk" id_tax="10"/>
-      <taxRule iso_code_country="ee" id_tax="11"/>
-      <taxRule iso_code_country="es" id_tax="12"/>
-      <taxRule iso_code_country="fi" id_tax="13"/>
-      <taxRule iso_code_country="fr" id_tax="14"/>
-      <taxRule iso_code_country="gb" id_tax="15"/>
-      <taxRule iso_code_country="gr" id_tax="16"/>
-      <taxRule iso_code_country="hr" id_tax="17"/>
-      <taxRule iso_code_country="hu" id_tax="18"/>
-      <taxRule iso_code_country="ie" id_tax="19"/>
-      <taxRule iso_code_country="it" id_tax="20"/>
-      <taxRule iso_code_country="lt" id_tax="21"/>
-      <taxRule iso_code_country="lu" id_tax="22"/>
-      <taxRule iso_code_country="lv" id_tax="23"/>
-      <taxRule iso_code_country="mt" id_tax="24"/>
-      <taxRule iso_code_country="nl" id_tax="25"/>
-      <taxRule iso_code_country="pl" id_tax="26"/>
-      <taxRule iso_code_country="pt" id_tax="27"/>
-      <taxRule iso_code_country="ro" id_tax="28"/>
-      <taxRule iso_code_country="si" id_tax="29"/>
-      <taxRule iso_code_country="sk" id_tax="30"/>
+      <taxRule iso_code_country="at" id_tax="5"/>
+      <taxRule iso_code_country="be" id_tax="6"/>
+      <taxRule iso_code_country="bg" id_tax="7"/>
+      <taxRule iso_code_country="cy" id_tax="8"/>
+      <taxRule iso_code_country="cz" id_tax="9"/>
+      <taxRule iso_code_country="de" id_tax="10"/>
+      <taxRule iso_code_country="dk" id_tax="11"/>
+      <taxRule iso_code_country="ee" id_tax="12"/>
+      <taxRule iso_code_country="es" id_tax="13"/>
+      <taxRule iso_code_country="fi" id_tax="14"/>
+      <taxRule iso_code_country="fr" id_tax="15"/>
+      <taxRule iso_code_country="gb" id_tax="16"/>
+      <taxRule iso_code_country="gr" id_tax="17"/>
+      <taxRule iso_code_country="hr" id_tax="18"/>
+      <taxRule iso_code_country="hu" id_tax="19"/>
+      <taxRule iso_code_country="ie" id_tax="20"/>
+      <taxRule iso_code_country="it" id_tax="21"/>
+      <taxRule iso_code_country="lt" id_tax="22"/>
+      <taxRule iso_code_country="lu" id_tax="23"/>
+      <taxRule iso_code_country="lv" id_tax="24"/>
+      <taxRule iso_code_country="mt" id_tax="25"/>
+      <taxRule iso_code_country="nl" id_tax="26"/>
+      <taxRule iso_code_country="pl" id_tax="27"/>
+      <taxRule iso_code_country="pt" id_tax="28"/>
+      <taxRule iso_code_country="ro" id_tax="29"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
   <units>

--- a/localization/si.xml
+++ b/localization/si.xml
@@ -21,7 +21,7 @@
     <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -33,7 +33,7 @@
     <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="SI Standard Rate (22%)">

--- a/localization/sk.xml
+++ b/localization/sk.xml
@@ -21,7 +21,7 @@
     <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="ΦΠΑ GR 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -33,7 +33,7 @@
     <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <taxRulesGroup name="SK Standard Rate (20%)">

--- a/localization/tn.xml
+++ b/localization/tn.xml
@@ -8,10 +8,23 @@
     <language iso_code="fr"/>
   </languages>
   <taxes>
-    <taxRulesGroup name="TVA Tunisie">
-      <taxRule iso_code_country="tn" behavior="0" id_tax="55"/>
+    <tax id="1" name="TN TVA 19%" rate="19"/>
+    <tax id="2" name="TN TVA 13%" rate="13"/>
+    <tax id="3" name="TN TVA 7%" rate="7"/>
+    <tax id="4" name="TN TVA 0%" rate="0"/>
+    <taxRulesGroup name="TN TVA Standard Rate (19%)">
+      <taxRule iso_code_country="tn" behavior="0" id_tax="1"/>
     </taxRulesGroup>
-    <tax id="55" name="TVA" rate="19.000"/>
+    <taxRulesGroup name="TN TVA Reduced Rate (13%)">
+      <taxRule iso_code_country="tn" behavior="0" id_tax="2"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="TN TVA Reduced Rate (7%)">
+      <taxRule iso_code_country="tn" behavior="0" id_tax="3"/>
+    </taxRulesGroup>
+    <taxRulesGroup name="TN TVA Zero Rate (0%)">
+      <taxRule iso_code_country="tn" behavior="0" id_tax="4"/>
+    </taxRulesGroup>
+
   </taxes>
   <units>
     <unit type="weight" value="kg"/>

--- a/src/PrestaShopBundle/Command/UpdateEUTaxruleGroupsCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateEUTaxruleGroupsCommand.php
@@ -88,7 +88,7 @@ class UpdateEUTaxruleGroupsCommand extends ContainerAwareCommand
 
         $euLocalizationFiles = array();
 
-        foreach (scandir($localizationPacksRoot, SCANDIR_SORT_NONE) as $entry) {
+        foreach (scandir($localizationPacksRoot, SCANDIR_SORT_ASCENDING) as $entry) {
             if (!preg_match('/\.xml$/', $entry)) {
                 continue;
             }


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Updates tax rates for Austria, Belarus, Bulgaria, China, Croatia, Italy, Latvia, Malta, Philippines, Panama, Portugal, Romania, Sweden and Tunisia.
| Type?         | improvement
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16122
| How to test?  | Install packs, verify that taxes are correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16291)
<!-- Reviewable:end -->
