### PR TITLE
Functional tests - Add test 'Help card' for orders page

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/02_orders/01_orders/01_helpCard.js
+++ b/tests/puppeteer/campaigns/functional/BO/02_orders/01_orders/01_helpCard.js
@@ -25,7 +25,7 @@ const init = async function () {
     ordersPage: new OrdersPage(page),
   };
 };
-
+// Check help card language in orders page
 describe('Helper card in order page', async () => {
   // before and after functions
   before(async function () {

--- a/tests/puppeteer/campaigns/functional/BO/02_orders/01_orders/01_helpCard.js
+++ b/tests/puppeteer/campaigns/functional/BO/02_orders/01_orders/01_helpCard.js
@@ -37,7 +37,7 @@ describe('Helper card in order page', async () => {
     await helper.closeBrowser(browser);
   });
 
-  // Login into BO and go to Pages page
+  // Login into BO and go to orders page
   loginCommon.loginBO();
 
   it('should go to orders page', async function () {

--- a/tests/puppeteer/campaigns/functional/BO/02_orders/01_orders/01_helpCard.js
+++ b/tests/puppeteer/campaigns/functional/BO/02_orders/01_orders/01_helpCard.js
@@ -1,0 +1,67 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const OrdersPage = require('@pages/BO/orders/index');
+// Test context imports
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_orders_orders_helperCard';
+
+let browser;
+let page;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    ordersPage: new OrdersPage(page),
+  };
+};
+
+describe('Helper card in order page', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+
+  // Login into BO and go to Pages page
+  loginCommon.loginBO();
+
+  it('should go to orders page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToOrdersPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.ordersParentLink,
+      this.pageObjects.boBasePage.ordersLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.ordersPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.ordersPage.pageTitle);
+  });
+
+  it('should open the help side bar and check the document language', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'openHelpSidebar', baseContext);
+    const isHelpSidebarVisible = await this.pageObjects.ordersPage.openHelpSideBar();
+    await expect(isHelpSidebarVisible).to.be.true;
+    const documentURL = await this.pageObjects.ordersPage.getHelpDocumentURL();
+    await expect(documentURL).to.contains('country=en');
+  });
+
+  it('should close the help side bar', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'closeHelpSidebar', baseContext);
+    const isHelpSidebarClosed = await this.pageObjects.ordersPage.closeHelpSideBar();
+    await expect(isHelpSidebarClosed).to.be.true;
+  });
+});


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add functional test 'Check help card language for orders page'
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | ` TEST_PATH="functional/BO/02_orders/01_orders/01_helpCard.js" URL_FO=shopUrl/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18242)
<!-- Reviewable:end -->
