### PR TITLE
Log Mail subject message correctly in case of alteration

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -605,7 +605,7 @@ class MailCore extends ObjectModel
             if ($send && Configuration::get('PS_LOG_EMAILS')) {
                 $mail = new Mail();
                 $mail->template = Tools::substr($template, 0, 62);
-                $mail->subject = Tools::substr($subject, 0, 255);
+                $mail->subject = Tools::substr($message->getSubject(), 0, 255);
                 $mail->id_lang = (int) $idLang;
                 $recipientsTo = $message->getTo();
                 $recipientsCc = $message->getCc();


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | In Mail.php, in case we alter the message subject with `actionMailAlterMessageBeforeSend`, the message is logged wrongly, this fixes the log
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | probably if relying on backend logs wrong
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Implement actionMailAlterMessageBeforeSend and alter the subject like in the following code, check in backend email logs to see the subject is logged correctly


```

public function hookActionMailAlterMessageBeforeSend($params)
    {
        /**
         * @var Swift_Message $message
         */
        $message = &$params['message'];
        $message->setSubject('altered subject test');
    }

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17439)
<!-- Reviewable:end -->
