### PR TITLE
[Blocked] Allow injection of extra variables inside twig

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2145,5 +2145,10 @@
       <title>Admin Order Buttons</title>
       <description>This hook is used to generate the buttons collection on the order view page thanks (see ActionsBarButtonsCollection)</description>
     </hook>
+    <hook id="actionBackOfficeControllerSetVariables">
+      <name>actionBackOfficeControllerSetVariables</name>
+      <title>Admin extra variables inside twig</title>
+      <description>This hook injects extra variables inside twig via controller parameters</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -537,6 +537,7 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'displayAdminOrderTabLink', 'Admin Order Tab Link', 'This hook displays new tab links on the order view page', '1 '),
   (NULL, 'displayAdminOrderTabContent', 'Admin Order Tab Content', 'This hook displays new tab contents on the order view page', '1 '),
   (NULL, 'actionGetAdminOrderButtons', 'Admin Order Buttons', 'This hook is used to generate the buttons collection on the order view page thanks (see ActionsBarButtonsCollection)', '1 '),
+  (NULL, 'actionBackOfficeControllerSetVariables', 'Admin extra variables inside twig', 'This hook injects extra variables inside twig via controller parameters', '1')
 ;
 
 INSERT INTO `PREFIX_hook_alias` (`name`, `alias`) VALUES ('displayAdminOrderTop', 'displayInvoice');

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Hook\RenderedHook;
+use PrestaShop\PrestaShop\Core\Hook\RenderedHookInterface;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
@@ -531,10 +532,10 @@ class FrameworkBundleAdminController extends Controller
     {
         /** @var HookDispatcherInterface $hookDispatcher */
         $hookDispatcher = $this->get('prestashop.core.hook.dispatcher');
-        /** @var RenderedHook $renderedHook */
+        /** @var RenderedHookInterface $renderedHook */
         $renderedHook = $hookDispatcher->dispatchRenderingWithParameters('actionBackOfficeControllerSetVariables');
 
-        $parameters = array_merge($renderedHook->getContent(), $parameters);
+        $parameters = array_merge($parameters, $renderedHook->getContent());
 
         return parent::render($view, $parameters, $response);
     }

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -31,6 +31,8 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShop\PrestaShop\Core\Hook\RenderedHook;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
@@ -523,5 +525,17 @@ class FrameworkBundleAdminController extends Controller
             $exceptionCode,
             $e->getMessage()
         );
+    }
+
+    protected function render($view, array $parameters = [], Response $response = null)
+    {
+        /** @var HookDispatcherInterface $hookDispatcher */
+        $hookDispatcher = $this->get('prestashop.core.hook.dispatcher');
+        /** @var RenderedHook $renderedHook */
+        $renderedHook = $hookDispatcher->dispatchRenderingWithParameters('actionBackOfficeControllerSetVariables');
+
+        $parameters = array_merge($renderedHook->getContent(), $parameters);
+
+        return parent::render($view, $parameters, $response);
     }
 }

--- a/src/PrestaShopBundle/EventListener/ActionDispatcherLegacyHooksSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/ActionDispatcherLegacyHooksSubscriber.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\EventListener;
 
+use Hook;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -91,6 +92,7 @@ class ActionDispatcherLegacyHooksSubscriber implements EventSubscriberInterface
 
         $requestAttributes->set('controller_type', $controllerType);
         $requestAttributes->set('controller_name', get_class($controller));
+        $requestAttributes->set('view_parameters', Hook::exec('actionBackOfficeControllerSetVariables'));
     }
 
     public function callActionDispatcherAfterHook(FilterResponseEvent $event)

--- a/src/PrestaShopBundle/EventListener/ActionDispatcherLegacyHooksSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/ActionDispatcherLegacyHooksSubscriber.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShopBundle\EventListener;
 
-use Hook;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -92,7 +91,6 @@ class ActionDispatcherLegacyHooksSubscriber implements EventSubscriberInterface
 
         $requestAttributes->set('controller_type', $controllerType);
         $requestAttributes->set('controller_name', get_class($controller));
-        $requestAttributes->set('extra_var', Hook::exec('actionBackOfficeControllerSetVariables'));
     }
 
     public function callActionDispatcherAfterHook(FilterResponseEvent $event)

--- a/src/PrestaShopBundle/EventListener/ActionDispatcherLegacyHooksSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/ActionDispatcherLegacyHooksSubscriber.php
@@ -92,7 +92,7 @@ class ActionDispatcherLegacyHooksSubscriber implements EventSubscriberInterface
 
         $requestAttributes->set('controller_type', $controllerType);
         $requestAttributes->set('controller_name', get_class($controller));
-        $requestAttributes->set('view_parameters', Hook::exec('actionBackOfficeControllerSetVariables'));
+        $requestAttributes->set('extra_var', Hook::exec('actionBackOfficeControllerSetVariables'));
     }
 
     public function callActionDispatcherAfterHook(FilterResponseEvent $event)


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Module developers want to display an additional information using a variable that was not passed to Twig by the Controller. This PR gives the possibility to hook additional parameter directly to the controller twig template.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no (I think)
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/13462
| How to test?  | register a hook 'actionBackOfficeControllerSetVariables' in the PrestaShop module. Write hook function 'hookActionBackOfficeControllerSetVariables' returning the extra variable. Use the injected variable inside any migrated rendered BO controller twig file {{ moduleName }} or {% moduleName %}

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17498)
<!-- Reviewable:end -->
