### PR TITLE
Allow to define authorized MIME types in ImageManager::validateUpload()

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -358,7 +358,7 @@ class ImageManagerCore
      *
      * @param string $filename File path to check
      * @param string $fileMimeType File known mime type (generally from $_FILES)
-     * @param array $mimeTypeList Allowed MIME types
+     * @param array<string>|null $mimeTypeList Allowed MIME types
      *
      * @return bool
      */
@@ -445,8 +445,8 @@ class ImageManagerCore
      *
      * @param array $file Upload $_FILE value
      * @param int $maxFileSize Maximum upload size
-     * @param array<string> $types Authorized extensions
-     * @param array<string> $mimeTypeList Authorized mimetypes
+     * @param array<string>|null $types Authorized extensions
+     * @param array<string>|null $mimeTypeList Authorized mimetypes
      *
      * @return bool|string Return false if no error encountered
      */

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -42,7 +42,7 @@ class ImageManagerCore
         'image/jpeg',
         'image/pjpeg',
         'image/png',
-        'image/x-png'
+        'image/x-png',
     ];
 
     /**

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -355,6 +355,7 @@ class ImageManagerCore
 
     /**
      * @param string $filename
+     *
      * @return string|bool
      */
     public static function getMimeType(string $filename)

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -388,6 +388,7 @@ class ImageManagerCore
                 $mimeType = trim(exec('file -bi ' . escapeshellarg($filename)));
             }
         }
+
         return $mimeType;
     }
 

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -442,15 +442,17 @@ class ImageManagerCore
      *
      * @param array $file Upload $_FILE value
      * @param int $maxFileSize Maximum upload size
+     * @param array<string> $types Authorized extensions
+     * @param array<string> $mimeTypeList Authorized mimetypes
      *
      * @return bool|string Return false if no error encountered
      */
-    public static function validateUpload($file, $maxFileSize = 0, $types = null)
+    public static function validateUpload($file, $maxFileSize = 0, $types = null, $mimeTypeList = null)
     {
         if ((int) $maxFileSize > 0 && $file['size'] > (int) $maxFileSize) {
             return Context::getContext()->getTranslator()->trans('Image is too large (%1$d kB). Maximum allowed: %2$d kB', array($file['size'] / 1024, $maxFileSize / 1024), 'Admin.Notifications.Error');
         }
-        if (!ImageManager::isRealImage($file['tmp_name'], $file['type']) || !ImageManager::isCorrectImageFileExt($file['name'], $types) || preg_match('/\%00/', $file['name'])) {
+        if (!ImageManager::isRealImage($file['tmp_name'], $file['type'], $mimeTypeList) || !ImageManager::isCorrectImageFileExt($file['name'], $types) || preg_match('/\%00/', $file['name'])) {
             return Context::getContext()->getTranslator()->trans('Image format not recognized, allowed formats are: .gif, .jpg, .png', array(), 'Admin.Notifications.Error');
         }
         if ($file['error']) {

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -36,6 +36,14 @@ class ImageManagerCore
     const ERROR_FILE_NOT_EXIST = 1;
     const ERROR_FILE_WIDTH = 2;
     const ERROR_MEMORY_LIMIT = 3;
+    const MIME_TYPE_SUPPORTED = [
+        'image/gif',
+        'image/jpg',
+        'image/jpeg',
+        'image/pjpeg',
+        'image/png',
+        'image/x-png'
+    ];
 
     /**
      * Generate a cached thumbnail for object lists (eg. carrier, order statuses...etc).
@@ -370,8 +378,7 @@ class ImageManagerCore
         }
         // Try with FileInfo
         if (!$mimeType && function_exists('finfo_open')) {
-            $const = defined('FILEINFO_MIME_TYPE') ? FILEINFO_MIME_TYPE : FILEINFO_MIME;
-            $finfo = finfo_open($const);
+            $finfo = finfo_open(FILEINFO_MIME_TYPE);
             $mimeType = finfo_file($finfo, $filename);
             finfo_close($finfo);
         }
@@ -405,10 +412,10 @@ class ImageManagerCore
     public static function isRealImage($filename, $fileMimeType = null, $mimeTypeList = null)
     {
         if (!$mimeTypeList) {
-            $mimeTypeList = ['image/gif', 'image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/x-png'];
+            $mimeTypeList = static::MIME_TYPE_SUPPORTED;
         }
 
-        $mimeType = self::getMimeType($filename);
+        $mimeType = static::getMimeType($filename);
 
         if ($fileMimeType && (empty($mimeType) || $mimeType == 'regular file' || $mimeType == 'text/plain')) {
             $mimeType = $fileMimeType;

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -379,14 +379,17 @@ class ImageManagerCore
             } else {
                 $fileMimeType = false;
             }
-        } elseif (function_exists('finfo_open')) {
+        }
+        if (!$mimeType && function_exists('finfo_open')) {
             $const = defined('FILEINFO_MIME_TYPE') ? FILEINFO_MIME_TYPE : FILEINFO_MIME;
             $finfo = finfo_open($const);
             $mimeType = finfo_file($finfo, $filename);
             finfo_close($finfo);
-        } elseif (function_exists('mime_content_type')) {
+        }
+        if (!$mimeType && function_exists('mime_content_type')) {
             $mimeType = mime_content_type($filename);
-        } elseif (function_exists('exec')) {
+        }
+        if (!$mimeType && function_exists('exec')) {
             $mimeType = trim(exec('file -b --mime-type ' . escapeshellarg($filename)));
             if (!$mimeType) {
                 $mimeType = trim(exec('file --mime ' . escapeshellarg($filename)));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | * Permit to override the mime-type list in ImageManager::validateUpload<br> * Check the mimetype (if the file is not managed by the previous method in ImageManager::isRealImage
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partial fix for #10600
| How to test?  | Upload doesn't change (sample : Image Product use ImageManager::validateUpload)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16316)
<!-- Reviewable:end -->
