### PR TITLE
Increase quantity when adding an already added product when creating order

### DIFF
--- a/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
@@ -69,7 +69,7 @@ final class AddProductToCartHandler extends AbstractCartHandler implements AddPr
     {
         $cartIdValue = $command->getCartId()->getValue();
         $productIdValue = $command->getProductId()->getValue();
-        $combinationId = $command->getCombinationId() ? $command->getCombinationId()->getValue() : null;
+        $combinationId = null !== $command->getCombinationId() ? $command->getCombinationId()->getValue() : null;
         $customizationId = null;
 
         if (!empty($command->getCustomizationsByFieldIds())) {

--- a/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Cart\CommandHandler;
 
+use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCustomizationFieldsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddProductToCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateProductQuantityInCartCommand;
@@ -37,7 +38,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
 /**
  * Handles add product to cart command
  */
-final class AddProductToCartHandler implements AddProductToCartHandlerInterface
+final class AddProductToCartHandler extends AbstractCartHandler implements AddProductToCartHandlerInterface
 {
     /**
      * @var AddCustomizationFieldsHandlerInterface
@@ -66,27 +67,31 @@ final class AddProductToCartHandler implements AddProductToCartHandlerInterface
      */
     public function handle(AddProductToCartCommand $command): void
     {
-        $quantity = $command->getQuantity();
-        $this->assertQuantityIsPositiveInt($quantity);
-
         $cartIdValue = $command->getCartId()->getValue();
         $productIdValue = $command->getProductId()->getValue();
-        $combinationId = $command->getCombinationId();
+        $combinationId = $command->getCombinationId() ? $command->getCombinationId()->getValue() : null;
+        $customizationId = null;
 
         if (!empty($command->getCustomizationsByFieldIds())) {
             $customizationId = $this->addCustomizationFieldsHandler->handle(new AddCustomizationFieldsCommand(
                 $cartIdValue,
                 $command->getProductId()->getValue(),
                 $command->getCustomizationsByFieldIds()
-            ));
+            ))->getValue();
         }
+
+        $cart = $this->getCart($command->getCartId());
+        $product = $cart->getProductQuantity($productIdValue, $combinationId, $customizationId);
+
+        $quantity = $command->getQuantity() + (int) $product['quantity'];
+        $this->assertQuantityIsPositiveInt($quantity);
 
         $this->updateProductQuantityInCartHandler->handle(new UpdateProductQuantityInCartCommand(
             $cartIdValue,
             $productIdValue,
             $quantity,
-            $combinationId ? $combinationId->getValue() : null,
-            isset($customizationId) ? $customizationId->getValue() : null
+            $combinationId,
+            $customizationId
         ));
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Increase quantity when adding an already added product when creating order
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18199
| How to test?  | 1. Go to BO => Order page shop.com/admin-dev/sell/orders/orders<br>2. Click on Add new order button<br>3. Choose a customer<br>4. Search for a product<br>5. Click add to cart => OK<br>6. Click add to cart again<br>7. Quantity should have been increased without any error message

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18208)
<!-- Reviewable:end -->
