### PR TITLE
fix pelago/emogrifier version spech in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "nikic/php-parser": "^4.0",
         "paragonie/random_compat": "^2.0",
         "pear/archive_tar": "^1.4.6",
-        "pelago/emogrifier": "^2.1",
+        "pelago/emogrifier": "2.1.1",
         "phpoffice/phpspreadsheet": "~1.5",
         "prestashop/blockreassurance": "^4.1",
         "prestashop/circuit-breaker": "^3.0",


### PR DESCRIPTION
I think the composer.json package version should be forced to be 2.1.1 or this bug could happen, see https://github.com/PrestaShop/PrestaShop/issues/16017

composer upgrade will bring 2.2.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17554)
<!-- Reviewable:end -->
