### PR TITLE
Functional Tests -  Add prefix verification for delivery slip file

### DIFF
--- a/tests/puppeteer/campaigns/data/faker/deliverySlipOptions.js
+++ b/tests/puppeteer/campaigns/data/faker/deliverySlipOptions.js
@@ -1,0 +1,7 @@
+const faker = require('faker');
+
+module.exports = class Invoice {
+  constructor(deliverySlipOptions = {}) {
+    this.prefix = deliverySlipOptions.prefix || `#${faker.lorem.word()}`;
+  }
+};

--- a/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.js
+++ b/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.js
@@ -1,0 +1,140 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const DeliverySlipsPage = require('@pages/BO/orders/deliverySlips/index');
+const OrdersPage = require('@pages/BO/orders/index');
+const ViewOrderPage = require('@pages/BO/orders/view');
+// Importing data
+const {Statuses} = require('@data/demo/orders');
+const DeliverySlipOptionsFaker = require('@data/faker/deliverySlipOptions');
+
+let browser;
+let page;
+let fileName;
+const deliverySlipData = new DeliverySlipOptionsFaker();
+const defaultPrefix = '#DE';
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    deliverySlipsPage: new DeliverySlipsPage(page),
+    ordersPage: new OrdersPage(page),
+    viewOrderPage: new ViewOrderPage(page),
+  };
+};
+
+/*
+Edit delivery slip prefix
+Change the Order status to Shipped
+Check the delivery slip file name
+Back to the default delivery slip prefix value
+Check the delivery slip file name
+ */
+describe('Edit delivery slip prefix and check the generated file name', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+
+  // Login into BO
+  loginCommon.loginBO();
+
+  describe(`Change the delivery slip prefix to '${deliverySlipData.prefix}'`, async () => {
+    it('should go to delivery slip page', async function () {
+      await this.pageObjects.boBasePage.goToSubMenu(
+        this.pageObjects.boBasePage.ordersParentLink,
+        this.pageObjects.boBasePage.deliverySlipslink,
+      );
+      await this.pageObjects.boBasePage.closeSfToolBar();
+      const pageTitle = await this.pageObjects.deliverySlipsPage.getPageTitle();
+      await expect(pageTitle).to.contains(this.pageObjects.deliverySlipsPage.pageTitle);
+    });
+
+    it(`should change the delivery slip prefix to ${deliverySlipData.prefix}`, async function () {
+      await this.pageObjects.deliverySlipsPage.changePrefix(deliverySlipData.prefix);
+      const textMessage = await this.pageObjects.deliverySlipsPage.saveDeliverySlipOptions();
+      await expect(textMessage).to.contains(this.pageObjects.deliverySlipsPage.successfulUpdateMessage);
+    });
+  });
+
+  describe(`Change the order status to '${Statuses.shipped.status}' and check the file Name`, async () => {
+    it('should go to the orders page', async function () {
+      await this.pageObjects.boBasePage.goToSubMenu(
+        this.pageObjects.boBasePage.ordersParentLink,
+        this.pageObjects.boBasePage.ordersLink,
+      );
+      const pageTitle = await this.pageObjects.ordersPage.getPageTitle();
+      await expect(pageTitle).to.contains(this.pageObjects.ordersPage.pageTitle);
+    });
+
+    it('should go to the first order page', async function () {
+      await this.pageObjects.ordersPage.goToOrder(1);
+      const pageTitle = await this.pageObjects.viewOrderPage.getPageTitle();
+      await expect(pageTitle).to.contains(this.pageObjects.viewOrderPage.pageTitle);
+    });
+
+    it(`should change the order status to '${Statuses.shipped.status}' and check it`, async function () {
+      const result = await this.pageObjects.viewOrderPage.modifyOrderStatus(Statuses.shipped.status);
+      await expect(result).to.be.true;
+    });
+
+    it(`should check that the delivery slip file name contain '${deliverySlipData.prefix}'`, async function () {
+      fileName = await this.pageObjects.viewOrderPage.getFileName(3);
+      expect(fileName).to.contains(deliverySlipData.prefix.replace('#', '').trim());
+    });
+  });
+
+  describe(`Back to the default delivery slip prefix value '${defaultPrefix}'`, async () => {
+    it('should go to delivery slips page', async function () {
+      await this.pageObjects.boBasePage.goToSubMenu(
+        this.pageObjects.boBasePage.ordersParentLink,
+        this.pageObjects.boBasePage.deliverySlipslink,
+      );
+      await this.pageObjects.boBasePage.closeSfToolBar();
+      const pageTitle = await this.pageObjects.deliverySlipsPage.getPageTitle();
+      await expect(pageTitle).to.contains(this.pageObjects.deliverySlipsPage.pageTitle);
+    });
+
+    it(`should change the delivery slip prefix to '${defaultPrefix}'`, async function () {
+      await this.pageObjects.deliverySlipsPage.changePrefix(defaultPrefix);
+      const textMessage = await this.pageObjects.deliverySlipsPage.saveDeliverySlipOptions();
+      await expect(textMessage).to.contains(this.pageObjects.deliverySlipsPage.successfulUpdateMessage);
+    });
+  });
+
+  describe('Check the default prefix in the delivery slip file Name', async () => {
+    it('should go to the orders page', async function () {
+      await this.pageObjects.boBasePage.goToSubMenu(
+        this.pageObjects.boBasePage.ordersParentLink,
+        this.pageObjects.boBasePage.ordersLink,
+      );
+      const pageTitle = await this.pageObjects.ordersPage.getPageTitle();
+      await expect(pageTitle).to.contains(this.pageObjects.ordersPage.pageTitle);
+    });
+
+    it('should go to the first order page', async function () {
+      await this.pageObjects.ordersPage.goToOrder(1);
+      const pageTitle = await this.pageObjects.viewOrderPage.getPageTitle();
+      await expect(pageTitle).to.contains(this.pageObjects.viewOrderPage.pageTitle);
+    });
+
+    it(`should check that the delivery slip file name contain the default prefix ${defaultPrefix}`, async function () {
+      fileName = await this.pageObjects.viewOrderPage.getFileName(3);
+      expect(fileName).to.contains(defaultPrefix.replace('#', '').trim());
+    });
+  });
+});

--- a/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.js
+++ b/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.js
@@ -45,6 +45,7 @@ describe('Edit delivery slip prefix and check the generated file name', async ()
     page = await helper.newTab(browser);
     this.pageObjects = await init();
   });
+
   after(async () => {
     await helper.closeBrowser(browser);
   });
@@ -58,6 +59,7 @@ describe('Edit delivery slip prefix and check the generated file name', async ()
         this.pageObjects.boBasePage.ordersParentLink,
         this.pageObjects.boBasePage.deliverySlipslink,
       );
+
       await this.pageObjects.boBasePage.closeSfToolBar();
       const pageTitle = await this.pageObjects.deliverySlipsPage.getPageTitle();
       await expect(pageTitle).to.contains(this.pageObjects.deliverySlipsPage.pageTitle);
@@ -76,6 +78,7 @@ describe('Edit delivery slip prefix and check the generated file name', async ()
         this.pageObjects.boBasePage.ordersParentLink,
         this.pageObjects.boBasePage.ordersLink,
       );
+
       const pageTitle = await this.pageObjects.ordersPage.getPageTitle();
       await expect(pageTitle).to.contains(this.pageObjects.ordersPage.pageTitle);
     });
@@ -103,6 +106,7 @@ describe('Edit delivery slip prefix and check the generated file name', async ()
         this.pageObjects.boBasePage.ordersParentLink,
         this.pageObjects.boBasePage.deliverySlipslink,
       );
+
       await this.pageObjects.boBasePage.closeSfToolBar();
       const pageTitle = await this.pageObjects.deliverySlipsPage.getPageTitle();
       await expect(pageTitle).to.contains(this.pageObjects.deliverySlipsPage.pageTitle);

--- a/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.js
+++ b/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.js
@@ -8,7 +8,7 @@ const BOBasePage = require('@pages/BO/BObasePage');
 const LoginPage = require('@pages/BO/login');
 const DashboardPage = require('@pages/BO/dashboard');
 const DeliverySlipsPage = require('@pages/BO/orders/deliverySlips/index');
-const OrdersPage = require('@pages/BO/orders/index');
+const OrdersPage = require('@pages/BO/orders');
 const ViewOrderPage = require('@pages/BO/orders/view');
 // Importing data
 const {Statuses} = require('@data/demo/orders');
@@ -37,7 +37,6 @@ Edit delivery slip prefix
 Change the Order status to Shipped
 Check the delivery slip file name
 Back to the default delivery slip prefix value
-Check the delivery slip file name
  */
 describe('Edit delivery slip prefix and check the generated file name', async () => {
   // before and after functions
@@ -113,28 +112,6 @@ describe('Edit delivery slip prefix and check the generated file name', async ()
       await this.pageObjects.deliverySlipsPage.changePrefix(defaultPrefix);
       const textMessage = await this.pageObjects.deliverySlipsPage.saveDeliverySlipOptions();
       await expect(textMessage).to.contains(this.pageObjects.deliverySlipsPage.successfulUpdateMessage);
-    });
-  });
-
-  describe('Check the default prefix in the delivery slip file Name', async () => {
-    it('should go to the orders page', async function () {
-      await this.pageObjects.boBasePage.goToSubMenu(
-        this.pageObjects.boBasePage.ordersParentLink,
-        this.pageObjects.boBasePage.ordersLink,
-      );
-      const pageTitle = await this.pageObjects.ordersPage.getPageTitle();
-      await expect(pageTitle).to.contains(this.pageObjects.ordersPage.pageTitle);
-    });
-
-    it('should go to the first order page', async function () {
-      await this.pageObjects.ordersPage.goToOrder(1);
-      const pageTitle = await this.pageObjects.viewOrderPage.getPageTitle();
-      await expect(pageTitle).to.contains(this.pageObjects.viewOrderPage.pageTitle);
-    });
-
-    it(`should check that the delivery slip file name contain the default prefix ${defaultPrefix}`, async function () {
-      fileName = await this.pageObjects.viewOrderPage.getFileName(3);
-      expect(fileName).to.contains(defaultPrefix.replace('#', '').trim());
     });
   });
 });

--- a/tests/puppeteer/pages/BO/orders/deliverySlips/index.js
+++ b/tests/puppeteer/pages/BO/orders/deliverySlips/index.js
@@ -7,6 +7,7 @@ module.exports = class DeliverySlips extends BOBasePage {
 
     this.pageTitle = 'Delivery Slips';
     this.errorMessageWhenGenerateFileByDate = 'No delivery slip was found for this period.';
+    this.successfulUpdateMessage = 'Update successful';
 
     // Delivery slips page
     // By date form
@@ -14,6 +15,10 @@ module.exports = class DeliverySlips extends BOBasePage {
     this.dateFromInput = '#slip_pdf_form_pdf_date_from';
     this.dateToInput = '#slip_pdf_form_pdf_date_to';
     this.generatePdfByDateButton = `${this.generateByDateForm} .btn.btn-primary`;
+    // Delivery slip options form
+    this.deliverySlipForm = '#delivery_options_fieldset';
+    this.deliveryPrefixInput = '#form_options_prefix_1';
+    this.saveDeliverySlipOptionsButton = `${this.deliverySlipForm} .btn.btn-primary`;
   }
 
   /*
@@ -34,5 +39,21 @@ module.exports = class DeliverySlips extends BOBasePage {
       await this.setValue(this.dateToInput, dateTo);
     }
     await this.page.click(this.generatePdfByDateButton);
+  }
+
+  /** Edit delivery slip Prefix
+   * @param prefix
+   * @return {Promise<void>}
+   */
+  async changePrefix(prefix) {
+    await this.setValue(this.deliveryPrefixInput, prefix);
+  }
+
+  /** Save delivery slip options
+   * @returns {Promise<textContent>}
+   */
+  async saveDeliverySlipOptions() {
+    await this.clickAndWaitForNavigation(this.saveDeliverySlipOptionsButton);
+    return this.getTextContent(this.alertSuccessBlockParagraph);
   }
 };


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add prefix verification for delivery slip file
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/orders/deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.js" URL_FO=yourShopURL npm run specific-test
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16960)
<!-- Reviewable:end -->
