### PR TITLE
Functional tests - Add delete modal for tests (taxes and cms pages)

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/08_design/04_pages/03_categoriesBulkActions.js
+++ b/tests/puppeteer/campaigns/functional/BO/08_design/04_pages/03_categoriesBulkActions.js
@@ -141,7 +141,7 @@ describe('Create Categories, Then disable / Enable and Delete with Bulk actions'
     });
 
     it('should delete categories with Bulk Actions and check Result', async function () {
-      const deleteTextResult = await this.pageObjects.pagesPage.deleteRowInTableBulkActions('cms_page_category');
+      const deleteTextResult = await this.pageObjects.pagesPage.deleteWithBulkActions('cms_page_category');
       await expect(deleteTextResult).to.be.equal(this.pageObjects.pagesPage.successfulMultiDeleteMessage);
     });
 

--- a/tests/puppeteer/campaigns/functional/BO/08_design/04_pages/04_filterAndQuickEditCategories.js
+++ b/tests/puppeteer/campaigns/functional/BO/08_design/04_pages/04_filterAndQuickEditCategories.js
@@ -179,7 +179,7 @@ describe('Filter And Quick Edit Categories', async () => {
       });
 
       it('should delete categories with Bulk Actions and check Result', async function () {
-        const deleteTextResult = await this.pageObjects.pagesPage.deleteRowInTableBulkActions('cms_page_category');
+        const deleteTextResult = await this.pageObjects.pagesPage.deleteWithBulkActions('cms_page_category');
         await expect(deleteTextResult).to.be.equal(this.pageObjects.pagesPage.successfulMultiDeleteMessage);
       });
     });

--- a/tests/puppeteer/campaigns/functional/BO/08_design/04_pages/05_pagesBulkActions.js
+++ b/tests/puppeteer/campaigns/functional/BO/08_design/04_pages/05_pagesBulkActions.js
@@ -130,7 +130,7 @@ describe('Create Pages, Then disable / Enable and Delete with Bulk actions', asy
     });
 
     it('should delete pages with Bulk Actions and check Result', async function () {
-      const deleteTextResult = await this.pageObjects.pagesPage.deleteRowInTableBulkActions('cms_page');
+      const deleteTextResult = await this.pageObjects.pagesPage.deleteWithBulkActions('cms_page');
       await expect(deleteTextResult).to.be.equal(this.pageObjects.pagesPage.successfulMultiDeleteMessage);
     });
 

--- a/tests/puppeteer/pages/BO/catalog/files/index.js
+++ b/tests/puppeteer/pages/BO/catalog/files/index.js
@@ -165,7 +165,7 @@ module.exports = class Files extends BOBasePage {
       this.page.click(this.bulkActionsDeleteButton),
       this.page.waitForSelector(`${this.confirmDeleteModal}.show`, {visible: true}),
     ]);
-    await this.confirmDeleteFiles(this.bulkActionsDeleteButton);
+    await this.confirmDeleteFiles();
     return this.getTextContent(this.alertSuccessBlockParagraph);
   }
 

--- a/tests/puppeteer/pages/BO/design/pages/index.js
+++ b/tests/puppeteer/pages/BO/design/pages/index.js
@@ -25,9 +25,11 @@ module.exports = class Pages extends BOBasePage {
     // Bulk Actions
     this.selectAllRowsLabel = `${this.listForm} .md-checkbox label`;
     this.bulkActionsToggleButton = `${this.listForm} button.js-bulk-actions-btn`;
-    this.bulkActionsDeleteButton = `${this.listForm} #%TABLE_grid_bulk_action_delete_bulk`;
-    this.bulkActionsEnableButton = `${this.listForm} #%TABLE_grid_bulk_action_enable_selection`;
-    this.bulkActionsDisableButton = `${this.listForm} #%TABLE_grid_bulk_action_disable_selection`;
+    this.bulkActionsDeleteButton = '#%TABLE_grid_bulk_action_delete_selection';
+    this.bulkActionsEnableButton = '#%TABLE_grid_bulk_action_enable_selection';
+    this.bulkActionsDisableButton = '#%TABLE_grid_bulk_action_disable_selection';
+    this.confirmDeleteModal = '#%TABLE_grid_confirm_modal';
+    this.confirmDeleteButton = `${this.confirmDeleteModal} button.btn-confirm-submit`;
     // Filters
     this.filterColumn = `${this.gridTable} #%TABLE_%FILTERBY`;
     this.filterSearchButton = `${this.gridTable} button[name='%TABLE[actions][search]']`;
@@ -124,6 +126,7 @@ module.exports = class Pages extends BOBasePage {
     const selectAllRowsLabel = await this.replaceAll(this.selectAllRowsLabel, '%TABLE', table);
     const bulkActionsToggleButton = await this.replaceAll(this.bulkActionsToggleButton, '%TABLE', table);
     const bulkActionsDeleteButton = await this.replaceAll(this.bulkActionsDeleteButton, '%TABLE', table);
+    const confirmDeleteModal = await this.replaceAll(this.confirmDeleteModal, '%TABLE', table);
     // Add listener to dialog to accept deletion
     this.dialogListener();
     // Click on Select All
@@ -138,10 +141,20 @@ module.exports = class Pages extends BOBasePage {
     ]);
     // Click on delete and wait for modal
     await Promise.all([
-      this.clickAndWaitForNavigation(bulkActionsDeleteButton),
-      this.page.waitForSelector(this.alertSuccessBlockParagraph, {visible: true}),
+      this.page.click(bulkActionsDeleteButton),
+      this.page.waitForSelector(`${confirmDeleteModal}.show`, {visible: true}),
     ]);
+    await this.confirmDeleteWithBulkActions(table);
     return this.getTextContent(this.alertSuccessBlockParagraph);
+  }
+
+  /**
+   * Confirm delete with in modal
+   * @param table
+   * @return {Promise<void>}
+   */
+  async confirmDeleteWithBulkActions(table) {
+    await this.clickAndWaitForNavigation(this.confirmDeleteButton.replace('%TABLE', table));
   }
 
   /**

--- a/tests/puppeteer/pages/BO/design/pages/index.js
+++ b/tests/puppeteer/pages/BO/design/pages/index.js
@@ -122,7 +122,7 @@ module.exports = class Pages extends BOBasePage {
    * @param table
    * @return {Promise<textContent>}
    */
-  async deleteRowInTableBulkActions(table) {
+  async deleteWithBulkActions(table) {
     const selectAllRowsLabel = await this.replaceAll(this.selectAllRowsLabel, '%TABLE', table);
     const bulkActionsToggleButton = await this.replaceAll(this.bulkActionsToggleButton, '%TABLE', table);
     const bulkActionsDeleteButton = await this.replaceAll(this.bulkActionsDeleteButton, '%TABLE', table);

--- a/tests/puppeteer/pages/BO/international/taxes/index.js
+++ b/tests/puppeteer/pages/BO/international/taxes/index.js
@@ -233,7 +233,7 @@ module.exports = class Taxes extends BOBasePage {
       this.page.click(this.deleteSelectionButton),
       this.page.waitForSelector(`${this.confirmDeleteModal}.show`, {visible: true}),
     ]);
-    await this.confirmDeleteTaxes(this.bulkActionsDeleteButton);
+    await this.confirmDeleteTaxes();
     return this.getTextContent(this.alertSuccessBlockParagraph);
   }
 

--- a/tests/puppeteer/pages/BO/international/taxes/index.js
+++ b/tests/puppeteer/pages/BO/international/taxes/index.js
@@ -23,6 +23,8 @@ module.exports = class Taxes extends BOBasePage {
     this.deleteSelectionButton = `${this.taxesGridPanelDiv} #tax_grid_bulk_action_delete_selection`;
     this.selectAllLabel = `${this.taxesGridPanelDiv} #tax_grid .md-checkbox label`;
     this.taxesGridTable = `${this.taxesGridPanelDiv} #tax_grid_table`;
+    this.confirmDeleteModal = '#tax_grid_confirm_modal';
+    this.confirmDeleteButton = `${this.confirmDeleteModal} button.btn-confirm-submit`;
     // Filters
     this.taxesFilterColumnInput = `${this.taxesGridTable} #tax_%FILTERBY`;
     this.resetFilterButton = `${this.taxesGridTable} button[name='tax[actions][reset]']`;
@@ -216,8 +218,6 @@ module.exports = class Taxes extends BOBasePage {
    * @return {Promise<textContent>}
    */
   async deleteTaxesBulkActions() {
-    // Add listener to dialog to accept deletion
-    this.dialogListener(true);
     // Click on Select All
     await Promise.all([
       this.page.click(this.selectAllLabel),
@@ -228,13 +228,21 @@ module.exports = class Taxes extends BOBasePage {
       this.page.click(this.bulkActionsToggleButton),
       this.page.waitForSelector(`${this.bulkActionsToggleButton}[aria-expanded='true']`, {visible: true}),
     ]);
-    // Click on delete
+    // Click on delete and wait for modal
     await Promise.all([
       this.page.click(this.deleteSelectionButton),
-      this.page.waitForNavigation({waitUntil: 'networkidle0'}),
-      this.page.waitForSelector(this.alertSuccessBlockParagraph, {visible: true}),
+      this.page.waitForSelector(`${this.confirmDeleteModal}.show`, {visible: true}),
     ]);
+    await this.confirmDeleteTaxes(this.bulkActionsDeleteButton);
     return this.getTextContent(this.alertSuccessBlockParagraph);
+  }
+
+  /**
+   * Confirm delete with in modal
+   * @return {Promise<void>}
+   */
+  async confirmDeleteTaxes() {
+    await this.clickAndWaitForNavigation(this.confirmDeleteButton);
   }
 
   /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add delete modal for tests (taxes and cms pages), (to be merged after #17287)
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Taxes : `TEST_PATH="functional/BO/11_international/03_taxes/03_taxesBulkActionsInBO.js" URL_FO=URL_FO npm run specific-test` <br> Cms_page : `TEST_PATH="functional/BO/08_design/04_pages/*" URL_FO=URL_FO npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17443)
<!-- Reviewable:end -->
