### PR TITLE
[WIP] Fix customer address required fields

### DIFF
--- a/src/Adapter/Address/CommandHandler/SetRequiredFieldsForAddressHandler.php
+++ b/src/Adapter/Address/CommandHandler/SetRequiredFieldsForAddressHandler.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Address\CommandHandler;
 
-use Address;
+use CustomerAddress;
 use PrestaShop\PrestaShop\Core\Domain\Address\Command\SetRequiredFieldsForAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Address\CommandHandler\SetRequiredFieldsForAddressHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Address\Exception\CannotSetRequiredFieldsForAddressException;
@@ -46,7 +46,7 @@ final class SetRequiredFieldsForAddressHandler implements SetRequiredFieldsForAd
      */
     public function handle(SetRequiredFieldsForAddressCommand $command)
     {
-        $address = new Address();
+        $address = new CustomerAddress();
 
         try {
             if ($address->addFieldsRequiredDatabase($command->getRequiredFields())) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Required fields in customer address was not able to be saved. This pr fixes it by createing CustomerAddress object instead of Address according to legacy page (so it passes the correct object name to db). `There are still some behavior to consider`: currently if you disable mobile_phone the field will not appear in form at all instead of just being not required. All other fields even when selected as non required still appears in form, just doesn't have the required attribute.. So which should be the correct behavior? `And another issue`: postcode required attribute appears by using javascript and it depends from country, so if the country requires postcode should it override the Required fields selection? (some info for user would be great in any case).
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #17032
| How to test?  | GO BO Customers->addresses and select required fields whichever you want and save. Then go to Create new address and you should be able to create address without filling fields which are not required.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17190)
<!-- Reviewable:end -->
