### PR TITLE
Functional tests - Product settings enable/disable default activation status

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus.js
@@ -89,7 +89,6 @@ describe('Enable/Disable default activation status', async () => {
       this.pageObjects.boBasePage.shopParametersParentLink,
       this.pageObjects.boBasePage.productSettingsLink,
     );
-    await this.pageObjects.boBasePage.closeSfToolBar();
     const pageTitle = await this.pageObjects.productSettingsPage.getPageTitle();
     await expect(pageTitle).to.contains(this.pageObjects.productSettingsPage.pageTitle);
   });

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus.js
@@ -48,6 +48,7 @@ describe('Enable/Disable default activation status', async () => {
   loginCommon.loginBO();
 
   it('should go to \'Shop parameters > Product Settings\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductSettingsPageToEnableStatus', baseContext);
     await this.pageObjects.boBasePage.goToSubMenu(
       this.pageObjects.boBasePage.shopParametersParentLink,
       this.pageObjects.boBasePage.productSettingsLink,
@@ -58,6 +59,7 @@ describe('Enable/Disable default activation status', async () => {
   });
 
   it('should enable default activation status', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'enableDefaultActivationStatus', baseContext);
     const result = await this.pageObjects.productSettingsPage.changeDefaultActivationStatus(true);
     await expect(result).to.contains(this.pageObjects.productSettingsPage.successfulUpdateMessage);
   });
@@ -73,13 +75,14 @@ describe('Enable/Disable default activation status', async () => {
   });
 
   it('should go to create product page and check that the new product is online by default', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'createProduct', baseContext);
+    await testContext.addContextItem(this, 'testIdentifier', 'goToAddProductPageToCheckStatus', baseContext);
     await this.pageObjects.productsPage.goToAddProductPage();
     const online = await this.pageObjects.addProductPage.getOnlineButtonStatus();
     await expect(online).to.be.true;
   });
 
   it('should go to \'Shop parameters > Product Settings\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductSettingsPageToDisableStatus', baseContext);
     await this.pageObjects.boBasePage.goToSubMenu(
       this.pageObjects.boBasePage.shopParametersParentLink,
       this.pageObjects.boBasePage.productSettingsLink,
@@ -90,6 +93,7 @@ describe('Enable/Disable default activation status', async () => {
   });
 
   it('should disable default activation status', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'disableDefaultActivationStatus', baseContext);
     const result = await this.pageObjects.productSettingsPage.changeDefaultActivationStatus(false);
     await expect(result).to.contains(this.pageObjects.productSettingsPage.successfulUpdateMessage);
   });

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus.js
@@ -62,7 +62,7 @@ describe('Enable/Disable default activation status', async () => {
 
   it('should enable default activation status', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'enableDefaultActivationStatus', baseContext);
-    const result = await this.pageObjects.productSettingsPage.changeDefaultActivationStatus(true);
+    const result = await this.pageObjects.productSettingsPage.setDefaultActivationStatus(true);
     await expect(result).to.contains(this.pageObjects.productSettingsPage.successfulUpdateMessage);
   });
 
@@ -96,7 +96,7 @@ describe('Enable/Disable default activation status', async () => {
 
   it('should disable default activation status', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'disableDefaultActivationStatus', baseContext);
-    const result = await this.pageObjects.productSettingsPage.changeDefaultActivationStatus(false);
+    const result = await this.pageObjects.productSettingsPage.setDefaultActivationStatus(false);
     await expect(result).to.contains(this.pageObjects.productSettingsPage.successfulUpdateMessage);
   });
 });

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus.js
@@ -1,0 +1,96 @@
+require('module-alias/register');
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_productSettings_enableDisableDefaultActivationStatus';
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const ProductSettingsPage = require('@pages/BO/shopParameters/productSettings');
+const ProductsPage = require('@pages/BO/catalog/products');
+const AddProductPage = require('@pages/BO/catalog/products/add');
+// Importing data
+
+let browser;
+let page;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    productSettingsPage: new ProductSettingsPage(page),
+    productsPage: new ProductsPage(page),
+    addProductPage: new AddProductPage(page),
+  };
+};
+
+/*
+
+ */
+describe('Enable/Disable default activation status', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+
+  // Login into BO and go to product settings page
+  loginCommon.loginBO();
+
+  it('should go to \'Shop parameters > Product Settings\' page', async function () {
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.shopParametersParentLink,
+      this.pageObjects.boBasePage.productSettingsLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.productSettingsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.productSettingsPage.pageTitle);
+  });
+
+  it('should enable default activation status', async function () {
+    const result = await this.pageObjects.productSettingsPage.changeDefaultActivationStatus(true);
+    await expect(result).to.contains(this.pageObjects.productSettingsPage.successfulUpdateMessage);
+  });
+
+  it('should go to \'Catalog > Products\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.catalogParentLink,
+      this.pageObjects.boBasePage.productsLink,
+    );
+    const pageTitle = await this.pageObjects.productsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.productsPage.pageTitle);
+  });
+
+  it('should go to create product page and check that the new product is online by default', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'createProduct', baseContext);
+    await this.pageObjects.productsPage.goToAddProductPage();
+    const online = await this.pageObjects.addProductPage.getOnlineButtonStatus();
+    await expect(online).to.be.true;
+  });
+
+  it('should go to \'Shop parameters > Product Settings\' page', async function () {
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.shopParametersParentLink,
+      this.pageObjects.boBasePage.productSettingsLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.productSettingsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.productSettingsPage.pageTitle);
+  });
+
+  it('should disable default activation status', async function () {
+    const result = await this.pageObjects.productSettingsPage.changeDefaultActivationStatus(false);
+    await expect(result).to.contains(this.pageObjects.productSettingsPage.successfulUpdateMessage);
+  });
+});

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus.js
@@ -31,7 +31,9 @@ const init = async function () {
 };
 
 /*
-
+Enable default activation status
+Check that a new product is online by default
+Disable default activation status
  */
 describe('Enable/Disable default activation status', async () => {
   // before and after functions

--- a/tests/puppeteer/pages/BO/catalog/products/add.js
+++ b/tests/puppeteer/pages/BO/catalog/products/add.js
@@ -22,7 +22,6 @@ module.exports = class AddProduct extends BOBasePage {
     this.previewProductLink = 'a#product_form_preview_btn';
     this.productOnlineSwitch = '.product-footer div.switch-input';
     this.productOnlineTitle = 'h2.for-switch.online-title';
-    this.productDescriotionTab = '#tab_description a';
     this.productShortDescriptionTab = '#tab_description_short a';
     this.productShortDescriptionIframe = '#form_step1_description_short_1_ifr';
     this.productDescriptionTab = '#tab_description a';
@@ -302,7 +301,7 @@ module.exports = class AddProduct extends BOBasePage {
    * Get online product status
    * @returns {Promise<boolean>}
    */
-  async getOnlineButtonStatus() {
+  getOnlineButtonStatus() {
     return this.elementVisible(this.productOnlineTitle, 1000);
   }
 };

--- a/tests/puppeteer/pages/BO/catalog/products/add.js
+++ b/tests/puppeteer/pages/BO/catalog/products/add.js
@@ -21,6 +21,8 @@ module.exports = class AddProduct extends BOBasePage {
     this.saveProductButton = 'input#submit[value=\'Save\']';
     this.previewProductLink = 'a#product_form_preview_btn';
     this.productOnlineSwitch = '.product-footer div.switch-input';
+    this.productOnlineTitle = 'h2.for-switch.online-title';
+    this.productDescriotionTab = '#tab_description a';
     this.productShortDescriptionTab = '#tab_description_short a';
     this.productShortDescriptionIframe = '#form_step1_description_short_1_ifr';
     this.productDescriptionTab = '#tab_description a';
@@ -294,5 +296,13 @@ module.exports = class AddProduct extends BOBasePage {
     await this.reloadPage();
     await this.goToFormStep(5);
     return this.getAttributeContent(this.friendlyUrlInput, 'value');
+  }
+
+  /**
+   * Get online product status
+   * @returns {Promise<boolean>}
+   */
+  async getOnlineButtonStatus() {
+    return this.elementVisible(this.productOnlineTitle, 1000);
   }
 };

--- a/tests/puppeteer/pages/BO/shopParameters/productSettings/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/productSettings/index.js
@@ -16,6 +16,7 @@ module.exports = class productSettings extends BOBasePage {
     this.maxSizeShortDescriptionInput = '#form_general_short_description_limit';
     this.newDaysNumberInput = '#form_general_new_days_number';
     this.switchForceUpdateFriendlyURLLabel = 'label[for=\'form_general_force_friendly_url_%TOGGLE\']';
+    this.switchDefaultActivationStatusLabel = 'label[for=\'form_general_default_status_%TOGGLE\']';
     this.saveProductGeneralFormButton = `${this.productGeneralForm} .card-footer button`;
   }
 
@@ -74,6 +75,17 @@ module.exports = class productSettings extends BOBasePage {
    */
   async setForceUpdateFriendlyURL(toEnable = true) {
     await this.waitForSelectorAndClick(this.switchForceUpdateFriendlyURLLabel.replace('%TOGGLE', toEnable ? 1 : 0));
+    await this.clickAndWaitForNavigation(this.saveProductGeneralFormButton);
+    return this.getTextContent(this.alertSuccessBloc);
+  }
+
+  /**
+   * Change default activation status
+   * @param toEnable
+   * @returns {Promise<string|*>}
+   */
+  async changeDefaultActivationStatus(toEnable = true) {
+    await this.waitForSelectorAndClick(this.switchDefaultActivationStatusLabel.replace('%TOGGLE', toEnable ? 1 : 0));
     await this.clickAndWaitForNavigation(this.saveProductGeneralFormButton);
     return this.getTextContent(this.alertSuccessBloc);
   }

--- a/tests/puppeteer/pages/BO/shopParameters/productSettings/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/productSettings/index.js
@@ -84,7 +84,7 @@ module.exports = class productSettings extends BOBasePage {
    * @param toEnable
    * @returns {Promise<string|*>}
    */
-  async changeDefaultActivationStatus(toEnable = true) {
+  async setDefaultActivationStatus(toEnable = true) {
     await this.waitForSelectorAndClick(this.switchDefaultActivationStatusLabel.replace('%TOGGLE', toEnable ? 1 : 0));
     await this.clickAndWaitForNavigation(this.saveProductGeneralFormButton);
     return this.getTextContent(this.alertSuccessBloc);

--- a/tests/puppeteer/pages/BO/shopParameters/trafficAndSeo/seoAndUrls/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/trafficAndSeo/seoAndUrls/index.js
@@ -135,7 +135,7 @@ module.exports = class SeoAndUrls extends BOBasePage {
   async enableDisableFriendlyURL(toEnable = true) {
     await this.waitForSelectorAndClick(this.switchFriendlyUrlLabel.replace('%TOGGLE', toEnable ? 1 : 0));
     await this.clickAndWaitForNavigation(this.saveSeoAndUrlFormButton);
-    return this.getTextContent(this.alertSuccessBloc);
+    return this.getTextContent(this.alertSuccessBlock);
   }
 
   /**
@@ -146,6 +146,6 @@ module.exports = class SeoAndUrls extends BOBasePage {
   async enableDisableAccentedURL(toEnable = true) {
     await this.waitForSelectorAndClick(this.switchAccentedUrlLabel.replace('%TOGGLE', toEnable ? 1 : 0));
     await this.clickAndWaitForNavigation(this.saveSeoAndUrlFormButton);
-    return this.getTextContent(this.alertSuccessBloc);
+    return this.getTextContent(this.alertSuccessBlock);
   }
 };


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | enable/disable default activation status
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/13_shopParameters/03_productSettings/06_enableDisableDefaultActivationStatus" URL_FO=yourShopUrl npm run specific-test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17605)
<!-- Reviewable:end -->
