### PR TITLE
Viewed products - the date is showing product id - not a  date

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/viewed_products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/viewed_products.html.twig
@@ -34,7 +34,7 @@
       <table class="table">
         <thead>
           <tr>
-            <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
+            <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
             <th>{{ 'Name'|trans({}, 'Admin.Global') }}</th>
           </tr>
         </thead>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Viewed products - the date is showing product id - not date
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16363
| How to test?  | Go to the BO => Customers page => view a customer & check the Viewed Product is showing ID

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16365)
<!-- Reviewable:end -->
