### PR TITLE
Fix email not translated when installing a new language

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -422,6 +422,8 @@ class ContextCore
         $translator->clearLanguage($locale);
 
         $adminContext = defined('_PS_ADMIN_DIR_');
+        // Do not load DB translations when $this->language is PrestashopBundle\Install\Language
+        // because it means that we're looking for the installer translations, so we're not yet connected to the DB
         $withDB = !$this->language instanceof PrestashopBundle\Install\Language;
         $theme = $this->shop !== null ? $this->shop->theme : null;
         (new TranslatorLanguageLoader($adminContext))->loadLanguage($translator, $locale, $withDB, $theme);

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -25,12 +25,11 @@
  */
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
-use PrestaShopBundle\Translation\Loader\SqlTranslationLoader;
 use PrestaShopBundle\Translation\TranslatorComponent as Translator;
+use PrestaShopBundle\Translation\TranslatorLanguageLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Translation\Loader\XliffFileLoader;
 
 /**
  * Class ContextCore.
@@ -405,7 +404,7 @@ class ContextCore
 
         // In case we have at least 1 translated message, we return the current translator.
         // If some translations are missing, clear cache
-        if ($locale === '' || count($translator->getCatalogue($locale)->all())) {
+        if ($locale === '' || null === $locale || count($translator->getCatalogue($locale)->all())) {
             return $translator;
         }
 
@@ -420,49 +419,13 @@ class ContextCore
             (new Filesystem())->remove($cache_file);
         }
 
+        $translator->clearLanguage($locale);
+
         $adminContext = defined('_PS_ADMIN_DIR_');
-        $translator->addLoader('xlf', new XliffFileLoader());
-
-        $sqlTranslationLoader = new SqlTranslationLoader();
-        if (null !== $this->shop) {
-            $sqlTranslationLoader->setTheme($this->shop->theme);
-        }
-
-        $translator->addLoader('db', $sqlTranslationLoader);
-        $notName = $adminContext ? '^Shop*' : '^Admin*';
-
-        $finder = Finder::create()
-            ->files()
-            ->name('*.' . $locale . '.xlf')
-            ->notName($notName)
-            ->in($this->getTranslationResourcesDirectories());
-
-        foreach ($finder as $file) {
-            list($domain, $locale, $format) = explode('.', $file->getBasename(), 3);
-
-            $translator->addResource($format, $file, $locale, $domain);
-            if (!$this->language instanceof PrestashopBundle\Install\Language) {
-                $translator->addResource('db', $domain . '.' . $locale . '.db', $locale, $domain);
-            }
-        }
+        $withDB = !$this->language instanceof PrestashopBundle\Install\Language;
+        $theme = $this->shop !== null ? $this->shop->theme : null;
+        (new TranslatorLanguageLoader($adminContext))->loadLanguage($translator, $locale, $withDB, $theme);
 
         return $translator;
-    }
-
-    /**
-     * @return array
-     */
-    protected function getTranslationResourcesDirectories()
-    {
-        $locations = array(_PS_ROOT_DIR_ . '/app/Resources/translations');
-
-        if (null !== $this->shop) {
-            $activeThemeLocation = _PS_ROOT_DIR_ . '/themes/' . $this->shop->theme_name . '/translations';
-            if (is_dir($activeThemeLocation)) {
-                $locations[] = $activeThemeLocation;
-            }
-        }
-
-        return $locations;
     }
 }

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -29,6 +29,7 @@ use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShopBundle\Translation\TranslatorLanguageLoader;
 
 class LanguageCore extends ObjectModel
 {
@@ -1391,7 +1392,11 @@ class LanguageCore extends ObjectModel
     {
         $shopDefaultLangId = Configuration::get('PS_LANG_DEFAULT', null, $shop->id_shop_group, $shop->id);
         $shopDefaultLanguage = new Language($shopDefaultLangId);
-        $translatorDefaultShopLanguage = Context::getContext()->getTranslatorFromLocale($shopDefaultLanguage->locale);
+
+        $translator = SymfonyContainer::getInstance()->get('translator');
+        if (!$translator->isLanguageLoaded($shopDefaultLanguage->locale)) {
+            (new TranslatorLanguageLoader(true))->loadLanguage($translator, $shopDefaultLanguage->locale);
+        }
 
         $shopFieldExists = $primary_key_exists = false;
         $columns = Db::getInstance()->executeS('SHOW COLUMNS FROM `' . $tableName . '`');
@@ -1430,7 +1435,7 @@ class LanguageCore extends ObjectModel
                         continue;
                     }
 
-                    $untranslated = $translatorDefaultShopLanguage->getSourceString($data[$toUpdate], $classObject->getDomain());
+                    $untranslated = $translator->getSourceString($data[$toUpdate], $classObject->getDomain());
                     $translatedField = $classObject->getFieldValue($toUpdate, $untranslated);
 
                     if (!empty($translatedField) && $translatedField != $data[$toUpdate]) {

--- a/composer.json
+++ b/composer.json
@@ -157,9 +157,9 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache"
         ],
         "test-all": [
+            "composer phpunit-admin",
             "composer phpunit-legacy",
             "composer unit-tests",
-            "composer phpunit-admin",
             "composer phpunit-sf",
             "composer integration-tests",
             "composer phpunit-controllers",

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -120,15 +120,16 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
             if (!$this->processInstallDatabase()) {
                 $this->printErrors();
             }
+
+            // Deferred Kernel Init
+            $this->initKernel();
+
             if (!$this->processInstallDefaultData()) {
                 $this->printErrors();
             }
             if (!$this->processPopulateDatabase()) {
                 $this->printErrors();
             }
-
-            // Deferred Kernel Init
-            $this->initKernel();
 
             if (!$this->processConfigureShop()) {
                 $this->printErrors();

--- a/src/Core/Domain/MailTemplate/CommandHandler/GenerateThemeMailTemplatesCommandHandler.php
+++ b/src/Core/Domain/MailTemplate/CommandHandler/GenerateThemeMailTemplatesCommandHandler.php
@@ -33,7 +33,6 @@ use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateGenerator;
 use PrestaShop\PrestaShop\Core\MailTemplate\ThemeCatalogInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\ThemeInterface;
-use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -99,34 +98,9 @@ class GenerateThemeMailTemplatesCommandHandler implements GenerateThemeMailTempl
         /** @var ThemeInterface $theme */
         $theme = $this->themeCatalog->getByName($command->getThemeName());
 
-        $this->cleanTranslatorLocaleCache($command->getLanguage());
-
         $coreMailsFolder = $command->getCoreMailsFolder() ?: $this->defaultCoreMailsFolder;
         $modulesMailFolder = $command->getModulesMailFolder() ?: $this->defaultModulesMailFolder;
 
         $this->generator->generateTemplates($theme, $language, $coreMailsFolder, $modulesMailFolder, $command->overwriteTemplates());
-    }
-
-    /**
-     * When installing a new Language, if it's a new one the Translator component can't manage it because its cache is
-     * already filled with the default one as fallback. We force the component to update its cache by adding a fake
-     * resource for this locale (this is the only way clean its local cache)
-     *
-     * @param string $locale
-     */
-    private function cleanTranslatorLocaleCache($locale)
-    {
-        if (!method_exists($this->translator, 'addLoader')
-            || !method_exists($this->translator, 'addResource')
-        ) {
-            return;
-        }
-
-        $this->translator->addLoader('array', new ArrayLoader());
-        $this->translator->addResource(
-            'array',
-            ['Fake clean cache message' => 'Fake clean cache message'],
-            $locale
-        );
     }
 }

--- a/src/PrestaShopBundle/Translation/Translator.php
+++ b/src/PrestaShopBundle/Translation/Translator.php
@@ -35,6 +35,7 @@ use Symfony\Bundle\FrameworkBundle\Translation\Translator as BaseTranslator;
 class Translator extends BaseTranslator
 {
     use PrestaShopTranslatorTrait;
+    use TranslatorLanguageTrait;
 
     /**
      * {@inheritdoc}

--- a/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
+++ b/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation;
+
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShopBundle\Translation\Loader\SqlTranslationLoader;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class TranslatorLanguageLoader
+{
+    const TRANSLATION_DIR = _PS_ROOT_DIR_ . '/app/Resources/translations';
+    /**
+     * @var bool
+     */
+    private $isAdminContext;
+
+    /**
+     * TranslatorLanguageLoader constructor.
+     *
+     * @param $isAdminContext
+     */
+    public function __construct($isAdminContext)
+    {
+        $this->isAdminContext = $isAdminContext;
+    }
+
+    /**
+     * Loads a language into a translator
+     *
+     * @param TranslatorInterface $translator Translator to modifiy
+     * @param string $locale Locale code for the language to load
+     * @param bool $withDB [default=true] Whether to load translations from the database or not
+     * @param Theme|null $theme [default=false] Currently active theme (Front office only)
+     */
+    public function loadLanguage(TranslatorInterface $translator, $locale, $withDB = true, Theme $theme = null)
+    {
+        if (!$translator->isLanguageLoaded($locale)) {
+            $translator->addLoader('xlf', new XliffFileLoader());
+
+            if ($withDB) {
+                $sqlTranslationLoader = new SqlTranslationLoader();
+                if (null !== $theme) {
+                    $sqlTranslationLoader->setTheme($theme);
+                }
+                $translator->addLoader('db', $sqlTranslationLoader);
+            }
+
+            $finder = Finder::create()
+                ->files()
+                ->name('*.' . $locale . '.xlf')
+                ->notName($this->isAdminContext ? '^Shop*' : '^Admin*')
+                ->in($this->getTranslationResourcesDirectories($theme));
+
+            foreach ($finder as $file) {
+                list($domain, $locale, $format) = explode('.', $file->getBasename(), 3);
+                $translator->addResource($format, $file, $locale, $domain);
+                if ($withDB) {
+                    $translator->addResource('db', $domain . '.' . $locale . '.db', $locale, $domain);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Theme|null $theme
+     *
+     * @return array
+     */
+    protected function getTranslationResourcesDirectories(Theme $theme = null)
+    {
+        $locations = [self::TRANSLATION_DIR];
+
+        if (null !== $theme) {
+            $activeThemeLocation = $theme->getDirectory() . '/translations';
+            if (is_dir($activeThemeLocation)) {
+                $locations[] = $activeThemeLocation;
+            }
+        }
+
+        return $locations;
+    }
+}

--- a/src/PrestaShopBundle/Translation/TranslatorLanguageTrait.php
+++ b/src/PrestaShopBundle/Translation/TranslatorLanguageTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * 2007-2019 PrestaShop and Contributors
+ * 2007-2019 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -27,13 +27,26 @@
 
 namespace PrestaShopBundle\Translation;
 
-use Symfony\Component\Translation\Translator as BaseTranslatorComponent;
-
 /**
- * Translator used by Context
+ * Trait TranslatorLanguageTrait used to check if a language has been loaded and reset a language
  */
-class TranslatorComponent extends BaseTranslatorComponent
+trait TranslatorLanguageTrait
 {
-    use PrestaShopTranslatorTrait;
-    use TranslatorLanguageTrait;
+    /**
+     * @param string $locale Locale code for the catalogue to check if loaded
+     *
+     * @return bool
+     */
+    public function isLanguageLoaded($locale)
+    {
+        return !empty($this->catalogues[$locale]);
+    }
+
+    /**
+     * @param string $locale Locale code for the catalogue to be cleared
+     */
+    public function clearLanguage($locale)
+    {
+        unset($this->catalogues[$locale]);
+    }
 }

--- a/tests-legacy/check_phpunit.sh
+++ b/tests-legacy/check_phpunit.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-composer run-script phpunit-legacy --timeout=0;
-LEGACY=$?
-
 composer run-script phpunit-admin --timeout=0;
 ADMIN=$?
+
+composer run-script phpunit-legacy --timeout=0;
+LEGACY=$?
 
 composer run-script phpunit-routing --timeout=0;
 ROUTING=$?


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | This fixes emails not being translated when installing a new language
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16273
| How to test?  | See #16273 ⚠ As it modifies quite a lot the language management, we should also test if mails are correctly generated during a fresh install (using something else than english) from web, and with CLI And check that the manual generation from the form also still works  ⚠

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16294)
<!-- Reviewable:end -->
