### PR TITLE
Fix X-Forwarded-For not supported properly

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -387,7 +387,7 @@ class ToolsCore
         }
 
         if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && $_SERVER['HTTP_X_FORWARDED_FOR'] && (!isset($_SERVER['REMOTE_ADDR'])
-            || preg_match('/^127\..*/i', trim($_SERVER['REMOTE_ADDR'])) || preg_match('/^172\.16.*/i', trim($_SERVER['REMOTE_ADDR']))
+            || preg_match('/^127\..*/i', trim($_SERVER['REMOTE_ADDR'])) || preg_match('/^172\.(1[6-9]|2\d|30|31)\..*/i', trim($_SERVER['REMOTE_ADDR']))
             || preg_match('/^192\.168\.*/i', trim($_SERVER['REMOTE_ADDR'])) || preg_match('/^10\..*/i', trim($_SERVER['REMOTE_ADDR'])))) {
             if (strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',')) {
                 $ips = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Range must be 172.16/12 instead of 172.16/16 (https://tools.ietf.org/html/rfc1918#section-3)
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13074.
| How to test?  | No need QA, it's related to server configuration.

Some tests
```
172.15.255.255 -> use REMOTE_ADDR
172.16.0.0    ->  use HTTP_X_FORWARDED_FOR
172.16.255.255 -> use HTTP_X_FORWARDED_FOR
172.22.255.0  ->  use HTTP_X_FORWARDED_FOR
172.31.0.0   ->   use HTTP_X_FORWARDED_FOR
172.31.255.255 -> use HTTP_X_FORWARDED_FOR
172.32.0.0   ->   use REMOTE_ADDR
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17785)
<!-- Reviewable:end -->
