### PR TITLE
Fixed error when generating link_rewrite with API

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6912,7 +6912,7 @@ class ProductCore extends ObjectModel
         if (empty($this->link_rewrite)) {
             $this->link_rewrite = array();
         }
-        
+
         foreach ($this->name as $id_lang => $name) {
             if (empty($this->link_rewrite[$id_lang])) {
                 $this->link_rewrite[$id_lang] = Tools::link_rewrite($name);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6909,6 +6909,10 @@ class ProductCore extends ObjectModel
     */
     public function modifierWsLinkRewrite()
     {
+        if (empty($this->link_rewrite)) {
+            $this->link_rewrite = array();
+        }
+        
         foreach ($this->name as $id_lang => $name) {
             if (empty($this->link_rewrite[$id_lang])) {
                 $this->link_rewrite[$id_lang] = Tools::link_rewrite($name);


### PR DESCRIPTION
You cant create a product with API without adding the `<link_rewrite>` tag to the XML. 
If you have PHP5, the product will be created (bug is not triggered).
If you have PHP7, the product wont be created (bug is triggered).

When creating a product, the function `modifierWsLinkRewrite()` works, and fill the `$this->link_rewrite` variable like it would be an array, BUT the variable is not initialized as an array. 

This cause that the variable wont be correctly setted, and the product wont be added.


<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In class Product, a uninitialized variable is setted as an array() so it wont cause errors when adding a product with API without addind the <link_rewrite> tag.
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | With a PHP7 server, try adding a Product with API without adding <link_rewrite> tag in the XML.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17233)
<!-- Reviewable:end -->
