### PR TITLE
Functional Tests - Enable/Disable current year in the invoice file name

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/orders/invoices/03_invoiceOptions/05_enableDisableCurrentYear.js
+++ b/tests/puppeteer/campaigns/functional/BO/orders/invoices/03_invoiceOptions/05_enableDisableCurrentYear.js
@@ -12,8 +12,6 @@ const DashboardPage = require('@pages/BO/dashboard');
 const InvoicesPage = require('@pages/BO/orders/invoices/index');
 const OrdersPage = require('@pages/BO/orders/index');
 const ViewOrderPage = require('@pages/BO/orders/view');
-const CheckoutPage = require('@pages/FO/checkout');
-const OrderConfirmationPage = require('@pages/FO/orderConfirmation');
 // Importing data
 const {Statuses} = require('@data/demo/orders');
 
@@ -32,8 +30,6 @@ const init = async function () {
     invoicesPage: new InvoicesPage(page),
     ordersPage: new OrdersPage(page),
     viewOrderPage: new ViewOrderPage(page),
-    checkoutPage: new CheckoutPage(page),
-    orderConfirmationPage: new OrderConfirmationPage(page),
   };
 };
 

--- a/tests/puppeteer/campaigns/functional/BO/orders/invoices/03_invoiceOptions/05_enableDisableCurrentYear.js
+++ b/tests/puppeteer/campaigns/functional/BO/orders/invoices/03_invoiceOptions/05_enableDisableCurrentYear.js
@@ -39,7 +39,10 @@ const init = async function () {
 
 /*
 Enable Add current year to invoice number
+Choose the option After the sequential number
 Change the first Order status to shipped
+Check the current year in the invoice file name
+Choose the option Before the sequential number
 Check the current year in the invoice file name
 Disable Add current year to invoice number
 Check that the current year does not exist in the invoice file name

--- a/tests/puppeteer/campaigns/functional/BO/orders/invoices/03_invoiceOptions/05_enableDisableCurrentYear.js
+++ b/tests/puppeteer/campaigns/functional/BO/orders/invoices/03_invoiceOptions/05_enableDisableCurrentYear.js
@@ -1,0 +1,148 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const InvoicesPage = require('@pages/BO/orders/invoices/index');
+const OrdersPage = require('@pages/BO/orders/index');
+const ViewOrderPage = require('@pages/BO/orders/view');
+const CheckoutPage = require('@pages/FO/checkout');
+const OrderConfirmationPage = require('@pages/FO/orderConfirmation');
+// Importing data
+const {Statuses} = require('@data/demo/orders');
+
+let browser;
+let page;
+let fileName;
+const today = new Date();
+const currentYear = today.getFullYear();
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    invoicesPage: new InvoicesPage(page),
+    ordersPage: new OrdersPage(page),
+    viewOrderPage: new ViewOrderPage(page),
+    checkoutPage: new CheckoutPage(page),
+    orderConfirmationPage: new OrderConfirmationPage(page),
+  };
+};
+
+/*
+Enable Add current year to invoice number
+Change the first Order status to Payment accepted
+Check the current year in the invoice file name
+Disable Add current year to invoice number
+Check that the current year does not exist in the invoice file name
+ */
+describe('Edit invoice prefix and check the generated invoice file name', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    await helper.setDownloadBehavior(page);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+
+  // Login into BO
+  loginCommon.loginBO();
+
+  describe('Enable add current year to invoice number then check the invoice file name', async () => {
+    describe('Enable add current year to invoice number', async () => {
+      it('should go to invoices page', async function () {
+        await this.pageObjects.boBasePage.goToSubMenu(
+          this.pageObjects.boBasePage.ordersParentLink,
+          this.pageObjects.boBasePage.invoicesLink,
+        );
+        await this.pageObjects.boBasePage.closeSfToolBar();
+        const pageTitle = await this.pageObjects.invoicesPage.getPageTitle();
+        await expect(pageTitle).to.contains(this.pageObjects.invoicesPage.pageTitle);
+      });
+
+      it('should enable add current year to invoice number', async function () {
+        await this.pageObjects.invoicesPage.enableAddCurrentYearToInvoice(true);
+        const textMessage = await this.pageObjects.invoicesPage.saveInvoiceOptions();
+        await expect(textMessage).to.contains(this.pageObjects.invoicesPage.successfulUpdateMessage);
+      });
+    });
+
+    describe('Check the invoice file Name', async () => {
+      it('should go to the orders page', async function () {
+        await this.pageObjects.boBasePage.goToSubMenu(
+          this.pageObjects.boBasePage.ordersParentLink,
+          this.pageObjects.boBasePage.ordersLink,
+        );
+        const pageTitle = await this.pageObjects.ordersPage.getPageTitle();
+        await expect(pageTitle).to.contains(this.pageObjects.ordersPage.pageTitle);
+      });
+
+      it('should go to the first order page', async function () {
+        await this.pageObjects.ordersPage.goToOrder(1);
+        const pageTitle = await this.pageObjects.viewOrderPage.getPageTitle();
+        await expect(pageTitle).to.contains(this.pageObjects.viewOrderPage.pageTitle);
+      });
+
+      it(`should change the order status to '${Statuses.shipped.status}' and check it`, async function () {
+        const result = await this.pageObjects.viewOrderPage.modifyOrderStatus(Statuses.shipped.status);
+        await expect(result).to.be.true;
+      });
+
+      it('should check that the invoice file name contain current year', async function () {
+        fileName = await this.pageObjects.viewOrderPage.getFileName();
+        expect(fileName).to.contains(currentYear);
+      });
+    });
+  });
+
+  describe('Disable add current year to invoice number then check the invoice file name', async () => {
+    describe('Disable add current year to invoice number', async () => {
+      it('should go to invoices page', async function () {
+        await this.pageObjects.boBasePage.goToSubMenu(
+          this.pageObjects.boBasePage.ordersParentLink,
+          this.pageObjects.boBasePage.invoicesLink,
+        );
+        await this.pageObjects.boBasePage.closeSfToolBar();
+        const pageTitle = await this.pageObjects.invoicesPage.getPageTitle();
+        await expect(pageTitle).to.contains(this.pageObjects.invoicesPage.pageTitle);
+      });
+
+      it('should disable add current year to invoice number', async function () {
+        await this.pageObjects.invoicesPage.enableAddCurrentYearToInvoice(false);
+        const textMessage = await this.pageObjects.invoicesPage.saveInvoiceOptions();
+        await expect(textMessage).to.contains(this.pageObjects.invoicesPage.successfulUpdateMessage);
+      });
+    });
+  });
+
+  describe('Change the order status to \'Payment accepted\' and check the invoice file Name', async () => {
+    it('should go to the orders page', async function () {
+      await this.pageObjects.boBasePage.goToSubMenu(
+        this.pageObjects.boBasePage.ordersParentLink,
+        this.pageObjects.boBasePage.ordersLink,
+      );
+      const pageTitle = await this.pageObjects.ordersPage.getPageTitle();
+      await expect(pageTitle).to.contains(this.pageObjects.ordersPage.pageTitle);
+    });
+
+    it('should go to the first order page', async function () {
+      await this.pageObjects.ordersPage.goToOrder(1);
+      const pageTitle = await this.pageObjects.viewOrderPage.getPageTitle();
+      await expect(pageTitle).to.contains(this.pageObjects.viewOrderPage.pageTitle);
+    });
+
+    it('should check that the invoice file name does not contain the current year', async function () {
+      fileName = await this.pageObjects.viewOrderPage.getFileName();
+      expect(fileName).to.not.contains(currentYear);
+    });
+  });
+});

--- a/tests/puppeteer/campaigns/functional/BO/orders/invoices/03_invoiceOptions/05_enableDisableCurrentYear.js
+++ b/tests/puppeteer/campaigns/functional/BO/orders/invoices/03_invoiceOptions/05_enableDisableCurrentYear.js
@@ -122,27 +122,27 @@ describe('Edit invoice prefix and check the generated invoice file name', async 
         await expect(textMessage).to.contains(this.pageObjects.invoicesPage.successfulUpdateMessage);
       });
     });
-  });
 
-  describe('Change the order status to \'Payment accepted\' and check the invoice file Name', async () => {
-    it('should go to the orders page', async function () {
-      await this.pageObjects.boBasePage.goToSubMenu(
-        this.pageObjects.boBasePage.ordersParentLink,
-        this.pageObjects.boBasePage.ordersLink,
-      );
-      const pageTitle = await this.pageObjects.ordersPage.getPageTitle();
-      await expect(pageTitle).to.contains(this.pageObjects.ordersPage.pageTitle);
-    });
+    describe('Check the invoice file Name', async () => {
+      it('should go to the orders page', async function () {
+        await this.pageObjects.boBasePage.goToSubMenu(
+          this.pageObjects.boBasePage.ordersParentLink,
+          this.pageObjects.boBasePage.ordersLink,
+        );
+        const pageTitle = await this.pageObjects.ordersPage.getPageTitle();
+        await expect(pageTitle).to.contains(this.pageObjects.ordersPage.pageTitle);
+      });
 
-    it('should go to the first order page', async function () {
-      await this.pageObjects.ordersPage.goToOrder(1);
-      const pageTitle = await this.pageObjects.viewOrderPage.getPageTitle();
-      await expect(pageTitle).to.contains(this.pageObjects.viewOrderPage.pageTitle);
-    });
+      it('should go to the first order page', async function () {
+        await this.pageObjects.ordersPage.goToOrder(1);
+        const pageTitle = await this.pageObjects.viewOrderPage.getPageTitle();
+        await expect(pageTitle).to.contains(this.pageObjects.viewOrderPage.pageTitle);
+      });
 
-    it('should check that the invoice file name does not contain the current year', async function () {
-      fileName = await this.pageObjects.viewOrderPage.getFileName();
-      expect(fileName).to.not.contains(currentYear);
+      it('should check that the invoice file name does not contain the current year', async function () {
+        fileName = await this.pageObjects.viewOrderPage.getFileName();
+        expect(fileName).to.not.contains(currentYear);
+      });
     });
   });
 });

--- a/tests/puppeteer/pages/BO/orders/invoices/index.js
+++ b/tests/puppeteer/pages/BO/orders/invoices/index.js
@@ -118,7 +118,7 @@ module.exports = class Invoice extends BOBasePage {
   }
 
   /**
-   * Enable disable invoices
+   * Enable add current year to invoice
    * @param enable
    * @return {Promise<void>}
    */

--- a/tests/puppeteer/pages/BO/orders/invoices/index.js
+++ b/tests/puppeteer/pages/BO/orders/invoices/index.js
@@ -132,6 +132,6 @@ module.exports = class Invoice extends BOBasePage {
    * @return {Promise<void>}
    */
   async chooseInvoiceOptionsYearPosition(id) {
-    await this.page.click(this.optionYearPositionRadioButton.replace('%ID', id === 1 ? 1 : 0));
+    await this.page.click(this.optionYearPositionRadioButton.replace('%ID', id));
   }
 };

--- a/tests/puppeteer/pages/BO/orders/invoices/index.js
+++ b/tests/puppeteer/pages/BO/orders/invoices/index.js
@@ -34,6 +34,7 @@ module.exports = class Invoice extends BOBasePage {
     this.footerTextInput = '#form_invoice_options_footer_text_1';
     this.saveInvoiceOptionsButton = `${this.invoiceOptionsForm} .btn.btn-primary`;
     this.invoiceAddCurrentYear = `${this.invoiceOptionsForm} label[for="form_invoice_options_add_current_year_%ID"]`;
+    this.optionYearPositionRadioButton = `${this.invoiceOptionsForm} #form_invoice_options_year_position_%ID`;
   }
 
   /*
@@ -123,5 +124,14 @@ module.exports = class Invoice extends BOBasePage {
    */
   async enableAddCurrentYearToInvoice(enable = true) {
     await this.page.click(this.invoiceAddCurrentYear.replace('%ID', enable ? 1 : 0));
+  }
+
+  /**
+   * Choose the position of the year
+   * @param id
+   * @return {Promise<void>}
+   */
+  async chooseInvoiceOptionsYearPosition(id) {
+    await this.page.click(this.optionYearPositionRadioButton.replace('%ID', id === 1 ? 1 : 0));
   }
 };

--- a/tests/puppeteer/pages/BO/orders/invoices/index.js
+++ b/tests/puppeteer/pages/BO/orders/invoices/index.js
@@ -33,6 +33,7 @@ module.exports = class Invoice extends BOBasePage {
     this.legalFreeTextInput = '#form_invoice_options_legal_free_text_1';
     this.footerTextInput = '#form_invoice_options_footer_text_1';
     this.saveInvoiceOptionsButton = `${this.invoiceOptionsForm} .btn.btn-primary`;
+    this.invoiceAddCurrentYear = `${this.invoiceOptionsForm} label[for="form_invoice_options_add_current_year_%ID"]`;
   }
 
   /*
@@ -113,5 +114,14 @@ module.exports = class Invoice extends BOBasePage {
     await this.setValue(this.invoiceNumberInput, data.invoiceNumber);
     await this.setValue(this.legalFreeTextInput, data.legalFreeText);
     await this.setValue(this.footerTextInput, data.footerText);
+  }
+
+  /**
+   * Enable disable invoices
+   * @param enable
+   * @return {Promise<void>}
+   */
+  async enableAddCurrentYearToInvoice(enable = true) {
+    await this.page.click(this.invoiceAddCurrentYear.replace('%ID', enable ? 1 : 0));
   }
 };


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Enable/Disable current year in the invoice file name
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/orders/invoices/03_invoiceOptions/05_enableDisableCurrentYear.js" URL_FO=yourShopURL npm run specific-test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16775)
<!-- Reviewable:end -->
