### PR TITLE
Multishop - BO : Fix orders not appearing in order list for shared space shops

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -1,3 +1,6 @@
+parameters:
+    multishop.settings.share_orders: !php/const Shop::SHARE_ORDER
+
 imports:
     - { resource: services/bundle/*.yml }
     - { resource: services/core/*.yml }

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -206,7 +206,7 @@ services:
             - '%database_prefix%'
             - '@prestashop.core.query.doctrine_search_criteria_applicator'
             - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
-            - '@=service("prestashop.adapter.shop.context").getContextListShopID()'
+            - '@=service("prestashop.adapter.shop.context").getContextListShopID("share_order")'
 
     prestashop.core.grid.query_builder.catalog_price_rule:
         class: 'PrestaShop\PrestaShop\Core\Grid\Query\CatalogPriceRuleQueryBuilder'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -206,7 +206,7 @@ services:
             - '%database_prefix%'
             - '@prestashop.core.query.doctrine_search_criteria_applicator'
             - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
-            - '@=service("prestashop.adapter.shop.context").getContextListShopID("share_order")'
+            - "@=service(\"prestashop.adapter.shop.context\").getContextListShopID(parameter('multishop.settings.share_orders'))"
 
     prestashop.core.grid.query_builder.catalog_price_rule:
         class: 'PrestaShop\PrestaShop\Core\Grid\Query\CatalogPriceRuleQueryBuilder'


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In multishop, when two shops share the same space and the space is configured to share orders: an order made on one shop should appear on the other in the order list in the BO. See issue for more detailed explanations.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17727
| How to test?  | **Copy pasted from the issue:**<br>- Go to Shop parameters > General and enable multistore<br> - Go to Advanced parameters > Multistore<br> - Click on Add new shop group "all shared group"<br> - Share customers, share available quantities to sell, share orders<br> - Create a new store "shop3" in "all shared group"<br> - Create a new store "shop4" in "all shared group"<br>- Make an order in FO in shop3<br> - Go to orders > orders **migrated** listing<br> - Select shop4<br> - You should see the order make in shop3 because orders are shared in this group

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17767)
<!-- Reviewable:end -->
