### PR TITLE
Add support for non-unity MySQL autoincrement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,9 @@ before_install:
   # PrestaShop configuration
   - cp tests-legacy/parameters.yml.travis app/config/parameters.yml
 
+  # Always test with non-unity MySQL autoincrement
+  - mysql -e 'SET @@GLOBAL.auto_increment_increment = 2, @@GLOBAL.auto_increment_offset = 2;'
+
 install:
   - composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --quiet;
   - if [ "$PRESTASHOP_TEST_TYPE" != "sanity" ]; then

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -868,20 +868,6 @@ abstract class DbCore
     }
 
     /**
-     * Checks if auto increment value and offset is 1.
-     *
-     * @param string $server
-     * @param string $user
-     * @param string $pwd
-     *
-     * @return bool
-     */
-    public static function checkAutoIncrement($server, $user, $pwd)
-    {
-        return call_user_func_array([Db::getClass(), 'checkAutoIncrement'], [$server, $user, $pwd]);
-    }
-
-    /**
      * Get used link instance.
      *
      * @return PDO|mysqli|resource Resource

--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -445,23 +445,4 @@ class DbMySQLiCore extends Db
 
         return $ret;
     }
-
-    /**
-     * Checks if auto increment value and offset is 1.
-     *
-     * @param string $server
-     * @param string $user
-     * @param string $pwd
-     *
-     * @return bool
-     */
-    public static function checkAutoIncrement($server, $user, $pwd)
-    {
-        $link = @new mysqli($server, $user, $pwd);
-        $ret = (bool) (($result = $link->query('SELECT @@auto_increment_increment as aii')) && ($row = $result->fetch_assoc()) && $row['aii'] == 1);
-        $ret &= (bool) (($result = $link->query('SELECT @@auto_increment_offset as aio')) && ($row = $result->fetch_assoc()) && $row['aio'] == 1);
-        $link->close();
-
-        return $ret;
-    }
 }

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -473,27 +473,4 @@ class DbPDOCore extends Db
 
         return ($result === false) ? false : true;
     }
-
-    /**
-     * Checks if auto increment value and offset is 1.
-     *
-     * @param string $server
-     * @param string $user
-     * @param string $pwd
-     *
-     * @return bool
-     */
-    public static function checkAutoIncrement($server, $user, $pwd)
-    {
-        try {
-            $link = DbPDO::getPDO($server, $user, $pwd, false, 5);
-        } catch (PDOException $e) {
-            return false;
-        }
-        $ret = (bool) (($result = $link->query('SELECT @@auto_increment_increment as aii')) && ($row = $result->fetch()) && $row['aii'] == 1);
-        $ret &= (bool) (($result = $link->query('SELECT @@auto_increment_offset as aio')) && ($row = $result->fetch()) && $row['aio'] == 1);
-        unset($link);
-
-        return $ret;
-    }
 }

--- a/src/PrestaShopBundle/Install/Database.php
+++ b/src/PrestaShopBundle/Install/Database.php
@@ -78,9 +78,6 @@ class Database extends AbstractInstall
                     if (!$clear && Db::hasTableWithSamePrefix($server, $login, $password, $database, $prefix)) {
                         $errors[] = $this->translator->trans('At least one table with same prefix was already found, please change your prefix or drop your database', [], 'Install');
                     }
-                    if (!Db::checkAutoIncrement($server, $login, $password)) {
-                        $errors[] = $this->translator->trans('The values of auto_increment increment and offset must be set to 1', [], 'Install');
-                    }
                     if (($create_error = Db::checkCreatePrivilege($server, $login, $password, $database, $prefix)) !== true) {
                         $errors[] = $this->translator->trans('Your database login does not have the privileges to create table on the database "%s". Ask your hosting provider:', ['%database%' => $database], 'Install');
                         if ($create_error != false) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -223,7 +223,8 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
 
         /** @var CategoryTreeChoiceProvider $categoryTreeChoiceProvider */
         $categoryTreeChoiceProvider = $this->container->get(
-            'prestashop.adapter.form.choice_provider.category_tree_choice_provider');
+            'prestashop.adapter.form.choice_provider.category_tree_choice_provider'
+        );
         $categoryTreeIterator = new CategoryTreeIterator($categoryTreeChoiceProvider);
         $parentCategoryId = $categoryTreeIterator->getCategoryId($testCaseData['Parent category']);
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -209,12 +209,12 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @When I update category :categoryReference position with following details:
+     * @When I update category :categoryReference with generated position and following details:
      *
      * @param string $categoryReference
      * @param TableNode $table
      */
-    public function updateCategoryPositionWithFollowingDetails(string $categoryReference, TableNode $table)
+    public function updateCategoryWithGeneratedPositionAndFollowingDetails(string $categoryReference, TableNode $table)
     {
         /** @var array $testCaseData */
         $testCaseData = $table->getRowsHash();
@@ -228,13 +228,12 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
         $parentCategoryId = $categoryTreeIterator->getCategoryId($testCaseData['Parent category']);
 
         $wayId = array_flip(self::CATEGORY_POSITION_WAYS_MAP)[$testCaseData['Way']];
-        $positionsArray = explode(',', $testCaseData['Positions']);
 
         $this->getCommandBus()->handle(new UpdateCategoryPositionCommand(
             $categoryId,
             $parentCategoryId,
             $wayId,
-            $positionsArray,
+            ['tr_' . $parentCategoryId . '_' . $categoryId], // generated position
             $testCaseData['Found first']
         ));
     }

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -53,10 +53,9 @@ Feature: Category Management
       | Displayed            | true             |
       | Parent category      | Home Accessories |
       | Friendly URL         | pc-parts2        |
-    And I update category "category2" position with following details:
+    And I update category "category2" with generated position and following details:
       | Parent category | Home Accessories    |
       | Way             | Up                  |
-      | Positions       | tr_8_15_1,tr_8_13_0 |
       | Found first     | false               |
 
   Scenario: Edit root category

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -74,4 +74,4 @@ Feature: Customer Management
       | defaultGroupId | Guest                     |
       | groupIds       | [Guest]                   |
     And I delete customer "CUST-5" with method "allow_registration_after"
-    Then if I query customer customer "CUST-5" I should get an error 'Customer with id "5" was not found'
+    Then if I query customer customer "CUST-5" I should get an error 'Customer with id "8" was not found'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add support for non-unity MySQL autoincrement
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/15019
| How to test?  | All tests neeed to pass.

Non-unity increment is well supported, only some tests and fixtures install from xml files expect fixed/unity autoincrement. This PR add global support for non-unity MySQL autoincrement and the code for creation of the initial data (which tests expect) was fixed.

Non-unity autoincrement support is important, as this is per DB server settings and can not be changed on per vhost basis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16813)
<!-- Reviewable:end -->
