### PR TITLE
Fix guest to customer transformation issue

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1119,11 +1119,23 @@ class CustomerCore extends ObjectModel
         $this->cleanGroups();
         $this->addGroups([Configuration::get('PS_CUSTOMER_GROUP')]);
         $this->id_default_group = Configuration::get('PS_CUSTOMER_GROUP');
+        $this->stampResetPasswordToken();
         if ($this->update()) {
             $vars = [
                 '{firstname}' => $this->firstname,
                 '{lastname}' => $this->lastname,
                 '{email}' => $this->email,
+                '{url}' => Context::getContext()->link->getPageLink(
+                    'password',
+                    true,
+                    null,
+                    sprintf(
+                        'token=%s&id_customer=%s&reset_token=%s',
+                        $this->secure_key,
+                        (int) $this->id,
+                        $this->reset_password_token
+                    )
+                ),
             ];
             Mail::Send(
                 (int) $idLang,

--- a/mails/themes/classic/core/guest_to_customer.html.twig
+++ b/mails/themes/classic/core/guest_to_customer.html.twig
@@ -28,7 +28,7 @@
             <span>
               {{ 'Your guest account for [1]{shop_name}[/1] has been transformed into a customer account.'|trans({'[1]': '<span><strong>', '[/1]': '</strong></span>'}, 'Emails.Body', locale)|raw }} <br/><br/>
               <span><strong>{{ 'E-mail address:'|trans({}, 'Emails.Body', locale)|raw }}</strong></span> {email}<br/><br/>
-              {{ 'To set up your password, please use the following link:'|trans({}, 'Emails.Body', locale)|raw }} <br/> <a href="{url}">{url}</a>
+              {{ 'Click on the following link to set up your password:'|trans({}, 'Emails.Body', locale)|raw }} <br/> <a href="{url}">{url}</a>
             </span>
           </font>
         </td>

--- a/mails/themes/classic/core/guest_to_customer.html.twig
+++ b/mails/themes/classic/core/guest_to_customer.html.twig
@@ -28,6 +28,7 @@
             <span>
               {{ 'Your guest account for [1]{shop_name}[/1] has been transformed into a customer account.'|trans({'[1]': '<span><strong>', '[/1]': '</strong></span>'}, 'Emails.Body', locale)|raw }} <br/><br/>
               <span><strong>{{ 'E-mail address:'|trans({}, 'Emails.Body', locale)|raw }}</strong></span> {email}
+              {{ 'To set up your password, please use the following link:'|trans({}, 'Emails.Body', locale)|raw }} <br/> <a href="{url}">{url}</a>
             </span>
           </font>
         </td>

--- a/mails/themes/classic/core/guest_to_customer.html.twig
+++ b/mails/themes/classic/core/guest_to_customer.html.twig
@@ -27,7 +27,7 @@
 {% endif %}
             <span>
               {{ 'Your guest account for [1]{shop_name}[/1] has been transformed into a customer account.'|trans({'[1]': '<span><strong>', '[/1]': '</strong></span>'}, 'Emails.Body', locale)|raw }} <br/><br/>
-              <span><strong>{{ 'E-mail address:'|trans({}, 'Emails.Body', locale)|raw }}</strong></span> {email}
+              <span><strong>{{ 'E-mail address:'|trans({}, 'Emails.Body', locale)|raw }}</strong></span> {email}<br/><br/>
               {{ 'To set up your password, please use the following link:'|trans({}, 'Emails.Body', locale)|raw }} <br/> <a href="{url}">{url}</a>
             </span>
           </font>

--- a/mails/themes/modern/core/guest_to_customer.html.twig
+++ b/mails/themes/modern/core/guest_to_customer.html.twig
@@ -251,7 +251,8 @@
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0px;word-break:break-word;">
                                         <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">
-                                          <span class="label">{{ 'Email address:'|trans({}, 'Emails.Body', locale)|raw }}</span> <span style="color:#25B9D7;font-weight:600">{email}</span>
+                                          <span class="label">{{ 'Email address:'|trans({}, 'Emails.Body', locale)|raw }}</span> <span style="color:#25B9D7;font-weight:600">{email}</span><br><br>
+                                          {{ 'To set up your password, please use the following link:'|trans({}, 'Emails.Body', locale)|raw }} <br/> <a href="{url}">{url}</a>
                                         </div>
                                       </td>
                                     </tr>

--- a/mails/themes/modern/core/guest_to_customer.html.twig
+++ b/mails/themes/modern/core/guest_to_customer.html.twig
@@ -17,11 +17,11 @@
         <tr>
           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
       <![endif]-->
-              <div style="Margin:0px auto;max-width:604px;">
+              <div style="margin:0px auto;max-width:604px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td style="direction:ltr;font-size:0px;padding:0 25px;text-align:center;vertical-align:top;">
+                      <td style="direction:ltr;font-size:0px;padding:0 25px;text-align:center;">
                         <!--[if mso | IE]>
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 
@@ -31,7 +31,7 @@
                class="" style="vertical-align:top;width:554px;"
             >
           <![endif]-->
-                        <div class="mj-column-per-100 outlook-group-fix" style="font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
                             <tbody>
                               <tr>
@@ -40,9 +40,7 @@
                                     <!-- TITLE BEGINING -->
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:20px;word-break:break-word;">
-                                        <div style="font-family:Open sans, arial, sans-serif;font-size:20px;font-weight:600;line-height:25px;text-align:left;color:#363A41;">
-                                          {{ 'Hi {firstname} {lastname},'|trans({}, 'Emails.Body', locale) }}
-                                        </div>
+                                        <div style="font-family:Open sans, arial, sans-serif;font-size:20px;font-weight:600;line-height:25px;text-align:left;color:#363A41;">{{ 'Hi {firstname} {lastname},'|trans({}, 'Emails.Body', locale) }}</div>
                                       </td>
                                     </tr>
                                     <!-- TITLE ENDING -->
@@ -85,11 +83,11 @@
         <tr>
           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
       <![endif]-->
-              <div style="Margin:0px auto;max-width:604px;">
+              <div style="margin:0px auto;max-width:604px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td style="direction:ltr;font-size:0px;padding:0 50px 40px;text-align:left;vertical-align:top;">
+                      <td style="direction:ltr;font-size:0px;padding:0 50px 40px;text-align:left;">
                         <!--[if mso | IE]>
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 
@@ -99,15 +97,15 @@
                class="" style="vertical-align:top;width:25px;"
             >
           <![endif]-->
-                        <div class="mj-column-px-25 outlook-group-fix" style="font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <div class="mj-column-px-25 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                             <tr>
                               <td class="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-right:0;padding-left:0;word-break:break-word;">
-                                <p style="border-top:solid 3px #505050;font-size:1;margin:0px auto;width:25px;">
+                                <p style="border-top:solid 3px #505050;font-size:1px;margin:0px auto;width:25px;">
                                 </p>
                                 <!--[if mso | IE]>
         <table
-           align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 3px #505050;font-size:1;margin:0px auto;width:25px;" role="presentation" width="25px"
+           align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 3px #505050;font-size:1px;margin:0px auto;width:25px;" role="presentation" width="25px"
         >
           <tr>
             <td style="height:0;line-height:0;">
@@ -154,11 +152,11 @@
         <tr>
           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
       <![endif]-->
-              <div style="Margin:0px auto;max-width:604px;">
+              <div style="margin:0px auto;max-width:604px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td style="direction:ltr;font-size:0px;padding:0 25px;text-align:center;vertical-align:top;">
+                      <td style="direction:ltr;font-size:0px;padding:0 25px;text-align:center;">
                         <!--[if mso | IE]>
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 
@@ -168,7 +166,7 @@
                class="" style="vertical-align:top;width:554px;"
             >
           <![endif]-->
-                        <div class="mj-column-per-100 outlook-group-fix" style="font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
                             <tbody>
                               <tr>
@@ -176,9 +174,7 @@
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:0px;word-break:break-word;">
-                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;font-weight:600;line-height:25px;text-align:left;color:#363A41;">
-                                          {{ 'Your guest account has been turned into a customer account'|trans({}, 'Emails.Body', locale)|raw }}
-                                        </div>
+                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;font-weight:600;line-height:25px;text-align:left;color:#363A41;">{{ 'Your guest account has been turned into a customer account'|trans({}, 'Emails.Body', locale)|raw }}</div>
                                       </td>
                                     </tr>
                                   </table>
@@ -221,11 +217,11 @@
         <tr>
           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
       <![endif]-->
-              <div style="Margin:0px auto;max-width:604px;">
+              <div style="margin:0px auto;max-width:604px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td style="direction:ltr;font-size:0px;padding:15px 50px 40px;text-align:center;vertical-align:top;">
+                      <td style="direction:ltr;font-size:0px;padding:15px 50px 40px;text-align:center;">
                         <!--[if mso | IE]>
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 
@@ -235,7 +231,7 @@
                class="" style="vertical-align:top;width:504px;"
             >
           <![endif]-->
-                        <div class="mj-column-per-100 outlook-group-fix" style="font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
                             <tbody>
                               <tr>
@@ -243,17 +239,15 @@
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                        <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">
-                                          {{ 'Congratulations, your guest account for [1]{shop_name}[/1] has been turned into a customer account!'|trans({'[1]': '<span class="label">', '[/1]': '</span>'}, 'Emails.Body', locale)|raw }}
-                                        </div>
+                                        <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">{{ 'Congratulations, your guest account for [1]{shop_name}[/1] has been turned into a customer account!'|trans({'[1]': '<span class="label">', '[/1]': '</span>'}, 'Emails.Body', locale)|raw }}</div>
                                       </td>
                                     </tr>
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0px;word-break:break-word;">
                                         <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">
-                                          <span class="label">{{ 'Email address:'|trans({}, 'Emails.Body', locale)|raw }}</span> <span style="color:#25B9D7;font-weight:600">{email}</span><br><br>
-                                          {{ 'Click on the following link to set up your password:'|trans({}, 'Emails.Body', locale)|raw }} <br/> <a href="{url}">{url}</a>
-                                        </div>
+<span class="label">{{ 'Email address:'|trans({}, 'Emails.Body', locale)|raw }}</span> <span style="color:#25B9D7;font-weight:600">{email}</span><br><br>
+                                          {{ 'Click on the following link to set up your password:'|trans({}, 'Emails.Body', locale)|raw }} <br> <a href="{url}">{url}</a>
+</div>
                                       </td>
                                     </tr>
                                   </table>
@@ -296,11 +290,11 @@
         <tr>
           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
       <![endif]-->
-              <div style="Margin:0px auto;max-width:604px;">
+              <div style="margin:0px auto;max-width:604px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td style="direction:ltr;font-size:0px;padding:0 25px 20px;text-align:center;vertical-align:top;">
+                      <td style="direction:ltr;font-size:0px;padding:0 25px 20px;text-align:center;">
                         <!--[if mso | IE]>
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 
@@ -310,13 +304,12 @@
                class="" style="vertical-align:top;width:554px;"
             >
           <![endif]-->
-                        <div class="mj-column-per-100 outlook-group-fix" style="font-size:13px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                             <tr>
                               <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:center;color:#363A41;">
-                                  {{ 'You can access your customer account on our shop:'|trans({}, 'Emails.Body', locale)|raw }} <a href="{shop_url}" target="_blank" style="color:#25B9D7; text-decoration:none; display:block; font-weight: 400;">{shop_name}</a>
-                                </div>
+                                <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:center;color:#363A41;">{{ 'You can access your customer account on our shop:'|trans({}, 'Emails.Body', locale)|raw }} <a href="{shop_url}" target="_blank" style="color:#25B9D7; text-decoration:none; display:block; font-weight: 400;">{shop_name}</a>
+</div>
                               </td>
                             </tr>
                           </table>
@@ -355,18 +348,6 @@
       padding: 0;
     }
 
-    .ReadMsgBody {
-      width: 100%;
-    }
-
-    .ExternalClass {
-      width: 100%;
-    }
-
-    .ExternalClass * {
-      line-height: 100%;
-    }
-
     body {
       margin: 0;
       padding: 0;
@@ -393,16 +374,6 @@
     p {
       display: block;
       margin: 13px 0;
-    }
-  </style><style type="text/css">
-    @media only screen and (max-width:480px) {
-      @-ms-viewport {
-        width: 320px;
-      }
-
-      @viewport {
-        width: 320px;
-      }
     }
   </style><style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700);

--- a/mails/themes/modern/core/guest_to_customer.html.twig
+++ b/mails/themes/modern/core/guest_to_customer.html.twig
@@ -252,7 +252,7 @@
                                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0px;word-break:break-word;">
                                         <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">
                                           <span class="label">{{ 'Email address:'|trans({}, 'Emails.Body', locale)|raw }}</span> <span style="color:#25B9D7;font-weight:600">{email}</span><br><br>
-                                          {{ 'To set up your password, please use the following link:'|trans({}, 'Emails.Body', locale)|raw }} <br/> <a href="{url}">{url}</a>
+                                          {{ 'Click on the following link to set up your password:'|trans({}, 'Emails.Body', locale)|raw }} <br/> <a href="{url}">{url}</a>
                                         </div>
                                       </td>
                                     </tr>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When transforming a guest into a customer in BO, the guest would receive an email without a password and without a link to generate a new password....
| Type?         | bug fix
| Category?     |  CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17955
| How to test?  | 1- In FO, make an order as a guest<br>2- In BO, go to guest's client page<br>3- Click on "Transform guest account to customer account"<br>4- You should receive a mail with a link to generate a new password

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18234)
<!-- Reviewable:end -->
