### PR TITLE
Do not allow negative amount in order payment block

### DIFF
--- a/classes/order/OrderPayment.php
+++ b/classes/order/OrderPayment.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop SA and Contributors
+ * 2007-2020 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @copyright 2007-2020 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
@@ -46,7 +46,7 @@ class OrderPaymentCore extends ObjectModel
         'fields' => [
             'order_reference' => ['type' => self::TYPE_STRING, 'validate' => 'isAnything', 'size' => 9],
             'id_currency' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
-            'amount' => ['type' => self::TYPE_FLOAT, 'validate' => 'isNegativePrice', 'required' => true],
+            'amount' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice', 'required' => true],
             'payment_method' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName'],
             'conversion_rate' => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat'],
             'transaction_id' => ['type' => self::TYPE_STRING, 'validate' => 'isAnything', 'size' => 254],

--- a/src/Core/Domain/Order/Exception/NegativePaymentAmountException.php
+++ b/src/Core/Domain/Order/Exception/NegativePaymentAmountException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\Exception;
+
+/**
+ * Exception thrown when the payment amount is negative
+ */
+class NegativePaymentAmountException extends OrderException
+{
+}

--- a/src/Core/Domain/Order/Payment/Command/AddPaymentCommand.php
+++ b/src/Core/Domain/Order/Payment/Command/AddPaymentCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop SA and Contributors
+ * 2007-2020 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @copyright 2007-2020 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Order\Payment\Command;
 use DateTimeImmutable;
 use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\NegativePaymentAmountException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
 
@@ -90,12 +91,14 @@ class AddPaymentCommand
         $orderInvoiceId = null,
         $transactionId = null
     ) {
+        $amount = new Number($paymentAmount);
+        $this->assertAmountIsPositive($amount);
         $this->assertPaymentMethodIsGenericName($paymentMethod);
 
         $this->orderId = new OrderId($orderId);
         $this->paymentDate = new DateTimeImmutable($paymentDate);
         $this->paymentMethod = $paymentMethod;
-        $this->paymentAmount = new Number($paymentAmount);
+        $this->paymentAmount = $amount;
         $this->paymentCurrencyId = new CurrencyId($paymentCurrencyId);
         $this->orderInvoiceId = $orderInvoiceId;
         $this->transactionId = $transactionId;
@@ -161,6 +164,13 @@ class AddPaymentCommand
     {
         if (empty($paymentMethod) || !preg_match('/^[^<>={}]*$/u', $paymentMethod)) {
             throw new OrderConstraintException('The selected payment method is invalid.');
+        }
+    }
+
+    private function assertAmountIsPositive(Number $amount)
+    {
+        if ($amount->isNegative()) {
+            throw new NegativePaymentAmountException('The amount should be greater than 0.');
         }
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop SA and Contributors
+ * 2007-2020 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @copyright 2007-2020 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
@@ -819,6 +819,10 @@ class OrderController extends FrameworkBundleAdminController
                 $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
             } catch (Exception $e) {
                 $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+            }
+        } elseif (!$form->isValid()) {
+            foreach ($form->getErrors(true) as $error) {
+                $this->addFlash('error', $error->getMessage());
             }
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1260,7 +1260,7 @@ class OrderController extends FrameworkBundleAdminController
                 'Admin.Notifications.Error'
             ),
             NegativePaymentAmountException::class => $this->trans(
-                'The amount should be greater than 0.',
+                'Invalid value: the payment must be a positive amount.',
                 'Admin.Notifications.Error'
             ),
         ];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -46,6 +46,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotEditDeliveredOrderProductException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidRefundException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\NegativePaymentAmountException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderEmailSendException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
@@ -1256,6 +1257,10 @@ class OrderController extends FrameworkBundleAdminController
             ],
             ProductOutOfStockException::class => $this->trans(
                 'There are not enough products in stock',
+                'Admin.Notifications.Error'
+            ),
+            NegativePaymentAmountException::class => $this->trans(
+                'The amount should be greater than 0.',
                 'Admin.Notifications.Error'
             ),
         ];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -800,29 +800,31 @@ class OrderController extends FrameworkBundleAdminController
         ]);
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
-            $data = $form->getData();
+        if ($form->isSubmitted()) {
+            if ($form->isValid()) {
+                $data = $form->getData();
 
-            try {
-                $this->getCommandBus()->handle(
-                    new AddPaymentCommand(
-                        $orderId,
-                        $data['date'],
-                        $data['payment_method'],
-                        $data['amount'],
-                        $data['id_currency'],
-                        $data['id_invoice'],
-                        $data['transaction_id']
-                    )
-                );
+                try {
+                    $this->getCommandBus()->handle(
+                        new AddPaymentCommand(
+                            $orderId,
+                            $data['date'],
+                            $data['payment_method'],
+                            $data['amount'],
+                            $data['id_currency'],
+                            $data['id_invoice'],
+                            $data['transaction_id']
+                        )
+                    );
 
-                $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
-            } catch (Exception $e) {
-                $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
-            }
-        } elseif (!$form->isValid()) {
-            foreach ($form->getErrors(true) as $error) {
-                $this->addFlash('error', $error->getMessage());
+                    $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+                } catch (Exception $e) {
+                    $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+                }
+            } else {
+                foreach ($form->getErrors(true) as $error) {
+                    $this->addFlash('error', $error->getMessage());
+                }
             }
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderPaymentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderPaymentType.php
@@ -112,7 +112,7 @@ class OrderPaymentType extends AbstractType
                     new GreaterThan([
                         'value' => 0,
                         'message' => $this->translator->trans(
-                            'The amount should be greater than 0.', [], 'Admin.Notifications.Error'
+                            'Invalid value: the payment must be a positive amount.', [], 'Admin.Notifications.Error'
                         ),
                     ]),
                 ],

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -981,6 +981,7 @@ services:
     form.type.order.order_payment:
       class: 'PrestaShopBundle\Form\Admin\Sell\Order\OrderPaymentType'
       arguments:
+        - '@translator'
         - '@prestashop.adapter.form.choice_provider.currency_symbol_by_id'
         - '@prestashop.adapter.form.choice_provider.order_invoice_by_id'
         - '@prestashop.adapter.form.choice_provider.installed_payment_modules'

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderPaymentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderPaymentFeatureContext.php
@@ -5,12 +5,12 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 use Behat\Gherkin\Node\TableNode;
 use DateTimeImmutable;
 use PHPUnit\Framework\Assert as Assert;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\NegativePaymentAmountException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Payment\Command\AddPaymentCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderPaymentForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderPaymentsForViewing;
-use PrestaShopException;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 
@@ -118,6 +118,7 @@ class OrderPaymentFeatureContext extends AbstractDomainFeatureContext
         $data = $table->getRowsHash();
 
         try {
+            $this->lastException = null;
             $this->getCommandBus()->handle(
                 new AddPaymentCommand(
                     $orderId,
@@ -129,13 +130,17 @@ class OrderPaymentFeatureContext extends AbstractDomainFeatureContext
                     $data['transaction_id']
                 )
             );
-        } catch (PrestaShopException $exception) {
-            $msg = $exception->getMessage();
-            $expectedMsg = 'Property Order->total_paid_real is not valid';
-            if ($msg !== 'Property Order->total_paid_real is not valid') {
-                throw new RuntimeException(sprintf('Not expected exception is thrown "%s" but "%s" was expected', $msg, $expectedMsg));
-            }
+        } catch (NegativePaymentAmountException $exception) {
+            $this->lastException = $exception;
         }
+    }
+
+    /**
+     * @Then I should get error that payment amount is negative
+     */
+    public function assertLastErrorIsNegativePaymentAmount()
+    {
+        $this->assertLastErrorIs(NegativePaymentAmountException::class);
     }
 
     private function mapToOrderPaymentForViewing(int $paymentId, array $data)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -43,16 +43,16 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" has Tracking number "TEST1234"
     And order "bo_order1" has Carrier "2 - My carrier (Delivery next day!)"
 
-#  failing scenario related to: https://github.com/PrestaShop/PrestaShop/issues/16582
-#  Scenario: pay order with negative amount and see it is not valid
-#    When order "bo_order1" has 0 payments
-#    And I pay order "bo_order1" with the invalid following details:
-#      | date           | 2019-11-26 13:56:22 |
-#      | payment_method | Payments by check   |
-#      | transaction_id | test!@#$%%^^&* OR 1 |
-#      | id_currency    | 1                   |
-#      | amount         | -5.548              |
-#    Then order "bo_order1" has 0 payments
+  Scenario: pay order with negative amount and see it is not valid
+    When order "bo_order1" has 0 payments
+    And I pay order "bo_order1" with the invalid following details:
+      | date           | 2019-11-26 13:56:22 |
+      | payment_method | Payments by check   |
+      | transaction_id | test!@#$%%^^&* OR 1 |
+      | id_currency    | 1                   |
+      | amount         | -5.548              |
+    Then I should get error that payment amount is negative
+    And order "bo_order1" has 0 payments
 
   Scenario: pay for order
     When I pay order "bo_order1" with the following details:


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Do not allow negative amount in order payment
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16582
| How to test?  | In the migrated order/view page, try to add a payment with a negative amount, an error should be displayed and the payment should not be added

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17241)
<!-- Reviewable:end -->
