### PR TITLE
Wrap OrderController::viewAction in try-catch

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -356,115 +356,122 @@ class OrderController extends FrameworkBundleAdminController
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @param int $orderId
+     * @param Request $request
      *
      * @return Response
      */
     public function viewAction(int $orderId, Request $request): Response
     {
-        /** @var OrderForViewing $orderForViewing */
-        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
-        $addOrderCartRuleForm = $this->createForm(AddOrderCartRuleType::class, [], [
-            'order_id' => $orderId,
-        ]);
-        $updateOrderStatusForm = $this->createForm(UpdateOrderStatusType::class, [
-            'new_order_status_id' => $orderForViewing->getHistory()->getCurrentOrderStatusId(),
-        ]);
-        $updateOrderStatusActionBarForm = $this->createForm(UpdateOrderStatusType::class, [
-            'new_order_status_id' => $orderForViewing->getHistory()->getCurrentOrderStatusId(),
-        ]);
-        $addOrderPaymentForm = $this->createForm(OrderPaymentType::class, [
-            'id_currency' => $orderForViewing->getCurrencyId(),
-        ], [
-            'id_order' => $orderId,
-        ]);
-
-        $orderMessageForm = $this->createForm(OrderMessageType::class, [], [
-            'action' => $this->generateUrl('admin_orders_send_message', ['orderId' => $orderId]),
-        ]);
-        $orderMessageForm->handleRequest($request);
-
-        $changeOrderCurrencyForm = $this->createForm(ChangeOrderCurrencyType::class, [], [
-            'current_currency_id' => $orderForViewing->getCurrencyId(),
-        ]);
-
-        $changeOrderAddressForm = null;
-        $privateNoteForm = null;
-
-        if (null !== $orderForViewing->getCustomer()) {
-            $changeOrderAddressForm = $this->createForm(ChangeOrderAddressType::class, [], [
-                'customer_id' => $orderForViewing->getCustomer()->getId(),
+        try {
+            /** @var OrderForViewing $orderForViewing */
+            $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+            $addOrderCartRuleForm = $this->createForm(AddOrderCartRuleType::class, [], [
+                'order_id' => $orderId,
+            ]);
+            $updateOrderStatusForm = $this->createForm(UpdateOrderStatusType::class, [
+                'new_order_status_id' => $orderForViewing->getHistory()->getCurrentOrderStatusId(),
+            ]);
+            $updateOrderStatusActionBarForm = $this->createForm(UpdateOrderStatusType::class, [
+                'new_order_status_id' => $orderForViewing->getHistory()->getCurrentOrderStatusId(),
+            ]);
+            $addOrderPaymentForm = $this->createForm(OrderPaymentType::class, [
+                'id_currency' => $orderForViewing->getCurrencyId(),
+            ], [
+                'id_order' => $orderId,
             ]);
 
-            $privateNoteForm = $this->createForm(PrivateNoteType::class, [
-                'note' => $orderForViewing->getCustomer()->getPrivateNote(),
+            $orderMessageForm = $this->createForm(OrderMessageType::class, [], [
+                'action' => $this->generateUrl('admin_orders_send_message', ['orderId' => $orderId]),
             ]);
+            $orderMessageForm->handleRequest($request);
+
+            $changeOrderCurrencyForm = $this->createForm(ChangeOrderCurrencyType::class, [], [
+                'current_currency_id' => $orderForViewing->getCurrencyId(),
+            ]);
+
+            $changeOrderAddressForm = null;
+            $privateNoteForm = null;
+
+            if (null !== $orderForViewing->getCustomer()) {
+                $changeOrderAddressForm = $this->createForm(ChangeOrderAddressType::class, [], [
+                    'customer_id' => $orderForViewing->getCustomer()->getId(),
+                ]);
+
+                $privateNoteForm = $this->createForm(PrivateNoteType::class, [
+                    'note' => $orderForViewing->getCustomer()->getPrivateNote(),
+                ]);
+            }
+
+            $updateOrderShippingForm = $this->createForm(UpdateOrderShippingType::class, [
+                'new_carrier_id' => $orderForViewing->getCarrierId(),
+            ], [
+                'order_id' => $orderId,
+            ]);
+
+            $currencyDataProvider = $this->container->get('prestashop.adapter.data_provider.currency');
+            $orderCurrency = $currencyDataProvider->getCurrencyById($orderForViewing->getCurrencyId());
+
+            $addProductRowForm = $this->createForm(AddProductRowType::class, [], [
+                'order_id' => $orderId,
+                'symbol' => $orderCurrency->symbol,
+            ]);
+            $editProductRowForm = $this->createForm(EditProductRowType::class, [], [
+                'order_id' => $orderId,
+                'symbol' => $orderCurrency->symbol,
+            ]);
+
+            $backOfficeOrderButtons = new ActionsBarButtonsCollection();
+            $hookParameters = [
+                'controller' => $this,
+                'id_order' => $orderId,
+                'actions_bar_buttons_collection' => $backOfficeOrderButtons,
+            ];
+
+            $this->dispatchHook(
+                'actionGetAdminOrderButtons',
+                $hookParameters
+            );
+
+            $formBuilder = $this->get('prestashop.core.form.identifiable_object.builder.cancel_product_form_builder');
+            $cancelProductForm = $formBuilder->getFormFor($orderId);
+
+            $this->handleOutOfStockProduct($orderForViewing);
+
+            $merchandiseReturnEnabled = (bool) $this->configuration->get('PS_ORDER_RETURN');
+
+            /** @var OrderSiblingProviderInterface $orderSiblingProvider */
+            $orderSiblingProvider = $this->get('prestashop.adapter.order.order_sibling_provider');
+
+            return $this->render('@PrestaShop/Admin/Sell/Order/Order/view.html.twig', [
+                'showContentHeader' => true,
+                'orderCurrency' => $orderCurrency,
+                'meta_title' => $this->trans('Orders', 'Admin.Orderscustomers.Feature'),
+                'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+                'orderForViewing' => $orderForViewing,
+                'addOrderCartRuleForm' => $addOrderCartRuleForm->createView(),
+                'updateOrderStatusForm' => $updateOrderStatusForm->createView(),
+                'updateOrderStatusActionBarForm' => $updateOrderStatusActionBarForm->createView(),
+                'addOrderPaymentForm' => $addOrderPaymentForm->createView(),
+                'changeOrderCurrencyForm' => $changeOrderCurrencyForm->createView(),
+                'privateNoteForm' => $privateNoteForm ? $privateNoteForm->createView() : null,
+                'updateOrderShippingForm' => $updateOrderShippingForm->createView(),
+                'cancelProductForm' => $cancelProductForm->createView(),
+                'invoiceManagementIsEnabled' => $orderForViewing->isInvoiceManagementIsEnabled(),
+                'changeOrderAddressForm' => $changeOrderAddressForm ? $changeOrderAddressForm->createView() : null,
+                'orderMessageForm' => $orderMessageForm->createView(),
+                'addProductRowForm' => $addProductRowForm->createView(),
+                'editProductRowForm' => $editProductRowForm->createView(),
+                'backOfficeOrderButtons' => $backOfficeOrderButtons,
+                'merchandiseReturnEnabled' => $merchandiseReturnEnabled,
+                'priceSpecification' => $this->getContextLocale()->getPriceSpecification($orderCurrency->iso_code)->toArray(),
+                'previousOrderId' => $orderSiblingProvider->getPreviousOrderId($orderId),
+                'nextOrderId' => $orderSiblingProvider->getNextOrderId($orderId),
+            ]);
+        } catch (Exception $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+
+            return $this->redirectToRoute('admin_orders_index');
         }
-
-        $updateOrderShippingForm = $this->createForm(UpdateOrderShippingType::class, [
-            'new_carrier_id' => $orderForViewing->getCarrierId(),
-        ], [
-            'order_id' => $orderId,
-        ]);
-
-        $currencyDataProvider = $this->container->get('prestashop.adapter.data_provider.currency');
-        $orderCurrency = $currencyDataProvider->getCurrencyById($orderForViewing->getCurrencyId());
-
-        $addProductRowForm = $this->createForm(AddProductRowType::class, [], [
-            'order_id' => $orderId,
-            'symbol' => $orderCurrency->symbol,
-        ]);
-        $editProductRowForm = $this->createForm(EditProductRowType::class, [], [
-            'order_id' => $orderId,
-            'symbol' => $orderCurrency->symbol,
-        ]);
-
-        $backOfficeOrderButtons = new ActionsBarButtonsCollection();
-        $hookParameters = [
-            'controller' => $this,
-            'id_order' => $orderId,
-            'actions_bar_buttons_collection' => $backOfficeOrderButtons,
-        ];
-
-        $this->dispatchHook(
-            'actionGetAdminOrderButtons',
-            $hookParameters
-        );
-
-        $formBuilder = $this->get('prestashop.core.form.identifiable_object.builder.cancel_product_form_builder');
-        $cancelProductForm = $formBuilder->getFormFor($orderId);
-
-        $this->handleOutOfStockProduct($orderForViewing);
-
-        $merchandiseReturnEnabled = (bool) $this->configuration->get('PS_ORDER_RETURN');
-
-        /** @var OrderSiblingProviderInterface $orderSiblingProvider */
-        $orderSiblingProvider = $this->get('prestashop.adapter.order.order_sibling_provider');
-
-        return $this->render('@PrestaShop/Admin/Sell/Order/Order/view.html.twig', [
-            'showContentHeader' => true,
-            'orderCurrency' => $orderCurrency,
-            'meta_title' => $this->trans('Orders', 'Admin.Orderscustomers.Feature'),
-            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
-            'orderForViewing' => $orderForViewing,
-            'addOrderCartRuleForm' => $addOrderCartRuleForm->createView(),
-            'updateOrderStatusForm' => $updateOrderStatusForm->createView(),
-            'updateOrderStatusActionBarForm' => $updateOrderStatusActionBarForm->createView(),
-            'addOrderPaymentForm' => $addOrderPaymentForm->createView(),
-            'changeOrderCurrencyForm' => $changeOrderCurrencyForm->createView(),
-            'privateNoteForm' => $privateNoteForm ? $privateNoteForm->createView() : null,
-            'updateOrderShippingForm' => $updateOrderShippingForm->createView(),
-            'cancelProductForm' => $cancelProductForm->createView(),
-            'invoiceManagementIsEnabled' => $orderForViewing->isInvoiceManagementIsEnabled(),
-            'changeOrderAddressForm' => $changeOrderAddressForm ? $changeOrderAddressForm->createView() : null,
-            'orderMessageForm' => $orderMessageForm->createView(),
-            'addProductRowForm' => $addProductRowForm->createView(),
-            'editProductRowForm' => $editProductRowForm->createView(),
-            'backOfficeOrderButtons' => $backOfficeOrderButtons,
-            'merchandiseReturnEnabled' => $merchandiseReturnEnabled,
-            'priceSpecification' => $this->getContextLocale()->getPriceSpecification($orderCurrency->iso_code)->toArray(),
-            'previousOrderId' => $orderSiblingProvider->getPreviousOrderId($orderId),
-            'nextOrderId' => $orderSiblingProvider->getNextOrderId($orderId),
-        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -428,17 +428,14 @@ class OrderController extends FrameworkBundleAdminController
 
         $formBuilder = $this->get('prestashop.core.form.identifiable_object.builder.cancel_product_form_builder');
         $backOfficeOrderButtons = new ActionsBarButtonsCollection();
-        $hookParameters = [
-            'controller' => $this,
-            'id_order' => $orderId,
-            'actions_bar_buttons_collection' => $backOfficeOrderButtons,
-        ];
 
         try {
             $this->dispatchHook(
-                'actionGetAdminOrderButtons',
-                $hookParameters
-            );
+                'actionGetAdminOrderButtons', [
+                'controller' => $this,
+                'id_order' => $orderId,
+                'actions_bar_buttons_collection' => $backOfficeOrderButtons,
+            ]);
 
             $cancelProductForm = $formBuilder->getFormFor($orderId);
         } catch (Exception $e) {


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | viewAction of Sell/Orders/OrderController didn't catch any exception, so in case of error the page would break. For example passing non existing order id would result in following error: ![Screenshot from 2020-02-26 13-22-35](https://user-images.githubusercontent.com/31609858/75340400-198bf800-589b-11ea-99a1-8e88be5eeded.png). After the fix it will redirect to index page with error like: ![Screenshot from 2020-02-26 13-23-30](https://user-images.githubusercontent.com/31609858/75340495-42ac8880-589b-11ea-8d49-7c4bad5631bc.png)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17732
| How to test?  | follow `admin-dev/sell/orders/orders` to see migrated order list. Select any order for view. Provoke the page to throw unexpected error (like write not existing order id in url). You should be redirected to index page with error message like mentioned in description. (error message might vary, depending if its defined in controller or not)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17839)
<!-- Reviewable:end -->
