### PR TITLE
Functional tests - Set FR text value for custom maintenance text

### DIFF
--- a/tests/puppeteer/pages/BO/shopParameters/general/maintenance/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/general/maintenance/index.js
@@ -13,6 +13,8 @@ module.exports = class shopParamsMaintenance extends BOBasePage {
     this.disableShopLabel = 'label[for=\'form_general_enable_shop_0\']';
     this.enableShopLabel = 'label[for=\'form_general_enable_shop_1\']';
     this.maintenanceTextInputEN = '#form_general_maintenance_text_1_ifr';
+    this.customMaintenanceFrTab = '#form_general_maintenance_text  a[data-locale="fr"]';
+    this.maintenanceTextInputFR = '#form_general_maintenance_text_2_ifr';
     this.addMyIPAddressButton = 'form .add_ip_button';
     this.maintenanceIpInput = '#form_general_maintenance_ip';
     this.saveFormButton = 'form .card-footer button';
@@ -49,6 +51,8 @@ module.exports = class shopParamsMaintenance extends BOBasePage {
    */
   async changeMaintenanceTextShopStatus(text) {
     await this.setValueOnTinymceInput(this.maintenanceTextInputEN, text);
+    await this.page.click(this.customMaintenanceFrTab);
+    await this.setValueOnTinymceInput(this.maintenanceTextInputFR, text);
     await this.page.click(this.saveFormButton);
     return this.getTextContent(this.alertSuccessBloc);
   }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Set FR text value for custom maintenance text
| Type?         | refacto
| Category?     |  TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/shopParameters/general/maintenance/01_enableDisableShop.js" URL_FO=yourShopURL npm run specific-test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17129)
<!-- Reviewable:end -->
