### PR TITLE
Remove useless TinyMCE scripts from brand form pages

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/add.html.twig
@@ -40,7 +40,4 @@
   {{ parent() }}
 
   <script src="{{ asset('themes/new-theme/public/supplier_form.bundle.js') }}"></script>
-  <script src="{{ asset('../js/tiny_mce/tiny_mce.js') }}"></script>
-  <script src="{{ asset('../js/admin/tinymce.inc.js') }}"></script>
-  <script src="{{ asset('../js/admin/tinymce_loader.js') }}"></script>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/edit.html.twig
@@ -40,7 +40,4 @@
   {{ parent() }}
 
   <script src="{{ asset('themes/new-theme/public/supplier_form.bundle.js') }}"></script>
-  <script src="{{ asset('../js/tiny_mce/tiny_mce.js') }}"></script>
-  <script src="{{ asset('../js/admin/tinymce.inc.js') }}"></script>
-  <script src="{{ asset('../js/admin/tinymce_loader.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Some scripts were added in the supplier form pages by this PR https://github.com/PrestaShop/PrestaShop/pull/16457 They are useless since the `TinyMCEEditor` component automatically includes the required scripts in the page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Checks that the rich editors still work in Supplier form pages

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17913)
<!-- Reviewable:end -->
