### PR TITLE
Add displayAdditionalCustomerAddressFields hook during update

### DIFF
--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -793,4 +793,6 @@ VALUES (NULL, 'actionAdminAdminPreferencesControllerPostProcessBefore', 'On post
        (NULL, 'actionAddressGridPresenterModifier', 'Modify address grid template data',
         'This hook allows to modify data which is about to be used in template for address grid', '1'),
        (NULL, 'actionCreditSlipGridPresenterModifier', 'Modify credit slip grid template data',
-        'This hook allows to modify data which is about to be used in template for credit slip grid', '1');
+        'This hook allows to modify data which is about to be used in template for credit slip grid', '1'),
+       (NULL, 'displayAdditionalCustomerAddressFields', 'Display additional customer address fields',
+        'This hook allows to display the extra field values added in an address from using hook ''additionalCustomerAddressFields''', '1');


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The `displayAdditionalCustomerAddressFields` hook was added at install, but not at update, this PR fixes that.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17851
| How to test?  | Nothing to test for QA

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17889)
<!-- Reviewable:end -->
