### PR TITLE
Fix date parsing in tests when TZ is changed to non-UTC during tests

### DIFF
--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -63,7 +63,14 @@ class ValidateCoreTest extends TestCase
      */
     public function testIsBirthDate($expected, $input)
     {
-        $this->assertSame($expected, Validate::isBirthDate($input));
+        // data from isBirthDateProvider provider are in UTC
+        $defaultTz = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+        try {
+            $this->assertSame($expected, Validate::isBirthDate($input));
+        } finally {
+            date_default_timezone_set($defaultTz);
+        }
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Tests are failing after midnight.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Fork repo, setup Travis and push some commit after CEST midnight.

For some reasons, when I var_dumped the datetime used in the `Validate::isBirthDate` in the related `ValidateCoreTest::testIsBirthDate` test, the TZ was `US/Eastern`. This fixes it, the test data are generated in UTC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16809)
<!-- Reviewable:end -->
