### PR TITLE
Functional tests - Product settings enable/disable allow ordering out of stock

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/03_productsStock/01_allowOrderingOutOfStock.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/03_productSettings/03_productsStock/01_allowOrderingOutOfStock.js
@@ -1,0 +1,134 @@
+require('module-alias/register');
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_productSettings_allowOrderingOutOfStock';
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const ProductSettingsPage = require('@pages/BO/shopParameters/productSettings');
+const ProductsPage = require('@pages/BO/catalog/products');
+const AddProductPage = require('@pages/BO/catalog/products/add');
+const ProductPage = require('@pages/FO/product');
+const HomePage = require('@pages/FO/home');
+const SearchResultsPage = require('@pages/FO/searchResults');
+// Importing data
+const ProductFaker = require('@data/faker/product');
+
+let browser;
+let page;
+const productData = new ProductFaker({type: 'Standard product', quantity: 0});
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    productSettingsPage: new ProductSettingsPage(page),
+    productsPage: new ProductsPage(page),
+    addProductPage: new AddProductPage(page),
+    homePage: new HomePage(page),
+    productPage: new ProductPage(page),
+    searchResultsPage: new SearchResultsPage(page),
+  };
+};
+
+describe('Enable/Disable Allow ordering of out-of-stock products ', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+
+  // Login into BO and go to product settings page
+  loginCommon.loginBO();
+
+  it('should go to \'Catalog > Products\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.catalogParentLink,
+      this.pageObjects.boBasePage.productsLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.productsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.productsPage.pageTitle);
+  });
+
+  it('should go to create product page and create a product', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'createProduct', baseContext);
+    await this.pageObjects.productsPage.goToAddProductPage();
+    const validationMessage = await this.pageObjects.addProductPage.createEditBasicProduct(productData);
+    await expect(validationMessage).to.equal(this.pageObjects.addProductPage.settingUpdatedMessage);
+  });
+
+  it('should go to \'Shop parameters > Product Settings\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductSettingsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.shopParametersParentLink,
+      this.pageObjects.boBasePage.productSettingsLink,
+    );
+    const pageTitle = await this.pageObjects.productSettingsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.productSettingsPage.pageTitle);
+  });
+
+  const tests = [
+    {args: {action: 'enable', enable: true}},
+    {args: {action: 'disable', enable: false}},
+  ];
+  tests.forEach((test) => {
+    it(`should ${test.args.action} allow ordering of out-of-stock products`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', `${test.args.action}`, baseContext);
+      const result = await this.pageObjects.productSettingsPage.setAllowOrderingOutOfStockStatus(test.args.enable);
+      await expect(result).to.contains(this.pageObjects.productSettingsPage.successfulUpdateMessage);
+    });
+
+    it('should check ordering out of stock', async function () {
+      await testContext.addContextItem(
+        this,
+        'testIdentifier',
+        `checkOrderingOutOfStock${test.args.state}`,
+        baseContext,
+      );
+      page = await this.pageObjects.productSettingsPage.viewMyShop();
+      this.pageObjects = await init();
+      await this.pageObjects.homePage.searchProduct(productData.name);
+      await this.pageObjects.searchResultsPage.goToProductPage(1);
+      const lastQuantityIsVisible = await this.pageObjects.productPage.isAddToCartButtonEnabled();
+      await expect(lastQuantityIsVisible).to.be.equal(test.args.enable);
+      page = await this.pageObjects.productPage.closePage(browser, 1);
+      this.pageObjects = await init();
+    });
+  });
+
+  it('should go to \'Catalog > Products\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPageToDeleteProduct', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.catalogParentLink,
+      this.pageObjects.boBasePage.productsLink,
+    );
+    const pageTitle = await this.pageObjects.productsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.productsPage.pageTitle);
+  });
+
+  it('should delete product', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'deleteProduct', baseContext);
+    const deleteTextResult = await this.pageObjects.productsPage.deleteProduct(productData);
+    await expect(deleteTextResult).to.equal(this.pageObjects.productsPage.productDeletedSuccessfulMessage);
+  });
+
+  it('should reset all filters', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'resetAllFilters', baseContext);
+    await this.pageObjects.productsPage.resetFilterCategory();
+    const numberOfProducts = await this.pageObjects.productsPage.resetAndGetNumberOfLines();
+    await expect(numberOfProducts).to.be.above(0);
+  });
+});

--- a/tests/puppeteer/pages/BO/shopParameters/productSettings/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/productSettings/index.js
@@ -19,13 +19,16 @@ module.exports = class productSettings extends BOBasePage {
     this.quantityDiscountBasedOnSelect = '#form_general_quantity_discount';
     this.switchDefaultActivationStatusLabel = 'label[for=\'form_general_default_status_%TOGGLE\']';
     this.saveProductGeneralFormButton = `${this.productGeneralForm} .card-footer button`;
-    // Product page selectors
+    // Product page form
     this.productPageForm = '#configuration_fieldset_fo_product_page';
     this.switchDisplayAvailableQuantities = 'label[for=\'form_page_display_quantities_%TOGGLE\']';
     this.remainingQuantityInput = '#form_page_display_last_quantities';
     this.displayUnavailableAttributesLabel = 'label[for=\'form_page_display_unavailable_attributes_%TOGGLE\']';
     this.separatorAttributeOnProductPageSelect = '#form_page_attribute_anchor_separator';
     this.saveProductPageFormButton = `${this.productPageForm} .card-footer button`;
+    // Products stock form
+    this.productsStockForm = '#configuration_fieldset_stock';
+    this.allowOrderingOosLabel = `${this.productsStockForm} label[for='form_stock_allow_ordering_oos_%TOGGLE']`;
   }
 
   /*
@@ -149,6 +152,17 @@ module.exports = class productSettings extends BOBasePage {
    */
   async setSeparatorOfAttributeOnProductLink(separator) {
     await this.selectByVisibleText(this.separatorAttributeOnProductPageSelect, separator);
+    await this.clickAndWaitForNavigation(this.saveProductPageFormButton);
+    return this.getTextContent(this.alertSuccessBlock);
+  }
+
+  /**
+   * Enable/Disable allow ordering out of stock
+   * @param toEnable
+   * @returns {Promise<string>}
+   */
+  async setAllowOrderingOutOfStockStatus(toEnable = true) {
+    await this.waitForSelectorAndClick(this.allowOrderingOosLabel.replace('%TOGGLE', toEnable ? 1 : 0));
     await this.clickAndWaitForNavigation(this.saveProductPageFormButton);
     return this.getTextContent(this.alertSuccessBlock);
   }

--- a/tests/puppeteer/pages/FO/product.js
+++ b/tests/puppeteer/pages/FO/product.js
@@ -125,6 +125,10 @@ module.exports = class Product extends FOBasePage {
     return this.getAttributeContent(this.metaLink, 'content');
   }
 
+  /**
+   * Is add to cart button enabled
+   * @returns {boolean}
+   */
   isAddToCartButtonEnabled() {
     return this.elementNotVisible(`${this.addToCartButton}:disabled`, 1000);
   }

--- a/tests/puppeteer/pages/FO/product.js
+++ b/tests/puppeteer/pages/FO/product.js
@@ -124,4 +124,8 @@ module.exports = class Product extends FOBasePage {
   getProductPageURL() {
     return this.getAttributeContent(this.metaLink, 'content');
   }
+
+  isAddToCartButtonEnabled() {
+    return this.elementNotVisible(`${this.addToCartButton}:disabled`, 1000);
+  }
 };


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | enable/disable allow ordering out of stock
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/13_shopParameters/03_productSettings/03_productsStock/01_allowOrderingOutOfStock.js" URL_FO=yourShopURL npm run specific-test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18224)
<!-- Reviewable:end -->
