### PR TITLE
Move the default_page at the end of the form

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1119,6 +1119,8 @@ class ToolsCore
      *
      * @param string $file File path
      * @param array $exclude_files Excluded files
+     *
+     * @return bool
      */
     public static function deleteFile($file, $exclude_files = array())
     {
@@ -1127,8 +1129,10 @@ class ToolsCore
         }
 
         if (file_exists($file) && is_file($file) && array_search(basename($file), $exclude_files) === false) {
-            unlink($file);
+            return unlink($file);
         }
+
+        return false;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -206,11 +206,6 @@
           'help': 'PrestaShop can provide you with guidance on a regular basis by sending you tips on how to optimize the management of your store which will help you grow your business. If you do not wish to receive these tips, you can disable this option.'|trans({}, 'Admin.Advparameters.Help')
         }) }}
 
-        {{ ps.form_group_row(employeeForm.default_page, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}, {
-          'label': 'Default page'|trans,
-          'help': 'This page will be displayed just after login.'|trans({}, 'Admin.Advparameters.Help')
-        }) }}
-
         {{ ps.form_group_row(employeeForm.language, {}, {
           'label': 'Language'|trans({}, 'Admin.Global')
         }) }}
@@ -237,6 +232,11 @@
             }) }}
           {% endif %}
         {% endif %}
+
+        {{ ps.form_group_row(employeeForm.default_page, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}, {
+          'label': 'Default page'|trans,
+          'help': 'This page will be displayed just after login.'|trans({}, 'Admin.Advparameters.Help')
+        }) }}
 
         {% block employee_form_rest %}
           {{ form_rest(employeeForm) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | >= 1.7.6.x
| Description?  | The Default page should be at the bottom of the form after the Permission profile. This is because the Permission profile must first be selected to be selected on the Default page according to the permissions it has.
| Type?         | improvement
| How to test?  | Create/Edit employee in the admin backend

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17919)
<!-- Reviewable:end -->
