### PR TITLE
Use country id while creating the Supplier form

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -131,7 +131,11 @@ class SupplierController extends FrameworkBundleAdminController
     public function createAction(Request $request)
     {
         try {
-            $supplierForm = $this->getFormBuilder()->getForm();
+            $supplierData = $request->request->get('supplier');
+            $supplierForm = $this->getFormBuilder()->getForm(
+                [],
+                isset($supplierData['id_country']) ? ['country_id' => (int) $supplierData['id_country']] : []
+            );
             $supplierForm->handleRequest($request);
 
             $result = $this->getFormHandler()->handle($supplierForm);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The country id must be used while creating the Supplier form in order to load states
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16293 
| How to test?  | Follow ticket instruction

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16530)
<!-- Reviewable:end -->
