### PR TITLE
Edit Installed modules translations (PS v1.7.6.2)

### DIFF
--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -153,12 +153,12 @@ class TranslationService
      */
     public function listDomainTranslation($locale, $domain, $theme = null, $search = null, $module = null)
     {
-        if (!empty($theme) && 'classic' !== $theme) {
+        if (!empty($theme) && 'classic' !== $theme && null === $module) {
             $translationProvider = $this->container->get('prestashop.translation.theme_provider');
             $translationProvider->setThemeName($theme);
         } else {
             $translationProvider = $this->container->get('prestashop.translation.search_provider');
-            if ($module !== null && $translationProvider instanceof UseModuleInterface) {
+            if (null !== $module && $translationProvider instanceof UseModuleInterface) {
                 $translationProvider->setModuleName($module);
             }
         }
@@ -178,7 +178,7 @@ class TranslationService
             'data' => array(),
         );
         $treeDomain = preg_split('/(?=[A-Z])/', $domain, -1, PREG_SPLIT_NO_EMPTY);
-        if (!empty($theme) && 'classic' !== $theme) {
+        if (!empty($theme) && 'classic' !== $theme && null === $module) {
             $defaultCatalog = current($translationProvider->getThemeCatalogue()->all());
         } else {
             $defaultCatalog = current($translationProvider->getDefaultCatalogue()->all());


### PR DESCRIPTION
In some cases when you edit installed modules translations you will edit with the wrong provider. And no translations will be found or some error will be shown. 
Adding in conditional some extra check for $module variable will fix it.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.2 (I had installed Prestashop 1.7.6.0 and upgraded it to 1.7.6.2)
| Description?  | Chrome latest, Apache 2.4, Mysql 5.7, Ubuntu 16.04, theme: not a classic
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Go to BO. Menu International / Translations and choose Type of translation -> Installed modules translations, Select your module -> Choose for example Contact Form, Select your language -> Choose lang, for example, French. My Prestashop 1.7.6.0 was installed in English. Now English is disabled and French enabled but user profile Language English.

It will get *theme_provider* for installed modules translations
```
if (!empty($theme) && 'classic' !== $theme) {
            $translationProvider = $this->container->get('prestashop.translation.theme_provider');
            $translationProvider->setThemeName($theme);
        } else {
            $translationProvider = $this->container->get('prestashop.translation.search_provider');
            if ($module !== null && $translationProvider instanceof UseModuleInterface) {
                $translationProvider->setModuleName($module);
            }
        }
```
Initial issue:
I couldn't save translations in BO for a module and the error was:
Could not crawl for translation files: The "/var/www/site-folder/var/cache/dev/themes/theme-name/translations" directory does not exist. I had found how to deal with this error, but not solved my problem for me and then I found current issue.

And I same errors for admin translation (var/www/site-folder/var/cache/dev/themes/theme-name/translations).
For solving this I tried to create a folder in **src/PrestaShopBundle/Translation/Provider/ThemeProvider.php**

```
public function getThemeCatalogue()
    {
        $path = $this->resourceDirectory . DIRECTORY_SEPARATOR . $this->themeName . DIRECTORY_SEPARATOR . 'translations';
        // this part will create folder
        $this->filesystem->mkdir($path);
        return $this->getCatalogueFromPaths($path, $this->locale, current($this->getFilters()));
    }
```

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16830)
<!-- Reviewable:end -->
