### PR TITLE
Added indexes for product reference and supplier_reference

### DIFF
--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -24,6 +24,11 @@ ALTER TABLE `PREFIX_hook` CHANGE `title` `title` VARCHAR(255) NOT NULL;
 ALTER TABLE `PREFIX_hook_alias` CHANGE `name` `name` VARCHAR(191) NOT NULL;
 ALTER TABLE `PREFIX_hook_alias` CHANGE `alias` `alias` VARCHAR(191) NOT NULL;
 
+/* improve performance of lookup by product reference/product_supplier avoiding full table scan */
+ALTER TABLE PREFIX_product
+    ADD INDEX reference_idx(reference),
+    ADD INDEX supplier_reference_idx(supplier_reference);
+
 /* Add fields for currencies */
 ALTER TABLE `PREFIX_currency` ADD `unofficial` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `active`;
 ALTER TABLE `PREFIX_currency` ADD `modified` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `unofficial`;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Added indexes for product.reference and product.supplier_reference, so lookups in imports by reference no longer causes full table scans. Should also improve search by reference in BO
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16323 

**How to test?** 
- Don't apply create index SQL yet.
- Turn on slow query log / queries not using indexes log on mysql
- RUN import when product table contains at least 1000 entries before, 
- Notice there should be SELECT statement on product table where reference = "XXXX". 
- Run `explain` on that SQL query it should report using full table scan and scanning many rows. 
- Now add indexes and run the `explain` for the same query, it should now report using newly created index and scanning only 1 row if all references are unique

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16440)
<!-- Reviewable:end -->
