### PR TITLE
Fix total tax in order confirmation

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -636,7 +636,7 @@ abstract class PaymentModuleCore extends Module
                             '{total_shipping_tax_excl}' => Tools::getContextLocale($this->context)->formatPrice($order->total_shipping_tax_excl, $this->context->currency->iso_code),
                             '{total_shipping_tax_incl}' => Tools::getContextLocale($this->context)->formatPrice($order->total_shipping_tax_incl, $this->context->currency->iso_code),
                             '{total_wrapping}' => Tools::getContextLocale($this->context)->formatPrice($order->total_wrapping, $this->context->currency->iso_code),
-                            '{total_tax_paid}' => Tools::getContextLocale($this->context)->formatPrice(($order->total_products_wt - $order->total_products) + ($order->total_shipping_tax_incl - $order->total_shipping_tax_excl), $this->context->currency->iso_code),
+                            '{total_tax_paid}' => Tools::getContextLocale($this->context)->formatPrice(($order->total_paid_tax_incl - $order->total_paid_tax_excl), $this->context->currency->iso_code),
                         );
 
                         if (is_array($extra_vars)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Type?         | bug fix
| Description?         | This fixes wrong total tax in order confirmation email
| Category?     | FO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | Fixes #16227
| How to test?  | Setup some discounts, order something, total tax will be wrong in confirmation email and in mailalerts (made a separate PR in module's repo).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16571)
<!-- Reviewable:end -->
