### PR TITLE
Fix selector for invoice note manager

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/invoice-note-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/order/invoice-note-manager.js
@@ -42,9 +42,8 @@ export default class InvoiceNoteManager {
   _initShowNoteFormEventHandler() {
     $('.js-open-invoice-note-btn').on('click', (event) => {
       event.preventDefault();
-
       const $btn = $(event.currentTarget);
-      const $noteRow = $btn.closest('tr').siblings('tr:first');
+      const $noteRow = $btn.closest('tr').next();
 
       $noteRow.removeClass('d-none');
     });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | If there are many invoices, you can't add a note for the second invoice
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/17918
| How to test?  | Steps to Reproduce from the issue - add one more product with new invoice chosen -> refresh page -> Documents -> Add note for second invoice

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18045)
<!-- Reviewable:end -->
