### PR TITLE
Improve cache for staticPrice for products with combinations

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3200,8 +3200,8 @@ class ProductCore extends ObjectModel
                 $sql = 'SELECT SUM(`quantity`)
                 FROM `' . _DB_PREFIX_ . 'cart_product`
                 WHERE `id_product` = ' . (int) $id_product . '
-                AND `id_cart` = ' . (int) $id_cart . '
-				AND `id_product_attribute` = ' . (int) $id_product_attribute;
+                AND `id_cart` = ' . (int) $id_cart;
+                $sql .= !empty($id_product_attribute) ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '';
                 $cart_quantity = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
                 Cache::store($cache_id, $cart_quantity);
             } else {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3195,12 +3195,13 @@ class ProductCore extends ObjectModel
 
         $cart_quantity = 0;
         if ((int) $id_cart) {
-            $cache_id = 'Product::getPriceStatic_' . (int) $id_product . '-' . (int) $id_cart;
+            $cache_id = 'Product::getPriceStatic_' . (int) $id_product . '-' . (int)$id_product_attribute . '-' . (int) $id_cart;
             if (!Cache::isStored($cache_id) || ($cart_quantity = Cache::retrieve($cache_id) != (int) $quantity)) {
                 $sql = 'SELECT SUM(`quantity`)
                 FROM `' . _DB_PREFIX_ . 'cart_product`
                 WHERE `id_product` = ' . (int) $id_product . '
-                AND `id_cart` = ' . (int) $id_cart;
+                AND `id_cart` = ' . (int) $id_cart . '
+				AND `id_product_attribute` = ' . (int) $id_product_attribute;
                 $cart_quantity = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
                 Cache::store($cache_id, $cart_quantity);
             } else {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3201,7 +3201,7 @@ class ProductCore extends ObjectModel
                 FROM `' . _DB_PREFIX_ . 'cart_product`
                 WHERE `id_product` = ' . (int) $id_product . '
                 AND `id_cart` = ' . (int) $id_cart;
-                $sql .= !empty($id_product_attribute) ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '';
+                $sql .= $id_product_attribute !== null ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '';
                 $cart_quantity = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
                 Cache::store($cache_id, $cart_quantity);
             } else {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3195,7 +3195,7 @@ class ProductCore extends ObjectModel
 
         $cart_quantity = 0;
         if ((int) $id_cart) {
-            $cache_id = 'Product::getPriceStatic_' . (int) $id_product . '-' . (int)$id_product_attribute . '-' . (int) $id_cart;
+            $cache_id = 'Product::getPriceStatic_' . (int) $id_product . '-' . (int) $id_product_attribute . '-' . (int) $id_cart;
             if (!Cache::isStored($cache_id) || ($cart_quantity = Cache::retrieve($cache_id) != (int) $quantity)) {
                 $sql = 'SELECT SUM(`quantity`)
                 FROM `' . _DB_PREFIX_ . 'cart_product`


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Initial PR #8542 from @jbustamanterendon<br>The "id_product_attribute" was not being cached when checking the quantity of each product in the cart, making multiple calls to the "cart_product" table and lowering the store's performance.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9803 & http://forge.prestashop.com/browse/BOOM-4368
| How to test?  | Many products with many combinations in the cart, for example : 77 products in the shopping cart where there were only about 20 products, the other 57 were different combinations of the products.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16404)
<!-- Reviewable:end -->
