### PR TITLE
Change and rename order view page hooks

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -141,6 +141,11 @@
       <title>Product footer</title>
       <description>This hook adds new blocks under the product's description</description>
     </hook>
+    <hook id="displayFooterCategory">
+      <name>displayFooterCategory</name>
+      <title>Category footer</title>
+      <description>This hook adds new blocks under the products listing in a category/search</description>
+    </hook>
     <hook id="displayInvoice">
       <name>displayInvoice</name>
       <title>Invoice</title>
@@ -2118,17 +2123,27 @@
     <hook id="displayBackOfficeOrderActions">
       <name>displayBackOfficeOrderActions</name>
       <title>Admin Order Actions</title>
-      <description>This hook displays content in the order view page in the side column under the customer view</description>
+      <description>This hook displays content in the order view page after action buttons (or aliased to side column in migrated page)</description>
     </hook>
     <hook id="displayAdminOrderSide">
       <name>displayAdminOrderSide</name>
       <title>Admin Order Side Column</title>
-      <description>This hook displays content in the order view page at the end of the side column</description>
+      <description>This hook displays content in the order view page in the side column under the customer view</description>
+    </hook>
+    <hook id="displayAdminOrderBottom">
+      <name>displayAdminOrderBottom</name>
+      <title>Admin Order Side Column Bottom</title>
+      <description>This hook displays content in the order view page at the bottom of the side column</description>
     </hook>
     <hook id="displayAdminOrderMain">
       <name>displayAdminOrderMain</name>
       <title>Admin Order Main Column</title>
-      <description>This hook displays content in the order view page at the end of the main column</description>
+      <description>This hook displays content in the order view page in the main column under the details view</description>
+    </hook>
+    <hook id="displayAdminOrderMainBottom">
+      <name>displayAdminOrderMainBottom</name>
+      <title>Admin Order Main Column Bottom</title>
+      <description>This hook displays content in the order view page at the bottom of the main column</description>
     </hook>
     <hook id="displayAdminOrderTabLink">
       <name>displayAdminOrderTabLink</name>

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -531,15 +531,22 @@ ALTER TABLE `PREFIX_tab` ADD enabled TINYINT(1) NOT NULL;
 
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'displayAdminOrderTop', 'Admin Order Top', 'This hook displays content at the top of the order view page', '1'),
-  (NULL, 'displayBackOfficeOrderActions', 'Admin Order Actions', 'This hook displays content in the order view page in the side column under the customer view', '1'),
-  (NULL, 'displayAdminOrderSide', 'Admin Order Side Column', 'This hook displays content in the order view page at the end of the side column', '1'),
-  (NULL, 'displayAdminOrderMain', 'Admin Order Main Column', 'This hook displays content in the order view page at the end of the main column', '1'),
+  (NULL, 'displayAdminOrderSide', 'Admin Order Side Column', 'This hook displays content in the order view page in the side column under the customer view', '1'),
+  (NULL, 'displayAdminOrderSideBottom', 'Admin Order Side Column Bottom', 'This hook displays content in the order view page at the bottom of the side column', '1'),
+  (NULL, 'displayAdminOrderMain', 'Admin Order Main Column', 'This hook displays content in the order view page in the main column under the details view', '1'),
+  (NULL, 'displayAdminOrderMainBottom', 'Admin Order Main Column Bottom', 'This hook displays content in the order view page at the bottom of the main column', '1'),
   (NULL, 'displayAdminOrderTabLink', 'Admin Order Tab Link', 'This hook displays new tab links on the order view page', '1'),
   (NULL, 'displayAdminOrderTabContent', 'Admin Order Tab Content', 'This hook displays new tab contents on the order view page', '1'),
   (NULL, 'actionGetAdminOrderButtons', 'Admin Order Buttons', 'This hook is used to generate the buttons collection on the order view page thanks (see ActionsBarButtonsCollection)', '1')
+  (NULL, 'displayFooterCategory', 'Category footer', 'This hook adds new blocks under the products listing in a category/search', '1'),
+  (NULL, 'displayBackOfficeOrderActions', 'Admin Order Actions', 'This hook displays content in the order view page after action buttons (or aliased to side column in migrated page)', '1'),
+  (NULL, 'actionAdminAdminPreferencesControllerPostProcessBefore', 'On post-process in Admin Preferences', 'This hook is called on Admin Preferences post-process before processing the form', '1'),
 ;
 
-INSERT INTO `PREFIX_hook_alias` (`name`, `alias`) VALUES ('displayAdminOrderTop', 'displayInvoice');
+INSERT INTO `PREFIX_hook_alias` (`name`, `alias`) VALUES
+  ('displayAdminOrderTop', 'displayInvoice'),
+  ('displayAdminOrderSide', 'displayBackOfficeOrderActions')
+;
 
 /* Add refund amount on order detail, and fill new columns via data in order_slip_detail table */
 ALTER TABLE `PREFIX_order_detail` ADD `total_refunded_tax_excl` DECIMAL(20, 6) NOT NULL DEFAULT '0.000000' AFTER `original_wholesale_price`;
@@ -560,10 +567,7 @@ SET
     ), 0)
 ;
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`)
-VALUES (NULL, 'actionAdminAdminPreferencesControllerPostProcessBefore', 'On post-process in Admin Preferences',
-        'This hook is called on Admin Preferences post-process before processing the form',
-        '1'),
-       (NULL, 'actionOrderMessageFormBuilderModifier', 'Modify order message identifiable object form',
+VALUES (NULL, 'actionOrderMessageFormBuilderModifier', 'Modify order message identifiable object form',
         'This hook allows to modify order message identifiable object forms content by modifying form builder data or FormBuilder itself',
         '1'),
        (NULL, 'actionCatalogPriceRuleFormBuilderModifier', 'Modify catalog price rule identifiable object form',

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -67,10 +67,10 @@
       <div class="col-md-4 left-column">
         {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/customer.html.twig' %}
 
-        {{ renderhook('displayBackOfficeOrderActions', {'id_order': orderForViewing.id}) }}
+        {{ renderhook('displayAdminOrderSide', {'id_order': orderForViewing.id}) }}
         {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/messages.html.twig' %}
 
-        {{ renderhook('displayAdminOrderSide', {'id_order': orderForViewing.id}) }}
+        {{ renderhook('displayAdminOrderSideBottom', {'id_order': orderForViewing.id}) }}
       </div>
 
       <div class="col-md-8 d-print-block right-column">
@@ -81,6 +81,8 @@
 
         {{ renderhook('displayAdminOrderMain', {'id_order': orderForViewing.id}) }}
         {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/payments.html.twig' %}
+
+        {{ renderhook('displayAdminOrderMainBottom', {'id_order': orderForViewing.id}) }}
       </div>
     </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Change and rename order view page hooks, reorder upgrade scripts request to group them by scope
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | To validate all the hooks you will need the order example module https://github.com/PrestaShop/example-modules/tree/master/demovieworderhooks But it needs to integrate these modifications first

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18009)
<!-- Reviewable:end -->
