### PR TITLE
Delete free shipping voucher after creating an order on BO

### DIFF
--- a/src/Adapter/Cart/CommandHandler/SetFreeShippingToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/SetFreeShippingToCartHandler.php
@@ -26,11 +26,14 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Cart\CommandHandler;
 
+use Cart;
 use CartRule;
 use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\SetFreeShippingToCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\SetFreeShippingToCartHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\CannotDeleteCartRuleException;
+use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\CartRuleException;
 use PrestaShopException;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -70,32 +73,23 @@ final class SetFreeShippingToCartHandler extends AbstractCartHandler implements 
 
         $freeShippingCartRule = $this->getCartRuleForBackOfficeFreeShipping($backOfficeOrderCode);
 
-        if (null === $freeShippingCartRule) {
-            $freeShippingCartRule = new CartRule();
-            $freeShippingCartRule->code = $backOfficeOrderCode;
-            $freeShippingCartRule->name = [
-                $this->configuration->get('PS_LANG_DEFAULT') => $this->translator->trans(
-                    'Free Shipping',
-                    [],
-                    'Admin.Orderscustomers.Feature'
-                ),
-            ];
-            $freeShippingCartRule->id_customer = (int) $cart->id_customer;
-            $freeShippingCartRule->free_shipping = true;
-            $freeShippingCartRule->quantity = 1;
-            $freeShippingCartRule->quantity_per_user = 1;
-            $freeShippingCartRule->minimum_amount_currency = (int) $cart->id_currency;
-            $freeShippingCartRule->reduction_currency = (int) $cart->id_currency;
-            $freeShippingCartRule->date_from = date('Y-m-d H:i:s');
-            $freeShippingCartRule->date_to = date('Y-m-d H:i:s', time() + 24 * 36000);
-            $freeShippingCartRule->active = 1;
-            $freeShippingCartRule->add();
+        if ($command->allowFreeShipping()) {
+            if (null === $freeShippingCartRule) {
+                $freeShippingCartRule = $this->createCartRule($cart, $backOfficeOrderCode);
+            }
+            $cart->addCartRule((int) $freeShippingCartRule->id);
+
+            return;
         }
 
         $cart->removeCartRule((int) $freeShippingCartRule->id);
 
-        if ($command->allowFreeShipping()) {
-            $cart->addCartRule((int) $freeShippingCartRule->id);
+        try {
+            if (false === $freeShippingCartRule->delete()) {
+                throw new CannotDeleteCartRuleException(sprintf('Failed deleting cart rule #%s', $freeShippingCartRule->id));
+            }
+        } catch (PrestaShopException $e) {
+            throw new CartRuleException(sprintf('An error occurred when trying to delete cart rule #%s', $freeShippingCartRule->id));
         }
     }
 
@@ -115,5 +109,30 @@ final class SetFreeShippingToCartHandler extends AbstractCartHandler implements 
         }
 
         return new CartRule((int) $cartRuleId);
+    }
+
+    private function createCartRule(Cart $cart, string $backOfficeOrderCode): CartRule
+    {
+        $freeShippingCartRule = new CartRule();
+        $freeShippingCartRule->code = $backOfficeOrderCode;
+        $freeShippingCartRule->name = [
+            $this->configuration->get('PS_LANG_DEFAULT') => $this->translator->trans(
+                'Free Shipping',
+                [],
+                'Admin.Orderscustomers.Feature'
+            ),
+        ];
+        $freeShippingCartRule->id_customer = (int) $cart->id_customer;
+        $freeShippingCartRule->free_shipping = true;
+        $freeShippingCartRule->quantity = 1;
+        $freeShippingCartRule->quantity_per_user = 1;
+        $freeShippingCartRule->minimum_amount_currency = (int) $cart->id_currency;
+        $freeShippingCartRule->reduction_currency = (int) $cart->id_currency;
+        $freeShippingCartRule->date_from = date('Y-m-d H:i:s');
+        $freeShippingCartRule->date_to = date('Y-m-d H:i:s', time() + 24 * 36000);
+        $freeShippingCartRule->active = 1;
+        $freeShippingCartRule->add();
+
+        return $freeShippingCartRule;
     }
 }

--- a/src/Core/Domain/CartRule/Exception/CannotDeleteCartRuleException.php
+++ b/src/Core/Domain/CartRule/Exception/CannotDeleteCartRuleException.php
@@ -1,4 +1,28 @@
 <?php
+/**
+ * 2007-2019 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
 
 namespace PrestaShop\PrestaShop\Core\Domain\CartRule\Exception;
 

--- a/src/Core/Domain/CartRule/Exception/CannotDeleteCartRuleException.php
+++ b/src/Core/Domain/CartRule/Exception/CannotDeleteCartRuleException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Domain\CartRule\Exception;
+
+class CannotDeleteCartRuleException extends CartRuleException
+{
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When creating an order on BO, if the merchant select the "Free shipping" option, a voucher is created, but is never removed even when free shipping option is switched back to false. This Pr fixes that, so the cart rule is deleted if free shipping cart rule exists by code and free shipping is switched to false. The fix is in BO, but affects FO too
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #17276
| How to test?  | see https://github.com/PrestaShop/PrestaShop/issues/17276

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17421)
<!-- Reviewable:end -->
