### PR TITLE
Enable bulk delete modal for Suppliers, Brands, Brand adresses

### DIFF
--- a/src/Core/Grid/Definition/Factory/ManufacturerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ManufacturerAddressGridDefinitionFactory.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;

--- a/src/Core/Grid/Definition/Factory/ManufacturerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ManufacturerAddressGridDefinitionFactory.php
@@ -49,6 +49,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class ManufacturerAddressGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
+
     const GRID_ID = 'manufacturer_address';
 
     /**
@@ -239,12 +241,8 @@ final class ManufacturerAddressGridDefinitionFactory extends AbstractGridDefinit
     protected function getBulkActions()
     {
         return (new BulkActionCollection())
-            ->add((new SubmitBulkAction('delete_manufacturer_address'))
-                ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                ->setOptions([
-                    'submit_route' => 'admin_manufacturer_addresses_bulk_delete',
-                    'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                ])
+            ->add(
+                $this->buildBulkDeleteAction('admin_manufacturer_addresses_bulk_delete')
             )
         ;
     }

--- a/src/Core/Grid/Definition/Factory/ManufacturerGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ManufacturerGridDefinitionFactory.php
@@ -51,6 +51,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class ManufacturerGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
+
     const GRID_ID = 'manufacturer';
 
     /**
@@ -157,8 +159,7 @@ final class ManufacturerGridDefinitionFactory extends AbstractGridDefinitionFact
                             ])
                         ),
                 ])
-            )
-        ;
+            );
     }
 
     /**
@@ -195,8 +196,7 @@ final class ManufacturerGridDefinitionFactory extends AbstractGridDefinitionFact
             ->add((new SimpleGridAction('common_export_sql_manager'))
                 ->setName($this->trans('Export to SQL Manager', [], 'Admin.Actions'))
                 ->setIcon('storage')
-            )
-        ;
+            );
     }
 
     /**
@@ -236,8 +236,7 @@ final class ManufacturerGridDefinitionFactory extends AbstractGridDefinitionFact
                     'redirect_route' => 'admin_manufacturers_index',
                 ])
                 ->setAssociatedColumn('actions')
-            )
-        ;
+            );
     }
 
     /**
@@ -257,14 +256,8 @@ final class ManufacturerGridDefinitionFactory extends AbstractGridDefinitionFact
                 ->setOptions([
                     'submit_route' => 'admin_manufacturers_bulk_disable_status',
                 ])
-            )
-            ->add((new SubmitBulkAction('delete_selection'))
-                ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                ->setOptions([
-                    'submit_route' => 'admin_manufacturers_bulk_delete',
-                    'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                ])
-            )
-        ;
+            )->add(
+                $this->buildBulkDeleteAction('admin_manufacturers_bulk_delete')
+            );
     }
 }

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -52,6 +52,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -229,12 +231,8 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                     'submit_route' => 'admin_suppliers_bulk_disable',
                 ])
             )
-            ->add((new SubmitBulkAction('suppliers_delete'))
-                ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                ->setOptions([
-                    'submit_route' => 'admin_suppliers_bulk_delete',
-                    'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                ])
+            ->add(
+                $this->buildBulkDeleteAction('admin_suppliers_bulk_delete')
             )
         ;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Enable bulk delete modal for Suppliers, Brands, Brand adresses
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes some items from https://github.com/PrestaShop/PrestaShop/issues/14462
| How to test?  | See ticket description, this PR solves it for pages Suppliers, Brands, Brand adresses

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17286)
<!-- Reviewable:end -->
