### PR TITLE
Avoid dropdowns from module page to appear under header element

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_bulk.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_bulk.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 <div class="ps-dropdown dropdown btn-group bordered mb-1 module-bulk-actions disabled">
-  <div id="bulk-actions-dropdown" class="dropdown-label" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <div id="bulk-actions-dropdown" class="dropdown-label" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-flip="false">
     <span class="js-selected-item selected-item module-bulk-actions-selector-label">
       {{ 'Uninstall'|trans({}, 'Admin.Actions') }}
     </span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories.html.twig
@@ -25,7 +25,7 @@
 <div class="ps-dropdown dropdown btn-group bordered mb-1">
   {% for menu in topMenuData %}
     {% set refMenu = menu.refMenu %}
-    <div id="{{refMenu}}" class="dropdown-label" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <div id="{{refMenu}}" class="dropdown-label" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-flip="false">
       <span class="js-selected-item selected-item module-category-selector-label">
         {{ 'All Categories'|trans({}, 'Admin.Modules.Feature') }}
       </span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_status.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 <div class="ps-dropdown dropdown btn-group bordered">
-    <div class="dropdown-label" id="module-status-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <div class="dropdown-label" id="module-status-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-flip="false">
         <span class="js-selected-item selected-item module-status-selector-label">{{ 'Show all modules'|trans({}, 'Admin.Modules.Feature') }}</span>
         <i class="material-icons arrow-down float-right">keyboard_arrow_down</i>
     </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the module page, dropdown were rendered over the select input in case you had a small screen height
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12165 
| How to test?  | 1. Go to tab Modules -> Module manager<br>2. Make sure to lower the height on your browser (specific devices uses different resolutions)<br>3. Try to sort on options through the selector to filter modules from specific categories<br>4. The selector will not be hidden under the header.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16510)
<!-- Reviewable:end -->
