### PR TITLE
Fixed bug with related products language names in BO product settings

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -97,7 +97,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
                         $product = $this->productAdapter->getProduct($id, false, $langId);
                         $collection[] = [
                             'id' => $id,
-                            'name' => reset($product->name) . ' (ref:' . $product->reference . ')',
+                            'name' => $product->name . ' (ref:' . $product->reference . ')',
                             'image' => $product->image,
                         ];
 

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -75,8 +75,8 @@ class TypeaheadProductCollectionType extends CommonAbstractType
         if (!empty($view->vars['value']) && !empty($view->vars['value']['data'])) {
             $collection = [];
             $langId = (int) $this->configuration->get('PS_LANG_DEFAULT');
-
             $i = 0;
+
             foreach ($view->vars['value']['data'] as $id) {
                 if (!$id) {
                     continue;

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
-use Configuration;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -41,18 +40,18 @@ class TypeaheadProductCollectionType extends CommonAbstractType
 {
     protected $productAdapter;
     protected $categoryAdapter;
-    private $configuration;
+    protected $configuration;
 
     /**
      * {@inheritdoc}
      *
      * @param object $productAdapter
      */
-    public function __construct($productAdapter, $categoryAdapter)
+    public function __construct($productAdapter, $categoryAdapter, $configuration)
     {
         $this->productAdapter = $productAdapter;
         $this->categoryAdapter = $categoryAdapter;
-        $this->configuration = new Configuration();
+        $this->configuration = $configuration;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use Configuration;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -40,6 +41,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
 {
     protected $productAdapter;
     protected $categoryAdapter;
+    private $configuration;
 
     /**
      * {@inheritdoc}
@@ -50,6 +52,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
     {
         $this->productAdapter = $productAdapter;
         $this->categoryAdapter = $categoryAdapter;
+        $this->configuration = new Configuration();
     }
 
     /**
@@ -71,6 +74,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
         //if form is submitted, inject datas to display collection
         if (!empty($view->vars['value']) && !empty($view->vars['value']['data'])) {
             $collection = [];
+            $langId = (int) $this->configuration->get('PS_LANG_DEFAULT');
 
             $i = 0;
             foreach ($view->vars['value']['data'] as $id) {
@@ -90,7 +94,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
                         break;
 
                     default:
-                        $product = $this->productAdapter->getProduct($id);
+                        $product = $this->productAdapter->getProduct($id, false, $langId);
                         $collection[] = [
                             'id' => $id,
                             'name' => reset($product->name) . ' (ref:' . $product->reference . ')',

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -212,6 +212,7 @@ services:
         arguments:
             - "@prestashop.adapter.data_provider.product"
             - "@prestashop.adapter.data_provider.category"
+            - "@prestashop.adapter.legacy.configuration"
         tags:
             - { name: form.type }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | When adding related product in BO to the product it is show only in that language that prestashop is installed. For example if customer has installed prestashop in English and he is using France language related products names in BO product settings will be show in English.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17822
| How to test?  | You need to have multi language shop and product which name is different between languages assign that product to another product as related product and switch between account languages.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17821)
<!-- Reviewable:end -->