### PR TITLE
Fix encoding on product name in viewed product

### DIFF
--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -370,7 +370,7 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
 
             $viewedProducts[] = new ViewedProductInformation(
                 (int) $product->id,
-                Tools::htmlentitiesUTF8($product->name),
+                $product->name,
                 $productUrl
             );
         }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/viewed_products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/viewed_products.html.twig
@@ -44,7 +44,7 @@
               <td>{{ product.productId }}</td>
               <td>
                 <a href="{{ product.productUrl }}">
-                  {{ product.productName|convert_encoding('UTF-8', 'HTML-ENTITIES') }}
+                  {{ product.productName }}
                 </a>
               </td>
             </tr>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Fixed encoding on product name in viewed product
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16739 
| How to test?  | From @khouloudbelguith in [comment](https://github.com/PrestaShop/PrestaShop/issues/16739#issuecomment-563176317) : <br>1. Add the Russian language<br>2. Edit the language employee to Russian<br>3. Add some product with a Russian name for example (СВИТЕР С КОЛИБРИ)<br>3.1 Add some product with accent ("T-shirt imprimé colibri"<br>4. Go to the FO, sign in with Customer C & add this product to cart<br>5. Go to the BO => Customer => View this customer<br>6. Check the Viewed Products section<br>![image](https://user-images.githubusercontent.com/1533248/71988833-e4671000-3230-11ea-858d-34c9da0fc566.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17065)
<!-- Reviewable:end -->
