### PR TITLE
Add missing entities in template inheritance.

### DIFF
--- a/classes/Smarty/TemplateFinder.php
+++ b/classes/Smarty/TemplateFinder.php
@@ -35,7 +35,7 @@ class TemplateFinderCore
     private $directories;
     private $extension;
     private $productListEntities = ['category', 'manufacturer', 'supplier'];
-    private $productListSearchEntities = ['search', 'price-drop', 'best-sale'];
+    private $productListSearchEntities = ['search', 'prices-drop', 'best-sales', 'new-products'];
     private $productEntities = ['product'];
     private $brandListEntities = ['manufacturers', 'suppliers'];
 

--- a/classes/Smarty/TemplateFinder.php
+++ b/classes/Smarty/TemplateFinder.php
@@ -35,7 +35,7 @@ class TemplateFinderCore
     private $directories;
     private $extension;
     private $productListEntities = ['category', 'manufacturer', 'supplier'];
-    private $productListSearchEntities = ['search', 'prices-drop', 'best-sales', 'new-products'];
+    private $productListSearchEntities = ['search', 'price-drop', 'best-sale', 'prices-drop', 'best-sales', 'new-products'];
     private $productEntities = ['product'];
     private $brandListEntities = ['manufacturers', 'suppliers'];
 

--- a/controllers/front/listing/BestSalesController.php
+++ b/controllers/front/listing/BestSalesController.php
@@ -54,7 +54,7 @@ class BestSalesControllerCore extends ProductListingFrontController
     {
         parent::initContent();
 
-        $this->doProductSearch('catalog/listing/best-sales');
+        $this->doProductSearch('catalog/listing/best-sales', ['entity' => 'best-sales']);
     }
 
     protected function getProductSearchQuery()

--- a/controllers/front/listing/NewProductsController.php
+++ b/controllers/front/listing/NewProductsController.php
@@ -38,7 +38,7 @@ class NewProductsControllerCore extends ProductListingFrontController
     {
         parent::initContent();
 
-        $this->doProductSearch('catalog/listing/new-products', ['entity'=>'new-products']);
+        $this->doProductSearch('catalog/listing/new-products', ['entity' => 'new-products']);
     }
 
     protected function getProductSearchQuery()

--- a/controllers/front/listing/NewProductsController.php
+++ b/controllers/front/listing/NewProductsController.php
@@ -38,7 +38,7 @@ class NewProductsControllerCore extends ProductListingFrontController
     {
         parent::initContent();
 
-        $this->doProductSearch('catalog/listing/new-products');
+        $this->doProductSearch('catalog/listing/new-products', ['entity'=>'new-products']);
     }
 
     protected function getProductSearchQuery()

--- a/controllers/front/listing/PricesDropController.php
+++ b/controllers/front/listing/PricesDropController.php
@@ -38,7 +38,7 @@ class PricesDropControllerCore extends ProductListingFrontController
     {
         parent::initContent();
 
-        $this->doProductSearch('catalog/listing/prices-drop');
+        $this->doProductSearch('catalog/listing/prices-drop', ['entity' => 'prices-drop']);
     }
 
     protected function getProductSearchQuery()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Adds missing page to template inheritance, adds missing parameters to existing controllers and fix some typos
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18107.
| How to test?  | Even if special templates  `catalog/listing/best-sales.tpl`,  `catalog/listing/new-products.tpl`, `catalog/listing/prices-drop.tpl`, `catalog/listing/search.tpl` are missing, the shop must display the `catalog/listing/product-list.tpl` as a default template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18125)
<!-- Reviewable:end -->
