### PR TITLE
Update addJqueryUI - Fix Issue #12035

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1205,14 +1205,12 @@ class FrontControllerCore extends Controller
         }
 
         foreach ($component as $ui) {
-
             $ui_path = Media::getJqueryUIPath($ui, $theme, $check_dependencies);
 
             //Css array is an array of media types indexed by path in order: ui-theme-css, ui-component-css, ui-dependency-css
             foreach ($ui_path['css'] as $css_path => $css_media) {
                 $css_name = basename($css_path);
                 $css_id = str_replace('.', '-', $css_name);
-
                 $css_path_min = str_replace($css_name, 'minified/' . $css_name, $css_path);
                 $css_path_min = str_replace('.css', '.min.css', $css_path_min);
                 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1200,13 +1200,35 @@ class FrontControllerCore extends Controller
      */
     public function addJqueryUI($component, $theme = 'base', $check_dependencies = true)
     {
-        $css_theme_path = '/js/jquery/ui/themes/' . $theme . '/minified/jquery.ui.theme.min.css';
-        $css_path = '/js/jquery/ui/themes/' . $theme . '/minified/jquery-ui.min.css';
-        $js_path = '/js/jquery/ui/jquery-ui.min.js';
+        if (!is_array($component)) {
+            $component = array($component);
+        }
 
-        $this->registerStylesheet('jquery-ui-theme', $css_theme_path, ['media' => 'all', 'priority' => 95]);
-        $this->registerStylesheet('jquery-ui', $css_path, ['media' => 'all', 'priority' => 90]);
-        $this->registerJavascript('jquery-ui', $js_path, ['position' => 'bottom', 'priority' => 90]);
+        foreach ($component as $ui) {
+
+            $ui_path = Media::getJqueryUIPath($ui, $theme, $check_dependencies);
+
+            //Css array is an array of media types indexed by path in order: ui-theme-css, ui-component-css, ui-dependency-css
+            foreach ($ui_path['css'] as $css_path => $css_media) {
+
+                $css_name = basename($css_path);
+                $css_id  = str_replace(".", "-", $css_name);
+
+                $css_path_min = str_replace($css_name,'minified/' . $css_name, $css_path);
+                $css_path_min = str_replace('.css','.min.css', $css_path_min);
+                
+                $this->registerStylesheet($css_id, $css_path_min, ['media' => $css_media, 'priority' => 51]);
+            }
+
+            //Js array is an indexed array of paths in order of dependency
+            foreach ($ui_path['js'] as $js_path) {
+
+                $js_id = basename($js_path,".js");
+                $js_id  = str_replace(".", "-", $js_id);
+
+                $this->registerJavascript($js_id, $js_path, ['position' => 'bottom', 'priority' => 51]);
+            }
+        }
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1210,21 +1210,19 @@ class FrontControllerCore extends Controller
 
             //Css array is an array of media types indexed by path in order: ui-theme-css, ui-component-css, ui-dependency-css
             foreach ($ui_path['css'] as $css_path => $css_media) {
-
                 $css_name = basename($css_path);
-                $css_id  = str_replace(".", "-", $css_name);
+                $css_id  = str_replace('.', '-', $css_name);
 
-                $css_path_min = str_replace($css_name,'minified/' . $css_name, $css_path);
-                $css_path_min = str_replace('.css','.min.css', $css_path_min);
+                $css_path_min = str_replace($css_name, 'minified/' . $css_name, $css_path);
+                $css_path_min = str_replace('.css', '.min.css', $css_path_min);
                 
                 $this->registerStylesheet($css_id, $css_path_min, ['media' => $css_media, 'priority' => 51]);
             }
 
             //Js array is an indexed array of paths in order of dependency
             foreach ($ui_path['js'] as $js_path) {
-
-                $js_id = basename($js_path,".js");
-                $js_id  = str_replace(".", "-", $js_id);
+                $js_id = basename($js_path, '.js');
+                $js_id  = str_replace('.', '-', $js_id);
 
                 $this->registerJavascript($js_id, $js_path, ['position' => 'bottom', 'priority' => 51]);
             }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1201,23 +1201,23 @@ class FrontControllerCore extends Controller
     public function addJqueryUI($component, $theme = 'base', $check_dependencies = true)
     {
         if (!is_array($component)) {
-            $component = array($component);
+            $component = [$component];
         }
 
         foreach ($component as $ui) {
             $ui_path = Media::getJqueryUIPath($ui, $theme, $check_dependencies);
 
-            //Css array is an array of media types indexed by path in order: ui-theme-css, ui-component-css, ui-dependency-css
+            //ui_path['css'] is array of media types indexed by path in order: ui-theme, ui-component, ui-dependency
             foreach ($ui_path['css'] as $css_path => $css_media) {
                 $css_name = basename($css_path);
                 $css_id = str_replace('.', '-', $css_name);
                 $css_path_min = str_replace($css_name, 'minified/' . $css_name, $css_path);
                 $css_path_min = str_replace('.css', '.min.css', $css_path_min);
-                
+
                 $this->registerStylesheet($css_id, $css_path_min, ['media' => $css_media, 'priority' => 51]);
             }
 
-            //Js array is an indexed array of paths in order of dependency
+            //ui_path['js'] is an indexed array of paths in order of dependency
             foreach ($ui_path['js'] as $js_path) {
                 $js_id = basename($js_path, '.js');
                 $js_id = str_replace('.', '-', $js_id);

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1211,7 +1211,7 @@ class FrontControllerCore extends Controller
             //Css array is an array of media types indexed by path in order: ui-theme-css, ui-component-css, ui-dependency-css
             foreach ($ui_path['css'] as $css_path => $css_media) {
                 $css_name = basename($css_path);
-                $css_id  = str_replace('.', '-', $css_name);
+                $css_id = str_replace('.', '-', $css_name);
 
                 $css_path_min = str_replace($css_name, 'minified/' . $css_name, $css_path);
                 $css_path_min = str_replace('.css', '.min.css', $css_path_min);
@@ -1222,7 +1222,7 @@ class FrontControllerCore extends Controller
             //Js array is an indexed array of paths in order of dependency
             foreach ($ui_path['js'] as $js_path) {
                 $js_id = basename($js_path, '.js');
-                $js_id  = str_replace('.', '-', $js_id);
+                $js_id = str_replace('.', '-', $js_id);
 
                 $this->registerJavascript($js_id, $js_path, ['position' => 'bottom', 'priority' => 51]);
             }


### PR DESCRIPTION

Updates the function to add individual JqueryUI components and dependencies to the FO instead of the whole JqueryUI library. Eg. Category page ui-slider is used but entire ui library is loaded. This reduces the size of the page.
Function uses Media::getJqueryUIPath to return js and css paths required. 
Alters path and filename to use minified versions of stylesheets.
Creates Id for each file from the filename.
Registers stylesheet and javascript files with priority 51 so as to be added after core.js, theme.css and theme.js
Fix breaks ps_facetedsearch due to incorrect call of addJquery('slider') instead of addJqueryUi('ui.slider')

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Updates the FrontController::addJqueryUI function to add individual JqueryUI components and dependencies to the FO instead of the whole JqueryUI library. On category page for example ui-slider is used but entire ui library is loaded. This reduces the size of the page.
| Type?         |  improvement / bug fix
| Category?     | FO 
| BC breaks?    | ps_facetedsearch breaks due to incorrect call of function with 'slider' instead of 'ui-slider'
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | "Fixes #12035"
| How to test?  | Compare FO css and js files loaded on category page before and after change. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16590)
<!-- Reviewable:end -->
