### PR TITLE
Add BA, BD, CM, MG and SN localization packs

### DIFF
--- a/localization/ba.xml
+++ b/localization/ba.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<localizationPack name="Bosnia and Herzegovina" version="1.0">
+	<currencies>
+		<currency name="Konvertibilna Marka" iso_code="BAM" iso_code_num="977" sign="KM" blank="0" format="1" decimals="1" />
+	</currencies>
+	<languages>
+		<language iso_code="bs" />
+	</languages>
+	<taxes>
+		<tax id="1" name="PDV BA 17%" rate="17" />
+		<tax id="2" name="PDV BA 0%" rate="0" />
+
+		<taxRulesGroup name="BA Standard Rate (17%)">
+			<taxRule iso_code_country="ba" id_tax="1" />
+		</taxRulesGroup>
+
+		<taxRulesGroup name="BA Zero Rate (0%)">
+			<taxRule iso_code_country="ba" id_tax="2" />
+		</taxRulesGroup>
+	</taxes>
+	<units>
+		<unit type="weight" value="kg" />
+		<unit type="volume" value="L" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
+	</units>
+</localizationPack>

--- a/localization/bd.xml
+++ b/localization/bd.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<localizationPack name="Bangladesh" version="1.0">
+	<currencies>
+		<currency name="Taka" iso_code="BDT" iso_code_num="050" sign="৳" blank="1" format="1" decimals="1" />
+	</currencies>
+	<languages>
+		<language iso_code="bn" />
+	</languages>
+	<taxes>
+		<tax id="1" name="VAT BD 15%" rate="15" />
+
+		<taxRulesGroup name="BD Standard Rate (15%)">
+			<taxRule iso_code_country="bd" id_tax="1" />
+		</taxRulesGroup>
+	</taxes>
+	<units>
+		<unit type="weight" value="kg" />
+		<unit type="volume" value="L" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
+	</units>
+</localizationPack>

--- a/localization/cm.xml
+++ b/localization/cm.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<localizationPack name="Cameroon" version="1.0">
+	<currencies>
+		<currency name="Franc CFA" iso_code="XAF" iso_code_num="950" sign="FCFA" blank="1" format="2" decimals="0" />
+	</currencies>
+	<languages>
+		<language iso_code="fr" />
+		<language iso_code="en" />
+	</languages>
+	<taxes>
+		<tax id="1" name="TVA CM 19.25%" rate="19.25" />
+		<tax id="2" name="TVA CM 0%" rate="0" />
+
+		<taxRulesGroup name="CM Standard Rate (19.25%)">
+			<taxRule iso_code_country="cm" id_tax="1" />
+		</taxRulesGroup>
+
+		<taxRulesGroup name="CM Zero Rate (0%)">
+			<taxRule iso_code_country="cm" id_tax="2" />
+		</taxRulesGroup>
+	</taxes>
+	<units>
+		<unit type="weight" value="kg" />
+		<unit type="volume" value="L" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
+	</units>
+</localizationPack>

--- a/localization/mg.xml
+++ b/localization/mg.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<localizationPack name="Madagascar" version="1.0">
+	<currencies>
+		<currency name="Ariary" iso_code="MGA" iso_code_num="969" sign="Ar" blank="1" conversion_rate="4078.42" format="2" decimals="0" />
+	</currencies>
+	<languages>
+		<language iso_code="fr" />
+		<language iso_code="mg" />
+	</languages>
+	<taxes>
+		<tax id="1" name="TVA MG 20%" rate="20" />
+
+		<taxRulesGroup name="MG Standard Rate (20%)">
+			<taxRule iso_code_country="mg" id_tax="1" />
+		</taxRulesGroup>
+	</taxes>
+	<units>
+		<unit type="weight" value="kg" />
+		<unit type="volume" value="L" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
+	</units>
+</localizationPack>

--- a/localization/sn.xml
+++ b/localization/sn.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<localizationPack name="Senegal" version="1.0">
+	<currencies>
+		<currency name="Franc CFA" iso_code="XOF" iso_code_num="952" sign="FCFA" blank="1" format="2" decimals="0" />
+	</currencies>
+	<languages>
+		<language iso_code="fr" />
+	</languages>
+	<taxes>
+		<tax id="1" name="TVA SN 18%" rate="18" />
+		<tax id="2" name="TVA SN 15%" rate="15" />
+		<tax id="3" name="TVA SN 10%" rate="10" />
+
+		<taxRulesGroup name="SN Standard Rate (18%)">
+			<taxRule iso_code_country="sn" id_tax="1" />
+		</taxRulesGroup>
+
+		<taxRulesGroup name="SN Tourism Rate (15%)">
+			<taxRule iso_code_country="sn" id_tax="2" />
+		</taxRulesGroup>
+
+		<taxRulesGroup name="SN Reduced Rate (10%)">
+			<taxRule iso_code_country="sn" id_tax="3" />
+		</taxRulesGroup>
+	</taxes>
+	<units>
+		<unit type="weight" value="kg" />
+		<unit type="volume" value="L" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
+	</units>
+</localizationPack>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Provide natively local information such as taxes, currencies, languages, units, etc. for Bosnia and Herzegovina, Bangladesh, Cameroon, Madagascar, and Senegal via the International > Localization section of the BO
| Type?         | new feature
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16435 
| How to test?  | Go in International > Localization and install BA, BD, CM, MG, and SN localization packs + Bosnian language has recently been added to PrestaShop, make sure it is fine with the Bosnia and Herzegovina localization pack

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16927)
<!-- Reviewable:end -->
