### PR TITLE
Prevent getter from changing class state

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -406,8 +406,6 @@ class ContextCore
         // In case we have at least 1 translated message, we return the current translator.
         // If some translations are missing, clear cache
         if ($locale === '' || count($translator->getCatalogue($locale)->all())) {
-            $this->translator = $translator;
-
             return $translator;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Calls to `Context::getContext()->getTranslatorFromLocale($locale)` would replace the contextual translator (and any loaded language) during that execution
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Install a language, no new unexpected behavior appears

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16522)
<!-- Reviewable:end -->
