### PR TITLE
Fix recursive check of updated files

### DIFF
--- a/src/Adapter/Requirement/CheckMissingOrUpdatedFiles.php
+++ b/src/Adapter/Requirement/CheckMissingOrUpdatedFiles.php
@@ -49,7 +49,7 @@ class CheckMissingOrUpdatedFiles
         );
 
         if (null === $dir) {
-            $xml = @simplexml_load_file(_PS_API_URL_ . '/xml/md5-1' . AppKernel::MAJOR_VERSION . '/' . AppKernel::VERSION . '.xml');
+            $xml = @simplexml_load_file(_PS_API_URL_ . '/xml/md5-' . AppKernel::MAJOR_VERSION . '/' . AppKernel::VERSION . '.xml');
             if (!$xml) {
                 return $fileList;
             }
@@ -74,7 +74,7 @@ class CheckMissingOrUpdatedFiles
         }
 
         foreach ($dir->dir as $subdir) {
-            $this->getListOfUpdatedFiles($subdir, $path . $subdir['name'] . '/');
+            $fileList = array_merge_recursive($fileList, $this->getListOfUpdatedFiles($subdir, $path . $subdir['name'] . '/'));
         }
 
         return $fileList;


### PR DESCRIPTION
The return value of the recursive call is not used, so even if it
reports changed files in subfolders, they won't be returned at the end.

The URL to the xml file was incorrect, so it never got to the recursive
call in the first place.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In version 1.7 the RequiredFilesChecker is broken. See the PR description for details.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | N/A
| How to test?  | Modify a file in the core and go to Back Office -> Advanced-> System information. Your modified file should be on the list. Note: there is no XML file for the `develop` version, so you should cherry-pick this in an already released version to test (or just modify the AppKernel::VERSION constant to something released, e.g. `1.7.6.2`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16765)
<!-- Reviewable:end -->
