### PR TITLE
Fix incorrect display value in Price Tab of admin product controller

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -86,10 +86,8 @@ class ProductPrice extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $this->tax_rules = array_merge(
-            [$this->translator->trans('No tax', [], 'Admin.Catalog.Feature') => 0],
-            $this->tax_rules
-        );
+        $this->tax_rules = [$this->translator->trans('No tax', [], 'Admin.Catalog.Feature') => 0] + $this->tax_rules;
+
         $builder->add(
             'price',
             FormType\MoneyType::class,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Use "+" operator instead of array_merge() when adding "No tax" option
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16308
| How to test?  | see issue #16308

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16312)
<!-- Reviewable:end -->
