### PR TITLE
Improve img accessibility

### DIFF
--- a/themes/classic/templates/catalog/_partials/miniatures/category.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/category.tpl
@@ -25,7 +25,10 @@
 {block name='category_miniature_item'}
   <section class="category-miniature">
     <a href="{$category.url}">
-      <img src="{$category.image.medium.url}" alt="{$category.image.legend}">
+      <img
+        src="{$category.image.medium.url}"
+        alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}"
+      >
     </a>
 
     <h1 class="h2">

--- a/themes/classic/templates/catalog/_partials/miniatures/pack-product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/pack-product.tpl
@@ -31,7 +31,12 @@
             <a href="{$product.url}" title="{$product.name}">
               <img
                 src="{$product.cover.medium.url}"
-                alt="{$product.cover.legend}"
+                {if !empty($product.cover.legend)}
+                  alt="{$product.cover.legend}"
+                  title="{$product.cover.legend}"
+                {else}
+                  alt="{$product.name}"
+                {/if}
                 data-full-size-image-url="{$product.cover.large.url}"
               >
             </a>

--- a/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -26,7 +26,18 @@
   {block name='product_cover'}
     <div class="product-cover">
       {if $product.cover}
-        <img class="js-qv-product-cover" src="{$product.cover.bySize.large_default.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" style="width:100%;" itemprop="image">
+        <img
+          class="js-qv-product-cover"
+          src="{$product.cover.bySize.large_default.url}"
+          {if !empty($product.cover.legend)}
+            alt="{$product.cover.legend}"
+            title="{$product.cover.legend}"
+          {else}
+            alt="{$product.name}"
+          {/if}
+          style="width:100%;"
+          itemprop="image"
+        >
         <div class="layer hidden-sm-down" data-toggle="modal" data-target="#product-modal">
           <i class="material-icons zoom-in">search</i>
         </div>
@@ -46,8 +57,12 @@
               data-image-medium-src="{$image.bySize.medium_default.url}"
               data-image-large-src="{$image.bySize.large_default.url}"
               src="{$image.bySize.home_default.url}"
-              alt="{$image.legend}"
-              title="{$image.legend}"
+              {if !empty($image.legend)}
+                alt="{$image.legend}"
+                title="{$image.legend}"
+              {else}
+                alt="{$product.name}"
+              {/if}
               width="100"
               itemprop="image"
             >

--- a/themes/classic/templates/catalog/_partials/product-images-modal.tpl
+++ b/themes/classic/templates/catalog/_partials/product-images-modal.tpl
@@ -28,7 +28,18 @@
       <div class="modal-body">
         {assign var=imagesCount value=$product.images|count}
         <figure>
-          <img class="js-modal-product-cover product-cover-modal" width="{$product.cover.large.width}" src="{$product.cover.large.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" itemprop="image">
+          <img
+            class="js-modal-product-cover product-cover-modal"
+            width="{$product.cover.large.width}"
+            src="{$product.cover.large.url}"
+            {if !empty($product.cover.legend)}
+              alt="{$product.cover.legend}"
+              title="{$product.cover.legend}"
+            {else}
+              alt="{$product.name}"
+            {/if}
+            itemprop="image"
+          >
           <figcaption class="image-caption">
           {block name='product_description_short'}
             <div id="product-description-short" itemprop="description">{$product.description_short nofilter}</div>
@@ -41,7 +52,19 @@
               <ul class="product-images js-modal-product-images">
                 {foreach from=$product.images item=image}
                   <li class="thumb-container">
-                    <img data-image-large-src="{$image.large.url}" class="thumb js-modal-thumb" src="{$image.medium.url}" alt="{$image.legend}" title="{$image.legend}" width="{$image.medium.width}" itemprop="image">
+                    <img
+                      data-image-large-src="{$image.large.url}"
+                      class="thumb js-modal-thumb"
+                      src="{$image.medium.url}"
+                      {if !empty($image.legend)}
+                        alt="{$image.legend}"
+                        title="{$image.legend}"
+                      {else}
+                        alt="{$product.name}"
+                      {/if}
+                      width="{$image.medium.width}"
+                      itemprop="image"
+                    >
                   </li>
                 {/foreach}
               </ul>

--- a/themes/classic/templates/cms/stores.tpl
+++ b/themes/classic/templates/cms/stores.tpl
@@ -35,7 +35,15 @@
       <article id="store-{$store.id}" class="store-item card">
         <div class="store-item-container clearfix">
           <div class="col-md-3 store-picture hidden-sm-down">
-            <img src="{$store.image.bySize.stores_default.url}" alt="{$store.image.legend}" title="{$store.image.legend}">
+            <img
+              src="{$store.image.bySize.stores_default.url}"
+              {if !empty($store.image.legend)}
+                alt="{$store.image.legend}"
+                title="{$store.image.legend}"
+              {else}
+                alt="{$store.name}"
+              {/if}
+            >
           </div>
           <div class="col-md-5 col-sm-7 col-xs-12 store-description">
             <p class="h3 card-title">{$store.name}</p>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Always set the img alt attribute:<br>Use name if legend its empty as img alt attribute.<br>
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17384
| How to test?  | Check that the alt attribute is set in the images.

In the past, only for product miniature.tpl to improve accessibility: https://github.com/PrestaShop/PrestaShop/commit/dfe593fbf30f05737c61734e455dbabaed3ee240#diff-f2a39218feae4cfb78f374d5c0909a9cR32

Before: empty alt and title attributes
![image](https://user-images.githubusercontent.com/194784/76247212-77c3be00-623f-11ea-8864-b23ac9892b74.png)

After: alt filled, title only if legend is set
![image](https://user-images.githubusercontent.com/194784/76247307-9e81f480-623f-11ea-8411-2d66d976656f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18068)
<!-- Reviewable:end -->
