### PR TITLE
Only trigger deploy on cron task, and tests on push / pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,19 @@ env:
     - PRESTASHOP_TEST_TYPE=integration
     - PRESTASHOP_TEST_TYPE=sanity
 
+stages:
+  - name: deploy
+    if: type = cron
+  - name: test
+    if: type IN (push, pull_request)
+
 matrix:
   include:
-    - php: 7.2
-      env: EXTRA_DEPS=phpHigh  PRESTASHOP_TEST_TYPE=unit
     - stage: deploy
       php: 7.2
       before_install: skip
+      before_script: skip
+      install: skip
       script:
         - mkdir -p /tmp/ps-release
         - php tools/build/CreateRelease.php --destination-dir=/tmp/ps-release
@@ -58,9 +64,6 @@ matrix:
         local-dir: "/tmp/ps-release"
         on:
           all_branches: true
-  allow_failures:
-    - php: 7.2
-      env: EXTRA_DEPS=phpHigh  PRESTASHOP_TEST_TYPE=unit
 
 before_install:
   - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_10.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :10 -ac -screen 0 1600x1200x16
@@ -74,12 +77,7 @@ before_install:
   - cp tests-legacy/parameters.yml.travis app/config/parameters.yml
 
 before_script:
-  - if [ "$EXTRA_DEPS" = "phpHigh" ]; then
-        composer update --ignore-platform-reqs --no-suggest --ansi --no-interaction --no-progress --quiet;
-    else
-        composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --quiet;
-    fi
-
+  - composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --quiet;
   - bash travis-scripts/install-prestashop;
 
 script:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Deploy should be trigger alone on cron task. And tests should be triggered on push / pull request only. Remove phpHigh which failing all the time, this test is useless an consume memory for nothing.
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16280
| How to test?  | Travis must be green. You should be able to trigger a cron task on my branch :)<br>FYI an example of CRON: https://travis-ci.org/PierreRambaud/PrestaShop/builds/609289135?utm_medium=notification&utm_source=email (failing because I wanted it)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16317)
<!-- Reviewable:end -->
