### PR TITLE
Cast employeeId to int in the bulk update employee command

### DIFF
--- a/src/Core/Domain/Employee/Command/BulkDeleteEmployeeCommand.php
+++ b/src/Core/Domain/Employee/Command/BulkDeleteEmployeeCommand.php
@@ -60,7 +60,7 @@ class BulkDeleteEmployeeCommand
     private function setEmployeeIds(array $employeeIds)
     {
         foreach ($employeeIds as $employeeId) {
-            $this->employeeIds[] = new EmployeeId($employeeId);
+            $this->employeeIds[] = new EmployeeId((int) $employeeId);
         }
     }
 }

--- a/src/Core/Domain/Employee/Command/BulkUpdateEmployeeStatusCommand.php
+++ b/src/Core/Domain/Employee/Command/BulkUpdateEmployeeStatusCommand.php
@@ -76,7 +76,7 @@ class BulkUpdateEmployeeStatusCommand
     private function setEmployeeIds(array $employeeIds)
     {
         foreach ($employeeIds as $employeeId) {
-            $this->employeeIds[] = new EmployeeId($employeeId);
+            $this->employeeIds[] = new EmployeeId((int) $employeeId);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This force `EmployeeId` constructor parameter to be an `int`
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16246
| How to test?  | Go to `Configure > Advanced Parameters > Team > Employees page` and try a bulk action

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16307)
<!-- Reviewable:end -->
