### PR TITLE
Fix conversion when adding payment to order

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1852,7 +1852,7 @@ class OrderCore extends ObjectModel
         if ($order_payment->id_currency == $this->id_currency) {
             $this->total_paid_real += $order_payment->amount;
         } else {
-            $this->total_paid_real += Tools::ps_round(Tools::convertPrice($order_payment->amount, $order_payment->id_currency, false), 2);
+            $this->total_paid_real += Tools::ps_round(Tools::convertPrice($order_payment->amount, $this->id_currency, false), 2);
         }
 
         // We put autodate parameter of add method to true if date_add field is null

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1848,11 +1848,35 @@ class OrderCore extends ObjectModel
             $order_payment->date_add .= ' ' . date('H:i:s');
         }
 
+        /*
+         * 4 cases
+         *
+         * Order is in default_currency + Payment is in Order currency
+         *    for example default = 1, order = 1, payment = 1
+         *    ==> NO conversion to do
+         * Order is in default_currency + Payment is NOT in Order currency
+         *    for example default = 1, order = 1, payment = 2
+         *    ==> convert payment in order's currency
+         * Order is NOT in default_currency + Payment is in Order currency
+         *    for example default = 1, order = 2, payment = 2
+         *    ==> NO conversion to do
+         * Order is NOT in default_currency + Payment is NOT in Order currency
+         *    for example default = 1, order = 2, payment = 3
+         *    ==> As conversion rates are set regarding the default currency,
+         *        convert payment to default and from default to order's currency
+         */
+
         // Update total_paid_real value for backward compatibility reasons
         if ($order_payment->id_currency == $this->id_currency) {
             $this->total_paid_real += $order_payment->amount;
         } else {
-            $this->total_paid_real += Tools::ps_round(Tools::convertPrice($order_payment->amount, $this->id_currency, false), 2);
+            $default_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+            if ($this->id_currency === $default_currency) {
+                $this->total_paid_real += Tools::ps_round(Tools::convertPrice($order_payment->amount, $this->id_currency, false), 2);
+            } else {
+                $amountInDefaultCurrency = Tools::convertPrice($order_payment->amount, $order_payment->id_currency, false);
+                $this->total_paid_real += Tools::ps_round(Tools::convertPrice($amountInDefaultCurrency, $this->id_currency, true), 2);
+            }
         }
 
         // We put autodate parameter of add method to true if date_add field is null

--- a/tests/Integration/Behaviour/Features/Context/Configuration/CommonConfigurationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Configuration/CommonConfigurationFeatureContext.php
@@ -26,6 +26,7 @@
 
 namespace Tests\Integration\Behaviour\Features\Context\Configuration;
 
+use Configuration;
 use Tools;
 
 class CommonConfigurationFeatureContext extends AbstractConfigurationFeatureContext
@@ -55,5 +56,13 @@ class CommonConfigurationFeatureContext extends AbstractConfigurationFeatureCont
     public function setShippingHandlingFees($value)
     {
         $this->setConfiguration('PS_SHIPPING_HANDLING', $value);
+    }
+
+    /**
+     * @Given /^groups feature is activated$/
+     */
+    public function activateGroupFeature()
+    {
+        Configuration::updateGlobalValue('PS_GROUP_FEATURE_ACTIVE', '1');
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCustomizationFieldsCommand
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\CreateEmptyCustomerCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\SetFreeShippingToCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartAddressesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartCurrencyCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateProductQuantityInCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationId;
@@ -87,6 +88,29 @@ class CartFeatureContext extends AbstractDomainFeatureContext
         );
 
         SharedStorage::getStorage()->set($cartReference, $cartIdObject->getValue());
+    }
+
+    /**
+     * @When I update the cart :cartReference currency to :currencyReference
+     *
+     * @param string $cartReference
+     * @param string $currencyReference
+     */
+    public function updateCartCurrency(string $cartReference, string $currencyReference)
+    {
+        /** @var Currency $currency */
+        $currency = SharedStorage::getStorage()->get($currencyReference);
+
+        $cartId = SharedStorage::getStorage()->get($cartReference);
+
+        $this->getCommandBus()->handle(
+            new UpdateCartCurrencyCommand(
+                $cartId,
+                (int) $currency->id
+            )
+        );
+
+        Cart::resetStaticCache();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -57,14 +57,21 @@ class CartFeatureContext extends AbstractDomainFeatureContext
      */
     public function addCurrencyToContext($currencyIsoCode)
     {
-        $currency = new Currency();
-        $currency->name = $currencyIsoCode;
-        $currency->precision = 2;
-        $currency->iso_code = $currencyIsoCode;
-        $currency->active = 1;
-        $currency->conversion_rate = 1;
+        $currencyId = (int) Currency::getIdByIsoCode($currencyIsoCode);
+
+        if ($currencyId) {
+            $currency = new Currency($currencyId);
+        } else {
+            $currency = new Currency();
+            $currency->name = $currencyIsoCode;
+            $currency->precision = 2;
+            $currency->iso_code = $currencyIsoCode;
+            $currency->active = 1;
+            $currency->conversion_rate = 1;
+        }
 
         Context::getContext()->currency = $currency;
+        SharedStorage::getStorage()->set($currencyIsoCode, $currency);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -650,6 +650,18 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then order :orderReference should have the following details:
+     *
+     * @param string $orderReference
+     * @param TableNode $table
+     */
+    public function queryOrderToGetTheFollowingProperties(string $orderReference, TableNode $table)
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+        $this->assertOrderPropertiesEquals(new Order($orderId), $table->getRowsHash());
+    }
+
+    /**
      * @param string $productName
      *
      * @return int
@@ -695,5 +707,25 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
         }
 
         return $productQuantities;
+    }
+
+    /**
+     * @param Order $order
+     * @param array $data
+     */
+    private function assertOrderPropertiesEquals(Order $order, array $data): void
+    {
+        foreach (array_keys($data) as $property) {
+            if (!property_exists($order, $property) || $data[$property] !== $order->$property) {
+                throw new RuntimeException(
+                    sprintf(
+                        'Expected %s value to be equal to %s, got %s instead',
+                        $property,
+                        $data[$property],
+                        $order->$property
+                    )
+                );
+            }
+        }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderPaymentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderPaymentFeatureContext.php
@@ -52,13 +52,17 @@ class OrderPaymentFeatureContext extends AbstractDomainFeatureContext
 
         $data = $table->getRowsHash();
 
+        $currencyId = is_numeric($data['id_currency']) ?
+            (int) $data['id_currency'] :
+            SharedStorage::getStorage()->get($data['id_currency'])->id;
+
         $this->getCommandBus()->handle(
             new AddPaymentCommand(
                 $orderId,
                 $data['date'],
                 $data['payment_method'],
                 $data['amount'],
-                (int) $data['id_currency'],
+                $currencyId,
                 isset($data['id_invoice']) ? (int) $data['id_invoice'] : null,
                 $data['transaction_id']
             )

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderPaymentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderPaymentFeatureContext.php
@@ -52,17 +52,13 @@ class OrderPaymentFeatureContext extends AbstractDomainFeatureContext
 
         $data = $table->getRowsHash();
 
-        $currencyId = is_numeric($data['id_currency']) ?
-            (int) $data['id_currency'] :
-            SharedStorage::getStorage()->get($data['id_currency'])->id;
-
         $this->getCommandBus()->handle(
             new AddPaymentCommand(
                 $orderId,
                 $data['date'],
                 $data['payment_method'],
                 $data['amount'],
-                $currencyId,
+                SharedStorage::getStorage()->get($data['currency'])->id,
                 isset($data['id_invoice']) ? (int) $data['id_invoice'] : null,
                 $data['transaction_id']
             )
@@ -153,7 +149,7 @@ class OrderPaymentFeatureContext extends AbstractDomainFeatureContext
                     $data['date'],
                     $data['payment_method'],
                     $data['amount'],
-                    (int) $data['id_currency'],
+                    SharedStorage::getStorage()->get($data['currency'])->id,
                     isset($data['id_invoice']) ? (int) $data['id_invoice'] : null,
                     $data['transaction_id']
                 )

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -4,6 +4,9 @@ Feature: Customer Management
   As a BO user
   I must be able to create, save and edit customers
 
+  Background:
+    Given groups feature is activated
+
   Scenario: Create a simple customer and edit it
     When I create a customer "CUST-1" with following properties:
       | firstName | Mathieu                    |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
@@ -1,0 +1,136 @@
+## ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order
+#@reset-database-before-feature
+#Feature: Add payment to Order from Back Office (BO)
+#  In order to manage orders for FO customers
+#  As a BO user
+#  I need to be able to add payment to orders from the BO
+#
+#  Background:
+#    Given email sending is disabled
+#    Given shop "shop1" with name "test_shop" exists
+#    And the current currency is "USD"
+#    And country "US" is enabled
+#    And country "FR" is enabled
+#    And language "French" with locale "fr-FR" exists
+#    And I add new currency "currency2" with following properties:
+#      | iso_code         | EUR                              |
+#      | exchange_rate    | 0.88                             |
+#      | name             | My Euros                         |
+#      | symbols          | en-US:€;fr-FR:€                  |
+#      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤ |
+#      | is_enabled       | 1                                |
+#      | is_unofficial    | 0                                |
+#      | shop_association | shop1                            |
+#    And I add new currency "currency3" with following properties:
+#      | iso_code         | JPY                                   |
+#      | exchange_rate    | 107.52                                |
+#      | name             | My Japanese Yen                       |
+#      | symbols          | en-US:¥;fr-FR:¥                       |
+#      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤      |
+#      | is_enabled       | 1                                     |
+#      | is_unofficial    | 0                                     |
+#      | shop_association | shop1                                 |
+#    And the module "dummy_payment" is installed
+#    And I am logged in as "test@prestashop.com" employee
+#    And there is customer "testCustomer" with email "pub@prestashop.com"
+#    And customer "testCustomer" has address in "US" country
+#    And I create an empty cart "dummy_cart" for customer "testCustomer"
+#    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+#    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
+#    And I add order "bo_order1" with the following details:
+#      | cart                | dummy_cart                 |
+#      | message             | test                       |
+#      | payment module name | dummy_payment              |
+#      | status              | Awaiting bank wire payment |
+#
+## 4 cases
+##
+##    Order is in default_currency + Payment is in Order currency
+##       for example default = 1, order = 1, payment = 1
+##       ==> NO conversion to do
+##    Order is in default_currency + Payment is NOT in Order currency
+##       for example default = 1, order = 1, payment = 2
+##       ==> convert payment in order's currency
+##    Order is NOT in default_currency + Payment is in Order currency
+##       for example default = 1, order = 2, payment = 2
+##       ==> NO conversion to do
+##    Order is NOT in default_currency + Payment is NOT in Order currency
+##       for example default = 1, order = 2, payment = 3
+##       ==> As conversion rates are set regarding the default currency,
+##           convert payment to default and from default to order's currency
+#
+#  Scenario: Add a payment when Order is in default_currency and Payment is in Order currency
+#    When order "bo_order1" has 0 payments
+#    When I pay order "bo_order1" with the following details:
+#      | date           | 2019-11-26 13:56:23 |
+#      | payment_method | Payments by check   |
+#      | transaction_id | test123             |
+#      | id_currency    | 1                   |
+#      | amount         | 6.00                |
+#    Then order "bo_order1" payments should have the following details:
+#      | date           | 2019-11-26 13:56:23 |
+#      | payment_method | Payments by check   |
+#      | transaction_id | test123             |
+#      | amount         | $6.00               |
+#    And order "bo_order1" should have the following details:
+#      | total_paid_real           | 6.000000 |
+#
+#  Scenario: Add a payment when Order is in default_currency and Payment is NOT in Order currency
+#    When order "bo_order1" has 0 payments
+#    When I pay order "bo_order1" with the following details:
+#      | date           | 2019-11-26 13:56:23 |
+#      | payment_method | Payments by check   |
+#      | transaction_id | test123             |
+#      | id_currency    | currency2           |
+#      | amount         | 6.00                |
+#    Then order "bo_order1" payments should have the following details:
+#      | date           | 2019-11-26 13:56:23 |
+#      | payment_method | Payments by check   |
+#      | transaction_id | test123             |
+#      | amount         | €6.00               |
+#    And order "bo_order1" should have the following details:
+#      | total_paid_real           | 6.820000 |
+#
+#  Scenario: Add a payment when Order is NOT in default_currency and Payment is in Order currency
+#    Given I update the cart "dummy_cart" currency to "currency2"
+#    And I add order "bo_order2" with the following details:
+#      | cart                | dummy_cart                 |
+#      | message             | test                       |
+#      | payment module name | dummy_payment              |
+#      | status              | Awaiting bank wire payment |
+#    When order "bo_order2" has 0 payments
+#    When I pay order "bo_order2" with the following details:
+#      | date           | 2019-11-26 13:56:23 |
+#      | payment_method | Payments by check   |
+#      | transaction_id | test123             |
+#      | id_currency    | currency2           |
+#      | amount         | 6.00                |
+#    Then order "bo_order2" payments should have the following details:
+#      | date           | 2019-11-26 13:56:23 |
+#      | payment_method | Payments by check   |
+#      | transaction_id | test123             |
+#      | amount         | €6.00               |
+#    And order "bo_order2" should have the following details:
+#      | total_paid_real           | 6.000000 |
+#
+#  Scenario: Add a payment when Order is NOT in default_currency and Payment is NOT in Order currency
+#    Given I update the cart "dummy_cart" currency to "currency2"
+#    And I add order "bo_order2" with the following details:
+#      | cart                | dummy_cart                 |
+#      | message             | test                       |
+#      | payment module name | dummy_payment              |
+#      | status              | Awaiting bank wire payment |
+#    When order "bo_order2" has 0 payments
+#    When I pay order "bo_order2" with the following details:
+#      | date           | 2019-11-26 13:56:23 |
+#      | payment_method | Payments by check   |
+#      | transaction_id | test123             |
+#      | id_currency    | currency3           |
+#      | amount         | 6.00                |
+#    Then order "bo_order2" payments should have the following details:
+#      | date           | 2019-11-26 13:56:23 |
+#      | payment_method | Payments by check   |
+#      | transaction_id | test123             |
+#      | amount         | ¥6               |
+#    And order "bo_order2" should have the following details:
+#      | total_paid_real           | 0.050000 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
@@ -1,96 +1,96 @@
-## ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order
-#@reset-database-before-feature
-#Feature: Add payment to Order from Back Office (BO)
-#  In order to manage orders for FO customers
-#  As a BO user
-#  I need to be able to add payment to orders from the BO
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order
+@reset-database-before-feature
+Feature: Add payment to Order from Back Office (BO)
+  In order to manage orders for FO customers
+  As a BO user
+  I need to be able to add payment to orders from the BO
+
+  Background:
+    Given email sending is disabled
+    Given shop "shop1" with name "test_shop" exists
+    And the current currency is "USD"
+    And country "US" is enabled
+    And country "FR" is enabled
+    And language "French" with locale "fr-FR" exists
+    And I add new currency "currency2" with following properties:
+      | iso_code         | EUR                              |
+      | exchange_rate    | 0.88                             |
+      | name             | My Euros                         |
+      | symbols          | en-US:€;fr-FR:€                  |
+      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤ |
+      | is_enabled       | 1                                |
+      | is_unofficial    | 0                                |
+      | shop_association | shop1                            |
+    And I add new currency "currency3" with following properties:
+      | iso_code         | JPY                                   |
+      | exchange_rate    | 107.52                                |
+      | name             | My Japanese Yen                       |
+      | symbols          | en-US:¥;fr-FR:¥                       |
+      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤      |
+      | is_enabled       | 1                                     |
+      | is_unofficial    | 0                                     |
+      | shop_association | shop1                                 |
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+
+# 4 cases
 #
-#  Background:
-#    Given email sending is disabled
-#    Given shop "shop1" with name "test_shop" exists
-#    And the current currency is "USD"
-#    And country "US" is enabled
-#    And country "FR" is enabled
-#    And language "French" with locale "fr-FR" exists
-#    And I add new currency "currency2" with following properties:
-#      | iso_code         | EUR                              |
-#      | exchange_rate    | 0.88                             |
-#      | name             | My Euros                         |
-#      | symbols          | en-US:€;fr-FR:€                  |
-#      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤ |
-#      | is_enabled       | 1                                |
-#      | is_unofficial    | 0                                |
-#      | shop_association | shop1                            |
-#    And I add new currency "currency3" with following properties:
-#      | iso_code         | JPY                                   |
-#      | exchange_rate    | 107.52                                |
-#      | name             | My Japanese Yen                       |
-#      | symbols          | en-US:¥;fr-FR:¥                       |
-#      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤      |
-#      | is_enabled       | 1                                     |
-#      | is_unofficial    | 0                                     |
-#      | shop_association | shop1                                 |
-#    And the module "dummy_payment" is installed
-#    And I am logged in as "test@prestashop.com" employee
-#    And there is customer "testCustomer" with email "pub@prestashop.com"
-#    And customer "testCustomer" has address in "US" country
-#    And I create an empty cart "dummy_cart" for customer "testCustomer"
-#    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
-#    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
-#    And I add order "bo_order1" with the following details:
-#      | cart                | dummy_cart                 |
-#      | message             | test                       |
-#      | payment module name | dummy_payment              |
-#      | status              | Awaiting bank wire payment |
-#
-## 4 cases
-##
-##    Order is in default_currency + Payment is in Order currency
-##       for example default = 1, order = 1, payment = 1
-##       ==> NO conversion to do
-##    Order is in default_currency + Payment is NOT in Order currency
-##       for example default = 1, order = 1, payment = 2
-##       ==> convert payment in order's currency
-##    Order is NOT in default_currency + Payment is in Order currency
-##       for example default = 1, order = 2, payment = 2
-##       ==> NO conversion to do
-##    Order is NOT in default_currency + Payment is NOT in Order currency
-##       for example default = 1, order = 2, payment = 3
-##       ==> As conversion rates are set regarding the default currency,
-##           convert payment to default and from default to order's currency
-#
-#  Scenario: Add a payment when Order is in default_currency and Payment is in Order currency
-#    When order "bo_order1" has 0 payments
-#    When I pay order "bo_order1" with the following details:
-#      | date           | 2019-11-26 13:56:23 |
-#      | payment_method | Payments by check   |
-#      | transaction_id | test123             |
-#      | id_currency    | 1                   |
-#      | amount         | 6.00                |
-#    Then order "bo_order1" payments should have the following details:
-#      | date           | 2019-11-26 13:56:23 |
-#      | payment_method | Payments by check   |
-#      | transaction_id | test123             |
-#      | amount         | $6.00               |
-#    And order "bo_order1" should have the following details:
-#      | total_paid_real           | 6.000000 |
-#
-#  Scenario: Add a payment when Order is in default_currency and Payment is NOT in Order currency
-#    When order "bo_order1" has 0 payments
-#    When I pay order "bo_order1" with the following details:
-#      | date           | 2019-11-26 13:56:23 |
-#      | payment_method | Payments by check   |
-#      | transaction_id | test123             |
-#      | id_currency    | currency2           |
-#      | amount         | 6.00                |
-#    Then order "bo_order1" payments should have the following details:
-#      | date           | 2019-11-26 13:56:23 |
-#      | payment_method | Payments by check   |
-#      | transaction_id | test123             |
-#      | amount         | €6.00               |
-#    And order "bo_order1" should have the following details:
-#      | total_paid_real           | 6.820000 |
-#
+#    Order is in default_currency + Payment is in Order currency
+#       for example default = 1, order = 1, payment = 1
+#       ==> NO conversion to do
+#    Order is in default_currency + Payment is NOT in Order currency
+#       for example default = 1, order = 1, payment = 2
+#       ==> convert payment in order's currency
+#    Order is NOT in default_currency + Payment is in Order currency
+#       for example default = 1, order = 2, payment = 2
+#       ==> NO conversion to do
+#    Order is NOT in default_currency + Payment is NOT in Order currency
+#       for example default = 1, order = 2, payment = 3
+#       ==> As conversion rates are set regarding the default currency,
+#           convert payment to default and from default to order's currency
+
+  Scenario: Add a payment when Order is in default_currency and Payment is in Order currency
+    When order "bo_order1" has 0 payments
+    When I pay order "bo_order1" with the following details:
+      | date           | 2019-11-26 13:56:23 |
+      | payment_method | Payments by check   |
+      | transaction_id | test123             |
+      | currency       | USD                 |
+      | amount         | 6.00                |
+    Then order "bo_order1" payments should have the following details:
+      | date           | 2019-11-26 13:56:23 |
+      | payment_method | Payments by check   |
+      | transaction_id | test123             |
+      | amount         | $6.00               |
+    And order "bo_order1" should have the following details:
+      | total_paid_real           | 6.000000 |
+
+  Scenario: Add a payment when Order is in default_currency and Payment is NOT in Order currency
+    When order "bo_order1" has 0 payments
+    When I pay order "bo_order1" with the following details:
+      | date           | 2019-11-26 13:56:23 |
+      | payment_method | Payments by check   |
+      | transaction_id | test123             |
+      | currency       | currency2           |
+      | amount         | 6.00                |
+    Then order "bo_order1" payments should have the following details:
+      | date           | 2019-11-26 13:56:23 |
+      | payment_method | Payments by check   |
+      | transaction_id | test123             |
+      | amount         | €6.00               |
+    And order "bo_order1" should have the following details:
+      | total_paid_real           | 6.820000 |
+
 #  Scenario: Add a payment when Order is NOT in default_currency and Payment is in Order currency
 #    Given I update the cart "dummy_cart" currency to "currency2"
 #    And I add order "bo_order2" with the following details:
@@ -103,7 +103,7 @@
 #      | date           | 2019-11-26 13:56:23 |
 #      | payment_method | Payments by check   |
 #      | transaction_id | test123             |
-#      | id_currency    | currency2           |
+#      | currency       | currency2           |
 #      | amount         | 6.00                |
 #    Then order "bo_order2" payments should have the following details:
 #      | date           | 2019-11-26 13:56:23 |
@@ -125,7 +125,7 @@
 #      | date           | 2019-11-26 13:56:23 |
 #      | payment_method | Payments by check   |
 #      | transaction_id | test123             |
-#      | id_currency    | currency3           |
+#      | currency       | currency3           |
 #      | amount         | 6.00                |
 #    Then order "bo_order2" payments should have the following details:
 #      | date           | 2019-11-26 13:56:23 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -52,7 +52,7 @@ Feature: Order from Back Office (BO)
       | date           | 2019-11-26 13:56:22 |
       | payment_method | Payments by check   |
       | transaction_id | test!@#$%%^^&* OR 1 |
-      | id_currency    | 1                   |
+      | currency       | USD                 |
       | amount         | -5.548              |
     Then I should get error that payment amount is negative
     And order "bo_order1" has 0 payments
@@ -63,7 +63,7 @@ Feature: Order from Back Office (BO)
       | date           | 2019-11-26 13:56:23 |
       | payment_method | Payments by check   |
       | transaction_id | test123             |
-      | id_currency    | 1                   |
+      | currency       | USD                 |
       | amount         | 6.00                |
     Then order "bo_order1" payments should have the following details:
       | date           | 2019-11-26 13:56:23 |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -20,6 +20,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CustomerManagerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
         category:
             paths:
                 features: Features/Scenario/Category
@@ -75,6 +76,10 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderRefundFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\TaxFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
         currency:
             paths:
                 features: Features/Scenario/Currency


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Conversion issue when adding a payment in another currency than the order one
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9850 http://forge.prestashop.com/browse/BOOM-4098
| How to test?  | <ul><li>Create a shop with Euro as default currency and USD as secondary</li><li>Create an order in USD with bankwire as payment method</li><li>In the BO, edit the order and add a new payment in Euro</li><li>In the Database the value for total_paid_real is incorrect. You can see it in the header of the payments section too</li></ul>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17938)
<!-- Reviewable:end -->
