### PR TITLE
Convert arabic/persian digits to latin digits in DatePickerType

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -63,12 +63,6 @@ $(document).ready(function() {
     $(this).val(parsedValue);
   });
 
-  /** Attach date picker */
-  $('.datepicker').datetimepicker({
-    locale: full_language_code,
-    format: 'YYYY-MM-DD'
-  });
-
   /** tooltips should be hidden when we move to another tab */
   $('#form-nav').on('click','.nav-item', function clearTooltipsAndPopovers() {
     $('[data-toggle="tooltip"]').tooltip('hide');

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -79,17 +79,23 @@ class AdminProductWrapper
     private $employeeAssociatedShops;
 
     /**
+     * @var FloatParser
+     */
+    private $floatParser;
+
+    /**
      * Constructor : Inject Symfony\Component\Translation Translator.
      *
      * @param object $translator
      * @param array $employeeAssociatedShops
      * @param Locale $locale
      */
-    public function __construct($translator, array $employeeAssociatedShops, Locale $locale)
+    public function __construct($translator, array $employeeAssociatedShops, Locale $locale, FloatParser $floatParser)
     {
         $this->translator = $translator;
         $this->employeeAssociatedShops = $employeeAssociatedShops;
         $this->locale = $locale;
+        $this->floatParser = $floatParser;
     }
 
     /**
@@ -260,8 +266,6 @@ class AdminProductWrapper
      */
     public function processProductSpecificPrice($id_product, $specificPriceValues, $idSpecificPrice = null)
     {
-        $floatParser = new FloatParser();
-
         // ---- data formatting ----
         $id_product_attribute = $specificPriceValues['sp_id_product_attribute'];
         $id_shop = $specificPriceValues['sp_id_shop'] ? $specificPriceValues['sp_id_shop'] : 0;
@@ -269,9 +273,9 @@ class AdminProductWrapper
         $id_country = $specificPriceValues['sp_id_country'] ? $specificPriceValues['sp_id_country'] : 0;
         $id_group = $specificPriceValues['sp_id_group'] ? $specificPriceValues['sp_id_group'] : 0;
         $id_customer = !empty($specificPriceValues['sp_id_customer']['data']) ? $specificPriceValues['sp_id_customer']['data'][0] : 0;
-        $price = isset($specificPriceValues['leave_bprice']) ? '-1' : $floatParser->fromString($specificPriceValues['sp_price']);
+        $price = isset($specificPriceValues['leave_bprice']) ? '-1' : $this->floatParser->fromString($specificPriceValues['sp_price']);
         $from_quantity = $specificPriceValues['sp_from_quantity'];
-        $reduction = $floatParser->fromString($specificPriceValues['sp_reduction']);
+        $reduction = $this->floatParser->fromString($specificPriceValues['sp_reduction']);
         $reduction_tax = $specificPriceValues['sp_reduction_tax'];
         $reduction_type = !$reduction ? 'amount' : $specificPriceValues['sp_reduction_type'];
         $reduction_type = $reduction_type == '-' ? 'amount' : $reduction_type;

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -89,13 +89,14 @@ class AdminProductWrapper
      * @param object $translator
      * @param array $employeeAssociatedShops
      * @param Locale $locale
+     * @param FloatParser|null $floatParser
      */
-    public function __construct($translator, array $employeeAssociatedShops, Locale $locale, FloatParser $floatParser)
+    public function __construct($translator, array $employeeAssociatedShops, Locale $locale, FloatParser $floatParser = null)
     {
         $this->translator = $translator;
         $this->employeeAssociatedShops = $employeeAssociatedShops;
         $this->locale = $locale;
-        $this->floatParser = $floatParser;
+        $this->floatParser = $floatParser ?? new FloatParser();
     }
 
     /**

--- a/src/Core/Util/ArabicToLatinDigitConverter.php
+++ b/src/Core/Util/ArabicToLatinDigitConverter.php
@@ -33,7 +33,11 @@ namespace PrestaShop\PrestaShop\Core\Util;
  */
 class ArabicToLatinDigitConverter
 {
-    private static $translationTable = [
+    public const ARABIC = 1;
+
+    public const PERSIAN = 2;
+
+    private const TRANSLATION_TABLE = [
         // arabic numbers
         '٠' => '0',
         '١' => '1',
@@ -67,20 +71,21 @@ class ArabicToLatinDigitConverter
      */
     public function convert(string $str): string
     {
-        return strtr($str, self::$translationTable);
+        return strtr($str, self::TRANSLATION_TABLE);
     }
 
     /**
-     * Convert from latin digits to arabic digits
+     * Convert from latin digits to arabic or persian digits
      *
      * @param string $str
+     * @param int $lang
      *
      * @return string
      */
-    public function reverseConvert(string $str): string
+    public function reverseConvert(string $str, int $lang = self::ARABIC): string
     {
-        $arabic = array_slice(self::$translationTable, 0, 10, true);
+        $table = array_slice(self::TRANSLATION_TABLE, $lang === self::ARABIC ? 0 : 10, 10, true);
 
-        return strtr($str, array_flip($arabic));
+        return strtr($str, array_flip($table));
     }
 }

--- a/src/Core/Util/ArabicToLatinDigitConverter.php
+++ b/src/Core/Util/ArabicToLatinDigitConverter.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Util;
+
+/**
+ * Utility class to convert arabic/persian digits to latin digits
+ */
+class ArabicToLatinDigitConverter
+{
+    private static $translationTable = [
+        // arabic numbers
+        '٠' => '0',
+        '١' => '1',
+        '٢' => '2',
+        '٣' => '3',
+        '٤' => '4',
+        '٥' => '5',
+        '٦' => '6',
+        '٧' => '7',
+        '٨' => '8',
+        '٩' => '9',
+        // persian numbers (NOT the same UTF codes!)
+        '۰' => '0',
+        '۱' => '1',
+        '۲' => '2',
+        '۳' => '3',
+        '۴' => '4',
+        '۵' => '5',
+        '۶' => '6',
+        '۷' => '7',
+        '۸' => '8',
+        '۹' => '9',
+    ];
+
+    /**
+     * Convert from arabic/persian digits to latin digits
+     *
+     * @param string $str
+     *
+     * @return string
+     */
+    public function convert(string $str): string
+    {
+        return strtr($str, self::$translationTable);
+    }
+
+    /**
+     * Convert from latin digits to arabic digits
+     *
+     * @param string $str
+     *
+     * @return string
+     */
+    public function reverseConvert(string $str): string
+    {
+        $arabic = array_slice(self::$translationTable, 0, 10, true);
+
+        return strtr($str, array_flip($arabic));
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
-use PrestaShopBundle\Form\DataTransformer\ArabicToLatinDigitDataTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -40,11 +40,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class DatePickerType extends AbstractType
 {
     /**
-     * @var ArabicToLatinDigitDataTransformer
+     * @var DataTransformerInterface
      */
     private $arabicToLatinDigitDataTransformer;
 
-    public function __construct(ArabicToLatinDigitDataTransformer $arabicToLatinDigitDataTransformer)
+    public function __construct(DataTransformerInterface $arabicToLatinDigitDataTransformer)
     {
         $this->arabicToLatinDigitDataTransformer = $arabicToLatinDigitDataTransformer;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
@@ -26,8 +26,10 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use PrestaShopBundle\Form\DataTransformer\ArabicToLatinDigitDataTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -38,11 +40,26 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class DatePickerType extends AbstractType
 {
     /**
+     * @var ArabicToLatinDigitDataTransformer
+     */
+    private $arabicToLatinDigitDataTransformer;
+
+    public function __construct(ArabicToLatinDigitDataTransformer $arabicToLatinDigitDataTransformer)
+    {
+        $this->arabicToLatinDigitDataTransformer = $arabicToLatinDigitDataTransformer;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getParent()
     {
         return TextType::class;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addViewTransformer($this->arabicToLatinDigitDataTransformer);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
@@ -51,11 +51,7 @@ final class ArabicToLatinDigitDataTransformer implements DataTransformerInterfac
      */
     public function transform($value)
     {
-        if (null === $value) {
-            return $value;
-        }
-
-        return $this->arabicToLatinDigitConverter->reverseConvert($value);
+        return $value;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\DataTransformer;
+
+use PrestaShop\PrestaShop\Core\Util\ArabicToLatinDigitConverter;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * Class ArabicToLatinDigitDataTransformer is responsible for converting arabic/persian digits to latin digits
+ */
+final class ArabicToLatinDigitDataTransformer implements DataTransformerInterface
+{
+    /**
+     * @var ArabicToLatinDigitConverter
+     */
+    private $arabicToLatinDigitConverter;
+
+    public function __construct(ArabicToLatinDigitConverter $arabicToLatinDigitConverter)
+    {
+        $this->arabicToLatinDigitConverter = $arabicToLatinDigitConverter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($value)
+    {
+        if (null === $value) {
+            return $value;
+        }
+
+        return $this->arabicToLatinDigitConverter->reverseConvert($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
+    {
+        if (null === $value) {
+            return  $value;
+        }
+
+        return $this->arabicToLatinDigitConverter->convert($value);
+    }
+}

--- a/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
@@ -47,6 +47,9 @@ final class ArabicToLatinDigitDataTransformer implements DataTransformerInterfac
     }
 
     /**
+     * Do not transform latin number to arabic/persian number as
+     * the javascript datepicker will handle that on its side
+     *
      * {@inheritdoc}
      */
     public function transform($value)

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -187,7 +187,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
      * @param ShopContext $shopContext
      * @param TaxRuleDataProvider $taxRuleDataProvider
      * @param Router $router
-     * @param FloatParser $floatParser
+     * @param FloatParser|null $floatParser
      */
     public function __construct(
         LegacyContext $legacyContext,
@@ -201,7 +201,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         ShopContext $shopContext,
         TaxRuleDataProvider $taxRuleDataProvider,
         Router $router,
-        FloatParser $floatParser
+        FloatParser $floatParser = null
     ) {
         $this->context = $legacyContext;
         $this->contextShop = $this->context->getContext();
@@ -218,7 +218,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         $this->shopContext = $shopContext;
         $this->taxRuleDataProvider = $taxRuleDataProvider;
         $this->router = $router;
-        $this->floatParser = $floatParser;
+        $this->floatParser = $floatParser ?? new FloatParser();
     }
 
     /**

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -82,6 +82,12 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
     private $warehouseAdapter;
     /** @var Router */
     private $router;
+
+    /**
+     * @var FloatParser
+     */
+    private $floatParser;
+
     /** @var array */
     private $multiShopKeys = [
         'category_box',
@@ -180,8 +186,8 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
      * @param PackDataProvider $packDataProvider
      * @param ShopContext $shopContext
      * @param TaxRuleDataProvider $taxRuleDataProvider
-     *
-     * @throws \PrestaShopException
+     * @param Router $router
+     * @param FloatParser $floatParser
      */
     public function __construct(
         LegacyContext $legacyContext,
@@ -194,7 +200,8 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         PackDataProvider $packDataProvider,
         ShopContext $shopContext,
         TaxRuleDataProvider $taxRuleDataProvider,
-        Router $router
+        Router $router,
+        FloatParser $floatParser
     ) {
         $this->context = $legacyContext;
         $this->contextShop = $this->context->getContext();
@@ -211,6 +218,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         $this->shopContext = $shopContext;
         $this->taxRuleDataProvider = $taxRuleDataProvider;
         $this->router = $router;
+        $this->floatParser = $floatParser;
     }
 
     /**
@@ -304,34 +312,32 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             $form_data['combinations'][$k]['attribute_weight_impact'] = 0;
             $form_data['combinations'][$k]['attribute_unit_impact'] = 0;
 
-            $floatParser = new FloatParser();
-
-            if ($floatParser->fromString($combination['attribute_price']) > 0) {
+            if ($this->floatParser->fromString($combination['attribute_price']) > 0) {
                 $form_data['combinations'][$k]['attribute_price_impact'] = 1;
-            } elseif ($floatParser->fromString($combination['attribute_price']) < 0) {
+            } elseif ($this->floatParser->fromString($combination['attribute_price']) < 0) {
                 $form_data['combinations'][$k]['attribute_price_impact'] = -1;
             }
 
-            if ($floatParser->fromString($combination['attribute_weight']) > 0) {
+            if ($this->floatParser->fromString($combination['attribute_weight']) > 0) {
                 $form_data['combinations'][$k]['attribute_weight_impact'] = 1;
-            } elseif ($floatParser->fromString($combination['attribute_weight']) < 0) {
+            } elseif ($this->floatParser->fromString($combination['attribute_weight']) < 0) {
                 $form_data['combinations'][$k]['attribute_weight_impact'] = -1;
             }
 
-            if ($floatParser->fromString($combination['attribute_unity']) > 0) {
+            if ($this->floatParser->fromString($combination['attribute_unity']) > 0) {
                 $form_data['combinations'][$k]['attribute_unit_impact'] = 1;
-            } elseif ($floatParser->fromString($combination['attribute_unity']) < 0) {
+            } elseif ($this->floatParser->fromString($combination['attribute_unity']) < 0) {
                 $form_data['combinations'][$k]['attribute_unit_impact'] = -1;
             }
 
             $form_data['combinations'][$k]['attribute_price'] = abs(
-                $floatParser->fromString($combination['attribute_price'])
+                $this->floatParser->fromString($combination['attribute_price'])
             );
             $form_data['combinations'][$k]['attribute_weight'] = abs(
-                $floatParser->fromString($combination['attribute_weight'])
+                $this->floatParser->fromString($combination['attribute_weight'])
             );
             $form_data['combinations'][$k]['attribute_unity'] = abs(
-                $floatParser->fromString($combination['attribute_unity'])
+                $this->floatParser->fromString($combination['attribute_unity'])
             );
         }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -25,6 +25,7 @@ services:
             - "@translator"
             - "@=service('prestashop.adapter.legacy.context').getContext().employee.getAssociatedShops()"
             - "@prestashop.core.localization.locale.context_locale"
+            - "@prestashop.utils.float_parser"
 
     prestashop.adapter.admin.controller.attribute_generator:
         class: PrestaShop\PrestaShop\Adapter\Attribute\AdminAttributeGeneratorControllerWrapper

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -109,6 +109,7 @@ services:
             - "@prestashop.adapter.shop.context"
             - "@prestashop.adapter.data_provider.tax"
             - "@router"
+            - "@prestashop.utils.float_parser"
 
     prestashop.adapter.translation_route_finder:
         class: PrestaShop\PrestaShop\Adapter\Translations\TranslationRouteFinder

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_transformer.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_transformer.yml
@@ -9,3 +9,8 @@ services:
     class: 'PrestaShopBundle\Form\DataTransformer\DefaultLanguageToFilledArrayDataTransformer'
     arguments:
       - '@=service("prestashop.adapter.legacy.configuration").get("PS_LANG_DEFAULT")'
+
+  prestashop.bundle.form.data_transformer.arabic_to_latin_digit:
+    class: 'PrestaShopBundle\Form\DataTransformer\ArabicToLatinDigitDataTransformer'
+    arguments:
+      - '@prestashop.core.util.arabic_to_latin_digit_converter'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -7,6 +7,8 @@ services:
 
     form.type.date_picker:
         class: PrestaShopBundle\Form\Admin\Type\DatePickerType
+        arguments:
+          - '@prestashop.bundle.form.data_transformer.arabic_to_latin_digit'
         tags:
           - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/utils.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/utils.yml
@@ -4,3 +4,8 @@ services:
 
     prestashop.utils.zip_manager:
         class: PrestaShopBundle\Utils\ZipManager
+
+    prestashop.utils.float_parser:
+      class: PrestaShopBundle\Utils\FloatParser
+      arguments:
+        - '@prestashop.core.util.arabic_to_latin_digit_converter'

--- a/src/PrestaShopBundle/Resources/config/services/core/util.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util.yml
@@ -15,3 +15,6 @@ services:
 
     prestashop.core.util.color_brightness_calculator:
         class: PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator
+
+    prestashop.core.util.arabic_to_latin_digit_converter:
+      class: PrestaShop\PrestaShop\Core\Util\ArabicToLatinDigitConverter

--- a/src/PrestaShopBundle/Utils/FloatParser.php
+++ b/src/PrestaShopBundle/Utils/FloatParser.php
@@ -38,9 +38,9 @@ class FloatParser
      */
     private $arabicToLatinNumberConverter;
 
-    public function __construct(ArabicToLatinDigitConverter $arabicToLatinDigitConverter)
+    public function __construct(ArabicToLatinDigitConverter $arabicToLatinDigitConverter = null)
     {
-        $this->arabicToLatinNumberConverter = $arabicToLatinDigitConverter;
+        $this->arabicToLatinNumberConverter = $arabicToLatinDigitConverter ?? new ArabicToLatinDigitConverter();
     }
 
     /**

--- a/src/PrestaShopBundle/Utils/FloatParser.php
+++ b/src/PrestaShopBundle/Utils/FloatParser.php
@@ -26,35 +26,22 @@
 
 namespace PrestaShopBundle\Utils;
 
+use PrestaShop\PrestaShop\Core\Util\ArabicToLatinDigitConverter;
+
 /**
  * Converts strings into floats.
  */
 class FloatParser
 {
-    private static $translationTable = [
-        // arabic numbers
-        '٠' => '0',
-        '١' => '1',
-        '٢' => '2',
-        '٣' => '3',
-        '٤' => '4',
-        '٥' => '5',
-        '٦' => '6',
-        '٧' => '7',
-        '٨' => '8',
-        '٩' => '9',
-        // persian numbers (NOT the same UTF codes!)
-        '۰' => '0',
-        '۱' => '1',
-        '۲' => '2',
-        '۳' => '3',
-        '۴' => '4',
-        '۵' => '5',
-        '۶' => '6',
-        '۷' => '7',
-        '۸' => '8',
-        '۹' => '9',
-    ];
+    /**
+     * @var ArabicToLatinDigitConverter
+     */
+    private $arabicToLatinNumberConverter;
+
+    public function __construct(ArabicToLatinDigitConverter $arabicToLatinDigitConverter)
+    {
+        $this->arabicToLatinNumberConverter = $arabicToLatinDigitConverter;
+    }
 
     /**
      * Constructs a float value from an arbitrarily-formatted string.
@@ -89,10 +76,7 @@ class FloatParser
         }
 
         // replace arabic numbers by latin
-        $value = strtr(
-            $value,
-            self::$translationTable
-        );
+        $value = $this->arabicToLatinNumberConverter->convert($value);
 
         // remove all non-digit characters
         $split = preg_split('/[^\dE-]+/', $value);

--- a/tests-legacy/PrestaShopBundle/Model/Product/AdminModelAdapterTest.php
+++ b/tests-legacy/PrestaShopBundle/Model/Product/AdminModelAdapterTest.php
@@ -193,7 +193,8 @@ class AdminModelAdapterTest extends KernelTestCase
             $this->container->get('prestashop.adapter.data_provider.pack'),
             $this->container->get('prestashop.adapter.shop.context'),
             $this->container->get('prestashop.adapter.data_provider.tax'),
-            $this->container->get('router')
+            $this->container->get('router'),
+            $this->container->get('prestashop.utils.float_parser')
         );
     }
 

--- a/tests-legacy/Unit/PrestaShopBundle/Utils/FloatParserTest.php
+++ b/tests-legacy/Unit/PrestaShopBundle/Utils/FloatParserTest.php
@@ -27,6 +27,7 @@
 namespace LegacyTests\Unit\PrestaShopBundle\Utils;
 
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Util\ArabicToLatinDigitConverter;
 use PrestaShopBundle\Utils\FloatParser;
 
 class FloatParserTest extends TestCase
@@ -43,7 +44,7 @@ class FloatParserTest extends TestCase
      */
     public function testItParsesNumbersFromString($string, $expected)
     {
-        $this->assertSame($expected, (new FloatParser())->fromString($string));
+        $this->assertSame($expected, (new FloatParser(new ArabicToLatinDigitConverter()))->fromString($string));
     }
 
     /**
@@ -58,7 +59,7 @@ class FloatParserTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        (new FloatParser())->fromString($value);
+        (new FloatParser(new ArabicToLatinDigitConverter()))->fromString($value);
     }
 
     public function provideValidStrings()

--- a/tests/Unit/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformerTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformerTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\PrestaShopBundle\Form\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Util\ArabicToLatinDigitConverter;
+use PrestaShopBundle\Form\DataTransformer\ArabicToLatinDigitDataTransformer;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * Class ArabicToLatinDigitDataTransformerTest
+ */
+class ArabicToLatinDigitDataTransformerTest extends TestCase
+{
+    /**
+     * @var DataTransformerInterface
+     */
+    private $dataTransformer;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->dataTransformer = new ArabicToLatinDigitDataTransformer(new ArabicToLatinDigitConverter());
+    }
+
+    public function testReverseTransformationForNullValue()
+    {
+        $data = null;
+
+        $this->assertEquals($data, $this->dataTransformer->reverseTransform($data));
+    }
+
+    public function testReverseTransformationForLatinDigits()
+    {
+        $data = '0123456789';
+
+        $this->assertEquals('0123456789', $this->dataTransformer->reverseTransform($data));
+    }
+
+    public function testReverseTransformationForArabicDigits()
+    {
+        $data = '٠١٢٣٤٥٦٧٨٩';
+
+        $this->assertEquals('0123456789', $this->dataTransformer->reverseTransform($data));
+    }
+
+    public function testReverseTransformationForPersianDigits()
+    {
+        $data = '۰۱۲۳۴۵۶۷۸۹';
+
+        $this->assertEquals('0123456789', $this->dataTransformer->reverseTransform($data));
+    }
+
+    // transform() method should not actually transform the data
+    public function testTransformationForNullValue()
+    {
+        $data = null;
+
+        $this->assertEquals($data, $this->dataTransformer->transform($data));
+    }
+
+    public function testTransformationForLatinDigits()
+    {
+        $data = '0123456789';
+
+        $this->assertEquals('0123456789', $this->dataTransformer->transform($data));
+    }
+
+    public function testTransformationForArabicDigits()
+    {
+        $data = '٠١٢٣٤٥٦٧٨٩';
+
+        $this->assertEquals('٠١٢٣٤٥٦٧٨٩', $this->dataTransformer->transform($data));
+    }
+
+    public function testTransformationForPersianDigits()
+    {
+        $data = '۰۱۲۳۴۵۶۷۸۹';
+
+        $this->assertEquals('۰۱۲۳۴۵۶۷۸۹', $this->dataTransformer->transform($data));
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When using arabic language in the BO, you weren't able to add a payment in the order page. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17916
| How to test?  | 1. Install & set Arabic as language in the BO<br>2. Open an order with the migrated page<br>3. Try to add a payment<br>4. The date & time should be displayed in arabic in the field and when adding the payment, no error should happend.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17975)
<!-- Reviewable:end -->
