### PR TITLE
Allow token for TokenisedUrlsListener class and in form using the method=GET attribute

### DIFF
--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -96,7 +96,7 @@ class TranslationRouteFinder
      */
     public function findRoute(ParameterBag $query)
     {
-        $routeProperties = $query->get('form')['modify_translations'];
+        $routeProperties = $query->get('form');
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $route = 'admin_international_translation_overview';
 
@@ -154,7 +154,7 @@ class TranslationRouteFinder
      */
     public function findRouteParameters(ParameterBag $query)
     {
-        $routeProperties = $query->get('form')['modify_translations'];
+        $routeProperties = $query->get('form');
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $language = $propertyAccessor->getValue($routeProperties, '[language]');
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Order;
 
-use PrestaShop\PrestaShop\Core\Form\FormHandler;
+use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -51,7 +51,7 @@ class DeliveryController extends FrameworkBundleAdminController
      */
     public function slipAction(Request $request)
     {
-        /** @var $formHandler FormHandler */
+        /** @var $formHandler FormHandlerInterface */
         $formHandler = $this->get('prestashop.adapter.order.delivery.slip.options.form_handler');
         /** @var $form Form */
         $form = $formHandler->getForm();
@@ -94,7 +94,7 @@ class DeliveryController extends FrameworkBundleAdminController
      */
     public function generatePdfAction(Request $request)
     {
-        /** @var $formHandler FormHandler */
+        /** @var $formHandler FormHandlerInterface */
         $formHandler = $this->get('prestashop.adapter.order.delivery.slip.pdf.form_handler');
         /** @var $form Form */
         $form = $formHandler->getForm();

--- a/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/TranslationsController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin;
 
+use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Language\Copier\LanguageCopierConfig;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -99,15 +100,20 @@ class TranslationsController extends FrameworkBundleAdminController
         $legacyController = $request->attributes->get('_legacy_controller');
         $legacyContext = $this->get('prestashop.adapter.legacy.context');
         $kpiRowFactory = $this->get('prestashop.core.kpi_row.factory.translations_page');
-        $formHandler = $this->get('prestashop.admin.translations_settings.form_handler');
-        $form = $formHandler->getForm();
+        $modifyTranslationsForm = $this->getModifyTranslationsFormHander()->getForm();
+        $addUpdateLanguageForm = $this->getAddUpdateLanguageTranslationsFormHander()->getForm();
+        $exportLanguageForm = $this->getExportLanguageTranslationsFormHander()->getForm();
+        $copyLanguageForm = $this->getCopyLanguageTranslationsFormHander()->getForm();
 
         return [
             'layoutTitle' => $this->trans('Translations', 'Admin.Navigation.Menu'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($legacyController),
             'kpiRow' => $kpiRowFactory->build(),
-            'translationSettingsForm' => $form->createView(),
+            'copyLanguageForm' => $copyLanguageForm->createView(),
+            'exportLanguageForm' => $exportLanguageForm->createView(),
+            'addUpdateLanguageForm' => $addUpdateLanguageForm->createView(),
+            'modifyTranslationsForm' => $modifyTranslationsForm->createView(),
             'addLanguageUrl' => $legacyContext->getAdminLink('AdminLanguages', true, ['addlang' => '']),
         ];
     }
@@ -142,13 +148,13 @@ class TranslationsController extends FrameworkBundleAdminController
      */
     public function addUpdateLanguageAction(Request $request)
     {
-        $formHandler = $this->get('prestashop.admin.translations_settings.form_handler');
+        $formHandler = $this->getAddUpdateLanguageTranslationsFormHander();
         $addUpdateLanguageForm = $formHandler->getForm();
         $addUpdateLanguageForm->handleRequest($request);
 
         if ($addUpdateLanguageForm->isSubmitted()) {
             $data = $addUpdateLanguageForm->getData();
-            $isoCode = $data['add_update_language']['iso_localization_pack'];
+            $isoCode = $data['iso_localization_pack'];
 
             $languagePackImporter = $this->get('prestashop.adapter.language.pack.importer');
             $errors = $languagePackImporter->import($isoCode);
@@ -181,15 +187,15 @@ class TranslationsController extends FrameworkBundleAdminController
      */
     public function exportThemeLanguageAction(Request $request)
     {
-        $formHandler = $this->get('prestashop.admin.translations_settings.form_handler');
+        $formHandler = $this->getExportLanguageTranslationsFormHander();
         $exportThemeLanguageForm = $formHandler->getForm();
         $exportThemeLanguageForm->handleRequest($request);
 
         if ($exportThemeLanguageForm->isSubmitted()) {
             $data = $exportThemeLanguageForm->getData();
 
-            $themeName = $data['export_language']['theme_name'];
-            $isoCode = $data['export_language']['iso_code'];
+            $themeName = $data['theme_name'];
+            $isoCode = $data['iso_code'];
 
             $langRepository = $this->get('prestashop.core.admin.lang.repository');
             $locale = $langRepository->getLocaleByIsoCode($isoCode);
@@ -219,7 +225,7 @@ class TranslationsController extends FrameworkBundleAdminController
      */
     public function copyLanguageAction(Request $request)
     {
-        $formHandler = $this->get('prestashop.admin.translations_settings.form_handler');
+        $formHandler = $this->getCopyLanguageTranslationsFormHander();
         $form = $formHandler->getForm();
         $form->handleRequest($request);
 
@@ -227,10 +233,10 @@ class TranslationsController extends FrameworkBundleAdminController
             $languageCopier = $this->get('prestashop.adapter.language.copier');
             $data = $form->getData();
             $languageCopierConfig = new LanguageCopierConfig(
-                $data['copy_language']['from_theme'],
-                $data['copy_language']['from_language'],
-                $data['copy_language']['to_theme'],
-                $data['copy_language']['to_language']
+                $data['from_theme'],
+                $data['from_language'],
+                $data['to_theme'],
+                $data['to_language']
             );
 
             if ($errors = $languageCopier->copy($languageCopierConfig)) {
@@ -244,5 +250,37 @@ class TranslationsController extends FrameworkBundleAdminController
         }
 
         return $this->redirectToRoute('admin_international_translations_show_settings');
+    }
+
+    /**
+     * @return FormHandlerInterface
+     */
+    private function getModifyTranslationsFormHander(): FormHandlerInterface
+    {
+        return $this->get('prestashop.admin.translations_settings.modify_translations.form_handler');
+    }
+
+    /**
+     * @return FormHandlerInterface
+     */
+    private function getAddUpdateLanguageTranslationsFormHander(): FormHandlerInterface
+    {
+        return $this->get('prestashop.admin.translations_settings.add_update_language.form_handler');
+    }
+
+    /**
+     * @return FormHandlerInterface
+     */
+    private function getExportLanguageTranslationsFormHander(): FormHandlerInterface
+    {
+        return $this->get('prestashop.admin.translations_settings.export_language.form_handler');
+    }
+
+    /**
+     * @return FormHandlerInterface
+     */
+    private function getCopyLanguageTranslationsFormHander(): FormHandlerInterface
+    {
+        return $this->get('prestashop.admin.translations_settings.copy_language.form_handler');
     }
 }

--- a/src/PrestaShopBundle/EventListener/TokenizedUrlsListener.php
+++ b/src/PrestaShopBundle/EventListener/TokenizedUrlsListener.php
@@ -30,7 +30,7 @@ use Employee;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
@@ -67,7 +67,7 @@ class TokenizedUrlsListener
         }
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(KernelEvent $event)
     {
         $request = $event->getRequest();
 
@@ -101,9 +101,14 @@ class TokenizedUrlsListener
             }
         }
 
-        $token = urldecode($request->query->get('_token', false));
+        $token = false;
+        if ($request->query->has('_token')) {
+            $token = new CsrfToken($this->username, $request->query->get('_token'));
+        } elseif (isset($request->query->get('form')['_token'])) {
+            $token = new CsrfToken('form', $request->query->get('form')['_token']);
+        }
 
-        if (false === $token || !$this->tokenManager->isTokenValid(new CsrfToken($this->username, $token))) {
+        if (false === $token || !$this->tokenManager->isTokenValid($token)) {
             // remove token if any
             if (false !== strpos($uri, '_token=')) {
                 $uri = substr($uri, 0, strpos($uri, '_token='));

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/TranslationsSettingsFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/TranslationsSettingsFormHandler.php
@@ -28,14 +28,14 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Translations;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
-use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
 
 final class TranslationsSettingsFormHandler implements FormHandlerInterface
 {
     /**
-     * @var FormBuilderInterface the form builder
+     * @var FormFactoryInterface the form builder
      */
-    protected $formBuilder;
+    protected $formFactory;
 
     /**
      * @var HookDispatcherInterface the event dispatcher
@@ -50,23 +50,23 @@ final class TranslationsSettingsFormHandler implements FormHandlerInterface
     /**
      * @var array the list of Form Types
      */
-    protected $formTypes;
+    protected $form;
 
     /**
-     * @param FormBuilderInterface $formBuilder
+     * @param FormFactoryInterface $formFactory
      * @param HookDispatcherInterface $hookDispatcher
-     * @param array $formTypes
+     * @param string $form
      * @param string $hookName
      */
     public function __construct(
-        FormBuilderInterface $formBuilder,
+        FormFactoryInterface $formFactory,
         HookDispatcherInterface $hookDispatcher,
-        array $formTypes,
-        $hookName
+        string $form,
+        string $hookName
     ) {
-        $this->formBuilder = $formBuilder;
+        $this->formFactory = $formFactory;
         $this->hookDispatcher = $hookDispatcher;
-        $this->formTypes = $formTypes;
+        $this->form = $form;
         $this->hookName = $hookName;
     }
 
@@ -75,18 +75,16 @@ final class TranslationsSettingsFormHandler implements FormHandlerInterface
      */
     public function getForm()
     {
-        foreach ($this->formTypes as $formName => $formType) {
-            $this->formBuilder->add($formName, $formType);
-        }
+        $formBuilder = $this->formFactory->createNamedBuilder('form', $this->form);
 
         $this->hookDispatcher->dispatchWithParameters(
             "action{$this->hookName}Form",
             [
-                'form_builder' => $this->formBuilder,
+                'form_builder' => $formBuilder,
             ]
         );
 
-        return $this->formBuilder->getForm();
+        return $formBuilder->getForm();
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -259,17 +259,37 @@ services:
               'webservice_configuration': 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Webservice\WebserviceConfigurationType'
             - 'WebservicePage'
 
-    prestashop.admin.translations_settings.form_handler:
+    prestashop.admin.translations_settings.modify_translations.form_handler:
         class: 'PrestaShopBundle\Form\Admin\Improve\International\Translations\TranslationsSettingsFormHandler'
         arguments:
-            - '@=service("form.factory").createBuilder()'
+            - '@form.factory'
             - '@prestashop.core.hook.dispatcher'
-            -
-              'modify_translations': 'PrestaShopBundle\Form\Admin\Improve\International\Translations\ModifyTranslationsType'
-              'add_update_language': 'PrestaShopBundle\Form\Admin\Improve\International\Translations\AddUpdateLanguageType'
-              'export_language': 'PrestaShopBundle\Form\Admin\Improve\International\Translations\ExportThemeLanguageType'
-              'copy_language': 'PrestaShopBundle\Form\Admin\Improve\International\Translations\CopyLanguageType'
-            - 'TranslationSettingsPage'
+            - 'PrestaShopBundle\Form\Admin\Improve\International\Translations\ModifyTranslationsType'
+            - 'TranslationSettingsPageModifyTranslations'
+
+    prestashop.admin.translations_settings.add_update_language.form_handler:
+        class: 'PrestaShopBundle\Form\Admin\Improve\International\Translations\TranslationsSettingsFormHandler'
+        arguments:
+            - '@form.factory'
+            - '@prestashop.core.hook.dispatcher'
+            - 'PrestaShopBundle\Form\Admin\Improve\International\Translations\AddUpdateLanguageType'
+            - 'TranslationSettingsPageAddUpdateLanguage'
+
+    prestashop.admin.translations_settings.export_language.form_handler:
+        class: 'PrestaShopBundle\Form\Admin\Improve\International\Translations\TranslationsSettingsFormHandler'
+        arguments:
+            - '@form.factory'
+            - '@prestashop.core.hook.dispatcher'
+            - 'PrestaShopBundle\Form\Admin\Improve\International\Translations\ExportThemeLanguageType'
+            - 'TranslationSettingsPageExportLanguage'
+
+    prestashop.admin.translations_settings.copy_language.form_handler:
+        class: 'PrestaShopBundle\Form\Admin\Improve\International\Translations\TranslationsSettingsFormHandler'
+        arguments:
+            - '@form.factory'
+            - '@prestashop.core.hook.dispatcher'
+            - 'PrestaShopBundle\Form\Admin\Improve\International\Translations\CopyLanguageType'
+            - 'TranslationSettingsPageCopyLanguage'
 
     prestashop.admin.meta_settings.form_handler:
         class: 'PrestaShop\PrestaShop\Core\Form\FormHandler'

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
@@ -26,11 +26,6 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% trans_default_domain 'Admin.International.Feature' %}
 
-{% set addUpdateLanguageForm, copyLanguageForm, exportLanguageForm, modifyTranslationsForm =
-        translationSettingsForm.add_update_language, translationSettingsForm.copy_language,
-        translationSettingsForm.export_language, translationSettingsForm.modify_translations
-%}
-
 {% block content %}
   <div class="row justify-content-center">
     <div class="col-xl-10">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Form CsrfToken should also work when working with a form using `method="GET"`. Also the `prestashop.tokenized_url_listener` service wasn't able to work because in `onRequest` context the `prestashop.user_provider` service is never initialized, so the `getUsername` is `null`. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #17188 
| How to test?  | Forms in Translations page should work as before. Ticket should be fixed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17482)
<!-- Reviewable:end -->
