### PR TITLE
In RTL I have to click 3 times on the checkbox to select the product

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-cancel.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-cancel.js
@@ -121,12 +121,13 @@ export default class OrderProductCancel {
     $(document).on('change', OrderViewPageMap.cancelProduct.inputs.selector, (event) => {
       const $productCheckbox = $(event.target);
       const $parentCell = $productCheckbox.parents(OrderViewPageMap.cancelProduct.table.cell);
-      const $productQuantity = $parentCell.find(OrderViewPageMap.cancelProduct.inputs.quantity);
-      const refundableQuantity = parseInt($productQuantity.data('quantityRefundable'), 10);
+      const productQuantityInput = $parentCell.find(OrderViewPageMap.cancelProduct.inputs.quantity);
+      const refundableQuantity = parseInt(productQuantityInput.data('quantityRefundable'), 10);
+      const productQuantity = parseInt(productQuantityInput.val(), 10);
       if (!$productCheckbox.is(':checked')) {
-        $productQuantity.val(0);
-      } else if (parseInt($productQuantity.val(), 10) === 0) {
-        $productQuantity.val(refundableQuantity);
+        productQuantityInput.val(0);
+      } else if (Number.isNaN(productQuantity) || productQuantity === 0) {
+        productQuantityInput.val(refundableQuantity);
       }
       this.updateVoucherRefund();
     });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In RTL I have to click 3 times on the checkbox to select the product to cancel, to refund or to return this table. The bug was caused because the default value was not a number and the code expected it to be 0
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17924
| How to test?  | See description inside issue ticket and also toggle on `Merchandise returns`: Customer Service > Merchandise return: you toggle it on to be able to cancel products.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18054)
<!-- Reviewable:end -->
