### PR TITLE
Wrong reduction input suffix on change the input reduction type in product specific price form

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.js
@@ -389,12 +389,15 @@ class SpecificPriceFormHandler {
    */
   enableSpecificPriceTaxFieldIfEligible(usePrefixForCreate) {
     const selectorPrefix = this.getPrefixSelector(usePrefixForCreate);
+    const spReductionSuffix = $(`${selectorPrefix}sp_reduction_type option:selected`).text();
 
     if ($(`${selectorPrefix}sp_reduction_type`).val() === 'percentage') {
       $(`${selectorPrefix}sp_reduction_tax`).hide();
     } else {
       $(`${selectorPrefix}sp_reduction_tax`).show();
     }
+
+    $(`${selectorPrefix}sp_reduction`).parent('.money-type').find('.input-group-text').text(spReductionSuffix);
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.js
@@ -391,11 +391,7 @@ class SpecificPriceFormHandler {
     const selectorPrefix = this.getPrefixSelector(usePrefixForCreate);
     const spReductionSuffix = $(`${selectorPrefix}sp_reduction_type option:selected`).text();
 
-    if ($(`${selectorPrefix}sp_reduction_type`).val() === 'percentage') {
-      $(`${selectorPrefix}sp_reduction_tax`).hide();
-    } else {
-      $(`${selectorPrefix}sp_reduction_tax`).show();
-    }
+    $(`${selectorPrefix}sp_reduction_tax`).toggle($(`${selectorPrefix}sp_reduction_type`).val() !== 'percentage');
 
     $(`${selectorPrefix}sp_reduction`).parent('.money-type').find('.input-group-text').text(spReductionSuffix);
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Wrong reduction input suffix on change the input reduction type in product specific price form.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18152.
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/18152.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18153)
<!-- Reviewable:end -->
