### PR TITLE
Adding default "Select" when sort not up in FO is selected on category page

### DIFF
--- a/themes/classic/templates/catalog/_partials/sort-orders.tpl
+++ b/themes/classic/templates/catalog/_partials/sort-orders.tpl
@@ -22,6 +22,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
+
 <span class="col-sm-3 col-md-3 hidden-sm-down sort-by">{l s='Sort by:' d='Shop.Theme.Global'}</span>
 <div class="{if !empty($listing.rendered_facets)}col-sm-9 col-xs-8{else}col-sm-12 col-xs-12{/if} col-md-9 products-sort-order dropdown">
   <button
@@ -30,7 +31,7 @@
     data-toggle="dropdown"
     aria-haspopup="true"
     aria-expanded="false">
-    {if isset($listing.sort_selected)}{$listing.sort_selected}{else}{l s='Select' d='Shop.Theme.Actions'}{/if}
+    {if $listing.sort_selected}{$listing.sort_selected}{else}{l s='Select' d='Shop.Theme.Actions'}{/if}
     <i class="material-icons float-xs-right">&#xE5C5;</i>
   </button>
   <div class="dropdown-menu">


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Empty select box in category page when a sort type is not up in FO
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14210 
| How to test?  | Go to backoffice> preferences > products, select sort order which is not avaiable on frontoffice and then verify that in category page there is "Select" or anything else instead of an empty box

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17005)
<!-- Reviewable:end -->
