### PR TITLE
Do not escape translations when using the legacy translator from the new one

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -177,7 +177,8 @@ class TranslateCore
         $sprintf = null,
         $js = false,
         $locale = null,
-        $fallback = true
+        $fallback = true,
+        $escape = true
     ) {
         global $_MODULES, $_MODULE, $_LANGADM;
 
@@ -256,7 +257,7 @@ class TranslateCore
 
             if ($js) {
                 $ret = addslashes($ret);
-            } else {
+            } elseif ($escape) {
                 $ret = htmlspecialchars($ret, ENT_COMPAT, 'UTF-8');
             }
 

--- a/src/Adapter/Localization/LegacyTranslator.php
+++ b/src/Adapter/Localization/LegacyTranslator.php
@@ -56,8 +56,18 @@ class LegacyTranslator
         $sprintf = null,
         $js = false,
         $locale = null,
-        $fallback = true
+        $fallback = true,
+        $escape = true
     ) {
-        return Translate::getModuleTranslation($moduleName, $originalString, $source, $sprintf, $js, $locale, $fallback);
+        return Translate::getModuleTranslation(
+            $moduleName,
+            $originalString,
+            $source,
+            $sprintf,
+            $js,
+            $locale,
+            $fallback,
+            $escape
+        );
     }
 }

--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -163,8 +163,8 @@ trait PrestaShopTranslatorTrait
         $moduleName = strtolower($domainParts[1]);
         $sourceFile = (!empty($domainParts[2])) ? strtolower($domainParts[2]) : $moduleName;
 
-        // translate using the legacy system WITHOUT fallback to the new system (to avoid infinite loop)
-        return (new LegacyTranslator())->translate($moduleName, $message, $sourceFile, $parameters, false, $locale, false);
+        // translate using the legacy system WITHOUT fallback and escape to the new system (to avoid infinite loop)
+        return (new LegacyTranslator())->translate($moduleName, $message, $sourceFile, $parameters, false, $locale, false, false);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Do not escape when the legacytranslator is called from the new one as fallback.<br>Backport of a PR in 177x : #16586 by @PierreRambaud 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17242
| How to test?  | 1. Make an order while logged in Arabic<br>2. **Before :** On the confirmation page, check the support link, which is not displayed properly<br>2. **After :** On the confirmation page, check the support link, which is displayed properly
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17433)
<!-- Reviewable:end -->
