### PR TITLE
Fix layout problem in BO Products category Filter

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_category_tree.scss
+++ b/admin-dev/themes/new-theme/scss/components/_category_tree.scss
@@ -37,6 +37,7 @@ ul.category-tree {
   .category-label {
     display: block;
     padding-left: 0;
+    padding-right: 1.563rem;
     position: relative;
     .category {
       cursor: pointer;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Long category names overflow over radio button in BO Products category Filter.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9551
| How to test?  | **Before**<br>![image](https://user-images.githubusercontent.com/194784/76162438-1667f600-613e-11ea-8eb9-975890a0ab77.png)<br><br>**After**<br>![image](https://user-images.githubusercontent.com/194784/76162416-e28cd080-613d-11ea-8543-97db31e85af7.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18041)
<!-- Reviewable:end -->
