### PR TITLE
Display error alert if editing order products in BO fails

### DIFF
--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -754,6 +754,9 @@ function init()
 					} else {
             jAlert(data.error);
           }
+				},
+				error: function(jqXHR, textStatus, errorThrown) {
+					jAlert('TECHNICAL ERROR:\n\nDetails:\n\nText status: ' + textStatus + '\n\nError thrown: ' + errorThrown + '\n\nResponse text:\n' + jqXHR.responseText);
 				}
 			});
 		}
@@ -820,6 +823,9 @@ function init()
 				}
 				else
 					jAlert(data.error);
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				jAlert('TECHNICAL ERROR:\n\nDetails:\n\nText status: ' + textStatus + '\n\nError thrown: ' + errorThrown + '\n\nResponse text:\n' + jqXHR.responseText);
 			}
 		});
 		e.preventDefault();


### PR DESCRIPTION
```
Both actions: editProductOnOrder and deleteProductLine may fail. If that
happens it's important for user experience & debugging purposes to
display error alert.
```

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In some corer cases database may get corrupted (e.g. due to bugs in code). Example: #17347. If that happens AJAX requests may fail and AJAX response may differ from what is expected (e.g. `editProductOnOrder` and `deleteProductLine`). It's important then to report a problem so it can be noticed/reported/debugged.<br>There are already few JavaScript files reporting `TECHNICAL ERROR`s like this.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | This doesn't **fix** any real bug. It **improves** BO behavior when dealing with bugs like #17347
| How to test?  | On your **experimental** shop execute<br>`UPDATE orders SET total_paid = 1 WHERE 0;`<br>(remove that `WHERE 0` to make it work), open any order in BO and try to delete a single product from it. Delete action should fail & you should see error alert.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17354)
<!-- Reviewable:end -->
