### PR TITLE
Fix upload security and working uploads when "upload_tmp_dir" is not included in "open_basedir"

### DIFF
--- a/classes/FileUploader.php
+++ b/classes/FileUploader.php
@@ -47,24 +47,6 @@ class FileUploaderCore
         }
     }
 
-    protected function toBytes($str)
-    {
-        $val = trim($str);
-        $last = strtolower($str[strlen($str) - 1]);
-        switch ($last) {
-            case 'g':
-                $val *= 1024;
-                // no break
-            case 'm':
-                $val *= 1024;
-                // no break
-            case 'k':
-                $val *= 1024;
-        }
-
-        return $val;
-    }
-
     /**
      * Returns array('success'=>true) or array('error'=>'error message').
      */

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -473,10 +473,10 @@ class ImageManagerCore
         if ((int) $maxFileSize > 0 && $file['size'] > (int) $maxFileSize) {
             return Context::getContext()->getTranslator()->trans('Image is too large (%1$d kB). Maximum allowed: %2$d kB', array($file['size'] / 1024, $maxFileSize / 1024), 'Admin.Notifications.Error');
         }
-        if (!ImageManager::isRealImage($file['tmp_name'], $file['type'], $mimeTypeList) || !ImageManager::isCorrectImageFileExt($file['name'], $types) || preg_match('/\%00/', $file['name'])) {
+        if (!ImageManager::isRealImage(Uploader::getUploadedFilePath($file['tmp_name'], -2), $file['type'], $mimeTypeList) || !ImageManager::isCorrectImageFileExt($file['name'], $types) || preg_match('/\%00/', $file['name'])) {
             return Context::getContext()->getTranslator()->trans('Image format not recognized, allowed formats are: .gif, .jpg, .png', array(), 'Admin.Notifications.Error');
         }
-        if ($file['error']) {
+        if ($file['error'] !== UPLOAD_ERR_OK) {
             return Context::getContext()->getTranslator()->trans('Error while uploading image; please change your server\'s settings. (Error code: %s)', array($file['error']), 'Admin.Notifications.Error');
         }
 
@@ -499,7 +499,7 @@ class ImageManagerCore
         if (substr($file['name'], -4) != '.ico') {
             return Context::getContext()->getTranslator()->trans('Image format not recognized, allowed formats are: .ico', array(), 'Admin.Notifications.Error');
         }
-        if ($file['error']) {
+        if ($file['error'] !== UPLOAD_ERR_OK) {
             return Context::getContext()->getTranslator()->trans('Error while uploading image; please change your server\'s settings.', array(), 'Admin.Notifications.Error');
         }
 

--- a/classes/QqUploadedFileForm.php
+++ b/classes/QqUploadedFileForm.php
@@ -72,7 +72,7 @@ class QqUploadedFileFormCore
         if (!$new_path = $image->getPathForCreation()) {
             return array('error' => Context::getContext()->getTranslator()->trans('An error occurred while attempting to create a new folder.', array(), 'Admin.Notifications.Error'));
         }
-        if (!($tmpName = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !move_uploaded_file($_FILES['qqfile']['tmp_name'], $tmpName)) {
+        if (!($tmpName = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !Uploader::moveUploadedFile('qqfile', $tmpName)) {
             return array('error' => Context::getContext()->getTranslator()->trans('An error occurred while uploading the image.', array(), 'Admin.Notifications.Error'));
         } elseif (!ImageManager::resize($tmpName, $new_path . '.' . $image->image_format)) {
             return array('error' => Context::getContext()->getTranslator()->trans('An error occurred while copying the image.', array(), 'Admin.Notifications.Error'));

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3266,12 +3266,8 @@ exit;
 
     /**
      * Convert a shorthand byte value from a PHP configuration directive to an integer value.
-     *
-     * @param string $value value to convert
-     *
-     * @return int
      */
-    public static function convertBytes($value)
+    public static function convertBytes(string $value): int
     {
         if (is_numeric($value)) {
             return $value;
@@ -3447,41 +3443,26 @@ exit;
     }
 
     /**
-     * getMemoryLimit allow to get the memory limit in octet.
+     * getMemoryLimit allow to get the memory limit in bytes.
      *
      * @since 1.4.5.0
-     *
-     * @return int the memory limit value in octet
      */
-    public static function getMemoryLimit()
+    public static function getMemoryLimit(): int
     {
-        $memory_limit = @ini_get('memory_limit');
-
-        return Tools::getOctets($memory_limit);
+        return self::convertBytes(@ini_get('memory_limit'));
     }
 
     /**
-     * getOctet allow to gets the value of a configuration option in octet.
+     * DEPRECATED, use Tools::convertBytes() method instead
      *
      * @since 1.5.0
-     *
-     * @return int the value of a configuration option in octet
+     * @deprecated 1.7.6
      */
     public static function getOctets($option)
     {
-        if (preg_match('/[0-9]+k/i', $option)) {
-            return 1024 * (int) $option;
-        }
+        Tools::displayAsDeprecated();
 
-        if (preg_match('/[0-9]+m/i', $option)) {
-            return 1024 * 1024 * (int) $option;
-        }
-
-        if (preg_match('/[0-9]+g/i', $option)) {
-            return 1024 * 1024 * 1024 * (int) $option;
-        }
-
-        return $option;
+        return self::convertBytes($option);
     }
 
     /**
@@ -3522,20 +3503,17 @@ exit;
      *
      * @return int max file size in bytes
      */
-    public static function getMaxUploadSize($max_size = 0)
+    public static function getMaxUploadSize(int $max_size = 0): int
     {
-        $values = array(Tools::convertBytes(ini_get('upload_max_filesize')));
-
-        if ($max_size > 0) {
-            $values[] = $max_size;
-        }
-
         $post_max_size = Tools::convertBytes(ini_get('post_max_size'));
-        if ($post_max_size > 0) {
-            $values[] = $post_max_size;
-        }
+        $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
 
-        return min($values);
+        return min(
+            $post_max_size > 0 ? $post_max_size : PHP_INT_MAX,
+            $upload_max_filesize > 0 ? $upload_max_filesize : PHP_INT_MAX,
+            $max_size > 0 ? $max_size : PHP_INT_MAX,
+            1024 * 1024 * 1024 // 1 GB
+        );
     }
 
     /**

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4043,7 +4043,7 @@ class AdminControllerCore extends Controller
      */
     protected function uploadImage($id, $name, $dir, $ext = false, $width = null, $height = null)
     {
-        if (isset($_FILES[$name]['tmp_name']) && !empty($_FILES[$name]['tmp_name'])) {
+        if (Uploader::isUploadedFile($name)) {
             // Delete old image
             if (Validate::isLoadedObject($object = $this->loadObject())) {
                 $object->deleteImage();
@@ -4062,7 +4062,7 @@ class AdminControllerCore extends Controller
                 return false;
             }
 
-            if (!move_uploaded_file($_FILES[$name]['tmp_name'], $tmp_name)) {
+            if (!Uploader::moveUploadedFile($name, $tmp_name)) {
                 return false;
             }
 

--- a/classes/helper/HelperImageUploader.php
+++ b/classes/helper/HelperImageUploader.php
@@ -25,11 +25,6 @@
  */
 class HelperImageUploaderCore extends HelperUploader
 {
-    public function getMaxSize()
-    {
-        return (int) Tools::getMaxUploadSize();
-    }
-
     public function getSavePath()
     {
         return $this->_normalizeDirectory(_PS_TMP_IMG_DIR_);
@@ -43,33 +38,13 @@ class HelperImageUploaderCore extends HelperUploader
 
     protected function validate(&$file)
     {
-        $file['error'] = $this->checkUploadError($file['error']);
-        if ($file['error'] !== UPLOAD_ERR_OK) {
+        if (!parent::validate($file)) {
             return false;
         }
 
-        $post_max_size = Tools::convertBytes(ini_get('post_max_size'));
-        if ($post_max_size && ($this->_getServerVars('CONTENT_LENGTH') > $post_max_size)) {
-            $file['error'] = Context::getContext()->getTranslator()->trans('The uploaded file exceeds the post_max_size directive in php.ini', array(), 'Admin.Notifications.Error');
-
-            return false;
-        }
-
-        $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
-        if ($upload_max_filesize && ($this->_getServerVars('CONTENT_LENGTH') > $upload_max_filesize)) {
-            $file['error'] = Context::getContext()->getTranslator()->trans('The uploaded file exceeds the upload_max_filesize directive in php.ini', array(), 'Admin.Notifications.Error');
-
-            return false;
-        }
-
-        if ($error = ImageManager::validateUpload($file, Tools::getMaxUploadSize($this->getMaxSize()), $this->getAcceptTypes())) {
+        $error = ImageManager::validateUpload($file, 0, $this->getAcceptTypes());
+        if ($error) {
             $file['error'] = $error;
-
-            return false;
-        }
-
-        if ($file['size'] > $this->getMaxSize()) {
-            $file['error'] = Context::getContext()->getTranslator()->trans('File is too big. Current size is %1s, maximum size is %2s.', array($file['size'], $this->getMaxSize()), 'Admin.Notifications.Error');
 
             return false;
         }

--- a/classes/helper/HelperImageUploader.php
+++ b/classes/helper/HelperImageUploader.php
@@ -44,17 +44,18 @@ class HelperImageUploaderCore extends HelperUploader
     protected function validate(&$file)
     {
         $file['error'] = $this->checkUploadError($file['error']);
+        if ($file['error'] !== UPLOAD_ERR_OK) {
+            return false;
+        }
 
         $post_max_size = Tools::convertBytes(ini_get('post_max_size'));
-
-        $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
-
         if ($post_max_size && ($this->_getServerVars('CONTENT_LENGTH') > $post_max_size)) {
             $file['error'] = Context::getContext()->getTranslator()->trans('The uploaded file exceeds the post_max_size directive in php.ini', array(), 'Admin.Notifications.Error');
 
             return false;
         }
 
+        $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
         if ($upload_max_filesize && ($this->_getServerVars('CONTENT_LENGTH') > $upload_max_filesize)) {
             $file['error'] = Context::getContext()->getTranslator()->trans('The uploaded file exceeds the upload_max_filesize directive in php.ini', array(), 'Admin.Notifications.Error');
 

--- a/classes/helper/HelperUploader.php
+++ b/classes/helper/HelperUploader.php
@@ -39,7 +39,6 @@ class HelperUploaderCore extends Uploader
     private $_name;
     private $_max_files;
     private $_multiple;
-    private $_post_max_size;
     protected $_template;
     private $_template_directory;
     private $_title;
@@ -139,23 +138,6 @@ class HelperUploaderCore extends Uploader
     public function getName()
     {
         return $this->_name;
-    }
-
-    public function setPostMaxSize($value)
-    {
-        $this->_post_max_size = $value;
-        $this->setMaxSize($value);
-
-        return $this;
-    }
-
-    public function getPostMaxSize()
-    {
-        if (!isset($this->_post_max_size)) {
-            $this->_post_max_size = parent::getPostMaxSize();
-        }
-
-        return $this->_post_max_size;
     }
 
     public function setTemplate($value)

--- a/controllers/admin/AdminAttachmentsController.php
+++ b/controllers/admin/AdminAttachmentsController.php
@@ -214,7 +214,7 @@ class AdminAttachmentsControllerCore extends AdminController
                 $_POST['mime'] = $a->mime;
             }
             if (!count($this->errors)) {
-                if (isset($_FILES['file']) && is_uploaded_file($_FILES['file']['tmp_name'])) {
+                if (Uploader::isUploadedFile('file')) {
                     if ($_FILES['file']['size'] > (Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024)) {
                         $this->errors[] = $this->trans(
                             'The file is too large. Maximum size allowed is: %1$d kB. The file you are trying to upload is %2$d kB.',
@@ -228,18 +228,17 @@ class AdminAttachmentsControllerCore extends AdminController
                         do {
                             $uniqid = sha1(microtime());
                         } while (file_exists(_PS_DOWNLOAD_DIR_ . $uniqid));
-                        if (!move_uploaded_file($_FILES['file']['tmp_name'], _PS_DOWNLOAD_DIR_ . $uniqid)) {
+                        if (!Uploader::moveUploadedFile('file', _PS_DOWNLOAD_DIR_ . $uniqid)) {
                             $this->errors[] = $this->trans('Failed to copy the file.', array(), 'Admin.Catalog.Notification');
                         }
                         $_POST['file_name'] = $_FILES['file']['name'];
-                        @unlink($_FILES['file']['tmp_name']);
                         if (!count($this->errors) && isset($a) && file_exists(_PS_DOWNLOAD_DIR_ . $a->file)) {
                             unlink(_PS_DOWNLOAD_DIR_ . $a->file);
                         }
                         $_POST['file'] = $uniqid;
                         $_POST['mime'] = $_FILES['file']['type'];
                     }
-                } elseif (array_key_exists('file', $_FILES) && (int) $_FILES['file']['error'] === 1) {
+                } elseif (isset($_FILES['file']) && $_FILES['file']['error'] === UPLOAD_ERR_INI_SIZE) {
                     $max_upload = (int) ini_get('upload_max_filesize');
                     $max_post = (int) ini_get('post_max_size');
                     $upload_mb = min($max_upload, $max_post);

--- a/controllers/admin/AdminAttachmentsController.php
+++ b/controllers/admin/AdminAttachmentsController.php
@@ -239,12 +239,10 @@ class AdminAttachmentsControllerCore extends AdminController
                         $_POST['mime'] = $_FILES['file']['type'];
                     }
                 } elseif (isset($_FILES['file']) && $_FILES['file']['error'] === UPLOAD_ERR_INI_SIZE) {
-                    $max_upload = (int) ini_get('upload_max_filesize');
-                    $max_post = (int) ini_get('post_max_size');
-                    $upload_mb = min($max_upload, $max_post);
+                    $max_upload_size_mb = round(Tools::getMaxUploadSize() / 1024 / 1024, 2);
                     $this->errors[] = $this->trans(
                         'The file %file% exceeds the size allowed by the server. The limit is set to %size% MB.',
-                        array('%file%' => '<b>' . $_FILES['file']['name'] . '</b> ', '%size%' => '<b>' . $upload_mb . '</b>'),
+                        array('%file%' => '<b>' . $_FILES['file']['name'] . '</b> ', '%size%' => '<b>' . $max_upload_size_mb . '</b>'),
                         'Admin.Catalog.Notification'
                     );
                 } elseif (!isset($a) || (isset($a) && !file_exists(_PS_DOWNLOAD_DIR_ . $a->file))) {

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -729,22 +729,15 @@ class AdminCarrierWizardControllerCore extends AdminController
             die('<return result="error" message="' . $this->trans('You do not have permission to use this wizard.', array(), 'Admin.Shipping.Notification') . '" />');
         }
 
-        $allowedExtensions = array('jpeg', 'gif', 'png', 'jpg');
-
-        $logo = (isset($_FILES['carrier_logo_input']) ? $_FILES['carrier_logo_input'] : false);
-        if ($logo && !empty($logo['tmp_name']) && $logo['tmp_name'] != 'none'
-            && (!isset($logo['error']) || !$logo['error'])
-            && preg_match('/\.(jpe?g|gif|png)$/', $logo['name'])
-            && is_uploaded_file($logo['tmp_name'])
-            && ImageManager::isRealImage($logo['tmp_name'], $logo['type'])) {
-            $file = $logo['tmp_name'];
+        if (Uploader::isUploadedFile('carrier_logo_input')
+            && preg_match('/\.(jpe?g|gif|png)$/', $_FILES['carrier_logo_input']['name'])
+            && ImageManager::isRealImage(Uploader::getUploadedFilePath('carrier_logo_input'), $_FILES['carrier_logo_input']['type'])) {
             do {
                 $tmp_name = uniqid() . '.jpg';
             } while (file_exists(_PS_TMP_IMG_DIR_ . $tmp_name));
-            if (!ImageManager::resize($file, _PS_TMP_IMG_DIR_ . $tmp_name)) {
+            if (!ImageManager::resize(Uploader::getUploadedFilePath('carrier_logo_input'), _PS_TMP_IMG_DIR_ . $tmp_name)) {
                 die('<return result="error" message="Impossible to resize the image into ' . Tools::safeOutput(_PS_TMP_IMG_DIR_) . '" />');
             }
-            @unlink($file);
             die('<return result="success" message="' . Tools::safeOutput(_PS_TMP_IMG_ . $tmp_name) . '" />');
         } else {
             die('<return result="error" message="Cannot upload file" />');

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -409,7 +409,7 @@ class AdminCartsControllerCore extends AdminController
                         }
                         $this->context->cart->addTextFieldToProduct((int) $product->id, (int) $customization_field['id_customization_field'], Product::CUSTOMIZE_TEXTFIELD, Tools::getValue($field_id));
                     } elseif ($customization_field['type'] == Product::CUSTOMIZE_FILE) {
-                        if (!isset($_FILES[$field_id]) || !isset($_FILES[$field_id]['tmp_name']) || empty($_FILES[$field_id]['tmp_name'])) {
+                        if (!Uploader::isUploadedFile($field_id)) {
                             if ($customization_field['required']) {
                                 $errors[] = $this->trans('Please fill in all the required fields.', array(), 'Admin.Notifications.Error');
                             }
@@ -419,7 +419,7 @@ class AdminCartsControllerCore extends AdminController
                         if ($error = ImageManager::validateUpload($_FILES[$field_id], (int) Configuration::get('PS_PRODUCT_PICTURE_MAX_SIZE'))) {
                             $errors[] = $error;
                         }
-                        if (!($tmp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !move_uploaded_file($_FILES[$field_id]['tmp_name'], $tmp_name)) {
+                        if (!($tmp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !Uploader::moveUploadedFile($field_id, $tmp_name)) {
                             $errors[] = $this->trans('An error occurred during the image upload process.', array(), 'Admin.Catalog.Notification');
                         }
                         $file_name = md5(uniqid(mt_rand(0, mt_getrandmax()), true));

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -439,12 +439,12 @@ class AdminCustomerThreadsControllerCore extends AdminController
                 $cm->message = Tools::getValue('reply_message');
                 if (($error = $cm->validateField('message', $cm->message, null, array(), true)) !== true) {
                     $this->errors[] = $error;
-                } elseif (isset($_FILES) && !empty($_FILES['joinFile']['name']) && $_FILES['joinFile']['error'] != 0) {
+                } elseif (isset($_FILES['joinFile']) && !empty($_FILES['joinFile']['name']) && !Uploader::isUploadedFile('joinFile')) {
                     $this->errors[] = $this->trans('An error occurred during the file upload process.', array(), 'Admin.Notifications.Error');
                 } elseif ($cm->add()) {
                     $file_attachment = null;
                     if (!empty($_FILES['joinFile']['name'])) {
-                        $file_attachment['content'] = file_get_contents($_FILES['joinFile']['tmp_name']);
+                        $file_attachment['content'] = file_get_contents(Uploader::getUploadedFilePath('joinFile'));
                         $file_attachment['name'] = $_FILES['joinFile']['name'];
                         $file_attachment['mime'] = $_FILES['joinFile']['type'];
                     }

--- a/controllers/admin/AdminGendersController.php
+++ b/controllers/admin/AdminGendersController.php
@@ -219,7 +219,7 @@ class AdminGendersControllerCore extends AdminController
         parent::afterImageUpload();
 
         if (($id_gender = (int) Tools::getValue('id_gender')) &&
-             isset($_FILES) && count($_FILES) && file_exists(_PS_GENDERS_DIR_ . $id_gender . '.jpg')) {
+             count($_FILES) && file_exists(_PS_GENDERS_DIR_ . $id_gender . '.jpg')) {
             $current_file = _PS_TMP_IMG_DIR_ . 'gender_mini_' . $id_gender . '_' . $this->context->shop->id . '.jpg';
 
             if (file_exists($current_file)) {

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -727,28 +727,8 @@ class AdminImportControllerCore extends AdminController
             $multiple_value_separator_selected = urldecode($this->context->cookie->multiple_value_separator_selected);
         }
 
-        //get post max size
-        $post_max_size = ini_get('post_max_size');
-        $bytes = (int) trim($post_max_size);
-        $last = strtolower($post_max_size[strlen($post_max_size) - 1]);
-
-        switch ($last) {
-            case 'g':
-                $bytes *= 1024;
-                // no break to fall-through
-            case 'm':
-                $bytes *= 1024;
-                // no break to fall-through
-            case 'k':
-                $bytes *= 1024;
-        }
-
-        if (!isset($bytes) || $bytes == '') {
-            $bytes = 20971520;
-        } // 20Mb
-
         $this->tpl_form_vars = array(
-            'post_max_size' => (int) $bytes,
+            'post_max_size' => Tools::getMaxUploadSize(),
             'module_confirmation' => Tools::isSubmit('import') && (isset($this->warnings) && !count($this->warnings)),
             'path_import' => AdminImportController::getPath(),
             'entities' => $this->entities,

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -771,7 +771,7 @@ class AdminImportControllerCore extends AdminController
     {
         $filename_prefix = date('YmdHis') . '-';
 
-        if (isset($_FILES['file']) && !empty($_FILES['file']['error'])) {
+        if (isset($_FILES['file']) && $_FILES['file']['error'] !== UPLOAD_ERR_OK) {
             switch ($_FILES['file']['error']) {
                 case UPLOAD_ERR_INI_SIZE:
                     $_FILES['file']['error'] = $this->trans('The uploaded file exceeds the upload_max_filesize directive in php.ini. If your server configuration allows it, you may add a directive in your .htaccess.', array(), 'Admin.Advparameters.Notification');
@@ -801,8 +801,8 @@ class AdminImportControllerCore extends AdminController
             }
         } elseif (!preg_match('#([^\.]*?)\.(csv|xls[xt]?|o[dt]s)$#is', $_FILES['file']['name'])) {
             $_FILES['file']['error'] = $this->trans('The extension of your file should be .csv.', array(), 'Admin.Advparameters.Notification');
-        } elseif (!@filemtime($_FILES['file']['tmp_name']) ||
-            !@move_uploaded_file($_FILES['file']['tmp_name'], AdminImportController::getPath() . $filename_prefix . str_replace("\0", '', $_FILES['file']['name']))) {
+        } elseif (!@filemtime(Uploader::getUploadedFilePath('file')) ||
+            !@Uploader::moveUploadedFile('file', AdminImportController::getPath() . $filename_prefix . str_replace("\0", '', $_FILES['file']['name']))) {
             $_FILES['file']['error'] = $this->trans('An error occurred while uploading / copying the file.', array(), 'Admin.Advparameters.Notification');
         } else {
             @chmod(AdminImportController::getPath() . $filename_prefix . $_FILES['file']['name'], 0664);

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -598,12 +598,12 @@ class AdminModulesControllerCore extends AdminController
 
                         break;
                 }
-            } elseif (!isset($_FILES['file']['tmp_name']) || empty($_FILES['file']['tmp_name'])) {
+            } elseif (!Uploader::isUploadedFile('file')) {
                 $this->errors[] = $this->trans('No file has been selected', array(), 'Admin.Notifications.Error');
             } elseif (substr($_FILES['file']['name'], -4) != '.tar' && substr($_FILES['file']['name'], -4) != '.zip'
                 && substr($_FILES['file']['name'], -4) != '.tgz' && substr($_FILES['file']['name'], -7) != '.tar.gz') {
                 $this->errors[] = $this->trans('Unknown archive type.', array(), 'Admin.Modules.Notification');
-            } elseif (!move_uploaded_file($_FILES['file']['tmp_name'], _PS_MODULE_DIR_ . $_FILES['file']['name'])) {
+            } elseif (!Uploader::moveUploadedFile('file', _PS_MODULE_DIR_ . $_FILES['file']['name'])) {
                 $this->errors[] = $this->trans('An error occurred while copying the archive to the module directory.', array(), 'Admin.Modules.Notification');
             } else {
                 $this->extractArchive(_PS_MODULE_DIR_ . $_FILES['file']['name']);

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -396,13 +396,11 @@ class AdminProductsControllerCore extends AdminController
             if ($_FILES['attachment_file']['error'] === UPLOAD_ERR_INI_SIZE) {
                 $_FILES['attachment_file']['error'] = array();
 
-                $max_upload = (int) ini_get('upload_max_filesize');
-                $max_post = (int) ini_get('post_max_size');
-                $upload_mb = min($max_upload, $max_post);
+                $max_upload_size_mb = round(Tools::getMaxUploadSize() / 1024 / 1024, 2);
                 $_FILES['attachment_file']['error'][] = sprintf(
                     'File %1$s exceeds the size allowed by the server. The limit is set to %2$d MB.',
                     '<b>' . $_FILES['attachment_file']['name'] . '</b> ',
-                    '<b>' . $upload_mb . '</b>'
+                    '<b>' . $max_upload_size_mb . '</b>'
                 );
             } else {
                 $_FILES['attachment_file']['error'] = array();
@@ -2237,8 +2235,7 @@ class AdminProductsControllerCore extends AdminController
             if (Uploader::isUploadedFile('virtual_product_file_uploader')) {
                 $virtual_product_filename = ProductDownload::getNewFilename();
                 $helper = new HelperUploader('virtual_product_file_uploader');
-                $helper->setPostMaxSize(Tools::getOctets(ini_get('upload_max_filesize')))
-                    ->setSavePath(_PS_DOWNLOAD_DIR_)->upload($_FILES['virtual_product_file_uploader'], $virtual_product_filename);
+                $helper->setSavePath(_PS_DOWNLOAD_DIR_)->upload($_FILES['virtual_product_file_uploader'], $virtual_product_filename);
             } else {
                 $virtual_product_filename = Tools::getValue('virtual_product_filename', ProductDownload::getNewFilename());
             }

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -358,8 +358,7 @@ class AdminRequestSqlControllerCore extends AdminController
                 }
                 if (file_exists($export_dir . $file)) {
                     $filesize = filesize($export_dir . $file);
-                    $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
-                    if ($filesize < $upload_max_filesize) {
+                    if ($filesize < Tools::getMaxUploadSize()) {
                         if (Configuration::get('PS_ENCODING_FILE_MANAGER_SQL')) {
                             $charset = Configuration::get('PS_ENCODING_FILE_MANAGER_SQL');
                         } else {

--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -638,7 +638,7 @@ class AdminStatusesControllerCore extends AdminController
         parent::afterImageUpload();
 
         if (($id_order_state = (int) Tools::getValue('id_order_state')) &&
-             isset($_FILES) && count($_FILES) && file_exists(_PS_ORDER_STATE_IMG_DIR_ . $id_order_state . '.gif')) {
+             count($_FILES) && file_exists(_PS_ORDER_STATE_IMG_DIR_ . $id_order_state . '.gif')) {
             $current_file = _PS_TMP_IMG_DIR_ . 'order_state_mini_' . $id_order_state . '_' . $this->context->shop->id . '.gif';
 
             if (file_exists($current_file)) {

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -406,7 +406,7 @@ class AdminStoresControllerCore extends AdminController
         $ret = parent::postImage($id);
         $generate_hight_dpi_images = (bool) Configuration::get('PS_HIGHT_DPI');
 
-        if (($id_store = (int) Tools::getValue('id_store')) && isset($_FILES) && count($_FILES) && file_exists(_PS_STORE_IMG_DIR_ . $id_store . '.jpg')) {
+        if (($id_store = (int) Tools::getValue('id_store')) && count($_FILES) && file_exists(_PS_STORE_IMG_DIR_ . $id_store . '.jpg')) {
             $images_types = ImageType::getImagesTypes('stores');
             foreach ($images_types as $image_type) {
                 ImageManager::resize(

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -432,7 +432,7 @@ class AdminSuppliersControllerCore extends AdminController
 
         /* Generate image with differents size */
         if (($id_supplier = (int) Tools::getValue('id_supplier')) &&
-             isset($_FILES) && count($_FILES) && file_exists(_PS_SUPP_IMG_DIR_ . $id_supplier . '.jpg')) {
+             count($_FILES) && file_exists(_PS_SUPP_IMG_DIR_ . $id_supplier . '.jpg')) {
             $images_types = ImageType::getImagesTypes('suppliers');
             foreach ($images_types as $image_type) {
                 $file = _PS_SUPP_IMG_DIR_ . $id_supplier . '.jpg';

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -764,10 +764,10 @@ class AdminTranslationsControllerCore extends AdminController
 
     public function submitImportLang()
     {
-        if (!isset($_FILES['file']['tmp_name']) || !$_FILES['file']['tmp_name']) {
+        if (!Uploader::isUploadedFile('file')) {
             $this->errors[] = $this->trans('No file has been selected.', array(), 'Admin.Notifications.Error');
         } else {
-            $gz = new Archive_Tar($_FILES['file']['tmp_name'], true);
+            $gz = new Archive_Tar(Uploader::getUploadedFilePath('file'), true);
             $filename = $_FILES['file']['name'];
             $iso_code = str_replace(array('.tar.gz', '.gzip'), '', $filename);
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -816,7 +816,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
         $indexes = array_flip($authorized_file_fields);
         foreach ($_FILES as $field_name => $file) {
-            if (in_array($field_name, $authorized_file_fields) && isset($file['tmp_name']) && !empty($file['tmp_name'])) {
+            if (in_array($field_name, $authorized_file_fields) && Uploader::isUploadedFile($field_name)) {
                 $file_name = md5(uniqid(mt_rand(0, mt_getrandmax()), true));
                 if ($error = ImageManager::validateUpload($file, (int) Configuration::get('PS_PRODUCT_PICTURE_MAX_SIZE'))) {
                     $this->errors[] = $error;
@@ -825,7 +825,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 $product_picture_width = (int) Configuration::get('PS_PRODUCT_PICTURE_WIDTH');
                 $product_picture_height = (int) Configuration::get('PS_PRODUCT_PICTURE_HEIGHT');
                 $tmp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS');
-                if ($error || (!$tmp_name || !move_uploaded_file($file['tmp_name'], $tmp_name))) {
+                if ($error || (!$tmp_name || !Uploader::moveUploadedFile($field_name, $tmp_name))) {
                     return false;
                 }
                 /* Original file */

--- a/images.inc.php
+++ b/images.inc.php
@@ -59,7 +59,7 @@ function isPicture($file, $types = null)
 {
     Tools::displayAsDeprecated();
 
-    return ImageManager::isRealImage($file['tmp_name'], $file['type'], $types);
+    return ImageManager::isRealImage(Uploader::getUploadedFilePath($file['tmp_name'], -2), $file['type'], $types);
 }
 
 /**
@@ -88,8 +88,8 @@ function imageResize($sourceFile, $destFile, $destWidth = null, $destHeight = nu
 function imageCut($srcFile, $destFile, $destWidth = null, $destHeight = null, $fileType = 'jpg', $destX = 0, $destY = 0)
 {
     Tools::displayAsDeprecated();
-    if (isset($srcFile['tmp_name'])) {
-        return ImageManager::cut($srcFile['tmp_name'], $destFile, $destWidth, $destHeight, $fileType, $destX, $destY);
+    if (Uploader::isUploadedFile($srcFile['tmp_name'], -2)) {
+        return ImageManager::cut(Uploader::getUploadedFilePath($srcFile['tmp_name'], -2), $destFile, $destWidth, $destHeight, $fileType, $destX, $destY);
     }
 
     return false;

--- a/install-dev/controllers/http/configure.php
+++ b/install-dev/controllers/http/configure.php
@@ -138,12 +138,11 @@ class InstallControllerHttpConfigure extends InstallControllerHttp implements Ht
     public function processUploadLogo()
     {
         $error = '';
-        if (isset($_FILES['fileToUpload']['tmp_name']) && $_FILES['fileToUpload']['tmp_name']) {
-            $file = $_FILES['fileToUpload'];
-            $error = ImageManager::validateUpload($file, 300000);
+        if (Uploader::isUploadedFile('fileToUpload')) {
+            $error = ImageManager::validateUpload($_FILES['fileToUpload'], 300000);
             if (!strlen($error)) {
                 $tmp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS');
-                if (!$tmp_name || !move_uploaded_file($file['tmp_name'], $tmp_name)) {
+                if (!$tmp_name || !Uploader::moveUploadedFile('fileToUpload', $tmp_name)) {
                     return false;
                 }
 

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -298,7 +298,7 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
     {
         $memoryLimit = Tools::getMemoryLimit();
         // The installer SHOULD take less than 32M, but may take up to 35/36M sometimes. So 42M is a good value :)
-        $lowMemory = ($memoryLimit != '-1' && $memoryLimit < Tools::getOctets('42M'));
+        $lowMemory = ($memoryLimit != '-1' && $memoryLimit < Tools::convertBytes('42M'));
 
         // We fill the process step used for Ajax queries
         $this->process_steps[] = array('key' => 'generateSettingsFile', 'lang' => $this->translator->trans('Create file parameters', array(), 'Install'));
@@ -383,7 +383,7 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
             closedir($dh);
         }
 
-        return $size > Tools::getOctets('10M');
+        return $size > Tools::convertBytes('10M');
     }
 
     private function clearConfigXML()

--- a/install-dev/theme/views/welcome.php
+++ b/install-dev/theme/views/welcome.php
@@ -25,7 +25,7 @@
  */
  $this->displayTemplate('header') ?>
 
-<?php if (Tools::getMemoryLimit() < Tools::getOctets('32M')): ?>
+<?php if (Tools::getMemoryLimit() < Tools::convertBytes('32M')): ?>
 	<div class="warnBlock"><?php echo $this->translator->trans('PrestaShop requires at least 32 MB of memory to run: please check the memory_limit directive in your php.ini file or contact your host provider about this.', array(), 'Install'); ?></div>
 <?php endif; ?>
 

--- a/src/Adapter/Image/Uploader/AbstractImageUploader.php
+++ b/src/Adapter/Image/Uploader/AbstractImageUploader.php
@@ -94,7 +94,7 @@ abstract class AbstractImageUploader implements ImageUploaderInterface
     {
         $temporaryImageName = tempnam(_PS_TMP_IMG_DIR_, 'PS');
 
-        if (!$temporaryImageName || !move_uploaded_file($image->getPathname(), $temporaryImageName)) {
+        if (!$temporaryImageName || !\Uploader::moveUploadedFile($image->getPathname(), $temporaryImageName, -2)) {
             throw new ImageUploadException('Failed to create temporary image file');
         }
 

--- a/src/Adapter/Image/Uploader/CategoryCoverImageUploader.php
+++ b/src/Adapter/Image/Uploader/CategoryCoverImageUploader.php
@@ -85,7 +85,7 @@ final class CategoryCoverImageUploader extends AbstractImageUploader
             throw new ImageUploadException('Failed to create temporary image file');
         }
 
-        if (!move_uploaded_file($image->getPathname(), $temporaryImageName)) {
+        if (!\Uploader::moveUploadedFile($image->getPathname(), $temporaryImageName, -2)) {
             throw new ImageUploadException('Failed to upload image');
         }
 

--- a/src/Adapter/Image/Uploader/CategoryMenuThumbnailUploader.php
+++ b/src/Adapter/Image/Uploader/CategoryMenuThumbnailUploader.php
@@ -119,13 +119,8 @@ final class CategoryMenuThumbnailUploader implements ImageUploaderInterface
             }
 
             // Necessary to prevent hacking
-            if (isset($uploadedFile['save_path'])) {
-                unset($uploadedFile['save_path']);
-            }
-
-            if (isset($uploadedFile['tmp_name'])) {
-                unset($uploadedFile['tmp_name']);
-            }
+            unset($uploadedFile['save_path']);
+            unset($uploadedFile['tmp_name']);
         }
 
         $this->cacheClearer->clearSmartyCache();

--- a/src/Adapter/Image/Uploader/CategoryThumbnailImageUploader.php
+++ b/src/Adapter/Image/Uploader/CategoryThumbnailImageUploader.php
@@ -62,7 +62,7 @@ final class CategoryThumbnailImageUploader extends AbstractImageUploader
                 throw new ImageUploadException('Failed to create temporary category thumbnail image file');
             }
 
-            if (!move_uploaded_file($uploadedImage->getPathname(), $tmpName)) {
+            if (!\Uploader::moveUploadedFile($uploadedImage->getPathname(), $tmpName, -2)) {
                 throw new ImageUploadException('Failed to upload category thumbnail image');
             }
 

--- a/src/Adapter/Image/Uploader/ManufacturerImageUploader.php
+++ b/src/Adapter/Image/Uploader/ManufacturerImageUploader.php
@@ -54,7 +54,7 @@ final class ManufacturerImageUploader extends AbstractImageUploader
             );
         }
 
-        if (!move_uploaded_file($image->getPathname(), $temporaryImageName)) {
+        if (!\Uploader::moveUploadedFile($image->getPathname(), $temporaryImageName, -2)) {
             throw new ImageUploadException(
                 'An error occurred while uploading the image. Check your directory permissions.'
             );
@@ -88,8 +88,7 @@ final class ManufacturerImageUploader extends AbstractImageUploader
 
         try {
             /* Generate images with different size */
-            if (isset($_FILES) &&
-                count($_FILES) &&
+            if (count($_FILES) &&
                 file_exists(_PS_MANU_IMG_DIR_ . $manufacturerId . '.jpg')
             ) {
                 $imageTypes = ImageType::getImagesTypes('manufacturers');

--- a/src/Adapter/Language/CommandHandler/AbstractLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AbstractLanguageHandler.php
@@ -51,7 +51,7 @@ abstract class AbstractLanguageHandler extends AbstractObjectModelHandler
     protected function copyNoPictureImage(IsoCode $isoCode, $noPictureImagePath)
     {
         if (!($temporaryImage = tempnam(_PS_TMP_IMG_DIR_, 'PS'))
-            || !move_uploaded_file($noPictureImagePath, $temporaryImage)
+            || !\Uploader::moveUploadedFile($noPictureImagePath, $temporaryImage, -2)
         ) {
             return;
         }
@@ -121,7 +121,7 @@ abstract class AbstractLanguageHandler extends AbstractObjectModelHandler
             return;
         }
 
-        if (!move_uploaded_file($newImagePath, $temporaryImage)) {
+        if (!\Uploader::moveUploadedFile($newImagePath, $temporaryImage, -2)) {
             return;
         }
 

--- a/src/Adapter/Upload/UploadQuotaConfiguration.php
+++ b/src/Adapter/Upload/UploadQuotaConfiguration.php
@@ -80,11 +80,11 @@ class UploadQuotaConfiguration implements DataConfigurationInterface
      */
     private function updateFileUploadConfiguration(array $configuration)
     {
-        $uploadMaxSize = (int) str_replace('M', '', ini_get('upload_max_filesize'));
+        $max_upload_size_mb = floor(Tools::getMaxUploadSize() * 100 / 1024 / 1024) / 100;
         $sizes = [
-            'max_size_attached_files' => $uploadMaxSize,
-            'max_size_downloadable_product' => (int) str_replace('M', '', ini_get('post_max_size')),
-            'max_size_product_image' => $uploadMaxSize,
+            'max_size_attached_files' => $max_upload_size_mb,
+            'max_size_downloadable_product' => $max_upload_size_mb,
+            'max_size_product_image' => $max_upload_size_mb,
         ];
 
         $errors = array();

--- a/src/Core/Addon/Theme/ThemeZipUploader.php
+++ b/src/Core/Addon/Theme/ThemeZipUploader.php
@@ -63,10 +63,7 @@ final class ThemeZipUploader implements ThemeUploaderInterface
             $destination = $themesDir . sha1_file($uploadedTheme->getPathname()) . '.zip';
         }
 
-        move_uploaded_file(
-            $uploadedTheme->getPathname(),
-            $destination
-        );
+        \Uploader::moveUploadedFile($uploadedTheme->getPathname(), $destination, -2);
 
         return $destination;
     }

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -84,23 +84,20 @@ class LogoUploader
      *
      * @param $fieldName
      * @param $logoPrefix
-     * @param $files[] the array of files to avoid use $_POST
      *
      * @return bool
      *
      * @throws PrestaShopException in case of upload failure
      */
-    public function update($fieldName, $logoPrefix, array $files = [])
+    public function update($fieldName, $logoPrefix)
     {
-        $files = empty($files) ? $_FILES : $files;
-
-        if (isset($files[$fieldName]['tmp_name'], $files[$fieldName]['tmp_name'], $files[$fieldName]['size'])) {
-            if ($error = ImageManager::validateUpload($files[$fieldName], Tools::getMaxUploadSize())) {
+        if (\Uploader::isUploadedFile($fieldName)) {
+            if ($error = ImageManager::validateUpload($_FILES[$fieldName], Tools::getMaxUploadSize())) {
                 throw new PrestaShopException($error);
             }
             $tmpName = tempnam(_PS_TMP_IMG_DIR_, 'PS');
 
-            if (!$tmpName || !move_uploaded_file($files[$fieldName]['tmp_name'], $tmpName)) {
+            if (!$tmpName || !\Uploader::moveUploadedFile($fieldName, $tmpName)) {
                 throw new PrestaShopException(sprintf('%Upload of temporary file to %s has failed.', $tmpName));
             }
 
@@ -162,19 +159,17 @@ class LogoUploader
         }
     }
 
-    public function uploadIco($name, $destination, $files = [])
+    public function uploadIco($name, $destination)
     {
-        $files = empty($files) ? $_FILES : $files;
-
-        if (isset($files[$name]['tmp_name']) && !empty($files[$name]['tmp_name'])) {
-            if ($error = ImageManager::validateIconUpload($files[$name])) {
+        if (\Uploader::isUploadedFile($name)) {
+            if ($error = ImageManager::validateIconUpload($_FILES[$name])) {
                 throw new PrestaShopException($error);
-            } elseif (!copy($_FILES[$name]['tmp_name'], $destination)) {
+            } elseif (!\Uploader::moveUploadedFile($name, $destination)) {
                 throw new PrestaShopException(
                     Context::getContext()->getTranslator()->trans(
                         'An error occurred while uploading the favicon: cannot copy file "%s" to folder "%s".',
                         array(
-                            $files[$name]['tmp_name'],
+                            $_FILES[$name]['tmp_name'],
                             $destination,
                         ),
                         'Admin.Design.Notification'

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -520,7 +520,7 @@ class ModuleController extends ModuleAbstractController
                 new Assert\NotNull(),
                 new Assert\File(
                     [
-                        'maxSize' => ini_get('upload_max_filesize'),
+                        'maxSize' => Tools::getMaxUploadSize(),
                         'mimeTypes' => [
                             'application/zip',
                             'application/x-gzip',

--- a/tests-legacy/resources/ModulesOverrideInstallUninstallTest/AdminProductsController.php
+++ b/tests-legacy/resources/ModulesOverrideInstallUninstallTest/AdminProductsController.php
@@ -251,13 +251,12 @@ class AdminProductsController extends AdminProductsControllerCore
         if (isset($_FILES['attachment_file'])) {
             if ($_FILES['attachment_file']['error'] === UPLOAD_ERR_INI_SIZE) {
                 $_FILES['attachment_file']['error'] = array();
-                $max_upload = (int)ini_get('upload_max_filesize');
-                $max_post = (int)ini_get('post_max_size');
-                $upload_mb = min($max_upload, $max_post);
+
+                $max_upload_size_mb = round(Tools::getMaxUploadSize() / 1024 / 1024, 2);
                 $_FILES['attachment_file']['error'][] = sprintf(
                     $this->l('File %1$s exceeds the size allowed by the server. The limit is set to %2$d MB.'),
                     '<b>'.$_FILES['attachment_file']['name'].'</b> ',
-                    '<b>'.$upload_mb.'</b>'
+                    '<b>'.$max_upload_size_mb.'</b>'
                 );
             } else {
                 $_FILES['attachment_file']['error'] = array();
@@ -1924,8 +1923,7 @@ class AdminProductsController extends AdminProductsControllerCore
             if (isset($_FILES['virtual_product_file_uploader']) && $_FILES['virtual_product_file_uploader']['size'] > 0) {
                 $virtual_product_filename = ProductDownload::getNewFilename();
                 $helper = new HelperUploader('virtual_product_file_uploader');
-                $helper->setPostMaxSize(Tools::getOctets(ini_get('upload_max_filesize')))
-                    ->setSavePath(_PS_DOWNLOAD_DIR_)->upload($_FILES['virtual_product_file_uploader'], $virtual_product_filename);
+                $helper->setSavePath(_PS_DOWNLOAD_DIR_)->upload($_FILES['virtual_product_file_uploader'], $virtual_product_filename);
             } else {
                 $virtual_product_filename = Tools::getValue('virtual_product_filename', ProductDownload::getNewFilename());
             }
@@ -2394,9 +2392,7 @@ class AdminProductsController extends AdminProductsControllerCore
         }
         $this->tpl_form_vars['form_action'] = $this->context->link->getAdminLink('AdminProducts').'&'.($id_product ? 'id_product='.(int)$id_product : 'addproduct');
         $this->tpl_form_vars['id_product'] = $id_product;
-        $upload_max_filesize = Tools::getOctets(ini_get('upload_max_filesize'));
-        $upload_max_filesize = ($upload_max_filesize / 1024) / 1024;
-        $this->tpl_form_vars['upload_max_filesize'] = $upload_max_filesize;
+        $this->tpl_form_vars['upload_max_filesize'] = Tools::convertBytes(ini_get('upload_max_filesize')) / (1024 * 1024);
         $this->tpl_form_vars['country_display_tax_label'] = $this->context->country->display_tax_label;
         $this->tpl_form_vars['has_combinations'] = $this->object->hasAttributes();
         $this->product_exists_in_shop = true;
@@ -2965,8 +2961,7 @@ class AdminProductsController extends AdminProductsControllerCore
         $virtual_product_file_uploader->setMultiple(false)->setUrl(
             Context::getContext()->link->getAdminLink('AdminProducts').'&ajax=1&id_product='.(int)$product->id
             .'&action=AddVirtualProductFile'
-        )->setPostMaxSize(Tools::getOctets(ini_get('upload_max_filesize')))
-            ->setTemplate('virtual_product.tpl');
+        )->setTemplate('virtual_product.tpl');
         $data->assign(array(
             'download_product_file_missing' => $msg,
             'download_dir_writable' => ProductDownload::checkWritableDir(),
@@ -3338,7 +3333,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 $attachment_uploader->setMultiple(false)->setUseAjax(true)->setUrl(
                     Context::getContext()->link->getAdminLink('AdminProducts').'&ajax=1&id_product='.(int)$obj->id
                     .'&action=AddAttachment'
-                )->setPostMaxSize((Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024))
+                )->setMaxSize(Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024)
                     ->setTemplate('attachment_ajax.tpl');
                 $data->assign(array(
                     'obj' => $obj,

--- a/tests-legacy/resources/ModulesOverrideInstallUninstallTest/AdminProductsController.php
+++ b/tests-legacy/resources/ModulesOverrideInstallUninstallTest/AdminProductsController.php
@@ -249,7 +249,7 @@ class AdminProductsController extends AdminProductsControllerCore
     public function ajaxProcessAddAttachment()
     {
         if (isset($_FILES['attachment_file'])) {
-            if ((int)$_FILES['attachment_file']['error'] === 1) {
+            if ($_FILES['attachment_file']['error'] === UPLOAD_ERR_INI_SIZE) {
                 $_FILES['attachment_file']['error'] = array();
                 $max_upload = (int)ini_get('upload_max_filesize');
                 $max_post = (int)ini_get('post_max_size');
@@ -259,8 +259,10 @@ class AdminProductsController extends AdminProductsControllerCore
                     '<b>'.$_FILES['attachment_file']['name'].'</b> ',
                     '<b>'.$upload_mb.'</b>'
                 );
+            } else {
+                $_FILES['attachment_file']['error'] = array();
             }
-            $_FILES['attachment_file']['error'] = array();
+
             $is_attachment_name_valid = false;
             $attachment_names = Tools::getValue('attachment_name');
             $attachment_descriptions = Tools::getValue('attachment_description');
@@ -290,64 +292,63 @@ class AdminProductsController extends AdminProductsControllerCore
             if (!$is_attachment_name_valid) {
                 $_FILES['attachment_file']['error'][] = Tools::displayError('An attachment name is required.');
             }
-            if (empty($_FILES['attachment_file']['error'])) {
-                if (is_uploaded_file($_FILES['attachment_file']['tmp_name'])) {
-                    if ($_FILES['attachment_file']['size'] > (Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024)) {
-                        $_FILES['attachment_file']['error'][] = sprintf(
-                            $this->l('The file is too large. Maximum size allowed is: %1$d kB. The file you are trying to upload is %2$d kB.'),
-                            (Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024),
-                            number_format(($_FILES['attachment_file']['size'] / 1024), 2, '.', '')
-                        );
+
+            if (Uploader::isUploadedFile('attachment_file')) {
+                if ($_FILES['attachment_file']['size'] > (Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024)) {
+                    $_FILES['attachment_file']['error'][] = sprintf(
+                        $this->l('The file is too large. Maximum size allowed is: %1$d kB. The file you are trying to upload is %2$d kB.'),
+                        (Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024),
+                        number_format(($_FILES['attachment_file']['size'] / 1024), 2, '.', '')
+                    );
+                } else {
+                    do {
+                        $uniqid = sha1(microtime());
+                    } while (file_exists(_PS_DOWNLOAD_DIR_.$uniqid));
+                    if (!Uploader::moveUploadedFile('attachment_file', _PS_DOWNLOAD_DIR_.$uniqid)) {
+                        $_FILES['attachment_file']['error'][] = $this->l('File copy failed');
+                    }
+                }
+            } else {
+                $_FILES['attachment_file']['error'][] = Tools::displayError('The file is missing.');
+            }
+            if (count($_FILES['attachment_file']['error']) === 0 && isset($uniqid)) {
+                $attachment = new Attachment();
+                foreach ($attachment_names as $lang => $name) {
+                    $attachment->name[(int)$lang] = $name;
+                }
+                foreach ($attachment_descriptions as $lang => $description) {
+                    $attachment->description[(int)$lang] = $description;
+                }
+                $attachment->file = $uniqid;
+                $attachment->mime = $_FILES['attachment_file']['type'];
+                $attachment->file_name = $_FILES['attachment_file']['name'];
+                if (empty($attachment->mime) || Tools::strlen($attachment->mime) > 128) {
+                    $_FILES['attachment_file']['error'][] = Tools::displayError('Invalid file extension');
+                }
+                if (!Validate::isGenericName($attachment->file_name)) {
+                    $_FILES['attachment_file']['error'][] = Tools::displayError('Invalid file name');
+                }
+                if (Tools::strlen($attachment->file_name) > 128) {
+                    $_FILES['attachment_file']['error'][] = Tools::displayError('The file name is too long.');
+                }
+                if (empty($this->errors)) {
+                    $res = $attachment->add();
+                    if (!$res) {
+                        $_FILES['attachment_file']['error'][] = Tools::displayError('This attachment was unable to be loaded into the database.');
                     } else {
-                        do {
-                            $uniqid = sha1(microtime());
-                        } while (file_exists(_PS_DOWNLOAD_DIR_.$uniqid));
-                        if (!copy($_FILES['attachment_file']['tmp_name'], _PS_DOWNLOAD_DIR_.$uniqid)) {
-                            $_FILES['attachment_file']['error'][] = $this->l('File copy failed');
+                        $_FILES['attachment_file']['id_attachment'] = $attachment->id;
+                        $_FILES['attachment_file']['filename'] = $attachment->name[$this->context->employee->id_lang];
+                        $id_product = (int)Tools::getValue($this->identifier);
+                        $res = $attachment->attachProduct($id_product);
+                        if (!$res) {
+                            $_FILES['attachment_file']['error'][] = Tools::displayError('We were unable to associate this attachment to a product.');
                         }
-                        @unlink($_FILES['attachment_file']['tmp_name']);
                     }
                 } else {
-                    $_FILES['attachment_file']['error'][] = Tools::displayError('The file is missing.');
-                }
-                if (empty($_FILES['attachment_file']['error']) && isset($uniqid)) {
-                    $attachment = new Attachment();
-                    foreach ($attachment_names as $lang => $name) {
-                        $attachment->name[(int)$lang] = $name;
-                    }
-                    foreach ($attachment_descriptions as $lang => $description) {
-                        $attachment->description[(int)$lang] = $description;
-                    }
-                    $attachment->file = $uniqid;
-                    $attachment->mime = $_FILES['attachment_file']['type'];
-                    $attachment->file_name = $_FILES['attachment_file']['name'];
-                    if (empty($attachment->mime) || Tools::strlen($attachment->mime) > 128) {
-                        $_FILES['attachment_file']['error'][] = Tools::displayError('Invalid file extension');
-                    }
-                    if (!Validate::isGenericName($attachment->file_name)) {
-                        $_FILES['attachment_file']['error'][] = Tools::displayError('Invalid file name');
-                    }
-                    if (Tools::strlen($attachment->file_name) > 128) {
-                        $_FILES['attachment_file']['error'][] = Tools::displayError('The file name is too long.');
-                    }
-                    if (empty($this->errors)) {
-                        $res = $attachment->add();
-                        if (!$res) {
-                            $_FILES['attachment_file']['error'][] = Tools::displayError('This attachment was unable to be loaded into the database.');
-                        } else {
-                            $_FILES['attachment_file']['id_attachment'] = $attachment->id;
-                            $_FILES['attachment_file']['filename'] = $attachment->name[$this->context->employee->id_lang];
-                            $id_product = (int)Tools::getValue($this->identifier);
-                            $res = $attachment->attachProduct($id_product);
-                            if (!$res) {
-                                $_FILES['attachment_file']['error'][] = Tools::displayError('We were unable to associate this attachment to a product.');
-                            }
-                        }
-                    } else {
-                        $_FILES['attachment_file']['error'][] = Tools::displayError('Invalid file');
-                    }
+                    $_FILES['attachment_file']['error'][] = Tools::displayError('Invalid file');
                 }
             }
+
             die(json_encode($_FILES));
         }
     }
@@ -1449,7 +1450,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 $this->copyFromPost($image, 'image');
                 if (count($this->errors) || !$image->update()) {
                     $this->errors[] = Tools::displayError('An error occurred while updating the image.');
-                } elseif (isset($_FILES['image_product']['tmp_name']) && $_FILES['image_product']['tmp_name'] != null) {
+                } elseif (Uploader::isUploadedFile('image_product')) {
                     $this->copyImage($product->id, $image->id, $method);
                 }
             }
@@ -1472,7 +1473,7 @@ class AdminProductsController extends AdminProductsControllerCore
     */
     public function copyImage($id_product, $id_image, $method = 'auto')
     {
-        if (!isset($_FILES['image_product']['tmp_name'])) {
+        if (!Uploader::isUploadedFile('image_product')) {
             return false;
         }
         if ($error = ImageManager::validateUpload($_FILES['image_product'])) {
@@ -1482,7 +1483,7 @@ class AdminProductsController extends AdminProductsControllerCore
             if (!$new_path = $image->getPathForCreation()) {
                 $this->errors[] = Tools::displayError('An error occurred while attempting to create a new folder.');
             }
-            if (!($tmpName = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !move_uploaded_file($_FILES['image_product']['tmp_name'], $tmpName)) {
+            if (!($tmpName = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !Uploader::moveUploadedFile('image_product', $tmpName)) {
                 $this->errors[] = Tools::displayError('An error occurred during the image upload process.');
             } elseif (!ImageManager::resize($tmpName, $new_path.'.'.$image->image_format)) {
                 $this->errors[] = Tools::displayError('An error occurred while copying the image.');

--- a/tests-legacy/resources/module/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests-legacy/resources/module/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -253,13 +253,11 @@ class AdminProductsController extends AdminProductsControllerCore
             if ($_FILES['attachment_file']['error'] === UPLOAD_ERR_INI_SIZE) {
                 $_FILES['attachment_file']['error'] = array();
 
-                $max_upload = (int)ini_get('upload_max_filesize');
-                $max_post = (int)ini_get('post_max_size');
-                $upload_mb = min($max_upload, $max_post);
+                $max_upload_size_mb = round(Tools::getMaxUploadSize() / 1024 / 1024, 2);
                 $_FILES['attachment_file']['error'][] = sprintf(
                     $this->l('File %1$s exceeds the size allowed by the server. The limit is set to %2$d MB.'),
                     '<b>'.$_FILES['attachment_file']['name'].'</b> ',
-                    '<b>'.$upload_mb.'</b>'
+                    '<b>'.$max_upload_size_mb.'</b>'
                 );
             } else {
                 $_FILES['attachment_file']['error'] = array();
@@ -1986,8 +1984,7 @@ class AdminProductsController extends AdminProductsControllerCore
             if (isset($_FILES['virtual_product_file_uploader']) && $_FILES['virtual_product_file_uploader']['size'] > 0) {
                 $virtual_product_filename = ProductDownload::getNewFilename();
                 $helper = new HelperUploader('virtual_product_file_uploader');
-                $helper->setPostMaxSize(Tools::getOctets(ini_get('upload_max_filesize')))
-                    ->setSavePath(_PS_DOWNLOAD_DIR_)->upload($_FILES['virtual_product_file_uploader'], $virtual_product_filename);
+                $helper->setSavePath(_PS_DOWNLOAD_DIR_)->upload($_FILES['virtual_product_file_uploader'], $virtual_product_filename);
             } else {
                 $virtual_product_filename = Tools::getValue('virtual_product_filename', ProductDownload::getNewFilename());
             }
@@ -2506,13 +2503,7 @@ class AdminProductsController extends AdminProductsControllerCore
         $this->tpl_form_vars['form_action'] = $this->context->link->getAdminLink('AdminProducts').'&'.($id_product ? 'id_product='.(int)$id_product : 'addproduct');
         $this->tpl_form_vars['id_product'] = $id_product;
 
-        // Transform configuration option 'upload_max_filesize' in octets
-        $upload_max_filesize = Tools::getOctets(ini_get('upload_max_filesize'));
-
-        // Transform configuration option 'upload_max_filesize' in MegaOctets
-        $upload_max_filesize = ($upload_max_filesize / 1024) / 1024;
-
-        $this->tpl_form_vars['upload_max_filesize'] = $upload_max_filesize;
+        $this->tpl_form_vars['upload_max_filesize'] = Tools::convertBytes(ini_get('upload_max_filesize')) / (1024 * 1024);
         $this->tpl_form_vars['country_display_tax_label'] = $this->context->country->display_tax_label;
         $this->tpl_form_vars['has_combinations'] = $this->object->hasAttributes();
         $this->product_exists_in_shop = true;
@@ -3159,8 +3150,7 @@ class AdminProductsController extends AdminProductsControllerCore
         $virtual_product_file_uploader->setMultiple(false)->setUrl(
             Context::getContext()->link->getAdminLink('AdminProducts').'&ajax=1&id_product='.(int)$product->id
             .'&action=AddVirtualProductFile'
-        )->setPostMaxSize(Tools::getOctets(ini_get('upload_max_filesize')))
-            ->setTemplate('virtual_product.tpl');
+        )->setTemplate('virtual_product.tpl');
 
         $data->assign(array(
             'download_product_file_missing' => $msg,
@@ -3541,7 +3531,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 $attachment_uploader->setMultiple(false)->setUseAjax(true)->setUrl(
                     Context::getContext()->link->getAdminLink('AdminProducts').'&ajax=1&id_product='.(int)$obj->id
                     .'&action=AddAttachment'
-                )->setPostMaxSize((Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024))
+                )->setMaxSize(Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024)
                     ->setTemplate('attachment_ajax.tpl');
 
                 $data->assign(array(

--- a/tests-legacy/resources/modules/ps_banner/ps_banner.php
+++ b/tests-legacy/resources/modules/ps_banner/ps_banner.php
@@ -105,16 +105,14 @@ class Ps_Banner extends Module implements WidgetInterface
             $update_images_values = false;
 
             foreach ($languages as $lang) {
-                if (isset($_FILES['BANNER_IMG_'.$lang['id_lang']])
-                    && isset($_FILES['BANNER_IMG_'.$lang['id_lang']]['tmp_name'])
-                    && !empty($_FILES['BANNER_IMG_'.$lang['id_lang']]['tmp_name'])) {
+                if (Uploader::isUploadedFile('BANNER_IMG_'.$lang['id_lang'])) {
                     if ($error = ImageManager::validateUpload($_FILES['BANNER_IMG_'.$lang['id_lang']], 4000000)) {
                         return $error;
                     } else {
                         $ext = substr($_FILES['BANNER_IMG_'.$lang['id_lang']]['name'], strrpos($_FILES['BANNER_IMG_'.$lang['id_lang']]['name'], '.') + 1);
                         $file_name = md5($_FILES['BANNER_IMG_'.$lang['id_lang']]['name']).'.'.$ext;
 
-                        if (!move_uploaded_file($_FILES['BANNER_IMG_'.$lang['id_lang']]['tmp_name'], dirname(__FILE__).DIRECTORY_SEPARATOR.'img'.DIRECTORY_SEPARATOR.$file_name)) {
+                        if (!Uploader::moveUploadedFile('BANNER_IMG_'.$lang['id_lang'], dirname(__FILE__).DIRECTORY_SEPARATOR.'img'.DIRECTORY_SEPARATOR.$file_name)) {
                             return $this->displayError($this->trans('An error occurred while attempting to upload the file.', array(), 'Admin.Notifications.Error'));
                         } else {
                             if (Configuration::hasContext('BANNER_IMG', $lang['id_lang'], Shop::getContext())

--- a/tests/Resources/modules/ps_banner/ps_banner.php
+++ b/tests/Resources/modules/ps_banner/ps_banner.php
@@ -105,15 +105,14 @@ class Ps_Banner extends Module implements WidgetInterface
             $update_images_values = false;
 
             foreach ($languages as $lang) {
-                if (isset($_FILES['BANNER_IMG_' . $lang['id_lang']], $_FILES['BANNER_IMG_' . $lang['id_lang']]['tmp_name'])
-                    && !empty($_FILES['BANNER_IMG_' . $lang['id_lang']]['tmp_name'])) {
+                if (Uploader::isUploadedFile('BANNER_IMG_' . $lang['id_lang'])) {
                     if ($error = ImageManager::validateUpload($_FILES['BANNER_IMG_' . $lang['id_lang']], 4000000)) {
                         return $error;
                     } else {
                         $ext = substr($_FILES['BANNER_IMG_' . $lang['id_lang']]['name'], strrpos($_FILES['BANNER_IMG_' . $lang['id_lang']]['name'], '.') + 1);
                         $file_name = md5($_FILES['BANNER_IMG_' . $lang['id_lang']]['name']) . '.' . $ext;
 
-                        if (!move_uploaded_file($_FILES['BANNER_IMG_' . $lang['id_lang']]['tmp_name'], __DIR__ . DIRECTORY_SEPARATOR . 'img' . DIRECTORY_SEPARATOR . $file_name)) {
+                        if (!Uploader::moveUploadedFile('BANNER_IMG_' . $lang['id_lang'], __DIR__ . DIRECTORY_SEPARATOR . 'img' . DIRECTORY_SEPARATOR . $file_name)) {
                             return $this->displayError($this->trans('An error occurred while attempting to upload the file.', array(), 'Admin.Notifications.Error'));
                         } else {
                             if (Configuration::hasContext('BANNER_IMG', $lang['id_lang'], Shop::getContext())


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix upload security and working uploads when "upload_tmp_dir" is not included in "open_basedir". PHP file uploads are designed to upload files firstly to an secured location not accessible from PHP directly and then upload files are expected to be moved by `move_uploaded_file` method.<br>Currently PrestaShop has no centralized code uploads and their validation, there are a lot of usages (like checking if the file is really an image) before the `move_uploaded_file` method is called. This PR addresses all there issues by providing custom `is_uploaded_file` (`Uploader::isUploadedFile`) and `move_uploaded_file` (`Uploader::moveUploadedFile`) methods which behave like the PHP methods, do extra validation and move the uploaded files to temporaly location before they are finally moved. They also take care to unlink the temproraly files if not done so by the user/script itself.
| Type?         | bug fix / improvement
| Category?     | FO / BO (all)
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | All tests should pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16643)
<!-- Reviewable:end -->
