### PR TITLE
Fix grids, when search finds no result we still display filters and reset button

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/filters_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/filters_row.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-<tr class="column-filters {% if 0 == grid.data.records_total or (grid.filters is empty and grid.actions.bulk|length < 0) %}d-none{% endif %}">
+<tr class="column-filters {% if 0 == grid.data.records_total and grid.filters is empty and grid.actions.bulk|length < 0 %}d-none{% endif %}">
   {% for column in grid.columns %}
     <td>
       {% if loop.first and grid.actions.bulk|length > 0 %}


### PR DESCRIPTION
This reverts commit 8647e5b514df931e06a9426a52fd573b1ee42439.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Reverts 8647e5b514df931e06a9426a52fd573b1ee42439. Fix grids, when search finds no result we still display filters and reset button
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/17548
| How to test?  | See ticket

Downside of this PR: when an empty grid (= no data, like no brands or no suppliers) is displayed, we display filters even though there is no data to filter. But it's better this way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17547)
<!-- Reviewable:end -->
