### PR TITLE
Add a confirmation modal when deleting a row from a grid in Catalog > Files

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/action/row/submit-row-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/action/row/submit-row-action-extension.js
@@ -23,6 +23,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+import ConfirmModal from '@components/modal';
+
 const {$} = window;
 
 /**
@@ -39,29 +41,62 @@ export default class SubmitRowActionExtension {
       event.preventDefault();
 
       const $button = $(event.currentTarget);
-      const confirmMessage = $button.data('confirm-message');
-
-      if (confirmMessage.length && !window.confirm(confirmMessage)) {
-        return;
-      }
+      const confirmMessage = $button.data('confirmMessage');
+      const confirmTitle = $button.data('title');
 
       const method = $button.data('method');
-      const isGetOrPostMethod = ['GET', 'POST'].includes(method);
+      if (confirmTitle) {
+        this.showConfirmModal($button, grid, confirmMessage, confirmTitle, method);
+      } else {
+        if (confirmMessage.length && !window.confirm(confirmMessage)) {
+          return;
+        }
 
-      const $form = $('<form>', {
-        action: $button.data('url'),
-        method: isGetOrPostMethod ? method : 'POST',
-      }).appendTo('body');
-
-      if (!isGetOrPostMethod) {
-        $form.append($('<input>', {
-          type: '_hidden',
-          name: '_method',
-          value: method,
-        }));
+        this.postForm($button, method);
       }
-
-      $form.submit();
     });
+  }
+
+  postForm($button, method) {
+    const isGetOrPostMethod = ['GET', 'POST'].includes(method);
+
+    const $form = $('<form>', {
+      action: $button.data('url'),
+      method: isGetOrPostMethod ? method : 'POST',
+    }).appendTo('body');
+
+    if (!isGetOrPostMethod) {
+      $form.append($('<input>', {
+        type: '_hidden',
+        name: '_method',
+        value: method,
+      }));
+    }
+
+    $form.submit();
+  }
+
+  /**
+   * @param {jQuery} $submitBtn
+   * @param {Grid} grid
+   * @param {string} confirmMessage
+   * @param {string} confirmTitle
+   * @param {string} method
+   */
+  showConfirmModal($submitBtn, grid, confirmMessage, confirmTitle, method) {
+    const confirmButtonLabel = $submitBtn.data('confirmButtonLabel');
+    const closeButtonLabel = $submitBtn.data('closeButtonLabel');
+    const confirmButtonClass = $submitBtn.data('confirmButtonClass');
+
+    const modal = new ConfirmModal({
+      id: `${grid.getId()}-grid-confirm-modal`,
+      confirmTitle,
+      confirmMessage,
+      confirmButtonLabel,
+      closeButtonLabel,
+      confirmButtonClass,
+    }, () => this.postForm($submitBtn, method));
+
+    modal.show();
   }
 }

--- a/src/Core/Grid/Action/Row/Type/SubmitRowAction.php
+++ b/src/Core/Grid/Action/Row/Type/SubmitRowAction.php
@@ -66,6 +66,7 @@ final class SubmitRowAction extends AbstractRowAction
                 'confirm_message_type' => self::MESSAGE_TYPE_STATIC,
                 'dynamic_message_field' => '',
                 'extra_route_params' => [],
+                'modal_options' => null,
             ])
             ->setAllowedTypes('route', 'string')
             ->setAllowedTypes('route_param_name', 'string')

--- a/src/Core/Grid/Definition/Factory/AttachmentGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttachmentGridDefinitionFactory.php
@@ -30,7 +30,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -49,6 +48,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 final class AttachmentGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
+    use DeleteActionTrait;
 
     public const GRID_ID = 'attachment';
 
@@ -148,21 +148,11 @@ final class AttachmentGridDefinitionFactory extends AbstractGridDefinitionFactor
                                 ])
                         )
                         ->add(
-                            (new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'route' => 'admin_attachments_delete',
-                                'route_param_name' => 'attachmentId',
-                                'route_param_field' => 'id_attachment',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                                'confirm_message_type' => SubmitRowAction::MESSAGE_TYPE_DYNAMIC,
-                                'dynamic_message_field' => 'dynamic_message',
-                            ])
+                            $this->buildDeleteAction(
+                                'admin_attachments_delete',
+                                'attachmentId',
+                                'id_attachment'
+                            )
                         ),
                 ])
             );

--- a/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
+++ b/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
@@ -47,7 +47,7 @@ trait DeleteActionTrait
                 'route_param_field' => $deleteRouteParamField,
                 'confirm_message' => $this->trans('Delete selected item?', [], 'Admin.Notifications.Warning'),
                 'modal_options' => new ModalOptions([
-                    'title' => $this->trans('Delete selected item', [], 'Admin.Actions'),
+                    'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
                     'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
                     'close_button_label' => $this->trans('Cancel', [], 'Admin.Actions'),
                     'confirm_button_class' => 'btn-danger',

--- a/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
+++ b/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
@@ -45,7 +45,7 @@ trait DeleteActionTrait
                 'route' => $deleteRouteName,
                 'route_param_name' => $deleteRouteParamName,
                 'route_param_field' => $deleteRouteParamField,
-                'confirm_message' => $this->trans('Delete selected item?', [], 'Admin.Notifications.Warning'),
+                'confirm_message' => $this->trans('Are you sure you want to delete the selected item?', [], 'Admin.Notifications.Warning'),
                 'modal_options' => new ModalOptions([
                     'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
                     'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),

--- a/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
+++ b/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
+
+/**
+ * Trait to help build the grid single line delete action
+ */
+trait DeleteActionTrait
+{
+    protected function buildDeleteAction(string $deleteRouteName, string $deleteRouteParamName, string $deleteRouteParamField): RowActionInterface
+    {
+        return (new SubmitRowAction('delete'))
+            ->setName($this->trans('Delete', [], 'Admin.Actions'))
+            ->setIcon('delete')
+            ->setOptions([
+                'route' => $deleteRouteName,
+                'route_param_name' => $deleteRouteParamName,
+                'route_param_field' => $deleteRouteParamField,
+                'confirm_message' => $this->trans('Delete selected item?', [], 'Admin.Notifications.Warning'),
+                'modal_options' => new ModalOptions([
+                    'title' => $this->trans('Delete selected item', [], 'Admin.Actions'),
+                    'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
+                    'close_button_label' => $this->trans('Cancel', [], 'Admin.Actions'),
+                    'confirm_button_class' => 'btn-danger',
+                ]),
+            ])
+        ;
+    }
+
+    /**
+     * Shortcut method to translate text.
+     */
+    abstract protected function trans($id, array $options, $domain);
+}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/submit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/submit.html.twig
@@ -47,6 +47,11 @@
    data-confirm-message="{{ confirmation_message }}"
    data-url="{{ path(action.options.route, route_params) }}"
    data-method="{{ action.options.method }}"
+  {% if action.options.modal_options.options is defined %}
+    {% for attribute, value in action.options.modal_options.options %}
+      data-{{ attribute|replace({'_':'-'}) }}="{{ value }}"
+    {% endfor %}
+  {% endif %}
   {% if attributes.tooltip_name %}
     data-toggle="pstooltip"
     data-placement="top"


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Catalog > Files
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Catalog > FIles in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17703)
<!-- Reviewable:end -->
