### PR TITLE
Rework ChangeOrderCurrencyHandler to private methods

### DIFF
--- a/src/Adapter/Order/AbstractOrderHandler.php
+++ b/src/Adapter/Order/AbstractOrderHandler.php
@@ -29,8 +29,10 @@ namespace PrestaShop\PrestaShop\Adapter\Order;
 use Customer;
 use Group;
 use Order;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
+use PrestaShopException;
 
 /**
  * Reusable methods for Order subdomain command/query handlers.
@@ -44,7 +46,18 @@ abstract class AbstractOrderHandler
      */
     protected function getOrderObject(OrderId $orderId)
     {
-        $order = new Order($orderId->getValue());
+        try {
+            $order = new Order($orderId->getValue());
+        } catch (PrestaShopException $e) {
+            throw new OrderException(
+                sprintf(
+                    'Error occured when trying to get order object #%s',
+                    $orderId->getValue()
+                ),
+                0,
+                $e
+            );
+        }
 
         if ($order->id !== $orderId->getValue()) {
             throw new OrderNotFoundException($orderId, sprintf('Order with id "%d" was not found.', $orderId->getValue()));

--- a/src/Adapter/Order/CommandHandler/ChangeOrderCurrencyHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderCurrencyHandler.php
@@ -88,20 +88,22 @@ final class ChangeOrderCurrencyHandler extends AbstractOrderHandler implements C
      */
     private function updateOrderCarrier(int $orderCarrierId, Currency $oldCurrency, Currency $newCurrency): void
     {
-        if ($orderCarrierId) {
-            $order_carrier = new OrderCarrier($orderCarrierId);
-            $order_carrier->shipping_cost_tax_excl = (float) Tools::convertPriceFull(
-                $order_carrier->shipping_cost_tax_excl,
-                $oldCurrency,
-                $newCurrency
-            );
-            $order_carrier->shipping_cost_tax_incl = (float) Tools::convertPriceFull(
-                $order_carrier->shipping_cost_tax_incl,
-                $oldCurrency,
-                $newCurrency
-            );
-            $order_carrier->update();
+        if (!$orderCarrierId) {
+            return;
         }
+
+        $order_carrier = new OrderCarrier($orderCarrierId);
+        $order_carrier->shipping_cost_tax_excl = (float) Tools::convertPriceFull(
+            $order_carrier->shipping_cost_tax_excl,
+            $oldCurrency,
+            $newCurrency
+        );
+        $order_carrier->shipping_cost_tax_incl = (float) Tools::convertPriceFull(
+            $order_carrier->shipping_cost_tax_incl,
+            $oldCurrency,
+            $newCurrency
+        );
+        $order_carrier->update();
     }
 
     /**
@@ -145,11 +147,13 @@ final class ChangeOrderCurrencyHandler extends AbstractOrderHandler implements C
      */
     private function updateInvoices(PrestaShopCollection $invoices, Currency $oldCurrency, Currency $newCurrency): void
     {
-        if ($invoices->count()) {
-            foreach ($invoices as $invoice) {
-                $this->convertPriceFields($invoice, $this->getSharedAmountFields(), $oldCurrency, $newCurrency);
-                $invoice->save();
-            }
+        if (!$invoices->count()) {
+            return;
+        }
+
+        foreach ($invoices as $invoice) {
+            $this->convertPriceFields($invoice, $this->getSharedAmountFields(), $oldCurrency, $newCurrency);
+            $invoice->save();
         }
     }
 

--- a/src/Adapter/Order/CommandHandler/ChangeOrderCurrencyHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderCurrencyHandler.php
@@ -61,7 +61,7 @@ final class ChangeOrderCurrencyHandler extends AbstractOrderHandler implements C
             $oldCurrency = new Currency($order->id_currency);
             $newCurrency = new Currency($command->getNewCurrencyId()->getValue());
 
-            if (!Validate::isLoadedObject($newCurrency)) {
+            if (!Validate::isLoadedObject($oldCurrency) || !Validate::isLoadedObject($newCurrency)) {
                 throw new OrderException('Can\'t load Currency object');
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix multiple todo's `handle in private method` in ChangeOrderCurrencyHandler
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #17282
| How to test?  | Make sure Changing order currency in BO order view page works as expected. You can change order currency in order view page payments block. There should be multiple active currencies in BO and the order must be valid to see that block (although I am not aware about precise specification what is a "valid" order, but I can see it being rendered on all fixture orders regardless their status :man_shrugging:) ![Screenshot from 2020-03-12 11-15-47](https://user-images.githubusercontent.com/31609858/76505933-f9d80080-6452-11ea-83fc-010418076e13.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17672)
<!-- Reviewable:end -->
