### PR TITLE
Remove tabs for summary and description fields in product page

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -74,15 +74,13 @@ $(document).ready(function() {
     $('[data-toggle="tooltip"]').tooltip('hide');
     $('[data-toggle="popover"]').popover('hide');
   });
-
-  $('.summary-description-container a[data-toggle="tab"]').on('shown.bs.tab', resetEditor);
 });
 
 /**
  * Reset active tinyMce editor (triggered when switch language, or switching tabs)
  */
 function resetEditor() {
-  const languageEditorsSelector = '.summary-description-container .panel.active div.translation-field.active textarea.autoload_rte';
+  const languageEditorsSelector = '.summary-description-container div.translation-field.active textarea.autoload_rte';
   $(languageEditorsSelector).each(function(index, textarea) {
     const editor = tinyMCE.get(textarea.id);
     if (editor) {

--- a/admin-dev/themes/new-theme/js/product-page/product-header.js
+++ b/admin-dev/themes/new-theme/js/product-page/product-header.js
@@ -49,11 +49,6 @@ export default function () {
     if (!$(e.target).hasClass('active')) {
       $('#form_content > .form-contenttab').removeClass('active');
     }
-    if ($(e.target).attr('href') === '#step1') {
-      setTimeout(() => {
-        $('#description_short, #tab_description_short .description-tab').addClass('active');
-      }, 100);
-    }
   });
 
   $arrow.on('click', (e) => {

--- a/admin-dev/themes/new-theme/scss/components/_tinymce.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tinymce.scss
@@ -1207,9 +1207,7 @@ i.mce-i-backcolor {
 .tab-content.translationsFields {
   padding: 0;
   .mce-tinymce {
-    border-bottom: 1px solid #DFDFDF !important;
-    border-left: 1px solid #DFDFDF !important;
-    border-right: 1px solid #DFDFDF !important;
+    border: 1px solid #DFDFDF !important;
   }
   .mce-container-body .mce-flow-layout {
     padding-top: 5px;

--- a/admin-dev/themes/new-theme/scss/pages/_product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_product_page.scss
@@ -176,24 +176,6 @@
 
   .summary-description-container {
     overflow: hidden; // fixes horizontal scrolling on the product page
-    .nav-tabs {
-      overflow: hidden; // fixes tab borders bleeding into the tab content
-
-      &.bordered {
-        .nav-link {
-          &.active {
-            border-left: 1px solid $gray-light;
-            border-right: 1px solid $gray-light;
-          }
-        }
-      }
-    }
-
-    .tab-content {
-      &.bordered {
-        border: 1px solid $gray-light;
-      }
-    }
   }
 
   .product-feature {

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig
@@ -91,18 +91,14 @@
             </div>
 
             <div class="summary-description-container">
-              <ul class="nav nav-tabs bordered">
-                <li id="tab_description_short" class="nav-item"><a href="#description_short" data-toggle="tab" class="nav-link description-tab active">{{ 'Summary'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
-                <li id="tab_description" class="nav-item"><a href="#description" data-toggle="tab" class="nav-link description-tab">{{ 'Description'|trans({}, 'Admin.Global') }}</a></li>
-              </ul>
+              <h2>{{ 'Summary'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+              <div id="description_short" class="mb-3">
+                {{ form_widget(formShortDescription) }}
+              </div>
 
-              <div class="tab-content bordered">
-                <div class="tab-pane panel panel-default active" id="description_short">
-                  {{ form_widget(formShortDescription) }}
-                </div>
-                <div class="tab-pane panel panel-default " id="description">
-                  {{ form_widget(formDescription) }}
-                </div>
+              <h2>{{ 'Description'|trans({}, 'Admin.Global') }}</h2>
+              <div id="description" class="mb-3">
+                {{ form_widget(formDescription) }}
               </div>
             </div>
 

--- a/tests/puppeteer/pages/BO/catalog/products/add.js
+++ b/tests/puppeteer/pages/BO/catalog/products/add.js
@@ -22,9 +22,7 @@ module.exports = class AddProduct extends BOBasePage {
     this.previewProductLink = 'a#product_form_preview_btn';
     this.productOnlineSwitch = '.product-footer div.switch-input';
     this.productOnlineTitle = 'h2.for-switch.online-title';
-    this.productShortDescriptionTab = '#tab_description_short a';
     this.productShortDescriptionIframe = '#form_step1_description_short_1_ifr';
-    this.productDescriptionTab = '#tab_description a';
     this.productDescriptionIframe = '#form_step1_description_1_ifr';
     this.productTaxRuleSelect = '#step2_id_tax_rules_group_rendered';
     this.productDeleteLink = '.product-footer a.delete';
@@ -72,10 +70,8 @@ module.exports = class AddProduct extends BOBasePage {
     await this.page.click(this.productPriceTtcInput, {clickCount: 3});
     await this.page.type(this.productPriceTtcInput, productData.price);
     // Set description value
-    await this.page.click(this.productDescriptionTab);
     await this.setValueOnTinymceInput(this.productDescriptionIframe, productData.description);
     // Set short description value
-    await this.page.click(this.productShortDescriptionTab);
     await this.setValueOnTinymceInput(this.productShortDescriptionIframe, productData.summary);
     // Add combinations if exists
     if (productData.withCombination) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove tabs for summary & description fields in product page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14985 & Fixes #9668
| How to test?  | Build assets, then go on product page, the fields should be separated as in screens, and it should save content properly

Before:
![image](https://user-images.githubusercontent.com/194784/76141521-7ccd1580-6065-11ea-87de-79a486946d6b.png)

After:
![image](https://user-images.githubusercontent.com/194784/76141554-ce75a000-6065-11ea-9fb6-1b9d6ea0d888.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18033)
<!-- Reviewable:end -->
