### PR TITLE
Fixing menu animation to be opened properly

### DIFF
--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -103,6 +103,17 @@ function scroll_if_anchor(href) {
 }
 
 $(document).ready(function() {
+    const $mainMenu = $('.main-menu');
+    const $navBar = $('.nav-bar');
+    const $body = $('body');
+
+    const NavBarTransitions = new NavbarTransitionHandler(
+      $navBar,
+      $mainMenu,
+      getAnimationEvent('transition', 'end'),
+      $body
+    );
+
     $(".nav-bar").find(".link-levelone").hover(function() {
         $(this).addClass("-hover");
     }, function() {
@@ -150,6 +161,8 @@ $(document).ready(function() {
 
     $('.nav-bar').on('click', '.menu-collapse', function() {
         $('body').toggleClass('page-sidebar-closed');
+
+        NavBarTransitions.toggle();
 
         if ($('body').hasClass('page-sidebar-closed')) {
             $('nav.nav-bar ul.main-menu > li')

--- a/admin-dev/themes/default/js/bundle/components/navbar-transition-handler.js
+++ b/admin-dev/themes/default/js/bundle/components/navbar-transition-handler.js
@@ -1,0 +1,63 @@
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Toggle a class on $mainMenu after the end of an event (transition, animation...)
+ * @param {jQuery element} $navBar - The navbar item which get a css transition property.
+ * @param {jQuery element} $mainMenu - The menu inside the $navBar element.
+ * @param {string} endTransitionEvent - The name of the event.
+ * @param {jQuery element} $body - The body of the page.
+ * @method showNavBarContent - Toggle the class based on event and if body got a class.
+ * @method toggle - Add the listener if there is no transition launched yet.
+ * @return {Object} The object with methods wich permit to toggle on specific event.
+*/
+function NavbarTransitionHandler($navBar, $mainMenu, endTransitionEvent, $body) {
+  this.$body = $body;
+  this.transitionFired = false;
+  this.$navBar = $navBar.get(0);
+  this.$mainMenu = $mainMenu;
+  this.endTransitionEvent = endTransitionEvent;
+
+  this.showNavBarContent = (event) => {
+    if (event.propertyName !== 'width') {
+      return;
+    }
+
+    this.$navBar.removeEventListener(this.endTransitionEvent, this.showNavBarContent);
+    const isSidebarClosed = this.$body.hasClass('page-sidebar-closed');
+    this.$mainMenu.toggleClass('sidebar-closed', isSidebarClosed);
+    this.transitionFired = false;
+  };
+
+  this.toggle = () => {
+    if (!this.transitionFired) {
+      this.$navBar.addEventListener(this.endTransitionEvent, this.showNavBarContent.bind(this));
+    } else {
+      this.$navBar.removeEventListener(this.endTransitionEvent, this.showNavBarContent);
+    }
+
+    this.transitionFired = !this.transitionFired;
+  };
+}

--- a/admin-dev/themes/default/js/bundle/components/navbar-transition-handler.js
+++ b/admin-dev/themes/default/js/bundle/components/navbar-transition-handler.js
@@ -1,5 +1,5 @@
 /**
- * 2007-2019 PrestaShop SA and Contributors
+ * 2007-2020 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *

--- a/admin-dev/themes/default/js/bundle/utils/animations.js
+++ b/admin-dev/themes/default/js/bundle/utils/animations.js
@@ -29,7 +29,8 @@
  * @param {string} lifecycle - Which lifecycle of the property name to catch (end, start...).
  * @return {string} The transition keywoard of the browser.
 */
-const getAnimationEvent = (type, lifecycle) => {
+
+function getAnimationEvent(type, lifecycle) {
   const el = document.createElement('element');
   const typeUpper = type.charAt(0).toUpperCase() + type.substring(1);
   const lifecycleUpper = lifecycle.charAt(0).toUpperCase() + lifecycle.substring(1);
@@ -41,9 +42,7 @@ const getAnimationEvent = (type, lifecycle) => {
     WebkitTransition: `webkit${typeUpper}${lifecycleUpper}`,
   };
 
-  const key = Object.keys(properties).find((propKey) => el.style[propKey] !== undefined);
+  const key = Object.keys(properties).find(propKey => el.style[propKey] !== undefined);
 
   return key !== undefined ? properties[key] : false;
-};
-
-export default getAnimationEvent;
+}

--- a/admin-dev/themes/default/js/modernizr-loads.js
+++ b/admin-dev/themes/default/js/modernizr-loads.js
@@ -28,5 +28,7 @@ Modernizr.load([
 		nope: [baseAdminDir + "themes/default/js/vendor/matchMedia.js", baseAdminDir + "themes/default/js/vendor/matchMedia.addListener.js"]
 	},
 	baseAdminDir + "themes/default/js/vendor/enquire.min.js",
+	baseAdminDir + "themes/default/js/bundle/utils/animations.js",
+	baseAdminDir + "themes/default/js/bundle/components/navbar-transition-handler.js",
 	baseAdminDir + "themes/default/js/admin-theme.js",
 ]);

--- a/admin-dev/themes/default/sass/partials/_nav.sass
+++ b/admin-dev/themes/default/sass/partials/_nav.sass
@@ -147,7 +147,7 @@
 	&.sidebar-closed
 		.link-levelone
 			.link > span
-				display: none;
+				display: none
 
 				&.open
 					> .submenu

--- a/admin-dev/themes/default/sass/partials/_nav.sass
+++ b/admin-dev/themes/default/sass/partials/_nav.sass
@@ -144,6 +144,18 @@
 	padding: 0 0 5.313rem 0
 	margin: 0
 
+	&.sidebar-closed
+		.link-levelone
+			.link > span
+				display: none;
+
+				&.open
+					> .submenu
+						display: none;
+
+		.categort-title > .title
+			display: none;
+
 	.category-title > .title
 		text-transform: uppercase
 

--- a/admin-dev/themes/default/sass/partials/_nav.sass
+++ b/admin-dev/themes/default/sass/partials/_nav.sass
@@ -154,7 +154,7 @@
 						display: none;
 
 		.categort-title > .title
-			display: none;
+			display: none
 
 	.category-title > .title
 		text-transform: uppercase
@@ -429,4 +429,3 @@
 
 	&.expanded
 		display: block
-

--- a/admin-dev/themes/default/sass/partials/_nav.sass
+++ b/admin-dev/themes/default/sass/partials/_nav.sass
@@ -151,7 +151,7 @@
 
 				&.open
 					> .submenu
-						display: none;
+						display: none
 
 		.categort-title > .title
 			display: none

--- a/admin-dev/themes/default/template/nav.tpl
+++ b/admin-dev/themes/default/template/nav.tpl
@@ -4,7 +4,7 @@
 		<i class="material-icons">chevron_left</i>
 	</span>
 
-	<ul class="main-menu">
+	<ul class="main-menu{if $collapse_menu} sidebar-closed{/if}">
 		{foreach $tabs as $level_1}
 			{if $level_1.active}
 				{* Dashboard exception *}

--- a/admin-dev/themes/new-theme/js/app/utils/animations.js
+++ b/admin-dev/themes/new-theme/js/app/utils/animations.js
@@ -1,0 +1,48 @@
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+const getAnimationEvent = (type, lifecycle) => {
+  const el = document.createElement('element');
+  let browserTransition;
+  const typeUpper = type.charAt(0).toUpperCase() + type.substring(1);
+  const lifecycleUpper = lifecycle.charAt(0).toUpperCase() + lifecycle.substring(1);
+
+  const properties = {
+    transition: `${type}${lifecycle}`,
+    OTransition: `o${typeUpper}${lifecycleUpper}`,
+    MozTransition: `${type}${lifecycle}`,
+    WebkitTransition: `webkit${typeUpper}${lifecycleUpper}`,
+  };
+
+  Object.keys(properties).forEach((e) => {
+    if (el.style[e] !== undefined) {
+      browserTransition = properties[e];
+    }
+  });
+
+  return browserTransition;
+};
+
+export default getAnimationEvent;

--- a/admin-dev/themes/new-theme/js/app/utils/animations.js
+++ b/admin-dev/themes/new-theme/js/app/utils/animations.js
@@ -23,9 +23,14 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+/**
+ * Get the correct transition keyword of the browser.
+ * @param {string} type - The property name (transition for example).
+ * @param {string} lifecycle - Which lifecycle of the property name to catch (end, start...).
+ * @return {string} The transition keywoard of the browser.
+*/
 const getAnimationEvent = (type, lifecycle) => {
   const el = document.createElement('element');
-  let browserTransition;
   const typeUpper = type.charAt(0).toUpperCase() + type.substring(1);
   const lifecycleUpper = lifecycle.charAt(0).toUpperCase() + lifecycle.substring(1);
 
@@ -36,13 +41,9 @@ const getAnimationEvent = (type, lifecycle) => {
     WebkitTransition: `webkit${typeUpper}${lifecycleUpper}`,
   };
 
-  Object.keys(properties).forEach((e) => {
-    if (el.style[e] !== undefined) {
-      browserTransition = properties[e];
-    }
-  });
+  const key = Object.keys(properties).find(propKey => el.style[propKey] !== undefined);
 
-  return browserTransition;
+  return key !== undefined ? properties[key] : false;
 };
 
 export default getAnimationEvent;

--- a/admin-dev/themes/new-theme/js/components/navbar-transition-handler.js
+++ b/admin-dev/themes/new-theme/js/components/navbar-transition-handler.js
@@ -29,8 +29,8 @@
  * @param {jQuery element} $mainMenu - The menu inside the $navBar element.
  * @param {string} endTransitionEvent - The name of the event.
  * @param {jQuery element} $body - The body of the page.
- * @function showNavBarContent - Toggle the class based on event and if body got a class.
- * @function toggle - Add the listener if there is no transition launched yet.
+ * @method showNavBarContent - Toggle the class based on event and if body got a class.
+ * @method toggle - Add the listener if there is no transition launched yet.
  * @return {Object} The object with methods wich permit to toggle on specific event.
 */
 function NavbarTransitionHandler($navBar, $mainMenu, endTransitionEvent, $body) {

--- a/admin-dev/themes/new-theme/js/components/navbar-transition-handler.js
+++ b/admin-dev/themes/new-theme/js/components/navbar-transition-handler.js
@@ -1,0 +1,65 @@
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Toggle a class on $mainMenu after the end of an event (transition, animation...)
+ * @param {jQuery element} $navBar - The navbar item which get a css transition property.
+ * @param {jQuery element} $mainMenu - The menu inside the $navBar element.
+ * @param {string} endTransitionEvent - The name of the event.
+ * @param {jQuery element} $body - The body of the page.
+ * @function showNavBarContent - Toggle the class based on event and if body got a class.
+ * @function toggle - Add the listener if there is no transition launched yet.
+ * @return {Object} The object with methods wich permit to toggle on specific event.
+*/
+function NavbarTransitionHandler($navBar, $mainMenu, endTransitionEvent, $body) {
+  this.$body = $body;
+  this.transitionFired = false;
+  this.$navBar = $navBar.get(0);
+  this.$mainMenu = $mainMenu;
+  this.endTransitionEvent = endTransitionEvent;
+
+  this.showNavBarContent = (event) => {
+    if (event.propertyName !== 'width') {
+      return;
+    }
+
+    this.$navBar.removeEventListener(this.endTransitionEvent, this.showNavBarContent);
+    const isSidebarClosed = this.$body.hasClass('page-sidebar-closed');
+    this.$mainMenu.toggleClass('sidebar-closed', isSidebarClosed);
+    this.transitionFired = false;
+  };
+
+  this.toggle = () => {
+    if (!this.transitionFired) {
+      this.$navBar.addEventListener(this.endTransitionEvent, this.showNavBarContent.bind(this));
+    } else {
+      this.$navBar.removeEventListener(this.endTransitionEvent, this.showNavBarContent);
+    }
+
+    this.transitionFired = !this.transitionFired;
+  };
+}
+
+export default NavbarTransitionHandler;

--- a/admin-dev/themes/new-theme/js/nav_bar.js
+++ b/admin-dev/themes/new-theme/js/nav_bar.js
@@ -41,7 +41,7 @@ export default class NavBar {
         $navBar,
         $mainMenu,
         getAnimationEvent('transition', 'end'),
-        $body
+        $body,
       );
 
       $navBar.find('.link-levelone').hover(

--- a/admin-dev/themes/new-theme/js/nav_bar.js
+++ b/admin-dev/themes/new-theme/js/nav_bar.js
@@ -25,6 +25,7 @@
 
 import PerfectScrollbar from 'perfect-scrollbar';
 import '@node_modules/perfect-scrollbar/css/perfect-scrollbar.css';
+import getAnimationEvent from './app/utils/animations';
 
 const {$} = window;
 
@@ -32,7 +33,10 @@ export default class NavBar {
   constructor() {
     $(() => {
       const $navBar = $('.nav-bar');
+      const navBar = document.querySelector('.nav-bar');
       new PerfectScrollbar($navBar.get(0));
+      let endTransitionEvent = getAnimationEvent('transition', 'end');
+      let transitionFired = false;
 
       $navBar.find('.link-levelone').hover(
         function onMouseEnter() {
@@ -85,14 +89,29 @@ export default class NavBar {
           $submenu.find('i.material-icons.sub-tabs-arrow').text('keyboard_arrow_up');
         });
 
+      function showNavBarContent(event) {
+        if (event.propertyName == 'width') {
+          navBar.removeEventListener(endTransitionEvent, showNavBarContent);
+
+          $('.main-menu').toggleClass('sidebar-closed');
+
+          transitionFired = false;
+        }
+      }
+
       $navBar.on(
         'click',
         '.menu-collapse',
         function onNavBarClick() {
           $('body').toggleClass('page-sidebar-closed');
-          setTimeout(() => {
-            $('.main-menu').toggleClass('sidebar-closed');
-          }, 400)
+
+          if(!transitionFired) {
+            transitionFired = true;
+            navBar.addEventListener(endTransitionEvent, showNavBarContent);
+          }else {
+            navBar.removeEventListener(endTransitionEvent, showNavBarContent);
+            transitionFired = false;
+          }
 
           $('.popover.show').remove();
           $('.help-box[aria-describedby]').removeAttr('aria-describedby');

--- a/admin-dev/themes/new-theme/js/nav_bar.js
+++ b/admin-dev/themes/new-theme/js/nav_bar.js
@@ -90,6 +90,9 @@ export default class NavBar {
         '.menu-collapse',
         function onNavBarClick() {
           $('body').toggleClass('page-sidebar-closed');
+          setTimeout(() => {
+            $('.main-menu').toggleClass('sidebar-closed');
+          }, 400)
 
           $('.popover.show').remove();
           $('.help-box[aria-describedby]').removeAttr('aria-describedby');

--- a/admin-dev/themes/new-theme/js/nav_bar.js
+++ b/admin-dev/themes/new-theme/js/nav_bar.js
@@ -33,7 +33,6 @@ export default class NavBar {
   constructor() {
     $(() => {
       const $navBar = $('.nav-bar');
-      const navBar = document.querySelector('.nav-bar');
       new PerfectScrollbar($navBar.get(0));
       let endTransitionEvent = getAnimationEvent('transition', 'end');
       let transitionFired = false;
@@ -91,7 +90,7 @@ export default class NavBar {
 
       function showNavBarContent(event) {
         if (event.propertyName == 'width') {
-          navBar.removeEventListener(endTransitionEvent, showNavBarContent);
+          $navBar[0].removeEventListener(endTransitionEvent, showNavBarContent);
 
           $('.main-menu').toggleClass('sidebar-closed');
 
@@ -107,9 +106,9 @@ export default class NavBar {
 
           if(!transitionFired) {
             transitionFired = true;
-            navBar.addEventListener(endTransitionEvent, showNavBarContent);
+            $navBar[0].addEventListener(endTransitionEvent, showNavBarContent);
           }else {
-            navBar.removeEventListener(endTransitionEvent, showNavBarContent);
+            $navBar[0].removeEventListener(endTransitionEvent, showNavBarContent);
             transitionFired = false;
           }
 

--- a/admin-dev/themes/new-theme/js/nav_bar.js
+++ b/admin-dev/themes/new-theme/js/nav_bar.js
@@ -26,16 +26,23 @@
 import PerfectScrollbar from 'perfect-scrollbar';
 import '@node_modules/perfect-scrollbar/css/perfect-scrollbar.css';
 import getAnimationEvent from './app/utils/animations';
+import NavbarTransitionHandler from './components/navbar-transition-handler';
 
 const {$} = window;
 
 export default class NavBar {
   constructor() {
     $(() => {
+      const $mainMenu = $('.main-menu');
       const $navBar = $('.nav-bar');
+      const $body = $('body');
       new PerfectScrollbar($navBar.get(0));
-      let endTransitionEvent = getAnimationEvent('transition', 'end');
-      let transitionFired = false;
+      const NavBarTransitions = new NavbarTransitionHandler(
+        $navBar,
+        $mainMenu,
+        getAnimationEvent('transition', 'end'),
+        $body
+      );
 
       $navBar.find('.link-levelone').hover(
         function onMouseEnter() {
@@ -88,29 +95,13 @@ export default class NavBar {
           $submenu.find('i.material-icons.sub-tabs-arrow').text('keyboard_arrow_up');
         });
 
-      function showNavBarContent(event) {
-        if (event.propertyName == 'width') {
-          $navBar[0].removeEventListener(endTransitionEvent, showNavBarContent);
-
-          $('.main-menu').toggleClass('sidebar-closed');
-
-          transitionFired = false;
-        }
-      }
-
       $navBar.on(
         'click',
         '.menu-collapse',
         function onNavBarClick() {
           $('body').toggleClass('page-sidebar-closed');
 
-          if(!transitionFired) {
-            transitionFired = true;
-            $navBar[0].addEventListener(endTransitionEvent, showNavBarContent);
-          }else {
-            $navBar[0].removeEventListener(endTransitionEvent, showNavBarContent);
-            transitionFired = false;
-          }
+          NavBarTransitions.toggle();
 
           $('.popover.show').remove();
           $('.help-box[aria-describedby]').removeAttr('aria-describedby');

--- a/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
@@ -213,6 +213,10 @@
         border-left: .25rem solid #25b9d7;
         padding-left: .638rem;
 
+        @at-root .sidebar-closed .link-levelone .link > span {
+          display: none;
+        }
+
         .material-icons {
           &:first-child {
             color: #25b9d7;
@@ -285,6 +289,10 @@
       display: none;
       white-space: nowrap;
       padding-left: 2.75rem;
+
+      @at-root .nav-bar .main-menu.sidebar-closed .link-levelone > .submenu {
+        display: none;
+      }
 
       & > li {
         @include media-breakpoint-down(md) {
@@ -374,6 +382,10 @@
   & > .title {
     color: white;
     background: $gray-dark;
+
+    @at-root .sidebar-closed & {
+      display: none;
+    }
   }
 }
 
@@ -402,7 +414,6 @@
 }
 
 .page-sidebar-closed:not(.mobile) {
-
   .menu-collapse {
     transform: rotate(180deg);
     padding-right: .8rem;

--- a/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
@@ -168,6 +168,20 @@
   padding: 0 0 5.313rem 0;
   margin: 0;
 
+  &.sidebar-closed {
+    .link-levelone {
+      .link > span {
+        display: none;
+      }
+
+      &.open {
+        > .submenu {
+          display: none;
+        }
+      }
+    }
+  }
+
   .category-title > .title {
     text-transform: uppercase;
   }
@@ -212,10 +226,6 @@
       > .link {
         border-left: .25rem solid #25b9d7;
         padding-left: .638rem;
-
-        @at-root .sidebar-closed .link-levelone .link > span {
-          display: none;
-        }
 
         .material-icons {
           &:first-child {
@@ -289,10 +299,6 @@
       display: none;
       white-space: nowrap;
       padding-left: 2.75rem;
-
-      @at-root .nav-bar .main-menu.sidebar-closed .link-levelone > .submenu {
-        display: none;
-      }
 
       & > li {
         @include media-breakpoint-down(md) {

--- a/admin-dev/themes/new-theme/template/components/layout/nav_bar.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/nav_bar.tpl
@@ -28,8 +28,7 @@
     <i class="material-icons">chevron_left</i>
   </span>
 
-  <ul class="main-menu">
-
+  <ul class="main-menu{if $collapse_menu} sidebar-closed{/if}">
     {foreach $tabs as $level1}
       {if $level1.active}
 
@@ -44,7 +43,6 @@
         {/if}
 
         {if $level1.icon != ''}
-
           <li class="link-levelone {if $level1.current}-active{/if}" data-submenu="{$level1.id_tab}" id="tab-{$level1.class_name}">
             <a href="{$level1Href}" class="link" >
               <i class="material-icons">{$level1.icon}</i> <span>{$level1Name}</span>


### PR DESCRIPTION
… same time

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the BO, when you open the lateral menu, the animation was not the same as when you close the menu
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10298
| How to test?  | Go in the BO and just play with the menu opening and closing, the text when you open it should appear after the sliding

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16543)
<!-- Reviewable:end -->
