### PR TITLE
Rework ChangeOrderCurrencyHandler to use Decimal for calculations

### DIFF
--- a/src/Adapter/Order/AbstractOrderHandler.php
+++ b/src/Adapter/Order/AbstractOrderHandler.php
@@ -29,8 +29,10 @@ namespace PrestaShop\PrestaShop\Adapter\Order;
 use Customer;
 use Group;
 use Order;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
+use PrestaShopException;
 
 /**
  * Reusable methods for Order subdomain command/query handlers.
@@ -44,7 +46,18 @@ abstract class AbstractOrderHandler
      */
     protected function getOrderObject(OrderId $orderId)
     {
-        $order = new Order($orderId->getValue());
+        try {
+            $order = new Order($orderId->getValue());
+        } catch (PrestaShopException $e) {
+            throw new OrderException(
+                sprintf(
+                    'Error occured when trying to get order object #%s',
+                    $orderId->getValue()
+                ),
+                0,
+                $e
+            );
+        }
 
         if ($order->id !== $orderId->getValue()) {
             throw new OrderNotFoundException($orderId, sprintf('Order with id "%d" was not found.', $orderId->getValue()));

--- a/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
@@ -32,6 +32,7 @@ use Order;
 use OrderCarrier;
 use OrderDetail;
 use OrderInvoice;
+use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\DeleteProductFromOrderCommand;
@@ -102,11 +103,31 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
     private function updateOrder(Order $order, OrderDetail $orderDetail)
     {
         // @todo: use https://github.com/PrestaShop/decimal for price computations
+        //@todo: this is the old code. After #17348 merged, create+run tests to accept this and then refactor to Number
         $order->total_paid -= $orderDetail->total_price_tax_incl;
         $order->total_paid_tax_incl -= $orderDetail->total_price_tax_incl;
         $order->total_paid_tax_excl -= $orderDetail->total_price_tax_excl;
         $order->total_products -= $orderDetail->total_price_tax_excl;
         $order->total_products_wt -= $orderDetail->total_price_tax_incl;
+
+        //@todo: WIP REFACTORING to Number calc. Blocked by #17348
+//        $orderPaid = new Number((string) $order->total_paid);
+//        $detailPriceTaxIncl = new Number((string) $orderDetail->total_price_tax_incl);
+//        $order->total_paid = (float) (string) $orderPaid->minus($detailPriceTaxIncl);
+//
+//        $orderPaidTaxIncl = new Number((string) $order->total_paid_tax_incl);
+//        $detailPaidTaxIncl = new Number((string) $orderDetail->total_price_tax_incl);
+//        $order->total_paid_tax_incl = (float) (string) $orderPaidTaxIncl->minus($detailPaidTaxIncl);
+//
+//        $orderPaidTaxExcl = new Number((string) $order->total_paid_tax_excl);
+//        $detailPriceTaxExcl = new Number((string) $orderDetail->total_price_tax_excl);
+//        $order->total_paid_tax_excl = (float) (string) $orderPaidTaxExcl->minus($detailPriceTaxExcl);
+//
+//        $orderProducts = new Number((string) $order->total_products);
+//        $order->total_products = (float) (string) $orderProducts->minus($detailPriceTaxExcl);
+//
+//        $orderProductsWt = new Number((string) $order->total_products_wt);
+//        $order->total_products_wt = $orderProductsWt->minus($detailPriceTaxExcl);
 
         return $order->update();
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -164,7 +164,7 @@
                   <i class="material-icons">delete</i>
               </a>
             </td>
-          </tr>
+          </tr>orderProductsOriginalPosition
         {% endfor %}
         </tbody>
       </table>

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -158,9 +158,34 @@ Feature: Order from Back Office (BO)
     When I change order "bo_order1" shipping address to "test-address"
     Then order "bo_order1" shipping address should be "test-address"
 
-  @order-from-bo
-  Scenario: Product cannot be deleted from delivered order
+  @order-from-bo-del
+  Scenario: Cannot delete product from delivered order
     When I update order "bo_order1" status to "Delivered"
     Then order "bo_order1" has status "Delivered"
     When I delete product "Mug The best is yet to come" from order "bo_order1"
     Then I should get an error "Delivered order cannot be modified."
+
+  @order-from-bo-del
+  Scenario: Delete product from order
+    Given order "bo_order1" has status "Awaiting bank wire payment"
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Mug Today is a good day |
+      | amount        | 2                       |
+      | price         | 5                       |
+      | free_shipping | true                    |
+    And order "bo_order1" should have 4 products in total
+    And Order "bo_order1" has following prices:
+    #todo: blocked by #17348
+      | products      | $33.80   |
+      | discounts     | $7.00    |
+      | shipping      | $14.00   |
+      | taxes         | $0.00    |
+      | total         | $40.80   |
+    When I delete product "Mug Today is a good day" from order "bo_order1"
+    And order "bo_order1" should have 2 products in total
+    And Order "bo_order1" has following prices:
+      | products      | $23.80   |
+      | discounts     | $0.00    |
+      | shipping      | $7.00    |
+      | taxes         | $0.00    |
+      | total         | $30.80   |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -1,4 +1,4 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags=order-from-bo
 @reset-database-before-feature
 Feature: Order from Back Office (BO)
   In order to manage orders for FO customers
@@ -34,15 +34,18 @@ Feature: Order from Back Office (BO)
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
 
+  @order-from-bo
   Scenario: Update order status
     When I update order "bo_order1" status to "Awaiting Cash On Delivery validation"
     Then order "bo_order1" has status "Awaiting Cash On Delivery validation"
 
+  @order-from-bo
   Scenario: Update order shipping details
     When I update order "bo_order1" Tracking number to "TEST1234" and Carrier to "2 - My carrier (Delivery next day!)"
     Then order "bo_order1" has Tracking number "TEST1234"
     And order "bo_order1" has Carrier "2 - My carrier (Delivery next day!)"
 
+  @order-from-bo
   Scenario: pay order with negative amount and see it is not valid
     When order "bo_order1" has 0 payments
     And I pay order "bo_order1" with the invalid following details:
@@ -54,6 +57,7 @@ Feature: Order from Back Office (BO)
     Then I should get error that payment amount is negative
     And order "bo_order1" has 0 payments
 
+  @order-from-bo
   Scenario: pay for order
     When I pay order "bo_order1" with the following details:
       | date           | 2019-11-26 13:56:23 |
@@ -67,15 +71,18 @@ Feature: Order from Back Office (BO)
       | transaction_id | test123             |
       | amount         | $6.00               |
 
+  @order-from-bo
   Scenario: Change order state to Delivered to be able to add valid invoice to new Payment
     When order "bo_order1" has 0 payments
     And I update order "bo_order1" status to "Delivered"
     Then order "bo_order1" payments should have invoice
 
+  @order-from-bo
   Scenario: Duplicate order cart
     When I duplicate order "bo_order1" cart "dummy_cart" with reference "duplicated_dummy_cart"
     Then there is duplicated cart "duplicated_dummy_cart" for cart dummy_cart
 
+  @order-from-bo
   Scenario: Add product to an existing Order with free shipping and new invoice
     Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
     When I add products to order "bo_order1" with new invoice and the following products details:
@@ -104,10 +111,12 @@ Feature: Order from Back Office (BO)
       | free_shipping | true                    |
     Then order "bo_order1" should contain 3 products "Mug Today is a good day"
 
+  @order-from-bo
   Scenario: Generating invoice for Order
     When I generate invoice for "bo_order1" order
     Then order "bo_order1" should have invoice
 
+  @order-from-bo
   Scenario: Add order from Back Office with free shipping
     And I set Free shipping to the cart "dummy_cart"
     And I add order "bo_order2" with the following details:
@@ -119,6 +128,7 @@ Feature: Order from Back Office (BO)
     And order "bo_order2" should have free shipping
     And order "bo_order2" should have "dummy_payment" payment method
 
+  @order-from-bo
   Scenario: Update multiple orders statuses using Bulk actions
     And I add order "bo_order2" with the following details:
       | cart                | dummy_cart          |
@@ -129,6 +139,7 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" has status "Delivered"
     And order "bo_order2" has status "Delivered"
 
+  @order-from-bo
   Scenario: Change order shipping address
     Given I create customer "testFirstName" with following details:
       | firstName        | testFirstName                      |
@@ -146,3 +157,10 @@ Feature: Order from Back Office (BO)
       | Postal code      | 12345                              |
     When I change order "bo_order1" shipping address to "test-address"
     Then order "bo_order1" shipping address should be "test-address"
+
+  @order-from-bo
+  Scenario: Product cannot be deleted from delivered order
+    When I update order "bo_order1" status to "Delivered"
+    Then order "bo_order1" has status "Delivered"
+    When I delete product "Mug The best is yet to come" from order "bo_order1"
+    Then I should get an error "Delivered order cannot be modified."


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | fix todo `use https://github.com/PrestaShop/decimal for price computations` in DeleteProductFromOrderHandler. Also adds behat tests to confirm behavior before refactoring and after.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #17282
| How to test?  | After deleting product from order in order view page, all prices should be correctly calculated.

:warning: Blocked by #17348
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17676)
<!-- Reviewable:end -->
