### PR TITLE
Fix "Products in order disappear when catalog product is deleted"

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -365,6 +365,7 @@ class OrderCore extends ObjectModel
         $product_id_list = array();
         $products = $this->getProducts();
         foreach ($products as &$product) {
+            $product['id_product'] = $product['product_id'];
             $product['id_product_attribute'] = $product['product_attribute_id'];
             $product['cart_quantity'] = $product['product_quantity'];
             $product_id_list[] = $this->id_address_delivery . '_'


### PR DESCRIPTION
For deleted products, `$product['id_product']` is NULL. using `$product['product_id']` resolves the issue.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | 
| Type?         | bug fix
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16841
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16930)
<!-- Reviewable:end -->
