### PR TITLE
Improve prestashop:linter:security-annotation

### DIFF
--- a/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
+++ b/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
@@ -111,7 +111,7 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
 
         switch ($actionToPerform) {
             case self::ACTION_LIST_ALL:
-                $this->listAllRoutesAndTheirPermissions($input, $output);
+                $this->listAllRoutesAndRelatedPermissions($input, $output);
                 break;
             case self::ACTION_FIND_MISSING:
                 $this->findRoutesWithMissingSecurityAnnotations($input, $output);
@@ -126,7 +126,7 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
      * @param InputInterface $input
      * @param OutputInterface $output
      */
-    private function listAllRoutesAndTheirPermissions(InputInterface $input, OutputInterface $output)
+    private function listAllRoutesAndRelatedPermissions(InputInterface $input, OutputInterface $output)
     {
         $container = $this->getContainer();
 
@@ -139,7 +139,7 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
         $listing = [];
 
         foreach ($adminRouteProvider->getRoutes() as $routeName => $route) {
-            /* @var \Symfony\Component\Routing\Route $route */
+            /* @var Route $route */
             try {
                 $annotation = $securityAnnotationLinter->getRouteSecurityAnnotation($routeName, $route);
                 $listing[] = [

--- a/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
+++ b/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
@@ -57,11 +57,11 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
         $matches1 = [];
         $matches2 = [];
         preg_match($pattern1, $expression, $matches1);
-        preg_match($pattern2, $expression, $matches2);
 
         if (count($matches1) > 1) {
             return $matches1[1];
         }
+        preg_match($pattern2, $expression, $matches2);
         if (count($matches2) > 1) {
             return $matches2[1];
         }

--- a/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
+++ b/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
@@ -27,7 +27,9 @@
 namespace PrestaShopBundle\Command;
 
 use PrestaShopBundle\Routing\Linter\Exception\LinterException;
+use PrestaShopBundle\Routing\Linter\SecurityAnnotationLinter;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -35,18 +37,61 @@ use Symfony\Component\Routing\Route;
 
 /**
  * Checks if all admin routes have @AdminSecurity configured
+ *
+ * @see \PrestaShopBundle\Security\Annotation\AdminSecurity
  */
 final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
 {
+    const ACTION_LIST_ALL = 'list';
+    const ACTION_FIND_MISSING = 'find-missing';
+
+    /**
+     * @param string $expression
+     *
+     * @return string
+     */
+    public static function parseExpression($expression)
+    {
+        $pattern1 = '#\[(.*)\]#';
+        $pattern2 = '#is_granted\((.*),#';
+        $matches1 = [];
+        $matches2 = [];
+        preg_match($pattern1, $expression, $matches1);
+        preg_match($pattern2, $expression, $matches2);
+
+        if (count($matches1) > 1) {
+            return $matches1[1];
+        }
+        if (count($matches2) > 1) {
+            return $matches2[1];
+        }
+
+        return '';
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAvailableActions()
+    {
+        return [self::ACTION_LIST_ALL, self::ACTION_FIND_MISSING];
+    }
+
     /**
      * {@inheritdoc}
      */
     public function configure()
     {
+        $description = 'Checks if Back Office route controllers has configured Security annotations.';
+        $actionDescription = sprintf(
+            'Action to perform, must be one of: %s',
+            implode(', ', self::getAvailableActions())
+        );
+
         $this
             ->setName('prestashop:linter:security-annotation')
-            ->setDescription('Checks if Back Office route controllers has configured Security annotations.')
-        ;
+            ->setDescription($description)
+            ->addArgument('action', InputArgument::REQUIRED, $actionDescription);
     }
 
     /**
@@ -54,8 +99,83 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $adminRouteProvider = $this->getContainer()->get('prestashop.bundle.routing.linter.admin_route_provider');
-        $securityAnnotationLinter = $this->getContainer()
+        $actionToPerform = $input->getArgument('action');
+
+        if (!in_array($actionToPerform, self::getAvailableActions())) {
+            throw new \InvalidArgumentException(sprintf(
+                    'Action must be one of: %s',
+                    implode(', ', self::getAvailableActions())
+                )
+            );
+        }
+
+        switch ($actionToPerform) {
+            case self::ACTION_LIST_ALL:
+                $this->listAllRoutesAndTheirPermissions($input, $output);
+                break;
+            case self::ACTION_FIND_MISSING:
+                $this->findRoutesWithMissingSecurityAnnotations($input, $output);
+                break;
+
+            default:
+                throw new \RuntimeException(sprintf('Unknown action %s', $actionToPerform));
+        }
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    private function listAllRoutesAndTheirPermissions(InputInterface $input, OutputInterface $output)
+    {
+        $container = $this->getContainer();
+
+        $adminRouteProvider = $container
+            ->get('prestashop.bundle.routing.linter.admin_route_provider');
+        /** @var SecurityAnnotationLinter $securityAnnotationLinter */
+        $securityAnnotationLinter = $container
+            ->get('prestashop.bundle.routing.linter.security_annotation_linter');
+
+        $listing = [];
+
+        foreach ($adminRouteProvider->getRoutes() as $routeName => $route) {
+            /* @var \Symfony\Component\Routing\Route $route */
+            try {
+                $annotation = $securityAnnotationLinter->getRouteSecurityAnnotation($routeName, $route);
+                $listing[] = [
+                    $route->getDefault('_controller'),
+                    implode(', ', $route->getMethods()),
+                    'Yes',
+                    self::parseExpression($annotation->getExpression()),
+                ];
+            } catch (LinterException $e) {
+                $listing[] = [
+                    $route->getDefault('_controller'),
+                    implode(', ', $route->getMethods()),
+                    'No',
+                    '',
+                ];
+            }
+        }
+
+        $io = new SymfonyStyle($input, $output);
+        $headers = ['Controller action', 'Methods', 'Is secured ?', 'Permissions'];
+
+        $io->table($headers, $listing);
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    private function findRoutesWithMissingSecurityAnnotations(InputInterface $input, OutputInterface $output)
+    {
+        $container = $this->getContainer();
+
+        $adminRouteProvider = $container
+            ->get('prestashop.bundle.routing.linter.admin_route_provider');
+        /** @var SecurityAnnotationLinter $securityAnnotationLinter */
+        $securityAnnotationLinter = $container
             ->get('prestashop.bundle.routing.linter.security_annotation_linter');
 
         $notConfiguredRoutes = [];
@@ -81,6 +201,6 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
             return;
         }
 
-        $io->success('Admin routes has @AdminSecurity configured.');
+        $io->success('All admin routes are secured with @AdminSecurity.');
     }
 }

--- a/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
+++ b/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
@@ -59,9 +59,15 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $routeName
+     * @param Route $route
+     *
+     * @return AdminSecurity
+     *
+     * @throws \ReflectionException
+     * @throws LinterException
      */
-    public function lint($routeName, Route $route)
+    public function getRouteSecurityAnnotation($routeName, Route $route)
     {
         $controllerAndMethod = $this->extractControllerAndMethodNamesFromRoute($route);
 
@@ -75,6 +81,16 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
         if (null === $annotation) {
             throw new LinterException(sprintf('"%s:%s" does not have AdminSecurity annotation configured', $controllerAndMethod['controller'], $controllerAndMethod['method']));
         }
+
+        return $annotation;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lint($routeName, Route $route)
+    {
+        $this->getRouteSecurityAnnotation($routeName, $route);
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | See below this table.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No need for QA. Try CLI Command `php bin/console prestashop:linter:security-annotation list`

## Description

I refactored and improve command `prestashop:linter:security-annotation`
Previous behavior (listing all Symfony routes without security annotation provided) is still available but now you must run `php bin/console prestashop:linter:security-annotation find-missing` to obtain it.

New behavior added: `php bin/console prestashop:linter:security-annotation list` will now output **all Symfony routes** available and display the controller, the action, the HTTP methods, whether it's secured using Security annotation and the permissions needed to use it.

This new behavior should help us to find unproperly configured routes with strange permission sets (example: a POST route modifying data* accepting READ permission).

*There is a few exceptions: for example some routes which are used to perform data search or data exports use POST.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18235)
<!-- Reviewable:end -->
