### PR TITLE
Functional tests - Retry to create Browser 3 times if first one fails

### DIFF
--- a/tests/puppeteer/campaigns/utils/helpers.js
+++ b/tests/puppeteer/campaigns/utils/helpers.js
@@ -3,8 +3,23 @@ require('./globals');
 const puppeteer = require('puppeteer');
 
 module.exports = {
-  async createBrowser() {
-    return puppeteer.launch(global.BROWSER_CONFIG);
+  /**
+   * Create puppeteer browser
+   * @param attempt, number of attempts to restart browser creation if function throw error
+   * @return {Promise<browser>}
+   */
+  async createBrowser(attempt = 1) {
+    try {
+      const browser = await puppeteer.launch(global.BROWSER_CONFIG);
+      return browser;
+    } catch (e) {
+      if (attempt <= 3) {
+        await (new Promise(resolve => setTimeout(resolve, 5000)));
+        return this.createBrowser(attempt + 1);
+      }
+
+      throw new Error(e);
+    }
   },
   async newTab(browser) {
     return browser.newPage();

--- a/tests/puppeteer/campaigns/utils/helpers.js
+++ b/tests/puppeteer/campaigns/utils/helpers.js
@@ -10,14 +10,12 @@ module.exports = {
    */
   async createBrowser(attempt = 1) {
     try {
-      const browser = await puppeteer.launch(global.BROWSER_CONFIG);
-      return browser;
+      return await puppeteer.launch(global.BROWSER_CONFIG);
     } catch (e) {
       if (attempt <= 3) {
         await (new Promise(resolve => setTimeout(resolve, 5000)));
         return this.createBrowser(attempt + 1);
       }
-
       throw new Error(e);
     }
   },


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | This PR fix problem of test not executed if browser creation fails (linked to [puppeteer problem](https://github.com/puppeteer/puppeteer/issues/2207))
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | No test needed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18216)
<!-- Reviewable:end -->
