### PR TITLE
Reintroduce hook displayAdditionalCustomerAddressFields

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2713,5 +2713,10 @@
       <description>This hook allows to modify data which is about to be used in template for credit slip grid
       </description>
     </hook>
+    <hook id="displayAdditionalCustomerAddressFields">
+      <name>displayAdditionalCustomerAddressFields</name>
+      <title>Display additional customer address fields</title>
+      <description>This hook allows to display the extra field values added in an address from using hook 'additionalCustomerAddressFields'</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/themes/classic/templates/customer/_partials/block-address.tpl
+++ b/themes/classic/templates/customer/_partials/block-address.tpl
@@ -27,6 +27,8 @@
     <div class="address-body">
       <h4>{$address.alias}</h4>
       <address>{$address.formatted nofilter}</address>
+      {* To display the fields value extra added in a address from by using hook 'additionalCustomerAddressFields' *}
+      {hook h='displayAdditionalCustomerAddressFields' address=$address}
     </div>
 
     {block name='address_block_item_actions'}

--- a/themes/classic/templates/customer/_partials/block-address.tpl
+++ b/themes/classic/templates/customer/_partials/block-address.tpl
@@ -27,7 +27,7 @@
     <div class="address-body">
       <h4>{$address.alias}</h4>
       <address>{$address.formatted nofilter}</address>
-      {* To display the fields value extra added in a address from by using hook 'additionalCustomerAddressFields' *}
+      {* Display the extra field values added in an address from using hook 'additionalCustomerAddressFields' *}
       {hook h='displayAdditionalCustomerAddressFields' address=$address}
     </div>
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The hook `displayAdditionalCustomerAddressFields` was added in #12033 then accidentally removed by [this commit](https://github.com/PrestaShop/PrestaShop/pull/15167/commits/1bfabce484e334574334cdf7f1c7bd250903a0be) in an unrelated PR: #15167. This PR reverts the offending commit then adds the forgotten description in hook.xml
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Nothing to test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17677)
<!-- Reviewable:end -->
