### PR TITLE
Fix reversed product sorting

### DIFF
--- a/src/Core/Product/Search/SortOrdersCollection.php
+++ b/src/Core/Product/Search/SortOrdersCollection.php
@@ -51,7 +51,7 @@ final class SortOrdersCollection
     public function getDefaults()
     {
         return [
-            (new SortOrder('product', 'position', 'desc'))->setLabel(
+            (new SortOrder('product', 'position', 'asc'))->setLabel(
                 $this->translator->trans('Relevance', [], 'Shop.Theme.Catalog')
             ),
             (new SortOrder('product', 'name', 'asc'))->setLabel(


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Product sorting (by position) is reversed when `ps_facetedsearch` module is disabled. Parameter in URL is `?order=product.position.desc` instead of `?order=product.position.asc`
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17400
| How to test?  | Steps to reproduce the behavior:<br>1. Disable module `ps_facetedsearch`<br>2. Go on category page<br>3. Sort by : **Name, A to Z**<br>4. Sort by : **Relevance**<br>5. **Before :** See reversed product sorting<br>5. **After :** See well product sorting
| Sponsor company | @Creabilis
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17401)
<!-- Reviewable:end -->
