### PR TITLE
Functional tests - Limit the legal free text length to 50

### DIFF
--- a/tests/puppeteer/campaigns/data/faker/invoice.js
+++ b/tests/puppeteer/campaigns/data/faker/invoice.js
@@ -3,7 +3,7 @@ const faker = require('faker');
 module.exports = class Invoice {
   constructor(invoiceOptions = {}) {
     this.invoiceNumber = invoiceOptions.invoiceNumber || faker.random.number({min: 100, max: 200}).toString();
-    this.legalFreeText = invoiceOptions.legalFreeText || faker.lorem.sentence();
+    this.legalFreeText = invoiceOptions.legalFreeText || faker.lorem.sentence().substring(0, 50);
     this.footerText = invoiceOptions.footerText || faker.lorem.word();
     this.prefix = invoiceOptions.prefix || `#${faker.lorem.word()}`;
   }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Limit the legal free text length to 50 to fix the random error in "02_invoices/03_invoiceOptions/06_otherOptions" test
| Type?         | refacto
| Category?     |  TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/02_orders/02_invoices/03_invoiceOptions/06_otherOptions" URL_FO=yourShopURL DOWNLOAD_PATH=yourDownloadPath npm run specific-test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17272)
<!-- Reviewable:end -->
