### PR TITLE
Fix duplicated orders for the same cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1628,15 +1628,9 @@ class CartCore extends ObjectModel
      */
     public function orderExists()
     {
-        $cache_id = 'Cart::orderExists_' . (int) $this->id;
-        if (!Cache::isStored($cache_id)) {
-            $result = (bool) Db::getInstance()->getValue('SELECT count(*) FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_cart` = ' . (int) $this->id);
-            Cache::store($cache_id, $result);
+        $result = (bool) Db::getInstance()->getValue('SELECT count(*) FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_cart` = ' . (int) $this->id);
 
-            return $result;
-        }
-
-        return Cache::retrieve($cache_id);
+        return $result;
     }
 
     /**

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -377,7 +377,7 @@ abstract class PaymentModuleCore extends Module
                     $transaction_id = null;
                 }
 
-                if (!$order->addOrderPayment($amount_paid, null, $transaction_id)) {
+                if (!isset($order) || !$order->addOrderPayment($amount_paid, null, $transaction_id)) {
                     PrestaShopLogger::addLog('PaymentModule::validateOrder - Cannot save Order Payment', 3, null, 'Cart', (int) $id_cart, true);
 
                     throw new PrestaShopException('Can\'t save Order Payment');
@@ -398,7 +398,7 @@ abstract class PaymentModuleCore extends Module
                         $message .= '<br />' . $this->trans('Warning: the secure key is empty, check your payment account before validation', [], 'Admin.Payment.Notification');
                     }
                     // Optional message to attach to this order
-                    if (isset($message) & !empty($message)) {
+                    if (!empty($message)) {
                         $msg = new Message();
                         $message = strip_tags($message, '<br>');
                         if (Validate::isCleanHtml($message)) {

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -13,13 +13,13 @@ Feature: Customer Management
       | lastName  | Napoler                    |
       | email     | napoler.dev@prestashop.com |
       | password  | PrestaShopForever1_!       |
-    Then if I query customer customer "CUST-1" I should get a Customer with properties:
+    Then if I query customer "CUST-1" I should get a Customer with properties:
       | firstName | Mathieu                    |
       | lastName  | Napoler                    |
       | email     | napoler.dev@prestashop.com |
     When I edit customer "CUST-1" and I change the following properties:
       | firstName | Jean |
-    Then if I query customer customer "CUST-1" I should get a Customer with properties:
+    Then if I query customer "CUST-1" I should get a Customer with properties:
       | firstName | Jean |
 
   Scenario: Fail to create a duplicate customer
@@ -47,7 +47,7 @@ Feature: Customer Management
       | isEnabled                 | false                     |
       | isPartnerOffersSubscribed | true                      |
       | birthday                  | 1987-02-22                |
-    Then if I query customer customer "CUST-4" I should get a Customer with properties:
+    Then if I query customer "CUST-4" I should get a Customer with properties:
       | firstName               | Mathieu                   |
       | lastName                | Polarn                    |
       | email                   | polarn.dev@prestashop.com |
@@ -62,7 +62,7 @@ Feature: Customer Management
       | defaultGroupId            | Customer   |
       | isPartnerOffersSubscribed | false      |
       | birthday                  | 1987-02-24 |
-    Then if I query customer customer "CUST-4" I should get a Customer with properties:
+    Then if I query customer "CUST-4" I should get a Customer with properties:
       | firstName            | Jean       |
       | defaultGroupId       | Customer   |
       | newsletterSubscribed | false      |
@@ -76,5 +76,5 @@ Feature: Customer Management
       | password       | PrestaShopForever1_!      |
       | defaultGroupId | Guest                     |
       | groupIds       | [Guest]                   |
-    And I delete customer "CUST-5" with method "allow_registration_after"
-    Then if I query customer customer "CUST-5" I should get an error 'Customer with id "8" was not found'
+    And I delete customer "CUST-5" with "allow registration after deletion" checked
+    Then the customer "CUST-5" should not be found

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -280,9 +280,12 @@ Feature: Order from Back Office (BO)
 
   @order-from-bo
   Scenario: Add order from Back Office with free shipping
-    And I set Free shipping to the cart "dummy_cart"
+    And I create an empty cart "dummy_cart2" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart2"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart2"
+    And I set Free shipping to the cart "dummy_cart2"
     And I add order "bo_order2" with the following details:
-      | cart                | dummy_cart          |
+      | cart                | dummy_cart2         |
       | message             | test                |
       | payment module name | dummy_payment       |
       | status              | Payment accepted    |
@@ -292,14 +295,19 @@ Feature: Order from Back Office (BO)
 
   @order-from-bo
   Scenario: Update multiple orders statuses using Bulk actions
-    And I add order "bo_order2" with the following details:
-      | cart                | dummy_cart          |
+    And I create an empty cart "dummy_cart3" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart3"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart3"
+    And I set Free shipping to the cart "dummy_cart3"
+    And I add order "bo_order3" with the following details:
+      | cart                | dummy_cart3         |
       | message             | test                |
       | payment module name | dummy_payment       |
       | status              | Payment accepted    |
-    When I update orders "bo_order1,bo_order2" statuses to "Delivered"
+    When I update orders "bo_order1,bo_order3" statuses to "Delivered"
     Then order "bo_order1" has status "Delivered"
-    And order "bo_order2" has status "Delivered"
+    Then order "bo_order2" has status "Payment accepted"
+    And order "bo_order3" has status "Delivered"
 
   @order-from-bo
   Scenario: Change order shipping address


### PR DESCRIPTION
Fix function for not using the cache and avoid the issue with duplicated orders.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | The function orderExists() from Cart.php has been modified in order to use only the cache when the order exists, avoiding the issue with duplicated orders
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17266 
| How to test?  | See #17266 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17302)
<!-- Reviewable:end -->
