### PR TITLE
Orders: don't force changing deleted carrier when editing shipping in BO

### DIFF
--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -429,7 +429,16 @@ $(document).ready(function() {
 
     $('#id_order_carrier').val($(this).data('id-order-carrier'));
     $('#shipping_tracking_number').val($(this).data('tracking-number'));
-    $('#shipping_carrier option[value='+$(this).data('id-carrier')+']').prop('selected', true);
+
+    var keep_selected = $('#shipping_carrier option[value=-1]');
+    var selected = $('#shipping_carrier option[value=' + $(this).data('id-carrier') + ']');
+    if (selected.length) {
+      keep_selected.remove();
+    } else {
+      keep_selected.attr('value', $(this).data('id-carrier'));
+      selected = keep_selected;
+    }
+    selected.prop('selected', true);
 
     $('#modal-shipping').modal();
   });

--- a/admin-dev/themes/default/template/controllers/orders/_shipping.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_shipping.tpl
@@ -109,6 +109,7 @@
 								<div class="col-lg-5">{l s='Carrier' d='Admin.Shipping.Feature'}</div>
 								<div class="col-lg-7">
 									<select name="shipping_carrier" id="shipping_carrier">
+										<option value="-1">[{l s='Keep selected carrier' d='Admin.Orderscustomers.Feature'}]</option>
 										{foreach from=$carrier_list item=carrier}
 											<option value="{$carrier.id_carrier|intval}">{$carrier.name|escape:'html':'UTF-8'} {if isset($carrier.delay)}({$carrier.delay|escape:'html':'UTF-8'}){/if}</option>
 										{/foreach}


### PR DESCRIPTION
```
BO user may want to edit shipping info e.g. to add tracking number.
PrestaShop should not require user to change carrier that has been
deleted meanwhile. It may still be valid for an order.
```

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Adding tracking number to existing order is a very common use case. It may happen carrier has been deleted/edited meanwhile. If that happens BO should still allow adding tracking number **without* forcing BO user to select a new carrier.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17355
| How to test?  | 1. FO: Add new order<br>2. BO: Modify or delete carrier used by customer (in step 1)<br>3. BO: Open order and click "Edit" in shipping carrier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17357)
<!-- Reviewable:end -->
