### PR TITLE
BO : Add Product on Order : Use previous cart rather than creating a new one

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -755,7 +755,7 @@ class OrderDetailCore extends ObjectModel
 
         unset(
             $this->vat_address,
-            $products, $this->customer
+            $this->customer
         );
     }
 

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -157,6 +157,10 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             $order->total_shipping = $invoice->total_shipping_tax_incl;
             $order->total_shipping_tax_incl = $invoice->total_shipping_tax_incl;
             $order->total_shipping_tax_excl = $invoice->total_shipping_tax_excl;
+
+            $order->total_wrapping = abs($cart->getOrderTotal(true, Cart::ONLY_WRAPPING));
+            $order->total_wrapping_tax_excl = abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING));
+            $order->total_wrapping_tax_incl = abs($cart->getOrderTotal(true, Cart::ONLY_WRAPPING));
         }
 
         // discount
@@ -499,15 +503,6 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         $invoice->total_wrapping_tax_excl = abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING));
         $invoice->total_wrapping_tax_incl = abs($cart->getOrderTotal(true, Cart::ONLY_WRAPPING));
         $invoice->shipping_tax_computation_method = (int) $taxCalculator->computation_method;
-
-        // Update current order field, only shipping because other field is updated later
-        $order->total_shipping += $invoice->total_shipping_tax_incl;
-        $order->total_shipping_tax_excl += $invoice->total_shipping_tax_excl;
-        $order->total_shipping_tax_incl += $invoice->total_shipping_tax_incl;
-
-        $order->total_wrapping += abs($cart->getOrderTotal(true, Cart::ONLY_WRAPPING));
-        $order->total_wrapping_tax_excl += abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING));
-        $order->total_wrapping_tax_incl += abs($cart->getOrderTotal(true, Cart::ONLY_WRAPPING));
         $invoice->add();
 
         $invoice->saveCarrierTaxCalculator($taxCalculator->getTaxesAmount($invoice->total_shipping_tax_excl));
@@ -535,16 +530,16 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         $precision = $this->getPrecisionFromCart($cart);
         $invoice = new OrderInvoice($orderInvoiceId);
 
-        $invoice->total_paid_tax_excl += Tools::ps_round(
+        $invoice->total_paid_tax_excl = Tools::ps_round(
             (float) $cart->getOrderTotal(false, Cart::BOTH_WITHOUT_SHIPPING),
             $precision
         );
-        $invoice->total_paid_tax_incl += Tools::ps_round(
+        $invoice->total_paid_tax_incl = Tools::ps_round(
             (float) $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING),
             $precision
         );
-        $invoice->total_products += (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
-        $invoice->total_products_wt += (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
+        $invoice->total_products = (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
+        $invoice->total_products_wt = (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
 
         $invoice->update();
 

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -572,12 +572,14 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
 
     /**
      * @param Cart $cart
+     *
      * @return int
      */
     private function getPrecisionFromCart(Cart $cart): int
     {
         $computingPrecision = new ComputingPrecision();
         $currency = new Currency((int) $cart->id_currency);
+
         return $computingPrecision->getPrecision($currency->precision);
     }
 }

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -34,6 +34,7 @@ use CartRule;
 use Combination;
 use Configuration;
 use Context;
+use Currency;
 use Customer;
 use Hook;
 use Order;
@@ -48,6 +49,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\AddProductToOrderCom
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\CommandHandler\AddProductToOrderHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
 use Product;
 use Shop;
 use SpecificPrice;
@@ -137,17 +139,18 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         $order->total_products = (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
         $order->total_products_wt = (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
 
+        $precision = $this->getPrecisionFromCart($cart);
         $order->total_paid = Tools::ps_round(
             (float) $cart->getOrderTotal(true, $totalMethod),
-            $this->context->getComputingPrecision()
+            $precision
         );
         $order->total_paid_tax_excl = Tools::ps_round(
             (float) $cart->getOrderTotal(false, $totalMethod),
-            $this->context->getComputingPrecision()
+            $precision
         );
         $order->total_paid_tax_incl = Tools::ps_round(
             (float) $cart->getOrderTotal(true, $totalMethod),
-            $this->context->getComputingPrecision()
+            $precision
         );
 
         if (null !== $invoice && Validate::isLoadedObject($invoice)) {
@@ -479,13 +482,14 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         $taxCalculator = $carrier->getTaxCalculator($invoice_address);
 
         // @todo: use https://github.com/PrestaShop/decimal to compute prices and taxes
+        $precision = $this->getPrecisionFromCart($cart);
         $invoice->total_paid_tax_excl = Tools::ps_round(
             (float) $cart->getOrderTotal(false, $totalMethod),
-            $this->context->getComputingPrecision()
+            $precision
         );
         $invoice->total_paid_tax_incl = Tools::ps_round(
             (float) $cart->getOrderTotal(true, $totalMethod),
-            $this->context->getComputingPrecision()
+            $precision
         );
         $invoice->total_products = (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
         $invoice->total_products_wt = (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
@@ -528,15 +532,16 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
      */
     private function updateExistingInvoice($orderInvoiceId, Cart $cart)
     {
+        $precision = $this->getPrecisionFromCart($cart);
         $invoice = new OrderInvoice($orderInvoiceId);
 
         $invoice->total_paid_tax_excl += Tools::ps_round(
             (float) $cart->getOrderTotal(false, Cart::BOTH_WITHOUT_SHIPPING),
-            $this->context->getComputingPrecision()
+            $precision
         );
         $invoice->total_paid_tax_incl += Tools::ps_round(
             (float) $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING),
-            $this->context->getComputingPrecision()
+            $precision
         );
         $invoice->total_products += (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
         $invoice->total_products_wt += (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
@@ -563,5 +568,16 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
                 throw new ProductOutOfStockException('Not enough products in stock');
             }
         }
+    }
+
+    /**
+     * @param Cart $cart
+     * @return int
+     */
+    private function getPrecisionFromCart(Cart $cart): int
+    {
+        $computingPrecision = new ComputingPrecision();
+        $currency = new Currency((int) $cart->id_currency);
+        return $computingPrecision->getPrecision($currency->precision);
     }
 }

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -137,9 +137,18 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         $order->total_products = (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
         $order->total_products_wt = (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
 
-        $order->total_paid = Tools::ps_round((float) $cart->getOrderTotal(true, $totalMethod), 2);
-        $order->total_paid_tax_excl = Tools::ps_round((float) $cart->getOrderTotal(false, $totalMethod), 2);
-        $order->total_paid_tax_incl = Tools::ps_round((float) $cart->getOrderTotal(true, $totalMethod), 2);
+        $order->total_paid = Tools::ps_round(
+            (float) $cart->getOrderTotal(true, $totalMethod),
+            $this->context->getComputingPrecision()
+        );
+        $order->total_paid_tax_excl = Tools::ps_round(
+            (float) $cart->getOrderTotal(false, $totalMethod),
+            $this->context->getComputingPrecision()
+        );
+        $order->total_paid_tax_incl = Tools::ps_round(
+            (float) $cart->getOrderTotal(true, $totalMethod),
+            $this->context->getComputingPrecision()
+        );
 
         if (null !== $invoice && Validate::isLoadedObject($invoice)) {
             $order->total_shipping = $invoice->total_shipping_tax_incl;
@@ -470,8 +479,14 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         $taxCalculator = $carrier->getTaxCalculator($invoice_address);
 
         // @todo: use https://github.com/PrestaShop/decimal to compute prices and taxes
-        $invoice->total_paid_tax_excl = Tools::ps_round((float) $cart->getOrderTotal(false, $totalMethod), 2);
-        $invoice->total_paid_tax_incl = Tools::ps_round((float) $cart->getOrderTotal(true, $totalMethod), 2);
+        $invoice->total_paid_tax_excl = Tools::ps_round(
+            (float) $cart->getOrderTotal(false, $totalMethod),
+            $this->context->getComputingPrecision()
+        );
+        $invoice->total_paid_tax_incl = Tools::ps_round(
+            (float) $cart->getOrderTotal(true, $totalMethod),
+            $this->context->getComputingPrecision()
+        );
         $invoice->total_products = (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
         $invoice->total_products_wt = (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
         $invoice->total_shipping_tax_excl = (float) $cart->getTotalShippingCost(null, false);
@@ -517,11 +532,11 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
 
         $invoice->total_paid_tax_excl += Tools::ps_round(
             (float) $cart->getOrderTotal(false, Cart::BOTH_WITHOUT_SHIPPING),
-            2
+            $this->context->getComputingPrecision()
         );
         $invoice->total_paid_tax_incl += Tools::ps_round(
             (float) $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING),
-            2
+            $this->context->getComputingPrecision()
         );
         $invoice->total_products += (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
         $invoice->total_products_wt += (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -22,6 +22,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\AddProductToOrderHandler
     arguments:
       - '@translator'
+      - '@prestashop.adapter.context_state_manager'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\AddProductToOrderCommand

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -167,6 +167,16 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^cart rule "(.+)" has no discount code$/
+     */
+    public function cartRuleNamedHasNoCode($cartRuleName)
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->cartRules[$cartRuleName]->code = '';
+        $this->cartRules[$cartRuleName]->save();
+    }
+
+    /**
      * @Given /^cart rule "(.+)" is restricted to product "(.+)"$/
      */
     public function cartRuleNamedIsRestrictedToProductNamed($cartRuleName, $productName)

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -211,6 +211,64 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then order :orderReference should have :expectedCount cart rule(s)
+     *
+     * @param string$orderReference
+     * @param int $expectedCount
+     */
+    public function checkOrderCartRulesCount(string $orderReference, int $expectedCount)
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+
+        /** @var OrderForViewing $orderForViewing */
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+        /** @var OrderProductForViewing[] $orderProducts */
+        $orderDiscounts = $orderForViewing->getDiscounts()->getDiscounts();
+
+        if (count($orderDiscounts) == $expectedCount) {
+            return;
+        }
+        throw new RuntimeException(
+            sprintf(
+                'Invalid number of cart rules for order %s, expected %s but got %s instead',
+                $orderReference,
+                $expectedCount,
+                count($orderDiscounts)
+            )
+        );
+    }
+
+    /**
+     * @Then order :reference should have cart rule :cartRuleName
+     *
+     * @param string $orderReference
+     * @param string $cartRuleName
+     */
+    public function createdOrderShouldHaveCartRule(string $orderReference, string $cartRuleName)
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+
+        /** @var OrderForViewing $orderForViewing */
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+        /** @var OrderDiscountForViewing[] $orderDiscountsForViewing */
+        $orderDiscountsForViewing = $orderForViewing->getDiscounts()->getDiscounts();
+
+        foreach ($orderDiscountsForViewing as $discount) {
+            if ($discount->getName() == $cartRuleName) {
+                return;
+            }
+        }
+
+        throw new RuntimeException(
+            sprintf(
+                'Order "%s" should have cart rule "%s".',
+                $orderReference,
+                $cartRuleName
+            )
+        );
+    }
+
+    /**
      * @Then order :orderReference should have :expectedCount invoices
      */
     public function checkOrderInvoicesCount(string $orderReference, int $expectedCount)
@@ -523,7 +581,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then order :orderReference should contain :quantity products :productName
+     * @Then order :orderReference should contain :quantity product(s) :productName
      *
      * @param string $orderReference
      * @param int $quantity
@@ -531,13 +589,31 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
      */
     public function orderContainsProductWithReference(string $orderReference, int $quantity, string $productName)
     {
-        $productQuantities = $this->getProductQuantitiesByReference($orderReference, $productName);
+        $orderId = SharedStorage::getStorage()->get($orderReference);
 
-        if ((int) $productQuantities['quantity'] === (int) $quantity) {
-            return;
+        /** @var OrderForViewing $orderForViewing */
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+        /** @var OrderProductForViewing[] $orderProducts */
+        $orderProducts = $orderForViewing->getProducts()->getProducts();
+
+        $productQuantity = 0;
+        foreach ($orderProducts as $orderProduct) {
+            if ($orderProduct->getName() == $productName) {
+                $productQuantity += $orderProduct->getQuantity();
+            }
         }
 
-        throw new RuntimeException(sprintf('Order was expected to have "%d" products "%s" in it. Instead got "%s"', $quantity, $productName, $productQuantities['quantity']));
+        if ($productQuantity == $quantity) {
+            return;
+        }
+        throw new RuntimeException(
+            sprintf(
+                'Order was expected to have "%d" products "%s" in it. Instead got "%d"',
+                $quantity,
+                $productName,
+                $productQuantity
+            )
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -101,6 +101,49 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should have 0 invoices
 
   @order-from-bo
+  Scenario: Add product linked to a cart rule to an existing Order without invoice with free shipping and new invoice
+    Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
+    Then order "bo_order1" should have 2 products in total
+    Then order "bo_order1" should have 0 invoices
+    Then order "bo_order1" should have 0 cart rule
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.228 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.228 |
+      | total_paid               | 32.228 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.0    |
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a product in the catalog named "Test Product Cart Rule On Select Product" with a price of 15.0 and 100 items in stock
+    And there is a cart rule named "CartRuleAmountOnSelectedProduct" that applies an amount discount of 500.0 with priority 1, quantity of 100 and quantity per user 100
+    And cart rule "CartRuleAmountOnSelectedProduct" has no discount code
+    And cart rule "CartRuleAmountOnSelectedProduct" is restricted to product "Test Product Cart Rule On Select Product"
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Product Cart Rule On Select Product  |
+      | amount        | 1                                         |
+      | price         | 15                                        |
+      | free_shipping | true                                      |
+    Then order "bo_order1" should have 3 products in total
+    Then order "bo_order1" should contain 1 product "Test Product Cart Rule On Select Product"
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "CartRuleAmountOnSelectedProduct"
+    Then order "bo_order1" should have following details:
+      | total_products           | 38.800 |
+      | total_products_wt        | 40.228 |
+      | total_discounts_tax_excl | 15.000 |
+      | total_discounts_tax_incl | 15.000 |
+      | total_paid_tax_excl      | 30.8   |
+      | total_paid_tax_incl      | 32.228 |
+      | total_paid               | 32.228 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.0    |
+
+  @order-from-bo
   Scenario: Add product to an existing Order with invoice with free shipping to new invoice
     Given I update order "bo_order1" status to "Payment accepted"
     And order "bo_order1" should have 1 invoices

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -55,6 +55,7 @@ default:
             paths:
                 features: Features/Scenario/Order
             contexts:
+                - Tests\Integration\Behaviour\Features\Context\CartRuleFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CustomerManagerFeatureContext
@@ -68,6 +69,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CarrierFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderPaymentFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderShippingFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderCartFeatureContext


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When you add a product (which add a discount), the discount block is not added
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fix #13880
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/13880#issuecomment-595189713 from @khouloudbelguith

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18205)
<!-- Reviewable:end -->
