### PR TITLE
Minor bug fix for Cache class

### DIFF
--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -459,7 +459,7 @@ abstract class CacheCore
                 foreach ($tables as $table) {
                     $this->initializeTableCache($table);
 
-                    if (isset($this->sql_tables_cached[$table][$key], $this->sql_tables_cached[$table][$key]['count'])) {
+                    if (isset($this->sql_tables_cached[$table][$key]['count'])) {
                         $this->sql_tables_cached[$table][$key]['count'] += $count;
                         $changedTables[$table] = true;
                     }

--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -459,7 +459,7 @@ abstract class CacheCore
                 foreach ($tables as $table) {
                     $this->initializeTableCache($table);
 
-                    if (isset($this->sql_tables_cached[$table][$key]) && isset($this->sql_tables_cached[$table][$key]['count'])) {
+                    if (isset($this->sql_tables_cached[$table][$key], $this->sql_tables_cached[$table][$key]['count'])) {
                         $this->sql_tables_cached[$table][$key]['count'] += $count;
                         $changedTables[$table] = true;
                     }

--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -459,7 +459,7 @@ abstract class CacheCore
                 foreach ($tables as $table) {
                     $this->initializeTableCache($table);
 
-                    if (isset($this->sql_tables_cached[$table][$key])) {
+                    if (isset($this->sql_tables_cached[$table][$key]) && isset($this->sql_tables_cached[$table][$key]['count'])) {
                         $this->sql_tables_cached[$table][$key]['count'] += $count;
                         $changedTables[$table] = true;
                     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | When APC cache and debug mode enabled you get a notice that says "Undefined index 'count' in array". This fix adds additional check if index 'count' is defined in array. Problem arises  because function 'updateQueryCacheStatistics' in line 358 is called before function 'updateTableToQueryMap' in line 360.
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16779
| How to test?  | Enable APC cache and debug mode, check if there any notices about undefined index 'count' in array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16819)
<!-- Reviewable:end -->
