### PR TITLE
Cart object is undefined after refreshing the cart

### DIFF
--- a/themes/_core/js/cart.js
+++ b/themes/_core/js/cart.js
@@ -28,7 +28,7 @@ import {refreshCheckoutPage} from './common';
 
 $(document).ready(() => {
   prestashop.on('updateCart', (event) => {
-    prestashop.cart = event.reason.cart;
+    prestashop.cart = event.resp.cart;
     let getCartViewUrl = $('.js-cart').data('refresh-url');
 
     if (!getCartViewUrl) {

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -157,7 +157,8 @@ $(document).ready(() => {
 
       // Refresh cart preview
       prestashop.emit('updateCart', {
-        reason: dataset
+        reason: dataset,
+        resp: resp
       });
     }).fail((resp) => {
       prestashop.emit('handleError', {
@@ -202,7 +203,8 @@ $(document).ready(() => {
 
       // Refresh cart preview
       prestashop.emit('updateCart', {
-        reason: dataset
+        reason: dataset,
+        resp: resp
       });
     }).fail((resp) => {
       prestashop.emit('handleError', {eventType: 'updateProductQuantityInCart', resp: resp})


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR tries to standardize the object that is sent when the `UpdateCart` event is emitted from the classic-theme. The goal is to make the object always contain the key `resp` and a value equal to the cart object. 
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9511 #16665 
| How to test?  | Try to emit the `updateCart` event from different places in shop (quickview, product page, cart page) and then `console.log(prestashop.cart)`, you will see that the object is always different than `undefinded`.<br><br>**Scenario from #16665 (use last version of ps_shoppingcart (>2.0.2)**<br>1. Add product to cart from product page or quickview <br>2. Click on Cart or Proceed to checkout <br>3. Increase quantity for product on this page<br>![cart?action=show](https://user-images.githubusercontent.com/25119923/70031048-19899e00-15b3-11ea-8fb6-810e050591e5.png)<br>4. Amount for product updated, but on the top cart button quantity is not <br>![Not updated cart](https://user-images.githubusercontent.com/25119923/70031372-c06e3a00-15b3-11ea-99df-f517e267c071.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17633)
<!-- Reviewable:end -->
