### PR TITLE
dynamic update of product and tax prices in the back office

### DIFF
--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -251,12 +251,22 @@ function refreshProductLineView(element, view)
 
 function updateAmounts(order)
 {
+  var display_tax_separately = $('#total_taxes').length;
 	$('#total_products td.amount').fadeOut('slow', function() {
-		formatCurrencyCldr(parseFloat(order.total_products_wt), function(value) {
+		formatCurrencyCldr(parseFloat(display_tax_separately ? order.total_products : order.total_products_wt), function(value) {
 			$('#total_products td.amount').html(value);
 			$('#total_products td.amount').fadeIn('slow');
 		});
 	});
+
+  if (display_tax_separately) {
+		$('#total_taxes td.amount').fadeOut('slow', function () {
+			formatCurrencyCldr(parseFloat(order.total_products_wt - order.total_products), function (value) {
+				$('#total_taxes td.amount').html(value);
+				$('#total_taxes td.amount').fadeIn('slow');
+			});
+		});
+	}
 
 	$('#total_discounts td.amount').fadeOut('slow', function() {
 		formatCurrencyCldr(parseFloat(order.total_discounts_tax_incl), function(value) {


### PR DESCRIPTION
This fixes the following scenario. User group configured with display tax excluding. Order edited in the back office and quantity or price changed. After update the products price (not total) and tax not have been updated correctly without the page refresh.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | dynamic update of product and tax prices when editing in the back office
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | 
| How to test?  | Configure user group with display tax excluding. edit order in the BO.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16484)
<!-- Reviewable:end -->
