### PR TITLE
Fixed filtering for date in Back Office / Logs

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/LogRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LogRepository.php
@@ -252,12 +252,18 @@ class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterfac
             }
 
             if ('date_add' == $filterName) {
-                if (!empty($filterValue['from']) &&
-                    !empty($filterValue['to'])
-                ) {
-                    $qb->andWhere('l.date_add BETWEEN :date_from AND :date_to');
-                    $qb->setParameter('date_from', $filterValue['from']);
-                    $qb->setParameter('date_to', $filterValue['to']);
+                $qb->andWhere('l.date_add >= :date_from AND l.date_add <= :date_to');
+                $qb->setParameter('date_from', sprintf('%s 0:0:0', $filterValue['from']));
+                $qb->setParameter('date_to', sprintf('%s 23:59:59', $filterValue['to']));
+
+                if (isset($filterValue['from'])) {
+                    $qb->andWhere('l.date_add >= :date_from');
+                    $qb->setParameter('date_from', sprintf('%s 0:0:0', $filterValue['from']));
+                }
+
+                if (isset($filterValue['to'])) {
+                    $qb->andWhere('l.date_add <= :date_to');
+                    $qb->setParameter('date_to', sprintf('%s 23:59:59', $filterValue['to']));
                 }
 
                 continue;

--- a/src/PrestaShopBundle/Entity/Repository/LogRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LogRepository.php
@@ -252,9 +252,13 @@ class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterfac
             }
 
             if ('date_add' == $filterName) {
-                $qb->andWhere('l.date_add >= :date_from AND l.date_add <= :date_to');
-                $qb->setParameter('date_from', sprintf('%s 0:0:0', $filterValue['from']));
-                $qb->setParameter('date_to', sprintf('%s 23:59:59', $filterValue['to']));
+                if (!empty($filterValue['from']) &&
+                    !empty($filterValue['to'])
+                ) {
+                    $qb->andWhere('l.date_add >= :date_from AND l.date_add <= :date_to');
+                    $qb->setParameter('date_from', sprintf('%s 0:0:0', $filterValue['from']));
+                    $qb->setParameter('date_to', sprintf('%s 23:59:59', $filterValue['to']));
+                }
 
                 continue;
             }

--- a/src/PrestaShopBundle/Entity/Repository/LogRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LogRepository.php
@@ -256,16 +256,6 @@ class LogRepository implements RepositoryInterface, DoctrineQueryBuilderInterfac
                 $qb->setParameter('date_from', sprintf('%s 0:0:0', $filterValue['from']));
                 $qb->setParameter('date_to', sprintf('%s 23:59:59', $filterValue['to']));
 
-                if (isset($filterValue['from'])) {
-                    $qb->andWhere('l.date_add >= :date_from');
-                    $qb->setParameter('date_from', sprintf('%s 0:0:0', $filterValue['from']));
-                }
-
-                if (isset($filterValue['to'])) {
-                    $qb->andWhere('l.date_add <= :date_to');
-                    $qb->setParameter('date_to', sprintf('%s 23:59:59', $filterValue['to']));
-                }
-
                 continue;
             }
 


### PR DESCRIPTION
Fix for filter by date.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed filtering for date in Back Office / Logs
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [Fixes issue #16540 ](https://github.com/PrestaShop/PrestaShop/issues/16540)
| How to test?  | See below

## How to test ?

Try to filter logs for 1 day : fill in the date filters with the same date (example: 2019-12-30 for both "from" and "to"). You should see the logs for date 2019-12-30 but instead got empty results. The PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16883)
<!-- Reviewable:end -->
