### PR TITLE
Fix "Products in orders disappear when catalog product is deleted " 

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -365,6 +365,7 @@ class OrderCore extends ObjectModel
         $product_id_list = array();
         $products = $this->getProducts();
         foreach ($products as &$product) {
+            $product['id_product'] = $product['product_id'];
             $product['id_product_attribute'] = $product['product_attribute_id'];
             $product['cart_quantity'] = $product['product_quantity'];
             $product_id_list[] = $this->id_address_delivery . '_'


### PR DESCRIPTION
For deleted products, `$product['id_product']` is NULL. Using `$product['product_id']` resolves the issue.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | 
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16841
| How to test?  | Refresh the order details page after deleting a product that belongs to that order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16919)
<!-- Reviewable:end -->
