### PR TITLE
Fix behavior of Module::isRegisteredInHook()

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2338,18 +2338,24 @@ abstract class ModuleCore implements ModuleInterface
         return Cache::retrieve('Module::isEnabled' . $module_name);
     }
 
+    /**
+     * Check if module is registered on hook
+     *
+     * @param string $hook Hook name
+     *
+     * @return bool
+     */
     public function isRegisteredInHook($hook)
     {
         if (!$this->id) {
             return false;
         }
 
-        $sql = 'SELECT COUNT(*)
-            FROM `' . _DB_PREFIX_ . 'hook_module` hm
-            LEFT JOIN `' . _DB_PREFIX_ . 'hook` h ON (h.`id_hook` = hm.`id_hook`)
-            WHERE h.`name` = \'' . pSQL($hook) . '\' AND hm.`id_module` = ' . (int) $this->id;
-
-        return Db::getInstance()->getValue($sql);
+        return Hook::isModuleRegisteredOnHook(
+            $this,
+            $hook,
+            (int) Context::getContext()->shop->id
+        );
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | if multistore enabled and 2 shops configured, result of Module::isRegisteredInHook() is not relevant due to missing usage of id_shop in query
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/16458
| How to test?  | Described in issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16459)
<!-- Reviewable:end -->
