### PR TITLE
Update Configuration::get phpdoc

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -196,7 +196,7 @@ class ConfigurationCore extends ObjectModel
      * @param string $key Key wanted
      * @param int $idLang Language ID
      *
-     * @return string Value
+     * @return string|false Value
      */
     public static function get($key, $idLang = null, $idShopGroup = null, $idShop = null, $default = false)
     {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Update php doc to match when configuration key doesn't exist it return false
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | phpstan trying to do some `false === Configuration::get('key')`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17589)
<!-- Reviewable:end -->
