### PR TITLE
Set php-cs-fixer to version 2.14.2

### DIFF
--- a/.prettyci.composer.json
+++ b/.prettyci.composer.json
@@ -1,0 +1,5 @@
+{
+  "require-dev": {
+    "friendsofphp/php-cs-fixer": "2.14.2"
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | PrettyCI has been updated and use an incompatible version of php-cs-fixer with 1.7.6.x branch. This PR set the right version of php-cs-fixer for this branch.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | /
| How to test?  | No test needed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17721)
<!-- Reviewable:end -->
