### PR TITLE
Use grid common search action where possible (1.7.7.x controllers only)

### DIFF
--- a/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
@@ -62,6 +62,7 @@ final class CmsPageCategoryDefinitionFactory extends AbstractGridDefinitionFacto
      * @var int
      */
     private $cmsCategoryParentId;
+
     /**
      * @var MultistoreContextCheckerInterface
      */

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -52,6 +52,11 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    /**
+     * @var string
+     */
+    public const GRID_ID = 'supplier';
+
     use BulkDeleteActionTrait;
 
     /**
@@ -59,7 +64,7 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getId()
     {
-        return 'supplier';
+        return self::GRID_ID;
     }
 
     /**
@@ -202,10 +207,9 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
             ->add((new Filter('actions', SearchAndResetType::class))
                 ->setAssociatedColumn('actions')
                 ->setTypeOptions([
-                    'reset_route' => 'admin_common_reset_search',
+                    'reset_route' => 'admin_common_reset_search_by_filter_id',
                     'reset_route_params' => [
-                        'controller' => 'supplier',
-                        'action' => 'index',
+                        'filterId' => self::GRID_ID,
                     ],
                     'redirect_route' => 'admin_suppliers_index',
                 ])

--- a/src/Core/Search/Filters/SupplierFilters.php
+++ b/src/Core/Search/Filters/SupplierFilters.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Search\Filters;
 
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SupplierGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters;
 
 /**
@@ -33,6 +34,11 @@ use PrestaShop\PrestaShop\Core\Search\Filters;
  */
 final class SupplierFilters extends Filters
 {
+    /**
+     * @var string
+     */
+    protected $filterId = SupplierGridDefinitionFactory::GRID_ID;
+
     /**
      * {@inheritdoc}
      */

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -34,8 +34,6 @@ use PrestaShop\PrestaShop\Core\Domain\Notification\Command\UpdateEmployeeNotific
 use PrestaShop\PrestaShop\Core\Domain\Notification\Query\GetNotificationLastElements;
 use PrestaShop\PrestaShop\Core\Domain\Notification\QueryResult\NotificationsResults;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
-use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderGridDefinitionFactory;
-use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowInterface;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\DataProvider\Admin\RecommendedModules;

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -31,14 +31,15 @@ use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Core\Domain\Notification\Command\UpdateEmployeeNotificationLastElementCommand;
-use PrestaShop\PrestaShop\Core\Domain\Notification\Exception\TypeException;
 use PrestaShop\PrestaShop\Core\Domain\Notification\Query\GetNotificationLastElements;
 use PrestaShop\PrestaShop\Core\Domain\Notification\QueryResult\NotificationsResults;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowInterface;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\DataProvider\Admin\RecommendedModules;
+use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -358,6 +359,8 @@ class CommonController extends FrameworkBundleAdminController
         $redirectRoute,
         array $redirectQueryParamsToKeep = []
     ) {
+        /** @var ResponseBuilder $responseBuilder */
+        $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
         /** @var GridDefinitionFactoryInterface $definitionFactory */
         $definitionFactory = $this->get($gridDefinitionFactoryServiceId);
         /** @var GridDefinitionInterface $definition */
@@ -381,6 +384,12 @@ class CommonController extends FrameworkBundleAdminController
             }
         }
 
-        return $this->redirectToRoute($redirectRoute, $redirectParams);
+        return $responseBuilder->buildSearchResponse(
+            $definitionFactory,
+            $request,
+            $definitionFactory::GRID_ID,
+            $redirectRoute,
+            $redirectParams
+        );
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -361,33 +361,13 @@ class CommonController extends FrameworkBundleAdminController
         $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
         /** @var GridDefinitionFactoryInterface $definitionFactory */
         $definitionFactory = $this->get($gridDefinitionFactoryServiceId);
-        /** @var GridDefinitionInterface $definition */
-        $definition = $definitionFactory->getDefinition();
-
-        $gridFilterFormFactory = $this->get('prestashop.core.grid.filter.form_factory');
-
-        $filtersForm = $gridFilterFormFactory->create($definition);
-        $filtersForm->handleRequest($request);
-
-        $redirectParams = [];
-        if ($filtersForm->isSubmitted()) {
-            $redirectParams = [
-                'filters' => $filtersForm->getData(),
-            ];
-        }
-
-        foreach ($redirectQueryParamsToKeep as $paramName) {
-            if ($request->query->has($paramName)) {
-                $redirectParams[$paramName] = $request->query->get($paramName);
-            }
-        }
 
         return $responseBuilder->buildSearchResponse(
             $definitionFactory,
             $request,
             $definitionFactory::GRID_ID,
             $redirectRoute,
-            $redirectParams
+            $redirectQueryParamsToKeep
         );
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -178,30 +178,6 @@ class AddressController extends FrameworkBundleAdminController
     }
 
     /**
-     * Responsible for grid filtering
-     *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))",
-     *     redirectRoute="admin_addresses_index",
-     * )
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function searchAction(Request $request)
-    {
-        /** @var ResponseBuilder $responseBuilder */
-        $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
-
-        return $responseBuilder->buildSearchResponse(
-            $this->get('prestashop.core.grid.definition.factory.address'),
-            $request,
-            AddressGridDefinitionFactory::GRID_ID,
-            'admin_addresses_index'
-        );
-    }
-
-    /**
      * @return array
      */
     private function getAddressToolbarButtons(): array

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -49,12 +49,10 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerByEmailNotFound
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\State\Exception\StateConstraintException;
-use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AddressGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\AddressFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Address\RequiredFieldsAddressType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
@@ -32,11 +32,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Attribute\Command\D
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Attribute\Exception\AttributeNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Attribute\Exception\DeleteAttributeException;
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Exception\AttributeGroupNotFoundException;
-use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\AttributeFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -130,32 +128,6 @@ class AttributeController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_attributes_index', [
             'attributeGroupId' => $attributeGroupId,
         ]);
-    }
-
-    /**
-     * Responsible for grid filtering
-     *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))",
-     *     redirectRoute="admin_attributes_index",
-     *     redirectQueryParamsToKeep={"attributeGroupId"}
-     * )
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function searchAction(Request $request)
-    {
-        /** @var ResponseBuilder $responseBuilder */
-        $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
-
-        return $responseBuilder->buildSearchResponse(
-            $this->get('prestashop.core.grid.definition.factory.attribute'),
-            $request,
-            AttributeGridDefinitionFactory::GRID_ID,
-            'admin_attributes_index',
-            ['attributeGroupId']
-        );
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeGroupController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeGroupController.php
@@ -33,11 +33,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Exception\Attribute
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Exception\DeleteAttributeGroupException;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
-use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGroupGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\AttributeGroupFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -121,30 +119,6 @@ class AttributeGroupController extends FrameworkBundleAdminController
         }
 
         return $this->redirectToRoute('admin_attribute_groups_index');
-    }
-
-    /**
-     * Responsible for grid filtering
-     *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))",
-     *     redirectRoute="admin_attribute_groups_index",
-     * )
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function searchAction(Request $request)
-    {
-        /** @var ResponseBuilder $responseBuilder */
-        $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
-
-        return $responseBuilder->buildSearchResponse(
-            $this->get('prestashop.core.grid.definition.factory.attribute_group'),
-            $request,
-            AttributeGroupGridDefinitionFactory::GRID_ID,
-            'admin_attribute_groups_index'
-        );
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -50,7 +50,6 @@ use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\EditableCategory;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\MenuThumbnailId;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
-use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CategoryGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\CategoryFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -89,33 +89,6 @@ class SupplierController extends FrameworkBundleAdminController
     }
 
     /**
-     * Filters list results.
-     *
-     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function searchAction(Request $request)
-    {
-        $definitionFactory = $this->get('prestashop.core.grid.definition.factory.supplier');
-        $supplierDefinition = $definitionFactory->getDefinition();
-
-        $gridFilterFormFactory = $this->get('prestashop.core.grid.filter.form_factory');
-        $searchParametersForm = $gridFilterFormFactory->create($supplierDefinition);
-
-        $searchParametersForm->handleRequest($request);
-        $filters = [];
-
-        if ($searchParametersForm->isSubmitted()) {
-            $filters = $searchParametersForm->getData();
-        }
-
-        return $this->redirectToRoute('admin_suppliers_index', ['filters' => $filters]);
-    }
-
-    /**
      * Displays supplier creation form and handles form submit which creates new supplier.
      *
      * @AdminSecurity(

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
@@ -27,12 +27,9 @@
 namespace PrestaShopBundle\Controller\Admin\Sell\CustomerService;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
-use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MerchandiseReturnGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\MerchandiseReturnFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use PrestaShopBundle\Service\Grid\ResponseBuilder;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
@@ -80,31 +80,6 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
     }
 
     /**
-     * Prepares filtering response
-     *
-     * @AdminSecurity(
-     *     "is_granted(['read'], request.get('_legacy_controller'))",
-     *     redirectRoute="admin_merchandise_return_index"
-     * )
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function filterAction(Request $request): RedirectResponse
-    {
-        /** @var ResponseBuilder $responseBuilder */
-        $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
-
-        return $responseBuilder->buildSearchResponse(
-            $this->get('prestashop.core.grid.definition.factory.merchandise_return'),
-            $request,
-            MerchandiseReturnGridDefinitionFactory::GRID_ID,
-            'admin_merchandise_returns_index'
-        );
-    }
-
-    /**
      * @return FormHandlerInterface
      */
     private function getOptionsFormHandler(): FormHandlerInterface

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
@@ -33,11 +33,9 @@ use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Exception\OrderMessageExcepti
 use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Exception\OrderMessageNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Query\GetOrderMessageForEditing;
 use PrestaShop\PrestaShop\Core\Domain\OrderMessage\QueryResult\EditableOrderMessage;
-use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderMessageGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderMessageFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
@@ -78,31 +78,6 @@ class OrderMessageController extends FrameworkBundleAdminController
     }
 
     /**
-     * Prepares filtering response
-     *
-     * @AdminSecurity(
-     *     "is_granted(['read'], request.get('_legacy_controller'))",
-     *     redirectRoute="admin_order_messages_index"
-     * )
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function filterAction(Request $request): RedirectResponse
-    {
-        /** @var ResponseBuilder $responseBuilder */
-        $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
-
-        return $responseBuilder->buildSearchResponse(
-            $this->get('prestashop.core.grid.definition.factory.order_message'),
-            $request,
-            OrderMessageGridDefinitionFactory::GRID_ID,
-            'admin_order_messages_index'
-        );
-    }
-
-    /**
      * Create new order message
      *
      * @AdminSecurity(

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -74,6 +74,7 @@ use PrestaShop\PrestaShop\Core\Multistore\MultistoreContextCheckerInterface;
 use PrestaShop\PrestaShop\Core\Order\OrderSiblingProviderInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderFilters;
 use PrestaShopBundle\Component\CsvResponse;
+use PrestaShopBundle\Controller\Admin\CommonController;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Customer\PrivateNoteType;
 use PrestaShopBundle\Form\Admin\Sell\Order\AddOrderCartRuleType;
@@ -98,7 +99,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Manages "Sell > Orders" page
  */
-class OrderController extends FrameworkBundleAdminController
+class OrderController extends CommonController
 {
     /**
      * Shows list of orders

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -75,7 +75,6 @@ use PrestaShop\PrestaShop\Core\Order\OrderSiblingProviderInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\CommonController;
-use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Customer\PrivateNoteType;
 use PrestaShopBundle\Form\Admin\Sell\Order\AddOrderCartRuleType;
 use PrestaShopBundle\Form\Admin\Sell\Order\AddProductRowType;

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute.yml
@@ -1,79 +1,80 @@
 # @todo: add legacy links after page is fully migrated
-
 admin_attributes_index:
-    path: /
-    methods: GET
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:index'
-        _legacy_controller: AdminAttributesGroups
-        redirectQueryParamsToKeep:
-            - 'attributeGroupId'
-#        _legacy_link: AdminAttributesGroups:viewattribute_group
-        _legacy_parameters:
-            id_attribute_group: attributeGroupId
-        requirements:
-            attributeGroupId: \d+
+  path: /
+  methods: GET
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:index'
+    _legacy_controller: AdminAttributesGroups
+    redirectQueryParamsToKeep:
+      - 'attributeGroupId'
+#    _legacy_link: AdminAttributesGroups:viewattribute_group
+    _legacy_parameters:
+      id_attribute_group: attributeGroupId
+    requirements:
+      attributeGroupId: \d+
 
 admin_attributes_search:
-    path: /
-    methods: POST
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:search'
-        _legacy_controller: AdminAttributesGroups
-#          _legacy_link: AdminAttributesGroups:submitFilterattribute_values
-        redirectQueryParamsToKeep:
-            - 'attributeGroupId'
+  path: /
+  methods: POST
+  defaults:
+    _controller: PrestaShopBundle:Admin\Common:searchGrid
+    _legacy_controller: AdminAttributesGroups
+    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.attribute
+    redirectRoute: admin_attributes_index
+#    _legacy_link: AdminAttributesGroups:submitFilterattribute_values
+    redirectQueryParamsToKeep:
+      - 'attributeGroupId'
 
 admin_attributes_create:
-    path: /new
-    methods: [GET, POST]
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:create'
-        _legacy_controller: AdminAttributesGroups
-        redirectQueryParamsToKeep:
-            - 'attributeGroupId'
-#        _legacy_link: AdminAttributesGroups:addattribute_group
+  path: /new
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:create'
+    _legacy_controller: AdminAttributesGroups
+    redirectQueryParamsToKeep:
+      - 'attributeGroupId'
+#    _legacy_link: AdminAttributesGroups:addattribute_group
 
 admin_attributes_edit:
-    path: /{attributeId}/edit
-    methods: [GET, POST]
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:edit'
-        _legacy_controller: AdminAttributesGroups
-        redirectQueryParamsToKeep:
-            - 'attributeGroupId'
-#        _legacy_link: AdminAttributesGroups:updateattribute
-        _legacy_parameters:
-            id_attribute_group: attributeGroupId
-            id_attribute: attributeId
-    requirements:
-        attributeId: \d+
+  path: /{attributeId}/edit
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:edit'
+    _legacy_controller: AdminAttributesGroups
+    redirectQueryParamsToKeep:
+      - 'attributeGroupId'
+#    _legacy_link: AdminAttributesGroups:updateattribute
+    _legacy_parameters:
+      id_attribute_group: attributeGroupId
+      id_attribute: attributeId
+  requirements:
+    attributeId: \d+
 
 admin_attributes_delete:
-    path: /{attributeId}/delete
-    methods: POST
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:delete'
-        _legacy_controller: AdminAttributesGroups
-        redirectQueryParamsToKeep:
-            - 'attributeGroupId'
-#        _legacy_link: AdminAttributesGroups:deleteattribute
-        _legacy_parameters:
-            id_attribute_group: attributeGroupId
-            id_attribute: attributeId
+  path: /{attributeId}/delete
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:delete'
+    _legacy_controller: AdminAttributesGroups
+    redirectQueryParamsToKeep:
+      - 'attributeGroupId'
+#    _legacy_link: AdminAttributesGroups:deleteattribute
+    _legacy_parameters:
+      id_attribute_group: attributeGroupId
+      id_attribute: attributeId
 
 admin_attributes_bulk_delete:
-    path: /delete
-    methods: POST
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:bulkDelete'
-        _legacy_controller: AdminAttributesGroups
-        redirectQueryParamsToKeep:
-            - 'attributeGroupId'
-#        _legacy_link: AdminAttributesGroups:bulkdeleteattribute
-        _legacy_parameters:
-            id_attribute_group: attributeGroupId
-            id_attribute: attributeId
+  path: /delete
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:bulkDelete'
+    _legacy_controller: AdminAttributesGroups
+    redirectQueryParamsToKeep:
+      - 'attributeGroupId'
+#    _legacy_link: AdminAttributesGroups:bulkdeleteattribute
+    _legacy_parameters:
+      id_attribute_group: attributeGroupId
+      id_attribute: attributeId
 
 admin_attributes_update_position:
   path: /update-position

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute_group.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute_group.yml
@@ -1,81 +1,82 @@
 # @todo: uncomment legacy links after page migration
-
 admin_attribute_groups_index:
-    path: /
-    methods: GET
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:index'
-        _legacy_controller: AdminAttributesGroups
-#        _legacy_link: AdminAttributesGroups
+  path: /
+  methods: GET
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:index'
+    _legacy_controller: AdminAttributesGroups
+#    _legacy_link: AdminAttributesGroups
 
 admin_attribute_groups_search:
-    path: /
-    methods: POST
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:search'
-        _legacy_controller: AdminAttributesGroups
-#        _legacy_link: AdminAttributeGroups:submitFilterattribute_group
+  path: /
+  methods: POST
+  defaults:
+    _controller: PrestaShopBundle:Admin\Common:searchGrid
+    _legacy_controller: AdminAttributesGroups
+    #    _legacy_link: AdminAttributeGroups:submitFilterattribute_group
+    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.attribute_group
+    redirectRoute: admin_attribute_groups_index
 
 admin_attribute_groups_create:
-    path: /new
-    methods: [GET, POST]
-    defaults:
-        #todo: implement create
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:index'
-        _legacy_controller: AdminAttributesGroups
-#        _legacy_link: AdminAttributeGroups:addattribute_group
+  path: /new
+  methods: [GET, POST]
+  defaults:
+    #todo: implement create
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:index'
+    _legacy_controller: AdminAttributesGroups
+#    _legacy_link: AdminAttributeGroups:addattribute_group
 
 admin_attribute_groups_view:
-    path: /{attributeGroupId}/view
-    methods: GET
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:index'
-        _legacy_controller: AdminAttributesGroups
-#        _legacy_link: AdminAttributesGroups:viewattribute_group
-#        _legacy_parameters:
-#          id_attribute_group: attributeGroupId
-    requirements:
-      attributeGroupId: \d+
+  path: /{attributeGroupId}/view
+  methods: GET
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:index'
+    _legacy_controller: AdminAttributesGroups
+#    _legacy_link: AdminAttributesGroups:viewattribute_group
+    _legacy_parameters:
+      id_attribute_group: attributeGroupId
+  requirements:
+    attributeGroupId: \d+
 
 admin_attribute_groups_edit:
-    path: /{attributeGroupId}/edit
-    methods: [GET, POST]
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:edit'
-        _legacy_controller: AdminAttributesGroups
-#        _legacy_link: AdminAttributesGroups:updateattribute_group
-        _legacy_parameters:
-            id_attribute_group: attributeGroupId
-    requirements:
-        attributeGroupId: \d+
+  path: /{attributeGroupId}/edit
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:edit'
+    _legacy_controller: AdminAttributesGroups
+#    _legacy_link: AdminAttributesGroups:updateattribute_group
+    _legacy_parameters:
+      id_attribute_group: attributeGroupId
+  requirements:
+    attributeGroupId: \d+
 
 admin_attribute_groups_delete:
-    path: /{attributeGroupId}/delete
-    methods: POST
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:delete'
-        _legacy_controller: AdminAttributesGroups
-#        _legacy_link: AdminAttributesGroups:deleteattribute_group
-        _legacy_parameters:
-            id_attribute_group: attributeGroupId
-    requirements:
-        attributeGroupId: \d+
+  path: /{attributeGroupId}/delete
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:delete'
+    _legacy_controller: AdminAttributesGroups
+#    _legacy_link: AdminAttributesGroups:deleteattribute_group
+    _legacy_parameters:
+      id_attribute_group: attributeGroupId
+  requirements:
+    attributeGroupId: \d+
 
 admin_attribute_groups_bulk_delete:
-    path: /bulk-delete
-    methods: POST
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:bulkDelete'
-        _legacy_controller: AdminAttributesGroups
-#        _legacy_link: AdminAttributesGroups:submitBulkdeleteattribute_group
+  path: /bulk-delete
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:bulkDelete'
+    _legacy_controller: AdminAttributesGroups
+#    _legacy_link: AdminAttributesGroups:submitBulkdeleteattribute_group
 
 admin_attribute_groups_export:
-    path: /export
-    methods: GET
-    defaults:
-        _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:export'
-        _legacy_controller: AdminAttributesGroups
-#        _legacy_link: AdminAttributesGroups:exportattribute_group
+  path: /export
+  methods: GET
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:export'
+    _legacy_controller: AdminAttributesGroups
+#    _legacy_link: AdminAttributesGroups:exportattribute_group
 
 admin_attribute_groups_update_position:
   path: /update-position

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -10,9 +10,11 @@ admin_suppliers_search:
   path: /
   methods: POST
   defaults:
-    _controller: 'PrestaShopBundle:Admin\Sell\Catalog\Supplier:search'
+    _controller: PrestaShopBundle:Admin\Common:searchGrid
     _legacy_controller: AdminSuppliers
     _legacy_link: AdminSuppliers:submitFiltersupplier
+    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.supplier
+    redirectRoute: admin_suppliers_index
 
 admin_suppliers_view:
   path: /{supplierId}/products

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer/addresses.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer/addresses.yml
@@ -10,7 +10,9 @@ admin_addresses_search:
   path: /
   methods: [POST]
   defaults:
-    _controller: PrestaShopBundle:Admin\Sell\Address\Address:search
+    _controller: PrestaShopBundle:Admin\Common:searchGrid
+    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.address
+    redirectRoute: admin_addresses_index
     _legacy_controller: AdminAddresses
     _legacy_link: AdminAddresses:submitFilteraddress
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/merchandise_return.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/merchandise_return.yml
@@ -7,7 +7,7 @@ admin_merchandise_returns_index:
 #    _legacy_link: AdminReturn
 
 admin_merchandise_returns_save_options:
-  path: /
+  path: /options
   methods: [POST]
   defaults:
     _controller: PrestaShopBundle:Admin/Sell/CustomerService/MerchandiseReturn:index
@@ -15,9 +15,11 @@ admin_merchandise_returns_save_options:
 #    _legacy_link: AdminReturn:submitOptionsorder_return
 
 admin_merchandise_returns_filter:
-  path: /filter
+  path: /
   methods: [POST]
   defaults:
-    _controller: PrestaShopBundle:Admin/Sell/CustomerService/MerchandiseReturn:filter
+    _controller: PrestaShopBundle:Admin\Common:searchGrid
+    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.merchandise_return
+    redirectRoute: admin_merchandise_returns_index
     _legacy_controller: AdminReturn
 #    _legacy_link: AdminReturn:submitFilterorder_return

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/order_message.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/order_message.yml
@@ -10,9 +10,11 @@ admin_order_messages_filter:
   path: /
   methods: [POST]
   defaults:
-    _controller: PrestaShopBundle:Admin/Sell/CustomerService/OrderMessage:filter
+    _controller: PrestaShopBundle:Admin\Common:searchGrid
+    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.order_message
     _legacy_controller: AdminOrderMessage
     _legacy_link: AdminOrderMessage:submitFilterorder_message
+    redirectRoute: admin_order_messages_index
 
 admin_order_messages_create:
   path: /new

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
@@ -26,8 +26,10 @@ admin_orders_search:
   path: /
   methods: [POST]
   defaults:
-    _controller: PrestaShopBundle:Admin/Sell/Order/Order:search
+    _controller: PrestaShopBundle:Admin\Common:searchGrid
     _legacy_controller: AdminOrders
+    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.order
+    redirectRoute: admin_orders_index
 
 admin_orders_generate_invoice_pdf:
   path: /{orderId}/generate-invoice-pdf


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Implements CommonController::searchGridAction (only of 1.7.7.x controllers)  where it was possible to do easily. Custom search actions are only left for multi-grid pages.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #13448
| How to test?  | Check that grid filtering works as before (if these changes broke something, then filtering would not work at all, not necessary to test all the edge-cases). Modified grids list below.<br>- orders,<br>- attributes and attribute groups (`sell/catalog/attribute-groups` view action opens attributes list),<br>- customer addresses,<br>- order messages,<br>- merchandise returns,<br>- suppliers ( this was migrated already in 1.7.6, but was still hidden)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18123)
<!-- Reviewable:end -->
