### PR TITLE
Use customer group price display preference when displaying orders in BO

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -827,7 +827,6 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
         return new OrderDiscountsForViewing($discountsForViewing);
     }
 
-
     /**
      * @param Order $order
      *

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
@@ -136,9 +136,11 @@
             </th>
             <th>{{ 'Reference'|trans({}, 'Admin.Global') }}</th>
             <th>{{ 'Stock location'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
-            <th class="text-center">
-              {{ 'Tax'|trans({}, 'Admin.Global') }}
-            </th>
+            {% if orderPreview.taxIncluded == false %}
+              <th class="text-center">
+                {{ 'Tax'|trans({}, 'Admin.Global') }}
+              </th>
+            {% endif %}
             <th class="text-center">{{ 'Quantity'|trans({}, 'Admin.Global') }}</th>
             <th class="text-center">
               {{ 'Total'|trans({}, 'Admin.Global') }}
@@ -154,7 +156,9 @@
               <td class="p-1">
                 {% if productDetail.location is not empty %}{{ productDetail.location }}{% else %}-{% endif %}
               </td>
-              <td class="p-1 text-center">{{ productDetail.totalTax }}</td>
+              {% if orderPreview.taxIncluded == false %}
+                <td class="p-1 text-center">{{ productDetail.totalTax }}</td>
+              {% endif %}
               <td class="p-1 text-center">{{ productDetail.quantity }}</td>
               <td class="p-1 text-center">{{ productDetail.totalPrice }}</td>
             </tr>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Use customer group price display preference for display order in BO
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/14732
| How to test?  | See below. Dont forget to rebuild assets.

### How to test?

Expected behavior:
In both migrated pages "Listing of orders" and "Edit/view an order",
- if the main customer group for the customer of the order has "display tax **included**" setting, then display the order as "tax included"
- if the main customer group for the customer of the order has "display tax **excluded**" setting, then display the order as "tax excluded"

Additionally, for Order Preview on listing of orders, if the display method is "tax included" then the "tax" column is not displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16319)
<!-- Reviewable:end -->
