### PR TITLE
Switch zone for BA, LI, and UA

### DIFF
--- a/install-dev/data/xml/country.xml
+++ b/install-dev/data/xml/country.xml
@@ -141,7 +141,7 @@
     <country id="LS" id_zone="Africa" iso_code="LS" call_prefix="266" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="LR" id_zone="Africa" iso_code="LR" call_prefix="231" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="LY" id_zone="Africa" iso_code="LY" call_prefix="218" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
-    <country id="LI" id_zone="Europe" iso_code="LI" call_prefix="423" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNN" display_tax_label="1"/>
+    <country id="LI" id_zone="Europe_out_E_U" iso_code="LI" call_prefix="423" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNN" display_tax_label="1"/>
     <country id="LT" id_zone="Europe" iso_code="LT" call_prefix="370" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNNN" display_tax_label="1"/>
     <country id="MO" id_zone="Asia" iso_code="MO" call_prefix="853" active="1" contains_states="0" need_identification_number="0" need_zip_code="0" zip_code_format="" display_tax_label="1"/>
     <country id="MK" id_zone="Europe_out_E_U" iso_code="MK" call_prefix="389" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
@@ -227,7 +227,7 @@
     <country id="TC" id_zone="Central_America_Antilla" iso_code="TC" call_prefix="0" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="LLLL NLL" display_tax_label="1"/>
     <country id="TV" id_zone="Oceania" iso_code="TV" call_prefix="688" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="UG" id_zone="Africa" iso_code="UG" call_prefix="256" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
-    <country id="UA" id_zone="Europe" iso_code="UA" call_prefix="380" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNNN" display_tax_label="1"/>
+    <country id="UA" id_zone="Europe_out_E_U" iso_code="UA" call_prefix="380" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNNN" display_tax_label="1"/>
     <country id="AE" id_zone="Asia" iso_code="AE" call_prefix="971" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="UY" id_zone="South_America" iso_code="UY" call_prefix="598" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="UZ" id_zone="Asia" iso_code="UZ" call_prefix="998" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
@@ -244,7 +244,7 @@
     <country id="AL" id_zone="Europe_out_E_U" iso_code="AL" call_prefix="355" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNN" display_tax_label="1"/>
     <country id="AF" id_zone="Asia" iso_code="AF" call_prefix="93" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNN" display_tax_label="1"/>
     <country id="AQ" id_zone="Oceania" iso_code="AQ" call_prefix="0" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
-    <country id="BA" id_zone="Europe" iso_code="BA" call_prefix="387" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
+    <country id="BA" id_zone="Europe_out_E_U" iso_code="BA" call_prefix="387" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="BV" id_zone="Oceania" iso_code="BV" call_prefix="0" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="IO" id_zone="Oceania" iso_code="IO" call_prefix="0" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="LLLL NLL" display_tax_label="1"/>
     <country id="BG" id_zone="Europe" iso_code="BG" call_prefix="359" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNN" display_tax_label="1"/>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In International > Locations > Countries, Bosnia and Herzegovina, Liechtenstein, and Ukraine are currently part of Europe (UE) zone, yet it should be classified in Europe (non-EU) zone since those three countries are not part of the UE. By default, their zone should be Europe (non-EU).
| Type?         | improvement
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16833 
| How to test?  | After a fresh install, in International > Locations > Countries, Bosnia and Herzegovina, Liechtenstein, and Ukraine must be in Europe (non-UE) zone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16834)
<!-- Reviewable:end -->
