### PR TITLE
Keep BO order page from displaying an exception when accessing a non existing order via URL

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -361,7 +361,12 @@ class OrderController extends FrameworkBundleAdminController
     public function viewAction(int $orderId, Request $request): Response
     {
         /** @var OrderForViewing $orderForViewing */
-        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+        try {
+            $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+        } catch (OrderNotFoundException $e) {
+            return $this->redirectToRoute('admin_orders_index');
+        }
+
         $addOrderCartRuleForm = $this->createForm(AddOrderCartRuleType::class, [], [
             'order_id' => $orderId,
         ]);

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -360,8 +360,8 @@ class OrderController extends FrameworkBundleAdminController
      */
     public function viewAction(int $orderId, Request $request): Response
     {
-        /** @var OrderForViewing $orderForViewing */
         try {
+            /* @var OrderForViewing $orderForViewing */
             $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
         } catch (OrderNotFoundException $e) {
             return $this->redirectToRoute('admin_orders_index');


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When accessing a non existing order via URL (order is doesn't exist), we display an exception, we should redirect to order list page instead. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    |no
| Deprecations? |no
| Fixed ticket? | Fixes #17732 
| How to test?  | This url: `/admin-dev/sell/orders/orders/999999/view` should redirect to the list order page (given there is no order with id **999999**.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17797)
<!-- Reviewable:end -->
