### PR TITLE
Suggest to have at least 2 payment methods

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
@@ -29,19 +29,19 @@
   <div class="container">
 
     {% if paymentModules|length < 2 %}
-    <div class="card-block row">
-      <div class="card-text">
-        <div class="row">
-          <div class="col-sm">
-            <div class="alert alert-info" role="alert">
-              <div class="alert-text">
-                {{ 'We recommend providing at least two different payment methods. Only one payment method could be problematic if this option cannot be used by a customer because it will prevent him/her from ordering.'|trans({}, 'Admin.Payment.Notification') }}
+      <div class="card-block row">
+        <div class="card-text">
+          <div class="row">
+            <div class="col-sm">
+              <div class="alert alert-info" role="alert">
+                <div class="alert-text">
+                  {{ 'We recommend providing at least two different payment methods. Only one payment method could be problematic if this option cannot be used by a customer because it will prevent him/her from ordering.'|trans({}, 'Admin.Payment.Notification') }}
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
     {% endif %}
 
     <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
@@ -62,6 +62,5 @@
         {% endif %}
       </div>
     </div>
-
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
@@ -35,7 +35,7 @@
           <div class="col-sm">
             <div class="alert alert-info" role="alert">
               <div class="alert-text">
-                {{ 'It is recommended to provide at least two different payment methods. Only one payment method could be problematical if this option cannot be used by a customer and prevent them from ordering.'|trans({}, 'Admin.Payment.Notification') }}
+                {{ 'We recommend providing at least two different payment methods. Only one payment method could be problematic if this option cannot be used by a customer because it will prevent him/her from ordering.'|trans({}, 'Admin.Payment.Notification') }}
               </div>
             </div>
           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
@@ -27,6 +27,23 @@
 
 {% block content %}
   <div class="container">
+
+    {% if paymentModules|length < 2 %}
+    <div class="card-block row">
+      <div class="card-text">
+        <div class="row">
+          <div class="col-sm">
+            <div class="alert alert-info" role="alert">
+              <div class="alert-text">
+                {{ 'It is recommended to provide at least two different payment methods. Only one payment method could be problematical if this option cannot be used by a customer and prevent them from ordering.'|trans({}, 'Admin.Payment.Notification') }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+
     <div class="row">
       <div class="col">
         {% if isSingleShopContext %}
@@ -45,5 +62,6 @@
         {% endif %}
       </div>
     </div>
+
   </div>
 {% endblock %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add an info message into "Payment methods" BO page to suggest to have at least 2 payment methods. This follows OpQuast [best practice 64](https://checklists.opquast.com/en/qualiteweb/the-site-accepts-at-least-two-means-of-payment) V3 (for Opquast V4 it is now best practice V57)
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | In "Payment methods" BO page, there is now a message to suggest to have at least 2 payment methods. The message disappears if at least 2 payment methods are active.

![Capture d’écran 2020-02-25 à 11 52 34](https://user-images.githubusercontent.com/3830050/75240864-584f7e80-57c5-11ea-8476-6d188667bc5a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17818)
<!-- Reviewable:end -->
