### PR TITLE
BO: Fix the display of tax in the order details page

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2430,6 +2430,7 @@ class AdminOrdersControllerCore extends AdminController
             'shipping_html' => $this->createTemplate('_shipping.tpl')->fetch(),
             'discount_form_html' => $this->createTemplate('_discount_form.tpl')->fetch(),
             'refresh' => $refresh,
+            'displayExcludedTaxMethod' => (bool)Group::getPriceDisplayMethod($this->context->customer->id_default_group),
         )));
     }
 
@@ -2677,6 +2678,7 @@ class AdminOrdersControllerCore extends AdminController
             'documents_html' => $this->createTemplate('_documents.tpl')->fetch(),
             'shipping_html' => $this->createTemplate('_shipping.tpl')->fetch(),
             'customized_product' => is_array(Tools::getValue('product_quantity')),
+            'displayExcludedTaxMethod' => (bool)Group::getPriceDisplayMethod($this->context->customer->id_default_group),
         )));
     }
 
@@ -2758,6 +2760,7 @@ class AdminOrdersControllerCore extends AdminController
             'invoices' => $invoice_array,
             'documents_html' => $this->createTemplate('_documents.tpl')->fetch(),
             'shipping_html' => $this->createTemplate('_shipping.tpl')->fetch(),
+            'displayExcludedTaxMethod' => (bool)Group::getPriceDisplayMethod($this->context->customer->id_default_group),
         )));
     }
 

--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -249,17 +249,19 @@ function refreshProductLineView(element, view)
 	});
 }
 
-function updateAmounts(order)
+function updateAmounts(order, displayExcludedTaxMethod)
 {
 	$('#total_products td.amount').fadeOut('slow', function() {
-		formatCurrencyCldr(parseFloat(order.total_products_wt), function(value) {
+    var valueAmount = displayExcludedTaxMethod ? order.total_products : order.total_products_wt;
+    formatCurrencyCldr(parseFloat(valueAmount), function(value) {
 			$('#total_products td.amount').html(value);
 			$('#total_products td.amount').fadeIn('slow');
 		});
 	});
 
 	$('#total_discounts td.amount').fadeOut('slow', function() {
-		formatCurrencyCldr(parseFloat(order.total_discounts_tax_incl), function(value) {
+    var valueAmount = displayExcludedTaxMethod ? order.total_discounts_tax_excl : order.total_discounts_tax_incl;
+    formatCurrencyCldr(parseFloat(valueAmount), function(value) {
 			$('#total_discounts td.amount').html(value);
 			$('#total_discounts td.amount').fadeIn('slow');
 		});
@@ -267,7 +269,8 @@ function updateAmounts(order)
 	if (order.total_discounts_tax_incl > 0)
 		$('#total_discounts').slideDown('slow');
 	$('#total_wrapping td.amount').fadeOut('slow', function() {
-		formatCurrencyCldr(parseFloat(order.total_wrapping_tax_incl), function(value) {
+    var valueAmount = displayExcludedTaxMethod ? order.total_wrapping_tax_excl : order.total_wrapping_tax_incl;
+    formatCurrencyCldr(parseFloat(valueAmount), function(value) {
 			$('#total_wrapping td.amount').html(value);
 			$('#total_wrapping td.amount').fadeIn('slow');
 		});
@@ -275,7 +278,8 @@ function updateAmounts(order)
 	if (order.total_wrapping_tax_incl > 0)
 		$('#total_wrapping').slideDown('slow');
 	$('#total_shipping td.amount').fadeOut('slow', function() {
-		formatCurrencyCldr(parseFloat(order.total_shipping_tax_incl), function(value) {
+    var valueAmount = displayExcludedTaxMethod ? order.total_shipping_tax_excl : order.total_shipping_tax_incl;
+    formatCurrencyCldr(parseFloat(valueAmount), function(value) {
 			$('#total_shipping td.amount').html(value);
 			$('#total_shipping td.amount').fadeIn('slow');
 		});
@@ -302,6 +306,13 @@ function updateAmounts(order)
 		$(this).html(order.weight);
 		$(this).fadeIn('slow');
 	});
+  $('#total_taxes td.amount').fadeOut('slow', function() {
+    var totalTaxes = parseFloat(order.total_paid_tax_incl) - parseFloat(order.total_paid_tax_excl);
+    formatCurrencyCldr(parseFloat(totalTaxes), function(value) {
+      $('#total_taxes td.amount').html(value);
+      $('#total_taxes td.amount').fadeIn('slow');
+    });
+  });
 
 	var shippingCarrierPrice = $('#shipping_table .price_carrier_' + order.id_carrier + ' span');
 	$(shippingCarrierPrice).fadeOut('slow', function() {
@@ -542,7 +553,7 @@ function init()
 							}
 							go = false;
 							addViewOrderDetailRow(data.view);
-							updateAmounts(data.order);
+							updateAmounts(data.order, data.displayExcludedTaxMethod);
 							updateInvoice(data.invoices);
 							updateDocuments(data.documents_html);
 							updateShipping(data.shipping_html);
@@ -738,7 +749,7 @@ function init()
 				success : function(data) {
 					if (data.result) {
 						refreshProductLineView(element, data.view);
-						updateAmounts(data.order);
+						updateAmounts(data.order, data.displayExcludedTaxMethod);
 						updateInvoice(data.invoices);
 						updateDocuments(data.documents_html);
 						updateDiscountForm(data.discount_form_html);
@@ -813,7 +824,7 @@ function init()
 					tr_product.fadeOut('slow', function() {
 						$(this).remove();
 					});
-					updateAmounts(data.order);
+					updateAmounts(data.order, data.displayExcludedTaxMethod);
 					updateInvoice(data.invoices);
 					updateDocuments(data.documents_html);
 					updateDiscountForm(data.discount_form_html);


### PR DESCRIPTION
From #8493 by @Azouz-Jribi 

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Configuration > customer group, set **tax excluded** as value for **Price display method** and edit the quantity of any product in the order. After saving the modification, the total product price and total tax are not displayed correctly. The total prices section is displayed with tax included, instead of tax excluded and recalculate the tax separately.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/PSCSX-8144 & Fixes #15528
| How to test?  | BO > Customers > Groups > set the customer group **Price display method** to **Tax excluded**, BO > Orders > edit order > edit product quantity and save, check if the total prices section is displayed correctly.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17098)
<!-- Reviewable:end -->
