### PR TITLE
[WIP] Change error message in case email is not configured properly

### DIFF
--- a/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php
+++ b/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php
@@ -117,7 +117,11 @@ final class CancelOrderProductHandler extends AbstractOrderCommandHandler implem
 
                 // Delete product
                 if (!$order->deleteProduct($order, $orderDetail, $qty_cancel_product)) {
-                    throw new OrderException($this->translator->trans('An error occurred while attempting to delete the product.', [], 'Admin.Orderscustomers.Notification'));
+                    throw new OrderException($this->translator->trans(
+                        'An error occurred while attempting to delete the product, or we were unable to send an email to the customer',
+                        [],
+                        'Admin.Orderscustomers.Notification'
+                    ));
                 }
 
                 // Update weight SUM

--- a/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php
+++ b/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php
@@ -118,7 +118,7 @@ final class CancelOrderProductHandler extends AbstractOrderCommandHandler implem
                 // Delete product
                 if (!$order->deleteProduct($order, $orderDetail, $qty_cancel_product)) {
                     throw new OrderException($this->translator->trans(
-                        'An error occurred while attempting to delete the product, or we were unable to send an email to the customer',
+                        'An error occurred while attempting to delete the product. It might be your email configuration, test it in the Advanced Parameters > E-mail section of your back office to make sure you properly reach your customers.',
                         [],
                         'Admin.Orderscustomers.Notification'
                     ));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Change an error message, so that it takes into account the case of shops not having mail configuration.
 Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #17615
| How to test?  | On a shop not having mail configuration, try cancelling all products on a PR: this will trigger the change of order status and then try to send an email to the customer,  you should not have an error message.

Migrated order page url:  **admin-dev/sell/orders/orders/14/view**  (replace 14 with your order ID)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17659)
<!-- Reviewable:end -->
