### PR TITLE
Avoid crash because of image timeout

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-use Exception;
 use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem;
 use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 use PrestaShop\TranslationToolsBundle\Translation\Helper\DomainHelper;
+use Exception;
 
 abstract class ModuleCore implements ModuleInterface
 {
@@ -1613,16 +1614,17 @@ abstract class ModuleCore implements ModuleInterface
         if (!Validate::isLoadedObject($modaddons)) {
             return null;
         }
+        
+        $filename = md5((int) $modaddons->id . '-' . $modaddons->name) . '.jpg';
+        $filepath = _PS_TMP_IMG_DIR_ . $filename;
+        $fileExist = file_exists($filepath);
 
-        $filepath = _PS_TMP_IMG_DIR_ . md5((int) $modaddons->id . '-' . $modaddons->name) . '.jpg';
-        $fileDoesNotExist = !file_exists($filepath);
-
-        if ($fileDoesNotExist) {
+        if (!$fileExist) {
             $remoteDownloadWasASuccess = false;
             try {
                 $remoteImage = Tools::file_get_contents($modaddons->img);
                 $remoteDownloadWasASuccess = true;
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 copy(_PS_IMG_DIR_ . '404.gif', $filepath);
             }
 
@@ -1631,8 +1633,8 @@ abstract class ModuleCore implements ModuleInterface
             }
         }
 
-        if (file_exists($filepath)) {
-            return '../img/tmp/' . md5((int) $modaddons->id . '-' . $modaddons->name) . '.jpg';
+        if ($fileExist) {
+            return '../img/tmp/' . $filename;
         }
     }
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1603,16 +1603,35 @@ abstract class ModuleCore implements ModuleInterface
         return $module_list;
     }
 
+    /**
+     * @param \StdClass $modaddons Addons Module object, provided by XML stream
+     *
+     * @return null|string
+     */
     public static function copyModAddonsImg($modaddons)
     {
         if (!Validate::isLoadedObject($modaddons)) {
-            return;
+            return null;
         }
-        if (!file_exists(_PS_TMP_IMG_DIR_ . md5((int) $modaddons->id . '-' . $modaddons->name) . '.jpg') &&
-        !file_put_contents(_PS_TMP_IMG_DIR_ . md5((int) $modaddons->id . '-' . $modaddons->name) . '.jpg', Tools::file_get_contents($modaddons->img))) {
-            copy(_PS_IMG_DIR_ . '404.gif', _PS_TMP_IMG_DIR_ . md5((int) $modaddons->id . '-' . $modaddons->name) . '.jpg');
+
+        $filepath = _PS_TMP_IMG_DIR_ . md5((int)$modaddons->id . '-' . $modaddons->name) . '.jpg';
+        $fileDoesNotExist = !file_exists($filepath);
+
+        if ($fileDoesNotExist) {
+            $remoteDownloadWasASuccess = false;
+            try {
+                $remoteImage = Tools::file_get_contents($modaddons->img);
+                $remoteDownloadWasASuccess = true;;
+            } catch (\Exception $e) {
+                copy(_PS_IMG_DIR_ . '404.gif', $filepath);
+            }
+
+            if ($remoteDownloadWasASuccess && !file_put_contents($filepath, $remoteImage)) {
+                copy(_PS_IMG_DIR_ . '404.gif', $filepath);
+            }
         }
-        if (file_exists(_PS_TMP_IMG_DIR_ . md5((int) $modaddons->id . '-' . $modaddons->name) . '.jpg')) {
+
+        if (file_exists($filepath)) {
             return '../img/tmp/' . md5((int) $modaddons->id . '-' . $modaddons->name) . '.jpg';
         }
     }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1633,7 +1633,7 @@ abstract class ModuleCore implements ModuleInterface
             }
         }
 
-        if ($fileExist) {
+        if (file_exists($filepath)) {
             return '../img/tmp/' . $filename;
         }
     }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1606,7 +1606,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * @param \StdClass $modaddons Addons Module object, provided by XML stream
      *
-     * @return null|string
+     * @return string|null
      */
     public static function copyModAddonsImg($modaddons)
     {
@@ -1614,14 +1614,14 @@ abstract class ModuleCore implements ModuleInterface
             return null;
         }
 
-        $filepath = _PS_TMP_IMG_DIR_ . md5((int)$modaddons->id . '-' . $modaddons->name) . '.jpg';
+        $filepath = _PS_TMP_IMG_DIR_ . md5((int) $modaddons->id . '-' . $modaddons->name) . '.jpg';
         $fileDoesNotExist = !file_exists($filepath);
 
         if ($fileDoesNotExist) {
             $remoteDownloadWasASuccess = false;
             try {
                 $remoteImage = Tools::file_get_contents($modaddons->img);
-                $remoteDownloadWasASuccess = true;;
+                $remoteDownloadWasASuccess = true;
             } catch (\Exception $e) {
                 copy(_PS_IMG_DIR_ . '404.gif', $filepath);
             }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+use Exception;
 use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
@@ -31,7 +32,6 @@ use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem;
 use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 use PrestaShop\TranslationToolsBundle\Translation\Helper\DomainHelper;
-use Exception;
 
 abstract class ModuleCore implements ModuleInterface
 {
@@ -1614,7 +1614,7 @@ abstract class ModuleCore implements ModuleInterface
         if (!Validate::isLoadedObject($modaddons)) {
             return null;
         }
-        
+
         $filename = md5((int) $modaddons->id . '-' . $modaddons->name) . '.jpg';
         $filepath = _PS_TMP_IMG_DIR_ . $filename;
         $fileExist = file_exists($filepath);


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Improve `Module::copyModAddonsImg()` to avoid crashes if timeout
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/18115
| How to test?  | I dont know 😓 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18116)
<!-- Reviewable:end -->
