### PR TITLE
Fix popover not hidden when changing product tab

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig
@@ -169,7 +169,7 @@
                         <div id="product_type_combinations_shortcut">
                           <span class="small font-secondary">
                             {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
-                            {{ "Advanced settings in [1][2]Combinations[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').tab(\'show\');" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+                            {{ "Advanced settings in [1][2]Combinations[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
                           </span>
                         </div>
                       </div>
@@ -205,7 +205,7 @@
                       </div>
                       <span class="small font-secondary">
                         {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
-                        {{ "Advanced settings in [1][2]Quantities[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').tab(\'show\');" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+                        {{ "Advanced settings in [1][2]Quantities[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
                       </span>
                     </div>
                   {% endif %}
@@ -243,7 +243,7 @@
                       <div class="col-md-12">
                         <span class="small font-secondary">
                           {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
-                          {{ "Advanced settings in [1][2]Pricing[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step2" onclick="$(\'a[href=\\\'#step2\\\']\').tab(\'show\');" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+                          {{ "Advanced settings in [1][2]Pricing[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step2" onclick="$(\'a[href=\\\'#step2\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
                         </span>
                       </div>
                     </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Before, the quick help popovers were not hidden when changing tabs using the links of the first tab in the product edit page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #13513.
| How to test?  | 1. Go to Catalog > Products > edit<br>2. Click on any hint ( marked as ?) in Basic settings tab.<br>3. Click on Quantities or Pricing reference in in corresponding sections( Quantity or Price) on right side of the screen.<br>4. Now popover are hidden.

Before
![before](https://user-images.githubusercontent.com/194784/76256774-c9287900-6250-11ea-90cf-ca11fd5bc38c.gif)
After
![after](https://user-images.githubusercontent.com/194784/76256777-cb8ad300-6250-11ea-963d-26dae5609fbd.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18035)
<!-- Reviewable:end -->
