### PR TITLE
Classic Theme : enable some hooks for BlockReassurance

### DIFF
--- a/themes/classic/config/theme.yml
+++ b/themes/classic/config/theme.yml
@@ -55,6 +55,10 @@ global_settings:
      - ps_linklist
   hooks:
     modules_to_hook:
+      displayAfterBodyOpeningTag:
+        - blockreassurance
+      displayNavFullWidth:
+        - blockreassurance
       displayNav1:
         - ps_contactinfo
       displayNav2:
@@ -71,12 +75,15 @@ global_settings:
         - ps_banner
         - ps_customtext
       displayFooterBefore:
+        - blockreassurance
         - ps_emailsubscription
         - ps_socialfollow
       displayFooter:
         - ps_linklist
         - ps_customeraccountlinks
         - ps_contactinfo
+      displayFooterAfter:
+        - blockreassurance
       displayLeftColumn:
         - ps_categorytree
         - ps_facetedsearch


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When you have a fresh install with BlockReassurance, only two hooks have been enabled
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17278
| How to test?  | **Before the patch**<br>When you execute this request : `SELECT ps_module.*, ps_hook.* FROM ps_hook_module INNER JOIN ps_module ON ps_hook_module.id_module = ps_module.id_module INNER JOIN ps_hook ON ps_hook_module.id_hook = ps_hook.id_hook WHERE ps_module.name="blockreassurance"`<br><br>> You have only two hooks<br>![image](https://user-images.githubusercontent.com/1533248/73084685-b68af800-3ecd-11ea-8b8e-183e670ad115.png)<br><br>**After the patch**<br>When you execute the request<br><br>> You have six hooks<br>![image](https://user-images.githubusercontent.com/1533248/73084619-8fccc180-3ecd-11ea-91a7-872876a3e479.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17349)
<!-- Reviewable:end -->
