### PR TITLE
Fix Module Catalog page - The Menu "process-icon-dropdown" is not well displayed on mobile by adjusting sass

### DIFF
--- a/admin-dev/themes/default/sass/partials/_toolbar.sass
+++ b/admin-dev/themes/default/sass/partials/_toolbar.sass
@@ -56,10 +56,18 @@
 		position: absolute
 		background-color: transparent!important
 		@include right(0)
+		@media (max-width: $screen-tablet)
+			width: 100%
 		#toolbar-nav
 			border: none
+			@media (max-width: $screen-tablet)
+				padding-top: 25px
+				padding-bottom: 10px
+				margin-top: 30px
+				background: white
 		.btn-toolbar
 			margin: 0
+			justify-content: flex-end
 			@include padding(3px, 0, 0, 0)
 			.toolbar_btn
 				position: relative

--- a/admin-dev/themes/default/sass/partials/_toolbar.sass
+++ b/admin-dev/themes/default/sass/partials/_toolbar.sass
@@ -64,7 +64,7 @@
 				padding-top: 25px
 				padding-bottom: 10px
 				margin-top: 30px
-				background: white
+				background: #ffffff
 		.btn-toolbar
 			margin: 0
 			justify-content: flex-end


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The menu on the top right was not well displayed when opened
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17553.
| How to test?  | Pull, build assets of default BO theme, go on Module Catalog Page, go on a media screen with width < 768, open the menu and the menu should be right displayed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18051)
<!-- Reviewable:end -->
