### PR TITLE
Fix notice on Invoice|DeliverySlip|CreditSlip pdf with product customization

### DIFF
--- a/pdf/delivery-slip.product-tab.tpl
+++ b/pdf/delivery-slip.product-tab.tpl
@@ -76,7 +76,7 @@
 						<td class="center"> &nbsp;</td>
 
 						<td>
-							{if isset($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) && count($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) > 0}
+							{if !empty($customization.datas[Product::CUSTOMIZE_TEXTFIELD])}
 								<table style="width: 100%;">
 									{foreach $customization.datas[Product::CUSTOMIZE_TEXTFIELD] as $customization_infos}
 										<tr>
@@ -89,7 +89,7 @@
 								</table>
 							{/if}
 
-							{if isset($customization.datas[Product::CUSTOMIZE_FILE]) && count($customization.datas[Product::CUSTOMIZE_FILE]) > 0}
+							{if !empty($customization.datas[Product::CUSTOMIZE_FILE])}
 								<table style="width: 100%;">
 									<tr>
 										<td style="width: 30%;">{l s='image(s):' d='Shop.Pdf' pdf='true'}</td>

--- a/pdf/invoice.product-tab.tpl
+++ b/pdf/invoice.product-tab.tpl
@@ -105,7 +105,7 @@
 					<td class="center"> &nbsp;</td>
 
 					<td>
-						{if isset($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) && count($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) > 0}
+						{if !empty($customization.datas[Product::CUSTOMIZE_TEXTFIELD])}
 							<table style="width: 100%;">
 								{foreach $customization.datas[Product::CUSTOMIZE_TEXTFIELD] as $customization_infos}
 									<tr>
@@ -118,7 +118,7 @@
 							</table>
 						{/if}
 
-						{if isset($customization.datas[Product::CUSTOMIZE_FILE]) && count($customization.datas[Product::CUSTOMIZE_FILE]) > 0}
+						{if !empty($customization.datas[Product::CUSTOMIZE_FILE])}
 							<table style="width: 100%;">
 								<tr>
 									<td style="width: 70%;">{l s='image(s):' d='Shop.Pdf' pdf='true'}</td>

--- a/pdf/order-slip.product-tab.tpl
+++ b/pdf/order-slip.product-tab.tpl
@@ -73,14 +73,14 @@
 							<td>
 								<table style="width: 100%;"><tr><td>
 									{foreach $customization.datas as $customization_types}
-										{if isset($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) && count($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) > 0}
+										{if !empty($customization.datas[Product::CUSTOMIZE_TEXTFIELD])}
 											{foreach $customization.datas[Product::CUSTOMIZE_TEXTFIELD] as $customization_infos}
 												{$customization_infos.name}: {$customization_infos.value}
 												{if !$smarty.foreach.custo_foreach.last}<br />{/if}
 											{/foreach}
 										{/if}
 
-										{if isset($customization.datas[Product::CUSTOMIZE_FILE]) && count($customization.datas[Product::CUSTOMIZE_FILE]) > 0}
+										{if !empty($customization.datas[Product::CUSTOMIZE_FILE])}
 											{count($customization.datas[Product::CUSTOMIZE_FILE])} {l s='image(s)' d='Shop.Pdf' pdf='true'}
 										{/if}
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If order contains product with a customization, an error notice thrown when invoice is generated. Same problem with CreditSlip and DeliverySlip
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/15358
| How to test?  | Add a product with a customization to cart, do an order, change OrderState to Payment accepted, try to get invoice ; change OrderState to Processing in progress, try to get a DeliverySlip ; do a Partial Refund, try to get a CreditSlip

With `isset` smarty generate `$_smarty_tpl->tpl_vars['customization']->value['datas'][@constant('_CUSTOMIZE_FILE_')] !== null` no problem with usage of `empty`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18186)
<!-- Reviewable:end -->
