### PR TITLE
Fix product cannot be deleted from cart IF another customization is made and not added to cart yet

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -297,6 +297,8 @@ class CartControllerCore extends FrontController
             . ' WHERE `id_cart` = ' . (int) $this->context->cart->id
             . ' AND `id_product` = ' . (int) $this->id_product
             . ' AND `id_customization` != ' . (int) $this->customization_id
+            . ' AND `in_cart` = 1'
+            . ' AND `quantity` > 0'
         );
 
         if (count($customization_product)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If customization for current product_id and cart_id exists and is not added to cart, it is not possible to remove any instance of this product from cart. The logic checks for amount of other customizations in cart, to check minimum quantity. BUT, somebody forgot to add a condition, so it checks only customizations that are actually in cart and have some quantity. This PR restores the correct function.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #16283
| How to test?  | -

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16574)
<!-- Reviewable:end -->
