### PR TITLE
Fix #16997 - assertion of first/classic theme from unsorted list

### DIFF
--- a/src/Core/MailTemplate/FolderThemeCatalog.php
+++ b/src/Core/MailTemplate/FolderThemeCatalog.php
@@ -77,6 +77,7 @@ final class FolderThemeCatalog implements ThemeCatalogInterface
         $this->checkThemesFolder();
 
         $finder = new Finder();
+        $finder->sortByName();
         $finder->directories()->in($this->mailThemesFolder)->depth(0);
         $mailThemes = new ThemeCollection();
         /** @var SplFileInfo $mailThemeFolder */


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes #16997 - Unit tests from FolderThemeCatalogTest class are failing
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16997
| How to test?  | All tests need to pass.

Issue introduced at 1.7.6.x as 1.7.5.x does not contain modern/multiple mail themes. Please merge into 1.7.6.x and develop asap. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16998)
<!-- Reviewable:end -->
