### PR TITLE
Add "total_shipping_tax_excl" and "total_shipping_tax_incl" in email data

### DIFF
--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -234,6 +234,8 @@ final class MailPreviewVariablesBuilder
             '{total_discounts}' => $this->locale->formatPrice($order->total_discounts, $this->context->currency->iso_code),
             '{total_wrapping}' => $this->locale->formatPrice($order->total_wrapping, $this->context->currency->iso_code),
             '{total_shipping}' => $this->locale->formatPrice($order->total_shipping, $this->context->currency->iso_code),
+            '{total_shipping_tax_excl}' => $this->locale->formatPrice($order->total_shipping_tax_excl, $this->context->currency->iso_code),
+            '{total_shipping_tax_incl}' => $this->locale->formatPrice($order->total_shipping_tax_incl, $this->context->currency->iso_code),
             '{total_tax_paid}' => $this->locale->formatPrice(($order->total_products_wt - $order->total_products) + ($order->total_shipping_tax_incl - $order->total_shipping_tax_excl), $this->context->currency->iso_code),
             '{total_paid}' => $this->locale->formatPrice($order->total_paid, $this->context->currency->iso_code),
         ]);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Solve the same issue than #11397
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Use "{total_shipping_tax_excl}" or "{total_shipping_tax_incl}" in "order_conf" email template

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16331)
<!-- Reviewable:end -->
