### PR TITLE
Update id_order_state at the right place

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -309,6 +309,14 @@ abstract class PaymentModuleCore extends Module
                 }
             }
 
+            // Amount paid by customer is not the right one -> Status = payment error
+            // We don't use the following condition to avoid the float precision issues : http://www.php.net/manual/en/language.types.float.php
+            // if ($order->total_paid != $order->total_paid_real)
+            // We use number_format in order to compare two string
+            if ($order_status->logable && number_format($cart_total_paid, _PS_PRICE_COMPUTE_PRECISION_) != number_format($amount_paid, _PS_PRICE_COMPUTE_PRECISION_)) {
+                $id_order_state = Configuration::get('PS_OS_ERROR');
+            }
+
             foreach ($package_list as $id_address => $packageByAddress) {
                 foreach ($packageByAddress as $id_package => $package) {
                     $orderData = $this->createOrderFromCart(
@@ -1013,14 +1021,6 @@ abstract class PaymentModuleCore extends Module
         if (!$result) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Order cannot be created', 3, null, 'Cart', (int) $cart->id, true);
             throw new PrestaShopException('Can\'t save Order');
-        }
-
-        // Amount paid by customer is not the right one -> Status = payment error
-        // We don't use the following condition to avoid the float precision issues : http://www.php.net/manual/en/language.types.float.php
-        // if ($order->total_paid != $order->total_paid_real)
-        // We use number_format in order to compare two string
-        if ($order_status->logable && number_format($cart_total_paid, _PS_PRICE_COMPUTE_PRECISION_) != number_format($amount_paid, _PS_PRICE_COMPUTE_PRECISION_)) {
-            $id_order_state = Configuration::get('PS_OS_ERROR');
         }
 
         if ($debug) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | In case where `$cart_total_paid` is different from `$amount_paid`, the `$id_order_state` wasn't updated in the right context
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15834
| How to test?  | See #15834

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16335)
<!-- Reviewable:end -->
