### PR TITLE
Category admin jumps to home when deleting a category.

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -629,9 +629,11 @@ class CategoryController extends FrameworkBundleAdminController
     {
         $deleteCategoriesForm = $this->createForm(DeleteCategoriesType::class);
         $deleteCategoriesForm->handleRequest($request);
+        $idParent = $this->configuration->getInt('PS_HOME_CATEGORY');
 
         if ($deleteCategoriesForm->isSubmitted()) {
             $categoriesDeleteData = $deleteCategoriesForm->getData();
+            $idParent = (int) $categoriesDeleteData['categories_to_delete_parent'];
 
             try {
                 $command = new DeleteCategoryCommand(
@@ -647,7 +649,7 @@ class CategoryController extends FrameworkBundleAdminController
             }
         }
 
-        return $this->redirectToRoute('admin_categories_index');
+        return $this->redirectToRoute('admin_categories_index', ['categoryId' => $idParent]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -92,7 +92,7 @@ class CategoryController extends FrameworkBundleAdminController
         $categoryViewDataProvider = $this->get('prestashop.adapter.category.category_view_data_provider');
         $categoryViewData = $categoryViewDataProvider->getViewData($currentCategoryId);
 
-        $deleteCategoriesForm = $this->createForm(DeleteCategoriesType::class);
+        $deleteCategoriesForm = $this->createForm(DeleteCategoriesType::class, ['categories_to_delete_parent' => (int) $currentCategoryId], []);
 
         $showcaseCardIsClosed = $this->getQueryBus()->handle(
             new GetShowcaseCardIsClosed((int) $this->getContext()->employee->id, ShowcaseCard::CATEGORIES_CARD)

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -584,10 +584,12 @@ class CategoryController extends FrameworkBundleAdminController
     {
         $deleteCategoriesForm = $this->createForm(DeleteCategoriesType::class);
         $deleteCategoriesForm->handleRequest($request);
+        $idParent = $this->configuration->getInt('PS_HOME_CATEGORY');
 
         if ($deleteCategoriesForm->isSubmitted()) {
             try {
                 $categoriesDeleteData = $deleteCategoriesForm->getData();
+                $idParent = (int) $categoriesDeleteData['categories_to_delete_parent'];
                 $categoryIds = array_map(function ($categoryId) {
                     return (int) $categoryId;
                 }, $categoriesDeleteData['categories_to_delete']);
@@ -608,7 +610,7 @@ class CategoryController extends FrameworkBundleAdminController
             }
         }
 
-        return $this->redirectToRoute('admin_categories_index');
+        return $this->redirectToRoute('admin_categories_index', ['categoryId' => $idParent]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Category/DeleteCategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Category/DeleteCategoriesType.php
@@ -67,6 +67,9 @@ class DeleteCategoriesType extends AbstractType
                 'entry_type' => HiddenType::class,
                 'label' => false,
                 'allow_add' => true,
+            ])
+            ->add('categories_to_delete_parent', HiddenType::class, [
+                'label' => false,
             ]);
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig
@@ -47,7 +47,7 @@
         {{ form_widget(deleteCategoriesForm.categories_to_delete) }}
       </div>
       <div class="d-none">
-        {{ form_widget(deleteCategoriesForm.categories_to_delete_parent, { 'attr': {'value': app.request.get('categoryId') } }) }}
+        {{ form_widget(deleteCategoriesForm.categories_to_delete_parent) }}
       </div>
     </div>
   {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig
@@ -46,6 +46,9 @@
       <div class="d-none">
         {{ form_widget(deleteCategoriesForm.categories_to_delete) }}
       </div>
+      <div class="d-none">
+        {{ form_widget(deleteCategoriesForm.categories_to_delete_parent, { 'attr': {'value': app.request.get('categoryId') } }) }}
+      </div>
     </div>
   {% endblock %}
 {% endembed %}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Category admin jumps to home when deleting a category.                           
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17463
| How to test?  | **Considere this category three :** <br>- Home > Cars > SUVs > Small<br>- Home > Cars > SUVs > Medium<br>- Home > Cars > SUVs > Big.<br><br>1. You are editing categories.<br>2. You are in SUVs category.<br>3. You delete Small category and the view jumps all the way back to Home category, annoying.<br><br>By @Hlavtox 

Sorry @khouloudbelguith, but these two issues (https://github.com/PrestaShop/PrestaShop/issues/17463 and https://github.com/PrestaShop/PrestaShop/issues/15588) are very different.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17467)
<!-- Reviewable:end -->
