### PR TITLE
Changed Product id_tax_rules_group default value to 0

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -227,7 +227,7 @@ class ProductCore extends ObjectModel
      */
     public $base_price;
 
-    public $id_tax_rules_group = 1;
+    public $id_tax_rules_group = 0;
 
     /**
      * We keep this variable for retrocompatibility for themes.


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PS version 1.7.6.0 . The default value of this variable doesn't seem logical. We had a business case where we needed to import products with a module. When creating a product in the module and not changing the id_tax_rules_group value the product gets assigned the tax group with id 1. In our case that tax group was disabled, but taxes were still being applied in BO product list and in FO. Also the tax group can be deleted, so the product would be assigned a non-existing tax group, so maybe it would be more logical if the product didn't get a task group assigned by default?
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | Not sure
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Delete tax group with ID = 1 . Create a Product object and save it without changing the default tax group id value. Check the database, the new product will be assigned a non-existing tax group.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16687)
<!-- Reviewable:end -->
