### PR TITLE
Use localized dates for order page

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -110,5 +110,6 @@ services:
       class: 'PrestaShopBundle\Twig\Extension\LocalizationExtension'
       arguments:
         - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
+        - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_lite'
       tags:
         - { name: twig.extension }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -76,7 +76,7 @@
           <p class="mb-1">
             <strong>{{ 'Account registered:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
           </p>
-          <p>{{ orderForViewing.customer.accountRegistrationDate|date("m/d/Y H:i:s") }}</p>
+          <p>{{ orderForViewing.customer.accountRegistrationDate|date_format_full }}</p>
         {% endif %}
       </div>
       <div class="col-md-6">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
@@ -48,7 +48,7 @@
     {% for document in orderForViewing.documents.documents %}
       <tr>
         <td>
-          {{ document.createdAt|date('Y-m-d') }}
+          {{ document.createdAt|date_format_lite }}
         </td>
         <td>
           {% if document.type == 'invoice' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/header.html.twig
@@ -44,7 +44,7 @@
   </span>
 
 <p class="lead d-inline">
-  {{ orderForViewing.createdAt|date('Y-m-d') }}
+  {{ orderForViewing.createdAt|date_format_lite }}
   <span class="text-muted">
       {{ 'at'|trans({}, 'Admin.Global') }}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/merchandise_returns.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/merchandise_returns.html.twig
@@ -37,7 +37,7 @@
       <tbody>
       {% for return in orderForViewing.returns.orderReturns %}
         <tr>
-          <td>{{ return.date|date('Y-m-d H:i:s') }}</td>
+          <td>{{ return.date|date_format_full }}</td>
           <td>{{ return.type }}</td>
           <td>{{ return.stateName }}</td>
           <td class="text-right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments.html.twig
@@ -56,7 +56,7 @@
       <tbody>
       {% for payment in orderForViewing.payments.payments %}
         <tr>
-          <td>{{ payment.date|date('Y-m-d H:i:s') }}</td>
+          <td>{{ payment.date|date_format_full }}</td>
           <td>{{ payment.paymentMethod }}</td>
           <td>{{ payment.transactionId }}</td>
           <td>{{ payment.amount }}</td>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -39,7 +39,7 @@
     <tbody>
       {% for carrier in orderForViewing.shipping.carriers %}
         <tr>
-          <td>{{ carrier.date|date('Y-m-d') }}</td>
+          <td>{{ carrier.date|date_format_lite }}</td>
           <td>&nbsp;</td>
           <td>{{ carrier.name }}</td>
           <td>{{ carrier.weight }}</td>

--- a/src/PrestaShopBundle/Twig/Extension/LocalizationExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/LocalizationExtension.php
@@ -39,20 +39,33 @@ class LocalizationExtension extends AbstractExtension
     private $dateFormatFull;
 
     /**
-     * @param string $contextDateFormatFull
+     * @var string
      */
-    public function __construct(string $contextDateFormatFull)
+    private $dateFormatLight;
+
+    /**
+     * @param string $contextDateFormatFull
+     * @param string $contextDateFormatLight
+     */
+    public function __construct(string $contextDateFormatFull, string $contextDateFormatLight)
     {
         $this->dateFormatFull = $contextDateFormatFull;
+        $this->dateFormatLight = $contextDateFormatLight;
     }
 
     public function getFilters(): array
     {
         return [
             new Twig_SimpleFilter('date_format_full', [$this, 'dateFormatFull']),
+            new Twig_SimpleFilter('date_format_lite', [$this, 'dateFormatLite']),
         ];
     }
 
+    /**
+     * @param DateTimeInterface|string $date
+     *
+     * @return string
+     */
     public function dateFormatFull($date): string
     {
         if (!$date instanceof DateTimeInterface) {
@@ -60,5 +73,19 @@ class LocalizationExtension extends AbstractExtension
         }
 
         return $date->format($this->dateFormatFull);
+    }
+
+    /**
+     * @param DateTimeInterface|string $date
+     *
+     * @return string
+     */
+    public function dateFormatLite($date): string
+    {
+        if (!$date instanceof DateTimeInterface) {
+            $date = new DateTime($date);
+        }
+
+        return $date->format($this->dateFormatLight);
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.7.x
| Description?  | Use twig LocalizationExtension to print dates using localized format in Order page. Enhanced LocalizationExtension to provide also "light" format (days only, no hours/minutes/seconds). No BC break as LocalizationExtension was created for 1770 so we can still modify its signature.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/16226
| How to test?  | Login to BO with employee using French language => all the dates displayed in Order page are displayed using French format. Modify Employee language to English and see dates displayed using US format.

Some dates might not be localized because the format was hardcoded for UI purposes. We can challenge this choice by discussing with PM and UX.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18063)
<!-- Reviewable:end -->
