### PR TITLE
Fixes undefined vars in some migrated controllers

### DIFF
--- a/src/Adapter/File/Uploader/AttachmentFileUploader.php
+++ b/src/Adapter/File/Uploader/AttachmentFileUploader.php
@@ -55,10 +55,6 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
      */
     private $uploadSizeConfiguration;
 
-    /**
-     * @param ConfigurationInterface $configuration
-     * @param UploadSizeConfigurationInterface $uploadSizeConfiguration
-     */
     public function __construct(
         ConfigurationInterface $configuration,
         UploadSizeConfigurationInterface $uploadSizeConfiguration
@@ -89,7 +85,6 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
     }
 
     /**
-     * @param int $attachmentId
      * @param bool $throwExceptionOnFailure
      *
      * @throws AttachmentNotFoundException
@@ -105,12 +100,7 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
                 try {
                     unlink($fileLink);
                 } catch (ErrorException $e) {
-                    throw new CannotUnlinkAttachmentException(
-                        $e->getMessage(),
-                        0,
-                        null,
-                        $fileLink
-                    );
+                    throw new CannotUnlinkAttachmentException($e->getMessage(), 0, null, $fileLink);
                 }
             }
 
@@ -121,10 +111,6 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
     }
 
     /**
-     * @param string $filePath
-     * @param string $uniqid
-     * @param int $fileSize
-     *
      * @throws AttachmentConstraintException
      * @throws AttachmentUploadFailedException
      */
@@ -142,8 +128,6 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
     }
 
     /**
-     * @param int $fileSize
-     *
      * @throws AttachmentConstraintException
      */
     private function checkFileAllowedForUpload(int $fileSize): void

--- a/src/Adapter/File/Uploader/AttachmentFileUploader.php
+++ b/src/Adapter/File/Uploader/AttachmentFileUploader.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\File\Uploader;
 
 use Attachment;
+use ErrorException;
 use PrestaShop\PrestaShop\Core\Configuration\UploadSizeConfigurationInterface;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\AttachmentFileUploaderInterface;
@@ -100,16 +101,17 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
             $attachment = new Attachment($attachmentId);
             $fileLink = _PS_DOWNLOAD_DIR_ . $attachment->file;
 
-            if ($throwExceptionOnFailure && !@unlink($fileLink)) {
-                throw new CannotUnlinkAttachmentException(
-                    sprintf(
-                        'Failed to unlink file %s from system',
+            if ($throwExceptionOnFailure) {
+                try {
+                    unlink($fileLink);
+                } catch (ErrorException $e) {
+                    throw new CannotUnlinkAttachmentException(
+                        $e->getMessage(),
+                        0,
+                        null,
                         $fileLink
-                    ),
-                    0,
-                    null,
-                    $fileLink
-                );
+                    );
+                }
             }
 
             @unlink($fileLink);

--- a/src/Adapter/File/Uploader/AttachmentFileUploader.php
+++ b/src/Adapter/File/Uploader/AttachmentFileUploader.php
@@ -117,7 +117,14 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
     private function uploadFile(string $filePath, string $uniqid, int $fileSize): void
     {
         if ($fileSize > ($this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024)) {
-            throw new AttachmentConstraintException(sprintf('Max file size allowed is "%s" bytes. Uploaded file size is "%s".', (string) ($this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024), number_format(($fileSize / 1024), 2, '.', '')), AttachmentConstraintException::INVALID_FILE_SIZE);
+            throw new AttachmentConstraintException(
+                sprintf(
+                    'Max file size allowed is "%s" bytes. Uploaded file size is "%s".',
+                    (string) ($this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024),
+                    number_format(($fileSize / 1024), 2, '.', '')
+                ),
+                AttachmentConstraintException::INVALID_FILE_SIZE
+            );
         }
 
         try {

--- a/src/Adapter/File/Uploader/AttachmentFileUploader.php
+++ b/src/Adapter/File/Uploader/AttachmentFileUploader.php
@@ -117,7 +117,14 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
     private function uploadFile(string $filePath, string $uniqid, int $fileSize): void
     {
         if ($fileSize > ($this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024)) {
-            throw new AttachmentConstraintException(sprintf('Max file size allowed is "%s" bytes. Uploaded file size is "%s".', (string) ($this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024), number_format(($fileSize / 1024), 2, '.', '')), AttachmentConstraintException::INVALID_FILE_SIZE);
+            throw new AttachmentConstraintException(
+                sprintf(
+                    'Max file size allowed is "%s" bytes. Uploaded file size is "%s".',
+                    (string) ($this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024),
+                    number_format(($fileSize / 1024), 2, '.', '')
+                ),
+                AttachmentConstraintException::INVALID_FILE_SIZE
+            );
         }
 
         try {
@@ -135,7 +142,10 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
         $maxFileSize = $this->uploadSizeConfiguration->getMaxUploadSizeInBytes();
 
         if ($maxFileSize > 0 && $fileSize > $maxFileSize) {
-            throw new AttachmentConstraintException(sprintf('Max file size allowed is "%s" bytes. Uploaded file size is "%s".', $maxFileSize, $fileSize), AttachmentConstraintException::INVALID_FILE_SIZE);
+            throw new AttachmentConstraintException(
+                sprintf('Max file size allowed is "%s" bytes. Uploaded file size is "%s".', $maxFileSize, $fileSize),
+                AttachmentConstraintException::INVALID_FILE_SIZE
+            );
         }
     }
 }

--- a/src/Adapter/File/Uploader/AttachmentFileUploader.php
+++ b/src/Adapter/File/Uploader/AttachmentFileUploader.php
@@ -96,15 +96,13 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
             $attachment = new Attachment($attachmentId);
             $fileLink = _PS_DOWNLOAD_DIR_ . $attachment->file;
 
-            if ($throwExceptionOnFailure) {
-                try {
-                    unlink($fileLink);
-                } catch (ErrorException $e) {
+            try {
+                unlink($fileLink);
+            } catch (ErrorException $e) {
+                if ($throwExceptionOnFailure) {
                     throw new CannotUnlinkAttachmentException($e->getMessage(), 0, null, $fileLink);
                 }
             }
-
-            @unlink($fileLink);
         } catch (PrestaShopException $e) {
             throw new AttachmentNotFoundException(sprintf('Attachment with id "%s" was not found.', $attachmentId));
         }

--- a/src/Adapter/File/Uploader/AttachmentFileUploader.php
+++ b/src/Adapter/File/Uploader/AttachmentFileUploader.php
@@ -117,14 +117,7 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
     private function uploadFile(string $filePath, string $uniqid, int $fileSize): void
     {
         if ($fileSize > ($this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024)) {
-            throw new AttachmentConstraintException(
-                sprintf(
-                    'Max file size allowed is "%s" bytes. Uploaded file size is "%s".',
-                    (string) ($this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024),
-                    number_format(($fileSize / 1024), 2, '.', '')
-                ),
-                AttachmentConstraintException::INVALID_FILE_SIZE
-            );
+            throw new AttachmentConstraintException(sprintf('Max file size allowed is "%s" bytes. Uploaded file size is "%s".', (string) ($this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024), number_format(($fileSize / 1024), 2, '.', '')), AttachmentConstraintException::INVALID_FILE_SIZE);
         }
 
         try {

--- a/src/Core/Domain/Attachment/Exception/CannotUnlinkAttachmentException.php
+++ b/src/Core/Domain/Attachment/Exception/CannotUnlinkAttachmentException.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop and Contributors
+ * 2007-2020 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @copyright 2007-2020 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */

--- a/src/Core/Domain/Attachment/Exception/CannotUnlinkAttachmentException.php
+++ b/src/Core/Domain/Attachment/Exception/CannotUnlinkAttachmentException.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Attachment\Exception;
+
+use Throwable;
+
+/**
+ * Thrown when file unlink fails
+ */
+class CannotUnlinkAttachmentException extends AttachmentException
+{
+    /**
+     * @var string
+     */
+    private $filePath = '';
+
+    /**
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     * @param string $filePath
+     */
+    public function __construct($message = '', $code = 0,  Throwable $previous = null, string $filePath = '')
+    {
+        parent::__construct($message, $code, $previous);
+        $this->filePath = $filePath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilePath(): string
+    {
+        return $this->filePath;
+    }
+}

--- a/src/Core/Domain/Attachment/Exception/CannotUnlinkAttachmentException.php
+++ b/src/Core/Domain/Attachment/Exception/CannotUnlinkAttachmentException.php
@@ -42,18 +42,13 @@ class CannotUnlinkAttachmentException extends AttachmentException
     /**
      * @param string $message
      * @param int $code
-     * @param Throwable|null $previous
-     * @param string $filePath
      */
-    public function __construct($message = '', $code = 0,  Throwable $previous = null, string $filePath = '')
+    public function __construct($message = '', $code = 0, Throwable $previous = null, string $filePath = '')
     {
         parent::__construct($message, $code, $previous);
         $this->filePath = $filePath;
     }
 
-    /**
-     * @return string
-     */
     public function getFilePath(): string
     {
         return $this->filePath;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
@@ -161,9 +161,10 @@ class AttachmentController extends FrameworkBundleAdminController
             }
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
-            if ($e instanceof AttachmentNotFoundException || $e instanceof ErrorException) {
-                return $this->redirectToRoute('admin_attachments_index');
-            }
+        }
+
+        if (!isset($attachmentInformation) || !isset($attachmentForm)) {
+            return $this->redirectToRoute('admin_attachments_index');
         }
 
         $names = $attachmentInformation->getName();

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
-use ErrorException;
 use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\Command\BulkDeleteAttachmentsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\Command\DeleteAttachmentCommand;
@@ -57,11 +56,6 @@ class AttachmentController extends FrameworkBundleAdminController
 {
     /**
      * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
-     *
-     * @param Request $request
-     * @param AttachmentFilters $filters
-     *
-     * @return Response
      */
     public function indexAction(Request $request, AttachmentFilters $filters): Response
     {
@@ -84,8 +78,6 @@ class AttachmentController extends FrameworkBundleAdminController
      *     redirectRoute="admin_attachments_index",
      *     message="You do not have permission to create this."
      * )
-     *
-     * @param Request $request
      *
      * @return Response
      */
@@ -132,7 +124,6 @@ class AttachmentController extends FrameworkBundleAdminController
      * )
      *
      * @param int $attachmentId
-     * @param Request $request
      *
      * @return Response
      */
@@ -190,10 +181,6 @@ class AttachmentController extends FrameworkBundleAdminController
      *     redirectRoute="admin_attachments_index",
      *     message="You do not have permission to edit this."
      * )
-     *
-     * @param int $attachmentId
-     *
-     * @return Response
      */
     public function viewAction(int $attachmentId): Response
     {
@@ -214,10 +201,6 @@ class AttachmentController extends FrameworkBundleAdminController
      *
      * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_attachments_index")
      * @DemoRestricted(redirectRoute="admin_attachments_index")
-     *
-     * @param int $attachmentId
-     *
-     * @return RedirectResponse
      */
     public function deleteAction(int $attachmentId): RedirectResponse
     {
@@ -242,10 +225,6 @@ class AttachmentController extends FrameworkBundleAdminController
      *     redirectRoute="admin_attachments_index",
      *     message="You do not have permission to delete this."
      * )
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
      */
     public function deleteBulkAction(Request $request): RedirectResponse
     {
@@ -266,8 +245,6 @@ class AttachmentController extends FrameworkBundleAdminController
 
     /**
      * @param Exception $e
-     *
-     * @return array
      */
     private function getErrorMessages(Exception $e = null): array
     {
@@ -337,11 +314,6 @@ class AttachmentController extends FrameworkBundleAdminController
         ];
     }
 
-    /**
-     * @param Request $request
-     *
-     * @return array
-     */
     private function getBulkAttachmentsFromRequest(Request $request): array
     {
         $attachmentIds = $request->request->get('attachment_files_bulk');
@@ -357,9 +329,6 @@ class AttachmentController extends FrameworkBundleAdminController
         return $attachmentIds;
     }
 
-    /**
-     * @return array
-     */
     private function getAttachmentToolbarButtons(): array
     {
         $toolbarButtons = [];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
@@ -323,6 +323,11 @@ class AttachmentController extends FrameworkBundleAdminController
         ];
     }
 
+    /**
+     * @param Request $request
+     *
+     * @return array
+     */
     private function getBulkAttachmentsFromRequest(Request $request): array
     {
         $attachmentIds = $request->request->get('attachment_files_bulk');
@@ -338,6 +343,9 @@ class AttachmentController extends FrameworkBundleAdminController
         return $attachmentIds;
     }
 
+    /**
+     * @return array
+     */
     private function getAttachmentToolbarButtons(): array
     {
         $toolbarButtons = [];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
@@ -320,11 +320,6 @@ class AttachmentController extends FrameworkBundleAdminController
                 $e instanceof BulkDeleteAttachmentsException ? implode(', ', $e->getAttachmentIds()) : ''
             ),
             EmptyFileException::class => $this->trans('No file has been selected', 'Admin.Notifications.Error'),
-            CannotUnlinkAttachmentException::class => $this->trans(
-                'An error occurred while trying to remove file %file%',
-                'Admin.Notifications.Error',
-                ['%file%' => $e->getFilePath()]
-            )
         ];
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CatalogPriceRuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CatalogPriceRuleController.php
@@ -160,12 +160,11 @@ class CatalogPriceRuleController extends FrameworkBundleAdminController
      */
     public function createAction(Request $request): Response
     {
+        $catalogPriceRuleForm = $this->getFormBuilder()->getForm();
+        $catalogPriceRuleForm->handleRequest($request);
+        $result = $this->getFormHandler()->handle($catalogPriceRuleForm);
+
         try {
-            $catalogPriceRuleForm = $this->getFormBuilder()->getForm();
-            $catalogPriceRuleForm->handleRequest($request);
-
-            $result = $this->getFormHandler()->handle($catalogPriceRuleForm);
-
             if (null !== $result->getIdentifiableObjectId()) {
                 $this->addFlash('success', $this->trans('Successful creation.', 'Admin.Notifications.Success'));
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Address\Command\BulkDeleteAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Address\Command\DeleteAddressCommand;
+use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressException;
 use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Address\Exception\DeleteAddressException;
@@ -222,6 +223,10 @@ class ManufacturerController extends FrameworkBundleAdminController
             }
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            if ($e instanceof ManufacturerNotFoundException) {
+                return $this->redirectToRoute('admin_manufacturers_index');
+            }
         }
 
         if (!isset($editableManufacturer) || !isset($manufacturerForm)) {
@@ -595,6 +600,10 @@ class ManufacturerController extends FrameworkBundleAdminController
             $editableAddress = $this->getQueryBus()->handle(new GetManufacturerAddressForEditing($addressId));
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            if ($e instanceof AddressNotFoundException || $e instanceof AddressConstraintException) {
+                return $this->redirectToRoute('admin_manufacturers_index');
+            }
         }
 
         if (!isset($editableAddress) || !isset($addressForm)) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Address\Command\BulkDeleteAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Address\Command\DeleteAddressCommand;
-use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressException;
 use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Address\Exception\DeleteAddressException;
@@ -79,10 +78,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      *
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
-     * @param Request $request
-     * @param ManufacturerFilters $manufacturerFilters
-     * @param ManufacturerAddressFilters $manufacturerAddressFilters
-     *
      * @return Response
      */
     public function indexAction(
@@ -109,8 +104,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      * Provides filters functionality
      *
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
-     *
-     * @param Request $request
      *
      * @return RedirectResponse
      */
@@ -140,8 +133,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      * @AdminSecurity(
      *     "is_granted(['create'], request.get('_legacy_controller'))"
      * )
-     *
-     * @param Request $request
      *
      * @return Response
      */
@@ -174,7 +165,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      *
      * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
      *
-     * @param Request $request
      * @param int $manufacturerId
      *
      * @return Response
@@ -211,7 +201,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      * )
      *
      * @param int $manufacturerId
-     * @param Request $request
      *
      * @return Response
      */
@@ -279,8 +268,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
      *
-     * @param Request $request
-     *
      * @return RedirectResponse
      */
     public function bulkDeleteAction(Request $request)
@@ -305,8 +292,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      *
      * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
-     *
-     * @param Request $request
      *
      * @return RedirectResponse
      */
@@ -333,8 +318,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      *
      * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
-     *
-     * @param Request $request
      *
      * @return RedirectResponse
      */
@@ -393,8 +376,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      *     redirectRoute="admin_manufacturers_index"
      * )
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
-     *
-     * @param ManufacturerFilters $filters
      *
      * @return Response
      */
@@ -467,8 +448,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      * )
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
      *
-     * @param ManufacturerAddressFilters $filters
-     *
      * @return Response
      */
     public function exportAddressAction(ManufacturerAddressFilters $filters)
@@ -513,8 +492,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
      *
-     * @param Request $request
-     *
      * @return RedirectResponse
      */
     public function bulkDeleteAddressAction(Request $request)
@@ -538,8 +515,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      * Show & process address creation.
      *
      * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
-     *
-     * @param Request $request
      *
      * @return Response
      */
@@ -586,7 +561,6 @@ class ManufacturerController extends FrameworkBundleAdminController
      * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
      *
      * @param int $addressId
-     * @param Request $request
      *
      * @return Response
      */
@@ -717,8 +691,6 @@ class ManufacturerController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param Request $request
-     *
      * @return array
      */
     private function getBulkManufacturersFromRequest(Request $request)
@@ -737,8 +709,6 @@ class ManufacturerController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param Request $request
-     *
      * @return array
      */
     private function getBulkAddressesFromRequest(Request $request)

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -583,7 +583,7 @@ class ManufacturerController extends FrameworkBundleAdminController
         }
 
         try {
-            /** @var EditableManufacturerAddress $address */
+            /** @var EditableManufacturerAddress $editableAddress */
             $editableAddress = $this->getQueryBus()->handle(new GetManufacturerAddressForEditing($addressId));
             $addressForm = $addressFormBuilder->getFormFor($addressId, $formData);
             $addressForm->handleRequest($request);
@@ -595,9 +595,6 @@ class ManufacturerController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_manufacturers_index');
             }
-
-            /** @var EditableManufacturerAddress $editableAddress */
-            $editableAddress = $this->getQueryBus()->handle(new GetManufacturerAddressForEditing($addressId));
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -344,10 +344,10 @@ class SupplierController extends FrameworkBundleAdminController
             }
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        }
 
-            if ($e instanceof SupplierNotFoundException || $e instanceof AddressNotFoundException) {
-                return $this->redirectToRoute('admin_suppliers_index');
-            }
+        if (!isset($supplierForm) || !isset($editableSupplier)) {
+            return $this->redirectToRoute('admin_suppliers_index');
         }
 
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Suppliers/edit.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
@@ -176,12 +176,12 @@ class OrderMessageController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_order_messages_index');
             }
-        } catch (OrderMessageNotFoundException $e) {
-            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
-
-            return $this->redirectToRoute('admin_order_messages_index');
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        }
+
+        if (!isset($form) || !isset($orderMessageName)) {
+            return $this->redirectToRoute('admin_order_messages_index');
         }
 
         return $this->render('@PrestaShop/Admin/Sell/CustomerService/OrderMessage/edit.html.twig', [


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Used phpstan static code analyzer locally to collect errors from Domain, Core and PrestashopBundle/Controllers of migrated pages. Found some possibly undefined vars in some of controllers. Removed possibility to try rendering a page with undefined variable.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Approve that following forms create/edit are rendering fine: `Catalog->Brand & Supplier`, `sell/catalog/catalog-price-rules `, `Catalog->Files`, `CustomerService->Order Message`. No changes visible.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17292)
<!-- Reviewable:end -->
