### PR TITLE
Introduces checkbox in list filter row

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/filters-submit-button-enabler-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/filters-submit-button-enabler-extension.js
@@ -37,7 +37,7 @@ export default class FiltersSubmitButtonEnablerExtension {
     const $filtersRow = grid.getContainer().find('.column-filters');
     $filtersRow.find('.grid-search-button').prop('disabled', true);
 
-    $filtersRow.find('input, select').on('input dp.change', () => {
+    $filtersRow.find('input:not(.js-bulk-action-select-all), select').on('input dp.change', () => {
       $filtersRow.find('.grid-search-button').prop('disabled', false);
       $filtersRow.find('.js-grid-reset-button').prop('hidden', false);
     });

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/filters_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/filters_row.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-<tr class="column-filters {% if 0 == grid.data.records_total and grid.filters is empty and grid.actions.bulk|length < 0 %}d-none{% endif %}">
+<tr class="column-filters {% if 0 == grid.data.records_total or (grid.filters is empty and grid.actions.bulk|length < 0) %}d-none{% endif %}">
   {% for column in grid.columns %}
     <td>
       {% if loop.first and grid.actions.bulk|length > 0 %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/filters_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/filters_row.html.twig
@@ -23,16 +23,20 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% if grid.filter_form|length > 1 %}
-  <tr class="column-filters {% if 0 == grid.data.records_total and grid.filters is empty %}d-none{% endif %}">
-    {% for column in grid.columns %}
-      <td>
+<tr class="column-filters {% if 0 == grid.data.records_total and grid.filters is empty and grid.actions.bulk|length < 0 %}d-none{% endif %}">
+  {% for column in grid.columns %}
+    <td>
+      {% if loop.first and grid.actions.bulk|length > 0 %}
+        {{ include('@PrestaShop/Admin/Common/Grid/Blocks/bulk_actions_select_all.html.twig', {'grid': grid}) }}
+      {% endif %}
+
+      {% if grid.filter_form|length > 1 %}
         {% if grid.column_filters[column.id] is defined %}
           {% for filter_name in grid.column_filters[column.id] %}
             {{ form_widget(grid.filter_form[filter_name]) }}
           {% endfor %}
         {% endif %}
-      </td>
-    {% endfor %}
-  </tr>
-{% endif %}
+      {% endif %}
+    </td>
+  {% endfor %}
+</tr>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/bulk_actions_select_all.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/bulk_actions_select_all.html.twig
@@ -23,15 +23,12 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% if grid.actions.bulk|length > 0 and grid.data.records_total > 0 %}
-  <div class="md-checkbox mt-3">
-    <label>
-      <input type="checkbox"
-             class="js-bulk-action-select-all"
-             id="{{ grid.id }}_grid_bulk_action_select_all"
-      >
-      <i class="md-checkbox-control"></i>
-      {{ 'Select all'|trans({}, 'Admin.Actions') }}
-    </label>
-  </div>
-{% endif %}
+<div class="md-checkbox mt-3">
+  <label>
+    <input type="checkbox"
+           class="js-bulk-action-select-all"
+           id="{{ grid.id }}_grid_bulk_action_select_all"
+    >
+    <i class="md-checkbox-control"></i>
+  </label>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/bulk_actions_select_all.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/bulk_actions_select_all.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-<div class="md-checkbox mt-3">
+<div class="md-checkbox">
   <label>
     <input type="checkbox"
            class="js-bulk-action-select-all"

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/grid.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/grid.html.twig
@@ -34,11 +34,6 @@
                 {{ include('@PrestaShop/Admin/Common/Grid/Blocks/bulk_actions.html.twig', {'grid': grid}) }}
               </div>
             </div>
-            <div class="row">
-              <div class="col-sm">
-                {{ include('@PrestaShop/Admin/Common/Grid/Blocks/bulk_actions_select_all.html.twig', {'grid': grid}) }}
-              </div>
-            </div>
           </div>
         {% endblock %}
       </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | To fit more into the screen for every migrated list the "Select all" checkbox has been moved to filters row. 
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/15971 point 4 and I think its the last one from the whole issue
| How to test?  | **Please rebuild assets**. Go to any or several migrated pages where lists are visible. You should see check all checkbox in different location. Try to use it. See below of some already checked cases<br><br><br>case 1 - filters and bulk actions are both in the list<br><br>![Screenshot (77)](https://user-images.githubusercontent.com/17051250/73526980-ef215900-441a-11ea-9580-36a344155a21.png)<br><br>case 2 - filters are missing from the list<br><br>![Screenshot (76)](https://user-images.githubusercontent.com/17051250/73527035-019b9280-441b-11ea-8749-0f2ea97b0448.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17456)
<!-- Reviewable:end -->
