### PR TITLE
Do not force the npm to be updated in the build.sh file

### DIFF
--- a/tools/assets/build.sh
+++ b/tools/assets/build.sh
@@ -30,9 +30,6 @@ function build {
   popd
 }
 
-echo ">>> Make sur you have the latest npm version"
-npm install -g npm
-
 echo ">>> Building admin default theme..."
 build "$ADMIN_DIR/themes/default"
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you install `npm` via `apt` or `yum` the script `./tools/assets/build.sh` will not working because of sudo requirements. This step shouldn't be mandatory to build assets.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | QA not needed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17389)
<!-- Reviewable:end -->
