### PR TITLE
Use hasBeenPaid instead of hasInvoice to enable refund feature

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1817,6 +1817,16 @@ class OrderCore extends ObjectModel
     }
 
     /**
+     * Indicates if order has any associated payments.
+     *
+     * @return bool
+     */
+    public function hasPayments(): bool
+    {
+        return $this->getOrderPaymentCollection()->count() > 0;
+    }
+
+    /**
      * This method allows to add a payment to the current order.
      *
      * @since 1.5.0.1

--- a/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php
+++ b/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php
@@ -184,7 +184,7 @@ final class CancelOrderProductHandler extends AbstractOrderCommandHandler implem
      */
     private function checkOrderState(Order $order)
     {
-        if ((bool) $order->hasBeenPaid() === true) {
+        if ($order->hasBeenPaid() || $order->hasPayments()) {
             throw new InvalidOrderStateException(
                 InvalidOrderStateException::ALREADY_PAID,
                 'Can not cancel product on an order which is already paid'

--- a/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php
+++ b/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php
@@ -184,8 +184,11 @@ final class CancelOrderProductHandler extends AbstractOrderCommandHandler implem
      */
     private function checkOrderState(Order $order)
     {
-        if ($order->hasInvoice() !== false) {
-            throw new InvalidOrderStateException(InvalidOrderStateException::UNEXPECTED_INVOICE);
+        if ((bool) $order->hasBeenPaid() === true) {
+            throw new InvalidOrderStateException(
+                InvalidOrderStateException::ALREADY_PAID,
+                'Can not cancel product on an order which is already paid'
+            );
         }
     }
 }

--- a/src/Adapter/Order/CommandHandler/IssuePartialRefundHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssuePartialRefundHandler.php
@@ -98,10 +98,10 @@ final class IssuePartialRefundHandler extends AbstractOrderCommandHandler implem
     {
         /** @var Order $order */
         $order = $this->getOrderObject($command->getOrderId());
-        if (!$order->hasInvoice()) {
+        if (!$order->hasBeenPaid()) {
             throw new InvalidOrderStateException(
-                InvalidOrderStateException::INVOICE_NOT_FOUND,
-                'Can not perform partial refund on order with no invoice'
+                InvalidOrderStateException::NOT_PAID,
+                'Can not perform partial refund on an order which is not paid'
             );
         }
 

--- a/src/Adapter/Order/CommandHandler/IssuePartialRefundHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssuePartialRefundHandler.php
@@ -98,7 +98,7 @@ final class IssuePartialRefundHandler extends AbstractOrderCommandHandler implem
     {
         /** @var Order $order */
         $order = $this->getOrderObject($command->getOrderId());
-        if (!$order->hasBeenPaid()) {
+        if (!$order->hasBeenPaid() && !$order->hasPayments()) {
             throw new InvalidOrderStateException(
                 InvalidOrderStateException::NOT_PAID,
                 'Can not perform partial refund on an order which is not paid'
@@ -141,7 +141,6 @@ final class IssuePartialRefundHandler extends AbstractOrderCommandHandler implem
         // Update refund details
         $productsReturned = (int) $this->configuration->get('PS_ORDER_RETURN') === 1 && $order->hasBeenDelivered();
         $this->refundUpdater->updateRefundData(
-            $order,
             $orderRefundSummary,
             $productsReturned,
             $shouldReinjectProducts

--- a/src/Adapter/Order/CommandHandler/IssueReturnProductHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssueReturnProductHandler.php
@@ -145,7 +145,6 @@ class IssueReturnProductHandler extends AbstractOrderCommandHandler implements I
 
         // Update refund details (by definition it returns products)
         $this->refundUpdater->updateRefundData(
-            $order,
             $orderRefundSummary,
             true,
             $command->restockRefundedProducts()

--- a/src/Adapter/Order/CommandHandler/IssueStandardRefundHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssueStandardRefundHandler.php
@@ -104,10 +104,10 @@ class IssueStandardRefundHandler extends AbstractOrderCommandHandler implements 
 
         /** @var Order $order */
         $order = $this->getOrderObject($command->getOrderId());
-        if (!$order->hasInvoice()) {
+        if (!$order->hasBeenPaid()) {
             throw new InvalidOrderStateException(
-                InvalidOrderStateException::INVOICE_NOT_FOUND,
-                'Can not perform standard refund on order with no invoice'
+                InvalidOrderStateException::NOT_PAID,
+                'Can not perform standard refund on an order which is not paid'
             );
         }
         if ($order->hasBeenDelivered()) {

--- a/src/Adapter/Order/CommandHandler/IssueStandardRefundHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssueStandardRefundHandler.php
@@ -104,7 +104,7 @@ class IssueStandardRefundHandler extends AbstractOrderCommandHandler implements 
 
         /** @var Order $order */
         $order = $this->getOrderObject($command->getOrderId());
-        if (!$order->hasBeenPaid()) {
+        if (!$order->hasBeenPaid() && !$order->hasPayments()) {
             throw new InvalidOrderStateException(
                 InvalidOrderStateException::NOT_PAID,
                 'Can not perform standard refund on an order which is not paid'
@@ -150,7 +150,6 @@ class IssueStandardRefundHandler extends AbstractOrderCommandHandler implements 
 
         // Update refund details (standard refund only happen for an order not delivered, so it can't return products)
         $this->refundUpdater->updateRefundData(
-            $order,
             $orderRefundSummary,
             false,
             true

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -181,6 +181,7 @@ final class GetOrderForViewingHandler implements GetOrderForViewingHandlerInterf
             $taxMethod,
             $isTaxIncluded,
             (bool) $order->valid,
+            $order->hasBeenPaid(),
             $order->hasInvoice(),
             $order->hasBeenDelivered(),
             $order->hasBeenShipped(),

--- a/src/Adapter/Order/Refund/OrderRefundUpdater.php
+++ b/src/Adapter/Order/Refund/OrderRefundUpdater.php
@@ -35,7 +35,6 @@ use PrestaShopException;
 class OrderRefundUpdater
 {
     /**
-     * @param Order $order
      * @param OrderRefundSummary $orderRefundSummary
      * @param bool $returnedProducts
      * @param bool $restock
@@ -45,17 +44,10 @@ class OrderRefundUpdater
      * @throws PrestaShopException
      */
     public function updateRefundData(
-        Order $order,
         OrderRefundSummary $orderRefundSummary,
         bool $returnedProducts,
         bool $restock
     ) {
-        // I wonder it this is really useful since partial refund is supposed to be enabled only once order
-        // is paid Maybe this should be a more general check at the beginning of the handler and throw an error
-        if (!$order->hasBeenPaid()) {
-            return;
-        }
-
         // Update order details (after credit slip to avoid updating refunded quantities while the credit slip fails)
         foreach ($orderRefundSummary->getProductRefunds() as $orderDetailId => $productRefund) {
             $orderDetail = $orderRefundSummary->getOrderDetailById($orderDetailId);

--- a/src/Core/Domain/Order/Exception/InvalidOrderStateException.php
+++ b/src/Core/Domain/Order/Exception/InvalidOrderStateException.php
@@ -33,14 +33,14 @@ namespace PrestaShop\PrestaShop\Core\Domain\Order\Exception;
 class InvalidOrderStateException extends OrderException
 {
     /**
-     * Used when the order has no invoice (and it should have)
+     * Used when the order is not paid (and it should be)
      */
-    const INVOICE_NOT_FOUND = 1;
+    const NOT_PAID = 1;
 
     /**
-     * Used when the order has an invoice (and it should not)
+     * Used when the order is already paid (and it should not be)
      */
-    const UNEXPECTED_INVOICE = 2;
+    const ALREADY_PAID = 2;
 
     /**
      * Used when the order has not been delivered (and it should have)

--- a/src/Core/Domain/Order/QueryResult/OrderForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderForViewing.php
@@ -397,6 +397,14 @@ class OrderForViewing
     }
 
     /**
+     * @return bool
+     */
+    public function hasPayments(): bool
+    {
+        return count($this->payments->getPayments()) > 0;
+    }
+
+    /**
      * @return OrderMessagesForViewing
      */
     public function getMessages(): OrderMessagesForViewing

--- a/src/Core/Domain/Order/QueryResult/OrderForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderForViewing.php
@@ -131,6 +131,11 @@ class OrderForViewing
     /**
      * @var bool
      */
+    private $hasBeenPaid;
+
+    /**
+     * @var bool
+     */
     private $hasInvoice;
 
     /**
@@ -179,6 +184,7 @@ class OrderForViewing
      * @param string $taxMethod
      * @param bool $isTaxIncluded
      * @param bool $isValid
+     * @param bool $hasBeenPaid
      * @param bool $hasInvoice
      * @param bool $isDelivered
      * @param bool $isShipped
@@ -208,6 +214,7 @@ class OrderForViewing
         string $taxMethod,
         bool $isTaxIncluded,
         bool $isValid,
+        bool $hasBeenPaid,
         bool $hasInvoice,
         bool $isDelivered,
         bool $isShipped,
@@ -245,6 +252,7 @@ class OrderForViewing
         $this->isShipped = $isShipped;
         $this->prices = $prices;
         $this->isTaxIncluded = $isTaxIncluded;
+        $this->hasBeenPaid = $hasBeenPaid;
         $this->hasInvoice = $hasInvoice;
         $this->discounts = $discounts;
         $this->createdAt = $createdAt;
@@ -426,6 +434,14 @@ class OrderForViewing
     public function isTaxIncluded(): bool
     {
         return $this->isTaxIncluded;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasBeenPaid(): bool
+    {
+        return $this->hasBeenPaid;
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1487,8 +1487,8 @@ class OrderController extends CommonController
                 'Admin.Notifications.Error'
             ),
             InvalidOrderStateException::class => [
-                InvalidOrderStateException::UNEXPECTED_INVOICE => $this->trans(
-                    'Invalid action: this order already has an invoice.',
+                InvalidOrderStateException::ALREADY_PAID => $this->trans(
+                    'Invalid action: this order has already been paid.',
                     'Admin.Notifications.Error'
                 ),
                 InvalidOrderStateException::DELIVERY_NOT_FOUND => $this->trans(
@@ -1499,8 +1499,8 @@ class OrderController extends CommonController
                     'Invalid action: this order has already been delivered.',
                     'Admin.Notifications.Error'
                 ),
-                InvalidOrderStateException::INVOICE_NOT_FOUND => $this->trans(
-                    'Invalid action: this order has no invoice.',
+                InvalidOrderStateException::NOT_PAID => $this->trans(
+                    'Invalid action: this order has not been paid.',
                     'Admin.Notifications.Error'
                 ),
             ],

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig
@@ -92,7 +92,7 @@
           </button>
         </div>
       </div>
-    {% elseif orderForViewing.hasInvoice() %}
+    {% elseif orderForViewing.hasBeenPaid() %}
       <div class="form-inline d-inline-block form-horizontal ml-2">
         <div class="input-group">
           <button class="btn btn-action standard-refund-display" type="button"{% if not orderForViewing.isRefundable() %} disabled{% endif %}>
@@ -111,7 +111,7 @@
       </div>
     {% endif %}
   {% endif %}
-  {% if orderForViewing.hasInvoice() %}
+  {% if orderForViewing.hasBeenPaid() %}
     <div class="form-inline d-inline-block form-horizontal ml-2">
       <div class="input-group">
         <button class="btn btn-action partial-refund-display" type="button"{% if not orderForViewing.isRefundable() %} disabled{% endif %}>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig
@@ -92,7 +92,7 @@
           </button>
         </div>
       </div>
-    {% elseif orderForViewing.hasBeenPaid() %}
+    {% elseif orderForViewing.hasBeenPaid() or orderForViewing.hasPayments() %}
       <div class="form-inline d-inline-block form-horizontal ml-2">
         <div class="input-group">
           <button class="btn btn-action standard-refund-display" type="button"{% if not orderForViewing.isRefundable() %} disabled{% endif %}>
@@ -111,7 +111,7 @@
       </div>
     {% endif %}
   {% endif %}
-  {% if orderForViewing.hasBeenPaid() %}
+  {% if orderForViewing.hasBeenPaid() or orderForViewing.hasPayments() %}
     <div class="form-inline d-inline-block form-horizontal ml-2">
       <div class="input-group">
         <button class="btn btn-action partial-refund-display" type="button"{% if not orderForViewing.isRefundable() %} disabled{% endif %}>

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderRefundFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderRefundFeatureContext.php
@@ -233,7 +233,7 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
 
     /**
      * @Then I should get error that refund quantity is too high and max is :maxRefund
-     * @then I should get error that cancel quantity is too high and max is :maxRefund
+     * @Then I should get error that cancel quantity is too high and max is :maxRefund
      */
     public function assertLastErrorIsRefundQuantityTooHigh(int $maxRefund)
     {
@@ -279,24 +279,24 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then I should get error that order has unexpected invoice
+     * @Then I should get error that order is already paid
      */
-    public function assertLastErrorIsOrderHasUnexpectedInvoice()
+    public function assertLastErrorIsOrderIsAlreadyPaid()
     {
         $this->assertLastErrorIs(
             InvalidOrderStateException::class,
-            InvalidOrderStateException::UNEXPECTED_INVOICE
+            InvalidOrderStateException::ALREADY_PAID
         );
     }
 
     /**
-     * @Then I should get error that order has no invoice
+     * @Then I should get error that order is not paid
      */
-    public function assertLastErrorIsOrderHasNoInvoice()
+    public function assertLastErrorIsOrderIsNotPaid()
     {
         $this->assertLastErrorIs(
             InvalidOrderStateException::class,
-            InvalidOrderStateException::INVOICE_NOT_FOUND
+            InvalidOrderStateException::NOT_PAID
         );
     }
 

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
@@ -71,7 +71,6 @@ Feature: Cancel Order Product from Back Office (BO)
     And order "bo_order_cancel_product" should contain 0 products "Mug Today is a good day"
     And order "bo_order_cancel_product" has status "Canceled"
 
-
   @order-cancel-product
   Scenario: Quantity is required
     Given I add order "bo_order_cancel_product" with the following details:

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
@@ -121,4 +121,4 @@ Feature: Cancel Order Product from Back Office (BO)
       | product_name                | quantity |
       | Mug The best is yet to come | 1       |
       | Mug Today is a good day     | 1        |
-    Then I should get error that order has unexpected invoice
+    Then I should get error that order is already paid

--- a/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
@@ -666,7 +666,7 @@ Feature: Refund Order from Back Office (BO)
       | product_name                | quantity                 | amount |
       | Mug The best is yet to come | 1                        | 10.5   |
       | Mug Today is a good day     | 1                        | 3.5    |
-    Then I should get error that order has no invoice
+    Then I should get error that order is not paid
     And "bo_order_refund" has 0 credit slips
 
   @order-refund

--- a/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
@@ -649,7 +649,7 @@ Feature: Refund Order from Back Office (BO)
 
   @order-refund
   @order-partial-refund
-  Scenario: Partial refund can't be done if order has no invoice
+  Scenario: Partial refund can't be done if order is not paid
     Given I add order "bo_order_refund" with the following details:
       | cart                | dummy_cart                 |
       | message             | test                       |
@@ -661,13 +661,60 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
     And there are 1 less "Mug Today is a good day" in stock
-    And return product is enabled
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug The best is yet to come | 1                        | 10.5   |
       | Mug Today is a good day     | 1                        | 3.5    |
     Then I should get error that order is not paid
     And "bo_order_refund" has 0 credit slips
+
+  @order-refund
+  @order-partial-refund
+  Scenario: Partial refund is possible if order is not paid but has payments
+    Given I add order "bo_order_refund" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting check payment     |
+    And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
+      | product_quantity            | 2 |
+    And product "Mug Today is a good day" in order "bo_order_refund" has following details:
+      | product_quantity            | 1 |
+    And there are 2 less "Mug The best is yet to come" in stock
+    And there are 1 less "Mug Today is a good day" in stock
+    And I pay order "bo_order_refund" with the following details:
+      | date           | 2019-11-26 13:56:23 |
+      | payment_method | Payments by check   |
+      | transaction_id | test123             |
+      | id_currency    | 1                   |
+      | amount         | 6.00                |
+    And order "bo_order_refund" has 1 payments
+    And "bo_order_refund" has 0 credit slips
+    And order "bo_order_refund" has status "Awaiting check payment"
+    When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
+      | product_name                | quantity                 | amount |
+      | Mug The best is yet to come | 1                        | 10.5   |
+      | Mug Today is a good day     | 1                        | 3.5    |
+    Then "bo_order_refund" has 1 credit slips
+    Then "bo_order_refund" last credit slip is:
+      | amount                  | 14.0  |
+      | shipping_cost_amount    | 0.0   |
+      | total_products_tax_excl | 14.0  |
+      | total_products_tax_incl | 14.84 |
+    And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
+      | product_quantity            | 2     |
+      | product_quantity_refunded   | 1     |
+      | product_quantity_reinjected | 1     |
+      | total_refunded_tax_excl     | 10.5  |
+      | total_refunded_tax_incl     | 11.13 |
+    And product "Mug Today is a good day" in order "bo_order_refund" has following details:
+      | product_quantity            | 1    |
+      | product_quantity_refunded   | 1    |
+      | product_quantity_reinjected | 1    |
+      | total_refunded_tax_excl     | 3.5  |
+      | total_refunded_tax_incl     | 3.71 |
+    And there are 1 more "Mug The best is yet to come" in stock
+    And there are 1 more "Mug Today is a good day" in stock
 
   @order-refund
   @order-partial-refund

--- a/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
@@ -43,7 +43,7 @@ Feature: Refund Order from Back Office (BO)
 
   @order-refund
   @order-standard-refund
-  Scenario: Standard refund can't be done if order has no invoice
+  Scenario: Standard refund can't be done if order is not paid
     Given I add order "bo_order_refund" with the following details:
       | cart                | dummy_cart             |
       | message             | test                   |
@@ -62,6 +62,54 @@ Feature: Refund Order from Back Office (BO)
       | Mug Today is a good day     | 1        |
     Then I should get error that order is not paid
     And "bo_order_refund" has 0 credit slips
+
+  @order-refund
+  @order-standard-refund
+  Scenario: Standard refund is possible if order is not paid but has payments
+    Given I add order "bo_order_refund" with the following details:
+      | cart                | dummy_cart             |
+      | message             | test                   |
+      | payment module name | dummy_payment          |
+      | status              | Awaiting check payment |
+    And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
+      | product_quantity            | 2 |
+    And product "Mug Today is a good day" in order "bo_order_refund" has following details:
+      | product_quantity            | 1 |
+    And there are 2 less "Mug The best is yet to come" in stock
+    And there are 1 less "Mug Today is a good day" in stock
+    And I pay order "bo_order_refund" with the following details:
+      | date           | 2019-11-26 13:56:23 |
+      | payment_method | Payments by check   |
+      | transaction_id | test123             |
+      | id_currency    | 1                   |
+      | amount         | 6.00                |
+    And "bo_order_refund" has 0 credit slips
+    And order "bo_order_refund" has status "Awaiting check payment"
+    And return product is enabled
+    When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
+      | product_name                | quantity |
+      | Mug The best is yet to come | 1        |
+      | Mug Today is a good day     | 1        |
+    Then "bo_order_refund" has 1 credit slips
+    Then "bo_order_refund" last credit slip is:
+      | amount                  | 23.8   |
+      | shipping_cost_amount    | 0.0    |
+      | total_products_tax_excl | 23.8   |
+      | total_products_tax_incl | 25.228 |
+    And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
+      | product_quantity            | 2      |
+      | product_quantity_refunded   | 1      |
+      | product_quantity_reinjected | 1      |
+      | total_refunded_tax_excl     | 11.9   |
+      | total_refunded_tax_incl     | 12.614 |
+    And product "Mug Today is a good day" in order "bo_order_refund" has following details:
+      | product_quantity            | 1      |
+      | product_quantity_refunded   | 1      |
+      | product_quantity_reinjected | 1      |
+      | total_refunded_tax_excl     | 11.9   |
+      | total_refunded_tax_incl     | 12.614 |
+    And there are 1 more "Mug The best is yet to come" in stock
+    And there are 1 more "Mug Today is a good day" in stock
 
   @order-refund
   @order-standard-refund

--- a/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
@@ -60,7 +60,7 @@ Feature: Refund Order from Back Office (BO)
       | product_name                | quantity |
       | Mug The best is yet to come | 1        |
       | Mug Today is a good day     | 1        |
-    Then I should get error that order has no invoice
+    Then I should get error that order is not paid
     And "bo_order_refund" has 0 credit slips
 
   @order-refund


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Refund buttons and actions/handlers were based on `Order::hasInvoice` to enable their feature, it is more logical to use `Order::hasBeenPaid` because an invoice can be generated manually without any payment previously made
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18157
| How to test?  | See issue, but basically create an invoice manually the refund buttons should not be visible They only appear once the status has been changed to a paid status

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18164)
<!-- Reviewable:end -->
