### PR TITLE
FIX Exception when adding a new discount with invalid amount - invalid discount

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1446,58 +1446,42 @@ class AdminOrdersControllerCore extends AdminController
 
                     $cart_rules = [];
                     $discount_value = (float) str_replace(',', '.', Tools::getValue('discount_value'));
-
-                    if (Tools::getValue('discount_type') == 1 && ((float) Tools::getValue('discount_value') < 0 || (float) Tools::getValue('discount_value') > 100)) {
-                        $this->errors[] = $this->trans('Reduction percentage must be between 0% and 100%', array(), 'Admin.Catalog.Notification');
-                        return false;
-                    } elseif (Tools::getValue('discount_type') == 2 && ((int) Tools::getValue('discount_value') < 0)) {
-                        $this->errors[] = $this->trans('Reduction amount cannot be lower than zero.', array(), 'Admin.Catalog.Notification');
-                        return false;
-                    }
-
                     switch (Tools::getValue('discount_type')) {
                         // Percent type
                         case 1:
-                            if (isset($order_invoice)) {
-                                $cart_rules[$order_invoice->id]['value_tax_incl'] = Tools::ps_round($order_invoice->total_paid_tax_incl * $discount_value / 100, 2);
-                                $cart_rules[$order_invoice->id]['value_tax_excl'] = Tools::ps_round($order_invoice->total_paid_tax_excl * $discount_value / 100, 2);
-
-                                // Update OrderInvoice
-                                $this->applyDiscountOnInvoice($order_invoice, $cart_rules[$order_invoice->id]['value_tax_incl'], $cart_rules[$order_invoice->id]['value_tax_excl']);
-                            } elseif ($order->hasInvoice()) {
-                                $order_invoices_collection = $order->getInvoicesCollection();
-                                foreach ($order_invoices_collection as $order_invoice) {
-                                    /* @var OrderInvoice $order_invoice */
+                            if ($discount_value > 0 && $discount_value < 100) {
+                                if (isset($order_invoice)) {
                                     $cart_rules[$order_invoice->id]['value_tax_incl'] = Tools::ps_round($order_invoice->total_paid_tax_incl * $discount_value / 100, 2);
                                     $cart_rules[$order_invoice->id]['value_tax_excl'] = Tools::ps_round($order_invoice->total_paid_tax_excl * $discount_value / 100, 2);
 
-                                     // Update OrderInvoice
-                                     $this->applyDiscountOnInvoice($order_invoice, $cart_rules[$order_invoice->id]['value_tax_incl'], $cart_rules[$order_invoice->id]['value_tax_excl']);
+                                    // Update OrderInvoice
+                                    $this->applyDiscountOnInvoice($order_invoice, $cart_rules[$order_invoice->id]['value_tax_incl'], $cart_rules[$order_invoice->id]['value_tax_excl']);
+                                } elseif ($order->hasInvoice()) {
+                                    $order_invoices_collection = $order->getInvoicesCollection();
+                                    foreach ($order_invoices_collection as $order_invoice) {
+                                        /* @var OrderInvoice $order_invoice */
+                                        $cart_rules[$order_invoice->id]['value_tax_incl'] = Tools::ps_round($order_invoice->total_paid_tax_incl * $discount_value / 100, 2);
+                                        $cart_rules[$order_invoice->id]['value_tax_excl'] = Tools::ps_round($order_invoice->total_paid_tax_excl * $discount_value / 100, 2);
+
+                                        // Update OrderInvoice
+                                        $this->applyDiscountOnInvoice($order_invoice, $cart_rules[$order_invoice->id]['value_tax_incl'], $cart_rules[$order_invoice->id]['value_tax_excl']);
+                                    }
+                                } else {
+                                    $cart_rules[0]['value_tax_incl'] = Tools::ps_round($order->total_paid_tax_incl * $discount_value / 100, 2);
+                                    $cart_rules[0]['value_tax_excl'] = Tools::ps_round($order->total_paid_tax_excl * $discount_value / 100, 2);
                                 }
                             } else {
-                                $cart_rules[0]['value_tax_incl'] = Tools::ps_round($order->total_paid_tax_incl * $discount_value / 100, 2);
-                                $cart_rules[0]['value_tax_excl'] = Tools::ps_round($order->total_paid_tax_excl * $discount_value / 100, 2);
+                                $this->errors[] = $this->trans('Reduction percentage must be between 0% and 100%', array(), 'Admin.Catalog.Notification');
+                                return false;
                             }
 
                             break;
                         // Amount type
                         case 2:
-                            if (isset($order_invoice)) {
-                                if ($discount_value > $order_invoice->total_paid_tax_incl) {
-                                    $this->errors[] = $this->trans('The discount value is greater than the order invoice total.', [], 'Admin.Orderscustomers.Notification');
-                                } else {
-                                    $cart_rules[$order_invoice->id]['value_tax_incl'] = Tools::ps_round($discount_value, 2);
-                                    $cart_rules[$order_invoice->id]['value_tax_excl'] = Tools::ps_round($discount_value / (1 + ($order->getTaxesAverageUsed() / 100)), 2);
-
-                                    // Update OrderInvoice
-                                    $this->applyDiscountOnInvoice($order_invoice, $cart_rules[$order_invoice->id]['value_tax_incl'], $cart_rules[$order_invoice->id]['value_tax_excl']);
-                                }
-                            } elseif ($order->hasInvoice()) {
-                                $order_invoices_collection = $order->getInvoicesCollection();
-                                foreach ($order_invoices_collection as $order_invoice) {
-                                    /** @var OrderInvoice $order_invoice */
+                            if ($discount_value > 0) {
+                                if (isset($order_invoice)) {
                                     if ($discount_value > $order_invoice->total_paid_tax_incl) {
-                                        $this->errors[] = $this->trans('The discount value is greater than the order invoice total.', [], 'Admin.Orderscustomers.Notification') . $order_invoice->getInvoiceNumberFormatted(Context::getContext()->language->id, (int) $order->id_shop) . ')';
+                                        $this->errors[] = $this->trans('The discount value is greater than the order invoice total.', [], 'Admin.Orderscustomers.Notification');
                                     } else {
                                         $cart_rules[$order_invoice->id]['value_tax_incl'] = Tools::ps_round($discount_value, 2);
                                         $cart_rules[$order_invoice->id]['value_tax_excl'] = Tools::ps_round($discount_value / (1 + ($order->getTaxesAverageUsed() / 100)), 2);
@@ -1505,14 +1489,31 @@ class AdminOrdersControllerCore extends AdminController
                                         // Update OrderInvoice
                                         $this->applyDiscountOnInvoice($order_invoice, $cart_rules[$order_invoice->id]['value_tax_incl'], $cart_rules[$order_invoice->id]['value_tax_excl']);
                                     }
+                                } elseif ($order->hasInvoice()) {
+                                    $order_invoices_collection = $order->getInvoicesCollection();
+                                    foreach ($order_invoices_collection as $order_invoice) {
+                                        /** @var OrderInvoice $order_invoice */
+                                        if ($discount_value > $order_invoice->total_paid_tax_incl) {
+                                            $this->errors[] = $this->trans('The discount value is greater than the order invoice total.', [], 'Admin.Orderscustomers.Notification') . $order_invoice->getInvoiceNumberFormatted(Context::getContext()->language->id, (int) $order->id_shop) . ')';
+                                        } else {
+                                            $cart_rules[$order_invoice->id]['value_tax_incl'] = Tools::ps_round($discount_value, 2);
+                                            $cart_rules[$order_invoice->id]['value_tax_excl'] = Tools::ps_round($discount_value / (1 + ($order->getTaxesAverageUsed() / 100)), 2);
+
+                                            // Update OrderInvoice
+                                            $this->applyDiscountOnInvoice($order_invoice, $cart_rules[$order_invoice->id]['value_tax_incl'], $cart_rules[$order_invoice->id]['value_tax_excl']);
+                                        }
+                                    }
+                                } else {
+                                    if ($discount_value > $order->total_paid_tax_incl) {
+                                        $this->errors[] = $this->trans('The discount value is greater than the order total.', [], 'Admin.Orderscustomers.Notification');
+                                    } else {
+                                        $cart_rules[0]['value_tax_incl'] = Tools::ps_round($discount_value, 2);
+                                        $cart_rules[0]['value_tax_excl'] = Tools::ps_round($discount_value / (1 + ($order->getTaxesAverageUsed() / 100)), 2);
+                                    }
                                 }
                             } else {
-                                if ($discount_value > $order->total_paid_tax_incl) {
-                                    $this->errors[] = $this->trans('The discount value is greater than the order total.', [], 'Admin.Orderscustomers.Notification');
-                                } else {
-                                    $cart_rules[0]['value_tax_incl'] = Tools::ps_round($discount_value, 2);
-                                    $cart_rules[0]['value_tax_excl'] = Tools::ps_round($discount_value / (1 + ($order->getTaxesAverageUsed() / 100)), 2);
-                                }
+                                $this->errors[] = $this->trans('Reduction amount cannot be lower than zero.', array(), 'Admin.Catalog.Notification');
+                                return false;
                             }
 
                             break;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | An exception was thrown when adding a negative amount/percentage in an order view. This PR fixes it by showing an error message.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17747 for PS1.7.6.3 and PS1.7.5.2
| How to test?  | In BO on the legacy order page `/index.php?controller=AdminOrders&vieworder&token=xxx&id_order=xxx` dd a new discount with an invalid amount for example -10 => an exception is displayed

The idea of ​​my PR is to keep the same behavior present on AdminCartRules (with the same error messages and validation conditions) see  : 

-  https://github.com/PrestaShop/PrestaShop/blob/1.7.6.x/controllers/admin/AdminCartRulesController.php#L217 
- https://github.com/PrestaShop/PrestaShop/blob/1.7.6.x/controllers/admin/AdminCartRulesController.php#L220

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17874)
<!-- Reviewable:end -->
