### PR TITLE
Cost price & unit price are erased when saving with a supplier

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2540,7 +2540,6 @@ class AdminProductsControllerCore extends AdminController
                                     AND a.id_product_attribute = ' . (int) $attribute['id_product_attribute'];
                                 ObjectModel::updateMultishopTable('Combination', $data, $where);
                             } else {
-                                $product->wholesale_price = (float) Tools::convertPrice($price, $id_currency); //converted in the default currency
                                 $product->supplier_reference = pSQL($reference);
                                 $product->update();
                             }

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2529,20 +2529,15 @@ class AdminProductsControllerCore extends AdminController
                             $product_supplier->update();
                         }
 
-                        if ($product->id_supplier == $supplier->id_supplier) {
-                            if ((int) $attribute['id_product_attribute'] > 0) {
-                                $data = array(
-                                    'supplier_reference' => pSQL($reference),
-                                    'wholesale_price' => (float) Tools::convertPrice($price, $id_currency),
-                                );
-                                $where = '
+                        if ($product->id_supplier == $supplier->id_supplier && (int) $attribute['id_product_attribute'] > 0) {
+                            $data = array(
+                                'supplier_reference' => pSQL($reference),
+                                'wholesale_price' => (float) Tools::convertPrice($price, $id_currency),
+                            );
+                            $where = '
                                     a.id_product = ' . (int) $product->id . '
                                     AND a.id_product_attribute = ' . (int) $attribute['id_product_attribute'];
-                                ObjectModel::updateMultishopTable('Combination', $data, $where);
-                            } else {
-                                $product->supplier_reference = pSQL($reference);
-                                $product->update();
-                            }
+                            ObjectModel::updateMultishopTable('Combination', $data, $where);
                         }
                     } elseif (Tools::isSubmit('supplier_reference_' . $product->id . '_' . $attribute['id_product_attribute'] . '_' . $supplier->id_supplier)) {
                         //int attribute with default values if possible


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | This data don't need to be saved while saving product suppliers information.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16353 
| How to test?  | Follow ticket instruction

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16729)
<!-- Reviewable:end -->
