### PR TITLE
Retrieve associated Specific Prices on the Product resource

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -417,6 +417,7 @@ class ProductCore extends ObjectModel
             'tax_rules_group' => array('type' => self::HAS_ONE),
             'categories' => array('type' => self::HAS_MANY, 'field' => 'id_category', 'object' => 'Category', 'association' => 'category_product'),
             'stock_availables' => array('type' => self::HAS_MANY, 'field' => 'id_stock_available', 'object' => 'StockAvailable', 'association' => 'stock_availables'),
+            'specific_prices' => array('type' => self::HAS_MANY, 'field' => 'id_specific_price', 'object' => 'SpecificPrice', 'association' => 'specific_prices'),
         ),
     );
 
@@ -536,6 +537,15 @@ class ProductCore extends ObjectModel
                     'id_product_attribute' => array(),
                     'quantity' => array(),
                 ),
+            ),
+            'specific_prices' => array(
+                'resource' => 'specific_price',
+                'getter' => 'getWsSpecificPricesIds',
+                'fields' => array(
+                    'id' => array('required' => true),
+                    'id_product_attribute' => array('required' => true),
+                ),
+                'setter' => false,
             ),
         ),
     );
@@ -6258,6 +6268,13 @@ class ProductCore extends ObjectModel
     public function getWsManufacturerName()
     {
         return Manufacturer::getNameById((int) $this->id_manufacturer);
+    }
+
+    public function getWsSpecificPricesIds()
+    {
+        return Db::getInstance()->executeS('SELECT `id_specific_price` id, `id_product_attribute`
+		FROM `' . _DB_PREFIX_ . 'specific_price`
+		WHERE `id_product`=' . (int) $this->id);
     }
 
     public static function resetEcoTax()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This improvement allow to retrieve the associated specific prices on the product resource using the webservices.
| Type?         | improvement 
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| How to test?  | 1. Create a specific price for a product<br>2. Retrieve the product using the webservice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16426)
<!-- Reviewable:end -->
