### PR TITLE
Duplicate address when submitting a form with errors

### DIFF
--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -246,6 +246,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
                 null,
                 array('newAddress' => 'invoice')
             ),
+            'id_address' => (int) Tools::getValue('id_address'),
             'id_address_delivery' => $idAddressDelivery,
             'id_address_invoice' => $idAddressInvoice,
             'show_delivery_address_form' => $this->show_delivery_address_form,

--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -54,35 +54,50 @@ class AddressControllerCore extends FrontController
     public function postProcess()
     {
         $this->context->smarty->assign('editing', false);
+        $id_address = (int) Tools::getValue('id_address');
+        // Initialize address if an id exists
+        if ($id_address) {
+            $this->address_form->loadAddressById($id_address);
+        }
+
+        // Fill the form with data
         $this->address_form->fillWith(Tools::getAllValues());
+
+        // Submit the address, don't care if it's an edit or add
         if (Tools::isSubmit('submitAddress')) {
             if (!$this->address_form->submit()) {
                 $this->errors[] = $this->trans('Please fix the error below.', array(), 'Shop.Notifications.Error');
             } else {
-                if (Tools::getValue('id_address')) {
+                if ($id_address) {
                     $this->success[] = $this->trans('Address successfully updated!', array(), 'Shop.Notifications.Success');
                 } else {
                     $this->success[] = $this->trans('Address successfully added!', array(), 'Shop.Notifications.Success');
                 }
+
                 $this->should_redirect = true;
             }
-        } elseif (($id_address = (int) Tools::getValue('id_address'))) {
-            $this->address_form->loadAddressById($id_address);
 
-            if (Tools::getValue('delete')) {
-                $ok = $this->makeAddressPersister()->delete(
-                    new Address($id_address, $this->context->language->id),
-                    Tools::getValue('token')
-                );
-                if ($ok) {
-                    $this->success[] = $this->trans('Address successfully deleted!', array(), 'Shop.Notifications.Success');
-                    $this->should_redirect = true;
-                } else {
-                    $this->errors[] = $this->trans('Could not delete address.', array(), 'Shop.Notifications.Error');
-                }
+            return;
+        }
+
+        // There is no id_adress, no need to continue
+        if (!$id_address) {
+            return;
+        }
+
+        if (Tools::getValue('delete')) {
+            $ok = $this->makeAddressPersister()->delete(
+                new Address($id_address, $this->context->language->id),
+                Tools::getValue('token')
+            );
+            if ($ok) {
+                $this->success[] = $this->trans('Address successfully deleted!', array(), 'Shop.Notifications.Success');
+                $this->should_redirect = true;
             } else {
-                $this->context->smarty->assign('editing', true);
+                $this->errors[] = $this->trans('Could not delete address.', array(), 'Shop.Notifications.Error');
             }
+        } else {
+            $this->context->smarty->assign('editing', true);
         }
     }
 
@@ -103,7 +118,13 @@ class AddressControllerCore extends FrontController
         }
 
         parent::initContent();
-        $this->setTemplate('customer/address', array('entity' => 'address', 'id' => Tools::getValue('id_address')));
+        $this->setTemplate(
+            'customer/address',
+            array(
+                'entity' => 'address',
+                'id' => (int) Tools::getValue('id_address'),
+            )
+        );
     }
 
     public function getBreadcrumbLinks()

--- a/themes/classic/templates/checkout/_partials/steps/addresses.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/addresses.tpl
@@ -1,34 +1,34 @@
 {**
- * 2007-2019 PrestaShop and Contributors
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/AFL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://www.prestashop.com for more information.
- *
- * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
- * International Registered Trademark & Property of PrestaShop SA
- *}
+  * 2007-2019 PrestaShop and Contributors
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+  * that is bundled with this package in the file LICENSE.txt.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/AFL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to https://www.prestashop.com for more information.
+  *
+  * @author    PrestaShop SA <contact@prestashop.com>
+  * @copyright 2007-2019 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+  * International Registered Trademark & Property of PrestaShop SA
+  *}
 {extends file='checkout/_partials/steps/checkout-step.tpl'}
 
 {block name='step_content'}
   <div class="js-address-form">
     <form
       method="POST"
-      action="{$urls.pages.order}"
+      action="{url entity='order' params=['id_address' => $id_address]}"
       data-refresh-url="{url entity='order' params=['ajax' => 1, 'action' => 'addressForm']}"
     >
 
@@ -49,20 +49,20 @@
       {if $show_delivery_address_form}
         <div id="delivery-address">
           {render file                      = 'checkout/_partials/address-form.tpl'
-                  ui                        = $address_form
-                  use_same_address          = $use_same_address
-                  type                      = "delivery"
-                  form_has_continue_button  = $form_has_continue_button
+            ui                        = $address_form
+            use_same_address          = $use_same_address
+            type                      = "delivery"
+            form_has_continue_button  = $form_has_continue_button
           }
         </div>
       {elseif $customer.addresses|count > 0}
         <div id="delivery-addresses" class="address-selector js-address-selector">
           {include  file        = 'checkout/_partials/address-selector-block.tpl'
-                    addresses   = $customer.addresses
-                    name        = "id_address_delivery"
-                    selected    = $id_address_delivery
-                    type        = "delivery"
-                    interactive = !$show_delivery_address_form and !$show_invoice_address_form
+            addresses   = $customer.addresses
+            name        = "id_address_delivery"
+            selected    = $id_address_delivery
+            type        = "delivery"
+            interactive = !$show_delivery_address_form and !$show_invoice_address_form
           }
         </div>
 
@@ -93,20 +93,20 @@
         {if $show_invoice_address_form}
           <div id="invoice-address">
             {render file                      = 'checkout/_partials/address-form.tpl'
-                    ui                        = $address_form
-                    use_same_address          = $use_same_address
-                    type                      = "invoice"
-                    form_has_continue_button  = $form_has_continue_button
+              ui                        = $address_form
+              use_same_address          = $use_same_address
+              type                      = "invoice"
+              form_has_continue_button  = $form_has_continue_button
             }
           </div>
         {else}
           <div id="invoice-addresses" class="address-selector js-address-selector">
             {include  file        = 'checkout/_partials/address-selector-block.tpl'
-                      addresses   = $customer.addresses
-                      name        = "id_address_invoice"
-                      selected    = $id_address_invoice
-                      type        = "invoice"
-                      interactive = !$show_delivery_address_form and !$show_invoice_address_form
+              addresses   = $customer.addresses
+              name        = "id_address_invoice"
+              selected    = $id_address_invoice
+              type        = "invoice"
+              interactive = !$show_delivery_address_form and !$show_invoice_address_form
             }
           </div>
 
@@ -126,7 +126,7 @@
       {if !$form_has_continue_button}
         <div class="clearfix">
           <button type="submit" class="btn btn-primary continue float-xs-right" name="confirm-addresses" value="1">
-              {l s='Continue' d='Shop.Theme.Actions'}
+            {l s='Continue' d='Shop.Theme.Actions'}
           </button>
           <input type="hidden" id="not-valid-addresses" value="{$not_valid_addresses}">
         </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | The form action does not have the good id_address because the form context is not properly loaded when there is an error.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18100 
| How to test?  | Steps to reproduce the behavior:<br>Log in, if you don't have an address, create it<br>Go to your profile, edit an address<br>Put numbers in the first name field in order to trigger a validation error<br>Then remove the number, and save<br>see the error => It will create a duplicate address
 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18103)
<!-- Reviewable:end -->
