### PR TITLE
Remove irrelevant Todo in order messages

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/message/order-view-page-messages-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/order/message/order-view-page-messages-handler.js
@@ -55,7 +55,6 @@ export default class OrderViewPageMessagesHandler {
         return;
       }
 
-      // @todo: check size if is over then max not allow?
       const message = this.$messagesContainer.find(`div[data-id=${valueId}]`).text().trim();
       const $orderMessage = $(OrderViewPageMap.orderMessage);
       const isSameMessage = $orderMessage.val().trim() === message;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Todo  `check size if is over then max not allow?` in order-view-page-messages-handler.js was irrelevant, as the code doesnt insert anything to databas, but just shows text which has 1200cahrs constraints, so no need to check length.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #17282
| How to test?  | No need to test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17531)
<!-- Reviewable:end -->
