### PR TITLE
Fix wrong case sensitiveness for email addresses

### DIFF
--- a/src/Core/Domain/Customer/ValueObject/Email.php
+++ b/src/Core/Domain/Customer/ValueObject/Email.php
@@ -72,7 +72,7 @@ class Email
      */
     public function isEqualTo(Email $email)
     {
-        return $email->getValue() === $this->getValue();
+        return strtolower($email->getValue()) === strtolower($this->getValue());
     }
 
     /**

--- a/src/Core/Domain/ValueObject/Email.php
+++ b/src/Core/Domain/ValueObject/Email.php
@@ -74,7 +74,7 @@ class Email
      */
     public function isEqualTo(Email $email)
     {
-        return $email->getValue() === $this->getValue();
+        return strtolower($email->getValue()) === strtolower($this->getValue());
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Email are not case sensitve, `Test@prestashop.com` is equal to `test@prestashop.com`. Plus the field in database is not case sensitive.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15889
| How to test?  | Go to the BO => Customers Page<br>Edit a customer (Jhon Doe)<br>Change the email for example from pub@prestashop.com to Pub@prestashop.com or PUB@prestashop.com<br> Click on save

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16375)
<!-- Reviewable:end -->
