### PR TITLE
Enable bulk delete modal for Languages, Taxes, CMS Pages, CMS Cats

### DIFF
--- a/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
@@ -54,6 +54,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 final class CmsPageCategoryDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
+
     const GRID_ID = 'cms_page_category';
 
     /**
@@ -302,12 +304,8 @@ final class CmsPageCategoryDefinitionFactory extends AbstractGridDefinitionFacto
                     'submit_route' => 'admin_cms_pages_category_bulk_status_disable',
                 ])
             )
-            ->add((new SubmitBulkAction('delete_bulk'))
-                ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                ->setOptions([
-                    'submit_route' => 'admin_cms_pages_category_delete_bulk',
-                    'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                ])
+            ->add(
+                $this->buildBulkDeleteAction('admin_cms_pages_category_delete_bulk')
             )
         ;
     }

--- a/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
@@ -55,6 +55,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
+
     const GRID_ID = 'cms_page';
 
     /**
@@ -342,12 +344,8 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
                     'submit_route' => 'admin_cms_pages_bulk_disable_status',
                 ])
             )
-            ->add((new SubmitBulkAction('delete_bulk'))
-                ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                ->setOptions([
-                    'submit_route' => 'admin_cms_pages_bulk_delete',
-                    'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                ])
+            ->add(
+                $this->buildBulkDeleteAction('admin_cms_pages_bulk_delete')
             )
             ;
     }

--- a/src/Core/Grid/Definition/Factory/CurrencyGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CurrencyGridDefinitionFactory.php
@@ -47,6 +47,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class CurrencyGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
+
     const GRID_ID = 'currency';
 
     /**

--- a/src/Core/Grid/Definition/Factory/CurrencyGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CurrencyGridDefinitionFactory.php
@@ -47,8 +47,6 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class CurrencyGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
-    use BulkDeleteActionTrait;
-
     const GRID_ID = 'currency';
 
     /**

--- a/src/Core/Grid/Definition/Factory/LanguageGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LanguageGridDefinitionFactory.php
@@ -52,6 +52,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class LanguageGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
+
     const GRID_ID = 'language';
 
     /**
@@ -321,12 +323,7 @@ final class LanguageGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ])
             )
             ->add(
-                (new SubmitBulkAction('delete_selection'))
-                ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                ->setOptions([
-                    'submit_route' => 'admin_languages_bulk_delete',
-                    'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                ])
+                $this->buildBulkDeleteAction('admin_languages_bulk_delete')
             );
     }
 }

--- a/src/Core/Grid/Definition/Factory/TaxGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/TaxGridDefinitionFactory.php
@@ -49,6 +49,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class TaxGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -244,12 +246,7 @@ final class TaxGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ])
             )
             ->add(
-                (new SubmitBulkAction('delete_selection'))
-                ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                ->setOptions([
-                    'submit_route' => 'admin_taxes_bulk_delete',
-                    'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                ])
+                $this->buildBulkDeleteAction('admin_taxes_bulk_delete')
             );
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Enable bulk delete modal for Languages, Taxes, CMS Pages, CMS Pages Categories
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes some items from https://github.com/PrestaShop/PrestaShop/issues/14462
| How to test?  | See ticket description, this PR solves it for pages Languages, Taxes, CMS Pages, CMS Pages Categories

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17287)
<!-- Reviewable:end -->
