### PR TITLE
Category update position test refactored to use generated position

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -223,7 +223,8 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
 
         /** @var CategoryTreeChoiceProvider $categoryTreeChoiceProvider */
         $categoryTreeChoiceProvider = $this->container->get(
-            'prestashop.adapter.form.choice_provider.category_tree_choice_provider');
+            'prestashop.adapter.form.choice_provider.category_tree_choice_provider'
+        );
         $categoryTreeIterator = new CategoryTreeIterator($categoryTreeChoiceProvider);
         $parentCategoryId = $categoryTreeIterator->getCategoryId($testCaseData['Parent category']);
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -209,12 +209,12 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @When I update category :categoryReference position with following details:
+     * @When I update category :categoryReference with generated position and following details:
      *
      * @param string $categoryReference
      * @param TableNode $table
      */
-    public function updateCategoryPositionWithFollowingDetails(string $categoryReference, TableNode $table)
+    public function updateCategoryWithGeneratedPositionAndFollowingDetails(string $categoryReference, TableNode $table)
     {
         /** @var array $testCaseData */
         $testCaseData = $table->getRowsHash();
@@ -228,13 +228,12 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
         $parentCategoryId = $categoryTreeIterator->getCategoryId($testCaseData['Parent category']);
 
         $wayId = array_flip(self::CATEGORY_POSITION_WAYS_MAP)[$testCaseData['Way']];
-        $positionsArray = explode(',', $testCaseData['Positions']);
 
         $this->getCommandBus()->handle(new UpdateCategoryPositionCommand(
             $categoryId,
             $parentCategoryId,
             $wayId,
-            $positionsArray,
+            ['tr_' . $parentCategoryId . '_' . $categoryId], // generated position
             $testCaseData['Found first']
         ));
     }

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -53,10 +53,9 @@ Feature: Category Management
       | Displayed            | true             |
       | Parent category      | Home Accessories |
       | Friendly URL         | pc-parts2        |
-    And I update category "category2" position with following details:
+    And I update category "category2" with generated position and following details:
       | Parent category | Home Accessories    |
       | Way             | Up                  |
-      | Positions       | tr_8_15_1,tr_8_13_0 |
       | Found first     | false               |
 
   Scenario: Edit root category


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Some community members suggest using mysql autoincrement different than 1 in .travis and then some tests relating with hard coded data fail
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/pull/16813
| How to test?  | travis behat pass

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17777)
<!-- Reviewable:end -->
