### PR TITLE
Enable TinyMCE on add/edit supplier page BO

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/supplier/supplier-form.js
+++ b/admin-dev/themes/new-theme/js/pages/supplier/supplier-form.js
@@ -28,6 +28,7 @@ import SupplierMap from './supplier-map';
 import TranslatableInput from '../../components/translatable-input';
 import TaggableField from '../../components/taggable-field';
 import ChoiceTree from '../../components/form/choice-tree';
+import TinyMCEEditor from '../../components/tinymce-editor';
 
 const $ = window.$;
 
@@ -41,6 +42,7 @@ $(document).ready(() => {
     SupplierMap.supplierStateBlock,
   );
 
+  new TinyMCEEditor();
   new TranslatableInput();
   new TaggableField({
     tokenFieldSelector: 'input.js-taggable-field',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -31,10 +31,12 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Address\AddressSettings;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\SupplierSettings;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslateType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -48,7 +50,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * Defines form for supplier create/edit actions (Sell > Catalog > Brands & Suppliers > Supplier)
  */
-class SupplierType extends AbstractType
+class SupplierType extends TranslatorAwareType
 {
     /**
      * @var array
@@ -81,15 +83,18 @@ class SupplierType extends AbstractType
      * @param $contextCountryId
      * @param TranslatorInterface $translator
      * @param $isMultistoreEnabled
+     * @param array $locales
      */
     public function __construct(
         array $countryChoices,
         ConfigurableFormChoiceProviderInterface $statesChoiceProvider,
         $contextCountryId,
         TranslatorInterface $translator,
-        $isMultistoreEnabled
+        $isMultistoreEnabled,
+        array $locales = []
     ) {
-        $this->translator = $translator;
+        parent::__construct($translator, $locales);
+
         $this->countryChoices = $countryChoices;
         $this->statesChoiceProvider = $statesChoiceProvider;
         $this->contextCountryId = $contextCountryId;
@@ -110,16 +115,16 @@ class SupplierType extends AbstractType
             ->add('name', TextType::class, [
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->translator->trans(
-                            'This field cannot be empty', [], 'Admin.Notifications.Error'
+                        'message' => $this->trans(
+                            'This field cannot be empty', 'Admin.Notifications.Error'
                         ),
                     ]),
                     new Length([
                         'max' => SupplierSettings::MAX_NAME_LENGTH,
-                        'maxMessage' => $this->translator->trans(
+                        'maxMessage' => $this->trans(
                             'This field cannot be longer than %limit% characters',
-                            ['%limit%' => SupplierSettings::MAX_NAME_LENGTH],
-                            'Admin.Notifications.Error'
+                            'Admin.Notifications.Error',
+                            ['%limit%' => SupplierSettings::MAX_NAME_LENGTH]
                         ),
                     ]),
                     new TypedRegex([
@@ -127,23 +132,15 @@ class SupplierType extends AbstractType
                     ]),
                 ],
             ])
-            ->add('description', TranslatableType::class, [
-                'type' => TextareaType::class,
-                'required' => false,
+            ->add('description', TranslateType::class, [
+                'type' => FormattedTextareaType::class,
+                'locales' => $this->locales,
+                'hideTabs' => false,
                 'options' => [
                     'constraints' => [
                         new CleanHtml([
-                            'message' => $this->translator->trans(
+                            'message' => $this->trans(
                                 '%s is invalid.',
-                                [],
-                                'Admin.Notifications.Error'
-                            ),
-                        ]),
-                        new TypedRegex([
-                            'type' => 'catalog_name',
-                            'message' => $this->translator->trans(
-                                '%s is invalid.',
-                                [],
                                 'Admin.Notifications.Error'
                             ),
                         ]),
@@ -173,10 +170,10 @@ class SupplierType extends AbstractType
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_POST_CODE_LENGTH,
-                        'maxMessage' => $this->translator->trans(
+                        'maxMessage' => $this->trans(
                             'This field cannot be longer than %limit% characters',
-                            ['%limit%' => AddressSettings::MAX_POST_CODE_LENGTH],
-                            'Admin.Notifications.Error'
+                            'Admin.Notifications.Error',
+                            ['%limit%' => AddressSettings::MAX_POST_CODE_LENGTH]
                         ),
                     ]),
                 ],
@@ -184,8 +181,8 @@ class SupplierType extends AbstractType
             ->add('city', TextType::class, [
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->translator->trans(
-                            'This field cannot be empty', [], 'Admin.Notifications.Error'
+                        'message' => $this->trans(
+                            'This field cannot be empty', 'Admin.Notifications.Error'
                         ),
                     ]),
                     new TypedRegex([
@@ -193,10 +190,10 @@ class SupplierType extends AbstractType
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_CITY_NAME_LENGTH,
-                        'maxMessage' => $this->translator->trans(
+                        'maxMessage' => $this->trans(
                             'This field cannot be longer than %limit% characters',
-                            ['%limit%' => AddressSettings::MAX_CITY_NAME_LENGTH],
-                            'Admin.Notifications.Error'
+                            'Admin.Notifications.Error',
+                            ['%limit%' => AddressSettings::MAX_CITY_NAME_LENGTH]
                         ),
                     ]),
                 ],
@@ -207,8 +204,8 @@ class SupplierType extends AbstractType
                 'translation_domain' => false,
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->translator->trans(
-                            'This field cannot be empty', [], 'Admin.Notifications.Error'
+                        'message' => $this->trans(
+                            'This field cannot be empty','Admin.Notifications.Error'
                         ),
                     ]),
                 ],
@@ -233,10 +230,10 @@ class SupplierType extends AbstractType
                         ]),
                         new Length([
                             'max' => SupplierSettings::MAX_META_TITLE_LENGTH,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => SupplierSettings::MAX_META_TITLE_LENGTH],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => SupplierSettings::MAX_META_TITLE_LENGTH]
                             ),
                         ]),
                     ],
@@ -252,10 +249,10 @@ class SupplierType extends AbstractType
                         ]),
                         new Length([
                             'max' => SupplierSettings::MAX_META_DESCRIPTION_LENGTH,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => SupplierSettings::MAX_META_DESCRIPTION_LENGTH],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => SupplierSettings::MAX_META_DESCRIPTION_LENGTH]
                             ),
                         ]),
                     ],
@@ -267,7 +264,7 @@ class SupplierType extends AbstractType
                 'options' => [
                     'attr' => [
                         'class' => 'js-taggable-field',
-                        'placeholder' => $this->translator->trans('Add tag', [], 'Admin.Actions'),
+                        'placeholder' => $this->trans('Add tag', 'Admin.Actions'),
                     ],
                     'constraints' => [
                         new TypedRegex([
@@ -275,10 +272,10 @@ class SupplierType extends AbstractType
                         ]),
                         new Length([
                             'max' => SupplierSettings::MAX_META_KEYWORD_LENGTH,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => SupplierSettings::MAX_META_KEYWORD_LENGTH],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => SupplierSettings::MAX_META_KEYWORD_LENGTH]
                             ),
                         ]),
                     ],
@@ -294,8 +291,8 @@ class SupplierType extends AbstractType
                 'required' => false,
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->translator->trans(
-                            'This field cannot be empty', [], 'Admin.Notifications.Error'
+                        'message' => $this->trans(
+                            'This field cannot be empty', 'Admin.Notifications.Error'
                         ),
                     ]),
                 ],
@@ -330,10 +327,10 @@ class SupplierType extends AbstractType
             ]),
             new Length([
                 'max' => AddressSettings::MAX_ADDRESS_LENGTH,
-                'maxMessage' => $this->translator->trans(
+                'maxMessage' => $this->trans(
                     'This field cannot be longer than %limit% characters',
-                    ['%limit%' => AddressSettings::MAX_ADDRESS_LENGTH],
-                    'Admin.Notifications.Error'
+                    'Admin.Notifications.Error',
+                    ['%limit%' => AddressSettings::MAX_ADDRESS_LENGTH]
                 ),
             ]),
         ];
@@ -352,10 +349,10 @@ class SupplierType extends AbstractType
             ]),
             new Length([
                 'max' => AddressSettings::MAX_PHONE_LENGTH,
-                'maxMessage' => $this->translator->trans(
+                'maxMessage' => $this->trans(
                     'This field cannot be longer than %limit% characters',
-                    ['%limit%' => AddressSettings::MAX_PHONE_LENGTH],
-                    'Admin.Notifications.Error'
+                    'Admin.Notifications.Error',
+                    ['%limit%' => AddressSettings::MAX_PHONE_LENGTH]
                 ),
             ]),
         ];

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -205,7 +205,7 @@ class SupplierType extends TranslatorAwareType
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(
-                            'This field cannot be empty','Admin.Notifications.Error'
+                            'This field cannot be empty', 'Admin.Notifications.Error'
                         ),
                     ]),
                 ],

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -904,6 +904,7 @@ services:
             - '@=service("prestashop.adapter.legacy.context").getContext().country.id'
             - '@translator'
             - '@=service("prestashop.adapter.multistore_feature").isActive()'
+            - "@=service('prestashop.adapter.legacy.context').getLanguages()"
         tags:
           - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/add.html.twig
@@ -40,4 +40,7 @@
   {{ parent() }}
 
   <script src="{{ asset('themes/new-theme/public/supplier_form.bundle.js') }}"></script>
+  <script src="{{ asset('../js/tiny_mce/tiny_mce.js') }}"></script>
+  <script src="{{ asset('../js/admin/tinymce.inc.js') }}"></script>
+  <script src="{{ asset('../js/admin/tinymce_loader.js') }}"></script>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/edit.html.twig
@@ -40,4 +40,7 @@
   {{ parent() }}
 
   <script src="{{ asset('themes/new-theme/public/supplier_form.bundle.js') }}"></script>
+  <script src="{{ asset('../js/tiny_mce/tiny_mce.js') }}"></script>
+  <script src="{{ asset('../js/admin/tinymce.inc.js') }}"></script>
+  <script src="{{ asset('../js/admin/tinymce_loader.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Enable TinyMCE for "description" field for suppliers
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10541
| How to test?  | This PR transforms the "description" field of Supplier Symfony page to a tinyMCE translatable field. Please rebuild assets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16457)
<!-- Reviewable:end -->
