### PR TITLE
Display symbols in form in case of error, remove DefaultLanguage constraint

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -138,9 +138,7 @@ class CurrencyType extends TranslatorAwareType
             ])
             ->add('symbols', TranslatableType::class, [
                 'type' => TextType::class,
-                'constraints' => [
-                    new DefaultLanguage(),
-                ],
+                'required' => false,
                 'options' => [
                     'constraints' => [
                         new Length([

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
@@ -73,9 +73,10 @@
           'label': 'Currency name'|trans({}, 'Admin.International.Feature'),
         }) }}
 
+        {% set symbolsClass = currencyForm.symbols.vars.errors|length ? '' : 'd-none' %}
         {{ ps.form_group_row(currencyForm.symbols, {}, {
           'label': 'Symbol'|trans({}, 'Admin.International.Feature'),
-          'class': 'd-none'
+          'class': symbolsClass
         }) }}
 
         {{ ps.form_group_row(currencyForm.iso_code, {}, {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Display symbols in form in case of error, remove DefaultLanguage constraint since it is automatically filled when the data is absent
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17040
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17043)
<!-- Reviewable:end -->
