### PR TITLE
Increase timeout to download translation packages from 5 to 20 seconds

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -40,6 +40,11 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     const SF_LANGUAGE_PACK_URL = 'https://i18n.prestashop.com/translations/%version%/%locale%/%locale%.zip';
     const EMAILS_LANGUAGE_PACK_URL = 'https://i18n.prestashop.com/mails/%version%/%locale%/%locale%.zip';
 
+    /**
+     * Timeout for downloading a translation pack, in seconds
+     */
+    const PACK_DOWNLOAD_TIMEOUT = 20;
+
     public $id;
 
     /** @var string Name */
@@ -1167,7 +1172,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         if (!is_writable(dirname($file))) {
             // @todo Throw exception
             $errors[] = Context::getContext()->getTranslator()->trans('Server does not have permissions for writing.', [], 'Admin.International.Notification') . ' (' . $file . ')';
-        } elseif ($content = Tools::file_get_contents($url)) {
+        } elseif ($content = Tools::file_get_contents($url, false, null, self::PACK_DOWNLOAD_TIMEOUT)) {
             file_put_contents($file, $content);
         } else {
             $errors[] = Context::getContext()->getTranslator()->trans('Language pack unavailable.', [], 'Admin.International.Notification') . ' ' . $url;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Sometimes the install fails because it takes the shop more than 5 seconds to download a translation package. This change increases this timeout to 20 seconds in hopes this will happen less frequently.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | You are able to install the shop (so in theory, this is validated by CI)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17515)
<!-- Reviewable:end -->
