### PR TITLE
Functional tests - Order settings enable/disable final summary

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/general/01_enableDisableFinalSummary.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/general/01_enableDisableFinalSummary.js
@@ -69,20 +69,20 @@ describe('Enable/Disable final summary', async () => {
   ];
   tests.forEach((test, index) => {
     it(`should ${test.args.action} final summary`, async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'disableShop', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', `${test.args.action}Shop`, baseContext);
       const result = await this.pageObjects.orderSettingsPage.setFinalSummary(test.args.exist);
       await expect(result).to.contains(this.pageObjects.orderSettingsPage.successfulUpdateMessage);
     });
 
     it('should go to FO and check the final summary after checkout', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', `checkFinalSummaryExistence${index}`, baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', `checkFinalSummary_${test.args.action}`, baseContext);
       // Click on view my shop
       page = await this.pageObjects.boBasePage.viewMyShop();
       this.pageObjects = await init();
       await this.pageObjects.foBasePage.changeLanguage('en');
       // Go to the first product page
       await this.pageObjects.homePage.goToProductPage(1);
-      // Add the created product to the cart
+      // Add the product to the cart
       await this.pageObjects.productPage.addProductToTheCart();
       // Proceed to checkout the shopping cart
       await this.pageObjects.cartPage.clickOnProceedToCheckout();

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/general/01_enableDisableFinalSummary.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/general/01_enableDisableFinalSummary.js
@@ -1,0 +1,108 @@
+require('module-alias/register');
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_orderSettings_enableDisableFinalSummary';
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const OrderSettingsPage = require('@pages/BO/shopParameters/orderSettings');
+const ProductPage = require('@pages/FO/product');
+const FOBasePage = require('@pages/FO/FObasePage');
+const HomePage = require('@pages/FO/home');
+const CartPage = require('@pages/FO/cart');
+const CheckoutPage = require('@pages/FO/checkout');
+const OrderConfirmationPage = require('@pages/FO/orderConfirmation');
+// Importing data
+const {DefaultAccount} = require('@data/demo/customer');
+
+let browser;
+let page;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    orderSettingsPage: new OrderSettingsPage(page),
+    productPage: new ProductPage(page),
+    foBasePage: new FOBasePage(page),
+    homePage: new HomePage(page),
+    cartPage: new CartPage(page),
+    checkoutPage: new CheckoutPage(page),
+    orderConfirmationPage: new OrderConfirmationPage(page),
+  };
+};
+
+describe('Enable/Disable final summary', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+  // Login into BO and go to Shop Parameters > Order Settings page
+  loginCommon.loginBO();
+
+  it('should go to \'Shop Parameters > Order Settings\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToOrderSettingsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.shopParametersParentLink,
+      this.pageObjects.boBasePage.orderSettingsLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.orderSettingsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.orderSettingsPage.pageTitle);
+  });
+
+  const tests = [
+    {args: {action: 'enable', exist: true}},
+    {args: {action: 'disable', exist: false}},
+  ];
+  tests.forEach((test, index) => {
+    it(`should ${test.args.action} final summary`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'disableShop', baseContext);
+      const result = await this.pageObjects.orderSettingsPage.setFinalSummary(test.args.exist);
+      await expect(result).to.contains(this.pageObjects.orderSettingsPage.successfulUpdateMessage);
+    });
+
+    it('should go to FO and check the final summary after checkout', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', `checkFinalSummaryExistence${index}`, baseContext);
+      // Click on view my shop
+      page = await this.pageObjects.boBasePage.viewMyShop();
+      this.pageObjects = await init();
+      await this.pageObjects.foBasePage.changeLanguage('en');
+      // Go to the first product page
+      await this.pageObjects.homePage.goToProductPage(1);
+      // Add the created product to the cart
+      await this.pageObjects.productPage.addProductToTheCart();
+      // Proceed to checkout the shopping cart
+      await this.pageObjects.cartPage.clickOnProceedToCheckout();
+      // Checkout the order
+      if (index === 0) {
+        // Personal information step - Login
+        await this.pageObjects.checkoutPage.clickOnSignIn();
+        await this.pageObjects.checkoutPage.customerLogin(DefaultAccount);
+      }
+      // Address step - Go to delivery step
+      const isStepAddressComplete = await this.pageObjects.checkoutPage.goToDeliveryStep();
+      await expect(isStepAddressComplete, 'Step Address is not complete').to.be.true;
+      // Delivery step - Go to payment step
+      const isStepDeliveryComplete = await this.pageObjects.checkoutPage.goToPaymentStep();
+      await expect(isStepDeliveryComplete, 'Step Address is not complete').to.be.true;
+      // Check the final summary existence in payment step
+      const isVisible = await this.pageObjects.orderConfirmationPage.isFinalSummaryVisible();
+      await expect(isVisible).to.be.equal(test.args.exist);
+      page = await this.pageObjects.orderConfirmationPage.closePage(browser, 1);
+      this.pageObjects = await init();
+    });
+  });
+});

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/general/01_enableFinalSummary.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/general/01_enableFinalSummary.js
@@ -69,13 +69,18 @@ describe('Enable/Disable final summary', async () => {
   ];
   tests.forEach((test, index) => {
     it(`should ${test.args.action} final summary`, async function () {
-      await testContext.addContextItem(this, 'testIdentifier', `${test.args.action}Shop`, baseContext);
-      const result = await this.pageObjects.orderSettingsPage.setFinalSummary(test.args.exist);
+      await testContext.addContextItem(this, 'testIdentifier', `${test.args.action}FinalSummary`, baseContext);
+      const result = await this.pageObjects.orderSettingsPage.setFinalSummaryStatus(test.args.exist);
       await expect(result).to.contains(this.pageObjects.orderSettingsPage.successfulUpdateMessage);
     });
 
     it('should go to FO and check the final summary after checkout', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', `checkFinalSummary_${test.args.action}`, baseContext);
+      await testContext.addContextItem(
+        this,
+        'testIdentifier',
+        `checkFinalSummary${this.pageObjects.boBasePage.uppercaseFirstCharacter(test.args.action)}`,
+        baseContext,
+      );
       // Click on view my shop
       page = await this.pageObjects.boBasePage.viewMyShop();
       this.pageObjects = await init();

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/general/01_enableFinalSummary.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/general/01_enableFinalSummary.js
@@ -1,7 +1,7 @@
 require('module-alias/register');
 const testContext = require('@utils/testContext');
 
-const baseContext = 'functional_BO_orderSettings_enableDisableFinalSummary';
+const baseContext = 'functional_BO_orderSettings_enableFinalSummary';
 // Using chai
 const {expect} = require('chai');
 const helper = require('@utils/helpers');

--- a/tests/puppeteer/pages/BO/BObasePage.js
+++ b/tests/puppeteer/pages/BO/BObasePage.js
@@ -88,6 +88,8 @@ module.exports = class BOBasePage extends CommonPage {
     this.shopParametersParentLink = '#subtab-ShopParameters';
     // General
     this.shopParametersGeneralLink = '#subtab-AdminParentPreferences';
+    // Order Settings
+    this.orderSettingsLink = '#subtab-AdminParentOrderPreferences';
     // Product Settings
     this.productSettingsLink = '#subtab-AdminPPreferences';
     // Customer Settings

--- a/tests/puppeteer/pages/BO/shopParameters/orderSettings/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/orderSettings/index.js
@@ -23,7 +23,7 @@ module.exports = class orderSettings extends BOBasePage {
    * @param toEnable, true to enable and false to disable
    * @return {Promise<string>}
    */
-  async setFinalSummary(toEnable = true) {
+  async setFinalSummaryStatus(toEnable = true) {
     await this.waitForSelectorAndClick(this.enableFinalSummaryLabel.replace('%TOGGLE', toEnable ? 1 : 0));
     await this.clickAndWaitForNavigation(this.saveGeneralFormButton);
     return this.getTextContent(this.alertSuccessBlock);

--- a/tests/puppeteer/pages/BO/shopParameters/orderSettings/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/orderSettings/index.js
@@ -1,0 +1,31 @@
+require('module-alias/register');
+const BOBasePage = require('@pages/BO/BObasePage');
+
+module.exports = class orderSettings extends BOBasePage {
+  constructor(page) {
+    super(page);
+
+    this.pageTitle = 'Order settings •';
+    this.successfulUpdateMessage = 'Update successful';
+
+    // Selectors
+    this.generalForm = '#configuration_form';
+    this.enableFinalSummaryLabel = 'label[for=\'form_general_enable_final_summary_%TOGGLE\']';
+    this.saveGeneralFormButton = `${this.generalForm} .card-footer button`;
+  }
+
+  /*
+    Methods
+  */
+
+  /**
+   * Enable/disable final summary
+   * @param toEnable, true to enable and false to disable
+   * @return {Promise<string>}
+   */
+  async setFinalSummary(toEnable = true) {
+    await this.waitForSelectorAndClick(this.enableFinalSummaryLabel.replace('%TOGGLE', toEnable ? 1 : 0));
+    await this.clickAndWaitForNavigation(this.saveGeneralFormButton);
+    return this.getTextContent(this.alertSuccessBlock);
+  }
+};

--- a/tests/puppeteer/pages/BO/shopParameters/orderSettings/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/orderSettings/index.js
@@ -1,7 +1,7 @@
 require('module-alias/register');
 const BOBasePage = require('@pages/BO/BObasePage');
 
-module.exports = class orderSettings extends BOBasePage {
+module.exports = class OrderSettings extends BOBasePage {
   constructor(page) {
     super(page);
 
@@ -10,7 +10,7 @@ module.exports = class orderSettings extends BOBasePage {
 
     // Selectors
     this.generalForm = '#configuration_form';
-    this.enableFinalSummaryLabel = 'label[for=\'form_general_enable_final_summary_%TOGGLE\']';
+    this.enableFinalSummaryLabel = `${this.generalForm} label[for='form_general_enable_final_summary_%TOGGLE']`;
     this.saveGeneralFormButton = `${this.generalForm} .card-footer button`;
   }
 

--- a/tests/puppeteer/pages/FO/orderConfirmation.js
+++ b/tests/puppeteer/pages/FO/orderConfirmation.js
@@ -11,5 +11,17 @@ module.exports = class OrderConfirmation extends FOBasePage {
     // Selectors
     this.orderConfirmationCardSection = '#content-hook_order_confirmation';
     this.orderConfirmationCardTitleH3 = `${this.orderConfirmationCardSection} h3.card-title`;
+    this.orderSummaryContent = '#order-summary-content';
+  }
+
+  /*
+    Methods
+     */
+  /**
+   * Check if final summary is visible
+   * @returns {boolean}
+   */
+  isFinalSummaryVisible() {
+    return this.elementVisible(this.orderSummaryContent, 2000);
   }
 };


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Enable/Disable final summary
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/general/01_enableDisableFinalSummary" URL_FO=yourShopURL npm run specific-test


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17805)
<!-- Reviewable:end -->
