### PR TITLE
Remove useless spaces for Ceuta and Melilla

### DIFF
--- a/localization/es.xml
+++ b/localization/es.xml
@@ -274,7 +274,7 @@
     <state name="Bizkaia" iso_code="ES-BI" country="ES" zone="Europe"/>
     <state name="Zamora" iso_code="ES-ZA" country="ES" zone="Europe"/>
     <state name="Zaragoza" iso_code="ES-Z" country="ES" zone="Europe"/>
-    <state name=" Ceuta" iso_code="ES-CE" country="ES" zone="Europe"/>
-    <state name=" Melilla" iso_code="ES-ML" country="ES" zone="Europe"/>
+    <state name="Ceuta" iso_code="ES-CE" country="ES" zone="Europe"/>
+    <state name="Melilla" iso_code="ES-ML" country="ES" zone="Europe"/>
   </states>
 </localizationPack>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove useless spaces in the code for Spanish states, Ceuta and Melilla
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes issue #18021
| How to test?  | No space before the two names

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18022)
<!-- Reviewable:end -->
