### PR TITLE
repetition of "SubmitCurrency=..&id_currency=.."

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -675,6 +675,8 @@ class ToolsCore
             $currency = Currency::getCurrencyInstance((int) $id_currency);
             if (is_object($currency) && $currency->id && !$currency->deleted && $currency->isAssociatedToShop()) {
                 $cookie->id_currency = (int) $currency->id;
+                unset($_GET['SubmitCurrency']);
+                unset($_GET['id_currency']);
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Infinite crawl loop on module ps_currencyselector due to repetition of "SubmitCurrency=..&id_currency=.."
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/16377 / #9481
| How to test?  | Please see related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16378)
<!-- Reviewable:end -->
