### PR TITLE
Check memory_limit during installation

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -85,11 +85,12 @@ class ConfigurationTestCore
                 'config_dir' => 'config',
                 'files' => false,
                 'mails_dir' => 'mails',
-                'openssl' => 'false',
+                'openssl' => false,
                 'simplexml' => false,
                 'zip' => false,
                 'fileinfo' => false,
                 'intl' => false,
+                'memory_limit' => false,
             ));
         }
 
@@ -112,6 +113,7 @@ class ConfigurationTestCore
             'pdo_mysql' => false,
             'fopen' => false,
             'intl' => false,
+            'memory_limit' => false,
         );
     }
 
@@ -169,6 +171,13 @@ class ConfigurationTestCore
     public static function test_intl()
     {
         return extension_loaded('intl');
+    }
+
+    public static function test_memory_limit()
+    {
+        $memoryLimit = Tools::getMemoryLimit();
+
+        return $memoryLimit === '-1' || $memoryLimit >= Tools::getOctets('256M');
     }
 
     public static function test_pdo_mysql()

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -297,60 +297,22 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
     public function display()
     {
         $memoryLimit = Tools::getMemoryLimit();
-        // The installer SHOULD take less than 32M, but may take up to 35/36M sometimes. So 42M is a good value :)
-        $lowMemory = ($memoryLimit != '-1' && $memoryLimit < Tools::getOctets('42M'));
-
         // We fill the process step used for Ajax queries
         $this->process_steps[] = array('key' => 'generateSettingsFile', 'lang' => $this->translator->trans('Create file parameters', array(), 'Install'));
         $this->process_steps[] = array('key' => 'installDatabase', 'lang' => $this->translator->trans('Create database tables', array(), 'Install'));
         $this->process_steps[] = array('key' => 'installDefaultData', 'lang' => $this->translator->trans('Create default shop and languages', array(), 'Install'));
 
-        // If low memory or big fixtures, create subtasks for populateDatabase step (entity per entity)
-        $populate_step = array('key' => 'populateDatabase', 'lang' => $this->translator->trans('Populate database tables', array(), 'Install'));
-        if ($lowMemory) {
-            $populate_step['subtasks'] = array();
-            $xml_loader = new XmlLoader();
-            $xml_loader->setTranslator($this->translator);
-
-            foreach ($xml_loader->getSortedEntities() as $entity) {
-                $populate_step['subtasks'][] = array('entity' => $entity);
-            }
-        }
-
-        $this->process_steps[] = $populate_step;
+        $this->process_steps[] = array('key' => 'populateDatabase', 'lang' => $this->translator->trans('Populate database tables', array(), 'Install'));
         $this->process_steps[] = array('key' => 'configureShop', 'lang' => $this->translator->trans('Configure shop information', array(), 'Install'));
 
-        $install_modules = array('key' => 'installModules', 'lang' => $this->translator->trans('Install modules', array(), 'Install'));
-        if ($lowMemory) {
-            foreach ($this->model_install->getModulesList() as $module) {
-                $install_modules['subtasks'][] = array('module' => $module);
-            }
-        }
-        $this->process_steps[] = $install_modules;
-
-        $install_modules = array('key' => 'installModulesAddons', 'lang' => $this->translator->trans('Install Addons modules', array(), 'Install'));
-
-        $params = array(
-            'iso_lang' => $this->language->getLanguageIso(),
-            'iso_country' => $this->session->shop_country,
-            'email' => $this->session->admin_email,
-            'shop_url' => Tools::getHttpHost(),
-            'version' => _PS_INSTALL_VERSION_,
-        );
-
-        if ($lowMemory) {
-            foreach ($this->model_install->getAddonsModulesList($params) as $module) {
-                $install_modules['subtasks'][] = array('module' => (string)$module['name'], 'id_module' => (string)$module['id_module']);
-            }
-        }
-
-        $this->process_steps[] = $install_modules;
+        $this->process_steps[] = array('key' => 'installModules', 'lang' => $this->translator->trans('Install modules', array(), 'Install'));
+        $this->process_steps[] = array('key' => 'installModulesAddons', 'lang' => $this->translator->trans('Install Addons modules', array(), 'Install'));
 
         $this->process_steps[] = array('key' => 'installTheme', 'lang' => $this->translator->trans('Install theme', array(), 'Install'));
 
         if ($this->session->install_type == 'full') {
             $fixtures_step = array('key' => 'installFixtures', 'lang' => $this->translator->trans('Install demonstration data', array(), 'Install'));
-            if ($lowMemory || $this->hasLargeFixtures()) {
+            if ($this->hasLargeFixtures()) {
                 $fixtures_step['subtasks'] = array();
                 $xml_loader = new XmlLoader();
                 $xml_loader->setTranslator($this->translator);

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -104,6 +104,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                         'zip' => $this->translator->trans('ZIP extension is not enabled', array(), 'Install'),
                         'fileinfo' => $this->translator->trans('Fileinfo extension is not enabled', array(), 'Install'),
                         'intl' => $this->translator->trans('Intl extension is not loaded', array(), 'Install'),
+                        'memory_limit' => $this->translator->trans('PHP\'s config "memory_limit" must be to a minimum of 256M', array(), 'Install'),
                     ),
                 ),
                 array(

--- a/install-dev/theme/views/welcome.php
+++ b/install-dev/theme/views/welcome.php
@@ -25,10 +25,6 @@
  */
  $this->displayTemplate('header') ?>
 
-<?php if (Tools::getMemoryLimit() < Tools::getOctets('32M')): ?>
-	<div class="warnBlock"><?php echo $this->translator->trans('PrestaShop requires at least 32 MB of memory to run: please check the memory_limit directive in your php.ini file or contact your host provider about this.', array(), 'Install'); ?></div>
-<?php endif; ?>
-
 <?php if ($this->can_upgrade): ?>
 	<div class="warnBlock">
 		<img src="theme/img/pict_error.png" alt="" style="vertical-align: middle;" /> &nbsp;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PHP's config memory_limit must be checked during installation process
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16507
| How to test?  | Decrease your memory_limit to 128M to see this message<br>![image](https://user-images.githubusercontent.com/1462701/69544612-5ee51480-0f90-11ea-9b54-b357b21eaef8.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16527)
<!-- Reviewable:end -->
