### PR TITLE
Fix order creation bug due to wrong computing precision

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -284,7 +284,10 @@ abstract class PaymentModuleCore extends Module
 
             $this->currentOrderReference = $reference;
 
-            $cart_total_paid = (float) Tools::ps_round((float) $this->context->cart->getOrderTotal(true, Cart::BOTH), 2);
+            $cart_total_paid = (float) Tools::ps_round(
+                (float) $this->context->cart->getOrderTotal(true, Cart::BOTH),
+                Context::getContext()->getComputingPrecision()
+            );
 
             foreach ($cart_delivery_option as $id_address => $key_carriers) {
                 foreach ($delivery_option_list[$id_address][$key_carriers]['carrier_list'] as $id_carrier => $data) {
@@ -424,7 +427,7 @@ abstract class PaymentModuleCore extends Module
                         $price = Product::getPriceStatic((int) $product['id_product'], false, ($product['id_product_attribute'] ? (int) $product['id_product_attribute'] : null), 6, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, null, true, $product['id_customization']);
                         $price_wt = Product::getPriceStatic((int) $product['id_product'], true, ($product['id_product_attribute'] ? (int) $product['id_product_attribute'] : null), 2, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, null, true, $product['id_customization']);
 
-                        $product_price = Product::getTaxCalculationMethod() == PS_TAX_EXC ? Tools::ps_round($price, 2) : $price_wt;
+                        $product_price = Product::getTaxCalculationMethod() == PS_TAX_EXC ? Tools::ps_round($price, Context::getContext()->getComputingPrecision()) : $price_wt;
 
                         $product_var_tpl = [
                             'id_product' => $product['id_product'],


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix wrong amount computing precision, it made some order creation go wrong, setting the "payment error" status because compared values were not rounded in the same way.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | Fixes #16871
| How to test?  | On a prestashop store with default demo products: <br>**1/** Go on order creation PAGE in the BO<br>**2/** select a customer, select the product **T-shirt imprimé colibri - Size : S**<br>**3/** Select the status "shipped"<br>**4** create the order<br>**5/** Check that the order doesn't have the "payment error" status, it should be green.<br><br>Note that It is important to test with the specified product, without having changed its price: 22,94 euros Tax Included.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17404)
<!-- Reviewable:end -->
