### PR TITLE
Fix customer informations on order page when customer is a guest

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -251,7 +251,8 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
             new DateTimeImmutable($customer->date_add),
             $totalSpentSinceRegistration !== null ? $this->locale->formatPrice($totalSpentSinceRegistration, $currency->iso_code) : '',
             $customerStats['nb_orders'],
-            $customer->note
+            $customer->note,
+            (bool) $customer->is_guest
         );
     }
 

--- a/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
@@ -76,6 +76,11 @@ class OrderCustomerForViewing
     private $privateNote;
 
     /**
+     * @var bool
+     */
+    private $isGuest;
+
+    /**
      * @param int $id
      * @param string $firstName
      * @param string $lastName
@@ -85,6 +90,7 @@ class OrderCustomerForViewing
      * @param string $totalSpentSinceRegistration
      * @param int $validOrdersPlaced
      * @param string|null $privateNote
+     * @param bool $isGuest
      */
     public function __construct(
         int $id,
@@ -95,7 +101,8 @@ class OrderCustomerForViewing
         DateTimeImmutable $accountRegistrationDate,
         string $totalSpentSinceRegistration,
         int $validOrdersPlaced,
-        ?string $privateNote
+        ?string $privateNote,
+        bool $isGuest
     ) {
         $this->id = $id;
         $this->firstName = $firstName;
@@ -106,6 +113,7 @@ class OrderCustomerForViewing
         $this->totalSpentSinceRegistration = $totalSpentSinceRegistration;
         $this->validOrdersPlaced = $validOrdersPlaced;
         $this->privateNote = $privateNote;
+        $this->isGuest = $isGuest;
     }
 
     /**
@@ -178,5 +186,13 @@ class OrderCustomerForViewing
     public function getPrivateNote(): ?string
     {
         return $this->privateNote;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isGuest(): bool
+    {
+        return $this->isGuest;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -44,6 +44,9 @@
 
             <strong class="text-muted ml-2">#{{ orderForViewing.customer.id }}</strong>
           </h2>
+          {%  if orderForViewing.customer.isGuest %}
+            <strong class="text-muted">Guest</strong>
+          {% endif %}
         </div>
         <div class="col-md-6 text-right">
           <a class="d-print-none" href="{{ path('admin_customers_view', {'customerId': orderForViewing.customer.id }) }}">
@@ -69,10 +72,12 @@
           </a>
         </p>
 
-        <p class="mb-1">
-          <strong>{{ 'Account registered:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-        </p>
-        <p>{{ orderForViewing.customer.accountRegistrationDate|date("m/d/Y H:i:s") }}</p>
+        {%  if orderForViewing.customer.isGuest == false %}
+          <p class="mb-1">
+            <strong>{{ 'Account registered:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+          </p>
+          <p>{{ orderForViewing.customer.accountRegistrationDate|date("m/d/Y H:i:s") }}</p>
+        {% endif %}
       </div>
       <div class="col-md-6">
         <p class="mb-1">
@@ -82,12 +87,14 @@
           <span class="badge rounded badge-dark">{{ orderForViewing.customer.validOrdersPlaced }}</span>
         </p>
 
-        <p class="mb-1">
-          <strong>{{ 'Total spent since registration:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-        </p>
-        <p>
-          <span class="badge rounded badge-dark">{{ orderForViewing.customer.totalSpentSinceRegistration }}</span>
-        </p>
+        {%  if orderForViewing.customer.isGuest == false %}
+          <p class="mb-1">
+            <strong>{{ 'Total spent since registration:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+          </p>
+          <p>
+            <span class="badge rounded badge-dark">{{ orderForViewing.customer.totalSpentSinceRegistration }}</span>
+          </p>
+        {% endif %}
       </div>
     </div>
     {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -72,7 +72,7 @@
           </a>
         </p>
 
-        {%  if orderForViewing.customer.isGuest == false %}
+        {%  if orderForViewing.customer.isGuest is same as(false) %}
           <p class="mb-1">
             <strong>{{ 'Account registered:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
           </p>
@@ -87,7 +87,7 @@
           <span class="badge rounded badge-dark">{{ orderForViewing.customer.validOrdersPlaced }}</span>
         </p>
 
-        {%  if orderForViewing.customer.isGuest == false %}
+        {%  if orderForViewing.customer.isGuest is same as(false) %}
           <p class="mb-1">
             <strong>{{ 'Total spent since registration:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
           </p>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | On order page, some customer information must not be displayed if customer is a guest.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17934
| How to test?  | - In FO, do a complete order as a guest<br>- In BO's go the order you just created<br>- In the "customer" block (top left), you should see "guest" written below customer's name<br>- Date of registration and total spent fields should not be displayed<br> For more informations, see the issue #17934

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17985)
<!-- Reviewable:end -->
