### PR TITLE
Fix issue where html tags from ps_emailsubscription module would be escaped and not interpreted as HTML

### DIFF
--- a/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -58,7 +58,7 @@
           </div>
           <div class="col-xs-12">
               {if $conditions}
-                <p>{$conditions}</p>
+                <p>{$conditions nofilter}</p>
               {/if}
               {if $msg}
                 <p class="alert {if $nw_error}alert-danger{else}alert-success{/if}">


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | HTML elements in the conditions field of emailsubscription module were not interpreted in FO
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15849
| How to test?  | Just put an html element in the conditions field of emailsubscription module and see if it render correctly in your account -> personal information/identity in FO

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16468)
<!-- Reviewable:end -->
