### PR TITLE
Rework OrderRefundCalculator to use Number

### DIFF
--- a/src/Adapter/Order/Refund/OrderRefundCalculator.php
+++ b/src/Adapter/Order/Refund/OrderRefundCalculator.php
@@ -89,7 +89,6 @@ class OrderRefundCalculator
         $voucherChosen = false;
         $voucherAmount = 0;
         if ($voucherRefundType === VoucherRefundType::PRODUCT_PRICES_EXCLUDING_VOUCHER_REFUND) {
-            //@todo: Check if it matches order_discount_price in legacy
             $refundedAmount -= $voucherAmount = (float) $order->total_discounts;
         } elseif ($voucherRefundType === VoucherRefundType::SPECIFIC_AMOUNT_REFUND) {
             $voucherChosen = true;

--- a/src/Adapter/Order/Refund/OrderRefundCalculator.php
+++ b/src/Adapter/Order/Refund/OrderRefundCalculator.php
@@ -82,13 +82,15 @@ class OrderRefundCalculator
             $precision
         );
 
-        $refundedAmount = new Number('0');
+        $numberZero = new Number('0');
+
+        $refundedAmount = $numberZero;
         foreach ($productRefunds as $orderDetailId => $productRefund) {
             $refundedAmount = $refundedAmount->plus(new Number((string) $productRefund['amount']));
         }
 
         $voucherChosen = false;
-        $voucherAmount = new Number('0');
+        $voucherAmount = $numberZero;
         if ($voucherRefundType === VoucherRefundType::PRODUCT_PRICES_EXCLUDING_VOUCHER_REFUND) {
             $voucherAmount = new Number((string) $order->total_discounts);
             $refundedAmount = $refundedAmount->minus($voucherAmount);
@@ -97,7 +99,7 @@ class OrderRefundCalculator
             $refundedAmount = $voucherAmount = $chosenVoucherAmount;
         }
 
-        $shippingCostAmount = new Number((string) ($shippingRefund ?? 0));
+        $shippingCostAmount = $shippingRefund ?? $numberZero;
         if ($shippingCostAmount->isPositive()) {
             $shippingMaxRefund = new Number(
                 $isTaxIncluded ?
@@ -123,7 +125,7 @@ class OrderRefundCalculator
         }
 
         // Something has to be refunded (check refunds count instead of the sum in case a voucher is implied)
-        if (count($productRefunds) <= 0 && $refundedAmount->isLowerOrEqualThan(new Number('0'))) {
+        if (count($productRefunds) <= 0 && $refundedAmount->isLowerOrEqualThan($numberZero)) {
             throw new InvalidCancelProductException(InvalidCancelProductException::NO_REFUNDS);
         }
 

--- a/src/Adapter/Order/Refund/OrderRefundCalculator.php
+++ b/src/Adapter/Order/Refund/OrderRefundCalculator.php
@@ -40,7 +40,6 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidCancelProductExcept
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderDetailRefund;
 use PrestaShop\PrestaShop\Core\Domain\Order\VoucherRefundType;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopDatabaseException;
 use PrestaShopException;
 use TaxCalculator;
@@ -82,6 +81,7 @@ class OrderRefundCalculator
             $orderDetailList,
             $precision
         );
+
         $refundedAmount = new Number('0');
         foreach ($productRefunds as $orderDetailId => $productRefund) {
             $refundedAmount = $refundedAmount->plus(new Number((string) $productRefund['amount']));
@@ -114,7 +114,7 @@ class OrderRefundCalculator
             }
             if (!$isTaxIncluded) {
                 $taxCalculator = $this->getCarrierTaxCalculatorFromOrder($order);
-                $taxesAmount = $taxCalculator->addTaxes((float) $shippingCostAmount->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS));
+                $taxesAmount = $taxCalculator->addTaxes((float) (string) $shippingCostAmount);
                 $taxes = new Number((string) $taxesAmount);
                 $refundedAmount = $refundedAmount->plus($taxes);
             } else {
@@ -130,9 +130,9 @@ class OrderRefundCalculator
         return new OrderRefundSummary(
             $orderDetailList,
             $productRefunds,
-            (float) $refundedAmount->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS),
-            (float) $shippingCostAmount->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS),
-            (float) $voucherAmount->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS),
+            (float) (string) $refundedAmount,
+            (float) (string) $shippingCostAmount,
+            (float) (string) $voucherAmount,
             $voucherChosen,
             $isTaxIncluded,
             $precision


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fixes todo's in OrderRefundCalculator.php.`@todo: Check if it matches order_discount_price in legacy`, `@todo: use https://github.com/PrestaShop/decimal for price computations`
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #17282
| How to test?  | Order refunds should work as expected in BO Order view page. Behavior tests covers most use-cases, so there shouldn't be any new bugs introduced by this pr.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17850)
<!-- Reviewable:end -->
