### PR TITLE
Wrong selector - It doesn't update combination attribute values

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -194,7 +194,7 @@ function updateProduct(event, eventType, updateUrl) {
 
         $('.quickview .product-prices, .page-product:not(.modal-open) .row .product-prices').replaceWith(data.product_prices);
         $('.quickview .product-customization, .page-product:not(.modal-open) .row .product-customization').replaceWith(data.product_customization);
-        $('.quickview .product-variants .page-product:not(.modal-open) .row .product-variants').replaceWith(data.product_variants);
+        $('.quickview .product-variants, .page-product:not(.modal-open) .row .product-variants').replaceWith(data.product_variants);
         $('.quickview .product-discounts, .page-product:not(.modal-open) .row .product-discounts').replaceWith(data.product_discounts);
         $('.quickview .product-additional-info, .page-product:not(.modal-open) .row .product-additional-info').replaceWith(data.product_additional_info);
         $('.quickview #product-details, #product-details').replaceWith(data.product_details);


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Combination attribute values are not updated when you select one attribute
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Create 1 product with these combinations (color - size): Blue - S, Blue - M, Red - S, Red - L. When you load product, Blue - S is default combination, If you change color, size values are not updated to S - L, it will remain S - M.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17701)
<!-- Reviewable:end -->
