### PR TITLE
Order slips - ignore order discounts in taxes breakdown

### DIFF
--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -273,12 +273,21 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
      */
     public function getProductTaxesBreakdown()
     {
-        // $breakdown will be an array with tax rates as keys and at least the columns:
-        // 	- 'total_price_tax_excl'
-        // 	- 'total_amount'
-        $breakdown = [];
+        // Ignore order's discounts
+        $tmp_total_discounts_tax_excl = $this->order->total_discounts_tax_excl;
+        $tmp_total_discounts_tax_incl = $this->order->total_discounts_tax_incl;
+
+        $this->order->total_discounts_tax_excl = $this->order->total_discounts_tax_incl = 0;
 
         $details = $this->order->getProductTaxesDetails($this->order->products);
+
+        $this->order->total_discounts_tax_excl = $tmp_total_discounts_tax_excl;
+        $this->order->total_discounts_tax_incl = $tmp_total_discounts_tax_incl;
+
+        // $breakdown will be an array with tax rates as keys and at least the columns:
+        //  - 'total_price_tax_excl'
+        //  - 'total_amount'
+        $breakdown = [];
 
         foreach ($details as $row) {
             $rate = sprintf('%.3f', $row['tax_rate']);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As order slips do not use the discounts of the order (http://forge.prestashop.com/browse/PSCSX-8967), the product taxes breakdown shouldn't use them neither. By reseting the order discount, we make sure that the product taxes breakdown only use the totals computed in the HTMLTemplateOrderSlip::getContent method.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #18742
| How to test?  | 1. Create an order with 2 products (total of 100 € with a 20% VAT) and a 10 € discount<br>2. Create an order slip for 1 product (45 €)<br>3. Open the order slip PDF<br>4.The taxes breakdown total taxes should be 9 € (`45 * 0.2`) but it is 7 € (`(45 - 10) * 0.2`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17719)
<!-- Reviewable:end -->
