### PR TITLE
Files translations.css and product_page.css do not exist

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -288,11 +288,6 @@
 
 {% endblock %}
 
-{% block stylesheets %}
-  {{ parent() }}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_page.css') }}">
-{% endblock %}
-
 {% block javascripts %}
   {{ parent() }}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Translations/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Translations/overview.html.twig
@@ -56,9 +56,3 @@
     {% endif %}
 
 {% endblock %}
-
-{% block stylesheets %}
-  {{ parent() }}
-
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/translations.css') }}">
-{% endblock %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | These files do not exist
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17584 
| How to test?  | Follow ticket instruction. You don't need to use Nginx, There is no 404 in the console log.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17613)
<!-- Reviewable:end -->
