### PR TITLE
Fixed Empty Option in Smarty Form in Advanced Parameters > Performance

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
@@ -48,6 +48,7 @@ class SmartyType extends TranslatorAwareType
                     'Recompile templates if the files have been updated' => 1,
                     'Force compilation' => 2,
                 ],
+                'placeholder' => false,
                 'required' => false,
                 'label' => $this->trans('Template compilation', 'Admin.Advparameters.Feature'),
                 'choice_translation_domain' => 'Admin.Advparameters.Feature',
@@ -70,6 +71,7 @@ class SmartyType extends TranslatorAwareType
                     'File System' => 'filesystem',
                     'MySQL' => 'mysql',
                 ],
+                'placeholder' => false,
                 'required' => false,
                 'label' => $this->trans('Caching type', 'Admin.Advparameters.Feature'),
                 'row_attr' => [
@@ -82,6 +84,7 @@ class SmartyType extends TranslatorAwareType
                     'Never clear cache files' => 'never',
                     'Clear cache everytime something has been modified' => 'everytime',
                 ],
+                'placeholder' => false,
                 'required' => false,
                 'label' => $this->trans('Clear cache', 'Admin.Advparameters.Feature'),
                 'row_attr' => [


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fixed Empty Option in Smarty Form in Advanced Parameters > Performance
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17590
| How to test?  | Steps to reproduce the behavior:<br>1. Go to Advanced parameters > Performances<br>2. Click on 'Template compilation' dropdown<br><br>**Before :**<br>![capture d'écran_2296](https://user-images.githubusercontent.com/13449658/74168547-38975280-4c2a-11ea-864a-f63dfd080b65.png)<br>**After :** No more empty line in three `select` of the page.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17612)
<!-- Reviewable:end -->
