### PR TITLE
Don't log bots anymore

### DIFF
--- a/classes/Connection.php
+++ b/classes/Connection.php
@@ -140,17 +140,8 @@ class ConnectionCore extends ObjectModel
     {
         if (isset($_SERVER['HTTP_USER_AGENT'])
             && preg_match('/BotLink|ahoy|AlkalineBOT|anthill|appie|arale|araneo|AraybOt|ariadne|arks|ATN_Worldwide|Atomz|bbot|Bjaaland|Ukonline|borg\-bot\/0\.9|boxseabot|bspider|calif|christcrawler|CMC\/0\.01|combine|confuzzledbot|CoolBot|cosmos|Internet Cruiser Robot|cusco|cyberspyder|cydralspider|desertrealm, desert realm|digger|DIIbot|grabber|downloadexpress|DragonBot|dwcp|ecollector|ebiness|elfinbot|esculapio|esther|fastcrawler|FDSE|FELIX IDE|ESI|fido|H�m�h�kki|KIT\-Fireball|fouineur|Freecrawl|gammaSpider|gazz|gcreep|golem|googlebot|griffon|Gromit|gulliver|gulper|hambot|havIndex|hotwired|htdig|iajabot|INGRID\/0\.1|Informant|InfoSpiders|inspectorwww|irobot|Iron33|JBot|jcrawler|Teoma|Jeeves|jobo|image\.kapsi\.net|KDD\-Explorer|ko_yappo_robot|label\-grabber|larbin|legs|Linkidator|linkwalker|Lockon|logo_gif_crawler|marvin|mattie|mediafox|MerzScope|NEC\-MeshExplorer|MindCrawler|udmsearch|moget|Motor|msnbot|muncher|muninn|MuscatFerret|MwdSearch|sharp\-info\-agent|WebMechanic|NetScoop|newscan\-online|ObjectsSearch|Occam|Orbsearch\/1\.0|packrat|pageboy|ParaSite|patric|pegasus|perlcrawler|phpdig|piltdownman|Pimptrain|pjspider|PlumtreeWebAccessor|PortalBSpider|psbot|Getterrobo\-Plus|Raven|RHCS|RixBot|roadrunner|Robbie|robi|RoboCrawl|robofox|Scooter|Search\-AU|searchprocess|Senrigan|Shagseeker|sift|SimBot|Site Valet|skymob|SLCrawler\/2\.0|slurp|ESI|snooper|solbot|speedy|spider_monkey|SpiderBot\/1\.0|spiderline|nil|suke|http:\/\/www\.sygol\.com|tach_bw|TechBOT|templeton|titin|topiclink|UdmSearch|urlck|Valkyrie libwww\-perl|verticrawl|Victoria|void\-bot|Voyager|VWbot_K|crawlpaper|wapspider|WebBandit\/1\.0|webcatcher|T\-H\-U\-N\-D\-E\-R\-S\-T\-O\-N\-E|WebMoose|webquest|webreaper|webs|webspider|WebWalker|wget|winona|whowhere|wlm|WOLP|WWWC|none|XGET|Nederland\.zoek|AISearchBot|woriobot|NetSeer|Nutch|YandexBot/i', $_SERVER['HTTP_USER_AGENT'])) {
-            // This is a bot and we have to retrieve its connection ID
-            $sql = 'SELECT SQL_NO_CACHE `id_connections` FROM `' . _DB_PREFIX_ . 'connections`
-					WHERE ip_address = ' . (int) ip2long(Tools::getRemoteAddr()) . '
-						AND `date_add` > \'' . pSQL(date('Y-m-d H:i:00', time() - 1800)) . '\'
-						' . Shop::addSqlRestriction(Shop::SHARE_CUSTOMER) . '
-					ORDER BY `date_add` DESC';
-            if ($idConnections = Db::getInstance()->getValue($sql, false)) {
-                $cookie->id_connections = (int) $idConnections;
-
-                return Page::getCurrentId();
-            }
+            // This is a bot : don't log connection
+            return false;
         }
 
         // A new connection is created if the guest made no actions during 30 minutes


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Search engine crawlers like googlebot generate a lots of traffic that is recorded as visits and page visits. This increase the traffic PKI artificially. This pr don't track bots anymore.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | it does not records anymore bots (this is a trade-off, see in comments the pros and cons)
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/13252
| How to test?  | Try to browse the site with a bot : the visit will appears in your BO. You can use "User-Agent Switcher for Chrome" and add Googlebot user agent. With this PR, bots are now ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17322)
<!-- Reviewable:end -->
