### PR TITLE
Fixed frontend 500 err. when deleting default cats

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -385,7 +385,7 @@ class LinkCore
             } elseif ((int) $category) {
                 $category = new Category((int) $category, $idLang);
             } else {
-                throw new PrestaShopException('Invalid category vars');
+		return null;
             }
         }
 
@@ -440,7 +440,17 @@ class LinkCore
         if (!$alias) {
             $category = $this->getCategoryObject($category, $idLang);
         }
-        $params['rewrite'] = (!$alias) ? $category->link_rewrite : $alias;
+
+	$params['rewrite'] = "";
+
+        if(!$alias){
+           if(is_object($category)) {
+              $params['rewrite'] = $category->link_rewrite;
+           }
+        } else{
+           $params['rewrite'] = $alias;
+        }
+
         if ($dispatcher->hasKeyword($rule, $idLang, 'meta_keywords', $idShop)) {
             $category = $this->getCategoryObject($category, $idLang);
             $params['meta_keywords'] = Tools::str2url($category->getFieldByLang('meta_keywords'));


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | After bulk deleting the default Prestashop's categories, an error 500 occured on the frontend. The backend was still working. I found out with the debug mode that it cames from the following file: classes/Link.php <br /> It seems that even after the deletion some data still remains and triggers the "throwError" when the category object is incorrectly formed. After that 1st fix, I had to fix a ternary condition for when the variable $category is not an object.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19751 
| How to test?  | Can replicate only on one website, not sure if the bug occures on other ones, but if I put back the previous code the 500 error remains.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16778)
<!-- Reviewable:end -->
