### PR TITLE
Disallow birth year in two digits

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -638,7 +638,8 @@ class ValidateCore
         if (!empty(DateTime::getLastErrors()['warning_count']) || false === $d) {
             return false;
         }
-        $twoHundredYearsAgo = time()-(200*365*24*60*60);
+        $twoHundredYearsAgo = time() - (200 * 365 * 24 * 60 * 60);
+
         return $d->setTime(0, 0, 0)->getTimestamp() <= time() && $d->setTime(0, 0, 0)->getTimestamp() >= $twoHundredYearsAgo;
     }
 

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -638,9 +638,10 @@ class ValidateCore
         if (!empty(DateTime::getLastErrors()['warning_count']) || false === $d) {
             return false;
         }
-        $twoHundredYearsAgo = time() - (200 * 365 * 24 * 60 * 60);
+        $twoHundredYearsAgo = new Datetime();
+        $twoHundredYearsAgo->sub(new DateInterval('P200Y'));
 
-        return $d->setTime(0, 0, 0)->getTimestamp() <= time() && $d->setTime(0, 0, 0)->getTimestamp() >= $twoHundredYearsAgo;
+        return $d->setTime(0, 0, 0) <= new Datetime() && $d->setTime(0, 0, 0) >= $twoHundredYearsAgo;
     }
 
     /**

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -621,7 +621,7 @@ class ValidateCore
     }
 
     /**
-     * Check for birthDate validity.
+     * Check for birthDate validity. To avoid year in two digits, disallow date < 200 years ago
      *
      * @param string $date birthdate to validate
      * @param string $format optional format
@@ -638,8 +638,8 @@ class ValidateCore
         if (!empty(DateTime::getLastErrors()['warning_count']) || false === $d) {
             return false;
         }
-
-        return $d->setTime(0, 0, 0)->getTimestamp() <= time();
+        $twoHundredYearsAgo = time()-(200*365*24*60*60);
+        return $d->setTime(0, 0, 0)->getTimestamp() <= time() && $d->setTime(0, 0, 0)->getTimestamp() >= $twoHundredYearsAgo;
     }
 
     /**

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -258,6 +258,8 @@ class ValidateCoreTest extends TestCase
             array(false, '3000-03-19'),
             array(false, '1991-03-33'),
             array(false, '1991-15-19'),
+            array(false, '1801-01-01'),
+            array(false, '0085-02-25'),
             array(true, date('Y-m-d', strtotime('now'))),
             array(true, date('Y-m-d', strtotime('-1 day'))),
             array(false, date('Y-m-d', strtotime('+1 day'))),
@@ -285,6 +287,7 @@ class ValidateCoreTest extends TestCase
             array(false, date('Y-m-d', strtotime('+1 year +1 month'))),
             array(false, date('Y-m-d', strtotime('+1 year +1 month -1 day'))),
             array(false, date('Y-m-d', strtotime('+1 year +1 month +1 day'))),
+            array(false, date('Y-m-d', strtotime('-201 year'))),
         );
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | To avoid year in two digits ob bug with xx-xx-0000 date, disallow date < 200 years ago
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/17341 & https://github.com/PrestaShop/PrestaShop/issues/17507
| How to test?  |  In customer creation/modification, fill in a bith date like xx-xx-85 or xx-xx-0000 : no more year date like 0085 or error 500 for xx-xx-0000

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17664)
<!-- Reviewable:end -->
