### PR TITLE
Rework help-box making it reusable and more maintenable by regrouping markups

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -62,6 +62,7 @@ twig:
     paths:
         '%admin_page%/Product': Product
         '%admin_page%/TwigTemplateForm': Twig
+        '%admin_page%/Common': Common
         '%admin_page%/Configure/AdvancedParameters': AdvancedParameters
         '%admin_page%/Configure/ShopParameters': ShopParameters
         '%kernel.root_dir%/../modules': Modules

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/HelpBox/helpbox.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/HelpBox/helpbox.html.twig
@@ -23,22 +23,19 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% trans_default_domain 'Admin.Advparameters.Feature' %}
+ <span 
+   class="help-box{% if classes is defined %} {{ classes }}{% endif %}"
+   data-toggle="popover"
+   {% if content is defined %}
+    data-content="{{ content }}"
+   {% endif %}
 
-<div class="card">
-  <h3 class="card-header">
-    <i class="material-icons">list</i> {{ 'Available fields'|trans }}
-  </h3>
-  <div class="card-block">
-    <div class="js-available-field-template d-none"></div>
-    {% include '@Common/HelpBox/helpbox.html.twig' with { "classes" : "js-available-field-popover-template d-none" } %}
-    <div
-      class="alert alert-info js-available-fields"
-      role="alert"
-      data-url="{{ path('admin_import_get_available_fields') }}"
-    >
-    </div>
+   {% if placement is defined %}
+    data-placement="{{ placement}}"
+   {% endif %}
 
-    <p>{{ '* Required field'|trans({}, 'Admin.Advparameters.Feature') }}</p>
-  </div>
-</div>
+   {% if title is defined %}
+    data-title="{{ title }}"
+   {% endif %}
+ >
+ </span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/HelpBox/helpbox.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/HelpBox/helpbox.html.twig
@@ -27,15 +27,15 @@
    class="help-box{% if classes is defined %} {{ classes }}{% endif %}"
    data-toggle="popover"
    {% if content is defined %}
-    data-content="{{ content }}"
+     data-content="{{ content }}"
    {% endif %}
 
    {% if placement is defined %}
-    data-placement="{{ placement}}"
+     data-placement="{{ placement}}"
    {% endif %}
 
    {% if title is defined %}
-    data-title="{{ title }}"
+     data-title="{{ title }}"
    {% endif %}
  >
  </span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
@@ -27,7 +27,7 @@
     <div class="col-lg-6">
       <div class="module-sorting-search-wording">
         <span id="selected_modules" class="module-search-result-title module-search-result-wording">{{ '%nbModules% modules and services selected for you'|trans({'%nbModules%' : totalModules}, 'Admin.Modules.Feature') }}</span>
-        {% include '@Common/HelpBox/helpbox.html.twig' with { 'content' : "Selection"|trans({}, 'Admin.Modules.Feature')  , 'title' : "Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules."|trans({}, 'Admin.Modules.Help')   } %}
+        {% include '@Common/HelpBox/helpbox.html.twig' with { 'content' : "Selection"|trans({}, 'Admin.Modules.Feature'), 'title' : "Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules."|trans({}, 'Admin.Modules.Help') } %}
       </div>
     </div>
     <div class="col-lg-6">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/sorting.html.twig
@@ -27,10 +27,7 @@
     <div class="col-lg-6">
       <div class="module-sorting-search-wording">
         <span id="selected_modules" class="module-search-result-title module-search-result-wording">{{ '%nbModules% modules and services selected for you'|trans({'%nbModules%' : totalModules}, 'Admin.Modules.Feature') }}</span>
-        <span class="help-box" data-toggle="popover"
-          data-title="{{ "Selection"|trans({}, 'Admin.Modules.Feature') }}"
-          data-content="{{ "Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules."|trans({}, 'Admin.Modules.Help') }}">
-        </span>
+        {% include '@Common/HelpBox/helpbox.html.twig' with { 'content' : "Selection"|trans({}, 'Admin.Modules.Feature')  , 'title' : "Customize your store with this selection of modules recommended for your shop, based on your country, language and version of PrestaShop. It includes the most popular modules from our Addons marketplace, and free partner modules."|trans({}, 'Admin.Modules.Help')   } %}
       </div>
     </div>
     <div class="col-lg-6">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/alerts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/alerts.html.twig
@@ -36,10 +36,7 @@
     <div class="col-lg-10">
       <div id="module-short-list-configure" class="module-short-list">
         <span class="module-search-result-title module-search-result-wording">{{ '%nbModules% modules to configure'|trans({'%nbModules%' : modules|length}, 'Admin.Modules.Feature') }}</span>
-        <span class="help-box" data-toggle="popover"
-          data-title="{{ "Modules to configure"|trans({}, 'Admin.Modules.Feature') }}"
-          data-content="{{ "These modules require your attention: you need to take some action to ensure they are fully operational."|trans({}, 'Admin.Modules.Help') }}">
-        </span>
+        {% include '@Common/HelpBox/helpbox.html.twig' with { 'content' : "These modules require your attention: you need to take some action to ensure they are fully operational."|trans({}, 'Admin.Modules.Help'), 'title' : "Modules to configure"|trans({}, 'Admin.Modules.Feature') } %}
       </div>
       {% include '@PrestaShop/Admin/Module/Includes/grid_notification_configure.html.twig' with { 'modules': modules, 'display_type': 'list', id: 'notification', 'category': 'notification'  } %}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig
@@ -36,10 +36,8 @@
     <div class="col-lg-10">
       <div id="module-short-list-update" class="module-short-list">
         <span class="module-search-result-title module-search-result-wording">{{ '%nbModules% modules to update'|trans({'%nbModules%' : modules|length}, 'Admin.Modules.Feature') }}</span>
-        <span class="help-box" data-toggle="popover"
-          data-title="{{ "Modules to update"|trans({}, 'Admin.Modules.Feature') }}"
-          data-content="{{ "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help') }}">
-        </span>
+        {% include '@Common/HelpBox/helpbox.html.twig' with { 'content' :  "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help') , 'title' :  "Modules to update"|trans({}, 'Admin.Modules.Feature')  } %}
+
         {% if (modules|length > 1) and (level >= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE')) %}
           <a class="btn btn-primary-reverse float-right btn-outline-primary light-button module_action_menu_upgrade_all" href="#" data-confirm_modal="module-modal-confirm-upgrade-all">{{ "Upgrade All"|trans({}, 'Admin.Modules.Feature') }}</a>
         {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig
@@ -36,7 +36,7 @@
     <div class="col-lg-10">
       <div id="module-short-list-update" class="module-short-list">
         <span class="module-search-result-title module-search-result-wording">{{ '%nbModules% modules to update'|trans({'%nbModules%' : modules|length}, 'Admin.Modules.Feature') }}</span>
-        {% include '@Common/HelpBox/helpbox.html.twig' with { 'content' :  "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help') , 'title' :  "Modules to update"|trans({}, 'Admin.Modules.Feature')  } %}
+        {% include '@Common/HelpBox/helpbox.html.twig' with { 'content' : "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help'), 'title' : "Modules to update"|trans({}, 'Admin.Modules.Feature') } %}
 
         {% if (modules|length > 1) and (level >= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE')) %}
           <a class="btn btn-primary-reverse float-right btn-outline-primary light-button module_action_menu_upgrade_all" href="#" data-confirm_modal="module-modal-confirm-upgrade-all">{{ "Upgrade All"|trans({}, 'Admin.Modules.Feature') }}</a>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
@@ -260,8 +260,7 @@
 
       {% if label_attr['popover'] is defined %}
         {% set placement = label_attr['popover_placement'] is defined ? label_attr['popover_placement'] : 'top' %}
-        <span class="help-box" data-toggle="popover" data-placement="{{ placement }}"
-           data-content="{{ label_attr['popover'] }}"></span>
+        {% include '@Common/HelpBox/helpbox.html.twig' with { "placement" : placement, "content": label_attr['popover'] } %}
       {% endif %}
     </label>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -80,8 +80,7 @@
 
     {% if label_attr['popover'] is defined %}
       {% set placement = label_attr['popover_placement'] is defined ? label_attr['popover_placement'] : 'top' %}
-      <span class="help-box" data-toggle="popover" data-placement="{{ placement }}"
-            data-content="{{ label_attr['popover'] }}"></span>
+      {% include '@Common/HelpBox/helpbox.html.twig' with { "placement" : placement, "content": label_attr['popover'] } %}
     {% endif %}
     </label>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -63,12 +63,9 @@
   {% endif %}
 
   {{ label }}
-  <span
-    class="help-box"
-    data-toggle="popover"
-    data-content="{{ help }}">
-  </span>
+  {{ include('@Common/HelpBox/helpbox.html.twig', {'content': help}) }}
 </label>
+
 <p class="sr-only">{{ help }}</p>
 {% endmacro %}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Help box was wrong used in some pages, I also extracted it to a reusable component. This aim the fact that we have only one file to change if we want to change the help box markup, it's also a POC about reusable components we should have on the project
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Build assets then try to see these helps box on every BO pages, they should work as expected

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18184)
<!-- Reviewable:end -->
