### PR TITLE
Restrict column existence search to whole word in order listing

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3279,7 +3279,7 @@ class AdminControllerCore extends Controller
                         $this->_listsql .= str_replace('!', '.`', $array_value['filter_key']) . '` AS `' . $key . '`, ';
                     } elseif ($key == 'id_' . $this->table) {
                         $this->_listsql .= 'a.`' . bqSQL($key) . '`, ';
-                    } elseif ($key != 'image' && !preg_match('/' . preg_quote($key, '/') . '/i', $this->_select)) {
+                    } elseif ($key != 'image' && !preg_match('/\b' . preg_quote($key, '/') . '\b/i', $this->_select)) {
                         $this->_listsql .= '`' . bqSQL($key) . '`, ';
                     }
                 }


### PR DESCRIPTION
Fix #16493 by searching only whole word in the SQL column existence search

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Restrict column existence search to whole word in order listing 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fix #16493
| How to test?  | See comment in #16493 issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16494)
<!-- Reviewable:end -->
