### PR TITLE
Add a space before the dash separator when building the attributes names string

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1024,6 +1024,10 @@ class CartCore extends ObjectModel
         $pa_implode = [];
         $separator = Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR');
 
+        if ($separator === '-') {
+            $separator = ' -'; // Fix #17309 Add a space before the dash between attributes
+        }
+
         foreach ($ipa_list as $id_product_attribute) {
             if ((int) $id_product_attribute && !array_key_exists($id_product_attribute . '-' . $id_lang, self::$_attributesLists)) {
                 $pa_implode[] = (int) $id_product_attribute;

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1025,7 +1025,8 @@ class CartCore extends ObjectModel
         $separator = Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR');
 
         if ($separator === '-') {
-            $separator = ' -'; // Fix #17309 Add a space before the dash between attributes
+            // Add a space before the dash between attributes
+            $separator = ' -';
         }
 
         foreach ($ipa_list as $id_product_attribute) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | #17309 In the method cacheSomeAttributesLists from the Cart class the attributes group names and selected values are glued together. At first there was only a comma, now you can have a dash. In case of a dash separator we need to add a missing space before the dash.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17309
| How to test?  | First, select the dash as the attributes separator in your shop settings. Now, order an item with a combination of at least two attributes, like Size and Color. In your confirmation page the product will appear as "Product name - Size : X- Color : Y" when it should be "Product name - Size : X - Color : Y" with a space between the X and the dash.

Please if you have any questions, let me know. I think this is straightforward.
The fix is pretty simple. May be there would be a better way to handle this. But as the separator (def. PS_ATTRIBUTE_ANCHOR_SEPARATOR) is used in other areas I did not feel comfortable to modify the dash to space+dash on the global scope.

Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17423)
<!-- Reviewable:end -->
