### PR TITLE
WIP: Fix "The promo value is not correct in the cart summary & checkout summary"

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -680,7 +680,7 @@ class CartPresenter implements PresenterInterface
     protected function getAmountVoucherReductionPercentage(Cart $cart, $products, $cartVoucher)
     {
         $amount = null;
-        $calculator = $cart->newCalculator($products, $cart->getCartRules(),null);
+        $calculator = $cart->newCalculator($products, $cart->getCartRules(), null);
         $cartRowCheapest = $calculator->getRowCheapest($cartVoucher);
         $cartRowCheapest->processCalculation($cart);
         $amount = $calculator->getAmountPercentageReduction($cartRowCheapest, $cartVoucher['obj']);

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -683,7 +683,7 @@ class CartPresenter implements PresenterInterface
         $calculator = $cart->newCalculator($products, $cart->getCartRules(), null);
         $cartRowCheapest = $calculator->getRowCheapest($cartVoucher);
         $cartRowCheapest->processCalculation($cart);
-        $amount = $calculator->getAmountPercentageReduction($cartRowCheapest, $cartVoucher['reduction_percent']);
+        $amount = $cartRowCheapest->applyPercentageDiscount($cartVoucher['reduction_percent'], true);
 
         return $amount;
     }

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
+use PrestaShop\PrestaShop\Core\Cart\AmountImmutable;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 use Product;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -663,5 +664,27 @@ class CartPresenter implements PresenterInterface
         }
 
         return $attributesArray;
+    }
+
+    /**
+     * Calculate the amount of reduction when cart rule contains percent reduction
+     *
+     * @todo renaming of method name and signature
+     *
+     * @param Cart $cart
+     * @param array $products
+     * @param array $cartVoucher
+     *
+     * @return AmountImmutable $amount
+     */
+    protected function getAmountVoucherReductionPercentage(Cart $cart, $products, $cartVoucher)
+    {
+        $amount = null;
+        $calculator = $cart->newCalculator($products, $cart->getCartRules(),null);
+        $cartRowCheapest = $calculator->getCheapestRow($cartVoucher);
+        $cartRowCheapest->processCalculation($cart);
+        $amount = $calculator->getAmountPercentageReduction($cartRowCheapest, $cartVoucher['obj']);
+
+        return $amount;
     }
 }

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -683,7 +683,7 @@ class CartPresenter implements PresenterInterface
         $calculator = $cart->newCalculator($products, $cart->getCartRules(), null);
         $cartRowCheapest = $calculator->getRowCheapest($cartVoucher);
         $cartRowCheapest->processCalculation($cart);
-        $amount = $calculator->getAmountPercentageReduction($cartRowCheapest, $cartVoucher['obj']);
+        $amount = $calculator->getAmountPercentageReduction($cartRowCheapest, $cartVoucher['reduction_percent']);
 
         return $amount;
     }

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -436,7 +436,7 @@ class CartPresenter implements PresenterInterface
         ];
 
         $discounts = $cart->getDiscounts();
-        $vouchers = $this->getTemplateVarVouchers($cart);
+        $vouchers = $this->getTemplateVarVouchers($cart, $products);
 
         $cartRulesIds = array_flip(array_map(
             function ($voucher) {
@@ -521,7 +521,7 @@ class CartPresenter implements PresenterInterface
         return $shippingDisplayValue;
     }
 
-    private function getTemplateVarVouchers(Cart $cart)
+    private function getTemplateVarVouchers(Cart $cart, $products)
     {
         $cartVouchers = $cart->getCartRules();
         $vouchers = [];
@@ -558,8 +558,8 @@ class CartPresenter implements PresenterInterface
                 $freeShippingOnly = true;
             }
             if ($this->cartVoucherHasPercentReduction($cartVoucher)) {
-                $productsTotalExcludingTax = $cart->getOrderTotal($this->includeTaxes(), Cart::ONLY_PRODUCTS);
-                $percentageReduction = ($productsTotalExcludingTax / 100) * $cartVoucher['reduction_percent'];
+                $percentageReductionAmount = $this->getAmountVoucherReductionPercentage($cart, $products, $cartVoucher);
+                $percentageReduction = $percentageReductionAmount->getTaxExcluded();
                 $freeShippingOnly = false;
             } elseif ($this->cartVoucherHasAmountReduction($cartVoucher)) {
                 $amountReduction = $this->includeTaxes() ? $cartVoucher['reduction_amount'] : $cartVoucher['value_tax_exc'];
@@ -681,7 +681,7 @@ class CartPresenter implements PresenterInterface
     {
         $amount = null;
         $calculator = $cart->newCalculator($products, $cart->getCartRules(),null);
-        $cartRowCheapest = $calculator->getCheapestRow($cartVoucher);
+        $cartRowCheapest = $calculator->getRowCheapest($cartVoucher);
         $cartRowCheapest->processCalculation($cart);
         $amount = $calculator->getAmountPercentageReduction($cartRowCheapest, $cartVoucher['obj']);
 

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -327,4 +327,34 @@ class Calculator
     {
         return $this->cartRuleCalculator->getCartRulesData();
     }
+
+    /**
+     * @param array $cartVoucher
+     *
+     * @return CartRow
+     */
+    public function getRowCheapest($cartVoucher)
+    {
+
+        $this->cartRuleCalculator->setCartRules($this->cartRules)
+            ->setCartRows($this->cartRows)
+            ->setCalculator($this);
+
+        $rowCheapest = $this->cartRuleCalculator->getRowCheapestProduct($cartVoucher['obj'], $this->cart);
+
+        return $rowCheapest;
+    }
+
+    /**
+     * @param CartRow $cartRow
+     * @param array $cartVoucher
+     *
+     * @return AmountImmutable
+     */
+    public function getAmountPercentageReduction($cartRow, $cartVoucher)
+    {
+        $amount = $this->cartRuleCalculator->getAmountReductionFromRow($cartRow, $cartVoucher);
+
+        return $amount;
+    }
 }

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -346,13 +346,13 @@ class Calculator
 
     /**
      * @param CartRow $cartRow
-     * @param array $cartVoucher
+     * @param float $percent
      *
      * @return AmountImmutable
      */
-    public function getAmountPercentageReduction($cartRow, $cartVoucher)
+    public function getAmountPercentageReduction($cartRow, $percent)
     {
-        $amount = $this->cartRuleCalculator->getAmountReductionFromRow($cartRow, $cartVoucher);
+        $amount = $cartRow->applyPercentageDiscount($percent, true);
 
         return $amount;
     }

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -335,7 +335,6 @@ class Calculator
      */
     public function getRowCheapest($cartVoucher)
     {
-
         $this->cartRuleCalculator->setCartRules($this->cartRules)
             ->setCartRows($this->cartRows)
             ->setCalculator($this);

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -343,17 +343,4 @@ class Calculator
 
         return $rowCheapest;
     }
-
-    /**
-     * @param CartRow $cartRow
-     * @param float $percent
-     *
-     * @return AmountImmutable
-     */
-    public function getAmountPercentageReduction($cartRow, $percent)
-    {
-        $amount = $cartRow->applyPercentageDiscount($percent, true);
-
-        return $amount;
-    }
 }

--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop SA and Contributors
+ * 2007-2020 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @copyright 2007-2020 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
@@ -447,17 +447,19 @@ class CartRow
 
     /**
      * @param float $percent 0-100
+     * @param bool $onUnitPrice
      *
      * @return AmountImmutable
      */
-    public function applyPercentageDiscount($percent)
+    public function applyPercentageDiscount($percent, $onUnitPrice = false)
     {
         $percent = (float) $percent;
         if ($percent < 0 || $percent > 100) {
             throw new \Exception('Invalid percentage discount given: ' . $percent);
         }
-        $discountTaxIncluded = $this->finalTotalPrice->getTaxIncluded() * $percent / 100;
-        $discountTaxExcluded = $this->finalTotalPrice->getTaxExcluded() * $percent / 100;
+        $priceUsed = (bool) $onUnitPrice ? $this->initialUnitPrice : $this->finalTotalPrice;
+        $discountTaxIncluded = $priceUsed->getTaxIncluded() * $percent / 100;
+        $discountTaxExcluded = $priceUsed->getTaxExcluded() * $percent / 100;
         $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
         $this->applyFlatDiscount($amount);
 

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -325,4 +325,28 @@ class CartRuleCalculator
         return $cartRowCheapest;
     }
 
+    /**
+     * Get the amount of the percentage reduction of a cart rule that contains specific row calculation
+     * ( as example: cheapest product and specific product
+     *
+     * @todo Rename this method name and signature
+     * @param CartRow $cartRow
+     * @param CartRule $cartRule
+     *
+     * @return AmountImmutable $amount
+     */
+    public function getAmountReductionFromRow($cartRow, $cartRule)
+    {
+
+        $amount = null;
+        if ($cartRow !== null) {
+            $discountTaxIncluded = $cartRow->getInitialUnitPrice()->getTaxIncluded()
+                * $cartRule->reduction_percent / 100;
+            $discountTaxExcluded = $cartRow->getInitialUnitPrice()->getTaxExcluded()
+                * $cartRule->reduction_percent / 100;
+            $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
+
+        }
+        return $amount;
+    }
 }

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -148,9 +148,10 @@ class CartRuleCalculator
             if ($cartRule->reduction_product == -1) {
                 /** @var CartRow|null $cartRowCheapest */
                 $cartRowCheapest = $this->getRowCheapestProduct($cartRule, $cart);
-                $amount = $this->getAmountReductionFromRow($cartRowCheapest, $cartRule);
-                $cartRowCheapest->applyFlatDiscount($amount);
-                $cartRuleData->addDiscountApplied($amount);
+                if($cartRowCheapest !== null) {
+                    $amount = $cartRowCheapest->applyPercentageDiscount($cartRule->reduction_percent, true);
+                    $cartRuleData->addDiscountApplied($amount);
+                }
             }
 
             // Discount (%) on the selection of products
@@ -315,28 +316,5 @@ class CartRuleCalculator
         }
 
         return $cartRowCheapest;
-    }
-
-    /**
-     * Get the amount of the percentage reduction of a cart rule that contains specific row calculation
-     * ( as example: cheapest product and specific product
-     *
-     * @param CartRow $cartRow
-     * @param CartRule $cartRule
-     *
-     * @return AmountImmutable $amount
-     */
-    public function getAmountReductionFromRow($cartRow, $cartRule)
-    {
-        $amount = null;
-        if ($cartRow !== null) {
-            $discountTaxIncluded = $cartRow->getInitialUnitPrice()->getTaxIncluded()
-                * $cartRule->reduction_percent / 100;
-            $discountTaxExcluded = $cartRow->getInitialUnitPrice()->getTaxExcluded()
-                * $cartRule->reduction_percent / 100;
-            $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
-        }
-
-        return $amount;
     }
 }

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -148,7 +148,7 @@ class CartRuleCalculator
             if ($cartRule->reduction_product == -1) {
                 /** @var CartRow|null $cartRowCheapest */
                 $cartRowCheapest = $this->getRowCheapestProduct($cartRule, $cart);
-                $amount= $this->getAmountReductionFromRow($cartRowCheapest, $cartRule);
+                $amount = $this->getAmountReductionFromRow($cartRowCheapest, $cartRule);
                 $cartRowCheapest->applyFlatDiscount($amount);
                 $cartRuleData->addDiscountApplied($amount);
             }
@@ -301,7 +301,6 @@ class CartRuleCalculator
      */
     public function getRowCheapestProduct($cartRule, $cart)
     {
-
         $cartRowCheapest = null;
         foreach ($this->cartRows as $cartRow) {
             $cartRow->processCalculation($cart);
@@ -322,7 +321,6 @@ class CartRuleCalculator
      * Get the amount of the percentage reduction of a cart rule that contains specific row calculation
      * ( as example: cheapest product and specific product
      *
-     * @todo Rename this method name and signature
      * @param CartRow $cartRow
      * @param CartRule $cartRule
      *
@@ -330,7 +328,6 @@ class CartRuleCalculator
      */
     public function getAmountReductionFromRow($cartRow, $cartRule)
     {
-
         $amount = null;
         if ($cartRow !== null) {
             $discountTaxIncluded = $cartRow->getInitialUnitPrice()->getTaxIncluded()
@@ -338,8 +335,8 @@ class CartRuleCalculator
             $discountTaxExcluded = $cartRow->getInitialUnitPrice()->getTaxExcluded()
                 * $cartRule->reduction_percent / 100;
             $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
-
         }
+
         return $amount;
     }
 }

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -148,16 +148,9 @@ class CartRuleCalculator
             if ($cartRule->reduction_product == -1) {
                 /** @var CartRow|null $cartRowCheapest */
                 $cartRowCheapest = $this->getRowCheapestProduct($cartRule, $cart);
-                if ($cartRowCheapest !== null) {
-                    // apply only on one product of the cheapest row
-                    $discountTaxIncluded = $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded()
-                        * $cartRule->reduction_percent / 100;
-                    $discountTaxExcluded = $cartRowCheapest->getInitialUnitPrice()->getTaxExcluded()
-                        * $cartRule->reduction_percent / 100;
-                    $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
-                    $cartRowCheapest->applyFlatDiscount($amount);
-                    $cartRuleData->addDiscountApplied($amount);
-                }
+                $amount= $this->getAmountReductionFromRow($cartRowCheapest, $cartRule);
+                $cartRowCheapest->applyFlatDiscount($amount);
+                $cartRuleData->addDiscountApplied($amount);
             }
 
             // Discount (%) on the selection of products

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -147,17 +147,7 @@ class CartRuleCalculator
             // Discount (%) on the cheapest product
             if ($cartRule->reduction_product == -1) {
                 /** @var CartRow|null $cartRowCheapest */
-                $cartRowCheapest = null;
-                foreach ($this->cartRows as $cartRow) {
-                    $product = $cartRow->getRowData();
-                    if (((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
-                            || !$cartRule->reduction_exclude_special)) && ($cartRowCheapest === null
-                            || $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded() > $cartRow->getInitialUnitPrice()
-                                ->getTaxIncluded())
-                    ) {
-                        $cartRowCheapest = $cartRow;
-                    }
-                }
+                $cartRowCheapest = $this->getRowCheapestProduct($cartRule, $cart);
                 if ($cartRowCheapest !== null) {
                     // apply only on one product of the cheapest row
                     $discountTaxIncluded = $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded()

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -148,7 +148,7 @@ class CartRuleCalculator
             if ($cartRule->reduction_product == -1) {
                 /** @var CartRow|null $cartRowCheapest */
                 $cartRowCheapest = $this->getRowCheapestProduct($cartRule, $cart);
-                if($cartRowCheapest !== null) {
+                if ($cartRowCheapest !== null) {
                     $amount = $cartRowCheapest->applyPercentageDiscount($cartRule->reduction_percent, true);
                     $cartRuleData->addDiscountApplied($amount);
                 }

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -307,4 +307,32 @@ class CartRuleCalculator
     {
         return $this->cartRules;
     }
+
+    /**
+     * Get the row of the cheapest product
+     *
+     * @param CartRuleData $cartRule
+     * @param Cart $cart
+     *
+     * @return CartRow $cartRowCheapest
+     */
+    public function getRowCheapestProduct($cartRule, $cart)
+    {
+
+        $cartRowCheapest = null;
+        foreach ($this->cartRows as $cartRow) {
+            $cartRow->processCalculation($cart);
+            $product = $cartRow->getRowData();
+            if (((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
+                    || !$cartRule->reduction_exclude_special)) && ($cartRowCheapest === null
+                    || $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded() > $cartRow->getInitialUnitPrice()
+                        ->getTaxIncluded())
+            ) {
+                $cartRowCheapest = $cartRow;
+            }
+        }
+
+        return $cartRowCheapest;
+    }
+
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.7.x 
| Description?  | The amount depends on the type of percentage reduction:- percent from cheapest product, or from specific product, or from selection of products, or from whole order. This processing already exists in getContextualValue() in classes/CartRule.php ([see this PR](https://github.com/PrestaShop/PrestaShop/pull/17502)). But this PR is trying another approach(Refactoring). 
| Type?         | bug fix and improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Check the amount of reduction of each cart voucher, now it depends of the types above and is not equal to all cart total (products total).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17578)
<!-- Reviewable:end -->
