### PR TITLE
Webservice: Updating category position is changed

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -256,11 +256,11 @@ class CategoryCore extends ObjectModel
         if ($changed) {
             if (Tools::isSubmit('checkBoxShopAsso_category')) {
                 foreach (Tools::getValue('checkBoxShopAsso_category') as $idAssoObject => $idShop) {
-                    $this->addPosition((int) Category::getLastPosition((int) $this->id_parent, (int) $idShop), (int) $idShop);
+                    $this->addPosition($this->position, (int) $idShop);
                 }
             } else {
                 foreach (Shop::getShops(true) as $shop) {
-                    $this->addPosition((int) Category::getLastPosition((int) $this->id_parent, $shop['id_shop']), $shop['id_shop']);
+                    $this->addPosition($this->position, $shop['id_shop']);
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | When updating a category with a certain position currently the position is changed to the last position during the update. This pull request fixes this. Seems the logic for adding was just copied to update without thought.
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14795
| How to test?  | Update existing category with webservice.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16431)
<!-- Reviewable:end -->
