### PR TITLE
Fix wrong address edit link in order detail

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -36,7 +36,7 @@
         <div class="col-md-7">
           <h2 class="mb-0">
             <i class="material-icons">account_box</i>
-            
+
             {{ orderForViewing.customer.gender }}
             {{ orderForViewing.customer.firstName }}
             {{ orderForViewing.customer.lastName }}
@@ -96,7 +96,7 @@
               <a class="dropdown-item"
                 href="{{ getAdminLink('AdminAddresses', true, {
                   'realedit': 1,
-                  'addaddress': 1,
+                  'updateaddress': 1,
                   'address_type': 1,
                   'id_order': orderForViewing.id,
                   'id_address': orderForViewing.shippingAddress.addressId,
@@ -150,7 +150,7 @@
               <a class="dropdown-item"
                 href="{{ getAdminLink('AdminAddresses', true, {
                   'realedit': 1,
-                  'addaddress': 1,
+                  'updateaddress': 1,
                   'address_type': 2,
                   'id_order': orderForViewing.id,
                   'id_address': orderForViewing.invoiceAddress.addressId,


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The link to edit an address in order details view was wrong. This PR fixes it
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17619
| How to test?  | 1. Go to Orders > orders<br>2. Click on View<br>3. Click on edit address for shipping or invoice<br>4. You should see the edit address page instead of the new address one

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17649)
<!-- Reviewable:end -->
