### PR TITLE
Avoid fatal error when module hookDisplayPaymentEU returns another thing instead of array

### DIFF
--- a/classes/checkout/PaymentOptionsFinder.php
+++ b/classes/checkout/PaymentOptionsFinder.php
@@ -40,7 +40,7 @@ class PaymentOptionsFinderCore extends HookFinder
     {
         // Payment options coming from intermediate, deprecated version of the Advanced API
         $this->hookName = 'displayPaymentEU';
-        $rawDisplayPaymentEUOptions = parent::find();
+        $rawDisplayPaymentEUOptions = array_filter(parent::find(), 'is_array');
         $paymentOptions = array_map(
             ['PrestaShop\PrestaShop\Core\Payment\PaymentOption', 'convertLegacyOption'],
             $rawDisplayPaymentEUOptions


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Avoid fatal error `Catchable Fatal Error: Argument 1 passed to PrestaShop\PrestaShop\Core\Payment\PaymentOption::convertLegacyOption() must be of the type array, null given.` when module **hookDisplayPaymentEU** returns another thing instead of array. See [PaymentOption::convertLegacyOption()](https://github.com/PrestaShop/PrestaShop/blob/develop/src/Core/Payment/PaymentOption.php#L337) method signature.
| Type?         | improvement 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18229.
| How to test?  | See #18229.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18230)
<!-- Reviewable:end -->
