### PR TITLE
Can't export data more than filters limits

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -670,6 +670,7 @@ class CategoryController extends FrameworkBundleAdminController
      */
     public function exportAction(CategoryFilters $filters)
     {
+        $filters = new CategoryFilters(['limit' => null] + $filters->all());
         $categoriesGridFactory = $this->get('prestashop.core.grid.factory.category');
         $categoriesGrid = $categoriesGridFactory->getGrid($filters);
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -399,6 +399,7 @@ class ManufacturerController extends FrameworkBundleAdminController
      */
     public function exportAction(ManufacturerFilters $filters)
     {
+        $filters = new ManufacturerFilters(['limit' => null] + $filters->all());
         $manufacturersGridFactory = $this->get('prestashop.core.grid.grid_factory.manufacturer');
         $manufacturersGrid = $manufacturersGridFactory->getGrid($filters);
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -363,6 +363,7 @@ class SupplierController extends FrameworkBundleAdminController
      */
     public function exportAction(SupplierFilters $filters)
     {
+        $filters = new SupplierFilters(['limit' => null] + $filters->all());
         $supplierGridFactory = $this->get('prestashop.core.grid.factory.supplier');
         $supplierGrid = $supplierGridFactory->getGrid($filters);
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -685,6 +685,7 @@ class CustomerController extends AbstractAdminController
      */
     public function exportAction(CustomerFilters $filters)
     {
+        $filters = new CustomerFilters(['limit' => null] + $filters->all());
         $gridFactory = $this->get('prestashop.core.grid.factory.customer');
         $grid = $gridFactory->getGrid($filters);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Customers, manufacturers and Categories can't be export over the default limit.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16328 
| How to test?  | Follow ticket instruction, and repeat with Categories, manufacturers and customers.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16742)
<!-- Reviewable:end -->
