### PR TITLE
Attributes bo_css & bo_theme can be empty

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -432,13 +432,20 @@ class AdminControllerCore extends Controller
             }
 
             $this->bo_theme = $default_theme_name;
-
             if (!@filemtime(_PS_BO_ALL_THEMES_DIR_ . $this->bo_theme . DIRECTORY_SEPARATOR . 'template')) {
                 $this->bo_theme = 'default';
             }
 
-            $this->bo_css = ((Validate::isLoadedObject($this->context->employee)
-                && $this->context->employee->bo_css) ? $this->context->employee->bo_css : 'theme.css');
+            $this->context->employee->bo_theme = (
+                Validate::isLoadedObject($this->context->employee)
+                && $this->context->employee->bo_theme
+            ) ? $this->context->employee->bo_theme : $this->bo_theme;
+
+            $this->bo_css = (
+                Validate::isLoadedObject($this->context->employee)
+                && $this->context->employee->bo_css
+            ) ? $this->context->employee->bo_css : 'theme.css';
+            $this->context->employee->bo_css = $this->bo_css;
 
             $adminThemeCSSFile = _PS_BO_ALL_THEMES_DIR_ . $this->bo_theme . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR . $this->bo_css;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | These attributes must not be empty because it prepares some context variables that are used in modules.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16730 
| How to test?  | Follow ticket instruction

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16746)
<!-- Reviewable:end -->
