### PR TITLE
Prevent email enumeration

### DIFF
--- a/src/Core/Crypto/Hashing.php
+++ b/src/Core/Crypto/Hashing.php
@@ -110,6 +110,18 @@ class Hashing
                     return password_hash($passwd, PASSWORD_BCRYPT);
                 },
                 'verify' => function ($passwd, $hash, $staticSalt) {
+                    /*
+                     * Prevent enumeration because nothing happens
+                     * when there is no, or an invalid hash.
+                     * Also, change the password to be sure it's not maching
+                     * the new hash.
+                     * The new hash is equal to 'test' in BCRYPT context.
+                     */
+                    if (empty($hash)) {
+                        $hash = '$2y$10$azRqq.pN0OlWjeVfVMZXOOwqYAx1hMfme6ZnDV.27grGOEZvG.uAO';
+                        $passwd = 'wrongPassword';
+                    }
+
                     return password_verify($passwd, $hash);
                 },
             ],


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The `password_hash` function does nothing when the hash is missing or invalid. Because of this, when you enter an invalid email address, there is no `hash` data retrieved from the database,
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | You are still able to login in the FO with a valid email / password, and can't login with an invalid email / password :smile: .


Details:

Without the fix when the email is invalid
![image](https://user-images.githubusercontent.com/1462701/74104155-509ba300-4b52-11ea-922b-6b4880053d16.png)
When the mail is valid
![image](https://user-images.githubusercontent.com/1462701/74104163-5b563800-4b52-11ea-8dac-dc3dff42ee22.png)


With the fix when the email is invalid:
![image](https://user-images.githubusercontent.com/1462701/74104179-75901600-4b52-11ea-8c75-8f4b5578b840.png)
No change with valid email 
![image](https://user-images.githubusercontent.com/1462701/74104183-7e80e780-4b52-11ea-90b9-8e7067aaf094.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17577)
<!-- Reviewable:end -->
