### PR TITLE
Hide pack products' prices when the show price option is disabled

### DIFF
--- a/themes/classic/templates/catalog/_partials/miniatures/pack-product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/pack-product.tpl
@@ -37,14 +37,19 @@
             </a>
           </div>
         </div>
+
         <div class="pack-product-name">
           <a href="{$product.url}" title="{$product.name}">
             {$product.name}
           </a>
         </div>
-        <div class="pack-product-price">
-          <strong>{$product.price}</strong>
-        </div>
+
+        {if $showPackProductsPrice} 
+          <div class="pack-product-price">
+            <strong>{$product.price}</strong>
+          </div>
+        {/if}
+        
         <div class="pack-product-quantity">
           <span>x {$product.pack_quantity}</span>
         </div>

--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -109,7 +109,7 @@
                         <p class="h4">{l s='This pack contains' d='Shop.Theme.Catalog'}</p>
                         {foreach from=$packItems item="product_pack"}
                           {block name='product_miniature'}
-                            {include file='catalog/_partials/miniatures/pack-product.tpl' product=$product_pack}
+                            {include file='catalog/_partials/miniatures/pack-product.tpl' product=$product_pack showPackProductsPrice=$product.show_price}
                           {/block}
                         {/foreach}
                     </section>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16329 
| How to test?  | Create a product pack, add products, disable sell ready and show price options then go to product page and see if the product prices are displaying or not depending on the show price option

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16503)
<!-- Reviewable:end -->
