### PR TITLE
Fix Brand dropdown empty value

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -229,7 +229,7 @@ class ProductInformation extends CommonAbstractType
                     'data-minimumResultsForSearch' => '7',
                 ],
                 'label' => $this->translator->trans('Brand', [], 'Admin.Catalog.Feature'),
-                'placeholder' => $this->translator->trans('Choose a manufacturer', [], 'Admin.Global'),
+                'placeholder' => $this->translator->trans('Choose a manufacturer', [], 'Admin.Catalog.Feature'),
             ])
             //RIGHT COL
             ->add('active', FormType\CheckboxType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -229,6 +229,7 @@ class ProductInformation extends CommonAbstractType
                     'data-minimumResultsForSearch' => '7',
                 ],
                 'label' => $this->translator->trans('Brand', [], 'Admin.Catalog.Feature'),
+                'placeholder' => $this->translator->trans('Choose a manufacturer', [], 'Admin.Global'),
             ])
             //RIGHT COL
             ->add('active', FormType\CheckboxType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -229,7 +229,7 @@ class ProductInformation extends CommonAbstractType
                     'data-minimumResultsForSearch' => '7',
                 ],
                 'label' => $this->translator->trans('Brand', [], 'Admin.Catalog.Feature'),
-                'placeholder' => $this->translator->trans('Choose a manufacturer', [], 'Admin.Catalog.Feature'),
+                'placeholder' => $this->translator->trans('Choose a brand', [], 'Admin.Catalog.Feature'),
             ])
             //RIGHT COL
             ->add('active', FormType\CheckboxType::class, [


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove empty option in select brand of product page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9678
| How to test?  | See issue

related: https://github.com/PrestaShop/PrestaShop/pull/17679

Need translation

Before:
![image](https://user-images.githubusercontent.com/194784/76401859-d8a7df00-6382-11ea-88e4-b5b64cfb6a8c.png)

After:
![image](https://user-images.githubusercontent.com/194784/76402154-481dce80-6383-11ea-84e8-9ec4afd4bb55.png)



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18040)
<!-- Reviewable:end -->
