### PR TITLE
Fix suppliers form description to be optional

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -137,6 +137,7 @@ class SupplierType extends TranslatorAwareType
                 ],
             ])
             ->add('description', TranslateType::class, [
+                'required' => false,
                 'type' => FormattedTextareaType::class,
                 'locales' => $this->locales,
                 'hideTabs' => false,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Suppliers form `description` field should have been optional according to legacy behavior. Furthermore the required description caused some conflict between tinyMCE and browser (can read more here https://stackoverflow.com/questions/22148080/an-invalid-form-control-with-name-is-not-focusable). This pr only adds required => false in SupplierType and that solves the issues.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #16569
| How to test?  | Try to add new supplier without filling description. It allows to create one, and doesn't print any error in console any more.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17180)
<!-- Reviewable:end -->
