### PR TITLE
Fix "Module Manager" menu item not being translatable

### DIFF
--- a/app/Resources/translations/default/AdminNavigationMenu.xlf
+++ b/app/Resources/translations/default/AdminNavigationMenu.xlf
@@ -406,6 +406,11 @@ Comment: subtab</note>
         <target>Module manager</target>
         <note>Line: 135</note>
       </trans-unit>
+      <trans-unit id="5f265dfcb9ab68a1258ec25393ffb886">
+        <source>Module Manager</source>
+        <target>Module Manager</target>
+        <note>Line: 135</note>
+      </trans-unit>
       <trans-unit id="9ac41b6a577daadd588f0fcde0071e8b">
         <source>Updates</source>
         <target>Updates</target>

--- a/classes/lang/KeysReference/TabLang.php
+++ b/classes/lang/KeysReference/TabLang.php
@@ -132,7 +132,7 @@ trans('Warehouses', 'Admin.Navigation.Menu');
 trans('Webservice', 'Admin.Navigation.Menu');
 trans('Zones', 'Admin.Navigation.Menu');
 trans('Modules Catalog', 'Admin.Navigation.Menu');
-trans('Module manager', 'Admin.Navigation.Menu');
+trans('Module Manager', 'Admin.Navigation.Menu');
 
 // subtab
 trans('Modules', 'Admin.Navigation.Menu');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The "Module Manager" section in the BO menu was not translatable because the wording was wrongly inserted in the default catalog as "Module manager" (lower case "m"), whereas it is written as "Module Manager" (capital "M") in the fixture ([see here](https://github.com/PrestaShop/PrestaShop/blob/1.7.7.x/install-dev/langs/en/data/tab.xml#L10)).
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12590
| How to test?  | Install. Go to the translation page, look for "Module Manager" within "Admin.Navigation.Menu". Write your translation. Do something that will trigger database retranslation in that language, like reinstalling the language you just edited (yes I know this sucks, but it works). See menu change.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Proof:
![Screenshot 2020-03-05 at 11 36 31](https://user-images.githubusercontent.com/1009343/75973541-9b9ca200-5ed5-11ea-8977-1114ed6291c5.png)

FYI you won't need to translate the item yourself once it's properly translated in Crowdin.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17986)
<!-- Reviewable:end -->
