### PR TITLE
Modified the string in success alert for attachements bulk deletion

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
@@ -254,7 +254,7 @@ class AttachmentController extends FrameworkBundleAdminController
             $this->getCommandBus()->handle(new BulkDeleteAttachmentsCommand($attachmentIds));
             $this->addFlash(
                 'success',
-                $this->trans('Successful deletion.', 'Admin.Notifications.Success')
+                $this->trans('The selection has been successfully deleted.', 'Admin.Notifications.Success')
             );
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));


### PR DESCRIPTION
Modified the string from "Successful deletion." to "The selection has been successfully deleted."

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | 
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16921 
| How to test?  | Go to the BO => Catalog => files (you should have more than one file). Try to delete files with Bulk action, and see the success alert string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16946)
<!-- Reviewable:end -->
