### PR TITLE
Correct class for tooltip

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
@@ -254,7 +254,7 @@
     <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ translation_domain is same as(false) ? label|raw : label|raw }}
       {% if label_attr['tooltip'] is defined %}
         {% set placement = label_attr['tooltip_placement'] is defined ? label_attr['tooltip_placement'] : 'top' %}
-        <i class="icon-question" data-toggle="pstooltip" data-placement="{{ placement }}"
+        <i class="help-box" data-toggle="pstooltip" data-placement="{{ placement }}"
            title="{{ label_attr['tooltip'] }}"></i>
       {% endif %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -74,7 +74,7 @@
     <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ translation_domain is same as(false) ? label|raw : label|raw }}
     {% if label_attr['tooltip'] is defined %}
       {% set placement = label_attr['tooltip_placement'] is defined ? label_attr['tooltip_placement'] : 'top' %}
-      <i class="icon-question" data-toggle="pstooltip" data-placement="{{ placement }}"
+      <i class="help-box" data-toggle="pstooltip" data-placement="{{ placement }}"
          title="{{ label_attr['tooltip'] }}"></i>
     {% endif %}
 


### PR DESCRIPTION
icon-question class does not exists, use help-box instead

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | icon-question class does not exists, use help-box instead
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See below

## How to test

Install following demo module
[demoextendsymfonyform1.zip](https://github.com/PrestaShop/PrestaShop/files/4657632/demoextendsymfonyform1.zip)
It adds a date-picker field into Configure > Advanced > Performance page at the end of the form.

Without the PR, the tooltip is not displayed.
With the PR, the tooltip is displayed:
<img width="1028" alt="Capture d’écran 2020-05-20 à 17 00 23" src="https://user-images.githubusercontent.com/3830050/82462361-c56c6a80-9abb-11ea-90bd-7d04209555fc.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16406)
<!-- Reviewable:end -->
