### PR TITLE
Add  hook to alter Mail subject before send

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -598,6 +598,12 @@ class MailCore extends ObjectModel
                 'message' => &$message,
             ]);
 
+            // Hook to alter Swift Message before sending mail
+            Hook::exec('actionMailAlterSubjectBeforeSend', [
+                'subject' => &$subject,
+            ]);
+
+
             $send = $swift->send($message);
 
             ShopUrl::resetMainDomainCache();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | I would like the ability to change the email subject without creating classes/Mail.php overrides, and given that the subject is changed in the send function, adding a [sitename] prefix, this would lead to a lot of repeated code
| Type?         | improvement
| BC breaks?    | no
| category | CO
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Creating a new hook listener for actionMailAlterSubjectBeforeSend and altering subject, this mimics the actionMailAlterMessageBeforeSend hook already available


example taken from https://github.com/PrestaShop/PrestaShop/pull/9428 

```
public function hookActionMailAlterSubjectBeforeSend($params)
{
     /**
     * @var String $subject
     */
     $shop_name = '[' . Tools::safeOutput(Configuration::get('PS_SHOP_NAME')) . '] ';
     if (substr($params['subject'], 0, strlen($shop_name)) == $shop_name) {
         $params['subject'] = substr_replace($params['subject'], '', 0, strlen($shop_name));
     }
}
````

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17431)
<!-- Reviewable:end -->
