### PR TITLE
Remove double border in TinyMCE translatable field

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_tinymce.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tinymce.scss
@@ -1218,4 +1218,5 @@ i.mce-i-backcolor {
 .nav-pills.translationsLocales {
   border-left: 1px solid #dfdfdf;
   border-right: 1px solid #dfdfdf;
+  border-bottom: none;
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove double border in TinyMCE translatable field added in #18033 
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No
| How to test?  | Only visual

In https://github.com/PrestaShop/PrestaShop/pull/18033 I add border top to fix this:
![image](https://user-images.githubusercontent.com/194784/76845745-a34a3800-683f-11ea-8f2a-9e6f414284ba.png)

But then double border appears in lang tabs

Before
![image](https://user-images.githubusercontent.com/194784/76844697-f622f000-683d-11ea-81a0-8f6ec536824f.png)

Afer
![image](https://user-images.githubusercontent.com/194784/76844770-12269180-683e-11ea-8ed5-e009ec263ec1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18176)
<!-- Reviewable:end -->
