### PR TITLE
Functional tests - Product settings display remaining quantity in product page

### DIFF
--- a/tests/puppeteer/campaigns/data/faker/product.js
+++ b/tests/puppeteer/campaigns/data/faker/product.js
@@ -6,7 +6,7 @@ module.exports = class Product {
     this.summary = productToCreate.summary === undefined ? faker.lorem.sentence() : productToCreate.summary;
     this.description = productToCreate.description === undefined ? faker.lorem.sentence() : productToCreate.description;
     this.reference = faker.random.alphaNumeric(7);
-    this.quantity = productToCreate.quantity || faker.random.number({min: 1, max: 9}).toString();
+    this.quantity = productToCreate.quantity.toString() || faker.random.number({min: 1, max: 9}).toString();
     this.quantity_wanted = productToCreate.wantedQuantity || '1';
     this.price = productToCreate.price || faker.random.number({min: 10, max: 20}).toString();
     this.type = productToCreate.type;

--- a/tests/puppeteer/campaigns/data/faker/product.js
+++ b/tests/puppeteer/campaigns/data/faker/product.js
@@ -6,7 +6,7 @@ module.exports = class Product {
     this.summary = productToCreate.summary === undefined ? faker.lorem.sentence() : productToCreate.summary;
     this.description = productToCreate.description === undefined ? faker.lorem.sentence() : productToCreate.description;
     this.reference = faker.random.alphaNumeric(7);
-    this.quantity = productToCreate.quantity.toString() || faker.random.number({min: 1, max: 9}).toString();
+    this.quantity = (productToCreate.quantity || faker.random.number({min: 1, max: 9})).toString();
     this.quantity_wanted = productToCreate.wantedQuantity || '1';
     this.price = productToCreate.price || faker.random.number({min: 10, max: 20}).toString();
     this.type = productToCreate.type;

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/02_productPage/02_displayRemainingQuantities.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/02_productPage/02_displayRemainingQuantities.js
@@ -1,0 +1,138 @@
+require('module-alias/register');
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_productSettings_displayAvailableQuantitiesOnProductPage';
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const ProductSettingsPage = require('@pages/BO/shopParameters/productSettings');
+const ProductsPage = require('@pages/BO/catalog/products');
+const AddProductPage = require('@pages/BO/catalog/products/add');
+const ProductPage = require('@pages/FO/product');
+const HomePage = require('@pages/FO/home');
+const SearchResultsPage = require('@pages/FO/searchResults');
+// Importing data
+const ProductFaker = require('@data/faker/product');
+
+let browser;
+let page;
+const productData = new ProductFaker({type: 'Standard product', quantity: 2});
+const remainingQuantity = 0;
+const defaultRemainingQuantity = 3;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    productSettingsPage: new ProductSettingsPage(page),
+    productsPage: new ProductsPage(page),
+    addProductPage: new AddProductPage(page),
+    homePage: new HomePage(page),
+    productPage: new ProductPage(page),
+    searchResultsPage: new SearchResultsPage(page),
+  };
+};
+
+/*
+Create product quantity 2
+Update display remaining quantities to 0
+Go to FO product page and check that the product availability is not displayed
+Update display remaining quantities to the default value
+Go to FO product page and check that the product availability is displayed
+ */
+describe('Test display remaining quantities', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+
+  // Login into BO and go to product settings page
+  loginCommon.loginBO();
+
+  it('should go to \'Catalog > Products\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.catalogParentLink,
+      this.pageObjects.boBasePage.productsLink,
+    );
+    const pageTitle = await this.pageObjects.productsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.productsPage.pageTitle);
+  });
+
+  it('should go to create product page and create a product', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'createProduct', baseContext);
+    await this.pageObjects.productsPage.goToAddProductPage();
+    const validationMessage = await this.pageObjects.addProductPage.createEditProduct(productData);
+    await expect(validationMessage).to.equal(this.pageObjects.addProductPage.settingUpdatedMessage);
+  });
+
+  it('should go to \'Shop parameters > Product Settings\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductSettingsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.shopParametersParentLink,
+      this.pageObjects.boBasePage.productSettingsLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.productSettingsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.productSettingsPage.pageTitle);
+  });
+
+  it('should update Display remaining quantities to 0', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'setDisplayRemainingQuantity', baseContext);
+    const result = await this.pageObjects.productSettingsPage.setDisplayRemainingQuantities(remainingQuantity);
+    await expect(result).to.contains(this.pageObjects.productSettingsPage.successfulUpdateMessage);
+  });
+
+  it('should check that the product availability is not displayed in FO product page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkRemainingQuantityAlert', baseContext);
+    page = await this.pageObjects.productSettingsPage.viewMyShop();
+    this.pageObjects = await init();
+    await this.pageObjects.homePage.searchProduct(productData.name);
+    await this.pageObjects.searchResultsPage.goToProductPage(1);
+    const AvailableQuantityIsVisible = await this.pageObjects.productPage.isAvailabilityQuantityDisplayed();
+    await expect(AvailableQuantityIsVisible).to.be.false;
+    page = await this.pageObjects.productPage.closePage(browser, 1);
+    this.pageObjects = await init();
+  });
+
+  it('should go to \'Shop parameters > Product Settings\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductSettingsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.shopParametersParentLink,
+      this.pageObjects.boBasePage.productSettingsLink,
+    );
+    const pageTitle = await this.pageObjects.productSettingsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.productSettingsPage.pageTitle);
+  });
+
+  it('should update Display remaining quantities to the default value', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'setDisplayRemainingQuantityDefaultValue', baseContext);
+    const result = await this.pageObjects.productSettingsPage.setDisplayRemainingQuantities(defaultRemainingQuantity);
+    await expect(result).to.contains(this.pageObjects.productSettingsPage.successfulUpdateMessage);
+  });
+
+  it('should check that the product availability is displayed in FO product page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkRemainingQuantityAlert', baseContext);
+    page = await this.pageObjects.productSettingsPage.viewMyShop();
+    this.pageObjects = await init();
+    await this.pageObjects.homePage.searchProduct(productData.name);
+    await this.pageObjects.searchResultsPage.goToProductPage(1);
+    this.pageObjects = await init();
+    const AvailableQuantityIsVisible = await this.pageObjects.productPage.isAvailabilityQuantityDisplayed();
+    await expect(AvailableQuantityIsVisible).to.be.true;
+    page = await this.pageObjects.productPage.closePage(browser, 1);
+    this.pageObjects = await init();
+  });
+});

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/02_productPage/02_displayRemainingQuantities.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/02_productPage/02_displayRemainingQuantities.js
@@ -1,7 +1,7 @@
 require('module-alias/register');
 const testContext = require('@utils/testContext');
 
-const baseContext = 'functional_BO_productSettings_displayAvailableQuantitiesOnProductPage';
+const baseContext = 'functional_BO_productSettings_displayRemainingQuantitiesOnProductPage';
 // Using chai
 const {expect} = require('chai');
 const helper = require('@utils/helpers');
@@ -67,6 +67,7 @@ describe('Test display remaining quantities', async () => {
       this.pageObjects.boBasePage.catalogParentLink,
       this.pageObjects.boBasePage.productsLink,
     );
+    await this.pageObjects.boBasePage.closeSfToolBar();
     const pageTitle = await this.pageObjects.productsPage.getPageTitle();
     await expect(pageTitle).to.contains(this.pageObjects.productsPage.pageTitle);
   });
@@ -84,7 +85,6 @@ describe('Test display remaining quantities', async () => {
       this.pageObjects.boBasePage.shopParametersParentLink,
       this.pageObjects.boBasePage.productSettingsLink,
     );
-    await this.pageObjects.boBasePage.closeSfToolBar();
     const pageTitle = await this.pageObjects.productSettingsPage.getPageTitle();
     await expect(pageTitle).to.contains(this.pageObjects.productSettingsPage.pageTitle);
   });
@@ -96,7 +96,7 @@ describe('Test display remaining quantities', async () => {
   });
 
   it('should check that the product availability is not displayed in FO product page', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'checkRemainingQuantityAlert', baseContext);
+    await testContext.addContextItem(this, 'testIdentifier', 'checkThatRemainingQuantityAlertNotVisible', baseContext);
     page = await this.pageObjects.productSettingsPage.viewMyShop();
     this.pageObjects = await init();
     await this.pageObjects.homePage.searchProduct(productData.name);
@@ -107,16 +107,6 @@ describe('Test display remaining quantities', async () => {
     this.pageObjects = await init();
   });
 
-  it('should go to \'Shop parameters > Product Settings\' page', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'goToProductSettingsPage', baseContext);
-    await this.pageObjects.boBasePage.goToSubMenu(
-      this.pageObjects.boBasePage.shopParametersParentLink,
-      this.pageObjects.boBasePage.productSettingsLink,
-    );
-    const pageTitle = await this.pageObjects.productSettingsPage.getPageTitle();
-    await expect(pageTitle).to.contains(this.pageObjects.productSettingsPage.pageTitle);
-  });
-
   it('should update Display remaining quantities to the default value', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'setDisplayRemainingQuantityDefaultValue', baseContext);
     const result = await this.pageObjects.productSettingsPage.setDisplayRemainingQuantities(defaultRemainingQuantity);
@@ -124,7 +114,7 @@ describe('Test display remaining quantities', async () => {
   });
 
   it('should check that the product availability is displayed in FO product page', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'checkRemainingQuantityAlert', baseContext);
+    await testContext.addContextItem(this, 'testIdentifier', 'checkThatRemainingQuantityAlertIsVisible', baseContext);
     page = await this.pageObjects.productSettingsPage.viewMyShop();
     this.pageObjects = await init();
     await this.pageObjects.homePage.searchProduct(productData.name);

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/02_productPage/02_displayRemainingQuantities.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/02_productPage/02_displayRemainingQuantities.js
@@ -101,8 +101,8 @@ describe('Test display remaining quantities', async () => {
     this.pageObjects = await init();
     await this.pageObjects.homePage.searchProduct(productData.name);
     await this.pageObjects.searchResultsPage.goToProductPage(1);
-    const AvailableQuantityIsVisible = await this.pageObjects.productPage.isAvailabilityQuantityDisplayed();
-    await expect(AvailableQuantityIsVisible).to.be.false;
+    const lastQuantityIsVisible = await this.pageObjects.productPage.isAvailabilityQuantityDisplayed();
+    await expect(lastQuantityIsVisible).to.be.false;
     page = await this.pageObjects.productPage.closePage(browser, 1);
     this.pageObjects = await init();
   });
@@ -120,8 +120,8 @@ describe('Test display remaining quantities', async () => {
     await this.pageObjects.homePage.searchProduct(productData.name);
     await this.pageObjects.searchResultsPage.goToProductPage(1);
     this.pageObjects = await init();
-    const AvailableQuantityIsVisible = await this.pageObjects.productPage.isAvailabilityQuantityDisplayed();
-    await expect(AvailableQuantityIsVisible).to.be.true;
+    const lastQuantityIsVisible = await this.pageObjects.productPage.isAvailabilityQuantityDisplayed();
+    await expect(lastQuantityIsVisible).to.be.true;
     page = await this.pageObjects.productPage.closePage(browser, 1);
     this.pageObjects = await init();
   });

--- a/tests/puppeteer/pages/BO/shopParameters/productSettings/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/productSettings/index.js
@@ -21,6 +21,7 @@ module.exports = class productSettings extends BOBasePage {
     // Product page selectors
     this.productPageForm = '#configuration_fieldset_fo_product_page';
     this.switchDisplayAvailableQuantities = 'label[for=\'form_page_display_quantities_%TOGGLE\']';
+    this.remainingQuantityInput = '#form_page_display_last_quantities';
     this.saveProductPageFormButton = `${this.productPageForm} .card-footer button`;
   }
 
@@ -101,6 +102,12 @@ module.exports = class productSettings extends BOBasePage {
    */
   async setDisplayAvailableQuantities(toEnable = true) {
     await this.waitForSelectorAndClick(this.switchDisplayAvailableQuantities.replace('%TOGGLE', toEnable ? 1 : 0));
+    await this.clickAndWaitForNavigation(this.saveProductPageFormButton);
+    return this.getTextContent(this.alertSuccessBlock);
+  }
+
+  async setDisplayRemainingQuantities(quantity) {
+    await this.setValue(this.remainingQuantityInput, quantity.toString());
     await this.clickAndWaitForNavigation(this.saveProductPageFormButton);
     return this.getTextContent(this.alertSuccessBlock);
   }

--- a/tests/puppeteer/pages/FO/home.js
+++ b/tests/puppeteer/pages/FO/home.js
@@ -15,6 +15,7 @@ module.exports = class Home extends FOBasePage {
     this.totalProducts = '#js-product-list-top .total-products > p';
     this.productPrice = `${this.productArticle} span[aria-label="Price"]`;
     this.newFlag = `${this.productArticle} .product-flag.new`;
+    this.searchInput = '#search_widget input.ui-autocomplete-input';
     // Quick View modal
     this.quickViewModalDiv = 'div[id*=\'quickview-modal\']';
     this.quantityWantedInput = `${this.quickViewModalDiv} input#quantity_wanted`;
@@ -110,5 +111,16 @@ module.exports = class Home extends FOBasePage {
    */
   async isNewFlagVisible(id = 1) {
     return this.elementVisible(this.newFlag.replace('%NUMBER', id), 1000);
+  }
+
+  /**
+   * Search product
+   * @param productName
+   * @returns {Promise<void>}
+   */
+  async searchProduct(productName) {
+    await this.setValue(this.searchInput, productName);
+    await this.page.keyboard.press('Enter');
+    await this.page.waitForNavigation({waitUntil: 'networkidle0'});
   }
 };

--- a/tests/puppeteer/pages/FO/product.js
+++ b/tests/puppeteer/pages/FO/product.js
@@ -49,7 +49,7 @@ module.exports = class Product extends FOBasePage {
 
   /**
    * Is availability product displayed
-   * @returns {boolean|true}
+   * @returns {boolean}
    */
   isAvailabilityQuantityDisplayed() {
     return this.elementVisible(this.productAvailabilityIcon, 1000);

--- a/tests/puppeteer/pages/FO/product.js
+++ b/tests/puppeteer/pages/FO/product.js
@@ -14,6 +14,7 @@ module.exports = class Product extends FOBasePage {
     this.proceedToCheckoutButton = '#blockcart-modal div.cart-content-btn a';
     this.productQuantitySpan = '#product-details div.product-quantities label';
     this.productDetail = 'div.product-information  a[href=\'#product-details\']';
+    this.productAvailabilityIcon = '#product-availability i';
   }
 
   /**
@@ -44,5 +45,13 @@ module.exports = class Product extends FOBasePage {
   async isQuantityDisplayed() {
     await this.waitForSelectorAndClick(this.productDetail);
     return this.elementVisible(this.productQuantitySpan, 1000);
+  }
+
+  /**
+   * Is availability product displayed
+   * @returns {boolean|true}
+   */
+  isAvailabilityQuantityDisplayed() {
+    return this.elementVisible(this.productAvailabilityIcon, 1000);
   }
 };

--- a/tests/puppeteer/pages/FO/searchResults.js
+++ b/tests/puppeteer/pages/FO/searchResults.js
@@ -15,9 +15,6 @@ module.exports = class SearchResults extends FOBasePage {
    * @param id, product id
    */
   async goToProductPage(id) {
-    await Promise.all([
-      this.page.waitForNavigation({waitUntil: 'networkidle0'}),
-      this.page.click(this.productImg.replace('%NUMBER', id)),
-    ]);
+    await this.clickAndWaitForNavigation(this.productImg.replace('%NUMBER', id));
   }
 };

--- a/tests/puppeteer/pages/FO/searchResults.js
+++ b/tests/puppeteer/pages/FO/searchResults.js
@@ -1,0 +1,23 @@
+require('module-alias/register');
+const FOBasePage = require('@pages/FO/FObasePage');
+
+module.exports = class SearchResults extends FOBasePage {
+  constructor(page) {
+    super(page);
+
+    // Selectors for search Results page
+    this.productArticle = '#js-product-list .products div:nth-child(%NUMBER) article';
+    this.productImg = `${this.productArticle} img`;
+  }
+
+  /**
+   * Go to the product page
+   * @param id, product id
+   */
+  async goToProductPage(id) {
+    await Promise.all([
+      this.page.waitForNavigation({waitUntil: 'networkidle0'}),
+      this.page.click(this.productImg.replace('%NUMBER', id)),
+    ]);
+  }
+};


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Test display remaining quantity in product page
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/13_shopParameters/03_productSettings/02_productPage/02_displayRemainingQuantities.js" URL_FO=yourShopURL npm run specific-test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17754)
<!-- Reviewable:end -->
