### PR TITLE
Display gift message into migrated Order page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -28,7 +28,7 @@
     {% if orderForViewing.shipping.giftMessage %}
       <div class="row col-lg-12">
         <label>
-          {{ 'Message:'|trans({}, 'Admin.Global') }}
+          {{ 'Gift message:'|trans({}, 'Admin.Global') }}
         </label>
         <div id="gift-message" class="col-lg-9">
            {{ orderForViewing.shipping.giftMessage }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -24,7 +24,19 @@
  *#}
 
 {% if not orderForViewing.virtual %}
-  <table class="table">
+
+    {% if orderForViewing.shipping.giftMessage %}
+      <div class="row col-lg-12">
+        <label>
+          {{ 'Message:'|trans({}, 'Admin.Global') }}
+        </label>
+        <div id="gift-message" class="col-lg-9">
+           {{ orderForViewing.shipping.giftMessage }}
+        </div>
+      </div>
+    {% endif %}
+
+    <table class="table">
     <thead>
       <tr>
         <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Display gift message into migrated Order page, in Shipping tab
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/18058
| How to test?  | See ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18091)
<!-- Reviewable:end -->
