### PR TITLE
Check if dev constant is defined when using isDebugEnabled in case boolean casting was used

### DIFF
--- a/src/Adapter/Debug/DebugMode.php
+++ b/src/Adapter/Debug/DebugMode.php
@@ -47,6 +47,10 @@ class DebugMode
      */
     public function isDebugModeEnabled()
     {
+        if ((!defined('_PS_IN_TEST_') || _PS_IN_TEST_ === false) && defined('_PS_MODE_DEV_')) {
+            return (bool) _PS_MODE_DEV_;
+        }
+
         $definesClean = '';
         $customDefinesPath = _PS_ROOT_DIR_ . '/config/defines_custom.inc.php';
         $definesPath = _PS_ROOT_DIR_ . '/config/defines.inc.php';


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The Official PrestaShop Docker related bash script copies a defines_custom.inc.php file which type casts getenv('PS_DEV_MODE') into a boolean. The function isDebugModeEnabled in the DebugMode class uses regex to which does not match (bool) '0' / (bool) '1' like values. This causes the Debug Mode switch to be OFF in the Performance page when in reality the _PS_MODE_DEV_ is set to true boolean.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Create a defines_custom.inc.php and define dev mode as a boolean cast. Performance page debug mode switch does not behave as expected.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17636)
<!-- Reviewable:end -->
