### PR TITLE
Avoiding to call several times the actionProductUpdate hook

### DIFF
--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -215,7 +215,7 @@ class AdminProductWrapper
         static $hookExecuted = [];
         if (!in_array($product->id, $hookExecuted)) {
             $hookExecuted[] = $product->id;
-            Hook::exec('actionProductUpdate', array('id_product' => (int) $product->id, 'product' => $product));
+            Hook::exec('actionProductUpdate', ['id_product' => (int) $product->id, 'product' => $product]);
         }
     }
 

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -212,7 +212,11 @@ class AdminProductWrapper
     {
         // Hook triggered by legacy code below: actionUpdateQuantity('id_product', 'id_product_attribute', 'quantity')
         StockAvailable::setQuantity((int) $product->id, $forAttributeId, $quantity);
-        Hook::exec('actionProductUpdate', ['id_product' => (int) $product->id, 'product' => $product]);
+        static $hookExecuted = [];
+        if (!in_array($product->id, $hookExecuted)) {
+            $hookExecuted[] = $product->id;
+            Hook::exec('actionProductUpdate', array('id_product' => (int) $product->id, 'product' => $product));
+        }
     }
 
     /**


### PR DESCRIPTION
If we save or update a product with any combination, the for loop that calls procdessProductAttribute will finally execute the line Hook::exec('actionProductUpdate', array('id_product' => (int) $product->id, 'product' => $product)); one time per each combination. It can be understood as a great performance problem if the user has a very big module that, for example, regenerates an index per each call.

The same Hook is also called in update and uptadeWS Product's functions, I do not know if could be better to just delete the line.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Avoiding to call many times the same hook
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Just save a product with combinations.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18167)
<!-- Reviewable:end -->
