### PR TITLE
Adjust zindex header to avoid it behind over the menu on mobile

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -4,10 +4,10 @@
   top: $size-header-height;
   left: $size-navbar-width;
   right: 0;
-  z-index: 990; // popup menus' z-index is 1000, so it has to be just below that
+  z-index: 501; // popup menus' z-index is 502, so it has to be just below that
   border-bottom: 0.0625rem solid $color-separator;
 
-  transition: left .5s ease; // transition when collapsing the nav menu
+  transition: left 0.5s ease; // transition when collapsing the nav menu
 
   .mobile & {
     top: $size-header-height + ($header-mobile-padding-y * 2);
@@ -42,7 +42,6 @@
 
   // toolbar buttons
   .toolbar-icons {
-
     @include media-breakpoint-down(sm) {
       overflow-x: auto;
       float: none;
@@ -71,7 +70,6 @@
 }
 
 .page-head-tabs {
-
   background: #fff;
 
   > ul {
@@ -82,8 +80,7 @@
     position: relative;
 
     .notification-container {
-      @include notification_container(1.5rem)
-      position: absolute;
+      @include notification_container(1.5rem) position: absolute;
       bottom: -5px;
       right: 15px;
 
@@ -98,7 +95,6 @@
       }
     }
   }
-
 }
 
 .page-sidebar-closed:not(.mobile) {

--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -30,6 +30,7 @@
     font-weight: normal;
     margin-bottom: 0;
     float: left;
+
     @include media-breakpoint-down(sm) {
       float: none;
     }
@@ -80,7 +81,8 @@
     position: relative;
 
     .notification-container {
-      @include notification_container(1.5rem) position: absolute;
+      @include notification_container(1.5rem);
+      position: absolute;
       bottom: -5px;
       right: 15px;
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The header-toolbar is over the opened menu on mobile
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Build admin-dev/themes/new-theme assets and go on Catalog -> Products on mobile, open the menu and the menu should be over everything

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17459)
<!-- Reviewable:end -->
