### PR TITLE
ProfileId accepts int and string as input type although int value is required

### DIFF
--- a/src/Adapter/Profile/CommandHandler/AddProfileHandler.php
+++ b/src/Adapter/Profile/CommandHandler/AddProfileHandler.php
@@ -53,6 +53,6 @@ final class AddProfileHandler implements AddProfileHandlerInterface
             throw new ProfileException('Failed to create Profile');
         }
 
-        return new ProfileId($profile->id);
+        return new ProfileId((int) $profile->id);
     }
 }

--- a/src/Core/Domain/Profile/Command/BulkDeleteProfileCommand.php
+++ b/src/Core/Domain/Profile/Command/BulkDeleteProfileCommand.php
@@ -60,7 +60,7 @@ class BulkDeleteProfileCommand
     private function setProfileIds(array $profileIds)
     {
         foreach ($profileIds as $profileId) {
-            $this->profileIds[] = new ProfileId($profileId);
+            $this->profileIds[] = new ProfileId((int) $profileId);
         }
     }
 }

--- a/src/Core/Domain/Profile/Command/DeleteProfileCommand.php
+++ b/src/Core/Domain/Profile/Command/DeleteProfileCommand.php
@@ -43,7 +43,7 @@ class DeleteProfileCommand
      */
     public function __construct($profileId)
     {
-        $this->profileId = new ProfileId($profileId);
+        $this->profileId = new ProfileId((int) $profileId);
     }
 
     /**

--- a/src/Core/Domain/Profile/Command/EditProfileCommand.php
+++ b/src/Core/Domain/Profile/Command/EditProfileCommand.php
@@ -48,7 +48,7 @@ class EditProfileCommand extends AbstractProfileCommand
     public function __construct($profileId, array $localizedNames)
     {
         parent::__construct($localizedNames);
-        $this->profileId = new ProfileId($profileId);
+        $this->profileId = new ProfileId((int) $profileId);
     }
 
     /**

--- a/src/Core/Domain/Profile/Query/GetProfileForEditing.php
+++ b/src/Core/Domain/Profile/Query/GetProfileForEditing.php
@@ -43,7 +43,7 @@ class GetProfileForEditing
      */
     public function __construct($profileId)
     {
-        $this->profileId = new ProfileId($profileId);
+        $this->profileId = new ProfileId((int) $profileId);
     }
 
     /**

--- a/src/Core/Domain/Profile/ValueObject/ProfileId.php
+++ b/src/Core/Domain/Profile/ValueObject/ProfileId.php
@@ -40,9 +40,16 @@ class ProfileId
 
     /**
      * @param int $profileId
+     *
+     * @throws ProfileException
      */
     public function __construct($profileId)
     {
+        // Strict type should be used in next major
+        if (!is_int($profileId)) {
+            @trigger_error('Invalid type, int is expected', E_STRICT);
+        }
+
         $this->setProfileId($profileId);
     }
 
@@ -56,13 +63,15 @@ class ProfileId
 
     /**
      * @param int $profileId
+     *
+     * @throws ProfileException
      */
     private function setProfileId($profileId)
     {
-        if (!is_int($profileId) || 0 >= $profileId) {
+        if ((!is_int($profileId) && !ctype_digit($profileId)) || 0 >= $profileId) {
             throw new ProfileException(sprintf('Invalid Profile id %s supplied', var_export($profileId, true)));
         }
 
-        $this->profileId = $profileId;
+        $this->profileId = (int) $profileId;
     }
 }

--- a/tests/Unit/Core/Domain/Profile/ValueObject/ProfileIdTest.php
+++ b/tests/Unit/Core/Domain/Profile/ValueObject/ProfileIdTest.php
@@ -32,15 +32,28 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\ValueObject\ProfileId;
 
 class ProfileIdTest extends TestCase
 {
-    public function testItCreatesProfileWithValidValues()
+    /**
+     * @dataProvider createsProfileWithValidValuesData
+     */
+    public function testItCreatesProfileWithValidValues($idValue)
     {
-        $profileId = new ProfileId(1);
+        $profileId = new ProfileId($idValue);
 
-        $this->assertEquals(1, $profileId->getValue());
+        $this->assertEquals((int) $idValue, $profileId->getValue());
+    }
+
+    public function createsProfileWithValidValuesData()
+    {
+        return [
+            [1],
+            [42],
+            ['1'],
+            ['51'],
+        ];
     }
 
     /**
-     * @dataProvider testItExceptionThrownWithInvalidValuesData
+     * @dataProvider exceptionThrownWithInvalidValuesData
      */
     public function testItExceptionThrownWithInvalidValues($profileId)
     {
@@ -48,7 +61,7 @@ class ProfileIdTest extends TestCase
         new ProfileId($profileId);
     }
 
-    public function testItExceptionThrownWithInvalidValuesData()
+    public function exceptionThrownWithInvalidValuesData()
     {
         return [
             ['-1'],


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Modify ProfileId so that it accepts both int and string type as input but still validates them correctly
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16899
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17331)
<!-- Reviewable:end -->
