### PR TITLE
Fixed in mutishop weight for attributes in cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -735,9 +735,10 @@ class CartCore extends ObjectModel
 
         if (Combination::isFeatureActive()) {
             $sql->select('
-                product_attribute_shop.`price` AS price_attribute, product_attribute_shop.`ecotax` AS ecotax_attr,
+                product_attribute_shop.`price` AS price_attribute,
+                product_attribute_shop.`ecotax` AS ecotax_attr,
                 IF (IFNULL(pa.`reference`, \'\') = \'\', p.`reference`, pa.`reference`) AS reference,
-                (p.`weight`+ pa.`weight`) weight_attribute,
+                (p.`weight`+ IFNULL(product_attribute_shop.`weight`, pa.`weight`)) weight_attribute,
                 IF (IFNULL(pa.`ean13`, \'\') = \'\', p.`ean13`, pa.`ean13`) AS ean13,
                 IF (IFNULL(pa.`isbn`, \'\') = \'\', p.`isbn`, pa.`isbn`) AS isbn,
                 IF (IFNULL(pa.`upc`, \'\') = \'\', p.`upc`, pa.`upc`) AS upc,


### PR DESCRIPTION
From #8861 by @axometeam 

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Having different weight for the same product in a multishop environment can lead to wrong attribute weight returned by the `Cart::getProducts` method
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  |  - Activate multishop<br>- Create an another shop<br>- Create a product with an attribute<br>- Configure the weight of an attribute with different values in different shops (first shop 12kg, second shop 34kg)<br>- Set a shipping pricing different between weight (0-20 : 10€ for example, 20-40 : 20€ for example)<br>- Add the product to cart in FO<br>- **BEFORE** : The weight entered for each attribute is not used for shipping<br>- **AFTER** : The shipping pricing change depending on the shop (so different weights)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17101)
<!-- Reviewable:end -->
