### PR TITLE
Use constant for reduction type in CatalogPriceRuleGridDataFactory

### DIFF
--- a/src/Core/Grid/Data/Factory/CatalogPriceRuleGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/CatalogPriceRuleGridDataFactory.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Reduction;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
@@ -87,8 +88,8 @@ final class CatalogPriceRuleGridDataFactory implements GridDataFactoryInterface
                     $value = '--';
                 }
             }
-            //@todo: take amount from Reduction VO. PR #13716
-            $priceRule['reduction_type'] === 'amount' ?
+
+            Reduction::TYPE_AMOUNT === $priceRule['reduction_type'] ?
                 $priceRule['reduction_type'] = $this->translator->trans('Amount', [], 'Admin.Global') :
                 $priceRule['reduction_type'] = $this->translator->trans('Percentage', [], 'Admin.Global');
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix todo `todo: take amount from Reduction VO. PR #13716`. Implements using Reduction::TYPE_AMOUNT instead of string.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #17282
| How to test?  | no need for QA

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17884)
<!-- Reviewable:end -->
