### PR TITLE
Don't loose group access on object model category save()

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -215,7 +215,7 @@ class CategoryCore extends ObjectModel
             Category::regenerateEntireNtree();
         }
         // if access group is not set, initialize it with 3 default groups
-        $this->updateGroup(($this->groupBox !== null)?$this->groupBox:[]);
+        $this->updateGroup(($this->groupBox !== null) ? $this->groupBox : []);
         Hook::exec('actionCategoryAdd', ['category' => $this]);
 
         return $ret;
@@ -1718,18 +1718,22 @@ class CategoryCore extends ObjectModel
      * Update customer groups associated to the object. Don't update group access if list is null.
      *
      * @param array $list groups
+     *
+     * @return bool
      */
     public function updateGroup($list)
     {
         // don't update group access if list is null
         if ($list === null) {
-            return;
+            return false;
         }
         $this->cleanGroups();
         if (empty($list)) {
             $list = [Configuration::get('PS_UNIDENTIFIED_GROUP'), Configuration::get('PS_GUEST_GROUP'), Configuration::get('PS_CUSTOMER_GROUP')];
         }
         $this->addGroups($list);
+
+        return true;
     }
 
     /**

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1722,7 +1722,7 @@ class CategoryCore extends ObjectModel
     public function updateGroup($list)
     {
         // don't update group access if list is null
-        if (!isset($list)) {
+        if ($list === null) {
             return;
         }
         $this->cleanGroups();

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1720,6 +1720,10 @@ class CategoryCore extends ObjectModel
      */
     public function updateGroup($list)
     {
+        // don't update group access if list is not set
+        if (!isset($list)) {
+            return;
+        }
         $this->cleanGroups();
         if (empty($list)) {
             $list = [Configuration::get('PS_UNIDENTIFIED_GROUP'), Configuration::get('PS_GUEST_GROUP'), Configuration::get('PS_CUSTOMER_GROUP')];

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -215,7 +215,7 @@ class CategoryCore extends ObjectModel
             Category::regenerateEntireNtree();
         }
         // if access group is not set, initialize it with 3 default groups
-        $this->updateGroup(($this->groupBox === null)?$this->groupBox:[]);
+        $this->updateGroup(($this->groupBox !== null)?$this->groupBox:[]);
         Hook::exec('actionCategoryAdd', ['category' => $this]);
 
         return $ret;

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1721,7 +1721,7 @@ class CategoryCore extends ObjectModel
     public function updateGroup($list)
     {
         // don't update group access if list is not set
-        if (!isset($list)) {
+        if ($list === null) {
             return false;
         }
         $this->cleanGroups();

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1722,7 +1722,7 @@ class CategoryCore extends ObjectModel
     {
         // don't update group access if list is not set
         if (!isset($list)) {
-            return;
+            return false;
         }
         $this->cleanGroups();
         if (empty($list)) {

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -214,7 +214,8 @@ class CategoryCore extends ObjectModel
         if (!$this->doNotRegenerateNTree) {
             Category::regenerateEntireNtree();
         }
-        $this->updateGroup($this->groupBox);
+        // if access group is not set, initialize it with 3 default groups
+        $this->updateGroup(($this->groupBox === null)?$this->groupBox:[]);
         Hook::exec('actionCategoryAdd', ['category' => $this]);
 
         return $ret;
@@ -1714,15 +1715,15 @@ class CategoryCore extends ObjectModel
     }
 
     /**
-     * Update customer groups associated to the object.
+     * Update customer groups associated to the object. Don't update group access if list is null.
      *
      * @param array $list groups
      */
     public function updateGroup($list)
     {
-        // don't update group access if list is not set
-        if ($list === null) {
-            return false;
+        // don't update group access if list is null
+        if (!isset($list)) {
+            return;
         }
         $this->cleanGroups();
         if (empty($list)) {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6931,7 +6931,7 @@ class ProductCore extends ObjectModel
     public function modifierWsLinkRewrite()
     {
         if (empty($this->link_rewrite)) {
-            $this->link_rewrite = array();
+            $this->link_rewrite = [];
         }
 
         foreach ($this->name as $id_lang => $name) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Category Object Model : don't update group access if group list is not set
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/17449 & https://github.com/PrestaShop/PrestaShop/issues/11289

**How to test?**  
- Go to category admin page id_category X
- Uncheck a group in group access or check and non default group (i.e. pro group).
- Save this category in another place (controller or module code) with `$category = new Category(X; $category->save();`
- See bug fix : group access is not lost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17450)
<!-- Reviewable:end -->
