### PR TITLE
Remove unofficial languages from language packs

### DIFF
--- a/localization/az.xml
+++ b/localization/az.xml
@@ -6,16 +6,15 @@
 	<languages>
 		<language iso_code="az" />
 		<language iso_code="en" />
-		<language iso_code="ru" />
 	</languages>
 	<taxes>
 		<tax id="1" name="ƏDV AZ 18%" rate="18" />
 		<tax id="2" name="ƏDV AZ 0%" rate="0" />
-		
+
 		<taxRulesGroup name="AZ Standard Rate (18%)">
 			<taxRule iso_code_country="az" id_tax="1" />
 		</taxRulesGroup>
-		
+
 		<taxRulesGroup name="AZ Zero Rate (0%)">
 			<taxRule iso_code_country="az" id_tax="2" />
 		</taxRulesGroup>

--- a/localization/cn.xml
+++ b/localization/cn.xml
@@ -6,7 +6,6 @@
 	<languages>
 		<language iso_code="tw" />
 		<language iso_code="zh" />
-		<language iso_code="ug" />
 	</languages>
 	<taxes>
     <tax id="1" name="增值税 CN 13%" rate="13"/>

--- a/localization/dz.xml
+++ b/localization/dz.xml
@@ -5,7 +5,6 @@
 	</currencies>
 	<languages>
 		<language iso_code="ar" />
-		<language iso_code="fr" />
 	</languages>
 	<taxes>
 		<tax id="1" name="TVA DZ 19%" rate="19" />

--- a/localization/es.xml
+++ b/localization/es.xml
@@ -4,10 +4,7 @@
     <currency name="Euro" iso_code="EUR" iso_code_num="978" sign="€" blank="1" conversion_rate="1.00" format="2" decimals="1"/>
   </currencies>
   <languages>
-    <language iso_code="ca"/>
     <language iso_code="es"/>
-    <language iso_code="gl"/>
-    <language iso_code="eu"/>
   </languages>
   <taxes>
     <tax id="1" name="IVA ES 21%" rate="21" eu-tax-group="virtual"/>

--- a/localization/fr.xml
+++ b/localization/fr.xml
@@ -5,7 +5,6 @@
   </currencies>
   <languages>
     <language iso_code="fr"/>
-    <language iso_code="bz"/>
   </languages>
   <accounting>
     <conf name="customer_prefix" value="411"/>

--- a/localization/il.xml
+++ b/localization/il.xml
@@ -4,17 +4,16 @@
 		<currency name="Shekel" iso_code="ILS" iso_code_num="376" sign="₪‎" blank="0" conversion_rate="4.97713" format="2" decimals="1" />
 	</currencies>
 	<languages>
-		<language iso_code="ar" />
 		<language iso_code="he" />
 	</languages>
 	<taxes>
 		<tax id="1" name="Ma'am IL 17%" rate="17" />
 		<tax id="2" name="Ma'am IL 7.5%" rate="7.5" />
-    
+
 		<taxRulesGroup name="IL Standard Rate (17%)">
 			<taxRule iso_code_country="il" id_tax="1" />
 		</taxRulesGroup>
-    
+
 		<taxRulesGroup name="IL Reduced Rate (7.5%)">
 			<taxRule iso_code_country="il" id_tax="2" />
 		</taxRulesGroup>

--- a/localization/ma.xml
+++ b/localization/ma.xml
@@ -5,7 +5,6 @@
 	</currencies>
 	<languages>
 		<language iso_code="ar" />
-		<language iso_code="fr" />
 	</languages>
 	<taxes>
 		<tax id="1" name="TVA MA 20%" rate="20" />

--- a/localization/md.xml
+++ b/localization/md.xml
@@ -5,12 +5,10 @@
 	</currencies>
 	<languages>
 		<language iso_code="ro" />
-		<language iso_code="ru" />
-		<language iso_code="uk" />
 	</languages>
 	<taxes>
 		<tax id="1" name="TVA MD 20%" rate="20" />
-		
+
 		<taxRulesGroup name="MD Standard Rate (20%)">
 			<taxRule iso_code_country="md" id_tax="1" />
 		</taxRulesGroup>

--- a/localization/rs.xml
+++ b/localization/rs.xml
@@ -5,13 +5,6 @@
   </currencies>
   <languages>
     <language iso_code="sr"/>
-    <language iso_code="bs"/>
-    <language iso_code="hu"/>
-    <language iso_code="sq"/>
-    <language iso_code="hr"/>
-    <language iso_code="sk"/>
-    <language iso_code="ro"/>
-    <language iso_code="bg"/>
   </languages>
 	<taxes>
 		<tax id="1" name="PDV RS 20%" rate="20" />

--- a/localization/tn.xml
+++ b/localization/tn.xml
@@ -5,7 +5,6 @@
   </currencies>
   <languages>
     <language iso_code="ar"/>
-    <language iso_code="fr"/>
   </languages>
   <taxes>
     <tax id="1" name="TN TVA 19%" rate="19"/>


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Language packs had unofficial languages in them. This change removes them as defined in the related issue.
| Type?         | improvement
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16321
| How to test?  | Install the related packs, verify that only included langages are added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16489)
<!-- Reviewable:end -->
