### PR TITLE
Prevent order controller from validating all guest addresses

### DIFF
--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -238,10 +238,13 @@ class OrderControllerCore extends FrontController
             $checksum = $this->cartChecksum->generateChecksum($cart);
         }
 
-        // Prepare all other addresses' warning messages (if relevant).
-        // These messages are displayed when changing the selected address.
-        $allInvalidAddressIds = $addressValidator->validateCustomerAddresses($customer, $this->context->language);
-        $this->checkoutWarning['invalid_addresses'] = $allInvalidAddressIds;
+        // Prevent check for guests
+        if($customer->id) {
+            // Prepare all other addresses' warning messages (if relevant).
+            // These messages are displayed when changing the selected address.
+            $allInvalidAddressIds = $addressValidator->validateCustomerAddresses($customer, $this->context->language);
+            $this->checkoutWarning['invalid_addresses'] = $allInvalidAddressIds;
+        }
 
         if (isset($data['checksum']) && $data['checksum'] === $checksum) {
             $process->restorePersistedData($data);

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -239,7 +239,7 @@ class OrderControllerCore extends FrontController
         }
 
         // Prevent check for guests
-        if($customer->id) {
+        if ($customer->id) {
             // Prepare all other addresses' warning messages (if relevant).
             // These messages are displayed when changing the selected address.
             $allInvalidAddressIds = $addressValidator->validateCustomerAddresses($customer, $this->context->language);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Order controller has two address validation checks, one is run for the cart addresses and the other is run for all customer addresses (from context). For guest checkout there's no id_customer added to the address or the guest, therefore we shouldn't try to validate a non-existing customer's addresses.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16584
| How to test?  | 1. Create tens of thousands of addresses. <br> 2. Navigate to /order <br> 3. Observe the time it takes to resolve the request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16620)
<!-- Reviewable:end -->
