### PR TITLE
Functional tests - Add tests 'Help card' for customers and addresses

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/04_customers/01_customers/07_helpCard.js
+++ b/tests/puppeteer/campaigns/functional/BO/04_customers/01_customers/07_helpCard.js
@@ -1,0 +1,67 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const CustomersPage = require('@pages/BO/customers');
+// Test context imports
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_customers_customers_helpCard';
+
+let browser;
+let page;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    customersPage: new CustomersPage(page),
+  };
+};
+
+// Check that help card is in english in customers page
+describe('Customers help card', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    await helper.setDownloadBehavior(page);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+  // Login into BO and go to customers page
+  loginCommon.loginBO();
+
+  it('should go to Customers page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToCustomersPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.customersParentLink,
+      this.pageObjects.boBasePage.customersLink,
+    );
+    const pageTitle = await this.pageObjects.customersPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.customersPage.pageTitle);
+  });
+
+  it('should open the help side bar and check the document language', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'openHelpSidebar', baseContext);
+    const isHelpSidebarVisible = await this.pageObjects.customersPage.openHelpSideBar();
+    await expect(isHelpSidebarVisible).to.be.true;
+    const documentURL = await this.pageObjects.customersPage.getHelpDocumentURL();
+    await expect(documentURL).to.contains('country=en');
+  });
+
+  it('should close the help side bar', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'closeHelpSidebar', baseContext);
+    const isHelpSidebarVisible = await this.pageObjects.customersPage.closeHelpSideBar();
+    await expect(isHelpSidebarVisible).to.be.true;
+  });
+});

--- a/tests/puppeteer/campaigns/functional/BO/04_customers/02_addresses/03_addressesBulkActions.js
+++ b/tests/puppeteer/campaigns/functional/BO/04_customers/02_addresses/03_addressesBulkActions.js
@@ -14,7 +14,7 @@ const AddressFaker = require('@data/faker/address');
 // Test context imports
 const testContext = require('@utils/testContext');
 
-const baseContext = 'functional_BO_customers_customers_AddressesBulkActions';
+const baseContext = 'functional_BO_customers_addresses_addressesBulkActions';
 
 let browser;
 let page;

--- a/tests/puppeteer/campaigns/functional/BO/04_customers/02_addresses/04_sortAddresses.js
+++ b/tests/puppeteer/campaigns/functional/BO/04_customers/02_addresses/04_sortAddresses.js
@@ -11,7 +11,7 @@ const AddressesPage = require('@pages/BO/customers/addresses');
 // Test context imports
 const testContext = require('@utils/testContext');
 
-const baseContext = 'functional_BO_customers_customers_sortAddresses';
+const baseContext = 'functional_BO_customers_addresses_sortAddresses';
 
 let browser;
 let page;

--- a/tests/puppeteer/campaigns/functional/BO/04_customers/02_addresses/05_helpCard.js
+++ b/tests/puppeteer/campaigns/functional/BO/04_customers/02_addresses/05_helpCard.js
@@ -11,7 +11,7 @@ const AddressesPage = require('@pages/BO/customers/addresses');
 // Test context imports
 const testContext = require('@utils/testContext');
 
-const baseContext = 'functional_BO_customers_customers_helpCard';
+const baseContext = 'functional_BO_customers_addresses_helpCard';
 
 let browser;
 let page;

--- a/tests/puppeteer/campaigns/functional/BO/04_customers/02_addresses/05_helpCard.js
+++ b/tests/puppeteer/campaigns/functional/BO/04_customers/02_addresses/05_helpCard.js
@@ -1,0 +1,66 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const AddressesPage = require('@pages/BO/customers/addresses');
+// Test context imports
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_customers_customers_helpCard';
+
+let browser;
+let page;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    addressesPage: new AddressesPage(page),
+  };
+};
+
+// Check that help card is in english in addresses page
+describe('Addresses help card', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+  // Login into BO and go to customers page
+  loginCommon.loginBO();
+
+  it('should go to addresses page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToAddressesPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.customersParentLink,
+      this.pageObjects.boBasePage.addressesLink,
+    );
+    const pageTitle = await this.pageObjects.addressesPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.addressesPage.pageTitle);
+  });
+
+  it('should open the help side bar and check the document language', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'openHelpSidebar', baseContext);
+    const isHelpSidebarVisible = await this.pageObjects.addressesPage.openHelpSideBar();
+    await expect(isHelpSidebarVisible).to.be.true;
+    const documentURL = await this.pageObjects.addressesPage.getHelpDocumentURL();
+    await expect(documentURL).to.contains('country=en');
+  });
+
+  it('should close the help side bar', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'closeHelpSidebar', baseContext);
+    const isHelpSidebarVisible = await this.pageObjects.addressesPage.closeHelpSideBar();
+    await expect(isHelpSidebarVisible).to.be.true;
+  });
+});


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add new tests 'Help card' for customers and addresses
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/04_customers/01_customers/07_helpCard.js" URL_FO=shopUrl/ npm run specific-test` <br> `TEST_PATH="functional/BO/04_customers/02_addresses/05_helpCard.js" URL_FO=shopUrl/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18180)
<!-- Reviewable:end -->
