### PR TITLE
Simplify Tools::getRemoteAddr function

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -389,29 +389,18 @@ class ToolsCore
      */
     public static function getRemoteAddr()
     {
-        if (function_exists('apache_request_headers')) {
-            $headers = apache_request_headers();
-        } else {
-            $headers = $_SERVER;
+        if (
+            !empty($_SERVER['HTTP_X_FORWARDED_FOR'])
+            && (empty($_SERVER['REMOTE_ADDR'])
+                || preg_match('/^127\..*/i', $_SERVER['REMOTE_ADDR'])
+                || preg_match('/^172\.(16|17|18|19|2\d|30|31)\.*/i', $_SERVER['REMOTE_ADDR'])
+                || preg_match('/^192\.168\.*/i', $_SERVER['REMOTE_ADDR'])
+                || preg_match('/^10\..*/i', $_SERVER['REMOTE_ADDR']))
+        ) {
+            return explode(',', $_SERVER['HTTP_X_FORWARDED_FOR'])[0];
         }
 
-        if (array_key_exists('X-Forwarded-For', $headers)) {
-            $_SERVER['HTTP_X_FORWARDED_FOR'] = $headers['X-Forwarded-For'];
-        }
-
-        if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && $_SERVER['HTTP_X_FORWARDED_FOR'] && (!isset($_SERVER['REMOTE_ADDR'])
-            || preg_match('/^127\..*/i', trim($_SERVER['REMOTE_ADDR'])) || preg_match('/^172\.(1[6-9]|2\d|30|31)\..*/i', trim($_SERVER['REMOTE_ADDR']))
-            || preg_match('/^192\.168\.*/i', trim($_SERVER['REMOTE_ADDR'])) || preg_match('/^10\..*/i', trim($_SERVER['REMOTE_ADDR'])))) {
-            if (strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',')) {
-                $ips = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
-
-                return $ips[0];
-            } else {
-                return $_SERVER['HTTP_X_FORWARDED_FOR'];
-            }
-        } else {
-            return $_SERVER['REMOTE_ADDR'];
-        }
+        return $_SERVER['REMOTE_ADDR'];
     }
 
     /**


### PR DESCRIPTION
After Fix X-Forwarded-For not supported properly https://github.com/PrestaShop/PrestaShop/pull/17785

I found it convenient to simplify the function because:
- Overcomplicated code to get `X-Forwarded-For` from `apache_request_headers()` or `HTTP_X_FORWARDED_FOR` from `$_SERVER`.
- `apache_request_headers()` is not necessary, since all headers are also included in `$_SERVER`
- `trim($_SERVER['REMOTE_ADDR'])` : is `trim `necessary? I do not think so
- Improved: Always return the first ip without explicitly searching if there are several ips.


TODO
- If `REMOTE_ADDR `in Proxy Whitelist -> use `X-Forwarded-For`.
- `X-Real-IP`
- IPv6 addresses

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify Tools::getRemoteAddr function. Improve readability and performance.
| Type?         | improvement / refacto
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Unit Test of Tools::getRemoteAddr().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17786)
<!-- Reviewable:end -->
