### PR TITLE
Fix wrong wordings on "New" translations

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -223,7 +223,7 @@ class ProductLazyArray extends AbstractLazyArray
             case 'new':
                 return [
                     'type' => 'new',
-                    'label' => $this->translator->trans('New product', [], 'Shop.Theme.Catalog'),
+                    'label' => $this->translator->trans('New', [], 'Shop.Theme.Catalog'),
                     'schema_url' => 'https://schema.org/NewCondition',
                 ];
             case 'used':
@@ -465,9 +465,9 @@ class ProductLazyArray extends AbstractLazyArray
         }
 
         if ($this->product['new']) {
-            $flags['new'] = [
+            $flags['new'] = [f
                 'type' => 'new',
-                'label' => $this->translator->trans('New', [], 'Shop.Theme.Catalog'),
+                'label' => $this->translator->trans('New product', [], 'Shop.Theme.Catalog'),
             ];
         }
 

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -465,7 +465,7 @@ class ProductLazyArray extends AbstractLazyArray
         }
 
         if ($this->product['new']) {
-            $flags['new'] = [f
+            $flags['new'] = [
                 'type' => 'new',
                 'label' => $this->translator->trans('New product', [], 'Shop.Theme.Catalog'),
             ];


### PR DESCRIPTION
Questions | Answers
-- | --
Branch? | develop
Description? | This PR fixes wrong wordings on _New_ translations (details below)
Type? | bug fix
Category? | FO
BC breaks? | no
Deprecations? | no
Fixed ticket? | Fixes #17455
How to test? | - _New product_ should be use for new products (_Nouveauté_ in french)<br>- _New_ should be use for product condition (_Neuf_ in french)
| Sponsor company | @Creabilis

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17461)
<!-- Reviewable:end -->
