### PR TITLE
Check if category is associated to the current shop

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -85,7 +85,7 @@ class CategoryControllerCore extends ProductListingFrontController
             $this->context->language->id
         );
 
-        if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
+        if (!Validate::isLoadedObject($this->category) || !$this->category->active || !$this->category->inShop() || !$this->category->isAssociatedToShop()) {
             Tools::redirect('index.php?controller=404');
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix check if category is associated to the shop
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Try to access to a category via its URL. <br>**Before :** Category shows without PR (NOK)<br>**After :** 404 with this PR (OK)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17408)
<!-- Reviewable:end -->
