### PR TITLE
Fix Exception when adding a new discount with invalid amount

### DIFF
--- a/src/Core/ConstraintValidator/Constraints/ValidReductionType.php
+++ b/src/Core/ConstraintValidator/Constraints/ValidReductionType.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\ValidReductionTypeValidator;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint for validating reduction type
+ */
+final class ValidReductionType extends Constraint
+{
+    public $message = 'Reduction type "%type%" is invalid. Allowed types are: %types%.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return ValidReductionTypeValidator::class;
+    }
+}

--- a/src/Core/ConstraintValidator/Constraints/ValidReductionValue.php
+++ b/src/Core/ConstraintValidator/Constraints/ValidReductionValue.php
@@ -34,9 +34,10 @@ use Symfony\Component\Validator\Constraint;
  */
 final class ValidReductionValue extends Constraint
 {
-    public $invalidAmountValueMessage = 'Reduction value "%value%" is invalid. Value cannot be negative';
+    const INVALID_AMOUNT_VALUE_MESSAGE = 'Reduction value "%value%" is invalid. Value cannot be negative';
 
-    public $invalidPercentageValueMessage = 'Reduction value "%value%" is invalid. Allowed values from 0 to %max%';
+    const INVALID_PERCENT_VALUE_MESSAGE = 'Reduction value "%value%" is invalid. Allowed values from 0 to %max%';
+
 
     public $propertyPath;
 

--- a/src/Core/ConstraintValidator/Constraints/ValidReductionValue.php
+++ b/src/Core/ConstraintValidator/Constraints/ValidReductionValue.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\ValidReductionValueValidator;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint for validating reduction value based on reduction type
+ */
+final class ValidReductionValue extends Constraint
+{
+    public $invalidAmountValueMessage = 'Reduction value "%value%" is invalid. Value cannot be negative';
+
+    public $invalidPercentageValueMessage = 'Reduction value "%value%" is invalid. Allowed values from 0 to %max%';
+
+    public $propertyPath;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return ValidReductionValueValidator::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'reductionType';
+    }
+}

--- a/src/Core/ConstraintValidator/ValidReductionTypeValidator.php
+++ b/src/Core/ConstraintValidator/ValidReductionTypeValidator.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\ConstraintValidator;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\ValidReductionType as TypeConstraint;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Reduction;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+
+/**
+ * Validates reduction type
+ */
+final class ValidReductionTypeValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof TypeConstraint) {
+            throw new UnexpectedTypeException($constraint, TypeConstraint::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if (!$this->isAllowedType($value)) {
+            $this->buildViolation(
+                $constraint->message,
+                [
+                    '%type%' => $value,
+                    '%types%' => implode(', ', [Reduction::TYPE_PERCENTAGE, Reduction::TYPE_AMOUNT]),
+                ],
+                '[type]'
+            );
+        }
+    }
+
+    /**
+     * Returns true if type is defined in allowed types, false otherwise
+     *
+     * @param string $type
+     *
+     * @return bool
+     */
+    private function isAllowedType(string $type): bool
+    {
+        return in_array($type, Reduction::ALLOWED_TYPES, true);
+    }
+
+
+    private function buildViolation(string $message, array $params, string $errorPath)
+    {
+        $this->context->buildViolation($message, $params)
+            ->setTranslationDomain('Admin.Notifications.Error')
+            ->atPath($errorPath)
+            ->setParameters($params)
+            ->addViolation()
+        ;
+    }
+}

--- a/src/Core/ConstraintValidator/ValidReductionTypeValidator.php
+++ b/src/Core/ConstraintValidator/ValidReductionTypeValidator.php
@@ -59,7 +59,7 @@ final class ValidReductionTypeValidator extends ConstraintValidator
                 $constraint->message,
                 [
                     '%type%' => $value,
-                    '%types%' => implode(', ', [Reduction::TYPE_PERCENTAGE, Reduction::TYPE_AMOUNT]),
+                    '%types%' => implode(', ', [Reduction::TYPE_PERCENTAGE, Reduction::TYPE_AMOUNT, Reduction::TYPE_FREE_SHIPPING]),
                 ],
                 '[type]'
             );

--- a/src/Core/ConstraintValidator/ValidReductionTypeValidator.php
+++ b/src/Core/ConstraintValidator/ValidReductionTypeValidator.php
@@ -32,7 +32,6 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-
 /**
  * Validates reduction type
  */
@@ -79,7 +78,13 @@ final class ValidReductionTypeValidator extends ConstraintValidator
         return in_array($type, Reduction::ALLOWED_TYPES, true);
     }
 
-
+    /**
+     * Builds violation dependent from exception code
+     *
+     * @param string $message
+     * @param array $params
+     * @param string $errorPath
+     */
     private function buildViolation(string $message, array $params, string $errorPath)
     {
         $this->context->buildViolation($message, $params)

--- a/src/Core/ConstraintValidator/ValidReductionValueValidator.php
+++ b/src/Core/ConstraintValidator/ValidReductionValueValidator.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\ConstraintValidator;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\ValidReductionValue as ValueConstraint;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Reduction;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+
+/**
+ * Validates reduction value
+ */
+final class ValidReductionValueValidator extends ConstraintValidator
+{
+    private $propertyAccessor;
+
+    public function __construct(PropertyAccessorInterface $propertyAccessor = null)
+    {
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+
+        if (!$constraint instanceof ValueConstraint) {
+            throw new UnexpectedTypeException($constraint, ValueConstraint::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_numeric($value)) {
+            throw new UnexpectedTypeException($value, 'numeric');
+        }
+
+        if ($path = $constraint->propertyPath) {
+            if (null === $object = $this->context->getObject()) {
+                return;
+            }
+
+            try {
+                $reductionType = $this->getPropertyAccessor()->getValue($object, $path);
+
+            } catch (NoSuchPropertyException $e) {
+                throw new ConstraintDefinitionException(sprintf('Invalid property path "%s" provided to "%s" constraint: %s', $path, \get_class($constraint), $e->getMessage()), 0, $e);
+            }
+        } else {
+            $reductionType = $constraint->reductionType;
+        }
+
+        if (Reduction::TYPE_AMOUNT === $reductionType) {
+            if (!$this->assertIsValidAmount($value)) {
+                $this->buildViolation(
+                    $constraint->invalidAmountValueMessage,
+                    ['%value%' => $value],
+                    '[value]'
+                );
+            }
+        } elseif (Reduction::TYPE_PERCENTAGE === $reductionType) {
+            if (!$this->assertIsValidPercentage($value)) {
+                $this->buildViolation(
+                    $constraint->invalidPercentageValueMessage,
+                    [
+                        '%value%' => $value,
+                        '%max%' => Reduction::MAX_ALLOWED_PERCENTAGE,
+                    ],
+                    '[value]'
+                );
+            }
+        }
+
+    }
+
+    /**
+     * Get PropertyAccessor service
+     *
+     * @return PropertyAccessorInterface
+     */
+    private function getPropertyAccessor()
+    {
+        if (null === $this->propertyAccessor) {
+            $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+        }
+
+        return $this->propertyAccessor;
+    }
+
+    /**
+     * Returns true is percentage is considered valid
+     *
+     * @param float $value
+     *
+     * @return bool
+     */
+    private function assertIsValidPercentage(float $value)
+    {
+        return 0 <= $value && Reduction::MAX_ALLOWED_PERCENTAGE >= $value;
+    }
+
+    /**
+     * Returns true if amount value is considered valid
+     *
+     * @param float $value
+     *
+     * @return bool
+     */
+    private function assertIsValidAmount(float $value)
+    {
+        return 0 <= $value;
+    }
+
+    /**
+     * Builds violation dependent from exception code
+     *
+     * @param string $message
+     * @param array $params
+     * @param string $errorPath
+     */
+    private function buildViolation(string $message, array $params, string $errorPath)
+    {
+        $this->context->buildViolation($message, $params)
+            ->setTranslationDomain('Admin.Notifications.Error')
+            ->atPath($errorPath)
+            ->setParameters($params)
+            ->addViolation()
+        ;
+    }
+}

--- a/src/Core/ConstraintValidator/ValidReductionValueValidator.php
+++ b/src/Core/ConstraintValidator/ValidReductionValueValidator.php
@@ -36,7 +36,6 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-
 /**
  * Validates reduction value
  */

--- a/src/Core/ConstraintValidator/ValidReductionValueValidator.php
+++ b/src/Core/ConstraintValidator/ValidReductionValueValidator.php
@@ -33,8 +33,8 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 
 /**
@@ -54,7 +54,6 @@ final class ValidReductionValueValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-
         if (!$constraint instanceof ValueConstraint) {
             throw new UnexpectedTypeException($constraint, ValueConstraint::class);
         }
@@ -71,10 +70,8 @@ final class ValidReductionValueValidator extends ConstraintValidator
             if (null === $object = $this->context->getObject()) {
                 return;
             }
-
             try {
                 $reductionType = $this->getPropertyAccessor()->getValue($object, $path);
-
             } catch (NoSuchPropertyException $e) {
                 throw new ConstraintDefinitionException(sprintf('Invalid property path "%s" provided to "%s" constraint: %s', $path, \get_class($constraint), $e->getMessage()), 0, $e);
             }
@@ -102,7 +99,6 @@ final class ValidReductionValueValidator extends ConstraintValidator
                 );
             }
         }
-
     }
 
     /**

--- a/src/Core/ConstraintValidator/ValidReductionValueValidator.php
+++ b/src/Core/ConstraintValidator/ValidReductionValueValidator.php
@@ -81,7 +81,7 @@ final class ValidReductionValueValidator extends ConstraintValidator
         if (Reduction::TYPE_AMOUNT === $reductionType) {
             if (!$this->assertIsValidAmount($value)) {
                 $this->buildViolation(
-                    $constraint->invalidAmountValueMessage,
+                    ValueConstraint::INVALID_AMOUNT_VALUE_MESSAGE,
                     ['%value%' => $value],
                     '[value]'
                 );
@@ -89,7 +89,7 @@ final class ValidReductionValueValidator extends ConstraintValidator
         } elseif (Reduction::TYPE_PERCENTAGE === $reductionType) {
             if (!$this->assertIsValidPercentage($value)) {
                 $this->buildViolation(
-                    $constraint->invalidPercentageValueMessage,
+                    ValueConstraint::INVALID_PERCENT_VALUE_MESSAGE,
                     [
                         '%value%' => $value,
                         '%max%' => Reduction::MAX_ALLOWED_PERCENTAGE,

--- a/src/Core/Domain/ValueObject/Reduction.php
+++ b/src/Core/Domain/ValueObject/Reduction.php
@@ -42,7 +42,7 @@ class Reduction
     /**
      * For reducing certain percentage calculated from price
      */
-    const TYPE_PERCENTAGE = 'percentage';
+    const TYPE_PERCENTAGE = 'percent';
 
     /**
      * Allowed reduction types

--- a/src/Core/Domain/ValueObject/Reduction.php
+++ b/src/Core/Domain/ValueObject/Reduction.php
@@ -45,11 +45,17 @@ class Reduction
     const TYPE_PERCENTAGE = 'percent';
 
     /**
+     * For reducing shipping fees from order total
+     */
+    const TYPE_FREE_SHIPPING = 'free_shipping';
+
+    /**
      * Allowed reduction types
      */
     const ALLOWED_TYPES = [
         self::TYPE_AMOUNT,
         self::TYPE_PERCENTAGE,
+        self::TYPE_FREE_SHIPPING,
     ];
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/AddOrderCartRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/AddOrderCartRuleType.php
@@ -27,6 +27,8 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Order;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\ValidReductionType;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\ValidReductionValue;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
@@ -103,14 +105,14 @@ class AddOrderCartRuleType extends AbstractType
             ])
             ->add('type', ChoiceType::class, [
                 'choices' => $this->orderDiscountTypeChoiceProvider->getChoices(),
+                'constraints' => new ValidReductionType(),
             ])
             ->add('value', NumberType::class, [
                 'attr' => [
                     'step' => 0.01,
                 ],
-                'constraints' => new Type([
-                    'type' => 'numeric',
-                    'message' => $this->trans('Discount value must be a number', [], 'Admin.Notifications.Error'),
+                'constraints' => new ValidReductionValue([
+                    'propertyPath' => 'parent.all[type].data'
                 ]),
             ])
             ->add('invoice_id', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/AddOrderCartRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/AddOrderCartRuleType.php
@@ -40,7 +40,6 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
-use Symfony\Component\Validator\Constraints\Type;
 
 class AddOrderCartRuleType extends AbstractType
 {
@@ -112,7 +111,7 @@ class AddOrderCartRuleType extends AbstractType
                     'step' => 0.01,
                 ],
                 'constraints' => new ValidReductionValue([
-                    'propertyPath' => 'parent.all[type].data'
+                    'propertyPath' => 'parent.all[type].data',
                 ]),
             ])
             ->add('invoice_id', ChoiceType::class, [


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x 
| Description?  | This PR is about validation of form "add discount", in order view page. It is inspired by the existing job done in `Reduction` and `ReductionValidator` classes. It rewrites them so that constraints are directly used in FormType. It also adds conditional constraint (because value validation depends on type) using `PropretyAccess`.  
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #17747
| How to test?  | Try to add a discount from the new order view page (`/sell/orders/orders/3/view`) with invalid values, like percentage `<0` or `>100`, or amount `<0` or `>total`. You will see corresponding error messages on the page instead of PrestashopException page.



PS: This PR needs a decision about the naming, whether it is `percent` or `percentage`.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17790)
<!-- Reviewable:end -->
