### PR TITLE
Show product customizations in the order BO page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
+++ b/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
@@ -73,6 +73,7 @@ export default {
   productsTableRowEdited: productId => `#editOrderProduct_${productId}`,
   productsCellLocation: 'tr .cellProductLocation',
   productsCellLocationDisplayed: 'tr:not(.d-none) .cellProductLocation',
+  productsTableCustomizationRows: '#orderProductsTable .order-product-customization',
   productEditBtn: '.js-order-product-edit-btn',
   productAddBtn: '#addProductBtn',
   productActionBtn: '.js-product-action-btn',

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
@@ -128,6 +128,7 @@ export default class OrderProductRenderer {
 
   paginate(numPage) {
     const $rows = $(OrderViewPageMap.productsTable).find('tr[id^="orderProduct_"]');
+    const $customizationRows = $(OrderViewPageMap.productsTable).find('.order-product-customization');
     const $tablePagination = $(OrderViewPageMap.productsTablePagination);
     const numRowsPerPage = parseInt($tablePagination.data('numPerPage'), 10);
     const maxPage = Math.ceil($rows.length / numRowsPerPage);
@@ -136,12 +137,19 @@ export default class OrderProductRenderer {
 
     // Hide all rows...
     $rows.addClass('d-none');
+    $customizationRows.addClass('d-none');
     // ... and display good ones
 
     const startRow = ((numPage - 1) * numRowsPerPage) + 1;
-    const endRow = numPage * numRowsPerPage + 1;
+    const endRow = numPage * numRowsPerPage;
     $(OrderViewPageMap.productsTable).find(`tr[id^="orderProduct_"]:nth-child(n+${startRow}):nth-child(-n+${endRow})`)
         .removeClass('d-none');
+    $customizationRows.each(function () {
+      if (!$(this).prev().hasClass('d-none')) {
+        $(this).removeClass('d-none');
+      }
+    });
+
     // Remove all edition rows (careful not to remove the template)
     $(OrderViewPageMap.productEditRow).not(OrderViewPageMap.productEditRowTemplate).remove();
 

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
@@ -128,7 +128,7 @@ export default class OrderProductRenderer {
 
   paginate(numPage) {
     const $rows = $(OrderViewPageMap.productsTable).find('tr[id^="orderProduct_"]');
-    const $customizationRows = $(OrderViewPageMap.productsTable).find('.order-product-customization');
+    const $customizationRows = $(OrderViewPageMap.productsTableCustomizationRows);
     const $tablePagination = $(OrderViewPageMap.productsTablePagination);
     const numRowsPerPage = parseInt($tablePagination.data('numPerPage'), 10);
     const maxPage = Math.ceil($rows.length / numRowsPerPage);

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-view-page.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-view-page.js
@@ -48,7 +48,12 @@ export default class OrderViewPage {
   listenToEvents() {
     EventEmitter.on(OrderViewEventMap.productDeletedFromOrder, (event) => {
       // Remove the row
-      $(OrderViewPageMap.productsTableRow(event.oldOrderDetailId)).remove();
+      const $row = $(OrderViewPageMap.productsTableRow(event.oldOrderDetailId));
+      const $next = $row.next();
+      $row.remove();
+      if ($next.hasClass('order-product-customization')) {
+        $next.remove();
+      }
 
       const $tablePagination = $(OrderViewPageMap.productsTablePagination);
       let numPages = $tablePagination.data('numPages');

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 
 use Configuration;
+use Customization;
 use Hook;
 use Order;
 use OrderCarrier;
@@ -64,18 +65,11 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
         // Check fields validity
         $this->assertProductCanBeUpdated($command, $orderDetail, $order, $orderInvoice);
 
-        // @todo: check if quantity can be array
-        // If multiple product_quantity, the order details concern a product customized
-//        $product_quantity = 0;
-//        if (is_array(Tools::getValue('product_quantity'))) {
-//            foreach (Tools::getValue('product_quantity') as $id_customization => $qty) {
-//                // Update quantity of each customization
-//                Db::getInstance()->update('customization', array('quantity' => (int)$qty), 'id_customization = ' . (int)$id_customization);
-//                // Calculate the real quantity of the product
-//                $product_quantity += $qty;
-//            }
-//        }
-
+        if (0 < $orderDetail->id_customization) {
+            $customization = new Customization($orderDetail->id_customization);
+            $customization->quantity = $command->getQuantity();
+            $customization->save();
+        }
         $product_quantity = $command->getQuantity();
 
         // @todo: use https://github.com/PrestaShop/decimal for price computations

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -66,6 +66,8 @@ use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderMessagesForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderPaymentForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderPaymentsForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderPricesForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductCustomizationForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductCustomizationsForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductsForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderReturnForViewing;
@@ -346,14 +348,21 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
             // Get total customized quantity for current product
             $customized_product_quantity = 0;
 
+            $customizations = [];
             if (is_array($product['customizedDatas'])) {
                 foreach ($product['customizedDatas'] as $customizationPerAddress) {
                     foreach ($customizationPerAddress as $customizationId => $customization) {
                         $customized_product_quantity += (int) $customization['quantity'];
+                        foreach ($customization['datas'] as $datas) {
+                            foreach ($datas as $data) {
+                                $customizations[] = new OrderProductCustomizationForViewing((int) $data['type'], $data['name'], $data['value']);
+                            }
+                        }
                     }
                 }
             }
 
+            $product['customizations'] = !empty($customizations) ? new OrderProductCustomizationsForViewing($customizations) : null;
             $product['customized_product_quantity'] = $customized_product_quantity;
             $product['current_stock'] = StockAvailable::getQuantityAvailableByProduct($product['product_id'], $product['product_attribute_id'], $product['id_shop']);
             $product['quantity_refundable'] = $product['product_quantity'] - $product['product_quantity_return'] - $product['product_quantity_refunded'];
@@ -500,7 +509,8 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
                 !empty($product['id_order_invoice']) ? $product['id_order_invoice'] : null,
                 !empty($product['id_order_invoice']) ? $orderInvoice->getInvoiceNumberFormatted($order->id_lang) : '',
                 $productType,
-                $packItems
+                $packItems,
+                $product['customizations']
             );
         }
 

--- a/src/Core/Domain/Order/QueryResult/OrderProductCustomizationForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductCustomizationForViewing.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\QueryResult;
+
+use PrestaShop\PrestaShop\Adapter\Entity\Product;
+
+class OrderProductCustomizationForViewing
+{
+    /**
+     * @var int
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @var string
+     */
+    private $image;
+
+    /**
+     * @param int $type
+     * @param string $name
+     * @param string $value
+     */
+    public function __construct(int $type, string $name, string $value)
+    {
+        $this->type = $type;
+        $this->name = $name;
+        $this->value = $value;
+        if (Product::CUSTOMIZE_FILE === $this->type) {
+            $this->image = _THEME_PROD_PIC_DIR_ . $this->value . '_small';
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getType(): int
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getImage(): ?string
+    {
+        return $this->image;
+    }
+}

--- a/src/Core/Domain/Order/QueryResult/OrderProductCustomizationsForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductCustomizationsForViewing.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\QueryResult;
+
+use PrestaShop\PrestaShop\Adapter\Entity\Product;
+
+class OrderProductCustomizationsForViewing
+{
+    /**
+     * @var OrderProductCustomizationForViewing[]
+     */
+    private $textCustomizations = [];
+
+    /**
+     * @var OrderProductCustomizationForViewing[]
+     */
+    private $fileCustomizations = [];
+
+    /**
+     * @param OrderProductCustomizationForViewing[] $customizations
+     */
+    public function __construct(array $customizations)
+    {
+        foreach ($customizations as $customization) {
+            $this->addCustomization($customization);
+        }
+    }
+
+    /**
+     * @param OrderProductCustomizationForViewing $customization
+     */
+    private function addCustomization(OrderProductCustomizationForViewing $customization): void
+    {
+        if (Product::CUSTOMIZE_FILE === $customization->getType()) {
+            $this->fileCustomizations[] = $customization;
+        } else {
+            $this->textCustomizations[] = $customization;
+        }
+    }
+
+    /**
+     * Returns customizations of type FILE
+     *
+     * @return OrderProductCustomizationForViewing[]
+     */
+    public function getFileCustomizations(): array
+    {
+        return $this->fileCustomizations;
+    }
+
+    /**
+     * Returns customizations of type TEXT
+     *
+     * @return OrderProductCustomizationForViewing[]
+     */
+    public function getTextCustomizations(): array
+    {
+        return $this->textCustomizations;
+    }
+}

--- a/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
@@ -145,6 +145,11 @@ class OrderProductForViewing implements JsonSerializable
     private $orderInvoiceNumber;
 
     /**
+     * @var OrderProductCustomizationsForViewing
+     */
+    private $customizations;
+
+    /**
      * @param int $orderDetailId
      * @param int $id
      * @param string $name
@@ -188,7 +193,8 @@ class OrderProductForViewing implements JsonSerializable
         ?int $orderInvoiceId,
         string $orderInvoiceNumber,
         string $type,
-        array $packItems = []
+        array $packItems = [],
+        ?OrderProductCustomizationsForViewing $customizations = null
     ) {
         $this->id = $id;
         $this->name = $name;
@@ -212,6 +218,7 @@ class OrderProductForViewing implements JsonSerializable
         $this->orderInvoiceNumber = $orderInvoiceNumber;
         $this->type = $type;
         $this->packItems = $packItems;
+        $this->customizations = $customizations;
     }
 
     /**
@@ -452,6 +459,16 @@ class OrderProductForViewing implements JsonSerializable
     public function getOrderInvoiceNumber(): string
     {
         return $this->orderInvoiceNumber;
+    }
+
+    /**
+     * Get the customizations of this product
+     *
+     * @return OrderProductCustomizationsForViewing
+     */
+    public function getCustomizations(): ?OrderProductCustomizationsForViewing
+    {
+        return $this->customizations;
     }
 
     /**

--- a/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
@@ -462,9 +462,9 @@ class OrderProductForViewing implements JsonSerializable
     }
 
     /**
-     * Get the customizations of this product
+     * Get customizations of this product
      *
-     * @return OrderProductCustomizationsForViewing
+     * @return OrderProductCustomizationsForViewing|null
      */
     public function getCustomizations(): ?OrderProductCustomizationsForViewing
     {

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -22,7 +22,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *#}
-<tr id="orderProduct_{{ product.orderDetailId }}"{% if productIndex is defined and paginationNum is defined and productIndex > paginationNum %} class="d-none"{% endif %}>
+{% set rowIsDisplayed =  (productIndex is defined and paginationNum is defined and productIndex > paginationNum) %}
+<tr id="orderProduct_{{ product.orderDetailId }}"{% if rowIsDisplayed %} class="d-none"{% endif %}>
   <td class="cellProductImg">
     {% if product.imagePath %}
       <img src="{{ product.imagePath }}" alt="{{ product.name }}" />
@@ -140,22 +141,18 @@
   </td>
 </tr>
 {% if product.customizations is not null %}
-  <tr class="order-product-customization{% if productIndex is defined and paginationNum is defined and productIndex > paginationNum %} d-none{% endif %}">
+  <tr class="order-product-customization{% if rowIsDisplayed %} d-none{% endif %}">
     <td class="border-top-0"></td>
     {% set colspan = 8 %}
-    {% if orderForViewing.hasInvoice() %}
-      {% set colspan = colspan + 1 %}
-    {% endif %}
-    {% if not orderForViewing.delivered %}
-      {% set colspan = colspan + 1 %}
-    {% endif %}
+    {% set colspan = (orderForViewing.hasInvoice() ? colspan + 1 : colspan) %}
+    {% set colspan = (not orderForViewing.delivered ? colspan + 1 : colspan) %}
     <td colspan="{{ colspan }}" class="border-top-0 text-muted">
       {% if product.customizations.fileCustomizations %}
         <div class="d-flex flex-row flex-wrap">
           {% for customization in product.customizations.fileCustomizations %}
             <div class="mr-4">
               <p><strong>{{ customization.name }}</strong></p>
-              <p><img src="{{ customization.image }}" alt=""></p>
+              <p><img src="{{ customization.image }}" alt="{{ customization.name }}"></p>
             </div>
           {% endfor %}
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -46,7 +46,7 @@
     </a>
     {% if product.type == constant('PrestaShop\\PrestaShop\\Core\\Domain\\Order\\QueryResult\\OrderProductForViewing::TYPE_PACK') and product.customizations is null %}
       <span class="btn-product-pack-modal" data-toggle="modal" data-target="#product-pack-modal" data-pack-items="{{ product.packItems|json_encode }}">
-        <strong>{{ 'View pack content'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+        <strong>{{ 'View pack content'|trans({}, 'Admin.Actions') }}</strong>
       </span>
     {% endif %}
   </td>
@@ -165,7 +165,7 @@
       {% endfor %}
       {% if product.type == constant('PrestaShop\\PrestaShop\\Core\\Domain\\Order\\QueryResult\\OrderProductForViewing::TYPE_PACK') %}
         <div class="btn-product-pack-modal mb-3" data-toggle="modal" data-target="#product-pack-modal" data-pack-items="{{ product.packItems|json_encode }}">
-          <strong>{{ 'View pack content'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+          <strong>{{ 'View pack content'|trans({}, 'Admin.Actions') }}</strong>
         </div>
       {% endif %}
     </td>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -44,7 +44,7 @@
         </p>
       {% endif %}
     </a>
-    {% if product.type == constant('PrestaShop\\PrestaShop\\Core\\Domain\\Order\\QueryResult\\OrderProductForViewing::TYPE_PACK') %}
+    {% if product.type == constant('PrestaShop\\PrestaShop\\Core\\Domain\\Order\\QueryResult\\OrderProductForViewing::TYPE_PACK') and product.customizations is null %}
       <span class="btn-product-pack-modal" data-toggle="modal" data-target="#product-pack-modal" data-pack-items="{{ product.packItems|json_encode }}">
         <strong>{{ 'View pack content'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
       </span>
@@ -139,3 +139,35 @@
     </div>
   </td>
 </tr>
+{% if product.customizations is not null %}
+  <tr class="order-product-customization{% if productIndex is defined and paginationNum is defined and productIndex > paginationNum %} d-none{% endif %}">
+    <td class="border-top-0"></td>
+    {% set colspan = 8 %}
+    {% if orderForViewing.hasInvoice() %}
+      {% set colspan = colspan + 1 %}
+    {% endif %}
+    {% if not orderForViewing.delivered %}
+      {% set colspan = colspan + 1 %}
+    {% endif %}
+    <td colspan="{{ colspan }}" class="border-top-0 text-muted">
+      {% if product.customizations.fileCustomizations %}
+        <div class="d-flex flex-row flex-wrap">
+          {% for customization in product.customizations.fileCustomizations %}
+            <div class="mr-4">
+              <p><strong>{{ customization.name }}</strong></p>
+              <p><img src="{{ customization.image }}" alt=""></p>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+      {% for customization in product.customizations.textCustomizations %}
+        <p><strong>{{ customization.name }}</strong> {{ customization.value }}</p>
+      {% endfor %}
+      {% if product.type == constant('PrestaShop\\PrestaShop\\Core\\Domain\\Order\\QueryResult\\OrderProductForViewing::TYPE_PACK') %}
+        <div class="btn-product-pack-modal mb-3" data-toggle="modal" data-target="#product-pack-modal" data-pack-items="{{ product.packItems|json_encode }}">
+          <strong>{{ 'View pack content'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+        </div>
+      {% endif %}
+    </td>
+  </tr>
+{% endif %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Shows the customized data of a customizable product in the migrated order page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16389
| How to test?  | In the FO, order a customizable product. In the BO, in the migrated order page, open the corresponding order. You should be able to see the custom data right under the product. **You should rebuild the assets before testing**

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17381)
<!-- Reviewable:end -->
