### PR TITLE
Fix output buffer not closed in Twig\HookExtension::renderHooksArray

### DIFF
--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -126,7 +126,7 @@ class HookExtension extends \Twig_Extension
         ob_start();
         $renderedHook = $this->hookDispatcher->dispatchRenderingWithParameters($hookName, $hookParameters);
         $renderedHook->outputContent();
-        ob_clean();
+        ob_end_clean();
 
         $render = [];
         foreach ($renderedHook->getContent() as $module => $hookRender) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | `HookExtension::renderHooksArray` increases ob level without closing it. <br><br> This can cause a WSOD on twig pages that make use of it in certain circumstances, but the WSOD isn't easily reproducible.<br><br>(The WSOD occurred after an autoupgrade from 1.7.5.1 to 1.7.6.1 with the `displayAdminProductsExtra` call in `product.html.twig` on PHP CGI, but couldn't be reproduced in a clean test under identical circumstances)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Dump `ob_get_level()` before calling `Request::send()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16360)
<!-- Reviewable:end -->
