### PR TITLE
Functional tests - Add test 'Sort brands and addresses'

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/03_catalog/05_brandsAndSuppliers/brands/06_sortBrandsAndAddresses.js
+++ b/tests/puppeteer/campaigns/functional/BO/03_catalog/05_brandsAndSuppliers/brands/06_sortBrandsAndAddresses.js
@@ -1,0 +1,221 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const BrandsPage = require('@pages/BO/catalog/brands');
+// Test context imports
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_catalog_brandsAndSuppliers_brands_sortBrandsAndAddresses';
+
+let browser;
+let page;
+let numberOfBrands = 0;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    brandsPage: new BrandsPage(page),
+  };
+};
+
+describe('Sort brands and addresses', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+  // Login into BO
+  loginCommon.loginBO();
+
+  it('should go to brands page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToBrandsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.catalogParentLink,
+      this.pageObjects.boBasePage.brandsAndSuppliersLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.brandsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.brandsPage.pageTitle);
+  });
+
+  it('should reset all filters and get Number of brands in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'resetFilter', baseContext);
+    numberOfBrands = await this.pageObjects.brandsPage.resetAndGetNumberOfLines('manufacturer');
+    await expect(numberOfBrands).to.be.above(0);
+  });
+
+  describe('Sort Brands', async () => {
+    const brandsTests = [
+      {
+        args:
+          {
+            testIdentifier: 'sortBrandsByIdBrandDesc', sortBy: 'id_manufacturer', sortDirection: 'desc', isFloat: true,
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortBrandsByNameAsc', sortBy: 'name', sortDirection: 'asc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortBrandsByNameDesc', sortBy: 'name', sortDirection: 'desc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortBrandsByIdBrandAsc', sortBy: 'id_manufacturer', sortDirection: 'asc', isFloat: true,
+          },
+      },
+    ];
+    brandsTests.forEach((test) => {
+      it(
+        `should sort Brands by '${test.args.sortBy}' '${test.args.sortDirection}' And check result`,
+        async function () {
+          await testContext.addContextItem(this, 'testIdentifier', test.args.testIdentifier, baseContext);
+          let nonSortedTable = await this.pageObjects.brandsPage.getAllRowsColumnContentBrandsTable(test.args.sortBy);
+          await this.pageObjects.brandsPage.sortTableBrands(test.args.sortBy, test.args.sortDirection);
+          let sortedTable = await this.pageObjects.brandsPage.getAllRowsColumnContentBrandsTable(test.args.sortBy);
+          if (test.args.isFloat) {
+            nonSortedTable = await nonSortedTable.map(text => parseFloat(text, 10));
+            sortedTable = await sortedTable.map(text => parseFloat(text, 10));
+          }
+          const expectedResult = await this.pageObjects.brandsPage.sortArray(nonSortedTable, test.args.isFloat);
+          if (test.args.sortDirection === 'asc') {
+            await expect(sortedTable).to.deep.equal(expectedResult);
+          } else {
+            await expect(sortedTable).to.deep.equal(expectedResult.reverse());
+          }
+        },
+      );
+    });
+  });
+
+  describe('Sort Addresses', async () => {
+    const brandsTests = [
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByIdAddressDesc', sortBy: 'id_address', sortDirection: 'desc', isFloat: true,
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByNameAsc', sortBy: 'name', sortDirection: 'asc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByNameDesc', sortBy: 'name', sortDirection: 'desc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByFirstNameAsc', sortBy: 'firstname', sortDirection: 'asc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByFirstNameDesc', sortBy: 'firstname', sortDirection: 'desc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByLastNameAsc', sortBy: 'lastname', sortDirection: 'asc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByLastNameDesc', sortBy: 'lastname', sortDirection: 'desc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByPostCodeAsc', sortBy: 'postcode', sortDirection: 'asc', isFloat: true,
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByPostCodeDesc', sortBy: 'postcode', sortDirection: 'desc', isFloat: true,
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByCityAsc', sortBy: 'city', sortDirection: 'asc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByCityDesc', sortBy: 'city', sortDirection: 'desc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByCountryAsc', sortBy: 'country', sortDirection: 'asc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByCountryDesc', sortBy: 'country', sortDirection: 'desc',
+          },
+      },
+      {
+        args:
+          {
+            testIdentifier: 'sortAddressesByIdAddressAsc', sortBy: 'id_address', sortDirection: 'asc', isFloat: true,
+          },
+      },
+    ];
+    brandsTests.forEach((test) => {
+      it(
+        `should sort Addresses by '${test.args.sortBy}' '${test.args.sortDirection}' And check result`,
+        async function () {
+          await testContext.addContextItem(this, 'testIdentifier', test.args.testIdentifier, baseContext);
+          let nonSortedTable = await this.pageObjects.brandsPage.getAllRowsColumnContentAddressesTable(
+            test.args.sortBy,
+          );
+          await this.pageObjects.brandsPage.sortTableAddresses(test.args.sortBy, test.args.sortDirection);
+          let sortedTable = await this.pageObjects.brandsPage.getAllRowsColumnContentAddressesTable(test.args.sortBy);
+          if (test.args.isFloat) {
+            nonSortedTable = await nonSortedTable.map(text => parseFloat(text, 10));
+            sortedTable = await sortedTable.map(text => parseFloat(text, 10));
+          }
+          const expectedResult = await this.pageObjects.brandsPage.sortArray(nonSortedTable, test.args.isFloat);
+          if (test.args.sortDirection === 'asc') {
+            await expect(sortedTable).to.deep.equal(expectedResult);
+          } else {
+            await expect(sortedTable).to.deep.equal(expectedResult.reverse());
+          }
+        },
+      );
+    });
+  });
+});

--- a/tests/puppeteer/pages/BO/catalog/brands/index.js
+++ b/tests/puppeteer/pages/BO/catalog/brands/index.js
@@ -35,6 +35,10 @@ module.exports = class Brands extends BOBasePage {
     this.dropdownToggleButton = `${this.actionsColumn} a.dropdown-toggle`;
     this.dropdownToggleMenu = `${this.actionsColumn} div.dropdown-menu`;
     this.deleteRowLink = `${this.dropdownToggleMenu} a[data-url*='/delete']`;
+    // Sort Selectors
+    this.tableHead = `${this.gridTable} thead`;
+    this.sortColumnDiv = `${this.tableHead} div.ps-sortable-column[data-sort-col-name='%COLUMN']`;
+    this.sortColumnSpanButton = `${this.sortColumnDiv} span.ps-sort`;
 
     // Brands list Selectors
     this.brandsTableEnableColumn = `${this.tableColumn
@@ -365,5 +369,92 @@ module.exports = class Brands extends BOBasePage {
    */
   async getTextColumnFromTableAddresses(row, column) {
     return this.getTextColumnFromTable('manufacturer_address', row, column);
+  }
+
+  /**
+   * Get content from all rows
+   * @param table
+   * @param column
+   * @return {Promise<[]>}
+   */
+  async getAllRowsColumnContent(table, column) {
+    const rowsNumber = await this.getNumberOfElementInGrid(table);
+    const allRowsContentTable = [];
+    let rowContent;
+    for (let i = 1; i <= rowsNumber; i++) {
+      switch (table) {
+        case 'manufacturer':
+          rowContent = await this.getTextColumnFromTableBrands(i, column);
+          break;
+        case 'manufacturer_address':
+          rowContent = await this.getTextColumnFromTableAddresses(i, column);
+          break;
+        default:
+          // Nothing to do
+      }
+      await allRowsContentTable.push(rowContent);
+    }
+    return allRowsContentTable;
+  }
+
+  /**
+   * Get content from all rows table brands
+   * @param column
+   * @return {Promise<[]>}
+   */
+  async getAllRowsColumnContentBrandsTable(column) {
+    return this.getAllRowsColumnContent('manufacturer', column);
+  }
+
+  /**
+   * Get content from all rows table addresses
+   * @param column
+   * @return {Promise<[]>}
+   */
+  async getAllRowsColumnContentAddressesTable(column) {
+    return this.getAllRowsColumnContent('manufacturer_address', column);
+  }
+
+  /* Sort methods */
+  /**
+   * Sort table by clicking on column name
+   * @param table, table to sort
+   * @param sortBy, column to sort with
+   * @param sortDirection, asc or desc
+   * @return {Promise<void>}
+   */
+  async sortTable(table, sortBy, sortDirection = 'asc') {
+    const sortColumnDiv = `${this.sortColumnDiv}[data-sort-direction='${sortDirection}']`
+      .replace('%COLUMN', sortBy)
+      .replace('%TABLE', table);
+    const sortColumnSpanButton = this.sortColumnSpanButton
+      .replace('%COLUMN', sortBy)
+      .replace('%TABLE', table);
+    let i = 0;
+    while (await this.elementNotVisible(sortColumnDiv, 1000) && i < 2) {
+      await this.clickAndWaitForNavigation(sortColumnSpanButton);
+      i += 1;
+    }
+    await this.page.waitForSelector(sortColumnDiv, {visible: true});
+  }
+
+  /**
+   * Sort table brands
+   * @param sortBy
+   * @param sortDirection
+   * @return {Promise<void>}
+   */
+  async sortTableBrands(sortBy, sortDirection = 'asc') {
+    return this.sortTable('manufacturer', sortBy, sortDirection);
+  }
+
+  /**
+   * Sort table addresses
+   * @param sortBy
+   * @param sortDirection
+   * @return {Promise<void>}
+   */
+  async sortTableAddresses(sortBy, sortDirection = 'asc') {
+    return this.sortTable('manufacturer_address', sortBy, sortDirection);
   }
 };


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add functional test `Sort brands and addresses`
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/03_catalog/05_brandsAndSuppliers/brands/06_sortBrandsAndAddresses" URL_FO=shopUrl npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17724)
<!-- Reviewable:end -->
