### PR TITLE
Restore GA for PHP CS Fixer

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,18 @@
+name: PHP tests
+on: [push, pull_request]
+jobs:
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+    name: PHP Coding Standards Fixer
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: '7.3'
+          extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+
+      - run: composer install --prefer-dist
+      - run: ./vendor/bin/php-cs-fixer fix --dry-run


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Restore GA to run PHP CS Fixer as PrettyCI seems to have issues
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Related to https://github.com/PrestaShop/PrestaShop/issues/17744
| How to test?  | No need for QA. GA must be green.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17746)
<!-- Reviewable:end -->
