### PR TITLE
Parent assets in yml used according to value

### DIFF
--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -42,6 +42,10 @@ class Theme implements AddonInterface
             $parentAttributes['preview'] = 'themes/' . $attributes['parent'] . '/preview.png';
             $parentAttributes['parent_directory'] = rtrim($attributes['directory'], '/') . '/';
             $attributes = array_merge($parentAttributes, $attributes);
+
+            if (isset($attributes['assets']['use_parent_assets']) && $attributes['assets']['use_parent_assets'] && isset($parentAttributes['assets']) {
+                $attributes['assets'] = array_merge_recursive($parentAttributes['assets'], $attributes['assets']);
+            }
         }
 
         $attributes['directory'] = rtrim($attributes['directory'], '/') . '/';

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -43,7 +43,7 @@ class Theme implements AddonInterface
             $parentAttributes['parent_directory'] = rtrim($attributes['directory'], '/') . '/';
             $attributes = array_merge($parentAttributes, $attributes);
 
-            if (isset($attributes['assets']['use_parent_assets']) && $attributes['assets']['use_parent_assets'] && isset($parentAttributes['assets']) {
+            if (!empty($attributes['assets']['use_parent_assets']) && isset($parentAttributes['assets'])) {
                 $attributes['assets'] = array_merge_recursive($parentAttributes['assets'], $attributes['assets']);
             }
         }


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | if "use_parent_assets" is enabled and set to true in child theme.yaml,<br>then we merge parent assets with child assets.<br>For now, only the child assets are taken in account and "use_parent_assets" mentioned in dev doc is not used
| Type?         | bug fix and improvement
| Category?     | FO
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | -
| How to test?  | Have js/css assets in parent theme.yml and child theme.yaml > remove cache + shop1.json files > reload front > front must use parent AND child assets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18018)
<!-- Reviewable:end -->
