### PR TITLE
WIP - Fix discounts subtotal - percentage reduction on specific product/selection of products

### DIFF
--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -447,7 +447,7 @@ class CartRow
 
     /**
      * @param float $percent 0-100
-     * @param boolean $onUnitPrice;
+     * @param bool $onUnitPrice;
      *
      * @return AmountImmutable
      */
@@ -462,8 +462,7 @@ class CartRow
             $discountTaxIncluded = $this->initialUnitPrice->getTaxIncluded() * $percent / 100;
             $discountTaxExcluded = $this->initialUnitPrice->getTaxExcluded() * $percent / 100;
             $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
-        }
-        else{
+        } else{
             $discountTaxIncluded = $this->finalTotalPrice->getTaxIncluded() * $percent / 100;
             $discountTaxExcluded = $this->finalTotalPrice->getTaxExcluded() * $percent / 100;
             $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);

--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -447,7 +447,7 @@ class CartRow
 
     /**
      * @param float $percent 0-100
-     * @param boolean $onUnitPrice;
+     * @param bool $onUnitPrice;
      *
      * @return AmountImmutable
      */
@@ -462,8 +462,7 @@ class CartRow
             $discountTaxIncluded = $this->initialUnitPrice->getTaxIncluded() * $percent / 100;
             $discountTaxExcluded = $this->initialUnitPrice->getTaxExcluded() * $percent / 100;
             $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
-        }
-        else{
+        } else {
             $discountTaxIncluded = $this->finalTotalPrice->getTaxIncluded() * $percent / 100;
             $discountTaxExcluded = $this->finalTotalPrice->getTaxExcluded() * $percent / 100;
             $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);

--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -447,18 +447,27 @@ class CartRow
 
     /**
      * @param float $percent 0-100
+     * @param boolean $onUnitPrice;
      *
      * @return AmountImmutable
      */
-    public function applyPercentageDiscount($percent)
+    public function applyPercentageDiscount($percent, $onUnitPrice = true)
     {
         $percent = (float) $percent;
+        $amount = null;
         if ($percent < 0 || $percent > 100) {
             throw new \Exception('Invalid percentage discount given: ' . $percent);
         }
-        $discountTaxIncluded = $this->finalTotalPrice->getTaxIncluded() * $percent / 100;
-        $discountTaxExcluded = $this->finalTotalPrice->getTaxExcluded() * $percent / 100;
-        $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
+        if ($onUnitPrice) {
+            $discountTaxIncluded = $this->initialUnitPrice->getTaxIncluded() * $percent / 100;
+            $discountTaxExcluded = $this->initialUnitPrice->getTaxExcluded() * $percent / 100;
+            $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
+        }
+        else{
+            $discountTaxIncluded = $this->finalTotalPrice->getTaxIncluded() * $percent / 100;
+            $discountTaxExcluded = $this->finalTotalPrice->getTaxExcluded() * $percent / 100;
+            $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
+        }
         $this->applyFlatDiscount($amount);
 
         return $amount;

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -128,7 +128,7 @@ class CartRuleCalculator
                     $product = $cartRow->getRowData();
                     if ((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
                         || !$cartRule->reduction_exclude_special)) {
-                        $amount = $cartRow->applyPercentageDiscount($cartRule->reduction_percent);
+                        $amount = $cartRow->applyPercentageDiscount($cartRule->reduction_percent, false);
                         $cartRuleData->addDiscountApplied($amount);
                     }
                 }
@@ -159,13 +159,7 @@ class CartRuleCalculator
                     }
                 }
                 if ($cartRowCheapest !== null) {
-                    // apply only on one product of the cheapest row
-                    $discountTaxIncluded = $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded()
-                        * $cartRule->reduction_percent / 100;
-                    $discountTaxExcluded = $cartRowCheapest->getInitialUnitPrice()->getTaxExcluded()
-                        * $cartRule->reduction_percent / 100;
-                    $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
-                    $cartRowCheapest->applyFlatDiscount($amount);
+                    $amount = $cartRowCheapest->applyPercentageDiscount($cartRule->reduction_percent);
                     $cartRuleData->addDiscountApplied($amount);
                 }
             }


### PR DESCRIPTION
For a percentage reduction, there are 4 types:
- On whole order.
- On cheapest product.
- On specific product.
- On selection of products.

For the whole order, it is obvious that the calculation should be performed on the final prices. ( perent * sum of final prices of rows)
But for cheapest product, specific product and selection of products, the calculation should be performed on unit price. This is already implemented for cheapest product. This PR tries to follow suit regarding specific product and selection of products.

This PR tries also to trigger discussion about cart rule calculations specs. An initial draft is [here](https://github.com/PrestaShop/prestashop-specs/blob/845b50998c2a5f0c783c72ae6806a92b0beecbaa/core/front-office/cart%20rules%20calculations.md) with hope of it being reviewed, corrected, tagged and helpful.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x 
| Description?  | 
| Type?         | bug fix / improvement / new feature / refacto / critical
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17666 and #17665 
| How to test?  | Reproduce issues and increase quantities of specific product in cart (or selection of products).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17667)
<!-- Reviewable:end -->
