### PR TITLE
Edit BO translations

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -67,7 +67,7 @@ class TranslationController extends ApiController
 
             $locale = $request->attributes->get('locale');
             $domain = $request->attributes->get('domain');
-            $theme = $request->attributes->get('theme');
+            $theme = (mb_stripos('Admin', $domain) !== false) ? $request->attributes->get('theme', $this->getSelectedTheme()) : null;
             $module = $request->query->get('module');
             $search = $request->query->get('search');
 


### PR DESCRIPTION
This related to https://github.com/PrestaShop/PrestaShop/pull/16830.
I couldn't find translations in BO for a back-office and the error was:
Could not crawl for translation files: The "/var/www/site-folder/var/cache/dev/themes/theme-name/translations" directory does not exist.

Please find a more elegant way to fix it. 
**$theme** always sent as the current shop theme.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.2 (I had installed Prestashop 1.7.6.0 and upgraded it to 1.7.6.2)
| Description?  | Chrome latest, Apache 2.4, Mysql 5.7, Ubuntu 16.04, Theme: not classic
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Go to BO. Menu International / Translations and choose Type of translation -> Back office translations, Select your language -> Choose lang, for example, French.<br>My Prestashop 1.7.6.0 was installed in English. Now English is disabled and French enabled but user profile Language English.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16890)
<!-- Reviewable:end -->
