### PR TITLE
Make BO menu translatable

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -23,7 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-use PrestaShop\PrestaShop\Adapter\EntityTranslation\DataLangClassNameNotFoundException;
+use PrestaShop\PrestaShop\Adapter\EntityTranslation\Exception\DataLangClassNameNotFoundException;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\DataLangFactory;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\EntityTranslatorFactory;
 use PrestaShop\PrestaShop\Adapter\Language\LanguageImageManager;

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -23,6 +23,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+use PrestaShop\PrestaShop\Adapter\EntityTranslation\DataLangClassNameNotFoundException;
+use PrestaShop\PrestaShop\Adapter\EntityTranslation\DataLangFactory;
+use PrestaShop\PrestaShop\Adapter\EntityTranslation\EntityTranslatorFactory;
 use PrestaShop\PrestaShop\Adapter\Language\LanguageImageManager;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
@@ -1427,8 +1430,11 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function updateMultilangTables(Language $language, array $tablesToUpdate)
     {
+        $translator = SymfonyContainer::getInstance()->get('translator');
+
         foreach ($tablesToUpdate as $tableName) {
-            $className = ucfirst(Tools::toCamelCase(str_replace(_DB_PREFIX_, '', $tableName)));
+            $className = (new DataLangFactory(_DB_PREFIX_, $translator))
+                ->getClassNameFromTable($tableName);
 
             if (_DB_PREFIX_ . 'country_lang' === $tableName) {
                 self::updateMultilangFromCldr($language);
@@ -1484,12 +1490,14 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function updateMultilangFromClass($table, $className, $lang)
     {
-        if (!class_exists($className)) {
+        $translator = SymfonyContainer::getInstance()->get('translator');
+
+        try {
+            $classObject = (new DataLangFactory(_DB_PREFIX_, $translator))
+                ->buildFromClassName($className, $lang->locale);
+        } catch (DataLangClassNameNotFoundException $e) {
             return;
         }
-
-        /** @var DataLangCore $classObject */
-        $classObject = new $className($lang->locale);
 
         $keys = $classObject->getKeys();
         $fieldsToUpdate = $classObject->getFieldsToUpdate();
@@ -1497,7 +1505,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         if (!empty($keys) && !empty($fieldsToUpdate)) {
             $shops = Shop::getShopsCollection(false);
             foreach ($shops as $shop) {
-                static::updateMultilangFromClassForShop($table, $classObject, $lang, $shop, $keys, $fieldsToUpdate);
+                static::updateMultilangFromClassForShop($classObject, $lang, $shop);
             }
         }
     }
@@ -1505,83 +1513,26 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     /**
      * untranslate then re-translate duplicated rows in tables with pattern xxx_lang.
      *
-     * @param string $tableName
-     * @param DataLang $classObject
+     * @param DataLangCore $classObject
      * @param Language $lang
      * @param Shop $shop
-     * @param array $keys
-     * @param array $fieldsToUpdate
      *
      * @throws \PrestaShopDatabaseException
+     * @throws PrestaShopException
      */
-    private static function updateMultilangFromClassForShop($tableName, $classObject, $lang, $shop, $keys, $fieldsToUpdate)
+    private static function updateMultilangFromClassForShop(DataLangCore $classObject, Language $lang, Shop $shop)
     {
-        $shopFieldExists = false;
-        $columns = Db::getInstance()->executeS('SHOW COLUMNS FROM `' . $tableName . '`');
-        foreach ($columns as $column) {
-            $fields[] = '`' . $column['Field'] . '`';
-            if ($column['Field'] == 'id_shop') {
-                $shopFieldExists = true;
-            }
+        $shopDefaultLangId = Configuration::get('PS_LANG_DEFAULT', null, $shop->id_shop_group, $shop->id);
+        $shopDefaultLanguage = new Language($shopDefaultLangId);
+
+        $translator = SymfonyContainer::getInstance()->get('translator');
+        if (!$translator->isLanguageLoaded($shopDefaultLanguage->locale)) {
+            (new TranslatorLanguageLoader(true))->loadLanguage($translator, $shopDefaultLanguage->locale);
         }
 
-        // get table data
-        $tableData = Db::getInstance()->executeS(
-            'SELECT * FROM `' . bqSQL($tableName) . '`
-            WHERE `id_lang` = "' . (int) $lang->id . '"'
-            . ($shopFieldExists ? ' AND `id_shop` = ' . (int) $shop->id : ''),
-            true,
-            false
-        );
-
-        if (!empty($tableData)) {
-            $shopDefaultLangId = Configuration::get('PS_LANG_DEFAULT', null, $shop->id_shop_group, $shop->id);
-            $shopDefaultLanguage = new Language($shopDefaultLangId);
-
-            $translator = SymfonyContainer::getInstance()->get('translator');
-            if (!$translator->isLanguageLoaded($shopDefaultLanguage->locale)) {
-                (new TranslatorLanguageLoader(true))->loadLanguage($translator, $shopDefaultLanguage->locale);
-            }
-
-            foreach ($tableData as $data) {
-                $updateWhere = '';
-                $updateField = '';
-
-                // Construct update where
-                foreach ($keys as $key) {
-                    if (!empty($updateWhere)) {
-                        $updateWhere .= ' AND ';
-                    }
-                    $updateWhere .= '`' . bqSQL($key) . '` = "' . pSQL($data[$key]) . '"';
-                }
-
-                // Construct update field
-                foreach ($fieldsToUpdate as $toUpdate) {
-                    if ('url_rewrite' === $toUpdate && self::$locale_crowdin_lang === $lang->locale) {
-                        continue;
-                    }
-
-                    $untranslated = $translator->getSourceString($data[$toUpdate], $classObject->getDomain());
-                    $translatedField = $classObject->getFieldValue($toUpdate, $untranslated);
-
-                    if (!empty($translatedField) && $translatedField != $data[$toUpdate]) {
-                        if (!empty($updateField)) {
-                            $updateField .= ' , ';
-                        }
-                        $updateField .= '`' . bqSQL($toUpdate) . '` = "' . pSQL($translatedField) . '"';
-                    }
-                }
-
-                // Update table
-                if (!empty($updateWhere) && !empty($updateField)) {
-                    $sql = 'UPDATE `' . bqSQL($tableName) . '` SET ' . $updateField . '
-                    WHERE ' . $updateWhere . ' AND `id_lang` = "' . (int) $lang->id . '"
-                    ' . ($shopFieldExists ? ' AND `id_shop` = ' . (int) $shop->id : '') . '
-                    LIMIT 1;';
-                    Db::getInstance()->execute($sql);
-                }
-            }
-        }
+        (new EntityTranslatorFactory($translator))
+            ->build($classObject)
+            ->translate($lang->id, $shop->id);
     }
 
     /**

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -139,13 +139,13 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
     public static function resetCache()
     {
-        self::$_checkedLangs = null;
-        self::$_LANGUAGES = null;
-        self::$countActiveLanguages = null;
-        self::$_cache_language_installation = null;
-        self::$_cache_language_installation_by_locale = null;
-        self::$_cache_all_language_json = null;
-        self::$_cache_all_languages_iso = null;
+        static::$_checkedLangs = null;
+        static::$_LANGUAGES = null;
+        static::$countActiveLanguages = null;
+        static::$_cache_language_installation = null;
+        static::$_cache_language_installation_by_locale = null;
+        static::$_cache_all_language_json = null;
+        static::$_cache_all_languages_iso = null;
     }
 
     /**
@@ -157,9 +157,9 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     private static function loadAllLanguagesDetails(): array
     {
-        if (null === self::$_cache_all_languages_iso) {
+        if (null === static::$_cache_all_languages_iso) {
             $allLanguages = file_get_contents(_PS_ROOT_DIR_ . self::ALL_LANGUAGES_FILE);
-            self::$_cache_all_languages_iso = json_decode($allLanguages, true);
+            static::$_cache_all_languages_iso = json_decode($allLanguages, true);
 
             if (JSON_ERROR_NONE !== json_last_error()) {
                 throw new RuntimeException(
@@ -168,7 +168,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             }
         }
 
-        return self::$_cache_all_languages_iso;
+        return static::$_cache_all_languages_iso;
     }
 
     /**
@@ -244,7 +244,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         }
 
         if ($this->is_rtl) {
-            self::getRtlStylesheetProcessor()
+            static::getRtlStylesheetProcessor()
                 ->setIsInstall(defined('PS_INSTALLATION_IN_PROGRESS'))
                 ->setProcessBOTheme(true)
                 ->setProcessDefaultModules(true)
@@ -272,7 +272,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         // Generate RTL stylesheets if language is_rtl parameter changes
         if ($this->is_rtl) {
-            self::getRtlStylesheetProcessor()
+            static::getRtlStylesheetProcessor()
                 ->setProcessBOTheme(true)
                 ->setProcessDefaultModules(true)
                 ->process();
@@ -304,7 +304,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function checkFilesWithIsoCode($iso_code)
     {
-        if (isset(self::$_checkedLangs[$iso_code]) && self::$_checkedLangs[$iso_code]) {
+        if (isset(static::$_checkedLangs[$iso_code]) && static::$_checkedLangs[$iso_code]) {
             return true;
         }
 
@@ -313,7 +313,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
                 return false;
             }
         }
-        self::$_checkedLangs[$iso_code] = true;
+        static::$_checkedLangs[$iso_code] = true;
 
         return true;
     }
@@ -693,13 +693,13 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function getLanguages($active = true, $id_shop = false, $ids_only = false)
     {
-        if (!self::$_LANGUAGES) {
+        if (!static::$_LANGUAGES) {
             Language::loadLanguages();
         }
 
         $languages = [];
-        foreach (self::$_LANGUAGES as $language) {
-            if ($active && !$language['active'] || ($id_shop && !isset($language['shops'][(int) $id_shop])) || self::$locale_crowdin_lang === $language['locale']) {
+        foreach (static::$_LANGUAGES as $language) {
+            if ($active && !$language['active'] || ($id_shop && !isset($language['shops'][(int) $id_shop])) || static::$locale_crowdin_lang === $language['locale']) {
                 continue;
             }
 
@@ -719,7 +719,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function getIDs($active = true, $id_shop = false)
     {
-        return self::getLanguages($active, $id_shop, true);
+        return static::getLanguages($active, $id_shop, true);
     }
 
     /**
@@ -731,14 +731,14 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function getLanguage($id_lang)
     {
-        if (!self::$_LANGUAGES) {
+        if (!static::$_LANGUAGES) {
             Language::loadLanguages();
         }
-        if (!array_key_exists((int) $id_lang, self::$_LANGUAGES)) {
+        if (!array_key_exists((int) $id_lang, static::$_LANGUAGES)) {
             return false;
         }
 
-        return self::$_LANGUAGES[(int) ($id_lang)];
+        return static::$_LANGUAGES[(int) ($id_lang)];
     }
 
     /**
@@ -750,11 +750,11 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function getIsoById($id_lang)
     {
-        if (!self::$_LANGUAGES) {
+        if (!static::$_LANGUAGES) {
             Language::loadLanguages();
         }
-        if (isset(self::$_LANGUAGES[(int) $id_lang]['iso_code'])) {
-            return self::$_LANGUAGES[(int) $id_lang]['iso_code'];
+        if (isset(static::$_LANGUAGES[(int) $id_lang]['iso_code'])) {
+            return static::$_LANGUAGES[(int) $id_lang]['iso_code'];
         }
 
         return false;
@@ -791,16 +791,16 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function getJsonLanguageDetails($locale)
     {
-        if (self::$_cache_all_language_json === null) {
-            self::$_cache_all_language_json = [];
-            $allLanguages = self::loadAllLanguagesDetails();
+        if (static::$_cache_all_language_json === null) {
+            static::$_cache_all_language_json = [];
+            $allLanguages = static::loadAllLanguagesDetails();
 
             foreach ($allLanguages as $isoCode => $langDetails) {
-                self::$_cache_all_language_json[$langDetails['locale']] = $langDetails;
+                static::$_cache_all_language_json[$langDetails['locale']] = $langDetails;
             }
         }
 
-        return isset(self::$_cache_all_language_json[$locale]) ? self::$_cache_all_language_json[$locale] : false;
+        return isset(static::$_cache_all_language_json[$locale]) ? static::$_cache_all_language_json[$locale] : false;
     }
 
     /**
@@ -872,7 +872,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     {
         $iso = (string) $iso; // $iso often comes from xml and is a SimpleXMLElement
 
-        $allLanguages = self::loadAllLanguagesDetails();
+        $allLanguages = static::loadAllLanguagesDetails();
 
         return isset($allLanguages[$iso]) ? $allLanguages[$iso] : false;
     }
@@ -892,7 +892,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             throw new Exception('The ISO code ' . $isoCode . ' is invalid');
         }
 
-        if ($details = self::getLangDetails($isoCode)) {
+        if ($details = static::getLangDetails($isoCode)) {
             return $details['locale'];
         }
 
@@ -914,7 +914,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             throw new Exception('The locale ' . $locale . ' is invalid');
         }
 
-        if ($details = self::getJsonLanguageDetails($locale)) {
+        if ($details = static::getJsonLanguageDetails($locale)) {
             return $details['iso_code'];
         }
 
@@ -1038,7 +1038,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function loadLanguages()
     {
-        self::$_LANGUAGES = [];
+        static::$_LANGUAGES = [];
 
         $sql = 'SELECT l.*, ls.`id_shop`
 				FROM `' . _DB_PREFIX_ . 'lang` l
@@ -1053,26 +1053,26 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         foreach ($result as $row) {
             $idLang = (int) $row['id_lang'];
 
-            if (!isset(self::$_LANGUAGES[$idLang])) {
-                self::$_LANGUAGES[$idLang] = $row;
+            if (!isset(static::$_LANGUAGES[$idLang])) {
+                static::$_LANGUAGES[$idLang] = $row;
             }
-            self::$_LANGUAGES[$idLang]['shops'][(int) $row['id_shop']] = true;
+            static::$_LANGUAGES[$idLang]['shops'][(int) $row['id_shop']] = true;
         }
     }
 
     public static function loadLanguagesLegacy()
     {
-        self::$_LANGUAGES = [];
+        static::$_LANGUAGES = [];
 
         $result = Db::getInstance()->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'lang`');
 
         foreach ($result as $row) {
             $idLang = (int) $row['id_lang'];
 
-            if (!isset(self::$_LANGUAGES[$idLang])) {
-                self::$_LANGUAGES[$idLang] = $row;
+            if (!isset(static::$_LANGUAGES[$idLang])) {
+                static::$_LANGUAGES[$idLang] = $row;
             }
-            self::$_LANGUAGES[$idLang]['shops'][1] = true;
+            static::$_LANGUAGES[$idLang]['shops'][1] = true;
         }
     }
 
@@ -1103,7 +1103,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         // If the language pack has not been provided, retrieve it from prestashop.com
         if (!$lang_pack) {
-            $lang_pack = self::getLangDetails($iso_code);
+            $lang_pack = static::getLangDetails($iso_code);
         }
 
         // If a language pack has been found or provided, prefill the language object with the value
@@ -1140,7 +1140,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         $languageManager->setupLanguageFlag($lang->locale, $lang->id, $lang_pack['flag'] ?? null);
         $languageManager->setupDefaultImagePlaceholder($lang->iso_code);
 
-        self::loadLanguages();
+        static::loadLanguages();
 
         return true;
     }
@@ -1160,28 +1160,28 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
     public static function isInstalled($iso_code)
     {
-        if (self::$_cache_language_installation === null) {
-            self::$_cache_language_installation = [];
+        if (static::$_cache_language_installation === null) {
+            static::$_cache_language_installation = [];
             $result = Db::getInstance()->executeS('SELECT `id_lang`, `iso_code` FROM `' . _DB_PREFIX_ . 'lang`');
             foreach ($result as $row) {
-                self::$_cache_language_installation[$row['iso_code']] = $row['id_lang'];
+                static::$_cache_language_installation[$row['iso_code']] = $row['id_lang'];
             }
         }
 
-        return isset(self::$_cache_language_installation[$iso_code]) ? self::$_cache_language_installation[$iso_code] : false;
+        return isset(static::$_cache_language_installation[$iso_code]) ? static::$_cache_language_installation[$iso_code] : false;
     }
 
     public static function isInstalledByLocale($locale)
     {
-        if (self::$_cache_language_installation_by_locale === null) {
-            self::$_cache_language_installation_by_locale = [];
+        if (static::$_cache_language_installation_by_locale === null) {
+            static::$_cache_language_installation_by_locale = [];
             $result = Db::getInstance()->executeS('SELECT `id_lang`, `locale` FROM `' . _DB_PREFIX_ . 'lang`');
             foreach ($result as $row) {
-                self::$_cache_language_installation_by_locale[$row['locale']] = $row['id_lang'];
+                static::$_cache_language_installation_by_locale[$row['locale']] = $row['id_lang'];
             }
         }
 
-        return isset(self::$_cache_language_installation_by_locale[$locale]);
+        return isset(static::$_cache_language_installation_by_locale[$locale]);
     }
 
     public static function countActiveLanguages($id_shop = null)
@@ -1190,15 +1190,15 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             $id_shop = (int) Context::getContext()->shop->id;
         }
 
-        if (!isset(self::$countActiveLanguages[$id_shop])) {
-            self::$countActiveLanguages[$id_shop] = Db::getInstance()->getValue('
+        if (!isset(static::$countActiveLanguages[$id_shop])) {
+            static::$countActiveLanguages[$id_shop] = Db::getInstance()->getValue('
 				SELECT COUNT(DISTINCT l.id_lang) FROM `' . _DB_PREFIX_ . 'lang` l
 				JOIN ' . _DB_PREFIX_ . 'lang_shop lang_shop ON (lang_shop.id_lang = l.id_lang AND lang_shop.id_shop = ' . (int) $id_shop . ')
 				WHERE l.`active` = 1
 			');
         }
 
-        return self::$countActiveLanguages[$id_shop];
+        return static::$countActiveLanguages[$id_shop];
     }
 
     public static function downloadAndInstallLanguagePack($iso, $version = _PS_VERSION_, $params = null, $install = true)
@@ -1224,11 +1224,11 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     {
         $iso = (string) $iso; // $iso often comes from xml and is a SimpleXMLElement
 
-        $lang_pack = self::getLangDetails($iso);
+        $lang_pack = static::getLangDetails($iso);
         if (!$lang_pack) {
             $errors[] = Context::getContext()->getTranslator()->trans('Sorry this language is not available', [], 'Admin.International.Notification');
         } else {
-            self::downloadXLFLanguagePack($lang_pack['locale'], $errors, self::PACK_TYPE_SYMFONY);
+            static::downloadXLFLanguagePack($lang_pack['locale'], $errors, self::PACK_TYPE_SYMFONY);
         }
 
         return count($errors) === 0;
@@ -1236,7 +1236,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
     public static function downloadXLFLanguagePack($locale, &$errors = [], $type = self::PACK_TYPE_SYMFONY)
     {
-        $file = self::getPathToCachedTranslationPack($type, $locale);
+        $file = static::getPathToCachedTranslationPack($type, $locale);
         $url = (self::PACK_TYPE_EMAILS === $type) ? self::EMAILS_LANGUAGE_PACK_URL : self::SF_LANGUAGE_PACK_URL;
         $url = str_replace(
             [
@@ -1253,7 +1253,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         if (!is_writable(dirname($file))) {
             // @todo Throw exception
             $errors[] = Context::getContext()->getTranslator()->trans('Server does not have permissions for writing.', [], 'Admin.International.Notification') . ' (' . $file . ')';
-        } elseif ($content = Tools::file_get_contents($url, false, null, self::PACK_DOWNLOAD_TIMEOUT)) {
+        } elseif ($content = Tools::file_get_contents($url, false, null, static::PACK_DOWNLOAD_TIMEOUT)) {
             file_put_contents($file, $content);
         } else {
             $errors[] = Context::getContext()->getTranslator()->trans('Language pack unavailable.', [], 'Admin.International.Notification') . ' ' . $url;
@@ -1264,12 +1264,12 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
     public static function installSfLanguagePack($locale, &$errors = [])
     {
-        if (!self::translationPackIsInCache($locale)) {
+        if (!static::translationPackIsInCache($locale)) {
             // @todo Throw exception
             $errors[] = Context::getContext()->getTranslator()->trans('Language pack unavailable.', [], 'Admin.International.Notification');
         } else {
             $zipArchive = new ZipArchive();
-            $zipArchive->open(self::getPathToCachedTranslationPack($locale));
+            $zipArchive->open(static::getPathToCachedTranslationPack($locale));
             $zipArchive->extractTo(_PS_ROOT_DIR_ . '/app/Resources/translations');
             $zipArchive->close();
         }
@@ -1327,7 +1327,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             E_USER_DEPRECATED
         );
 
-        self::generateEmailsLanguagePack($lang_pack, $errors, true);
+        static::generateEmailsLanguagePack($lang_pack, $errors, true);
     }
 
     public static function installLanguagePack($iso, $params, &$errors = [])
@@ -1381,7 +1381,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
     public static function updateLanguagePack($iso, &$errors = [])
     {
-        $lang_pack = self::getLangDetails($iso);
+        $lang_pack = static::getLangDetails($iso);
         if (!empty($lang_pack['locale'])) {
             //Update locale field if empty (manually created, or imported without it)
             $language = new Language(Language::getIdByIso($iso));
@@ -1390,9 +1390,9 @@ class LanguageCore extends ObjectModel implements LanguageInterface
                 $language->save();
             }
 
-            self::installSfLanguagePack($lang_pack['locale'], $errors);
+            static::installSfLanguagePack($lang_pack['locale'], $errors);
             Language::updateMultilangTable($iso);
-            self::generateEmailsLanguagePack($lang_pack, $errors, false);
+            static::generateEmailsLanguagePack($lang_pack, $errors, false);
         }
     }
 
@@ -1617,7 +1617,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function translationPackIsInCache(string $locale, string $type = self::PACK_TYPE_SYMFONY): bool
     {
-        return file_exists(self::getPathToCachedTranslationPack($locale, $type));
+        return file_exists(static::getPathToCachedTranslationPack($locale, $type));
     }
 
     /**

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -23,9 +23,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-use PrestaShop\PrestaShop\Adapter\EntityTranslation\Exception\DataLangClassNameNotFoundException;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\DataLangFactory;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\EntityTranslatorFactory;
+use PrestaShop\PrestaShop\Adapter\EntityTranslation\Exception\DataLangClassNameNotFoundException;
 use PrestaShop\PrestaShop\Adapter\Language\LanguageImageManager;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1248,7 +1248,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function downloadXLFLanguagePack($locale, &$errors = [], $type = self::PACK_TYPE_SYMFONY)
     {
-        $file = static::getPathToCachedTranslationPack($type, $locale);
+        $file = static::getPathToCachedTranslationPack($locale, $type);
         $url = (self::PACK_TYPE_EMAILS === $type) ? self::EMAILS_LANGUAGE_PACK_URL : self::SF_LANGUAGE_PACK_URL;
         $url = str_replace(
             [
@@ -1480,10 +1480,15 @@ class LanguageCore extends ObjectModel implements LanguageInterface
                 $language->save();
             }
 
-            static::installSfLanguagePack($lang_pack['locale'], $errors);
+            if (!static::installSfLanguagePack($lang_pack['locale'], $errors)) {
+                return false;
+            }
+
             Language::updateMultilangTable($iso);
             static::generateEmailsLanguagePack($lang_pack, $errors, false);
         }
+
+        return true;
     }
 
     /**

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1404,10 +1404,10 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function updateMultilangTable($iso_code)
     {
-        $langId = Language::getIdByIso($iso_code);
+        $langId = static::getIdByIso($iso_code);
 
         if (!empty($langId)) {
-            $lang = new Language($langId);
+            $lang = new static($langId);
 
             $rows = Db::getInstance()->executeS('SHOW TABLES LIKE \'' . str_replace('_', '\\_', _DB_PREFIX_) . '%\_lang\' ');
             if (!empty($rows)) {
@@ -1437,9 +1437,9 @@ class LanguageCore extends ObjectModel implements LanguageInterface
                 ->getClassNameFromTable($tableName);
 
             if (_DB_PREFIX_ . 'country_lang' === $tableName) {
-                self::updateMultilangFromCldr($language);
+                static::updateMultilangFromCldr($language);
             } else {
-                self::updateMultilangFromClass($tableName, $className, $language);
+                static::updateMultilangFromClass($tableName, $className, $language);
             }
         }
 
@@ -1484,7 +1484,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      *
      * @param string $table
      * @param string $className
-     * @param Language $lang
+     * @param static $lang
      *
      * @throws PrestaShopDatabaseException
      */
@@ -1514,13 +1514,13 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      * untranslate then re-translate duplicated rows in tables with pattern xxx_lang.
      *
      * @param DataLangCore $classObject
-     * @param Language $lang
+     * @param static $lang
      * @param Shop $shop
      *
      * @throws \PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    private static function updateMultilangFromClassForShop(DataLangCore $classObject, Language $lang, Shop $shop)
+    private static function updateMultilangFromClassForShop(DataLangCore $classObject, self $lang, Shop $shop)
     {
         $shopDefaultLangId = Configuration::get('PS_LANG_DEFAULT', null, $shop->id_shop_group, $shop->id);
         $shopDefaultLanguage = new Language($shopDefaultLangId);

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1230,6 +1230,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         $lang_pack = static::getLangDetails($iso);
         if (!$lang_pack) {
             $errors[] = Context::getContext()->getTranslator()->trans('Sorry this language is not available', [], 'Admin.International.Notification');
+
             return false;
         }
 
@@ -1264,6 +1265,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         if (!is_writable(dirname($file))) {
             // @todo Throw exception
             $errors[] = Context::getContext()->getTranslator()->trans('Server does not have permissions for writing.', [], 'Admin.International.Notification') . ' (' . $file . ')';
+
             return false;
         }
 
@@ -1271,10 +1273,11 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         if (empty($content)) {
             $errors[] = Context::getContext()->getTranslator()->trans('Language pack unavailable.', [], 'Admin.International.Notification') . ' ' . $url;
+
             return false;
         }
 
-        return (false !== file_put_contents($file, $content));
+        return false !== file_put_contents($file, $content);
     }
 
     /**
@@ -1290,6 +1293,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         if (!static::translationPackIsInCache($locale)) {
             // @todo Throw exception
             $errors[] = Context::getContext()->getTranslator()->trans('Language pack unavailable.', [], 'Admin.International.Notification');
+
             return false;
         }
 
@@ -1381,6 +1385,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         if (!Language::checkAndAddLanguage((string) $iso, $lang_pack, false, $params)) {
             $errors[] = Context::getContext()->getTranslator()->trans('An error occurred while creating the language: %s', [(string) $iso], 'Admin.International.Notification');
+
             return $errors;
         }
 
@@ -1421,6 +1426,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         if (!Language::checkAndAddLanguage((string) $iso, $lang_pack, false, $params)) {
             $errors[] = Context::getContext()->getTranslator()->trans('An error occurred while creating the language: %s', [(string) $iso], 'Admin.International.Notification');
+
             return false;
         }
 
@@ -1689,7 +1695,6 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         return $processor;
     }
-
 
     /**
      * Indicates if a given translation pack exists in cache

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -43,8 +43,8 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     const ALL_LANGUAGES_FILE = '/app/Resources/all_languages.json';
     const SF_LANGUAGE_PACK_URL = 'https://i18n.prestashop.com/translations/%version%/%locale%/%locale%.zip';
     const EMAILS_LANGUAGE_PACK_URL = 'https://i18n.prestashop.com/mails/%version%/%locale%/%locale%.zip';
-    const PACK_TYPE_EMAILS = 'emails';
-    const PACK_TYPE_SYMFONY = 'sf';
+    public const PACK_TYPE_EMAILS = 'emails';
+    public const PACK_TYPE_SYMFONY = 'sf';
 
     /**
      * Timeout for downloading a translation pack, in seconds
@@ -1420,7 +1420,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    public static function installFirstLanguagePack(string $iso, array $params = [], &$errors = []): bool
+    public static function installFirstLanguagePack(string $iso, array $params = [], array &$errors = []): bool
     {
         $lang_pack = static::getLangDetails($iso);
 

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -86,8 +86,8 @@ class TabCore extends ObjectModel
             'enabled' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'hide_host_mode' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'icon' => ['type' => self::TYPE_STRING, 'size' => 64],
-            'wording' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'size' => 194],
-            'wording_domain' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'size' => 194],
+            'wording' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'size' => 255],
+            'wording_domain' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'size' => 255],
             /* Lang fields */
             'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'required' => true, 'validate' => 'isTabName', 'size' => 64],
         ],

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -59,10 +59,10 @@ class TabCore extends ObjectModel
     public $icon;
 
     /** @var string Wording to use for the display name */
-    public $wording = '';
+    public $wording;
 
     /** @var string Wording domain to use for the display name */
-    public $wording_domain = '';
+    public $wording_domain;
 
     /**
      * @deprecated Since 1.7.7

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -58,10 +58,10 @@ class TabCore extends ObjectModel
     /** @var string Icon font */
     public $icon;
 
-    /** @var string Wording to use for the display name */
+    /** @var string|null Wording to use for the display name */
     public $wording;
 
-    /** @var string Wording domain to use for the display name */
+    /** @var string|null Wording domain to use for the display name */
     public $wording_domain;
 
     /**
@@ -86,8 +86,8 @@ class TabCore extends ObjectModel
             'enabled' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'hide_host_mode' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'icon' => ['type' => self::TYPE_STRING, 'size' => 64],
-            'wording' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'size' => 255],
-            'wording_domain' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'size' => 255],
+            'wording' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'allow_null' => true, 'size' => 255],
+            'wording_domain' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'allow_null' => true, 'size' => 255],
             /* Lang fields */
             'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'required' => true, 'validate' => 'isTabName', 'size' => 64],
         ],

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -58,6 +58,12 @@ class TabCore extends ObjectModel
     /** @var string Icon font */
     public $icon;
 
+    /** @var string Translatable wording to use */
+    public $wording;
+
+    /** @var string domain name for the wording */
+    public $wording_domain;
+
     /**
      * @deprecated Since 1.7.7
      */
@@ -80,6 +86,8 @@ class TabCore extends ObjectModel
             'enabled' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'hide_host_mode' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'icon' => ['type' => self::TYPE_STRING, 'size' => 64],
+            'wording' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'size' => 194],
+            'wording_domain' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'size' => 194],
             /* Lang fields */
             'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'required' => true, 'validate' => 'isTabName', 'size' => 64],
         ],

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -58,11 +58,11 @@ class TabCore extends ObjectModel
     /** @var string Icon font */
     public $icon;
 
-    /** @var string Translatable wording to use */
-    public $wording;
+    /** @var string Wording to use for the display name */
+    public $wording = '';
 
-    /** @var string domain name for the wording */
-    public $wording_domain;
+    /** @var string Wording domain to use for the display name */
+    public $wording_domain = '';
 
     /**
      * @deprecated Since 1.7.7

--- a/classes/lang/DataLang.php
+++ b/classes/lang/DataLang.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
-use PrestaShopBundle\Translation\TranslatorComponent as Translator;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use PrestaShopBundle\Translation\TranslatorLanguageLoader;
 
 /**
@@ -36,26 +36,33 @@ use PrestaShopBundle\Translation\TranslatorLanguageLoader;
  */
 class DataLangCore
 {
-    /** @var Translator */
+    /** @var TranslatorInterface */
     protected $translator;
 
-    /** @var string */
+    /** @var string Locale to translate to */
     protected $locale;
 
-    /** @var array */
+    /** @var string[] Table primary key */
     protected $keys;
 
-    /** @var array */
+    /** @var string[] Database fields to translate */
     protected $fieldsToUpdate;
 
-    /** @var string */
+    /** @var string Default translation domain */
     protected $domain;
 
-    public function __construct($locale)
+    /**
+     * @param string $locale
+     * @param TranslatorInterface|null $translator If defined, use this translator
+     */
+    public function __construct($locale, $translator = null)
     {
         $this->locale = $locale;
 
-        $this->translator = SymfonyContainer::getInstance()->get('translator');
+        $this->translator = $translator instanceof TranslatorInterface
+            ? $translator
+            : SymfonyContainer::getInstance()->get('translator');
+
         $isAdminContext = defined('_PS_ADMIN_DIR_');
 
         if (!$this->translator->isLanguageLoaded($this->locale)) {
@@ -64,26 +71,56 @@ class DataLangCore
         }
     }
 
+    /**
+     * Translates a value to the current locale
+     *
+     * @param string $field Name of the database field to translate
+     * @param string $value Value to translate
+     *
+     * @return string Translated value
+     */
     public function getFieldValue($field, $value)
     {
         return $this->translator->trans($value, [], $this->domain, $this->locale);
     }
 
+    /**
+     * Returns the table primary key
+     *
+     * @return string[]
+     */
     public function getKeys()
     {
         return $this->keys;
     }
 
+    /**
+     * Returns the list of database fields to update
+     *
+     * @return string[]
+     */
     public function getFieldsToUpdate()
     {
         return $this->fieldsToUpdate;
     }
 
+    /**
+     * Creates a slug from the provided string
+     *
+     * @param string $string
+     *
+     * @return string
+     */
     public function slugify($string)
     {
         return strtolower(str_replace(' ', '-', Tools::replaceAccentedChars($string)));
     }
 
+    /**
+     * Returns the default translation domain
+     *
+     * @return string
+     */
     public function getDomain()
     {
         return $this->domain;

--- a/classes/lang/DataLang.php
+++ b/classes/lang/DataLang.php
@@ -57,7 +57,7 @@ class DataLangCore
      * @param string $locale
      * @param TranslatorInterface|null $translator If defined, use this translator
      */
-    public function __construct($locale, $translator = null)
+    public function __construct($locale, ?TranslatorInterface $translator = null)
     {
         $this->locale = $locale;
 

--- a/classes/lang/DataLang.php
+++ b/classes/lang/DataLang.php
@@ -23,6 +23,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+use Doctrine\Common\Inflector\Inflector;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShopBundle\Translation\TranslatorInterface;
 use PrestaShopBundle\Translation\TranslatorLanguageLoader;
@@ -124,5 +126,17 @@ class DataLangCore
     public function getDomain()
     {
         return $this->domain;
+    }
+
+    /**
+     * Returns the table name where the translations are to be performed
+     *
+     * @return string
+     */
+    public function getTableName(): string
+    {
+        $shortClassName = substr(strrchr('\\' . get_class($this), '\\'), 1);
+
+        return Inflector::tableize($shortClassName);
     }
 }

--- a/classes/lang/TabLang.php
+++ b/classes/lang/TabLang.php
@@ -47,6 +47,11 @@ class TabLangCore extends DataLangCore
             $message = $value;
         }
 
-        return $this->translator->trans($message, [], (!empty($domain)) ? $domain : $this->domain, $this->locale);
+        return $this->translator->trans(
+            $message,
+            [],
+            (!empty($domain)) ? $domain : $this->domain,
+            $this->locale
+        );
     }
 }

--- a/classes/lang/TabLang.php
+++ b/classes/lang/TabLang.php
@@ -23,12 +23,30 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+/**
+ * Translates content from the tab entity
+ */
 class TabLangCore extends DataLangCore
 {
-    // Don't replace domain in init() with $this->domain for translation parsing
     protected $domain = 'Admin.Navigation.Menu';
 
     protected $keys = ['id_tab'];
 
     protected $fieldsToUpdate = ['name'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFieldValue($field, $value)
+    {
+        $domain = '';
+        if (is_array($value)) {
+            list($message, $domain) = $value;
+        } else {
+            $message = $value;
+        }
+
+        return $this->translator->trans($message, [], (!empty($domain)) ? $domain : $this->domain, $this->locale);
+    }
 }

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -811,7 +811,7 @@ class ShopCore extends ObjectModel
      * @param bool $active
      * @param int $id_shop_group
      *
-     * @return PrestaShopCollection Collection of Shop
+     * @return PrestaShopCollection<Shop> Collection of Shop
      */
     public static function getShopsCollection($active = true, $id_shop_group = null)
     {

--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -135,7 +135,7 @@
                     </tab>
                 <tab id="Stock" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminStockManagement</class_name>
-                    <wording>Stocks</wording>
+                    <wording>Stock</wording>
                     <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 

--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -593,6 +593,8 @@
 
                 <tab id="Tabs" id_parent="Advanced_Parameters" active="1" enabled="1"  hide_host_mode="0" icon="">
                     <class_name>AdminTabs</class_name>
+                    <wording>Menus</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Information" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminInformation</class_name>

--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -5,382 +5,590 @@
         <field name="class_name"/>
         <field name="active"/>
         <field name="icon"/>
+        <field name="wording"/>
+        <field name="wording_domain"/>
     </fields>
     <entities>
 
         <tab id="Dashboard" id_parent="" active="1" enabled="1" hide_host_mode="0" icon="trending_up">
             <class_name>AdminDashboard</class_name>
+            <wording>Dashboard</wording>
+            <wording_domain>Admin.Navigation.Menu</wording_domain>
         </tab>
 
         <!--SELL-->
         <tab id="SELL" id_parent="" active="1" enabled="1" hide_host_mode="0" icon="">
             <class_name>SELL</class_name>
+            <wording>Sell</wording>
+            <wording_domain>Admin.Navigation.Menu</wording_domain>
         </tab>
 
             <!--ORDERS-->
             <tab id="Orders" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="shopping_basket">
                 <class_name>AdminParentOrders</class_name>
+                <wording>Orders</wording>
+                <wording_domain>Admin.Navigation.Menu</wording_domain>
             </tab>
 
                 <tab id="Orders_1" id_parent="Orders" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminOrders</class_name>
+                    <wording>Orders</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Invoices" id_parent="Orders" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminInvoices</class_name>
+                    <wording>Invoices</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Credit_Slips" id_parent="Orders" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminSlip</class_name>
+                    <wording>Credit Slips</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Delivery_Slips" id_parent="Orders" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminDeliverySlip</class_name>
+                    <wording>Delivery Slips</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Shopping_Carts" id_parent="Orders" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminCarts</class_name>
+                    <wording>Shopping Carts</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
             <!--CATALOG-->
             <tab id="Catalog" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="store">
                 <class_name>AdminCatalog</class_name>
+                <wording>Catalog</wording>
+                <wording_domain>Admin.Navigation.Menu</wording_domain>
             </tab>
 
                 <tab id="Products" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminProducts</class_name>
+                    <wording>Products</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Categories" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminCategories</class_name>
+                    <wording>Categories</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Monitoring" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminTracking</class_name>
+                    <wording>Monitoring</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Attributes_and_features" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentAttributesGroups</class_name>
+                    <wording>Attributes &amp; Features</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Attributes_and_Values" id_parent="Attributes_and_features" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminAttributesGroups</class_name>
+                        <wording>Attributes</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Features" id_parent="Attributes_and_features" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminFeatures</class_name>
+                        <wording>Features</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Manufacturers_and_suppliers" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentManufacturers</class_name>
+                    <wording>Brands &amp; Suppliers</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Manufacturers" id_parent="Manufacturers_and_suppliers" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminManufacturers</class_name>
+                        <wording>Brands</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Suppliers" id_parent="Manufacturers_and_suppliers" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminSuppliers</class_name>
+                        <wording>Suppliers</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Attachments" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminAttachments</class_name>
+                    <wording>Files</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Price_Rules" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentCartRules</class_name>
+                    <wording>Discounts</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Cart_Rules" id_parent="Price_Rules" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminCartRules</class_name>
+                        <wording>Cart Rules</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Catalog_Price_Rules" id_parent="Price_Rules" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminSpecificPriceRule</class_name>
+                        <wording>Catalog Price Rules</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                 <tab id="Stock" id_parent="Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminStockManagement</class_name>
+                    <wording>Stocks</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
             <!--CUSTOMERS-->
             <tab id="Customers" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="account_circle">
                 <class_name>AdminParentCustomer</class_name>
+                <wording>Customers</wording>
+                <wording_domain>Admin.Navigation.Menu</wording_domain>
             </tab>
 
                 <tab id="Customers_2" id_parent="Customers" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminCustomers</class_name>
+                    <wording>Customers</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Addresses" id_parent="Customers" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminAddresses</class_name>
+                    <wording>Addresses</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Outstanding" id_parent="Customers" active="0" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminOutstanding</class_name>
+                    <wording>Outstanding</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
             <!--CUSTOMER SERVICE-->
             <tab id="Customer_Service" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="chat">
                 <class_name>AdminParentCustomerThreads</class_name>
+                <wording>Customer Service</wording>
+                <wording_domain>Admin.Navigation.Menu</wording_domain>
             </tab>
 
                 <tab id="Customer_Service_2" id_parent="Customer_Service" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminCustomerThreads</class_name>
+                    <wording>Customer Service</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Order_Messages" id_parent="Customer_Service" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminOrderMessage</class_name>
+                    <wording>Order Messages</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Merchandise_Returns" id_parent="Customer_Service" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminReturn</class_name>
+                    <wording>Merchandise Returns</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
             <!--STATISTICS-->
             <tab id="Stats" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="assessment">
                 <class_name>AdminStats</class_name>
+                <wording>Stats</wording>
+                <wording_domain>Admin.Navigation.Menu</wording_domain>
             </tab>
 
             <!--ADVANCED STOCK MANAGEMENT-->
             <tab id="Advanced_stock_management" id_parent="SELL" active="1" enabled="1" hide_host_mode="0" icon="store">
                 <class_name>AdminStock</class_name>
+                <wording/>
+                <wording_domain/>
             </tab>
 
                 <tab id="Warehouses" id_parent="Advanced_stock_management" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminWarehouses</class_name>
+                    <wording>Warehouses</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
-                <tab id="Stock_Management" id_parent="Advanced_stock_management" active="1" enabled="1" hide_host_mode="0" icon="">
+                <tab id="Stock_Management_Parent" id_parent="Advanced_stock_management" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentStockManagement</class_name>
+                    <wording>Stock Management</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
-                    <tab id="Stock_Management" id_parent="Stock_Management" active="1" enabled="1" hide_host_mode="0" icon="">
+                    <tab id="Stock_Management" id_parent="Stock_Management_Parent" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStockManagement</class_name>
+                        <wording>Stock Management</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Stock_Movement" id_parent="Stock_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStockMvt</class_name>
+                        <wording>Stock Movement</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Instant_Stock_Status" id_parent="Stock_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStockInstantState</class_name>
+                        <wording>Instant Stock Status</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Stock_Coverage" id_parent="Stock_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStockCover</class_name>
+                        <wording>Stock Coverage</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Supply_orders" id_parent="Advanced_stock_management" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminSupplyOrders</class_name>
+                    <wording>Supply orders</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Configuration" id_parent="Advanced_stock_management" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminStockConfiguration</class_name>
+                    <wording>Configuration</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
 
         <!--IMPROVE-->
         <tab id="IMPROVE" id_parent="" active="1" enabled="1" hide_host_mode="0" icon="">
             <class_name>IMPROVE</class_name>
+            <wording>Improve</wording>
+            <wording_domain>Admin.Navigation.Menu</wording_domain>
         </tab>
 
             <!--MODULES-->
             <tab id="Modules" id_parent="IMPROVE" active="1" enabled="1" hide_host_mode="0" icon="extension">
                 <class_name>AdminParentModulesSf</class_name>
+                <wording>Modules</wording>
+                <wording_domain>Admin.Navigation.Menu</wording_domain>
             </tab>
                 <tab id="Module_Page" id_parent="Modules" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminModulesSf</class_name>
+                    <wording>Module Manager</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                     <tab id="Module_Page_Manage" id_parent="Module_Page" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminModulesManage</class_name>
+                        <wording>Modules</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Module_Page_Notifications" id_parent="Module_Page" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminModulesNotifications</class_name>
+                        <wording>Alerts</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Module_Page_Updates" id_parent="Module_Page" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminModulesUpdates</class_name>
+                        <wording>Updates</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                 <tab id="Module_Catalog" id_parent="Modules" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentModulesCatalog</class_name>
+                    <wording>Module Catalog</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                     <tab id="Module_Page_Catalog" id_parent="Module_Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminModulesCatalog</class_name>
+                        <wording>Module Catalog</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Marketing_tools" id_parent="Module_Catalog" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminAddonsCatalog</class_name>
+                        <wording>Module Selections</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                 <tab id="Module_Page_old" id_parent="Modules" active="0" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminModules</class_name>
+                    <wording/>
+                    <wording_domain/>
                 </tab>
 
             <!--LOOK & FEEL-->
             <tab id="Look_feel" id_parent="IMPROVE" active="1" enabled="1" hide_host_mode="0" icon="desktop_mac">
                 <class_name>AdminParentThemes</class_name>
+                <wording>Design</wording>
+                <wording_domain>Admin.Navigation.Menu</wording_domain>
             </tab>
 
                 <tab id="Themes" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminThemes</class_name>
+                    <wording>Theme &amp; Logo</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Themes_Catalog" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminThemesCatalog</class_name>
+                    <wording>Theme Catalog</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Mail_Theme_Parent" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
-                  <class_name>AdminParentMailTheme</class_name>
+                    <class_name>AdminParentMailTheme</class_name>
+                    <wording>Email Theme</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                     <tab id="Mail_Theme" id_parent="Mail_Theme_Parent" active="1" enabled="1" hide_host_mode="0" icon="">
-                      <class_name>AdminMailTheme</class_name>
+                        <class_name>AdminMailTheme</class_name>
+                        <wording>Email Theme</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Pages" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminCmsContent</class_name>
+                    <wording>Pages</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Positions" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminModulesPositions</class_name>
+                    <wording>Positions</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Image_Settings" id_parent="Look_feel" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminImages</class_name>
+                    <wording>Image Settings</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                 <tab id="Shipping" id_parent="IMPROVE" active="1" enabled="1" hide_host_mode="0" icon="local_shipping">
                     <class_name>AdminParentShipping</class_name>
+                    <wording>Shipping</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Carriers" id_parent="Shipping" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminCarriers</class_name>
+                        <wording>Carriers</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Shipping_1" id_parent="Shipping" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminShipping</class_name>
+                        <wording>Preferences</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Payment" id_parent="IMPROVE" active="1" enabled="1" hide_host_mode="0" icon="payment">
                     <class_name>AdminParentPayment</class_name>
+                    <wording>Payment</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Payment_methods" id_parent="Payment" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminPayment</class_name>
+                        <wording>Payment Methods</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Payment_preferences" id_parent="Payment" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminPaymentPreferences</class_name>
+                        <wording>Preferences</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
             <!--INTERNATIONAL OK-->
             <tab id="International" id_parent="IMPROVE" active="1" enabled="1" hide_host_mode="0" icon="language">
                 <class_name>AdminInternational</class_name>
+                <wording>International</wording>
+                <wording_domain>Admin.Navigation.Menu</wording_domain>
             </tab>
 
                 <tab id="Localization" id_parent="International" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentLocalization</class_name>
+                    <wording>Localization</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Localization_1" id_parent="Localization" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminLocalization</class_name>
+                        <wording>Localization</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Languages" id_parent="Localization" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminLanguages</class_name>
+                        <wording>Languages</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Currencies" id_parent="Localization" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminCurrencies</class_name>
+                        <wording>Currencies</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Geolocation" id_parent="Localization" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminGeolocation</class_name>
+                        <wording>Geolocation</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Locations" id_parent="International" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentCountries</class_name>
+                    <wording>Locations</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                     <tab id="Zones" id_parent="Locations" active="1" enabled="1" hide_host_mode="0" icon="">
-                      <class_name>AdminZones</class_name>
+                        <class_name>AdminZones</class_name>
+                        <wording>Zones</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Countries" id_parent="Locations" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminCountries</class_name>
+                        <wording>Countries</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="States" id_parent="Locations" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStates</class_name>
+                        <wording>States</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Tax_Management" id_parent="International" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentTaxes</class_name>
+                    <wording>Taxes</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Taxes" id_parent="Tax_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminTaxes</class_name>
+                        <wording>Taxes</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Tax_Rules" id_parent="Tax_Management" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminTaxRulesGroup</class_name>
+                        <wording>Tax Rules</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Translations" id_parent="International" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminTranslations</class_name>
+                    <wording>Translations</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
         <!--CONFIGURE-->
         <tab id="CONFIGURE" id_parent="" active="1" enabled="1" hide_host_mode="0" icon="">
             <class_name>CONFIGURE</class_name>
+            <wording>Configure</wording>
+            <wording_domain>Admin.Navigation.Menu</wording_domain>
         </tab>
 
             <!--SHOP PARAMETERS-->
             <tab id="Shop_parameters" id_parent="CONFIGURE" active="1" enabled="1" hide_host_mode="0" icon="settings">
                 <class_name>ShopParameters</class_name>
+                <wording>Shop Parameters</wording>
+                <wording_domain>Admin.Navigation.Menu</wording_domain>
             </tab>
 
                 <tab id="General" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentPreferences</class_name>
+                    <wording>General</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="General_1" id_parent="General" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminPreferences</class_name>
+                        <wording>General</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Maintenance" id_parent="General" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminMaintenance</class_name>
+                        <wording>Maintenance</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Order_settings" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentOrderPreferences</class_name>
+                    <wording>Order Settings</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Order_settings_2" id_parent="Order_settings" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminOrderPreferences</class_name>
+                        <wording>Order Settings</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Statuses" id_parent="Order_settings" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStatuses</class_name>
+                        <wording>Statuses</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Products_1" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminPPreferences</class_name>
+                    <wording>Product Settings</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Customer_settings" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentCustomerPreferences</class_name>
+                    <wording>Customer Settings</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Customers_2" id_parent="Customer_settings" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminCustomerPreferences</class_name>
+                        <wording>Customer Settings</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Groups" id_parent="Customer_settings" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminGroups</class_name>
+                        <wording>Groups</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Titles" id_parent="Customer_settings" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminGenders</class_name>
+                        <wording>Titles</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Contact" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentStores</class_name>
+                    <wording>Contact</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Contacts" id_parent="Contact" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminContacts</class_name>
+                        <wording>Contacts</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Store_Contacts" id_parent="Contact" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminStores</class_name>
+                        <wording>Stores</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Traffic" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentMeta</class_name>
+                    <wording>Traffic &amp; SEO</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="SEO_URLs" id_parent="Traffic" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminMeta</class_name>
+                        <wording>SEO &amp; URLs</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Search_Engines" id_parent="Traffic" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminSearchEngines</class_name>
+                        <wording>Search Engines</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Referrers" id_parent="Traffic" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminReferrers</class_name>
+                        <wording>Referrers</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Search" id_parent="Shop_parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentSearchConf</class_name>
+                    <wording>Search</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Search_1" id_parent="Search" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminSearchConf</class_name>
+                        <wording>Search</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Tags" id_parent="Search" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminTags</class_name>
+                        <wording>Tags</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
             <!--ADVANCED PARAMETERS-->
             <tab id="Advanced_Parameters" id_parent="CONFIGURE" active="1" enabled="1" hide_host_mode="0" icon="settings_applications">
                 <class_name>AdminAdvancedParameters</class_name>
+                <wording>Advanced Parameters</wording>
+                <wording_domain>Admin.Navigation.Menu</wording_domain>
             </tab>
 
                 <tab id="Tabs" id_parent="Advanced_Parameters" active="1" enabled="1"  hide_host_mode="0" icon="">
@@ -388,56 +596,88 @@
                 </tab>
                 <tab id="Information" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminInformation</class_name>
+                    <wording>Information</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Performance" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminPerformance</class_name>
+                    <wording>Performance</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Administration" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminAdminPreferences</class_name>
+                    <wording>Administration</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="E-mail" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminEmails</class_name>
+                    <wording>E-mail</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="CSV_Import" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminImport</class_name>
+                    <wording>Import</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                 <tab id="Employees" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentEmployees</class_name>
+                    <wording>Team</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="Employees_1" id_parent="Employees" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminEmployees</class_name>
+                        <wording>Employees</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Profiles" id_parent="Employees" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminProfiles</class_name>
+                        <wording>Profiles</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Permissions" id_parent="Employees" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminAccess</class_name>
+                        <wording>Permissions</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Database" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminParentRequestSql</class_name>
+                    <wording>Database</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
                     <tab id="SQL_Manager" id_parent="Database" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminRequestSql</class_name>
+                        <wording>SQL Manager</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="DB_Backup" id_parent="Database" active="1" enabled="1" hide_host_mode="0" icon="">
                         <class_name>AdminBackup</class_name>
+                        <wording>DB Backup</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Logs" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminLogs</class_name>
+                    <wording>Logs</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Webservice" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminWebservice</class_name>
+                    <wording>Webservice</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Multistore" id_parent="Advanced_Parameters" active="0" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminShopGroup</class_name>
+                    <wording>Multistore</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="Multistore" id_parent="Advanced_Parameters" active="0" enabled="1" hide_host_mode="0" icon="">
                     <class_name>AdminShopUrl</class_name>
+                    <wording>Multistore</wording>
+                    <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                 <tab id="FeatureFlag" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                   <class_name>AdminFeatureFlag</class_name>
@@ -445,16 +685,23 @@
 
       <!--QUICK ACCESS-->
       <tab id="Quick_Access" id_parent="-1" active="1" enabled="1" hide_host_mode="0" icon="">
-        <class_name>AdminQuickAccesses</class_name>
+          <class_name>AdminQuickAccesses</class_name>
+          <wording>Quick Access</wording>
+          <wording_domain>Admin.Navigation.Menu</wording_domain>
       </tab>
 
       <!--DEFAULT-->
       <tab id="DEFAULT" id_parent="" active="1" enabled="1" hide_host_mode="0" icon="">
-        <class_name>DEFAULT</class_name>
+          <class_name>DEFAULT</class_name>
+          <wording>More</wording>
+          <wording_domain>Admin.Navigation.Menu</wording_domain>
       </tab>
 
       <tab id="Patterns" id_parent="-1" active="1" enabled="1" hide_host_mode="0" icon="">
-        <class_name>AdminPatterns</class_name>
+          <class_name>AdminPatterns</class_name>
+          <wording/>
+          <wording_domain/>
       </tab>
     </entities>
 </entity_tab>
+

--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -683,6 +683,8 @@
                 </tab>
                 <tab id="FeatureFlag" id_parent="Advanced_Parameters" active="1" enabled="1" hide_host_mode="0" icon="">
                   <class_name>AdminFeatureFlag</class_name>
+                  <wording>Experimental Features</wording>
+                  <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
 
       <!--QUICK ACCESS-->

--- a/install-dev/langs/en/data/tab.xml
+++ b/install-dev/langs/en/data/tab.xml
@@ -113,7 +113,7 @@
     <tab id="Stats" name="Stats" />
     <tab id="Statuses" name="Statuses" />
     <tab id="Stock_Coverage" name="Stock Coverage" />
-    <tab id="Stock_Management" name="Stock Management" />
+    <tab id="Stock_Management_Parent" name="Stock Management" />
     <tab id="Stock_Movement" name="Stock Movement" />
     <tab id="Stock" name="Stocks" />
     <tab id="Store_Contacts" name="Stores" />

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -45,6 +45,9 @@ ALTER TABLE `PREFIX_log`
   ADD `in_all_shops` TINYINT(1) unsigned NOT NULL DEFAULT '0'
 ;
 
+ALTER TABLE `PREFIX_tab` ADD `wording` VARCHAR(196) NOT NULL  DEFAULT '' AFTER `icon`;
+ALTER TABLE `PREFIX_tab` ADD `wording_domain` VARCHAR(196) NOT NULL DEFAULT '' AFTER `wording`;
+
 UPDATE `PREFIX_product` SET `location` = '' WHERE `location` IS NULL;
 ALTER TABLE `PREFIX_product` MODIFY COLUMN `location` VARCHAR(255) NOT NULL DEFAULT '';
 UPDATE `PREFIX_product_attribute` SET `location` = '' WHERE `location` IS NULL;

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -45,8 +45,8 @@ ALTER TABLE `PREFIX_log`
   ADD `in_all_shops` TINYINT(1) unsigned NOT NULL DEFAULT '0'
 ;
 
-ALTER TABLE `PREFIX_tab` ADD `wording` VARCHAR(196) NOT NULL  DEFAULT '' AFTER `icon`;
-ALTER TABLE `PREFIX_tab` ADD `wording_domain` VARCHAR(196) NOT NULL DEFAULT '' AFTER `wording`;
+ALTER TABLE `PREFIX_tab` ADD `wording` VARCHAR(196) DEFAULT NULL AFTER `icon`;
+ALTER TABLE `PREFIX_tab` ADD `wording_domain` VARCHAR(196) DEFAULT NULL AFTER `wording`;
 
 UPDATE `PREFIX_product` SET `location` = '' WHERE `location` IS NULL;
 ALTER TABLE `PREFIX_product` MODIFY COLUMN `location` VARCHAR(255) NOT NULL DEFAULT '';

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -45,8 +45,8 @@ ALTER TABLE `PREFIX_log`
   ADD `in_all_shops` TINYINT(1) unsigned NOT NULL DEFAULT '0'
 ;
 
-ALTER TABLE `PREFIX_tab` ADD `wording` VARCHAR(196) DEFAULT NULL AFTER `icon`;
-ALTER TABLE `PREFIX_tab` ADD `wording_domain` VARCHAR(196) DEFAULT NULL AFTER `wording`;
+ALTER TABLE `PREFIX_tab` ADD `wording` VARCHAR(255) DEFAULT NULL AFTER `icon`;
+ALTER TABLE `PREFIX_tab` ADD `wording_domain` VARCHAR(255) DEFAULT NULL AFTER `wording`;
 
 UPDATE `PREFIX_product` SET `location` = '' WHERE `location` IS NULL;
 ALTER TABLE `PREFIX_product` MODIFY COLUMN `location` VARCHAR(255) NOT NULL DEFAULT '';

--- a/src/Adapter/EntityTranslation/DataLangClassNameNotFoundException.php
+++ b/src/Adapter/EntityTranslation/DataLangClassNameNotFoundException.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
+
+class DataLangClassNameNotFoundException extends \RuntimeException
+{
+}

--- a/src/Adapter/EntityTranslation/DataLangFactory.php
+++ b/src/Adapter/EntityTranslation/DataLangFactory.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
+
+use DataLangCore;
+use Doctrine\Common\Inflector\Inflector;
+use PrestaShopBundle\Translation\TranslatorInterface;
+
+/**
+ * Builds instances of DataLang classes
+ */
+class DataLangFactory
+{
+    /**
+     * @var string
+     */
+    private $dbPrefix;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @param string $dbPrefix
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(string $dbPrefix, TranslatorInterface $translator)
+    {
+        $this->dbPrefix = $dbPrefix;
+        $this->translator = $translator;
+    }
+
+    /**
+     * Returns the appropriate DataLang class name using a table name as source. Note: the class may not exist.
+     *
+     * @param string $tableName Table name, accepts with and without db prefix and _lang suffix
+     *
+     * @return string dataLang class name
+     */
+    public function getClassNameFromTable(string $tableName): string
+    {
+        $tableName = $this->removeDbPrefixIfPresent($tableName);
+        $tableName = $this->ensureLangSuffix($tableName);
+
+        return Inflector::classify($tableName);
+    }
+
+    /**
+     * Instantiates the appropriate DataLang class for the provided locale
+     *
+     * @param string $className Class name to instantiate
+     * @param string $locale IETF language tag
+     *
+     * @return DataLangCore
+     *
+     * @throws DataLangClassNameNotFoundException
+     */
+    public function buildFromClassName(string $className, string $locale): DataLangCore
+    {
+        if (!class_exists($className)) {
+            throw new DataLangClassNameNotFoundException(sprintf("Class name \"%s\" doesn't exist", $className));
+        }
+
+        /** @var DataLangCore $classObject */
+        $classObject = new $className($locale, $this->translator);
+
+        return $classObject;
+    }
+
+    /**
+     * Instantiates the appropriate DataLang class for the provided table name and locale code
+     *
+     * @param string $tableName Table name (accepts with and without db prefix and _lang suffix)
+     * @param string $locale IETF language tag
+     *
+     * @return DataLangCore
+     */
+    public function buildFromTableName(string $tableName, string $locale): DataLangCore
+    {
+        return $this->buildFromClassName($this->getClassNameFromTable($tableName), $locale);
+    }
+
+    /**
+     * Removes the db prefix from the table name if present
+     *
+     * @param string $tableName
+     *
+     * @return string
+     */
+    private function removeDbPrefixIfPresent(string $tableName): string
+    {
+        $length = strlen($this->dbPrefix);
+        if (substr($tableName, 0, $length) === $this->dbPrefix) {
+            $tableName = substr($tableName, $length - 1) ?? '';
+        }
+
+        return $tableName;
+    }
+
+    /**
+     * Adds the _lang suffix if not present
+     *
+     * @param string $tableName
+     *
+     * @return string
+     */
+    private function ensureLangSuffix(string $tableName): string
+    {
+        if (substr($tableName, -5) !== '_lang') {
+            $tableName .= '_lang';
+        }
+
+        return $tableName;
+    }
+}

--- a/src/Adapter/EntityTranslation/DataLangFactory.php
+++ b/src/Adapter/EntityTranslation/DataLangFactory.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
 
 use DataLangCore;
 use Doctrine\Common\Inflector\Inflector;
+use PrestaShop\PrestaShop\Adapter\EntityTranslation\Exception\DataLangClassNameNotFoundException;
 use PrestaShopBundle\Translation\TranslatorInterface;
 
 /**

--- a/src/Adapter/EntityTranslation/DataLangFactory.php
+++ b/src/Adapter/EntityTranslation/DataLangFactory.php
@@ -25,6 +25,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
 
 use DataLangCore;

--- a/src/Adapter/EntityTranslation/DataLangFactory.php
+++ b/src/Adapter/EntityTranslation/DataLangFactory.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-
+declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
 
 use DataLangCore;

--- a/src/Adapter/EntityTranslation/EntityTranslator.php
+++ b/src/Adapter/EntityTranslation/EntityTranslator.php
@@ -68,18 +68,26 @@ class EntityTranslator implements EntityTranslatorInterface
     protected $shopId;
 
     /**
+     * @var string
+     */
+    protected $dbPrefix;
+
+    /**
      * @param Db $db
+     * @param string $dbPrefix
      * @param TranslatorInterface $translator
      * @param DataLangCore $dataLang
      */
     public function __construct(
         Db $db,
+        string $dbPrefix,
         TranslatorInterface $translator,
         DataLangCore $dataLang
     ) {
         //$this->translatorLanguageLoader = new TranslatorLanguageLoader(true);
         $this->dataLang = $dataLang;
         $this->db = $db;
+        $this->dbPrefix = $dbPrefix;
         $this->translator = $translator;
         $this->tableName = $this->buildTableNameFromDataLang($dataLang);
     }
@@ -229,8 +237,8 @@ class EntityTranslator implements EntityTranslatorInterface
     private function buildTableNameFromDataLang(DataLangCore $dataLang): string
     {
         $tableName = Inflector::tableize(get_class($dataLang));
-        if (substr($tableName, 0, strlen(_DB_PREFIX_)) !== _DB_PREFIX_) {
-            $tableName = _DB_PREFIX_ . $tableName;
+        if (substr($tableName, 0, strlen($this->dbPrefix)) !== $this->dbPrefix) {
+            $tableName = $this->dbPrefix . $tableName;
         }
 
         return $tableName;

--- a/src/Adapter/EntityTranslation/EntityTranslator.php
+++ b/src/Adapter/EntityTranslation/EntityTranslator.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
+
+use DataLangCore;
+use Db;
+use Doctrine\Common\Inflector\Inflector;
+use Language;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Translation\EntityTranslatorInterface;
+use PrestaShopBundle\Translation\TranslatorInterface;
+
+/**
+ * Translates an entity in database using DataLang classes
+ */
+class EntityTranslator implements EntityTranslatorInterface
+{
+    /**
+     * @var DataLangCore
+     */
+    protected $dataLang;
+
+    /**
+     * @var Db
+     */
+    protected $db;
+
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
+     * @var string
+     */
+    protected $tableName;
+
+    /**
+     * @var int
+     */
+    protected $shopId;
+
+    /**
+     * @param Db $db
+     * @param TranslatorInterface $translator
+     * @param DataLangCore $dataLang
+     */
+    public function __construct(
+        Db $db,
+        TranslatorInterface $translator,
+        DataLangCore $dataLang
+    ) {
+        //$this->translatorLanguageLoader = new TranslatorLanguageLoader(true);
+        $this->dataLang = $dataLang;
+        $this->db = $db;
+        $this->translator = $translator;
+        $this->tableName = $this->buildTableNameFromDataLang($dataLang);
+    }
+
+    /**
+     * Translate the entity's data in database using reverse translation technique
+     *
+     * @param int $languageId
+     * @param int $shopId
+     *
+     * @throws LanguageNotFoundException
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    public function translate(int $languageId, int $shopId)
+    {
+        $lang = new Language($languageId);
+        if (empty($lang->id)) {
+            throw new LanguageNotFoundException(new LanguageId($languageId));
+        }
+
+        $tableNameSql = bqSQL($this->tableName);
+
+        $shopFieldExists = $this->shopFieldExists($tableNameSql);
+
+        // get table data
+        $sql = "SELECT * FROM `$tableNameSql` WHERE `id_lang` = $languageId"
+            . ($shopFieldExists ? sprintf(' AND `id_shop` = %d', $this->shopId) : '');
+
+        $tableData = $this->db->executeS($sql, true, false);
+
+        if (!empty($tableData)) {
+            $keys = $this->dataLang->getKeys();
+            $fieldsToUpdate = $this->dataLang->getFieldsToUpdate();
+
+            foreach ($tableData as $data) {
+                $updateWhere = [];
+                $updateField = [];
+
+                // Construct update where
+                foreach ($keys as $key) {
+                    $updateWhere[] = '`' . bqSQL($key) . '` = "' . pSQL($data[$key]) . '"';
+                }
+
+                // Construct update field
+                foreach ($fieldsToUpdate as $fieldName) {
+                    if ('url_rewrite' === $fieldName && Language::$locale_crowdin_lang === $lang->locale) {
+                        continue;
+                    }
+
+                    $translatedField = $this->doTranslate($data, $fieldName);
+
+                    if (!empty($translatedField) && $translatedField != $data[$fieldName]) {
+                        $updateField[] = '`' . bqSQL($fieldName) . '` = "' . pSQL($translatedField) . '"';
+                    }
+                }
+
+                // Update table
+                if (!empty($updateWhere) && !empty($updateField)) {
+                    $updateWhere = implode(' AND ', $updateWhere);
+                    $updateField = implode(', ', $updateField);
+
+                    $sql = "UPDATE `$tableNameSql` SET $updateField
+                        WHERE $updateWhere AND `id_lang` = $languageId"
+                        . ($shopFieldExists ? sprintf(' AND `id_shop` = %d', $this->shopId) : '')
+                        . ' LIMIT 1';
+
+                    $this->db->execute($sql);
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns true if an id_shop field exists in database
+     *
+     * @param string $tableNameSql
+     *
+     * @return bool
+     *
+     * @throws \PrestaShopDatabaseException
+     */
+    protected function shopFieldExists(string $tableNameSql): bool
+    {
+        $columns = $this->db->executeS(
+            sprintf('SHOW COLUMNS FROM `%s`', $tableNameSql)
+        );
+
+        foreach ($columns as $column) {
+            if ($column['Field'] == 'id_shop') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieves the original wording via reverse dictionary search (aka "untranslation")
+     *
+     * @param array $data
+     * @param string $fieldName
+     *
+     * @return string
+     */
+    protected function getSourceString(array $data, string $fieldName): string
+    {
+        return $this->translator->getSourceString($data[$fieldName], $this->dataLang->getDomain());
+    }
+
+    /**
+     * Finds out the original wording and translates it
+     *
+     * @param $data
+     * @param $fieldName
+     *
+     * @return string
+     */
+    protected function doTranslate(array $data, string $fieldName): string
+    {
+        $untranslated = $this->getSourceString($data, $fieldName);
+
+        return $this->dataLang->getFieldValue($fieldName, $untranslated);
+    }
+
+    /**
+     * Builds the table name using the DataLang class as source
+     *
+     * @param DataLangCore $dataLang
+     *
+     * @return string The table name, including prefix
+     */
+    private function buildTableNameFromDataLang(DataLangCore $dataLang): string
+    {
+        $tableName = Inflector::tableize(get_class($dataLang));
+        if (substr($tableName, 0, strlen(_DB_PREFIX_)) !== _DB_PREFIX_) {
+            $tableName = _DB_PREFIX_ . $tableName;
+        }
+
+        return $tableName;
+    }
+}

--- a/src/Adapter/EntityTranslation/EntityTranslator.php
+++ b/src/Adapter/EntityTranslation/EntityTranslator.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
 use DataLangCore;
 use Db;
 use Doctrine\Common\Inflector\Inflector;
+use InvalidArgumentException;
 use Language;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
@@ -184,23 +185,32 @@ class EntityTranslator implements EntityTranslatorInterface
     /**
      * Retrieves the original wording via reverse dictionary search (aka "untranslation")
      *
-     * @param array $data
-     * @param string $fieldName
+     * @param array $data Database record
+     * @param string $fieldName Name of the field from $data to translate
      *
-     * @return string
+     * @return string "Untranslated" value
      */
     protected function getSourceString(array $data, string $fieldName): string
     {
+        if (!array_key_exists($fieldName, $data)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Unable to reverse translate entity field "%s" because it\'s not defined in the provided database record',
+                    $fieldName
+                )
+            );
+        }
+
         return $this->translator->getSourceString($data[$fieldName], $this->dataLang->getDomain());
     }
 
     /**
      * Finds out the original wording and translates it
      *
-     * @param $data
-     * @param $fieldName
+     * @param array $data Database record
+     * @param string $fieldName Name of the field from $data to translate
      *
-     * @return string
+     * @return string Translated value
      */
     protected function doTranslate(array $data, string $fieldName): string
     {

--- a/src/Adapter/EntityTranslation/EntityTranslator.php
+++ b/src/Adapter/EntityTranslation/EntityTranslator.php
@@ -237,7 +237,7 @@ class EntityTranslator implements EntityTranslatorInterface
      */
     private function buildTableNameFromDataLang(DataLangCore $dataLang): string
     {
-        $tableName = Inflector::tableize(get_class($dataLang));
+        $tableName = $this->dataLang->getTableName();
         if (substr($tableName, 0, strlen($this->dbPrefix)) !== $this->dbPrefix) {
             $tableName = $this->dbPrefix . $tableName;
         }

--- a/src/Adapter/EntityTranslation/EntityTranslator.php
+++ b/src/Adapter/EntityTranslation/EntityTranslator.php
@@ -84,7 +84,6 @@ class EntityTranslator implements EntityTranslatorInterface
         TranslatorInterface $translator,
         DataLangCore $dataLang
     ) {
-        //$this->translatorLanguageLoader = new TranslatorLanguageLoader(true);
         $this->dataLang = $dataLang;
         $this->db = $db;
         $this->dbPrefix = $dbPrefix;

--- a/src/Adapter/EntityTranslation/EntityTranslator.php
+++ b/src/Adapter/EntityTranslation/EntityTranslator.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
 

--- a/src/Adapter/EntityTranslation/EntityTranslator.php
+++ b/src/Adapter/EntityTranslation/EntityTranslator.php
@@ -30,7 +30,6 @@ namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
 
 use DataLangCore;
 use Db;
-use Doctrine\Common\Inflector\Inflector;
 use InvalidArgumentException;
 use Language;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;

--- a/src/Adapter/EntityTranslation/EntityTranslator.php
+++ b/src/Adapter/EntityTranslation/EntityTranslator.php
@@ -177,11 +177,11 @@ class EntityTranslator implements EntityTranslatorInterface
     protected function shopFieldExists(string $tableNameSql): bool
     {
         $columns = $this->db->executeS(
-            sprintf('SHOW COLUMNS FROM `%s`', $tableNameSql)
+            sprintf('SHOW COLUMNS FROM `%s`', bqSQL($tableNameSql))
         );
 
         foreach ($columns as $column) {
-            if ($column['Field'] == 'id_shop') {
+            if ($column['Field'] === 'id_shop') {
                 return true;
             }
         }

--- a/src/Adapter/EntityTranslation/EntityTranslatorFactory.php
+++ b/src/Adapter/EntityTranslation/EntityTranslatorFactory.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
+
+use DataLangCore;
+use Db;
+use PrestaShop\PrestaShop\Core\Translation\EntityTranslatorInterface;
+use PrestaShopBundle\Translation\TranslatorInterface;
+use TabLang;
+
+/**
+ * Builds entity translators
+ */
+class EntityTranslatorFactory
+{
+    /**
+     * @var Db
+     */
+    private $db;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var DataLangFactory
+     */
+    private $dataLangFactory;
+
+    /**
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->db = Db::getInstance();
+        $this->dataLangFactory = new DataLangFactory(_DB_PREFIX_, $translator);
+        $this->translator = $translator;
+    }
+
+    /**
+     * Builds an entity translator based on a table name
+     *
+     * @param string $tableName Table name (accepts with or without db prefix and _lang suffix)
+     * @param string $locale IETF language tag
+     *
+     * @return EntityTranslatorInterface
+     */
+    public function buildFromTableName(string $tableName, string $locale): EntityTranslatorInterface
+    {
+        $dataLang = $this->dataLangFactory->buildFromTableName($tableName, $locale);
+
+        return $this->build($dataLang);
+    }
+
+    /**
+     * Builds an entity translator
+     *
+     * @param DataLangCore $dataLang DataLang class for this entity
+     *
+     * @return EntityTranslatorInterface
+     */
+    public function build(DataLangCore $dataLang): EntityTranslatorInterface
+    {
+        $selfTranslator = ($dataLang instanceof TabLang)
+            ? TabTranslator::class
+            : EntityTranslator::class;
+
+        return new $selfTranslator(
+            $this->db,
+            $this->translator,
+            $dataLang
+        );
+    }
+}

--- a/src/Adapter/EntityTranslation/EntityTranslatorFactory.php
+++ b/src/Adapter/EntityTranslation/EntityTranslatorFactory.php
@@ -54,12 +54,18 @@ class EntityTranslatorFactory
     private $dataLangFactory;
 
     /**
+     * @var string
+     */
+    private $dbPrefix;
+
+    /**
      * @param TranslatorInterface $translator
      */
     public function __construct(TranslatorInterface $translator)
     {
         $this->db = Db::getInstance();
-        $this->dataLangFactory = new DataLangFactory(_DB_PREFIX_, $translator);
+        $this->dbPrefix = _DB_PREFIX_;
+        $this->dataLangFactory = new DataLangFactory($this->dbPrefix, $translator);
         $this->translator = $translator;
     }
 
@@ -93,6 +99,7 @@ class EntityTranslatorFactory
 
         return new $selfTranslator(
             $this->db,
+            $this->dbPrefix,
             $this->translator,
             $dataLang
         );

--- a/src/Adapter/EntityTranslation/EntityTranslatorFactory.php
+++ b/src/Adapter/EntityTranslation/EntityTranslatorFactory.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
 

--- a/src/Adapter/EntityTranslation/Exception/DataLangClassNameNotFoundException.php
+++ b/src/Adapter/EntityTranslation/Exception/DataLangClassNameNotFoundException.php
@@ -25,7 +25,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
+namespace PrestaShop\PrestaShop\Adapter\EntityTranslation\Exception;
 
 class DataLangClassNameNotFoundException extends \RuntimeException
 {

--- a/src/Adapter/EntityTranslation/Exception/DataLangClassNameNotFoundException.php
+++ b/src/Adapter/EntityTranslation/Exception/DataLangClassNameNotFoundException.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\EntityTranslation\Exception;
 

--- a/src/Adapter/EntityTranslation/TabTranslator.php
+++ b/src/Adapter/EntityTranslation/TabTranslator.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
+
+/**
+ * Translates tabs (menu items) in database using DataLang
+ */
+class TabTranslator extends EntityTranslator
+{
+    const TABLE_NAME = _DB_PREFIX_ . 'tab';
+
+    /**
+     * @var array[] Sets of wording, wording_domain
+     */
+    private $sourceIndex = [];
+
+    /**
+     * Translate using wordings
+     * {@inheritdoc}
+     */
+    public function translate(int $languageId, int $shopId)
+    {
+        $this->sourceIndex = $this->buildIndex();
+        parent::translate($languageId, $shopId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doTranslate(array $data, string $fieldName): string
+    {
+        $message = ($this->sourceIndex[$data['id_tab']]) ?? $this->getSourceString($data, $fieldName);
+
+        return $this->dataLang->getFieldValue($fieldName, $message);
+    }
+
+    /**
+     * Builds an index of source wordings from the entity table
+     *
+     * @return array[] Array of [wording, wording_domain], indexed by id_tab
+     *
+     * @throws \PrestaShopDatabaseException
+     */
+    private function buildIndex(): array
+    {
+        $tableName = self::TABLE_NAME;
+
+        $sql = "SELECT id_tab, wording, wording_domain FROM $tableName";
+        $results = $this->db->executeS($sql);
+
+        $souceIndex = [];
+        foreach ($results as $result) {
+            $souceIndex[$result['id_tab']] = [
+                $result['wording'],
+                $result['wording_domain'],
+            ];
+        }
+
+        return $souceIndex;
+    }
+}

--- a/src/Adapter/EntityTranslation/TabTranslator.php
+++ b/src/Adapter/EntityTranslation/TabTranslator.php
@@ -32,8 +32,6 @@ namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
  */
 class TabTranslator extends EntityTranslator
 {
-    const TABLE_NAME = _DB_PREFIX_ . 'tab';
-
     /**
      * @var array[] Sets of wording, wording_domain
      */
@@ -68,7 +66,7 @@ class TabTranslator extends EntityTranslator
      */
     private function buildIndex(): array
     {
-        $tableName = self::TABLE_NAME;
+        $tableName = $this->dbPrefix . 'tab';
 
         $sql = "SELECT id_tab, wording, wording_domain FROM $tableName";
         $results = $this->db->executeS($sql);

--- a/src/Adapter/EntityTranslation/TabTranslator.php
+++ b/src/Adapter/EntityTranslation/TabTranslator.php
@@ -43,7 +43,7 @@ class TabTranslator extends EntityTranslator
      * Translate using wordings
      * {@inheritdoc}
      */
-    public function translate(int $languageId, int $shopId)
+    public function translate(int $languageId, int $shopId): void
     {
         $this->sourceIndex = $this->buildIndex();
         parent::translate($languageId, $shopId);

--- a/src/Adapter/EntityTranslation/TabTranslator.php
+++ b/src/Adapter/EntityTranslation/TabTranslator.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\EntityTranslation;
 

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -367,6 +367,8 @@ class ModuleTabRegister
         $tab->name = $this->getTabNames($tabDetails->get('name', $tab->class_name));
         $tab->icon = $tabDetails->get('icon');
         $tab->id_parent = $this->findParentId($tabDetails);
+        $tab->wording = $tabDetails->get('wording');
+        $tab->wording_domain = $tabDetails->get('wording_domain');
 
         if (!$tab->save()) {
             throw new Exception($this->translator->trans('Failed to install admin tab "%name%".', ['%name%' => $tab->name], 'Admin.Modules.Notification'));

--- a/src/Core/Translation/EntityTranslatorInterface.php
+++ b/src/Core/Translation/EntityTranslatorInterface.php
@@ -37,5 +37,5 @@ interface EntityTranslatorInterface
      * @param int $languageId
      * @param int $shopId
      */
-    public function translate(int $languageId, int $shopId);
+    public function translate(int $languageId, int $shopId): void;
 }

--- a/src/Core/Translation/EntityTranslatorInterface.php
+++ b/src/Core/Translation/EntityTranslatorInterface.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation;
 

--- a/src/Core/Translation/EntityTranslatorInterface.php
+++ b/src/Core/Translation/EntityTranslatorInterface.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Translation;
+
+/**
+ * Translates multi language items in database using DataLang classes
+ */
+interface EntityTranslatorInterface
+{
+    /**
+     * Executes the translation
+     *
+     * @param int $languageId
+     * @param int $shopId
+     */
+    public function translate(int $languageId, int $shopId);
+}

--- a/src/PrestaShopBundle/Entity/Tab.php
+++ b/src/PrestaShopBundle/Entity/Tab.php
@@ -111,14 +111,14 @@ class Tab
     /**
      * @var string
      *
-     * @ORM\Column(name="wording", type="string", length=194, nullable=true)
+     * @ORM\Column(name="wording", type="string", length=255, nullable=true)
      */
     private $wording;
 
     /**
      * @var string
      *
-     * @ORM\Column(name="wording_domain", type="string", length=194, nullable=true)
+     * @ORM\Column(name="wording_domain", type="string", length=255, nullable=true)
      */
     private $wordingDomain;
 

--- a/src/PrestaShopBundle/Entity/Tab.php
+++ b/src/PrestaShopBundle/Entity/Tab.php
@@ -111,14 +111,14 @@ class Tab
     /**
      * @var string
      *
-     * @ORM\Column(name="wording", type="string", length=194)
+     * @ORM\Column(name="wording", type="string", length=194, nullable=true)
      */
     private $wording;
 
     /**
      * @var string
      *
-     * @ORM\Column(name="wording_domain", type="string", length=194)
+     * @ORM\Column(name="wording_domain", type="string", length=194, nullable=true)
      */
     private $wordingDomain;
 
@@ -170,6 +170,22 @@ class Tab
     public function getTabLangs()
     {
         return $this->tabLangs;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getWording()
+    {
+        return $this->wording;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getWordingDomain()
+    {
+        return $this->wordingDomain;
     }
 
     /**

--- a/src/PrestaShopBundle/Entity/Tab.php
+++ b/src/PrestaShopBundle/Entity/Tab.php
@@ -109,6 +109,20 @@ class Tab
     private $icon;
 
     /**
+     * @var string
+     *
+     * @ORM\Column(name="wording", type="string", length=194)
+     */
+    private $wording;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="wording_domain", type="string", length=194)
+     */
+    private $wordingDomain;
+
+    /**
      * @ORM\OneToMany(targetEntity="PrestaShopBundle\Entity\TabLang", mappedBy="id")
      */
     private $tabLangs;

--- a/src/PrestaShopBundle/Entity/Tab.php
+++ b/src/PrestaShopBundle/Entity/Tab.php
@@ -109,14 +109,14 @@ class Tab
     private $icon;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="wording", type="string", length=255, nullable=true)
      */
     private $wording;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="wording_domain", type="string", length=255, nullable=true)
      */
@@ -175,7 +175,7 @@ class Tab
     /**
      * @return string|null
      */
-    public function getWording()
+    public function getWording(): ?string
     {
         return $this->wording;
     }
@@ -183,7 +183,7 @@ class Tab
     /**
      * @return string|null
      */
-    public function getWordingDomain()
+    public function getWordingDomain(): ?string
     {
         return $this->wordingDomain;
     }

--- a/src/PrestaShopBundle/Install/EntityLoader/FileLoader.php
+++ b/src/PrestaShopBundle/Install/EntityLoader/FileLoader.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Install\EntityLoader;
+
+use PrestashopInstallerException;
+
+class FileLoader
+{
+    private $cache = [];
+
+    /**
+     * @var string
+     */
+    private $dataPath;
+
+    /**
+     * @var string
+     */
+    private $langPath;
+
+    public function __construct(string $dataPath, string $langPath)
+    {
+        $this->dataPath = $dataPath;
+        $this->langPath = $langPath;
+    }
+
+    /**
+     * Load an entity XML file.
+     *
+     * @param string $entity Name of the entity to load (eg. 'tab')
+     * @param string|null $iso Language in which to load said entity. If not found, will fall back to default language.
+     *
+     * @return SimplexmlElement|null
+     *
+     * @throws PrestashopInstallerException
+     */
+    public function load(string $entity, $iso = null): ?\SimpleXMLElement
+    {
+        if (!isset($this->cache[$entity][$iso])) {
+            // skip hidden files on macos (see https://github.com/PrestaShop/PrestaShop/commit/dd2d7491b483c223b3fe8c010d093b8e6e82f0e6)
+            if (in_array($entity[0], ['.', '_'])) {
+                return null;
+            }
+
+            $path = $this->dataPath . $entity . '.xml';
+            if ($iso) {
+                $path = $this->langPath . $this->getFallBackToDefaultEntityLanguage($iso, $entity) . '/data/' . $entity . '.xml';
+            }
+
+            if (!file_exists($path)) {
+                throw new PrestashopInstallerException('XML data file ' . $entity . '.xml not found');
+            }
+
+            $this->cache[$entity][$iso] = @simplexml_load_file($path, 'SimplexmlElement');
+            if (!$this->cache[$entity][$iso]) {
+                throw new PrestashopInstallerException('XML data file ' . $entity . '.xml invalid');
+            }
+        }
+
+        return $this->cache[$entity][$iso];
+    }
+
+    /**
+     * @param string $entity
+     * @param string|null $iso
+     */
+    public function flushCache(string $entity, ?string $iso = null)
+    {
+        if (!empty($iso)) {
+            unset($this->cache[$entity][$iso]);
+        } else {
+            unset($this->cache[$entity]);
+        }
+    }
+
+    private function getFallBackToDefaultLanguage(string $iso)
+    {
+        return file_exists($this->langPath . $iso . '/data/') ? $iso : 'en';
+    }
+
+    private function getFallBackToDefaultEntityLanguage($iso, $entity)
+    {
+        if ($this->getFallBackToDefaultLanguage($iso) === 'en') {
+            return 'en';
+        }
+
+        return file_exists($this->langPath . $this->getFallBackToDefaultLanguage($iso) . '/data/' . $entity . '.xml') ? $iso : 'en';
+    }
+}

--- a/src/PrestaShopBundle/Install/EntityLoader/FileLoader.php
+++ b/src/PrestaShopBundle/Install/EntityLoader/FileLoader.php
@@ -145,7 +145,7 @@ class FileLoader
         // default path
         if (empty($iso)) {
             return [
-                $this->dataPath . $fileName
+                $this->dataPath . $fileName,
             ];
         }
 

--- a/src/PrestaShopBundle/Install/EntityLoader/FileLoader.php
+++ b/src/PrestaShopBundle/Install/EntityLoader/FileLoader.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+declare(strict_types=1);
 
 namespace PrestaShopBundle\Install\EntityLoader;
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -627,6 +627,17 @@ class Install extends AbstractInstall
             }
 
             $errors = [];
+            $locale = $params_lang['locale'];
+
+            /* @todo check if a newer pack is available */
+            if (!EntityLanguage::translationPackIsInCache($locale)) {
+                EntityLanguage::downloadXLFLanguagePack($locale, $errors);
+
+                if (!empty($errors)) {
+                    throw new PrestashopInstallerException($this->translator->trans('Cannot download language pack "%iso%"', ['%iso%' => $iso], 'Install'));
+                }
+            }
+
             $this->callWithUnityAutoincrement(function () use ($iso, $params_lang, &$errors) {
                 EntityLanguage::installLanguagePack($iso, $params_lang, $errors);
             });

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -464,6 +464,10 @@ class Install extends AbstractInstall
     /**
      * PROCESS : populateDatabase
      * Populate database with default data.
+     *
+     * @param string|null $entity [default=null] If provided, entity to populate
+     *
+     * @return bool
      */
     public function populateDatabase($entity = null)
     {

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Install;
 
 use AppKernel;
-use InstallSession;
 use Language as LanguageLegacy;
 use PhpEncryption;
 use PrestaShop\PrestaShop\Adapter\Entity\Cache;

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -618,24 +618,18 @@ class Install extends AbstractInstall
                 'locale' => (string) $xml->locale,
             ];
 
-            if (InstallSession::getInstance()->safe_mode) {
-                $this->callWithUnityAutoincrement(function () use ($iso, $params_lang) {
-                    EntityLanguage::checkAndAddLanguage($iso, false, true, $params_lang);
-                });
-            } else {
-                if (file_exists(_PS_TRANSLATIONS_DIR_ . (string) $iso . '.gzip') == false) {
-                    $language = EntityLanguage::downloadLanguagePack($iso, _PS_INSTALL_VERSION_);
+            if (file_exists(_PS_TRANSLATIONS_DIR_ . (string) $iso . '.gzip') == false) {
+                $language = EntityLanguage::downloadLanguagePack($iso, _PS_INSTALL_VERSION_);
 
-                    if ($language == false) {
-                        throw new PrestashopInstallerException($this->translator->trans('Cannot download language pack "%iso%"', ['%iso%' => $iso], 'Install'));
-                    }
+                if ($language == false) {
+                    throw new PrestashopInstallerException($this->translator->trans('Cannot download language pack "%iso%"', ['%iso%' => $iso], 'Install'));
                 }
-
-                $errors = [];
-                $this->callWithUnityAutoincrement(function () use ($iso, $params_lang, &$errors) {
-                    EntityLanguage::installLanguagePack($iso, $params_lang, $errors);
-                });
             }
+
+            $errors = [];
+            $this->callWithUnityAutoincrement(function () use ($iso, $params_lang, &$errors) {
+                EntityLanguage::installLanguagePack($iso, $params_lang, $errors);
+            });
 
             EntityLanguage::loadLanguages();
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -639,12 +639,8 @@ class Install extends AbstractInstall
             }
 
             $this->callWithUnityAutoincrement(function () use ($iso, $params_lang, &$errors) {
-                EntityLanguage::installLanguagePack($iso, $params_lang, $errors);
+                EntityLanguage::installFirstLanguagePack($iso, $params_lang, $errors);
             });
-
-            EntityLanguage::loadLanguages();
-
-            Tools::clearCache();
 
             if (!$id_lang = EntityLanguage::getIdByIso($iso, true)) {
                 throw new PrestashopInstallerException($this->translator->trans(

--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -388,7 +388,7 @@ class XmlLoader
      */
     public function populateEntityCountry()
     {
-        $xml = $this->loadEntity('country');
+        $xml = $this->fileLoader->load('country');
 
         // Read list of fields
         if (empty($xml->fields)) {

--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -247,8 +247,9 @@ class XmlLoader
      */
     public function populateEntity($entity)
     {
-        if (method_exists($this, 'populateEntity' . Tools::toCamelCase($entity))) {
-            $this->{'populateEntity' . Tools::toCamelCase($entity)}();
+        $populateEntityMethod = 'populateEntity' . Tools::toCamelCase($entity);
+        if (method_exists($this, $populateEntityMethod)) {
+            $this->$populateEntityMethod();
 
             return;
         }
@@ -327,17 +328,18 @@ class XmlLoader
             }
 
             $data = $this->rewriteRelationedData($entity, $data);
-            if (method_exists($this, 'createEntity' . Tools::toCamelCase($entity))) {
+            $createEntityMethod = 'createEntity' . Tools::toCamelCase($entity);
+            if (method_exists($this, $createEntityMethod)) {
                 // Create entity with custom method in current class
-                $method = 'createEntity' . Tools::toCamelCase($entity);
-                $this->$method($identifier, $data, $data_lang);
+                $this->$createEntityMethod($identifier, $data, $data_lang);
             } else {
                 $this->createEntity($entity, $identifier, (string) $xml->fields['class'], $data, $data_lang);
             }
 
             if ($xml->fields['image']) {
-                if (method_exists($this, 'copyImages' . Tools::toCamelCase($entity))) {
-                    $this->{'copyImages' . Tools::toCamelCase($entity)}($identifier, $data);
+                $copyImagesMethod = 'copyImages' . Tools::toCamelCase($entity);
+                if (method_exists($this, $copyImagesMethod)) {
+                    $this->{$copyImagesMethod}($identifier, $data);
                 } else {
                     $this->copyImages($entity, $identifier, (string) $xml->fields['image'], $data);
                 }

--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Adapter\Entity\StockAvailable;
 use PrestaShop\PrestaShop\Adapter\Entity\Tag;
 use PrestaShop\PrestaShop\Adapter\Entity\Tools;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem;
+use PrestaShopBundle\Install\EntityLoader\FileLoader;
 use PrestaShopDatabaseException;
 use PrestashopInstallerException;
 use SimpleXMLElement;
@@ -59,11 +60,6 @@ class XmlLoader
     protected $languages = [];
 
     /**
-     * @var array Store in cache all loaded XML files
-     */
-    protected $cache_xml_entity = [];
-
-    /**
      * @var array List of errors
      */
     protected $errors = [];
@@ -78,6 +74,11 @@ class XmlLoader
     protected $primaries = [];
 
     protected $delayed_inserts = [];
+
+    /**
+     * @var FileLoader
+     */
+    private $fileLoader;
 
     public function __construct()
     {
@@ -108,6 +109,7 @@ class XmlLoader
         $this->data_path = _PS_INSTALL_DATA_PATH_ . 'xml/';
         $this->lang_path = _PS_INSTALL_LANGS_PATH_;
         $this->img_path = _PS_INSTALL_DATA_PATH_ . 'img/';
+        $this->fileLoader = new FileLoader($this->data_path, $this->lang_path);
     }
 
     public function setFixturesPath($path = null)
@@ -120,6 +122,7 @@ class XmlLoader
         $this->data_path = $path . 'data/';
         $this->lang_path = $path . 'langs/';
         $this->img_path = $path . 'img/';
+        $this->fileLoader = new FileLoader($this->data_path, $this->lang_path);
     }
 
     /**
@@ -188,7 +191,7 @@ class XmlLoader
         foreach (scandir($this->data_path) as $file) {
             if (preg_match('#^(.+)\.xml$#', $file, $m)) {
                 $entity = $m[1];
-                $xml = $this->loadEntity($entity);
+                $xml = $this->fileLoader->load($entity);
 
                 // Store entities dependencies (with field type="relation")
                 if ($xml instanceof \SimpleXMLElement && isset($xml->fields, $xml->fields->field)) {
@@ -267,7 +270,7 @@ class XmlLoader
             return;
         }
 
-        $xml = $this->loadEntity($entity);
+        $xml = $this->fileLoader->load($entity);
 
         // Read list of fields
         if (!$xml instanceof \SimpleXMLElement && !empty($xml->fields)) {
@@ -286,7 +289,7 @@ class XmlLoader
                 }
 
                 try {
-                    $xml_langs[$id_lang] = $this->loadEntity($entity, $iso);
+                    $xml_langs[$id_lang] = $this->fileLoader->load($entity, $iso);
                 } catch (PrestashopInstallerException $e) {
                     $xml_langs[$id_lang] = null;
                 }
@@ -363,7 +366,7 @@ class XmlLoader
         }
 
         $this->flushDelayedInserts();
-        unset($this->cache_xml_entity[$this->path_type][$entity]);
+        $this->fileLoader->flushCache($entity);
     }
 
     protected function getFallBackToDefaultLanguage($iso)
@@ -443,7 +446,7 @@ class XmlLoader
                 continue;
             }
 
-            $xml = $this->loadEntity('tag', $this->getFallBackToDefaultLanguage($iso));
+            $xml = $this->fileLoader->load('tag', $this->getFallBackToDefaultLanguage($iso));
             $tags = [];
             foreach ($xml->tag as $tag_node) {
                 $products = trim((string) $tag_node['products']);
@@ -468,41 +471,6 @@ class XmlLoader
     }
 
     /**
-     * Load an entity XML file.
-     *
-     * @param string $entity Name of the entity to load (eg. 'tab')
-     * @param string|null $iso Language in which to load said entity. If not found, will fall back to default language.
-     *
-     * @return \SimpleXMLElement|null
-     *
-     * @throws PrestashopInstallerException
-     */
-    protected function loadEntity($entity, $iso = null)
-    {
-        if (!isset($this->cache_xml_entity[$this->path_type][$entity][$iso])) {
-            if (substr($entity, 0, 1) == '.' || substr($entity, 0, 1) == '_') {
-                return null;
-            }
-
-            $path = $this->data_path . $entity . '.xml';
-            if ($iso) {
-                $path = $this->lang_path . $this->getFallBackToDefaultEntityLanguage($iso, $entity) . '/data/' . $entity . '.xml';
-            }
-
-            if (!file_exists($path)) {
-                throw new PrestashopInstallerException('XML data file ' . $entity . '.xml not found');
-            }
-
-            $this->cache_xml_entity[$this->path_type][$entity][$iso] = @simplexml_load_file($path, 'SimplexmlElement');
-            if (!$this->cache_xml_entity[$this->path_type][$entity][$iso]) {
-                throw new PrestashopInstallerException('XML data file ' . $entity . '.xml invalid');
-            }
-        }
-
-        return $this->cache_xml_entity[$this->path_type][$entity][$iso];
-    }
-
-    /**
      * Check fields related to an other entity, and replace their values by the ID created by the other entity.
      *
      * @param string $entity
@@ -510,7 +478,7 @@ class XmlLoader
      */
     protected function rewriteRelationedData($entity, array $data)
     {
-        $xml = $this->loadEntity($entity);
+        $xml = $this->fileLoader->load($entity);
         foreach ($xml->fields->field as $field) {
             if ($field['relation']) {
                 $id = $this->retrieveId((string) $field['relation'], $data[(string) $field['name']]);
@@ -551,7 +519,7 @@ class XmlLoader
      */
     public function createEntity($entity, $identifier, $classname, array $data, array $data_lang = [])
     {
-        $xml = $this->loadEntity($entity);
+        $xml = $this->fileLoader->load($entity);
         if ($classname) {
             $classname = '\\' . $classname;
             // Create entity with ObjectModel class
@@ -675,7 +643,7 @@ class XmlLoader
         static $position = [];
 
         $entity = 'tab';
-        $xml = $this->loadEntity($entity);
+        $xml = $this->fileLoader->load($entity);
 
         if (!isset($position[$data['id_parent']])) {
             $position[$data['id_parent']] = 0;
@@ -1098,7 +1066,7 @@ class XmlLoader
     public function generateEntitySchema($entity, array $fields, array $config)
     {
         if ($this->entityExists($entity)) {
-            $xml = $this->loadEntity($entity);
+            $xml = $this->fileLoader->load($entity);
         } else {
             $xml = new SimplexmlElement('<entity_' . $entity . ' />');
         }
@@ -1179,7 +1147,7 @@ class XmlLoader
 
     public function generateEntityContent($entity)
     {
-        $xml = $this->loadEntity($entity);
+        $xml = $this->fileLoader->load($entity);
         if (method_exists($this, 'getEntityContents' . Tools::toCamelCase($entity))) {
             $content = $this->{'getEntityContents' . Tools::toCamelCase($entity)}($entity);
         } else {
@@ -1223,7 +1191,7 @@ class XmlLoader
      */
     public function getEntityContents($entity)
     {
-        $xml = $this->loadEntity($entity);
+        $xml = $this->fileLoader->load($entity);
         $primary = (isset($xml->fields['primary']) && $xml->fields['primary']) ? (string) $xml->fields['primary'] : 'id_' . $entity;
         $is_multilang = $this->isMultilang($entity);
 
@@ -1504,7 +1472,7 @@ class XmlLoader
             $this->setError(sprintf('Cannot create directory <i>%s</i>', $backup_path));
         }
 
-        $xml = $this->loadEntity('tab');
+        $xml = $this->fileLoader->load('tab');
         foreach ($xml->entities->tab as $tab) {
             if (file_exists($from_path . $tab->class_name . '.gif')) {
                 copy($from_path . $tab->class_name . '.gif', $backup_path . $tab->class_name . '.gif');

--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -175,6 +175,11 @@ class XmlLoader
         $this->ids = $ids;
     }
 
+    /**
+     * @return string[] Entity names
+     *
+     * @throws PrestashopInstallerException
+     */
     public function getSortedEntities()
     {
         // Browse all XML files from data/xml directory
@@ -229,6 +234,8 @@ class XmlLoader
 
     /**
      * Read all XML files from data folder and populate tables.
+     *
+     * @throws PrestashopInstallerException
      */
     public function populateFromXmlFiles()
     {
@@ -243,7 +250,9 @@ class XmlLoader
     /**
      * Populate an entity.
      *
-     * @param string $entity
+     * @param string $entity Entity name to populate
+     *
+     * @throws PrestashopInstallerException
      */
     public function populateEntity($entity)
     {
@@ -268,6 +277,7 @@ class XmlLoader
         $is_multi_lang_entity = $this->isMultilang($entity);
         $xml_langs = $multilang_columns = [];
         $default_lang = null;
+
         if ($is_multi_lang_entity) {
             $multilang_columns = $this->getColumns($entity, true);
             foreach ($this->languages as $id_lang => $iso) {
@@ -464,6 +474,8 @@ class XmlLoader
      * @param string|null $iso Language in which to load said entity. If not found, will fall back to default language.
      *
      * @return \SimpleXMLElement|null
+     *
+     * @throws PrestashopInstallerException
      */
     protected function loadEntity($entity, $iso = null)
     {
@@ -671,17 +683,19 @@ class XmlLoader
         $data['position'] = $position[$data['id_parent']]++;
 
         // Generate primary key manually
-        $primary = '';
-        $entity_id = 0;
         if (!$xml->fields['primary']) {
             $primary = 'id_' . $entity;
         } elseif (strpos((string) $xml->fields['primary'], ',') === false) {
             $primary = (string) $xml->fields['primary'];
+        } else {
+            $primary = '';
         }
 
         if ($primary) {
             $entity_id = $this->generatePrimary($entity, $primary);
             $data[$primary] = $entity_id;
+        } else {
+            $entity_id = 0;
         }
 
         // Store INSERT queries in order to optimize install with grouped inserts

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -57,7 +57,7 @@ class TranslationService
     /**
      * @param string $locale
      *
-     * @return mixed
+     * @return Lang
      *
      * @throws InvalidLanguageException
      */
@@ -65,6 +65,7 @@ class TranslationService
     {
         $doctrine = $this->container->get('doctrine');
 
+        /** @var Lang $lang */
         $lang = $doctrine->getManager()->getRepository('PrestaShopBundle:Lang')->findOneByLocale($locale);
 
         if (!$lang) {

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -65,10 +65,10 @@ class TranslationService
     {
         $doctrine = $this->container->get('doctrine');
 
-        /** @var Lang $lang */
+        /** @var Lang|null $lang */
         $lang = $doctrine->getManager()->getRepository('PrestaShopBundle:Lang')->findOneByLocale($locale);
 
-        if (!$lang) {
+        if (!$lang instanceof Lang) {
             throw InvalidLanguageException::localeNotFound($locale);
         }
 

--- a/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
+++ b/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
@@ -46,6 +46,6 @@ class DataCollectorTranslator extends BaseTranslator implements TranslatorInterf
      */
     public function clearLanguage($locale)
     {
-        return  $this->__call('clearLanguage', [$locale]);
+        return $this->__call('clearLanguage', [$locale]);
     }
 }

--- a/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
+++ b/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
@@ -38,7 +38,8 @@ class DataCollectorTranslator extends BaseTranslator implements TranslatorInterf
      */
     public function isLanguageLoaded($locale)
     {
-        return $this->__call('isLanguageLoaded', [$locale]);
+        // this will be magically routed to the translator within BaseTranslator
+        return parent::isLanguageLoaded($locale);
     }
 
     /**
@@ -46,6 +47,7 @@ class DataCollectorTranslator extends BaseTranslator implements TranslatorInterf
      */
     public function clearLanguage($locale)
     {
-        return  $this->__call('clearLanguage', [$locale]);
+        // this will be magically routed to the translator within BaseTranslator
+        return parent::clearLanguage($locale);
     }
 }

--- a/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
+++ b/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
@@ -29,7 +29,23 @@ namespace PrestaShopBundle\Translation;
 
 use Symfony\Component\Translation\DataCollectorTranslator as BaseTranslator;
 
-class DataCollectorTranslator extends BaseTranslator
+class DataCollectorTranslator extends BaseTranslator implements TranslatorInterface
 {
     use PrestaShopTranslatorTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isLanguageLoaded($locale)
+    {
+        return $this->__call('isLanguageLoaded', [$locale]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clearLanguage($locale)
+    {
+        return  $this->__call('clearLanguage', [$locale]);
+    }
 }

--- a/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
+++ b/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
@@ -38,8 +38,7 @@ class DataCollectorTranslator extends BaseTranslator implements TranslatorInterf
      */
     public function isLanguageLoaded($locale)
     {
-        // this will be magically routed to the translator within BaseTranslator
-        return parent::isLanguageLoaded($locale);
+        return $this->__call('isLanguageLoaded', [$locale]);
     }
 
     /**
@@ -47,7 +46,6 @@ class DataCollectorTranslator extends BaseTranslator implements TranslatorInterf
      */
     public function clearLanguage($locale)
     {
-        // this will be magically routed to the translator within BaseTranslator
-        return parent::clearLanguage($locale);
+        return  $this->__call('clearLanguage', [$locale]);
     }
 }

--- a/src/PrestaShopBundle/Translation/Translator.php
+++ b/src/PrestaShopBundle/Translation/Translator.php
@@ -32,7 +32,7 @@ use Symfony\Bundle\FrameworkBundle\Translation\Translator as BaseTranslator;
 /**
  * Replacement for the original Symfony FrameworkBundle translator
  */
-class Translator extends BaseTranslator
+class Translator extends BaseTranslator implements TranslatorInterface
 {
     use PrestaShopTranslatorTrait;
     use TranslatorLanguageTrait;

--- a/src/PrestaShopBundle/Translation/TranslatorComponent.php
+++ b/src/PrestaShopBundle/Translation/TranslatorComponent.php
@@ -32,7 +32,7 @@ use Symfony\Component\Translation\Translator as BaseTranslatorComponent;
 /**
  * Translator used by Context
  */
-class TranslatorComponent extends BaseTranslatorComponent
+class TranslatorComponent extends BaseTranslatorComponent implements TranslatorInterface
 {
     use PrestaShopTranslatorTrait;
     use TranslatorLanguageTrait;

--- a/src/PrestaShopBundle/Translation/TranslatorInterface.php
+++ b/src/PrestaShopBundle/Translation/TranslatorInterface.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+declare(strict_types=1);
 
 namespace PrestaShopBundle\Translation;
 

--- a/src/PrestaShopBundle/Translation/TranslatorInterface.php
+++ b/src/PrestaShopBundle/Translation/TranslatorInterface.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\Translation;
+
+/**
+ * Interface for PrestaShop translators
+ */
+interface TranslatorInterface extends \Symfony\Component\Translation\TranslatorInterface
+{
+    /**
+     * Performs a reverse search in the catalogue and returns the translation key if found.
+     * AVOID USING THIS, IT PROVIDES APPROXIMATE RESULTS.
+     *
+     * @param string $translated Translated string
+     * @param string $domain Translation domain
+     * @param string|null $locale Unused
+     *
+     * @return string The translation
+     *
+     * @deprecated This method should not be used and will be removed
+     */
+    public function getSourceString($translated, $domain, $locale = null);
+
+    /**
+     * @param string $locale Locale code for the catalogue to check if loaded
+     *
+     * @return bool
+     */
+    public function isLanguageLoaded($locale);
+
+    /**
+     * @param string $locale Locale code for the catalogue to be cleared
+     */
+    public function clearLanguage($locale);
+}

--- a/src/PrestaShopBundle/Translation/TranslatorInterface.php
+++ b/src/PrestaShopBundle/Translation/TranslatorInterface.php
@@ -26,10 +26,11 @@
 
 namespace PrestaShopBundle\Translation;
 
+use Symfony\Component\Translation\TranslatorInterface as SymfonyTranslatorInterface;
 /**
  * Interface for PrestaShop translators
  */
-interface TranslatorInterface extends \Symfony\Component\Translation\TranslatorInterface
+interface TranslatorInterface extends SymfonyTranslatorInterface
 {
     /**
      * Performs a reverse search in the catalogue and returns the translation key if found.

--- a/src/PrestaShopBundle/Translation/TranslatorInterface.php
+++ b/src/PrestaShopBundle/Translation/TranslatorInterface.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Translation;
 
 use Symfony\Component\Translation\TranslatorInterface as SymfonyTranslatorInterface;
+
 /**
  * Interface for PrestaShop translators
  */

--- a/tests/Unit/Adapter/Translations/DataLangFactoryTest.php
+++ b/tests/Unit/Adapter/Translations/DataLangFactoryTest.php
@@ -28,6 +28,7 @@ namespace Tests\Unit\Adapter\Translations;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\DataLangFactory;
+use PrestaShopBundle\Translation\TranslatorInterface;
 
 class DataLangFactoryTest extends TestCase
 {
@@ -41,7 +42,7 @@ class DataLangFactoryTest extends TestCase
      */
     public function testItCreatesClassNamesFromTableNames(string $tableName, string $expected)
     {
-        $factory = new DataLangFactory(self::DB_PREFIX);
+        $factory = new DataLangFactory(self::DB_PREFIX, $this->getMockBuilder(TranslatorInterface::class)->getMock());
         $this->assertSame($expected, $factory->getClassNameFromTable($tableName));
     }
 

--- a/tests/Unit/Adapter/Translations/DataLangFactoryTest.php
+++ b/tests/Unit/Adapter/Translations/DataLangFactoryTest.php
@@ -31,6 +31,8 @@ use PrestaShop\PrestaShop\Adapter\EntityTranslation\DataLangFactory;
 
 class DataLangFactoryTest extends TestCase
 {
+    const DB_PREFIX = 'ps_';
+
     /**
      * @param string $tableName
      * @param string $expected
@@ -39,17 +41,17 @@ class DataLangFactoryTest extends TestCase
      */
     public function testItCreatesClassNamesFromTableNames(string $tableName, string $expected)
     {
-        $factory = new DataLangFactory(_DB_PREFIX_);
+        $factory = new DataLangFactory(self::DB_PREFIX);
         $this->assertSame($expected, $factory->getClassNameFromTable($tableName));
     }
 
     public function provideTableNames()
     {
         return [
-            [_DB_PREFIX_ . 'tab_lang', 'TabLang'],
-            [_DB_PREFIX_ . 'cart_rule_lang', 'CartRuleLang'],
+            [self::DB_PREFIX . 'tab_lang', 'TabLang'],
+            [self::DB_PREFIX . 'cart_rule_lang', 'CartRuleLang'],
             ['cart_rule_lang', 'CartRuleLang'],
-            [_DB_PREFIX_ . 'tab_lang', 'TabLang'],
+            [self::DB_PREFIX . 'tab_lang', 'TabLang'],
             ['tab', 'TabLang'],
         ];
     }

--- a/tests/Unit/Adapter/Translations/DataLangFactoryTest.php
+++ b/tests/Unit/Adapter/Translations/DataLangFactoryTest.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+declare(strict_types=1);
 
 namespace Tests\Unit\Adapter\Translations;
 

--- a/tests/Unit/Adapter/Translations/DataLangFactoryTest.php
+++ b/tests/Unit/Adapter/Translations/DataLangFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace Tests\Unit\Adapter\Translations;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\EntityTranslation\DataLangFactory;
+
+class DataLangFactoryTest extends TestCase
+{
+    /**
+     * @param string $tableName
+     * @param string $expected
+     *
+     * @dataProvider provideTableNames
+     */
+    public function testItCreatesClassNamesFromTableNames(string $tableName, string $expected)
+    {
+        $factory = new DataLangFactory(_DB_PREFIX_);
+        $this->assertSame($expected, $factory->getClassNameFromTable($tableName));
+    }
+
+    public function provideTableNames()
+    {
+        return [
+            [_DB_PREFIX_ . 'tab_lang', 'TabLang'],
+            [_DB_PREFIX_ . 'cart_rule_lang', 'CartRuleLang'],
+            ['cart_rule_lang', 'CartRuleLang'],
+            [_DB_PREFIX_ . 'tab_lang', 'TabLang'],
+            ['tab', 'TabLang'],
+        ];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Make the BO menu translatable through the translation interface and get rid of translation problems when installing other languages.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9762 & Fixes #9893
| How to test?  | See below.

## About this change

This PR introduces several changes to the way automatic database content translation works.

### Understanding multi language entities, the menu, installer fixtures and automatic translation

Multi language entities in PrestaShop manage translated content by means of a second table, called `{entity_name}_lang`, where a copy of each one of the entity's multilingual fields are stored, translated to each of the installed languages.

Elements from the back office menu are stored in database and are managed by an entity called Tab. In order to have elements from the tab menu translated, the wordings from those "tabs" are multilingual.

On install, PrestaShop uses "data fixtures" (XML files containing predefined data) to populate certain tables, like shop configuration and elements of the BO menu, with default data. As a side note, this system is used for demo products as well.

During this process, wordings for multilingual entities are inserted on the database in the language chosen during install, or in English if translated fixtures for said data are not available (this is the case for Tab, which only has fixtures in English).

But as you have probably noticed, elements in the menu appear translated after you finish the translation in another language, like French. How does this happen?

PrestaShop has an _"automagic translation"_ feature for most multilingual entities. `Language::updateMultilangFromClass()` will loop through all tables finishing in `_lang`, and will try to translate their content using the appropriate class for that entity that extends `DataLang` (like `TabLang`, `ConfigurationLang`, `OrderStateLang`, and so forth) and is located in `classes/lang/`. 

Content is translated by performing a technique accurately described by @tomlev as _"untranslating and re-translating"_. It consists in taking the already translated content in the `lang` table, finding the original translation key by performing a reverse lookup in the translator component's dictionary, then using that key to translate the content into another language. 

This process is triggered during the install and whenever a new language is installed.

During install, Tab content is initially in English, regardless of your language of choice, because of fixtures. If you are installing in, say, French, the translator will contain a dictionary with pairs like `"Some Wording" => "Le wording en français"`. When the install process triggers this translation, it will find wordings like _"Some Wording"_ and will try to untranslate them. Since it won't find them, it will fall back to the original key. Then, it will perform a translation, resulting in _"Le wording en français"_, which is the value it will save.

If later on you install another language, like Spanish, then your dictionary will have pairs like `"Some Wording" => "El wording en español"`. Since content is saved in French, it will find values like _"Le wording en français"_ which results in _"Some Wording"_ when performing a reverse translation using the French dictionary. Using that key, we can translate the wording again using the Spanish dictionary, and we get _"El wording en español"_, which is saved in database.

### The problems

This sounds like a clever hack, and in most cases it works fine. However, in some cases two different wordings translate to the same phrase in a particular language. In those cases, a reverse translation could yield the wrong key, resulting in an erroneous translation to the target language.

The second problem appears in the specific case of the menu. Default menu entries are  supposed to be translatable via the translation interface in the Back Office (wordings are placed in the `Admin.Navigation.Menu` translation domain). However, translations modified through this interface are not reflected in the menu. This is because the automatic translation is not triggered after editing a translation, but even if it was, it would never work: the dictionary we're using to _"untranslate and retranslate"_ is the same we're updating. If the dictionary was updated before retranslation process, then the reverse lookup wouldn't work (because the menu name stored in database would be different from the one in the dictionary and therefore never found), and if the dictionary was updated after the retranslation process, then the previous value would be inserted in database, resulting in no change.

### The solutions

In my view, multilanguage data should be classified in two distinct groups. In the first one, wordings are stored as translation key and translation domain pairs, and are translated on the fly, exclusively via the translator component. In the second one, content is translated exclusively by the user via form (like, for example, a product's description). Mixing the two by performing untranslation and retranslation is an absurdity that results in too much complexity, which is at best unreliable.

This means that content which is not directly user-editable, like menu names, should always be translated using the translator, and never stored translated.

Ideally, this could be solved simply by adding a "wording" and "wording_domain" to each element in `tab`, and getting rid of `tab_lang` altogether. After that, it would be up to the presentation layer to get these properties and translate them on the fly using the translator. However, this would introduce a breaking change, since modules rely on the "name" property being stored translated. Therefore, this required a more complex solution.

In this change, I introduced the aforementioned columns, but kept the automatic translation feature so that the `name` column is still stored translated in `tab_lang` just as before. However, I added a specific behavior for Tab so that when the automatic translation is triggered, instead of performing a reverse translation lookup, it uses the provided wording and wording domain as basis for the retranslation. In order to provide zero-effort retrocompatibility, Tabs with no `wording` and `wording_domain` are translated using reverse lookup, just like before.

In addition, I refactored the retranslation feature a little so that I could trigger it on a single entity. This allows me to trigger a retranslation of Tabs whenever wordings from the menu domain (`Admin.Navigation.Menu`) are updated in the translation interface. 

Modules can also benefit from this system: they just need to fill out the `wording` and `wording_domain` fields on the tabs they create. If the wording exists in the catalogue, it will be translated. However, translating it from the back office interface won't trigger a retranslation unless it's attached to the `Admin.Navigation.Menu` domain. A future improvement could add a hook so that modules can add elements to the list of domains that trigger this.

**Updates on November 9, 2020:**

- Reworked how language packs are set up during the install 
  ⚠️ **WARNING:** This also includes that language packs are no longer downloaded again during install if already present in the `/translations` folder
- Removed a reference to "safe mode" during install, which no longer exists

**As noted on [April 8, 2021](https://github.com/PrestaShop/PrestaShop/pull/18082#issuecomment-815829907):**

Modules [need to be updated](https://devdocs.prestashop.com/1.7/modules/concepts/controllers/admin-controllers/tabs/#since-prestashop-178) to allow their tabs to be translated automatically when installing a new language.

## How to test

1. Install PrestaShop in French. Menu and other auto translatable things like order states should be in French.
2. Install PrestaShop in English, then add French. Menu and other auto translatable things like order states should be in French or English depending on your choice of language.
3. Edit a menu item in the BO translation page. After refreshing the page, the menu item should appear as translated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18082)
<!-- Reviewable:end -->
