### PR TITLE
1.7.6.x

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -406,8 +406,6 @@ class ContextCore
         // In case we have at least 1 translated message, we return the current translator.
         // If some translations are missing, clear cache
         if ($locale === '' || count($translator->getCatalogue($locale)->all())) {
-            $this->translator = $translator;
-
             return $translator;
         }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1446,9 +1446,9 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                 throw new PrestaShopException('Validation function not found. ' . $data['validate']);
             }
 
-            $value = Tools::getValue($field);
+            $value = Tools::getValue($field, null);
 
-            if (empty($value)) {
+            if ($value === null) {
                 $errors[$field] = $this->trans('The field %s is required.', array(self::displayFieldName($field, get_class($this), $htmlentities)), 'Admin.Notifications.Error');
             }
         }

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -82,7 +82,7 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
         // to check if required fields are set
         if ($command->isPartnerOffersSubscribed() !== null) {
             $_POST[RequiredField::PARTNER_OFFERS] = $command->isPartnerOffersSubscribed();
-        } else if ($command->isNewsletterSubscribed() !== null) {
+        } elseif ($command->isNewsletterSubscribed() !== null) {
             $_POST[RequiredField::NEWSLETTER] = $command->isNewsletterSubscribed();
         }
 

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -80,7 +80,20 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
 
         // validateFieldsRequiredDatabase() below is using $_POST
         // to check if required fields are set
-        $_POST[RequiredField::PARTNER_OFFERS] = $command->isPartnerOffersSubscribed();
+        if ($command->isPartnerOffersSubscribed() !== null) {
+            $_POST[RequiredField::PARTNER_OFFERS] = $command->isPartnerOffersSubscribed();
+        } else if ($command->isNewsletterSubscribed() !== null) {
+            $_POST[RequiredField::NEWSLETTER] = $command->isNewsletterSubscribed();
+        }
+
+        // before validation, we need to get the list of customer mandatory fields from the database
+        // and set their current values (only if it is not being modified: if it is not in $_POST)
+        $requiredFields = $customer->getFieldsRequiredDatabase();
+        foreach ($requiredFields as $field) {
+            if (!array_key_exists($field['field_name'], $_POST)) {
+                $_POST[$field['field_name']] = $customer->{$field['field_name']};
+            }
+        }
 
         $this->assertRequiredFieldsAreNotMissing($customer);
 

--- a/src/Core/Domain/Customer/ValueObject/RequiredField.php
+++ b/src/Core/Domain/Customer/ValueObject/RequiredField.php
@@ -48,5 +48,4 @@ class RequiredField
         self::PARTNER_OFFERS,
         self::NEWSLETTER,
     ];
-
 }

--- a/src/Core/Domain/Customer/ValueObject/RequiredField.php
+++ b/src/Core/Domain/Customer/ValueObject/RequiredField.php
@@ -37,9 +37,16 @@ class RequiredField
     const PARTNER_OFFERS = 'optin';
 
     /**
+     * Newsletter field name
+     */
+    const NEWSLETTER = 'newsletter';
+
+    /**
      * All allowed required fields for customer
      */
     const ALLOWED_REQUIRED_FIELDS = [
         self::PARTNER_OFFERS,
+        self::NEWSLETTER,
     ];
+
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -473,6 +473,8 @@ class CustomerController extends AbstractAdminController
             $editableCustomer = $this->getQueryBus()->handle(new GetCustomerForEditing((int) $customerId));
 
             $editCustomerCommand = new EditCustomerCommand((int) $customerId);
+
+            // toggle newsletter subscription
             $editCustomerCommand->setNewsletterSubscribed(!$editableCustomer->isNewsletterSubscribed());
 
             $this->getCommandBus()->handle($editCustomerCommand);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.6.x / 1.6.1.x
| Description?  | This PR fixes a JavaScript error which occures when function "updateCartProducts" is called  from AdminOrdersController. The error is due to a call of an unassigned variable.
| Type?         | bug fix
| Category?     |  BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Make cart in front office then go in back-office and create an order from the cart, any JS error should appear in console.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16716)
<!-- Reviewable:end -->
