### PR TITLE
Frontend Translation mixed up when switching languages

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -378,7 +378,9 @@ class ContextCore
     public function getTranslator($isInstaller = false)
     {
         if (null !== $this->translator) {
-            return $this->translator;
+            if ($this->language->locale === $this->translator->getLocale()) {
+                return $this->translator;
+            }
         }
 
         $sfContainer = SymfonyContainer::getInstance();

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -377,10 +377,8 @@ class ContextCore
      */
     public function getTranslator($isInstaller = false)
     {
-        if (null !== $this->translator) {
-            if ($this->language->locale === $this->translator->getLocale()) {
-                return $this->translator;
-            }
+        if (null !== $this->translator && $this->language->locale === $this->translator->getLocale()) {
+            return $this->translator;
         }
 
         $sfContainer = SymfonyContainer::getInstance();


### PR DESCRIPTION
Please review, this has not been tested in depth.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In some cases smarty translation will show previous language setting.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16412
| How to test?  | See #16412 for reproduction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16439)
<!-- Reviewable:end -->
