### PR TITLE
Can't explore a category when all subcats are disabled

### DIFF
--- a/src/Adapter/Grid/Action/Row/AccessibilityChecker/CategoryForViewAccessibilityChecker.php
+++ b/src/Adapter/Grid/Action/Row/AccessibilityChecker/CategoryForViewAccessibilityChecker.php
@@ -54,8 +54,6 @@ final class CategoryForViewAccessibilityChecker implements AccessibilityCheckerI
      */
     public function isGranted(array $category)
     {
-        $categoryChildren = Category::getChildren($category['id_category'], $this->contextLangId);
-
-        return !empty($categoryChildren);
+        return Category::hasChildren($category['id_category'], $this->contextLangId, false);
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | When all subcategories from a parent are disabled then it's imposible to explore the parent again.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/17379
| How to test?  | Steps to reproduce the behavior:<br><br>Go to Catalog / Categories<br>Create new category<br>Create a new subcategory with parent category equals the previous created category.<br>Edit the last new category and set it to disabled.<br>Go to main list, then it's imposible to enter the in the "view" of the parent category, list only allows to edit it but it is not possible to explore the disabled subcategory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17395)
<!-- Reviewable:end -->
