### PR TITLE
Fix error when trying to translate Serbian using the BO interface

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -27,15 +27,14 @@
 namespace PrestaShopBundle\Controller\Api;
 
 use Exception;
-use PrestaShop\PrestaShop\Core\Translation\Locale\Converter;
 use PrestaShopBundle\Api\QueryTranslationParamsCollection;
+use PrestaShopBundle\Exception\InvalidLanguageException;
 use PrestaShopBundle\Service\TranslationService;
 use PrestaShopBundle\Translation\View\TreeBuilder;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use PrestaShopBundle\Translation\Exception\UnsupportedLocaleException;
-use Symfony\Component\Validator\Constraints\Locale;
 
 class TranslationController extends ApiController
 {
@@ -71,13 +70,11 @@ class TranslationController extends ApiController
             $module = $request->query->get('module');
             $search = $request->query->get('search');
 
-            $icuLocale = Converter::toPrestaShopLocale($locale);
-            $validationErrors = $this->container->get('validator')->validate($icuLocale, [
-                new Locale(),
-            ]);
-
-            // If the locale is invalid, no need to call the translation provider.
-            if ($locale !== 'default' && count($validationErrors) > 0) {
+            try {
+                $this->translationService->findLanguageByLocale($locale);
+            }
+            catch (InvalidLanguageException $e) {
+                // If the locale is invalid, no need to call the translation provider.
                 throw UnsupportedLocaleException::invalidLocale($locale);
             }
 

--- a/src/PrestaShopBundle/Exception/InvalidLanguageException.php
+++ b/src/PrestaShopBundle/Exception/InvalidLanguageException.php
@@ -33,6 +33,6 @@ class InvalidLanguageException extends \RuntimeException
 
     public static function localeNotFound($locale)
     {
-        return new self(sprintf('The locale "%s" is not available', $locale), self::LOCALE_NOT_FOUND);
+        return new static(sprintf('The locale "%s" is not available', $locale), self::LOCALE_NOT_FOUND);
     }
 }

--- a/src/PrestaShopBundle/Exception/InvalidLanguageException.php
+++ b/src/PrestaShopBundle/Exception/InvalidLanguageException.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Exception;
+
+class InvalidLanguageException extends \RuntimeException
+{
+    const LOCALE_NOT_FOUND = 1;
+
+    public static function localeNotFound($locale)
+    {
+        return new self(sprintf('The locale "%s" is not available', $locale), self::LOCALE_NOT_FOUND);
+    }
+}

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Service;
 
 use Exception;
 use PrestaShopBundle\Entity\Translation;
+use PrestaShopBundle\Exception\InvalidLanguageException;
 use PrestaShopBundle\Translation\Constraints\PassVsprintf;
 use PrestaShopBundle\Translation\Provider\UseModuleInterface;
 use Symfony\Component\DependencyInjection\Container;
@@ -57,7 +58,7 @@ class TranslationService
      *
      * @return mixed
      *
-     * @throws Exception
+     * @throws InvalidLanguageException
      */
     public function findLanguageByLocale($locale)
     {
@@ -66,7 +67,7 @@ class TranslationService
         $lang = $doctrine->getManager()->getRepository('PrestaShopBundle:Lang')->findOneByLocale($locale);
 
         if (!$lang) {
-            throw new Exception('The language for this locale is not available');
+            throw InvalidLanguageException::localeNotFound($locale);
         }
 
         return $lang;

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Api/TranslationControllerTest.php
@@ -76,10 +76,10 @@ class TranslationControllerTest extends ApiTestCase
     {
         return [
             [
-                ['locale' => 'default', 'domain' => 'AdminGlobal'],
+                ['locale' => 'en-US', 'domain' => 'AdminGlobal'],
             ],
             [
-                ['locale' => 'default', 'domain' => 'AdminNavigationMenu'],
+                ['locale' => 'en-US', 'domain' => 'AdminNavigationMenu'],
             ],
         ];
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | This change makes it so that it is possible to translate Serbian again using the BO interface. Read below for more.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixed #18062
| How to test?  | See steps in issue.

## More information

In 1.7.6, a [change was introduced](https://github.com/PrestaShop/PrestaShop/pull/11321/files#diff-f0c2048d6122a903ce9515acfd72098dR74-R77) where the locale code provided to the controller in charge of listing the translations to display would be verified against the server's ICU list instead of the list of installed languages. 

This was a double mistake because not only would it let a non-installed locale pass through (it would throw an unhandled exception later in code resulting in a 500 error), but it would also invalidate nonstandard locale codes like `sr-CS` (which we use for Serbian for [some unknown reason](https://github.com/PrestaShop/PrestaShop/issues/17890#issuecomment-596583744)).

This PR changes this verification so that the locale code is compared against the list of installed locales.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18064)
<!-- Reviewable:end -->
