### PR TITLE
Fix discount calculation if two gift-cartrules exist for the same product.

### DIFF
--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -115,8 +115,8 @@ class CartRuleCalculator
                     && ($product['id_product_attribute'] == $cartRule->gift_product_attribute
                         || !(int) $cartRule->gift_product_attribute)
                 ) {
-                    $cartRuleData->addDiscountApplied($cartRow->getFinalUnitPrice());
-                    $cartRow->applyFlatDiscount($cartRow->getFinalUnitPrice());
+                    $cartRuleData->addDiscountApplied($cartRow->getInitialUnitPrice());
+                    $cartRow->applyFlatDiscount($cartRow->getInitialUnitPrice());
                 }
             }
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR fixes a bug, where the discount was not calculated correctly if you specified two cart rules with the same gift product - as described in #11722.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes topwatcher issue #11722
| How to test?  | Make two identical cart rules, make them apply, see the wrong discount total.

**A fix was two lines of code:**
- The logic got the unit price of a product and added it to total discounts.
- BUT, it was using getFinalUnitPrice instead of getInitialUnitPrice. 
- The problem?
- You got 2 gift products in cart, unit price 100.
- In the first pass, it discounted 100, but in the second pass, it discounted only 50.
- After this fix, it gets the original price before discounts. Thus fixing the issue.

**Screenshot - correct function**
![Výstřižek](https://user-images.githubusercontent.com/6097524/69907028-86dbda00-13cd-11ea-9cdf-b923511d9136.JPG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16635)
<!-- Reviewable:end -->
