### PR TITLE
Fix deleted customer's order preview/details

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -220,12 +220,17 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
     /**
      * @param Order $order
      *
-     * @return OrderCustomerForViewing
+     * @return OrderCustomerForViewing|null
      */
-    private function getOrderCustomer(Order $order): OrderCustomerForViewing
+    private function getOrderCustomer(Order $order): ?OrderCustomerForViewing
     {
         $currency = new Currency($order->id_currency);
         $customer = new Customer($order->id_customer);
+
+        if (!Validate::isLoadedObject($customer)) {
+            return null;
+        }
+
         $gender = new Gender($customer->id_gender);
         $genderName = '';
 

--- a/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
@@ -133,7 +133,7 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
             $address->postcode,
             $stateName,
             $country->name[$order->id_lang],
-            $customer->email,
+            $customer ? $customer->email : null,
             $address->phone
         );
     }

--- a/src/Core/Domain/Order/QueryResult/OrderForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderForViewing.php
@@ -183,7 +183,7 @@ class OrderForViewing
      * @param bool $isShipped
      * @param bool $invoiceManagementIsEnabled
      * @param DateTimeImmutable $createdAt
-     * @param OrderCustomerForViewing $customer
+     * @param OrderCustomerForViewing|null $customer
      * @param OrderShippingAddressForViewing $shippingAddress
      * @param OrderInvoiceAddressForViewing $invoiceAddress
      * @param OrderProductsForViewing $products
@@ -212,7 +212,7 @@ class OrderForViewing
         bool $isShipped,
         bool $invoiceManagementIsEnabled,
         DateTimeImmutable $createdAt,
-        OrderCustomerForViewing $customer,
+        ?OrderCustomerForViewing $customer,
         OrderShippingAddressForViewing $shippingAddress,
         OrderInvoiceAddressForViewing $invoiceAddress,
         OrderProductsForViewing $products,
@@ -308,9 +308,9 @@ class OrderForViewing
     }
 
     /**
-     * @return OrderCustomerForViewing
+     * @return OrderCustomerForViewing|null
      */
-    public function getCustomer(): OrderCustomerForViewing
+    public function getCustomer(): ?OrderCustomerForViewing
     {
         return $this->customer;
     }

--- a/src/Core/Domain/Order/QueryResult/OrderPreviewInvoiceDetails.php
+++ b/src/Core/Domain/Order/QueryResult/OrderPreviewInvoiceDetails.php
@@ -104,7 +104,7 @@ class OrderPreviewInvoiceDetails
      * @param string $postalCode
      * @param string|null $stateName
      * @param string $country
-     * @param string $email
+     * @param string|null $email
      * @param string $phone
      */
     public function __construct(
@@ -118,7 +118,7 @@ class OrderPreviewInvoiceDetails
         string $postalCode,
         ?string $stateName,
         string $country,
-        string $email,
+        ?string $email,
         string $phone
     ) {
         $this->firstName = $firstName;
@@ -176,9 +176,9 @@ class OrderPreviewInvoiceDetails
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getEmail(): string
+    public function getEmail(): ?string
     {
         return $this->email;
     }

--- a/src/Core/Grid/Column/Type/DisableableLinkColumn.php
+++ b/src/Core/Grid/Column/Type/DisableableLinkColumn.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Column\Type;
+
+use PrestaShop\PrestaShop\Core\Grid\Column\AbstractColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class DisableableLinkColumn extends AbstractColumn
+{
+    /**
+     * @var LinkColumn
+     */
+    private $linkColumn;
+
+    public function __construct($id)
+    {
+        parent::__construct($id);
+        $this->linkColumn = new LinkColumn($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'disableable_link';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setRequired(['disabled_field'])
+            ->setAllowedTypes('disabled_field', ['string', 'null'])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(array $options)
+    {
+        $disabledOptions = [];
+
+        if (isset($options['disabled_field'])) {
+            $disabledOptions['disabled_field'] = $options['disabled_field'];
+            unset($options['disabled_field']);
+        }
+
+        $this->linkColumn->setOptions($options);
+        parent::setOptions($disabledOptions);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOptions()
+    {
+        return array_merge($this->linkColumn->getOptions(), parent::getOptions());
+    }
+}

--- a/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
@@ -45,8 +45,8 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ChoiceColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\IdentifierColumn;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\DisableableLinkColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\OrderPriceColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\PreviewColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
@@ -200,10 +200,11 @@ final class OrderGridDefinitionFactory extends AbstractGridDefinitionFactory
                     'clickable' => true,
                 ])
             )
-            ->add((new LinkColumn('customer'))
+            ->add((new DisableableLinkColumn('customer'))
                 ->setName($this->trans('Customer', [], 'Admin.Global'))
                 ->setOptions([
                     'field' => 'customer',
+                    'disabled_field' => 'deleted_customer',
                     'route' => 'admin_customers_view',
                     'route_param_name' => 'customerId',
                     'route_param_field' => 'id_customer',

--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -100,6 +100,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
             ->addSelect('o.id_order, o.reference, o.total_paid_tax_incl, os.paid, osl.name AS osname')
             ->addSelect('o.current_state, o.id_customer')
             ->addSelect('CONCAT(LEFT(cu.`firstname`, 1), \'. \', cu.`lastname`) AS `customer`')
+            ->addSelect('cu.`id_customer` IS NULL as `deleted_customer`')
             ->addSelect('os.color, o.payment, s.name AS shop_name')
             ->addSelect('o.date_add, cu.company, cl.name AS country_name, o.invoice_number, o.delivery_number')
             ->addSelect('IF ((' . $newCustomerSubSelect->getSQL() . ') > 0, 0, 1) AS new')

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -385,13 +385,20 @@ class OrderController extends FrameworkBundleAdminController
         $changeOrderCurrencyForm = $this->createForm(ChangeOrderCurrencyType::class, [], [
             'current_currency_id' => $orderForViewing->getCurrencyId(),
         ]);
-        $changeOrderAddressForm = $this->createForm(ChangeOrderAddressType::class, [], [
-            'customer_id' => $orderForViewing->getCustomer()->getId(),
-        ]);
 
-        $privateNoteForm = $this->createForm(PrivateNoteType::class, [
-            'note' => $orderForViewing->getCustomer()->getPrivateNote(),
-        ]);
+        $changeOrderAddressForm = null;
+        $privateNoteForm = null;
+
+        if (null !== $orderForViewing->getCustomer()) {
+            $changeOrderAddressForm = $this->createForm(ChangeOrderAddressType::class, [], [
+                'customer_id' => $orderForViewing->getCustomer()->getId(),
+            ]);
+
+            $privateNoteForm = $this->createForm(PrivateNoteType::class, [
+                'note' => $orderForViewing->getCustomer()->getPrivateNote(),
+            ]);
+        }
+
         $updateOrderShippingForm = $this->createForm(UpdateOrderShippingType::class, [
             'new_carrier_id' => $orderForViewing->getCarrierId(),
         ], [
@@ -440,11 +447,11 @@ class OrderController extends FrameworkBundleAdminController
             'updateOrderStatusActionBarForm' => $updateOrderStatusActionBarForm->createView(),
             'addOrderPaymentForm' => $addOrderPaymentForm->createView(),
             'changeOrderCurrencyForm' => $changeOrderCurrencyForm->createView(),
-            'privateNoteForm' => $privateNoteForm->createView(),
+            'privateNoteForm' => $privateNoteForm ? $privateNoteForm->createView() : null,
             'updateOrderShippingForm' => $updateOrderShippingForm->createView(),
             'cancelProductForm' => $cancelProductForm->createView(),
             'invoiceManagementIsEnabled' => $orderForViewing->isInvoiceManagementIsEnabled(),
-            'changeOrderAddressForm' => $changeOrderAddressForm->createView(),
+            'changeOrderAddressForm' => $changeOrderAddressForm ? $changeOrderAddressForm->createView() : null,
             'orderMessageForm' => $orderMessageForm->createView(),
             'addProductRowForm' => $addProductRowForm->createView(),
             'editProductRowForm' => $editProductRowForm->createView(),

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/disableable_link.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/disableable_link.html.twig
@@ -23,31 +23,13 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-<h1 class="d-inline">
-  <strong class="text-muted">#{{ orderForViewing.id }}</strong>
-  <strong>{{ orderForViewing.reference }}</strong>
-</h1>
+{% extends "@PrestaShop/Admin/Common/Grid/Columns/Content/link.html.twig" %}
 
-<p class="lead d-inline">
-  {{ 'from'|trans({}, 'Admin.Global') }}
 
-  {% if orderForViewing.customer is not null %}
-    {{ orderForViewing.customer.firstName }}
-    {{ orderForViewing.customer.lastName }}
-  {% else %}
+{% block link %}
+  {% if record[column.options.disabled_field] %}
     {{ 'Deleted customer'|trans({}, 'Admin.Global') }}
+  {% else %}
+    {{ parent() }}
   {% endif %}
-</p>
-
-<span class="badge rounded badge-dark ml-2 mr-2 font-size-100">
-    {{ orderForViewing.prices.totalAmountFormatted }}
-  </span>
-
-<p class="lead d-inline">
-  {{ orderForViewing.createdAt|date('Y-m-d') }}
-  <span class="text-muted">
-      {{ 'at'|trans({}, 'Admin.Global') }}
-
-    {{ orderForViewing.createdAt|date('H:i:s') }}
-    </span>
-</p>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/link.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/link.html.twig
@@ -35,9 +35,11 @@
   {% endif %}
 {% endif %}
 
+{% block link %}
 <a class="{{ class }}" href="{{ path(column.options.route, { (column.options.route_param_name) : record[column.options.route_param_field]}) }}">
   {% if column.options.icon is defined %}
     <i class="material-icons">{{ column.options.icon }}</i>
   {% endif %}
   {{ record[column.options.field] }}
 </a>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/view_all_messages_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/view_all_messages_modal.html.twig
@@ -30,7 +30,12 @@
         <div class="row">
           <div class="col">
             <h3 class="card-header-title">
-              {{ 'Message history with %name%'|trans({'%name%': orderForViewing.customer.firstName ~ ' ' ~ orderForViewing.customer.lastName}, 'Admin.Global') }} ({{ orderForViewing.messages.messages|length }})
+              {% if orderForViewing.customer is not null %}
+                {{ 'Message history with %name%'|trans({'%name%': orderForViewing.customer.firstName ~ ' ' ~ orderForViewing.customer.lastName}, 'Admin.Global') }}
+              {% else %}
+                {{ 'Message history'|trans({}, 'Admin.Global') }}
+              {% endif %}
+              ({{ orderForViewing.messages.messages|length }})
             </h3>
           </div>
           <div class="col">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -33,6 +33,7 @@
   <div class="card-body">
     <div class="info-block">
       <div class="row">
+        {% if orderForViewing.customer is not null %}
         <div class="col-md-6">
           <h2 class="mb-0">
             <i class="material-icons">account_box</i>
@@ -49,8 +50,14 @@
             {{ 'View full details'|trans({}, 'Admin.Actions') }}
           </a>
         </div>
+        {% else %}
+        <div class="col">
+          <h2 class="mb-0">{{ 'Deleted customer'|trans({}, 'Admin.Global') }}</h2>
+        </div>
+        {% endif %}
       </div>
     </div>
+    {% if orderForViewing.customer is not null %}
     <div class="row mt-3">
       <div class="col-md-6">
         <p class="mb-1">
@@ -83,11 +90,13 @@
         </p>
       </div>
     </div>
+    {% endif %}
     <div class="mt-2 info-block">
       <div class="row">
         <div class="col-md-6">
           <div class="row justify-content-between no-gutters">
             <strong>{{ 'Shipping address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            {% if orderForViewing.customer is not null %}
             <a class="tooltip-link d-print-none" href="#" data-toggle="dropdown">
               <i class="material-icons">more_vert</i>
             </a>
@@ -115,6 +124,7 @@
                 {{ 'Change address'|trans({}, 'Admin.Actions') }}
               </a>
             </div>
+            {% endif %}
           </div>
 
           <p class="mb-0">{{ orderForViewing.shippingAddress.fullName }}</p>
@@ -142,6 +152,7 @@
           <div class="row justify-content-between no-gutters">
             <strong>{{ 'Invoice address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
 
+            {% if orderForViewing.customer is not null %}
             <a class="tooltip-link d-print-none" href="#" data-toggle="dropdown">
               <i class="material-icons">more_vert</i>
             </a>
@@ -169,6 +180,7 @@
                 {{ 'Change address'|trans({}, 'Admin.Actions') }}
               </a>
             </div>
+            {% endif %}
           </div>
 
           <p class="mb-0">{{ orderForViewing.invoiceAddress.fullName }}</p>
@@ -194,6 +206,7 @@
         </div>
       </div>
     </div>
+    {% if orderForViewing.customer is not null %}
     <div class="mt-2 info-block">
       <div class="row">
         {% set isPrivateNoteOpen = not orderForViewing.customer.privateNote is empty %}
@@ -240,5 +253,6 @@
         </div>
       </div>
     </div>
+    {% endif %}
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -86,7 +86,9 @@
     {{ renderhook('displayAdminOrder', {'id_order': orderForViewing.id}) }}
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig' %}
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig' %}
-    {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/update_customer_address_modal.html.twig' %}
+    {% if orderForViewing.customer is not null %}
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/update_customer_address_modal.html.twig' %}
+    {% endif %}
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/view_all_messages_modal.html.twig' %}
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/view_product_pack_modal.html.twig' %}
   </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When a customer was hard deleted, you couldn't see his orders preview and details. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17311
| How to test?  | 1. Go to BO > Customers > Customers<br>2. Delete John Doe<br>3. Go on the migrated order list<br>4. See this [issue comment](https://github.com/PrestaShop/PrestaShop/issues/17311#issuecomment-581481515) to see what should be displayed on the list and on the order details.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17535)
<!-- Reviewable:end -->
