### PR TITLE
Handle profile name above 32 chars exception

### DIFF
--- a/src/Core/Domain/Profile/Command/AbstractProfileCommand.php
+++ b/src/Core/Domain/Profile/Command/AbstractProfileCommand.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Profile\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileException;
+use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
+
+abstract class AbstractProfileCommand
+{
+    /**
+     * @var string[]
+     */
+    protected $localizedNames;
+
+    /**
+     * @param string[] $localizedNames
+     *
+     * @throws ProfileConstraintException
+     */
+    public function __construct(array $localizedNames)
+    {
+        if (empty($localizedNames)) {
+            throw new ProfileException('Profile name cannot be empty');
+        }
+
+        foreach ($localizedNames as $localizedName) {
+            $this->assertNameIsStringAndRequiredLength($localizedName);
+        }
+        $this->localizedNames = $localizedNames;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedNames()
+    {
+        return $this->localizedNames;
+    }
+
+    /**
+     * @param string $name
+     */
+    protected function assertNameIsStringAndRequiredLength($name)
+    {
+        if (null !== $name && !is_string($name) || strlen($name) > ProfileSettings::NAME_MAX_LENGTH) {
+            throw new ProfileConstraintException(
+                sprintf(
+                    'Profile name should not exceed %d characters length but %s given',
+                    ProfileSettings::NAME_MAX_LENGTH,
+                    var_export($name, true)
+                ),
+                ProfileConstraintException::INVALID_NAME
+            );
+        }
+    }
+}

--- a/src/Core/Domain/Profile/Command/AddProfileCommand.php
+++ b/src/Core/Domain/Profile/Command/AddProfileCommand.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Domain\Profile\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
 
 /**
  * Adds new profile
@@ -64,11 +65,11 @@ class AddProfileCommand
      */
     private function assertNameIsStringAndRequiredLength($name)
     {
-        if (!is_string($name) || strlen($name) !== ProfileConstraintException::NAME_MAX_LENGTH) {
+        if (null !== $name && !is_string($name) || strlen($name) > ProfileSettings::NAME_MAX_LENGTH) {
             throw new ProfileConstraintException(
                 sprintf(
                     'Profile name should not exceed %d characters length but %s given',
-                    ProfileConstraintException::NAME_MAX_LENGTH,
+                    ProfileSettings::NAME_MAX_LENGTH,
                     var_export($name, true)
                 ),
                 ProfileConstraintException::INVALID_NAME

--- a/src/Core/Domain/Profile/Command/AddProfileCommand.php
+++ b/src/Core/Domain/Profile/Command/AddProfileCommand.php
@@ -26,54 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Profile\Command;
 
-use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
-
 /**
  * Adds new profile
  */
-class AddProfileCommand
+class AddProfileCommand extends AbstractProfileCommand
 {
-    /**
-     * @var string[] As langId => name
-     */
-    private $localizedNames;
-
-    /**
-     * @param string[] $localizedNames
-     *
-     * @throws ProfileConstraintException
-     */
-    public function __construct(array $localizedNames)
-    {
-        foreach ($localizedNames as $localizedName) {
-            $this->assertNameIsStringAndRequiredLength($localizedName);
-        }
-        $this->localizedNames = $localizedNames;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getLocalizedNames()
-    {
-        return $this->localizedNames;
-    }
-
-    /**
-     * @param string $name
-     */
-    private function assertNameIsStringAndRequiredLength($name)
-    {
-        if (null !== $name && !is_string($name) || strlen($name) > ProfileSettings::NAME_MAX_LENGTH) {
-            throw new ProfileConstraintException(
-                sprintf(
-                    'Profile name should not exceed %d characters length but %s given',
-                    ProfileSettings::NAME_MAX_LENGTH,
-                    var_export($name, true)
-                ),
-                ProfileConstraintException::INVALID_NAME
-            );
-        }
-    }
 }

--- a/src/Core/Domain/Profile/Command/AddProfileCommand.php
+++ b/src/Core/Domain/Profile/Command/AddProfileCommand.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Profile\Command;
 
+use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
+
 /**
  * Adds new profile
  */
@@ -38,9 +40,14 @@ class AddProfileCommand
 
     /**
      * @param string[] $localizedNames
+     *
+     * @throws ProfileConstraintException
      */
     public function __construct(array $localizedNames)
     {
+        foreach ($localizedNames as $localizedName) {
+            $this->assertNameIsStringAndRequiredLength($localizedName);
+        }
         $this->localizedNames = $localizedNames;
     }
 
@@ -50,5 +57,22 @@ class AddProfileCommand
     public function getLocalizedNames()
     {
         return $this->localizedNames;
+    }
+
+    /**
+     * @param string $name
+     */
+    private function assertNameIsStringAndRequiredLength($name)
+    {
+        if (!is_string($name) || strlen($name) !== ProfileConstraintException::NAME_MAX_LENGTH) {
+            throw new ProfileConstraintException(
+                sprintf(
+                    'Profile name should not exceed %d characters length but %s given',
+                    ProfileConstraintException::NAME_MAX_LENGTH,
+                    var_export($name, true)
+                ),
+                ProfileConstraintException::INVALID_NAME
+            );
+        }
     }
 }

--- a/src/Core/Domain/Profile/Command/EditProfileCommand.php
+++ b/src/Core/Domain/Profile/Command/EditProfileCommand.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Profile\Command;
 
+use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\ValueObject\ProfileId;
 
@@ -56,6 +57,10 @@ class EditProfileCommand
             throw new ProfileException('Profile name cannot be empty');
         }
 
+        foreach ($this->localizedNames as $localizedName) {
+            $this->assertNameIsStringAndRequiredLength($localizedName);
+        }
+
         $this->profileId = new ProfileId($profileId);
         $this->localizedNames = $localizedNames;
     }
@@ -74,5 +79,22 @@ class EditProfileCommand
     public function getLocalizedNames()
     {
         return $this->localizedNames;
+    }
+
+    /**
+     * @param string $name
+     */
+    private function assertNameIsStringAndRequiredLength($name)
+    {
+        if (!is_string($name) || strlen($name) !== ProfileConstraintException::NAME_MAX_LENGTH) {
+            throw new ProfileConstraintException(
+                sprintf(
+                    'Profile name should not exceed %d characters length but %s given',
+                    ProfileConstraintException::NAME_MAX_LENGTH,
+                    var_export($name, true)
+                ),
+                ProfileConstraintException::INVALID_NAME
+            );
+        }
     }
 }

--- a/src/Core/Domain/Profile/Command/EditProfileCommand.php
+++ b/src/Core/Domain/Profile/Command/EditProfileCommand.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Profile\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileException;
+use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
 use PrestaShop\PrestaShop\Core\Domain\Profile\ValueObject\ProfileId;
 
 /**
@@ -57,7 +58,7 @@ class EditProfileCommand
             throw new ProfileException('Profile name cannot be empty');
         }
 
-        foreach ($this->localizedNames as $localizedName) {
+        foreach ($localizedNames as $localizedName) {
             $this->assertNameIsStringAndRequiredLength($localizedName);
         }
 
@@ -86,11 +87,11 @@ class EditProfileCommand
      */
     private function assertNameIsStringAndRequiredLength($name)
     {
-        if (!is_string($name) || strlen($name) !== ProfileConstraintException::NAME_MAX_LENGTH) {
+        if (null !== $name && !is_string($name) || strlen($name) > ProfileSettings::NAME_MAX_LENGTH) {
             throw new ProfileConstraintException(
                 sprintf(
                     'Profile name should not exceed %d characters length but %s given',
-                    ProfileConstraintException::NAME_MAX_LENGTH,
+                    ProfileSettings::NAME_MAX_LENGTH,
                     var_export($name, true)
                 ),
                 ProfileConstraintException::INVALID_NAME

--- a/src/Core/Domain/Profile/Command/EditProfileCommand.php
+++ b/src/Core/Domain/Profile/Command/EditProfileCommand.php
@@ -26,25 +26,18 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Profile\Command;
 
-use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileException;
-use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
 use PrestaShop\PrestaShop\Core\Domain\Profile\ValueObject\ProfileId;
 
 /**
  * Edits existing Profile
  */
-class EditProfileCommand
+class EditProfileCommand extends AbstractProfileCommand
 {
     /**
      * @var ProfileId
      */
     private $profileId;
-
-    /**
-     * @var string[]
-     */
-    private $localizedNames;
 
     /**
      * @param int $profileId
@@ -54,16 +47,8 @@ class EditProfileCommand
      */
     public function __construct($profileId, array $localizedNames)
     {
-        if (empty($localizedNames)) {
-            throw new ProfileException('Profile name cannot be empty');
-        }
-
-        foreach ($localizedNames as $localizedName) {
-            $this->assertNameIsStringAndRequiredLength($localizedName);
-        }
-
+        parent::__construct($localizedNames);
         $this->profileId = new ProfileId($profileId);
-        $this->localizedNames = $localizedNames;
     }
 
     /**
@@ -72,30 +57,5 @@ class EditProfileCommand
     public function getProfileId()
     {
         return $this->profileId;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getLocalizedNames()
-    {
-        return $this->localizedNames;
-    }
-
-    /**
-     * @param string $name
-     */
-    private function assertNameIsStringAndRequiredLength($name)
-    {
-        if (null !== $name && !is_string($name) || strlen($name) > ProfileSettings::NAME_MAX_LENGTH) {
-            throw new ProfileConstraintException(
-                sprintf(
-                    'Profile name should not exceed %d characters length but %s given',
-                    ProfileSettings::NAME_MAX_LENGTH,
-                    var_export($name, true)
-                ),
-                ProfileConstraintException::INVALID_NAME
-            );
-        }
     }
 }

--- a/src/Core/Domain/Profile/Exception/ProfileConstraintException.php
+++ b/src/Core/Domain/Profile/Exception/ProfileConstraintException.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Profile\Exception;
+
+/**
+ * Is thrown when some constraint is violated in Profile subdomain
+ */
+class ProfileConstraintException extends ProfileException
+{
+    /**
+     * Profile name max length as defined in the ObjectModel
+     */
+    const NAME_MAX_LENGTH = 32;
+
+    /**
+     * @var string Code is used when invalid profile name is encountered
+     */
+    const INVALID_NAME = 1;
+}

--- a/src/Core/Domain/Profile/ProfileSettings.php
+++ b/src/Core/Domain/Profile/ProfileSettings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop SA and Contributors
+ * 2007-2020 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -24,15 +24,12 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Profile\Exception;
+namespace PrestaShop\PrestaShop\Core\Domain\Profile;
 
-/**
- * Is thrown when some constraint is violated in Profile subdomain
- */
-class ProfileConstraintException extends ProfileException
+final class ProfileSettings
 {
     /**
-     * @var string Code is used when invalid profile name is encountered
+     * Profile name max length as defined in the ObjectModel
      */
-    const INVALID_NAME = 1;
+    const NAME_MAX_LENGTH = 32;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\Command\BulkDeleteProfileCommand;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Command\DeleteProfileCommand;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\CannotDeleteSuperAdminProfileException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\FailedToDeleteProfileException;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Query\GetProfileForEditing;
@@ -264,6 +265,13 @@ class ProfileController extends FrameworkBundleAdminController
     protected function getErrorMessages()
     {
         return [
+            ProfileConstraintException::class => [
+                ProfileConstraintException::INVALID_NAME => $this->trans(
+                    'Your entry in field name exceeds max length %d chars (incl. HTML tags)',
+                    'Admin.Notifications.Error',
+                    [ProfileConstraintException::NAME_MAX_LENGTH]
+                ),
+            ],
             ProfileNotFoundException::class => $this->trans(
                 'The object cannot be loaded (or found)',
                 'Admin.Notifications.Error'

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\FailedToDeleteProfileExc
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Query\GetProfileForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Profile\QueryResult\EditableProfile;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProfileFilters;
@@ -267,9 +268,9 @@ class ProfileController extends FrameworkBundleAdminController
         return [
             ProfileConstraintException::class => [
                 ProfileConstraintException::INVALID_NAME => $this->trans(
-                    'Your entry in field name exceeds max length %d chars (incl. HTML tags)',
+                    'This field cannot be longer than %limit% characters (incl. HTML tags)',
                     'Admin.Notifications.Error',
-                    [ProfileConstraintException::NAME_MAX_LENGTH]
+                    ['%limit%' => ProfileSettings::NAME_MAX_LENGTH]
                 ),
             ],
             ProfileNotFoundException::class => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -28,16 +28,29 @@ namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraints\Length;
 
 /**
  * Builds form for Profile
  */
 class ProfileType extends AbstractType
 {
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -53,6 +66,14 @@ class ProfileType extends AbstractType
                     'constraints' => [
                         new TypedRegex([
                             'type' => 'generic_name',
+                        ]),
+                        new Length([
+                            'max' => ProfileConstraintException::NAME_MAX_LENGTH,
+                            'maxMessage' => $this->translator->trans(
+                                'This field cannot be longer than %limit% characters',
+                                ['%limit%' => ProfileConstraintException::NAME_MAX_LENGTH],
+                                'Admin.Notifications.Error'
+                            ),
                         ]),
                     ],
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -28,7 +28,7 @@ namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
-use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -68,10 +68,10 @@ class ProfileType extends AbstractType
                             'type' => 'generic_name',
                         ]),
                         new Length([
-                            'max' => ProfileConstraintException::NAME_MAX_LENGTH,
+                            'max' => ProfileSettings::NAME_MAX_LENGTH,
                             'maxMessage' => $this->translator->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => ProfileConstraintException::NAME_MAX_LENGTH],
+                                ['%limit%' => ProfileSettings::NAME_MAX_LENGTH],
                                 'Admin.Notifications.Error'
                             ),
                         ]),

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -867,3 +867,11 @@ services:
             - '@=service("prestashop.core.form.choice_provider.mail_themes").getChoices()'
         tags:
             - { name: form.type }
+
+    form.type.configure.advanced_parameters.profile:
+      class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile\ProfileType'
+      public: true
+      arguments:
+        - '@translator'
+      tags:
+        - { name: form.type }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | This handles exception when saving a profile name that is longer that 32 chars
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16725
| How to test?  | In _Advanced Parameters -> Team -> Profiles_ try adding a new profile with a name longer that 32 chars. Same thing when editing a profile name.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16906)
<!-- Reviewable:end -->
