### PR TITLE
Sort on priority when minified versions of css or js are generated

### DIFF
--- a/classes/assets/CccReducer.php
+++ b/classes/assets/CccReducer.php
@@ -78,6 +78,8 @@ class CccReducerCore
             'priority' => StylesheetManager::DEFAULT_PRIORITY,
         ];
 
+        $cssFileList = $this->sortCssList($cssFileList);
+
         return $cssFileList;
     }
 
@@ -124,11 +126,46 @@ class CccReducerCore
             $list['external'] = array_merge($cccItem, $list['external']);
         }
 
+        $jsFileList = $this->sortJsList($jsFileList);
+        
         return $jsFileList;
     }
 
     private function getFileNameIdentifierFromList(array $files)
     {
         return substr(sha1(implode('|', $files)), 0, 6);
+    }
+
+    private function sortJsList($jsFileList)
+    {
+        foreach ($jsFileList as $position => &$list) {
+            foreach ($jsFileList[$position] as $type => $items) {
+                Tools::uasort($items, function ($a, $b) {
+                    if ($a['priority'] === $b['priority']) {
+                        return 0;
+                    }
+
+                    return ($a['priority'] < $b['priority']) ? -1 : 1;
+                });
+                $jsFileList[$position][$type] = $items;
+            }
+        }
+        return $jsFileList;
+    }
+
+    private function sortCssList($cssFileList)
+    {
+        Tools::uasort(
+            $cssFileList['external'],
+            function ($a, $b) {
+                if ($a['priority'] === $b['priority']) {
+                    return 0;
+                }
+
+                return ($a['priority'] < $b['priority']) ? -1 : 1;
+            }
+        );
+    
+        return $cssFileList;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?       | When having external remote css or js loaded, and set priority higher then 50. The priority is not handled anymore after it is minified. That means it wont put the files in the right order. This fix will reorder it all again.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? |no
| How to test?  | when using registerJavascript and registerStylesheet as below, the custom.js and custom.css are loaded after minified versions.
```
$this->registerJavascript('test-external', '/themes/classic-rocket/assets/js/custom.js?' . time(),
    ['position' => 'bottom', 'priority' => 200, 'server' => 'remote']
);
$this->registerStylesheet('test-external', '/themes/classic-rocket/assets/css/custom.css?' . time(),
    ['position' => 'bottom', 'priority' => 200, 'server' => 'remote']
);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17813)
<!-- Reviewable:end -->
