### PR TITLE
Minor optimization when installing a language

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1485,15 +1485,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     private static function updateMultilangFromClassForShop($tableName, $classObject, $lang, $shop, $keys, $fieldsToUpdate)
     {
-        $shopDefaultLangId = Configuration::get('PS_LANG_DEFAULT', null, $shop->id_shop_group, $shop->id);
-        $shopDefaultLanguage = new Language($shopDefaultLangId);
-
-        $translator = SymfonyContainer::getInstance()->get('translator');
-        if (!$translator->isLanguageLoaded($shopDefaultLanguage->locale)) {
-            (new TranslatorLanguageLoader(true))->loadLanguage($translator, $shopDefaultLanguage->locale);
-        }
-
-        $shopFieldExists = $primary_key_exists = false;
+        $shopFieldExists = false;
         $columns = Db::getInstance()->executeS('SHOW COLUMNS FROM `' . $tableName . '`');
         foreach ($columns as $column) {
             $fields[] = '`' . $column['Field'] . '`';
@@ -1512,6 +1504,15 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         );
 
         if (!empty($tableData)) {
+
+            $shopDefaultLangId = Configuration::get('PS_LANG_DEFAULT', null, $shop->id_shop_group, $shop->id);
+            $shopDefaultLanguage = new Language($shopDefaultLangId);
+
+            $translator = SymfonyContainer::getInstance()->get('translator');
+            if (!$translator->isLanguageLoaded($shopDefaultLanguage->locale)) {
+                (new TranslatorLanguageLoader(true))->loadLanguage($translator, $shopDefaultLanguage->locale);
+            }
+
             foreach ($tableData as $data) {
                 $updateWhere = '';
                 $updateField = '';

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1476,7 +1476,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      *
      * @param string $tableName
      * @param DataLang $classObject
-     * @param string $lang
+     * @param Language $lang
      * @param Shop $shop
      * @param array $keys
      * @param array $fieldsToUpdate


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | During the database content translation process (which happens whenever a new language is installed), some operations where needlessly being done before checking if there was effectively data to translate. Delaying this until after we have verified that there will be data to translate might speed up the install process.
| Type?         | refacto
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Install a shop in a language. Add a new language and switch to it. The BO menu should be translated as usual.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17979)
<!-- Reviewable:end -->
