### PR TITLE
Round remaining value of reduction amount

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1104,7 +1104,7 @@ abstract class PaymentModuleCore extends Module
             // THEN
             //  The voucher is cloned with a new value corresponding to the remainder
             $remainingValue = $cartRule->reduction_amount - $values[$cartRule->reduction_tax ? 'tax_incl' : 'tax_excl'];
-            $remainingValue = Tools::ps_round($remainingValue, _PS_PRICE_COMPUTE_PRECISION_);
+            $remainingValue = Tools::ps_round($remainingValue, Context::getContext()->getComputingPrecision());
             if (count($order_list) == 1 && $remainingValue > 0 && $cartRule->partial_use == 1 && $cartRule->reduction_amount > 0) {
                 // Create a new voucher from the original
                 $voucher = new CartRule((int) $cartRule->id); // We need to instantiate the CartRule without lang parameter to allow saving it

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1076,10 +1076,11 @@ abstract class PaymentModuleCore extends Module
         $id_order_state
     ) {
         $cart_rule_used = array();
+        $computingPrecision = Context::getContext()->getComputingPrecision();
 
         // prepare cart calculator to correctly get the value of each cart rule
         $calculator = $cart->newCalculator($order->product_list, $cart->getCartRules(), $order->id_carrier);
-        $calculator->processCalculation(Context::getContext()->getComputingPrecision());
+        $calculator->processCalculation($computingPrecision);
         $cartRulesData = $calculator->getCartRulesData();
 
         $cart_rules_list = array();
@@ -1104,7 +1105,7 @@ abstract class PaymentModuleCore extends Module
             // THEN
             //  The voucher is cloned with a new value corresponding to the remainder
             $remainingValue = $cartRule->reduction_amount - $values[$cartRule->reduction_tax ? 'tax_incl' : 'tax_excl'];
-            $remainingValue = Tools::ps_round($remainingValue, Context::getContext()->getComputingPrecision());
+            $remainingValue = Tools::ps_round($remainingValue, $computingPrecision);
             if (count($order_list) == 1 && $remainingValue > 0 && $cartRule->partial_use == 1 && $cartRule->reduction_amount > 0) {
                 // Create a new voucher from the original
                 $voucher = new CartRule((int) $cartRule->id); // We need to instantiate the CartRule without lang parameter to allow saving it

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1104,6 +1104,7 @@ abstract class PaymentModuleCore extends Module
             // THEN
             //  The voucher is cloned with a new value corresponding to the remainder
             $remainingValue = $cartRule->reduction_amount - $values[$cartRule->reduction_tax ? 'tax_incl' : 'tax_excl'];
+            $remainingValue = Tools::ps_round($remainingValue, _PS_PRICE_COMPUTE_PRECISION_);
             if (count($order_list) == 1 && $remainingValue > 0 && $cartRule->partial_use == 1 && $cartRule->reduction_amount > 0) {
                 // Create a new voucher from the original
                 $voucher = new CartRule((int) $cartRule->id); // We need to instantiate the CartRule without lang parameter to allow saving it


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Please see issue #16491 to see and reproduce the bug. Please note this proposal fix the issue but we also see the limit value of the method : here we generate a remaining reduction with a value 0€ (first effect of the bug) but it will not have an impact on the current value of reduction. So for us the code after line 1008 is quite dangerous. In fact, this bug highlight in this case. If you log $values on line 1007, you'll see the reduction amount is OK. $remaining value = 0.3xxxE-15 (that's why we propose to add round)/. After that log $values at line 1180, you'll see that $values had been corrupted in the if condition. That's the second perverse effect of this bug.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16491
| How to test?  | Please see issue #16491

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16531)
<!-- Reviewable:end -->
