### PR TITLE
Show all product combination images

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -99,15 +99,7 @@ class ImageRetriever
             return $image;
         }, $images);
 
-        $filteredImages = [];
-
-        foreach ($images as $image) {
-            if (in_array($productAttributeId, $image['associatedVariants'])) {
-                $filteredImages[] = $image;
-            }
-        }
-
-        return (0 === count($filteredImages)) ? $images : $filteredImages;
+        return $images;
     }
 
     /**

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -606,7 +606,7 @@ class ProductLazyArray extends AbstractLazyArray
                 foreach ($this->product['images'] as $image) {
                     if (isset($image['cover'])) {
                         $this->product['cover'] = $image;
-    
+
                         break;
                     }
                 }

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -617,7 +617,7 @@ class ProductLazyArray extends AbstractLazyArray
 
         if (count($this->product['images']) > 0) {
             foreach ($this->product['images'] as $image) {
-                if (isset($image['cover'])]) {
+                if (isset($image['cover'])) {
                     $this->product['catalogCover'] = $image;
 
                     break;

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -617,7 +617,7 @@ class ProductLazyArray extends AbstractLazyArray
 
         if (count($this->product['images']) > 0) {
             foreach ($this->product['images'] as $image) {
-                if (isset($image['cover']) && null !== $image['cover']) {
+                if (isset($image['cover'])]) {
                     $this->product['catalogCover'] = $image;
 
                     break;

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -592,7 +592,7 @@ class ProductLazyArray extends AbstractLazyArray
 
         if (isset($product['id_product_attribute'])) {
             foreach ($this->product['images'] as $image) {
-                if (isset($image['cover']) && null !== $image['cover']) {
+                if (in_array($product['id_product_attribute'], $image['associatedVariants'])) {
                     $this->product['cover'] = $image;
 
                     break;
@@ -603,9 +603,28 @@ class ProductLazyArray extends AbstractLazyArray
         if (!isset($this->product['cover'])) {
             if (count($this->product['images']) > 0) {
                 $this->product['cover'] = array_values($this->product['images'])[0];
+                foreach ($this->product['images'] as $image) {
+                    if (isset($image['cover']) && null !== $image['cover']) {
+                        $this->product['cover'] = $image;
+    
+                        break;
+                    }
+                }
             } else {
                 $this->product['cover'] = null;
             }
+        }
+
+        if (count($this->product['images']) > 0) {
+            foreach ($this->product['images'] as $image) {
+                if (isset($image['cover']) && null !== $image['cover']) {
+                    $this->product['catalogCover'] = $image;
+
+                    break;
+                }
+            }
+        } else {
+            $this->product['catalogCover'] = null;
         }
     }
 

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -604,7 +604,7 @@ class ProductLazyArray extends AbstractLazyArray
             if (count($this->product['images']) > 0) {
                 $this->product['cover'] = array_values($this->product['images'])[0];
                 foreach ($this->product['images'] as $image) {
-                    if (isset($image['cover']) && null !== $image['cover']) {
+                    if (isset($image['cover'])) {
                         $this->product['cover'] = $image;
     
                         break;

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -28,14 +28,12 @@
   <article class="product-miniature js-product-miniature" data-id-product="{$product.id_product}" data-id-product-attribute="{$product.id_product_attribute}" itemprop="item" itemscope itemtype="http://schema.org/Product">
     <div class="thumbnail-container">
       {block name='product_thumbnail'}
-        {if $product.cover}
-          {assign var='coverImage' value=Product::getCover($product->id)}
-          {assign var='coverImageId' value="{$product->id}-{$coverImage.id_image}"}
+        {if $product.catalogCover}
           <a href="{$product.url}" class="thumbnail product-thumbnail">
             <img
               src="{$link->getImageLink($product.link_rewrite, $coverImageId)}"
-              alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
-              data-full-size-image-url="{$product.cover.large.url}"
+              alt="{if !empty($product.catalogCover.legend)}{$product.catalogCover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
+              data-full-size-image-url="{$product.catalogCover.large.url}"
               />
           </a>
         {else}

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -31,7 +31,7 @@
         {if $product.catalogCover}
           <a href="{$product.url}" class="thumbnail product-thumbnail">
             <img
-              src="{$link->getImageLink($product.link_rewrite, $coverImageId)}"
+              src="{$product.catalogCover.bySize.home_default.url}"
               alt="{if !empty($product.catalogCover.legend)}{$product.catalogCover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
               data-full-size-image-url="{$product.catalogCover.large.url}"
               />


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Show all images for a product and select the current combination image instead of only showing combination images. Also updates catalog product miniature to use new  catalogCover image so that all sizes and legend are available. Removes need to call Product::getCover() and $link->getImageLink() from the template.
| Type?         | improvement
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17317
| How to test?  | Add additional images to a product.<br>Select specific images for a combination. <br>View the product in FO, all product images should be shown.<br> Change a combination and the combination image should be selected in the thumbnails and shown as the main image. <br>On the catalog listing the selected cover should be displayed and the correct alt atrribute assigned. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17943)
<!-- Reviewable:end -->
