### PR TITLE
Fix decoding of single quote/double quote in the rss feed (and others char I guess)

### DIFF
--- a/src/Adapter/News/NewsDataProvider.php
+++ b/src/Adapter/News/NewsDataProvider.php
@@ -162,7 +162,7 @@ class NewsDataProvider
             $date = strtotime($item->pubDate);
             $data['rss'][] = [
                 'date' => $this->tools->displayDate(date('Y-m-d H:i:s', $date), null, false),
-                'title' => htmlentities($item->title, ENT_QUOTES, 'utf-8'),
+                'title' => html_entity_decode($item->title, ENT_QUOTES, 'utf-8'),
                 'short_desc' => $this->tools->truncateString(strip_tags((string) $item->description), 150),
                 'link' => (string) $article_link,
             ];


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Wrong displaying single quote and double quote in the "PrestaShop News" RSS feed. Helpful for the Italian news that could have the 'single quote' in the title.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No ticket found
| How to test?  | Add Italian language to PrestaShop, in your employee profile switch to Italian language, go to dashboard. At the moment, the single quote is displayed like this => `\&#039;`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16755)
<!-- Reviewable:end -->
