### PR TITLE
Use appropriate hook name in contact right column

### DIFF
--- a/themes/classic/templates/contact.tpl
+++ b/themes/classic/templates/contact.tpl
@@ -35,7 +35,7 @@
 {else if $layout === 'layouts/layout-right-column.tpl'}
   {block name="right_column"}
     <div id="right-column" class="col-xs-12 col-sm-4 col-md-3">
-      {widget name="ps_contactinfo" hook='displayLeftColumn'}
+      {widget name="ps_contactinfo" hook='displayRightColumn'}
     </div>
   {/block}
 {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The contact layout used an inappropriate hook name in its right column The template has been fixed which allows to validate the fix made on the module in this PR https://github.com/PrestaShop/ps_contactinfo/pull/25
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | You need to use this branch for the core, and use the module branch Then as in this issue https://github.com/PrestaShop/PrestaShop/pull/16520 You need to change the contact layout to check that the contact widget is correctly displayed in the right column (and is still correctly displayed in the left one of course)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17917)
<!-- Reviewable:end -->

Note: before this PR is merged/validated we should first merge the fix from the module, release its new version and then update the composer.lock to use the new version in fresh installs Only then can this PR be merged