### PR TITLE
Fixed display for first cell (select all & input) in grid

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -93,6 +93,15 @@ table .column-filters td:last-child .grid-reset-button {
             display: inline-block;
             width: 60px;
           }
+          .md-checkbox {
+            &:not(:last-child) {
+              display: inline-block;
+            }
+            & ~ .form-control {
+              display: inline-block;
+              width: calc(100% - 29px);
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fixed display for first cell (select all & input) in grid
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17563 
| How to test?  | Steps to reproduce the behavior:<br>0. Build assets<br>1. Go to Categories<br>2. Sort the tab (for example, by ID)<br>3. **Before :** Bulk action checkbox display is not OK<br>3. **After :** Bulk action checkbox display is OK
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17650)
<!-- Reviewable:end -->
