### PR TITLE
Fix pagination on migrated order listing

### DIFF
--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -122,10 +122,8 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
      */
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        return $this->connection
-            ->createQueryBuilder()
-            ->select('FOUND_ROWS()')
-        ;
+        return $this->getBaseQueryBuilder($searchCriteria->getFilters())
+            ->select('COUNT(o.id_order)');
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.7.x
| Description?  | The pagination was broken because the query fetching the total number of orders (listing page) was wrong.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17868
| How to test?  | - Go to orders list (/index.php/sell/orders/orders/), with at least 11 items in list<br>- Change item per page to 10<br>- The pagination should still be there


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17973)
<!-- Reviewable:end -->
