### PR TITLE
Fix exception thrown when editing a customer with a bad email address

### DIFF
--- a/src/Core/Domain/Customer/ValueObject/Email.php
+++ b/src/Core/Domain/Customer/ValueObject/Email.php
@@ -26,106 +26,14 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject;
 
-use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
-
 /**
- * Stores customer's email address
+ * @deprecated since version 1.7.6.4 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email instead
  */
 class Email
 {
-    /**
-     * @var int Maximum allowed length for customer email
-     */
-    const MAX_LENGTH = 255;
-
-    /**
-     * @var string
-     */
-    private $email;
-
-    /**
-     * @param string $email
-     */
     public function __construct($email)
     {
-        $this->assertEmailIsString($email);
-        $this->assertEmailDoesNotExceedAllowedLength($email);
-        $this->assertEmailIsValid($email);
-
-        $this->email = $email;
-    }
-
-    /**
-     * @return string
-     */
-    public function getValue()
-    {
-        return $this->email;
-    }
-
-    /**
-     * Check if given email is the same as current
-     *
-     * @param Email $email
-     *
-     * @return bool
-     */
-    public function isEqualTo(Email $email)
-    {
-        return $email->getValue() === $this->getValue();
-    }
-
-    /**
-     * Assert that email is in valid format
-     *
-     * @param string $email
-     *
-     * @throws CustomerConstraintException
-     */
-    private function assertEmailIsValid($email)
-    {
-        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            throw new CustomerConstraintException(
-                sprintf('Customer email %s is invalid.', var_export($email, true)),
-                CustomerConstraintException::INVALID_EMAIL
-            );
-        }
-    }
-
-    /**
-     * Assert that email length does not exceed allowed value
-     *
-     * @param string $email
-     *
-     * @throws CustomerConstraintException
-     */
-    private function assertEmailDoesNotExceedAllowedLength($email)
-    {
-        $email = html_entity_decode($email, ENT_COMPAT, 'UTF-8');
-
-        $length = function_exists('mb_strlen') ? mb_strlen($email, 'UTF-8') : strlen($email);
-        if (self::MAX_LENGTH < $length) {
-            throw new CustomerConstraintException(
-                sprintf('Customer email is too long. Max allowed length is %s', self::MAX_LENGTH),
-                CustomerConstraintException::INVALID_EMAIL
-            );
-        }
-    }
-
-    /**
-     * Assert email is of type string
-     *
-     * @param string $email
-     *
-     * @throws CustomerConstraintException
-     */
-    private function assertEmailIsString($email)
-    {
-        if (!is_string($email)) {
-            throw new CustomerConstraintException(
-                'Customer email must be of type string',
-                CustomerConstraintException::INVALID_EMAIL
-            );
-        }
+        @trigger_error(self::class . ' is deprecated. Use ' . BaseEmail::class . ' instead', E_USER_DEPRECATED);
+        parent::__construct($email);
     }
 }

--- a/src/Core/Domain/ValueObject/Email.php
+++ b/src/Core/Domain/ValueObject/Email.php
@@ -51,8 +51,8 @@ class Email
     public function __construct($email)
     {
         $this->assertEmailIsString($email);
+        $this->assertEmailIsNotEmpty($email);
         $this->assertEmailDoesNotExceedAllowedLength($email);
-        $this->assertEmailIsValid($email);
 
         $this->email = $email;
     }
@@ -78,19 +78,16 @@ class Email
     }
 
     /**
-     * Assert that email is in valid format
+     * Check that email is not an empty string
      *
-     * @param string $email
+     * @param $email
      *
      * @throws DomainConstraintException
      */
-    private function assertEmailIsValid($email)
+    public function assertEmailIsNotEmpty($email)
     {
-        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            throw new DomainConstraintException(
-                sprintf('Email %s is invalid.', var_export($email, true)),
-                DomainConstraintException::INVALID_EMAIL
-            );
+        if (0 === strlen($email)) {
+            throw new DomainConstraintException('Email must not be empty', DomainConstraintException::INVALID_EMAIL);
         }
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | The email address format verification was too strict on the BO so a valid email address saved in the FO could throw an exception on the BO when editing the customer. This PR fixes it.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17809
| How to test?  | 1. Go to the FO => Create a new account with an email: test@test.com.777<br>2. Go to the BO => Customers page => Edit the last customer created.<br>3. No error should be thrown

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17846)
<!-- Reviewable:end -->
