### PR TITLE
Add transactions support to Db and use them when moving carrier

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -203,6 +203,27 @@ abstract class DbCore
     abstract public function getBestEngine();
 
     /**
+     * Initiates a new transaction.
+     *
+     * @return bool
+     */
+    abstract public function beginTransaction();
+
+    /**
+     * Commits a transaction.
+     *
+     * @return bool
+     */
+    abstract public function commit();
+
+    /**
+     * Rolls back a transaction.
+     *
+     * @return bool
+     */
+    abstract public function rollBack();
+
+    /**
      * Returns database object instance.
      *
      * @param bool $master Decides whether the connection to be returned by the master server or the slave server

--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -390,6 +390,36 @@ class DbMySQLiCore extends Db
     }
 
     /**
+     * Initiates a new transaction.
+     *
+     * @return bool
+     */
+    public function beginTransaction()
+    {
+        return $this->link->autocommit(false);
+    }
+
+    /**
+     * Commits a transaction.
+     *
+     * @return bool
+     */
+    public function commit()
+    {
+        return $this->link->commit() && $this->link->autocommit(true);
+    }
+
+    /**
+     * Rolls back a transaction.
+     *
+     * @return bool
+     */
+    public function rollBack()
+    {
+	return $this->link->rollback() && $this->link->autocommit(true);
+    }
+
+    /**
      * Tries to connect to the database and create a table (checking creation privileges).
      *
      * @param string $server

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -451,6 +451,36 @@ class DbPDOCore extends Db
     }
 
     /**
+     * Initiates a new transaction.
+     *
+     * @return bool
+     */
+    public function beginTransaction()
+    {
+        return $this->link->beginTransaction();
+    }
+
+    /**
+     * Commits a transaction.
+     *
+     * @return bool
+     */
+    public function commit()
+    {
+        return $this->link->commit();
+    }
+
+    /**
+     * Rolls back a transaction.
+     *
+     * @return bool
+     */
+    public function rollBack()
+    {
+        return $this->link->rollBack();
+    }
+
+    /**
      * Try a connection to the database and set names to UTF-8.
      *
      * @see Db::checkEncoding()

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2125,6 +2125,8 @@ class AdminOrdersControllerCore extends AdminController
         // Total method
         $total_method = Cart::BOTH_WITHOUT_SHIPPING;
 
+        Db::getInstance()->beginTransaction();
+
         // Create new cart
         $cart = new Cart();
         $cart->id_shop_group = $order->id_shop_group;
@@ -2420,6 +2422,8 @@ class AdminOrdersControllerCore extends AdminController
         // Update Order
         $res &= $order->update();
 
+        Db::getInstance()->commit();
+
         die(json_encode([
             'result' => true,
             'view' => $this->createTemplate('_product_line.tpl')->fetch(),
@@ -2491,6 +2495,8 @@ class AdminOrdersControllerCore extends AdminController
 
         // Check fields validity
         $this->doEditProductValidation($order_detail, $order, isset($order_invoice) ? $order_invoice : null);
+
+        Db::getInstance()->beginTransaction();
 
         // If multiple product_quantity, the order details concern a product customized
         $product_quantity = 0;
@@ -2595,6 +2601,8 @@ class AdminOrdersControllerCore extends AdminController
         // Update product available quantity
         StockAvailable::updateQuantity($order_detail->product_id, $order_detail->product_attribute_id, ($old_quantity - $order_detail->product_quantity), $order->id_shop);
 
+        Db::getInstance()->commit();
+
         $products = $this->getProducts($order);
         // Get the last product
         $product = $products[$order_detail->id];
@@ -2689,6 +2697,8 @@ class AdminOrdersControllerCore extends AdminController
 
         $this->doDeleteProductLineValidation($order_detail, $order);
 
+        Db::getInstance()->beginTransaction();
+
         // Update OrderInvoice of this OrderDetail
         if ($order_detail->id_order_invoice != 0) {
             $order_invoice = new OrderInvoice($order_detail->id_order_invoice);
@@ -2710,6 +2720,8 @@ class AdminOrdersControllerCore extends AdminController
 
         // Reinject quantity in stock
         $this->reinjectQuantity($order_detail, $order_detail->product_quantity, true);
+
+        Db::getInstance()->commit();
 
         // Update weight SUM
         $order_carrier = new OrderCarrier((int) $order->getIdOrderCarrier());


### PR DESCRIPTION
```
Carrier: use transaction when moving carrier

It's required to keep database in consistent state if a later query
fails for whatever reason. As much as it's unlikely in this simple case
it's still a good practice and provides an example of using
transactions.
```
```
Db: add support for SQL transactions

Transactions should be used when executing multiple related queries.
They are required to keep database in consistent state in case of any
errors.

MySQL supports transactions only when using InnoDB however this code is
safe even for MyISAM. PHP "checks for transaction capabilities" for a
given driver only. So this code won't cause exception on MyISAM (it'll
just do nothing).

Ref: https://www.php.net/manual/en/pdo.transactions.php
```

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | All related database change queries should be executed in a single transaction. This way we make sure database won't get in inconsistent state if processing fails at some point.<br>This Pull Request adds transaction support to `Db` API and uses it when moving carrier. PrestaShop code should be updated incrementally to use transactions in all critical actions.
| Type?         | bug fix / improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Those changes are **inspired** by my problems with **orders** inconsistenty as reported in the [#17347](https://github.com/PrestaShop/PrestaShop/issues/17347). As this point I focused on moving carrier though (to start with something simple).
| How to test?  | Navigate to Carrier & make sure carriers can be moved up/down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17360)
<!-- Reviewable:end -->
