### PR TITLE
Show "No picture" image instead of broken one

### DIFF
--- a/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -26,7 +26,11 @@
   <!--  product line left content: image-->
   <div class="product-line-grid-left col-md-3 col-xs-4">
     <span class="product-image media-middle">
-      <img src="{$product.cover.bySize.cart_default.url}" alt="{$product.name|escape:'quotes'}">
+      {if $product.cover}
+        <img src="{$product.cover.bySize.cart_default.url}" alt="{$product.name|escape:'quotes'}">
+      {else}
+        <img src="{$urls.no_picture_image.bySize.home_default.url}" />
+      {/if}
     </span>
   </div>
 

--- a/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -29,7 +29,7 @@
       {if $product.cover}
         <img src="{$product.cover.bySize.cart_default.url}" alt="{$product.name|escape:'quotes'}">
       {else}
-        <img src="{$urls.no_picture_image.bySize.home_default.url}" />
+        <img src="{$urls.no_picture_image.bySize.cart_default.url}" />
       {/if}
     </span>
   </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If product doesn't have cover, a broken image is show.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Add a product without cover image into cart and look at cart details

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16868)
<!-- Reviewable:end -->
