### PR TITLE
Fix orders page dropdown going under header by adding a flip false property

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/choice.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/choice.html.twig
@@ -49,6 +49,7 @@
       data-toggle="dropdown"
       aria-haspopup="true"
       aria-expanded="false"
+      data-flip="false"
     >
       {{ selectedChoiceName }}
     </button>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Some items of status dropdown were not clickable by being under the header
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17717  .
| How to test?  | You should find a grid with dropdowns in list and see if you are able to click on every items by scrolling top or bottom when the dropdown is opened

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/17849)
<!-- Reviewable:end -->
