### PR TITLE
Fix logic and display of customer's cart rules

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -393,7 +393,6 @@ class CartRuleCore extends ObjectModel
         }
 
         $sql = '(SELECT SQL_NO_CACHE ' . $sql_part1 . ' WHERE cr.`id_customer` = ' . (int) $id_customer . ' ' . $sql_part2 . ')';
-        // $sql .= ' UNION (SELECT ' . $sql_part1 . ' WHERE cr.`group_restriction` = 1 ' . $sql_part2 . ')';
         if ($includeGeneric && (int) $id_customer != 0) {
             $sql .= ' UNION (SELECT ' . $sql_part1 . ' WHERE cr.`id_customer` = 0 ' . $sql_part2 . ')';
         }

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -393,7 +393,7 @@ class CartRuleCore extends ObjectModel
         }
 
         $sql = '(SELECT SQL_NO_CACHE ' . $sql_part1 . ' WHERE cr.`id_customer` = ' . (int) $id_customer . ' ' . $sql_part2 . ')';
-        $sql .= ' UNION (SELECT ' . $sql_part1 . ' WHERE cr.`group_restriction` = 1 ' . $sql_part2 . ')';
+        // $sql .= ' UNION (SELECT ' . $sql_part1 . ' WHERE cr.`group_restriction` = 1 ' . $sql_part2 . ')';
         if ($includeGeneric && (int) $id_customer != 0) {
             $sql .= ' UNION (SELECT ' . $sql_part1 . ' WHERE cr.`id_customer` = 0 ' . $sql_part2 . ')';
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This fixes a million-times reported issues of customers seeing cart rules they should not see.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10766 #13002
| How to test?  | See below

**What's wrong**
There is a bug in getCustomerCartRules function. The function accidentaly includes ALL CART RULES THAT HAVE SOME KIND OF GROUP RESTRICTION.

If you set some kind of group restriction on a cart rule, it group_restriction in database to 1. Then it stores the rules in a separate table.

Now, no matter what parameters you specify when calling the function, this part of code gets done. Does the cart rule have any kind of group restriction? It gets included. **Even the generic ones, without a code.**
`$sql .= ' UNION (SELECT ' . $sql_part1 . ' WHERE cr.`group_restriction` = 1 ' . $sql_part2 . ')';`

Removing this part of code restores the correct function and logic.

The logic works fine, because it's done later in the code - near `// Remove cart rule that does not match the customer groups`

**Why it's important**
Imagine you have X of vouchers, that reduce amount of order by X percent. They are unlimited by all means and have a code. You have them ready to be told to customers if you need to persuade them about ordering. Now (if conditions are met), every customers sees all of that "hidden vouchers" and can use it. Do you realise how crucial it can be if some merchants don't know about it?

**How to test**
- Make a customer A. Customer group 3.
- Make a new customer group ID 4, for example "Business Customers". Do NOT assign the customer to it.
- Make a cart rule - limited to customer A, no group restrictions, voucher code ABCDE, discount order by 10 %.
- Make a cart rule - limited to groups 1,2,3 (not for 4), voucher code EFGHI, discount order by 10 %.
- Make a cart rule - no restrictions on customers or groups, voucher code JKLMN, discount order by 10 %.

**Results - before a fix**
ABCDE - Visible - OK
EFGHI - Visible - WRONG
JKLMN - Not visible - OK

**Results - before a fix**
ABCDE - Visible - OK
EFGHI - Not visible - OK
JKLMN - Not visible - OK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16638)
<!-- Reviewable:end -->
