### PR TITLE
Display display_name instead of name in theme card and add author.url

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig
@@ -46,7 +46,7 @@
       {{ 'Version'|trans({}, 'Admin.Global') }} {{ themeVersion }}
     </span>
     <div class="theme-author">
-      {{ 'Designed by %s'|trans({'%s': themeAuthor}, 'Admin.Design.Feature') }}
+      <a href="{{ themeAuthorUrl }}" target="_blank">{{ 'Designed by %s'|trans({'%s': themeAuthor}, 'Admin.Design.Feature') }}</a>
     </div>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -87,6 +87,7 @@
               'themeName': currentlyUsedTheme.get('display_name'),
               'themeVersion': currentlyUsedTheme.get('version'),
               'themeAuthor': currentlyUsedTheme.get('author.name'),
+              'themeAuthorUrl': theme.get('author.url'),
               'isActive': true
               } %}
               {% block image %}
@@ -106,6 +107,7 @@
                   'themeName': theme.get('display_name'),
                   'themeVersion': theme.get('version'),
                   'themeAuthor': theme.get('author.name'),
+                  'themeAuthorUrl': theme.get('author.url'),
                   'isActive': false
                   }  %}
                   {% block image %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -84,13 +84,13 @@
           <div class="card-body row">
 
             {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
-              'themeName': currentlyUsedTheme.name,
+              'themeName': currentlyUsedTheme.get('display_name'),
               'themeVersion': currentlyUsedTheme.get('version'),
               'themeAuthor': currentlyUsedTheme.get('author.name'),
               'isActive': true
               } %}
               {% block image %}
-                <img src="{{ baseShopUrl }}{{ currentlyUsedTheme.get('preview') }}" alt="{{ currentlyUsedTheme.name }}">
+                <img src="{{ baseShopUrl }}{{ currentlyUsedTheme.get('preview') }}" alt="{{ currentlyUsedTheme.get('display_name')   }}">
               {% endblock %}
               {% block button_container %}
                 <button class="btn action-button">
@@ -103,13 +103,13 @@
             {% if notUsedThemes is not empty %}
               {% for theme in notUsedThemes %}
                 {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
-                  'themeName': theme.name,
+                  'themeName': theme.get('display_name'),
                   'themeVersion': theme.get('version'),
                   'themeAuthor': theme.get('author.name'),
                   'isActive': false
                   }  %}
                   {% block image %}
-                    <img src="{{ baseShopUrl }}{{ theme.get('preview') }}" alt="{{ theme.name }}">
+                    <img src="{{ baseShopUrl }}{{ theme.get('preview') }}" alt="{{ theme.get('display_name') }}">
                   {% endblock %}
                   {% block button_container %}
                     <form action="{{ path('admin_themes_enable', {'themeName': theme.name}) }}" method="post" class="d-inline">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Changing the name of theme cards in theme options to display name
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16054
| How to test?  | Go to the Appearance->Theme and logo pannel and watch the theme name<br> and then check the author url on the Designed by line

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16461)
<!-- Reviewable:end -->
