### PR TITLE
Do not display shipping address when order is virtual product only

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -100,6 +100,7 @@
     {% endif %}
     <div class="mt-2 info-block">
       <div class="row">
+        {% if orderForViewing.virtual is same as(false) %}
         <div class="col-md-6">
           <div class="row justify-content-between no-gutters">
             <strong>{{ 'Shipping address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
@@ -155,7 +156,8 @@
             {{ orderForViewing.shippingAddress.mobilePhoneNumber }}
           </p>
         </div>
-        <div class="col-md-6">
+        {% endif %}
+        <div class="{% if orderForViewing.virtual %}col-md-12{% else %}col-md-6{% endif %}">
           <div class="row justify-content-between no-gutters">
             <strong>{{ 'Invoice address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When ordering only virtual products, the shipping shouldn't be displayed in the BO order view page.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17935
| How to test?  | 1. Go to the FO and order a virtual product (ex: Illustration vectorielle Renard)<br>2. Go to the BO and view the order<br>3. The shipping address shouldn't be displayed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18202)
<!-- Reviewable:end -->
