### PR TITLE
Prevent adding or editing an invalid product quantity on order

### DIFF
--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -402,6 +402,21 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
     }
 
     /**
+     * Retrieve the last result.
+     *
+     * @return ObjectModel|false
+     */
+    public function getLast()
+    {
+        $this->getAll();
+        if (!count($this)) {
+            return false;
+        }
+
+        return $this[count($this) - 1];
+    }
+
+    /**
      * Get results array.
      *
      * @return array

--- a/src/Core/Domain/Order/Exception/InvalidProductQuantityException.php
+++ b/src/Core/Domain/Order/Exception/InvalidProductQuantityException.php
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Order\Exception;
 

--- a/src/Core/Domain/Order/Exception/InvalidProductQuantityException.php
+++ b/src/Core/Domain/Order/Exception/InvalidProductQuantityException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\Exception;
+
+/**
+ * Thrown when trying to add an invalid quantity or a product (<= 0)
+ */
+class InvalidProductQuantityException extends OrderException
+{
+}

--- a/src/Core/Domain/Order/Product/Command/AddProductToOrderCommand.php
+++ b/src/Core/Domain/Order/Product/Command/AddProductToOrderCommand.php
@@ -29,6 +29,8 @@ namespace PrestaShop\PrestaShop\Core\Domain\Order\Product\Command;
 use InvalidArgumentException;
 use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidAmountException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidProductQuantityException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
@@ -89,6 +91,10 @@ class AddProductToOrderCommand
      * @param bool $isFreeShipping
      *
      * @return self
+     *
+     * @throws InvalidProductQuantityException
+     * @throws InvalidAmountException
+     * @throws OrderException
      */
     public static function withNewInvoice(
         int $orderId,
@@ -125,6 +131,10 @@ class AddProductToOrderCommand
      * @param int $productQuantity
      *
      * @return self
+     *
+     * @throws InvalidProductQuantityException
+     * @throws InvalidAmountException
+     * @throws OrderException
      */
     public static function toExistingInvoice(
         int $orderId,
@@ -156,6 +166,10 @@ class AddProductToOrderCommand
      * @param string $productPriceTaxIncluded
      * @param string $productPriceTaxExcluded
      * @param int $productQuantity
+     *
+     * @throws InvalidProductQuantityException
+     * @throws InvalidAmountException
+     * @throws OrderException
      */
     private function __construct(
         int $orderId,
@@ -174,7 +188,7 @@ class AddProductToOrderCommand
         } catch (InvalidArgumentException $e) {
             throw new InvalidAmountException();
         }
-        $this->productQuantity = $productQuantity;
+        $this->setProductQuantity($productQuantity);
     }
 
     /**
@@ -239,5 +253,18 @@ class AddProductToOrderCommand
     public function isFreeShipping()
     {
         return $this->isFreeShipping;
+    }
+
+    /**
+     * @param int $productQuantity
+     *
+     * @throws InvalidProductQuantityException
+     */
+    private function setProductQuantity(int $productQuantity): void
+    {
+        if ($productQuantity <= 0) {
+            throw new InvalidProductQuantityException('When adding a product quantity must be strictly positive');
+        }
+        $this->productQuantity = $productQuantity;
     }
 }

--- a/src/Core/Domain/Order/Product/Command/UpdateProductInOrderCommand.php
+++ b/src/Core/Domain/Order/Product/Command/UpdateProductInOrderCommand.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Order\Product\Command;
 use InvalidArgumentException;
 use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidAmountException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidProductQuantityException;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
 
 /**
@@ -90,7 +91,7 @@ class UpdateProductInOrderCommand
         } catch (InvalidArgumentException $e) {
             throw new InvalidAmountException();
         }
-        $this->quantity = $quantity;
+        $this->setQuantity($quantity);
         $this->orderInvoiceId = $orderInvoiceId;
     }
 
@@ -140,5 +141,18 @@ class UpdateProductInOrderCommand
     public function getOrderInvoiceId()
     {
         return $this->orderInvoiceId;
+    }
+
+    /**
+     * @param int $quantity
+     *
+     * @throws InvalidProductQuantityException
+     */
+    private function setQuantity(int $quantity): void
+    {
+        if ($quantity <= 0) {
+            throw new InvalidProductQuantityException('When adding a product quantity must be strictly positive');
+        }
+        $this->quantity = $quantity;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -49,6 +49,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidAmountException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidCancelProductException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidOrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidProductQuantityException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\NegativePaymentAmountException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderEmailSendException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
@@ -1503,6 +1504,10 @@ class OrderController extends FrameworkBundleAdminController
                     'Admin.Notifications.Error'
                 ),
             ],
+            InvalidProductQuantityException::class => $this->trans(
+                'Please enter a positive quantity.',
+                'Admin.Orderscustomers.Notification'
+            ),
         ];
     }
 

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -161,6 +161,50 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should contain 2 products "Mug Today is a good day"
 
   @order-from-bo
+  Scenario: Update product in order
+    When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
+      | amount        | 3                       |
+      | price         | 12                      |
+    Then order "bo_order1" should contain 3 products "Mug The best is yet to come"
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 3  |
+      | product_price               | 12 |
+      | unit_price_tax_incl         | 12 |
+      | unit_price_tax_excl         | 12 |
+      | total_price_tax_incl        | 36 |
+      | total_price_tax_excl        | 36 |
+
+  @order-from-bo
+  Scenario: Update product in order with zero quantity is forbidden
+    When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
+      | amount        | 0                       |
+      | price         | 12                      |
+    Then I should get error that product quantity is invalid
+    And order "bo_order1" should contain 2 products "Mug The best is yet to come"
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2    |
+      | product_price               | 11.9 |
+      | unit_price_tax_incl         | 11.9 |
+      | unit_price_tax_excl         | 11.9 |
+      | total_price_tax_incl        | 23.8 |
+      | total_price_tax_excl        | 23.8 |
+
+  @order-from-bo
+  Scenario: Update product in order with negative quantity is forbidden
+    When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
+      | amount        | -1                      |
+      | price         | 12                      |
+    Then I should get error that product quantity is invalid
+    And order "bo_order1" should contain 2 products "Mug The best is yet to come"
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2    |
+      | product_price               | 11.9 |
+      | unit_price_tax_incl         | 11.9 |
+      | unit_price_tax_excl         | 11.9 |
+      | total_price_tax_incl        | 23.8 |
+      | total_price_tax_excl        | 23.8 |
+
+  @order-from-bo
   Scenario: Generating invoice for Order
     When I generate invoice for "bo_order1" order
     Then order "bo_order1" should have invoice

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -101,7 +101,7 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should have 0 invoices
 
   @order-from-bo
-  Scenario: Add product to an existing Order WITH invoice with free shipping to NEW invoice
+  Scenario: Add product to an existing Order with invoice with free shipping to new invoice
     Given I update order "bo_order1" status to "Payment accepted"
     And order "bo_order1" should have 1 invoices
     And order with reference "bo_order1" does not contain product "Mug Today is a good day"
@@ -114,7 +114,7 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should have 2 invoices
 
   @order-from-bo
-  Scenario: Add product to an existing Order WITH invoice with free shipping to last invoice
+  Scenario: Add product to an existing Order with invoice with free shipping to last invoice
     Given I update order "bo_order1" status to "Payment accepted"
     And order "bo_order1" should have 1 invoices
     And order with reference "bo_order1" does not contain product "Mug Today is a good day"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Commands that manage edit and add product to order had no validation regarding the input quantity So from now on an exception is thrown when trying to set a negative or zero value The controller and front js already handled the display of an error correctly (through a json response)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17963 and #17967
| How to test?  | See the issues or more details but basically try to add or edit a product with an invalid quantity (<= 0) the action should not be allowed and an error is displayed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18168)
<!-- Reviewable:end -->
