### PR TITLE
Functional tests - Enable disable image in delivery slip file

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/03_enableDisableProductImage.js
+++ b/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/03_enableDisableProductImage.js
@@ -1,0 +1,170 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const DeliverySlipsPage = require('@pages/BO/orders/deliverySlips/index');
+const OrdersPage = require('@pages/BO/orders/index');
+const ViewOrderPage = require('@pages/BO/orders/view');
+const ProductPage = require('@pages/FO/product');
+const FOBasePage = require('@pages/FO/FObasePage');
+const HomePage = require('@pages/FO/home');
+const CartPage = require('@pages/FO/cart');
+const CheckoutPage = require('@pages/FO/checkout');
+const OrderConfirmationPage = require('@pages/FO/orderConfirmation');
+const files = require('@utils/files');
+// Importing data
+const {PaymentMethods} = require('@data/demo/orders');
+const {DefaultAccount} = require('@data/demo/customer');
+const {Statuses} = require('@data/demo/orders');
+
+let browser;
+let page;
+let fileName;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    deliverySlipsPage: new DeliverySlipsPage(page),
+    ordersPage: new OrdersPage(page),
+    viewOrderPage: new ViewOrderPage(page),
+    productPage: new ProductPage(page),
+    foBasePage: new FOBasePage(page),
+    homePage: new HomePage(page),
+    cartPage: new CartPage(page),
+    checkoutPage: new CheckoutPage(page),
+    orderConfirmationPage: new OrderConfirmationPage(page),
+  };
+};
+
+/*
+Enable product image in delivery slip
+Create order
+Create delivery slip
+Check that there is 2 images in the delivery slip (Logo and product image)
+Disable product image in invoice
+Create order
+Create delivery slip
+Check that there is 1 image in the delivery slip (Logo)
+ */
+describe('Test enable/disable product image in delivery slips', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    await helper.setDownloadBehavior(page);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+
+  // Login into BO
+  loginCommon.loginBO();
+
+  const tests = [
+    {args: {action: 'Enable', enable: true, imageNumber: 2}},
+    {args: {action: 'Disable', enable: false, imageNumber: 1}},
+  ];
+
+  tests.forEach((test) => {
+    describe(`${test.args.action} product image in delivery slip then check the file created`, async () => {
+      describe(`${test.args.action} product image`, async () => {
+        it('should go to delivery slips page', async function () {
+          await this.pageObjects.boBasePage.goToSubMenu(
+            this.pageObjects.boBasePage.ordersParentLink,
+            this.pageObjects.boBasePage.deliverySlipsLink,
+          );
+          await this.pageObjects.boBasePage.closeSfToolBar();
+          const pageTitle = await this.pageObjects.deliverySlipsPage.getPageTitle();
+          await expect(pageTitle).to.contains(this.pageObjects.deliverySlipsPage.pageTitle);
+        });
+
+        it(`should ${test.args.action} product image`, async function () {
+          await this.pageObjects.deliverySlipsPage.enableProductImage(test.args.enable);
+          const textMessage = await this.pageObjects.deliverySlipsPage.saveDeliverySlipOptions();
+          await expect(textMessage).to.contains(this.pageObjects.deliverySlipsPage.successfulUpdateMessage);
+        });
+      });
+
+      describe('Create new order in FO', async () => {
+        it('should go to FO and create an order', async function () {
+          // Click on view my shop
+          page = await this.pageObjects.boBasePage.viewMyShop();
+          this.pageObjects = await init();
+          await this.pageObjects.foBasePage.changeLanguage('en');
+          // Go to the first product page
+          await this.pageObjects.homePage.goToProductPage(1);
+          // Add the created product to the cart
+          await this.pageObjects.productPage.addProductToTheCart();
+          // Proceed to checkout the shopping cart
+          await this.pageObjects.cartPage.clickOnProceedToCheckout();
+          // Checkout the order
+          // Personal information step - Login
+          await this.pageObjects.checkoutPage.clickOnSignIn();
+          await this.pageObjects.checkoutPage.customerLogin(DefaultAccount);
+          // Address step - Go to delivery step
+          const isStepAddressComplete = await this.pageObjects.checkoutPage.goToDeliveryStep();
+          await expect(isStepAddressComplete, 'Step Address is not complete').to.be.true;
+          // Delivery step - Go to payment step
+          const isStepDeliveryComplete = await this.pageObjects.checkoutPage.goToPaymentStep();
+          await expect(isStepDeliveryComplete, 'Step Address is not complete').to.be.true;
+          // Payment step - Choose payment step
+          await this.pageObjects.checkoutPage.choosePaymentAndOrder(PaymentMethods.wirePayment.moduleName);
+          const cardTitle = await this.pageObjects.orderConfirmationPage
+            .getTextContent(this.pageObjects.orderConfirmationPage.orderConfirmationCardTitleH3);
+          // Check the confirmation message
+          await expect(cardTitle).to.contains(this.pageObjects.orderConfirmationPage.orderConfirmationCardTitle);
+          // Logout from FO
+          await this.pageObjects.foBasePage.logout();
+          page = await this.pageObjects.orderConfirmationPage.closePage(browser, 1);
+          this.pageObjects = await init();
+        });
+      });
+
+      describe('Generate the delivery slip and check product image', async () => {
+        it('should go to the orders page', async function () {
+          await this.pageObjects.boBasePage.goToSubMenu(
+            this.pageObjects.boBasePage.ordersParentLink,
+            this.pageObjects.boBasePage.ordersLink,
+          );
+          const pageTitle = await this.pageObjects.ordersPage.getPageTitle();
+          await expect(pageTitle).to.contains(this.pageObjects.ordersPage.pageTitle);
+        });
+
+        it('should go to the created order page', async function () {
+          await this.pageObjects.ordersPage.goToOrder(1);
+          const pageTitle = await this.pageObjects.viewOrderPage.getPageTitle();
+          await expect(pageTitle).to.contains(this.pageObjects.viewOrderPage.pageTitle);
+        });
+
+        it(`should change the order status to '${Statuses.shipped.status}' and check it`, async function () {
+          const result = await this.pageObjects.viewOrderPage.modifyOrderStatus(Statuses.shipped.status);
+          await expect(result).to.be.true;
+        });
+
+        it('should download the delivery slip', async function () {
+          fileName = await this.pageObjects.viewOrderPage.getFileName(3);
+          await this.pageObjects.viewOrderPage.downloadInvoice(3);
+          const exist = await files.checkFileExistence(`${fileName}.pdf`);
+          await expect(exist).to.be.true;
+        });
+
+        it('should check the product images in the PDF File', async () => {
+          const imageNumber = await files.getImageNumberInPDF(
+            `${fileName}.pdf`,
+          );
+          await expect(imageNumber).to.be.equal(test.args.imageNumber);
+          await files.deleteFile(`${global.BO.DOWNLOAD_PATH}/${fileName}.pdf`);
+        });
+      });
+    });
+  });
+});

--- a/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/03_enableDisableProductImage.js
+++ b/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/03_enableDisableProductImage.js
@@ -49,7 +49,7 @@ Enable product image in delivery slip
 Create order
 Create delivery slip
 Check that there is 2 images in the delivery slip (Logo and product image)
-Disable product image in invoice
+Disable product image in delivery slip
 Create order
 Create delivery slip
 Check that there is 1 image in the delivery slip (Logo)
@@ -62,6 +62,7 @@ describe('Test enable/disable product image in delivery slips', async () => {
     await helper.setDownloadBehavior(page);
     this.pageObjects = await init();
   });
+
   after(async () => {
     await helper.closeBrowser(browser);
   });
@@ -80,7 +81,7 @@ describe('Test enable/disable product image in delivery slips', async () => {
         it('should go to delivery slips page', async function () {
           await this.pageObjects.boBasePage.goToSubMenu(
             this.pageObjects.boBasePage.ordersParentLink,
-            this.pageObjects.boBasePage.deliverySlipsLink,
+            this.pageObjects.boBasePage.deliverySlipslink,
           );
           await this.pageObjects.boBasePage.closeSfToolBar();
           const pageTitle = await this.pageObjects.deliverySlipsPage.getPageTitle();
@@ -152,7 +153,7 @@ describe('Test enable/disable product image in delivery slips', async () => {
 
         it('should download the delivery slip', async function () {
           fileName = await this.pageObjects.viewOrderPage.getFileName(3);
-          await this.pageObjects.viewOrderPage.downloadInvoice(3);
+          await this.pageObjects.viewOrderPage.downloadDeliverySlip();
           const exist = await files.checkFileExistence(`${fileName}.pdf`);
           await expect(exist).to.be.true;
         });

--- a/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/03_enableDisableProductImage.js
+++ b/tests/puppeteer/campaigns/functional/BO/orders/deliverySlips/02_deliverySlipOptions/03_enableDisableProductImage.js
@@ -89,7 +89,7 @@ describe('Test enable/disable product image in delivery slips', async () => {
         });
 
         it(`should ${test.args.action} product image`, async function () {
-          await this.pageObjects.deliverySlipsPage.enableProductImage(test.args.enable);
+          await this.pageObjects.deliverySlipsPage.setEnableProductImage(test.args.enable);
           const textMessage = await this.pageObjects.deliverySlipsPage.saveDeliverySlipOptions();
           await expect(textMessage).to.contains(this.pageObjects.deliverySlipsPage.successfulUpdateMessage);
         });

--- a/tests/puppeteer/pages/BO/orders/deliverySlips/index.js
+++ b/tests/puppeteer/pages/BO/orders/deliverySlips/index.js
@@ -69,7 +69,7 @@ module.exports = class DeliverySlips extends BOBasePage {
   }
 
   /** Save delivery slip options
-   * @return {Promise<textContent>}
+   * @return {Promise<string>}
    */
   async saveDeliverySlipOptions() {
     await this.clickAndWaitForNavigation(this.saveDeliverySlipOptionsButton);

--- a/tests/puppeteer/pages/BO/orders/deliverySlips/index.js
+++ b/tests/puppeteer/pages/BO/orders/deliverySlips/index.js
@@ -19,6 +19,7 @@ module.exports = class DeliverySlips extends BOBasePage {
     this.deliverySlipForm = '#delivery_options_fieldset';
     this.deliveryPrefixInput = '#form_options_prefix_1';
     this.deliveryNumberInput = '#form_options_number';
+    this.deliveryEnableProductImage = `${this.deliverySlipForm} label[for='form_options_enable_product_image_%ID']`;
     this.saveDeliverySlipOptionsButton = `${this.deliverySlipForm} .btn.btn-primary`;
   }
 
@@ -60,6 +61,25 @@ module.exports = class DeliverySlips extends BOBasePage {
 
   /** Save delivery slip options
    * @returns {Promise<textContent>}
+  /** Edit delivery slip Prefix
+   * @param number
+   * @return {Promise<void>}
+   */
+  async changeNumber(number) {
+    await this.setValue(this.deliveryNumberInput, number);
+  }
+
+  /**
+   * Enable disable product image
+   * @param enable
+   * @return {Promise<void>}
+   */
+  async enableProductImage(enable = true) {
+    await this.page.click(this.deliveryEnableProductImage.replace('%ID', enable ? 1 : 0));
+  }
+
+  /** Save delivery slip options
+   * @return {Promise<void>}
    */
   async saveDeliverySlipOptions() {
     await this.clickAndWaitForNavigation(this.saveDeliverySlipOptionsButton);

--- a/tests/puppeteer/pages/BO/orders/deliverySlips/index.js
+++ b/tests/puppeteer/pages/BO/orders/deliverySlips/index.js
@@ -64,7 +64,7 @@ module.exports = class DeliverySlips extends BOBasePage {
    * @param enable
    * @return {Promise<void>}
    */
-  async enableProductImage(enable = true) {
+  async setEnableProductImage(enable = true) {
     await this.page.click(this.deliveryEnableProductImage.replace('%ID', enable ? 1 : 0));
   }
 

--- a/tests/puppeteer/pages/BO/orders/deliverySlips/index.js
+++ b/tests/puppeteer/pages/BO/orders/deliverySlips/index.js
@@ -59,16 +59,6 @@ module.exports = class DeliverySlips extends BOBasePage {
     await this.setValue(this.deliveryNumberInput, number);
   }
 
-  /** Save delivery slip options
-   * @returns {Promise<textContent>}
-  /** Edit delivery slip Prefix
-   * @param number
-   * @return {Promise<void>}
-   */
-  async changeNumber(number) {
-    await this.setValue(this.deliveryNumberInput, number);
-  }
-
   /**
    * Enable disable product image
    * @param enable
@@ -79,7 +69,7 @@ module.exports = class DeliverySlips extends BOBasePage {
   }
 
   /** Save delivery slip options
-   * @return {Promise<void>}
+   * @return {Promise<textContent>}
    */
   async saveDeliverySlipOptions() {
     await this.clickAndWaitForNavigation(this.saveDeliverySlipOptionsButton);

--- a/tests/puppeteer/pages/BO/orders/view.js
+++ b/tests/puppeteer/pages/BO/orders/view.js
@@ -122,4 +122,16 @@ module.exports = class Order extends BOBasePage {
     await this.page.click(this.partialRefundSubmitButton);
     return this.getTextContent(this.alertSuccessBloc);
   }
+
+  /**
+   * Download delivery slip
+   * @returns {Promise<void>}
+   */
+  async downloadDeliverySlip() {
+    /* eslint-disable no-return-assign, no-param-reassign */
+    // Delete the target because a new tab is opened when downloading the file
+    await this.page.$eval(this.documentNumberLink.replace('%ID', 3), el => el.target = '');
+    await this.page.click(this.documentNumberLink.replace('%ID', 3));
+    /* eslint-enable no-return-assign, no-param-reassign */
+  }
 };


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Enable disable image in delivery slip file
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/orders/deliverySlips/02_deliverySlipOptions.js/03_enableDisableProductImage.js" URL_FO=yourShopURL DOWNLOAD_PATH=yourDownloadPath npm run specific-test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17047)
<!-- Reviewable:end -->
