### PR TITLE
Fix Currency i18n fields issue in webservice

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -244,6 +244,10 @@ class CurrencyCore extends ObjectModel
     public function getWebserviceParameters($ws_params_attribute_name = null)
     {
         $parameters = parent::getWebserviceParameters($ws_params_attribute_name);
+        // name & symbol are i18n fields but casted to single string in the constructor
+        // so we need to force the webservice to consider those fields as non-i18n fields.
+        // Also, in 1.7.5 the field symbol didn't exists and name wasn't an i18n field so in order
+        // to keep 1.7.6 backward compatible we need to make those fields non-i18n.
         $parameters['fields']['name']['i18n'] = false;
         $parameters['fields']['symbol']['i18n'] = false;
 

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -37,6 +37,13 @@ class CurrencyCore extends ObjectModel
     public $name;
 
     /**
+     * Localized names of the currency
+     *
+     * @var string[]
+     */
+    protected $localizedNames;
+
+    /**
      * Alphabetic ISO 4217 code of this currency.
      *
      * @var string
@@ -94,6 +101,13 @@ class CurrencyCore extends ObjectModel
     public $symbol;
 
     /**
+     * Localized Currency's symbol.
+     *
+     * @var string[]
+     */
+    private $localizedSymbol;
+
+    /**
      * CLDR price formatting pattern
      * e.g.: In french (fr-FR), price formatting pattern is : #,##0.00 ¤.
      *
@@ -149,6 +163,24 @@ class CurrencyCore extends ObjectModel
 
     protected $webserviceParameters = array(
         'objectsNodeName' => 'currencies',
+        'fields' => array(
+            'name' => array(
+                'setter' => false,
+                'getter' => 'getName',
+                'modifier' => array(
+                    'http_method' => WebserviceRequest::HTTP_POST | WebserviceRequest::HTTP_PUT,
+                    'modifier' => 'setNameForWebservice',
+                ),
+            ),
+            'symbol' => array(
+                'setter' => false,
+                'getter' => 'getSymbol',
+                'modifier' => array(
+                    'http_method' => WebserviceRequest::HTTP_POST | WebserviceRequest::HTTP_PUT,
+                    'modifier' => 'setSymbolForWebservice',
+                ),
+            ),
+        ),
     );
 
     /**
@@ -183,14 +215,18 @@ class CurrencyCore extends ObjectModel
                 $idLang = Context::getContext()->language->id;
             }
             if (is_array($this->symbol)) {
+                $this->localizedSymbol = $this->symbol;
                 $this->sign = $this->symbol = $this->symbol[$idLang];
             } else {
+                $this->localizedSymbol = [$idLang => $this->symbol];
                 $this->sign = $this->symbol;
             }
 
             if (is_array($this->name)) {
+                $this->localizedNames = $this->name;
                 $this->name = Tools::ucfirst($this->name[$idLang]);
             } else {
+                $this->localizedNames = [$idLang => $this->name];
                 $this->name = Tools::ucfirst($this->name);
             }
 
@@ -203,6 +239,25 @@ class CurrencyCore extends ObjectModel
         if (!$this->conversion_rate) {
             $this->conversion_rate = 1;
         }
+    }
+
+    public function getWebserviceParameters($ws_params_attribute_name = null)
+    {
+        $parameters = parent::getWebserviceParameters($ws_params_attribute_name);
+        $parameters['fields']['name']['i18n'] = false;
+        $parameters['fields']['symbol']['i18n'] = false;
+
+        return $parameters;
+    }
+
+    public function setNameForWebservice()
+    {
+        $this->name = $this->localizedNames;
+    }
+
+    public function setSymbolForWebservice()
+    {
+        $this->symbol = $this->localizedSymbol;
     }
 
     /**
@@ -377,6 +432,20 @@ class CurrencyCore extends ObjectModel
         }
 
         return Tools::ucfirst($this->name[$id_lang]);
+    }
+
+    public function getSymbol()
+    {
+        if (is_string($this->symbol)) {
+            return $this->symbol;
+        }
+
+        $id_lang = $this->id_lang;
+        if (null === $id_lang) {
+            $id_lang = Configuration::get('PS_LANG_DEFAULT');
+        }
+
+        return Tools::ucfirst($this->symbol[$id_lang]);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Correctly show `name` and `symbol` in the xml output of the currency webservice and prevent updating those fields when updating the currency.
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16760
| How to test?  | See below

# How to test

1. After enabling webservice in `Advanced Parameters -> Webservice` and adding a key with full access on the currency endpoint, send a GET request to `/api/currencies?display=full`. The field `name` and `symbol` should be present with the correct value.

2. Send a PUT request on `/api/currencies` with the necessary XML body : 
```
<?xml version="1.0" encoding="UTF-8"?>
<prestashop
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <currency>
    <id><![CDATA[1]]></id>
    <iso_code><![CDATA[EUR]]></iso_code>
    <numeric_iso_code><![CDATA[978]]></numeric_iso_code>
    <precision><![CDATA[2]]></precision>
    <conversion_rate><![CDATA[1.000000]]></conversion_rate>
    <deleted><![CDATA[0]]></deleted>
    <active><![CDATA[1]]></active>
  </currency>
</prestashop>
```

In the database, the field `name` and `symbol` should not be empty in the `ps_currency_lang` table.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17069)
<!-- Reviewable:end -->
