### PR TITLE
Functional tests - Fix nightly 16-03

### DIFF
--- a/tests/puppeteer/pages/BO/BObasePage.js
+++ b/tests/puppeteer/pages/BO/BObasePage.js
@@ -259,8 +259,8 @@ module.exports = class BOBasePage extends CommonPage {
    * @returns {Promise<boolean>}
    */
   async closeHelpSideBar() {
-    await this.waitForSelectorAndClick(this.closeHelpSidebarButton);
-    return this.elementNotVisible(`${this.rightSidebar}.sidebar-open`, 2000);
+    await this.waitForSelectorAndClick(this.helpButton);
+    return this.elementVisible(`${this.rightSidebar}:not(.sidebar-open)`, 2000);
   }
 
   /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fixing nightly 16-03 by closing help card block with a element that is always visible
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/08_design/04_pages/06_helperCard.js" URL_FO=shopURL/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18156)
<!-- Reviewable:end -->
