### PR TITLE
[*] FO : Add default attribute to canonical url for better seo

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -735,7 +735,12 @@ class ProductLazyArray extends AbstractLazyArray
         $linkRewrite = isset($product['link_rewrite']) ? $product['link_rewrite'] : null;
         $category = isset($product['category']) ? $product['category'] : null;
         $ean13 = isset($product['ean13']) ? $product['ean13'] : null;
-
+        $attribute = null;
+        if (!$canonical && $product['id_product_attribute'] > 0) {
+            $attribute = $product['id_product_attribute'];
+        } elseif ($product['cache_default_attribute'] > 0){
+            $attribute = $product['cache_default_attribute'];
+        }
         return $this->link->getProductLink(
             $product['id_product'],
             $linkRewrite,
@@ -743,7 +748,7 @@ class ProductLazyArray extends AbstractLazyArray
             $ean13,
             $language->id,
             null,
-            !$canonical && $product['id_product_attribute'] > 0 ? $product['id_product_attribute'] : $product['cache_default_attribute'] > 0 ? $product['cache_default_attribute'] : null,
+            $attribute,
             false,
             false,
             true

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -743,7 +743,7 @@ class ProductLazyArray extends AbstractLazyArray
             $ean13,
             $language->id,
             null,
-            !$canonical && $product['id_product_attribute'] > 0 ? $product['id_product_attribute'] : null,
+            !$canonical && $product['id_product_attribute'] > 0 ? $product['id_product_attribute'] : $product['cache_default_attribute'] > 0 ? $product['cache_default_attribute'] : null,
             false,
             false,
             true


### PR DESCRIPTION
It's recommended to avoid sending 301 redirect to canonical, otherwise Google will decide for you which url is the best as the canonical. It's better to send the default attribute as the canonical.



| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Send canonical with attribute
| Type?         | improvment
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Verify that canonical includes attribute

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16806)
<!-- Reviewable:end -->
