### PR TITLE
Fix display for RTL languages for Helper cards by changing animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ tests-legacy/resources/modules/referralprogram/
 /admin-dev/themes/default/public/*
 /admin-dev/themes/new-theme/css/module/drop_rtl.css
 /admin-dev/themes/new-theme/css/right-sidebar_rtl.css
-/admin-dev/themes/new-theme/public
+/admin-dev/themes/new-theme/public/*
 !/admin-dev/themes/new-theme/public/theme.rtlfix
 !/admin-dev/themes/default/public/theme.rtlfix
 

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,8 @@ tests-legacy/resources/modules/referralprogram/
 /admin-dev/themes/new-theme/css/module/drop_rtl.css
 /admin-dev/themes/new-theme/css/right-sidebar_rtl.css
 /admin-dev/themes/new-theme/public
+!/admin-dev/themes/new-theme/public/theme.rtlfix
+!/admin-dev/themes/default/public/theme.rtlfix
 
 themes/*/cache/*
 themes/core.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ tests-legacy/resources/modules/referralprogram/
 /admin-dev/themes/default/css/vendor/nv.d3_rtl.css
 /admin-dev/themes/default/css/vendor/titatoggle-min_rtl.css
 /admin-dev/themes/default/public/theme_rtl.css
-/admin-dev/themes/default/public
+/admin-dev/themes/default/public/*
 /admin-dev/themes/new-theme/css/module/drop_rtl.css
 /admin-dev/themes/new-theme/css/right-sidebar_rtl.css
 /admin-dev/themes/new-theme/public

--- a/admin-dev/themes/default/public/theme.rtlfix
+++ b/admin-dev/themes/default/public/theme.rtlfix
@@ -1,0 +1,153 @@
+@font-face {
+  font-family: Vazir;
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.eot');
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.eot?#iefix') format('embedded-opentype'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.woff') format('woff'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir.ttf') format('truetype');
+  font-weight: normal;
+}
+
+@font-face {
+  font-family: Vazir;
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045523/vazir_v18.0.0/Vazir-Bold.eot');
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045523/vazir_v18.0.0/Vazir-Bold.eot?#iefix') format('embedded-opentype'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.woff') format('woff'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522045523/vazir_v18.0.0/Vazir-Bold.ttf') format('truetype');
+  font-weight: bold;
+}
+
+@font-face {
+  font-family: Vazir;
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.eot');
+  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.eot?#iefix') format('embedded-opentype'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.woff') format('woff'),
+       url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.ttf') format('truetype');
+  font-weight: 300;
+}
+.bootstrap body.lang-fa, body.lang-fa, .lang-fa #content.bootstrap .panel .panel-heading a.btn, .lang-fa #content.bootstrap #dash_version .panel-heading a.btn, .lang-fa #content.bootstrap .message-item-initial .message-item-initial-body .panel-heading a.btn, .lang-fa #content.bootstrap .timeline .timeline-item .timeline-caption .timeline-panel .panel-heading a.btn, .lang-fa #notification .dropdown-menu .notifications .nav-tabs .nav-item .nav-link, .lang-fa .bootstrap .tooltip, .lang-fa .bootstrap .btn-group-action .btn, .lang-fa .bootstrap .page-head h2.page-title, .lang-fa .bootstrap .page-head h4.page-subtitle, .lang-fa .bootstrap #dashboard section > section header .small, .lang-fa .bootstrap #login-panel #shop_name, .bootstrap #login-panel #reset_name, .bootstrap #login-panel #reset_confirm_name, .bootstrap #login-panel #forgot_name, .bootstrap #login-panel #forgot_confirm_name, .bootstrap h1, .lang-fa .bootstrap h2, .lang-fa .bootstrap h3, .lang-fa .bootstrap h4, .lang-fa .bootstrap h5, .lang-fa .bootstrap h6, .lang-fa .bootstrap .h1, .lang-fa .bootstrap .h2, .lang-fa .bootstrap .h3, .lang-fa .bootstrap .h4, .lang-fa .bootstrap .h5, .lang-fa .bootstrap .h6, .lang-fa #content.bootstrap .panel .panel-heading, .lang-fa #content.bootstrap #dash_version .panel-heading, .lang-fa #content.bootstrap .message-item-initial .message-item-initial-body .panel-heading, .lang-fa #content.bootstrap .timeline .timeline-item .timeline-caption .timeline-panel .panel-heading, .bootstrap .nav-tabs li a, .bootstrap .list-empty .list-empty-msg, .bootstrap #dashboard #dashtrends dt, .bootstrap #dashboard #dashproducts nav, .lang-fa .bootstrap #dashboard .tooltip-panel-heading {
+  font-family:"Vazir",Helvetica,Arial,sans-serif;
+}
+.lang-fa .bootstrap input[type="text"], .lang-fa .bootstrap input[type="search"], .lang-fa .bootstrap input[type="password"], .lang-fa .bootstrap input[type="email"], .lang-fa .bootstrap input[type="tel"] {
+  font-family:"Vazir",Helvetica,Arial,sans-serif !important;
+}
+.rtl-flip:not(.rtl-no-flip) {
+  -moz-transform: scaleX(-1);
+  -o-transform: scaleX(-1);
+  -webkit-transform: scaleX(-1);
+  transform: scaleX(-1);
+  -ms-transform: scale(-1, 1);
+  filter: FlipH;
+  -ms-filter: "FlipH";
+}
+
+i[class*="right"], i[class*="left"], i[class*="backward"], i[class*="forward"] {
+  -moz-transform: scale(-1, 1);
+  -webkit-transform: scale(-1, 1);
+  -o-transform: scale(-1, 1);
+  -ms-transform: scale(-1, 1);
+  transform: scale(-1, 1);
+  filter: FlipH;
+  -ms-filter: "FlipH";
+}
+
+.magnitude:before {
+  content: "?";
+  opacity: 0;
+}
+
+.dropdown-menu, .mce-window {
+  right: auto;
+}
+
+ul.category-tree .category-label .category {
+  left: 9px;
+}
+
+.adminproducts .dz-hidden-input {
+  display: none;
+}
+
+ul.category-tree .more::before {
+  content: "\E5CB";
+}
+
+.product-page .product-header {
+  overflow: hidden;
+}
+
+.select2-container--open .select2-dropdown {
+  right: auto;
+  left: 0;
+}
+
+.collapse-button[data-v-442d0f8a], #search .search-input {
+  text-align: right;
+}
+
+.ui-datepicker-rtl {
+  right: auto;
+}
+
+svg {
+  direction: ltr
+}
+
+.mce-panel {
+  right: auto;
+}
+
+.process-icon-rtl:before {
+  content : "\f1dd\f0d9";
+}
+
+#header_infos #header_logo {
+  background-position: right;
+}
+
+/* fix notification dropdown */
+.notification-center .dropdown-menu {
+  right: auto;
+  left: 85px !important;
+}
+
+/* fix popover */
+.popover {
+  right: auto;
+  left: 5px;
+  margin-right: 0;
+  margin-left: 8px;
+}
+.popover .arrow {
+  left: -8px;
+  right: auto;
+  transform: scaleX(-1);
+}
+
+/* fix stock quantity arrow direction */
+.stock-app .stock-overview .table .qty-update .material-icons {
+  transform: scaleX(-1);
+}
+
+@keyframes showcase-img-appearance-rtl {
+  from {
+    -webkit-transform: translate(-20px) translateX(-1);
+    -ms-transform: translate(-20px) translateX(-1);
+    -webkit-transform: translate(-20px) translateX(-1);
+    transform: translate(-20px) translateX(-1);
+    opacity: 0;
+ }
+  to {
+    -webkit-transform: translate(0) translateX(-1);
+    -ms-transform: translate(0) translateX(-1);
+    -webkit-transform: translate(0) translateX(-1);
+    transform: translate(0) translateX(-1);
+    opacity: 1;
+ }
+}
+
+/* Fixes image flipping for RTL language */
+.img-rtl {
+  -webkit-transform: scaleX(-1);
+  transform: scaleX(-1);
+  animation: showcase-img-appearance-rtl .4s;
+}

--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -1,0 +1,72 @@
+@keyframes showcase-img-appearance-rtl {
+  from {
+    -webkit-transform: translate(-20px) translateX(-1);
+    -ms-transform: translate(-20px) translateX(-1);
+    -webkit-transform: translate(-20px) translateX(-1);
+    transform: translate(-20px) translateX(-1);
+    opacity: 0;
+ }
+  to {
+    -webkit-transform: translate(0) translateX(-1);
+    -ms-transform: translate(0) translateX(-1);
+    -webkit-transform: translate(0) translateX(-1);
+    transform: translate(0) translateX(-1);
+    opacity: 1;
+ }
+}
+
+.sidebar.sidebar-right {
+  -webkit-transform: translate(-100%, 0);
+  -moz-transform: translate(-100%, 0);
+  -ms-transform: translate(-100%, 0);
+  -o-transform: translate(-100%, 0);
+  transform: translate(-100%, 0);
+}
+
+/* fix logo position */
+.main-header > .logo {
+  background-position: right;
+}
+
+/* fix profile menu position */
+.employee-dropdown .dropdown-menu {
+  right: auto !important;
+  left: .3em !important;
+}
+
+/* fix select dropdown */
+.select2-container--open .select2-dropdown {
+  right: auto;
+  left: 0;
+}
+
+/* fix notification dropdown */
+.notification-center .dropdown-menu {
+  right: auto;
+  left: 85px !important;
+}
+
+/* fix popover */
+.popover {
+  right: auto;
+  left: 5px;
+  margin-right: 0;
+  margin-left: 8px;
+}
+.popover .arrow {
+  left: -8px;
+  right: auto;
+  transform: scaleX(-1);
+}
+
+/* fix stock quantity arrow direction */
+.stock-app .stock-overview .table .qty-update .material-icons {
+  transform: scaleX(-1);
+}
+
+/* Fixes image flipping for RTL language */
+.img-rtl {
+  -webkit-transform: scaleX(-1);
+  transform: scaleX(-1);
+  animation: showcase-img-appearance-rtl .4s;
+}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/showcase_card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/showcase_card.html.twig
@@ -25,7 +25,7 @@
 
 {% if not isShowcaseCardClosed %}
   <div id="employeesShowcaseCard" class="showcase-card card">
-    <div class="helper-card__left helper-card__team shape-one">
+    <div class="helper-card__left helper-card__team shape-one img-rtl">
       <img src="{{ asset('themes/new-theme/public/helper-card/team@3x.png') }}" class="img-fluid">
     </div>
     <div class="helper-card__right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig
@@ -28,7 +28,7 @@
 {% block meta_showcase_card %}
   {% if not showcaseCardIsClosed %}
   <div id="seo-urls-showcase-card" class="showcase-card card">
-    <div class="showcase-card__left shape-one helper-card__meta-background">
+    <div class="showcase-card__left shape-one helper-card__meta-background img-rtl">
       <img src="{{ asset('themes/new-theme/public/helper-card/seo@3x.png') }}" class="img-fluid">
     </div>
     <div class="showcase-card__right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/showcase_card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/showcase_card.html.twig
@@ -25,8 +25,8 @@
 
 {% if not isShowcaseCardClosed %}
   <div id="customersShowcaseCard" class="showcase-card card">
-    <div class="helper-card__left helper-card__customer shape-one">
-      <img src="{{ asset('themes/new-theme/public/helper-card/customer@3x.png') }}" class="img-fluid img-rtl">
+    <div class="helper-card__left helper-card__customer shape-one img-rtl">
+      <img src="{{ asset('themes/new-theme/public/helper-card/customer@3x.png') }}" class="img-fluid">
     </div>
     <div class="helper-card__right">
       <h2>{{ 'Administrate your customers'|trans({}, 'Admin.Orderscustomers.Feature') }}</h2>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix display for RTL languages for Helper cards, also pushing .rtlfix again because this is not assets and its a regression when we deleted assets
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/12715
| How to test?  | Use a RTL language for your backoffice (example: if your BO is in english, set the English language to RTL from the Languages > edit page). Check the 3 URLs stated in https://github.com/PrestaShop/PrestaShop/issues/12715: the helper cards should be correctly displayed (from right to left).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12809)
<!-- Reviewable:end -->
