### PR TITLE
Order: avoid Notice error in case of missing state with PHP 7.4+

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -952,11 +952,11 @@ class OrderCore extends ObjectModel
         }
 
         foreach ($res as $key => $val) {
-            // In case order creation crashed midway some data might be absent
+            // In case state is hidden or order creation crashed midway some data might be absent
             $orderState = !empty($val['id_order_state']) ? $indexedOrderStates[$val['id_order_state']] : null;
-            $res[$key]['order_state'] = $orderState['name'] ?: null;
-            $res[$key]['invoice'] = $orderState['invoice'] ?: null;
-            $res[$key]['order_state_color'] = $orderState['color'] ?: null;
+            $res[$key]['order_state'] = !empty($orderState['name']) ? $orderState['name'] : null;
+            $res[$key]['invoice'] = !empty($orderState['invoice']) ? $orderState['invoice'] : null;
+            $res[$key]['order_state_color'] = !empty($orderState['color']) ? $orderState['color'] : null;
         }
 
         return $res;


### PR DESCRIPTION
```
Starting with PHP 7.4 code like null['foo'] causes a notice error.
```

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix PHP 7.4 notice caused by PHP backward incompatible change, see:https://www.php.net/manual/en/migration74.incompatible.php ("Array-style access of non-arrays"). It's not allowed to use `null['foo']` anymore.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13838 [ContextErrorException while hide the only order state associate to an order](https://github.com/PrestaShop/PrestaShop/issues/13838).
| How to test?  | Open orders history page in FO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17337)
<!-- Reviewable:end -->
