### PR TITLE
Functional tests - Customer settings enable/disable re-display cart at login

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/04_customerSettings/01_customers/01_enableDisableRedisplayCartAtLogin.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/04_customerSettings/01_customers/01_enableDisableRedisplayCartAtLogin.js
@@ -1,0 +1,104 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const CustomerSettingsPage = require('@pages/BO/shopParameters/customerSettings');
+const HomePage = require('@pages/FO/home');
+const FOBasePage = require('@pages/FO/FObasePage');
+const LoginFOPage = require('@pages/FO/login');
+// Importing data
+const {DefaultAccount} = require('@data/demo/customer');
+
+let browser;
+let page;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    customerSettingsPage: new CustomerSettingsPage(page),
+    homePage: new HomePage(page),
+    foBasePage: new FOBasePage(page),
+    loginFOPage: new LoginFOPage(page),
+  };
+};
+
+/*
+Enable re-display cart at login
+Login FO and add a product to the cart
+Logout FO then Login and check that the cart is not empty
+Disable re-display cart at login
+ */
+describe('Enable/Disable re-display cart at login', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+
+  // Login into BO and go to customer settings page
+  loginCommon.loginBO();
+
+  it('should go to \'Shop parameters > Customer Settings\' page', async function () {
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.shopParametersParentLink,
+      this.pageObjects.boBasePage.customerSettingsLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.customerSettingsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.customerSettingsPage.pageTitle);
+  });
+
+  it('should enable re-display cart at login', async function () {
+    const result = await this.pageObjects.customerSettingsPage.setRedisplayCartAtLogin(true);
+    await expect(result).to.contains(this.pageObjects.customerSettingsPage.successfulUpdateMessage);
+  });
+
+  it('should login FO and add the first product to the cart then logout ', async function () {
+    page = await this.pageObjects.boBasePage.viewMyShop();
+    this.pageObjects = await init();
+    // Login FO
+    await this.pageObjects.homePage.goToLoginPage();
+    await this.pageObjects.loginFOPage.customerLogin(DefaultAccount);
+    const connected = await this.pageObjects.homePage.isCustomerConnected();
+    await expect(connected, 'Customer is not connected in FO').to.be.true;
+    // Add first product to the cart
+    await this.pageObjects.homePage.goToHomePage();
+    await this.pageObjects.homePage.addProductToCartByQuickView(1, 1);
+    await this.pageObjects.homePage.proceedToCheckout();
+    const notificationsNumber = await this.pageObjects.homePage.getCartNotificationsNumber();
+    await expect(notificationsNumber).to.be.above(0);
+    // Logout from FO
+    await this.pageObjects.foBasePage.logout();
+  });
+
+  it('should login FO and check that the cart is not empty', async function () {
+    // Login FO
+    await this.pageObjects.homePage.goToLoginPage();
+    await this.pageObjects.loginFOPage.customerLogin(DefaultAccount);
+    const connected = await this.pageObjects.homePage.isCustomerConnected();
+    await expect(connected, 'Customer is not connected in FO').to.be.true;
+    const notificationsNumber = await this.pageObjects.homePage.getCartNotificationsNumber();
+    await expect(notificationsNumber).to.be.above(0);
+    // Logout from FO
+    await this.pageObjects.foBasePage.logout();
+    page = await this.pageObjects.homePage.closePage(browser, 1);
+    this.pageObjects = await init();
+  });
+
+  it('should disable re-display cart at login', async function () {
+    const result = await this.pageObjects.customerSettingsPage.setRedisplayCartAtLogin(false);
+    await expect(result).to.contains(this.pageObjects.customerSettingsPage.successfulUpdateMessage);
+  });
+});

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/04_customerSettings/01_customers/01_enableDisableRedisplayCartAtLogin.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/04_customerSettings/01_customers/01_enableDisableRedisplayCartAtLogin.js
@@ -1,4 +1,7 @@
 require('module-alias/register');
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_customerSettings_customer_enableDisableRedisplayCartAtLogin';
 // Using chai
 const {expect} = require('chai');
 const helper = require('@utils/helpers');
@@ -51,6 +54,7 @@ describe('Enable/Disable re-display cart at login', async () => {
   loginCommon.loginBO();
 
   it('should go to \'Shop parameters > Customer Settings\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPage', baseContext);
     await this.pageObjects.boBasePage.goToSubMenu(
       this.pageObjects.boBasePage.shopParametersParentLink,
       this.pageObjects.boBasePage.customerSettingsLink,
@@ -61,11 +65,13 @@ describe('Enable/Disable re-display cart at login', async () => {
   });
 
   it('should enable re-display cart at login', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'enableRedisplayCartAtLogin', baseContext);
     const result = await this.pageObjects.customerSettingsPage.setRedisplayCartAtLogin(true);
     await expect(result).to.contains(this.pageObjects.customerSettingsPage.successfulUpdateMessage);
   });
 
   it('should login FO and add the first product to the cart then logout ', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'addProductToTheCart', baseContext);
     page = await this.pageObjects.boBasePage.viewMyShop();
     this.pageObjects = await init();
     // Login FO
@@ -84,6 +90,7 @@ describe('Enable/Disable re-display cart at login', async () => {
   });
 
   it('should login FO and check that the cart is not empty', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginFOAndCheckNotificationNumber', baseContext);
     // Login FO
     await this.pageObjects.homePage.goToLoginPage();
     await this.pageObjects.loginFOPage.customerLogin(DefaultAccount);
@@ -98,6 +105,7 @@ describe('Enable/Disable re-display cart at login', async () => {
   });
 
   it('should disable re-display cart at login', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'disableRedisplayCartAtLogin', baseContext);
     const result = await this.pageObjects.customerSettingsPage.setRedisplayCartAtLogin(false);
     await expect(result).to.contains(this.pageObjects.customerSettingsPage.successfulUpdateMessage);
   });

--- a/tests/puppeteer/pages/BO/BObasePage.js
+++ b/tests/puppeteer/pages/BO/BObasePage.js
@@ -85,6 +85,8 @@ module.exports = class BOBasePage extends CommonPage {
     this.shopParametersGeneralLink = '#subtab-AdminParentPreferences';
     // Product Settings
     this.productSettingsLink = '#subtab-AdminPPreferences';
+    // Customer Settings
+    this.customerSettingsLink = '#subtab-AdminParentCustomerPreferences';
     // Contact
     this.contactLink = '#subtab-AdminParentStores';
     // traffic and SEO

--- a/tests/puppeteer/pages/BO/shopParameters/customerSettings/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/customerSettings/index.js
@@ -1,0 +1,31 @@
+require('module-alias/register');
+const BOBasePage = require('@pages/BO/BObasePage');
+
+module.exports = class customerSettings extends BOBasePage {
+  constructor(page) {
+    super(page);
+
+    this.pageTitle = 'Customers •';
+    this.successfulUpdateMessage = 'Update successful';
+
+    // Selectors
+    this.generalForm = '#configuration_form';
+    this.redisplayCartAtLoginLabel = 'label[for=\'form_general_redisplay_cart_at_login_%TOGGLE\']';
+    this.saveGeneralFormButton = `${this.generalForm} .card-footer button`;
+  }
+
+  /*
+    Methods
+  */
+
+  /**
+   * Enable/disable redisplay cart at login
+   * @param toEnable, true to enable and false to disable
+   * @return {Promise<string>}
+   */
+  async setRedisplayCartAtLogin(toEnable = true) {
+    await this.waitForSelectorAndClick(this.redisplayCartAtLoginLabel.replace('%TOGGLE', toEnable ? 1 : 0));
+    await this.clickAndWaitForNavigation(this.saveGeneralFormButton);
+    return this.getTextContent(this.alertSuccessBloc);
+  }
+};

--- a/tests/puppeteer/pages/FO/FObasePage.js
+++ b/tests/puppeteer/pages/FO/FObasePage.js
@@ -141,4 +141,12 @@ module.exports = class Home extends CommonPage {
   async getFooterLinksBlockTitle(position) {
     return this.getTextContent(this.wrapperTitle.replace('%POSITION', position));
   }
+
+  /**
+   * Get cart notifications number
+   * @returns {Promise<integer>}
+   */
+  async getCartNotificationsNumber() {
+    return this.getNumberFromText(this.cartProductsCount);
+  }
 };

--- a/tests/puppeteer/pages/FO/home.js
+++ b/tests/puppeteer/pages/FO/home.js
@@ -76,7 +76,7 @@ module.exports = class Home extends FOBasePage {
    */
   async addProductToCartByQuickView(id, quantity_wanted = '1') {
     await this.quickViewProduct(id);
-    await this.setValue(this.quantityWantedInput, quantity_wanted);
+    await this.setValue(this.quantityWantedInput, quantity_wanted.toString());
     await Promise.all([
       this.page.waitForSelector(this.blockCartModalDiv, {visible: true}),
       this.page.click(this.addToCartButton),


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Customer settings enable/disable re-display cart at login
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/13_shopParameters/04_customerSettings/01_customers/*" URL_FO=yourShopUrl npm run specific-test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17640)
<!-- Reviewable:end -->
