### PR TITLE
PassVsprintfValidator: Add separate regex for arguments only

### DIFF
--- a/src/PrestaShopBundle/Command/CheckTranslationDuplicatesCommand.php
+++ b/src/PrestaShopBundle/Command/CheckTranslationDuplicatesCommand.php
@@ -114,7 +114,7 @@ class CheckTranslationDuplicatesCommand extends ContainerAwareCommand
         // Remove PrestaShop arguments %<arg>%
         $message = preg_replace(PrestaShopTranslatorTrait::$regexClassicParams, '~', $message);
         // Remove all related sprintf arguments
-        $message = preg_replace(PrestaShopTranslatorTrait::$regexSprintfParams, '~', $message);
+        $message = preg_replace(PrestaShopTranslatorTrait::$regexSprintfArgs, '~', $message);
 
         return $message;
     }

--- a/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
+++ b/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
@@ -54,7 +54,7 @@ class PassVsprintfValidator extends ConstraintValidator
     private function countArgumentsOfTranslation($property)
     {
         $matches = array();
-        if (preg_match_all(PrestaShopTranslatorTrait::$regexSprintfParams, $property, $matches) === false) {
+        if (preg_match_all(PrestaShopTranslatorTrait::$regexSprintfArgs, $property, $matches) === false) {
             throw new Exception('Preg_match failed');
         }
 

--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -34,6 +34,7 @@ trait PrestaShopTranslatorTrait
 {
     public static $regexSprintfParams = '#(?:%%|%(?:[0-9]+\$)?[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFosxX])#';
     public static $regexClassicParams = '/%\w+%/';
+    public static $regexSprintfArgs = '#(?:%(?:[0-9]+\$)?[+-]?(?:[ 0]|\'.)?-?[0-9]*(?:\.[0-9]+)?[bcdeufFosxX])#';
 
     /**
      * Translates the given message.


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes a bug preventing the saving of translations containing a `%%` literal
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16421 
| How to test?  | Attempt a translation containing a literal `%%` - it will not be saved (Despite a green popup)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16359)
<!-- Reviewable:end -->
