### PR TITLE
Fix bug when changing addresses on virtual product command

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2688,10 +2688,13 @@ class OrderCore extends ObjectModel
         $this->update();
 
         // save order_carrier prices, we'll save order right after this in update() method
-        $order_carrier = new OrderCarrier((int) $this->getIdOrderCarrier());
-        $order_carrier->shipping_cost_tax_excl = $this->total_shipping_tax_excl;
-        $order_carrier->shipping_cost_tax_incl = $this->total_shipping_tax_incl;
-        $order_carrier->update();
+        $orderCarrierId = (int) $this->getIdOrderCarrier();
+        if ($orderCarrierId > 0) {
+            $order_carrier = new OrderCarrier($orderCarrierId);
+            $order_carrier->shipping_cost_tax_excl = $this->total_shipping_tax_excl;
+            $order_carrier->shipping_cost_tax_incl = $this->total_shipping_tax_incl;
+            $order_carrier->update();
+        }
 
         // remove fake cart
         $new_cart->delete();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When changing the address of an order having only a virtual product, there is an error message, because the order carrier is not found.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12442 
| How to test?  | - Create a virtual product (don't forget to fill its quantity)<br>- create an order with the virtual product you created<br>- Try to change the invoice address, it should work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17804)
<!-- Reviewable:end -->
