### PR TITLE
Added an hook to customize the Product form in the Back Office

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -704,6 +704,10 @@ class ProductController extends FrameworkBundleAdminController
             }
         }
 
+        $this->dispatchHook('actionProductFormBuilderModifier', [
+            'formBuilder' => &$formBuilder
+        ]);
+        
         return $formBuilder->getForm();
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -705,7 +705,7 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         $this->dispatchHook('actionProductFormBuilderModifier', [
-            'formBuilder' => $formBuilder,
+            'form_builder' => $formBuilder,
             'data' => $product,
             'id_product' => $product->id,
         ]);

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -709,7 +709,7 @@ class ProductController extends FrameworkBundleAdminController
             'data' => $product,
             'id_product' => $product->id,
         ]);
-        
+
         return $formBuilder->getForm();
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -705,7 +705,7 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         $this->dispatchHook('actionProductFormBuilderModifier', [
-            'formBuilder' => &$formBuilder,
+            'formBuilder' => $formBuilder,
             'data' => $product,
             'id_product' => $product->id,
         ]);

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -705,7 +705,9 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         $this->dispatchHook('actionProductFormBuilderModifier', [
-            'formBuilder' => &$formBuilder
+            'formBuilder' => &$formBuilder,
+            'data' => $product,
+            'id_product' => $product->id,
         ]);
         
         return $formBuilder->getForm();


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simple use case: add a css class to a form input. Before: override the Twig template and hide the current form type and create your own and now: only do $formBuilder->get('your_field')->setAttribute('class', 'your-specific-class')
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | I'm lazy
| How to test?  | Create your own module and setup the following hook: `actionProductFormBuilder`.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16545)
<!-- Reviewable:end -->
