### PR TITLE
Fix Search by product name & category doesn't work in the second of the Stocks page

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/app.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/app.vue
@@ -44,6 +44,8 @@
   import LowFilter from './header/filters/low-filter';
   import PSPagination from '@app/widgets/ps-pagination';
 
+  const FIRST_PAGE = 1;
+
   export default {
     name: 'app',
     computed: {
@@ -89,6 +91,9 @@
       },
       resetFilters() {
         this.filters = {};
+      },
+      resetPagination() {
+          this.$store.dispatch('updatePageIndex', FIRST_PAGE);
       },
       onLowStockChecked(isChecked) {
         this.filters = Object.assign({}, this.filters, {

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/app.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/app.vue
@@ -83,10 +83,12 @@
       },
       onSearch(keywords) {
         this.$store.dispatch('updateKeywords', keywords);
+        this.resetPagination();
         this.fetch();
       },
       applyFilter(filters) {
         this.filters = filters;
+        this.resetPagination();
         this.fetch();
       },
       resetFilters() {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.7.x
| Description?  | If a merchant is on page number N, and he decides to use the filter (filter by keywords, by supplier, by category, or by status), then results should start from page=1  and not page=N, because filter results may not reach page N. This PR adds a small method that resets the page index to 1,  and call the method when applying a filter.
| Type?         | bug fix
| Category?     | BO 
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #16851
| How to test?  |  Reproduce issue as describe by Khouloud.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17881)
<!-- Reviewable:end -->
