### PR TITLE
Add check when adding a product in an order that it is not out of stock

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -49,6 +49,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderInvoiceAddressForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider;
 use Product;
@@ -169,6 +170,8 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
             );
         } catch (InvalidProductQuantityException $e) {
             $this->lastException = $e;
+        } catch (ProductOutOfStockException $e) {
+            $this->lastException = $e;
         }
     }
 
@@ -260,6 +263,14 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
     public function assertLastErrorIsNegativeProductQuantity()
     {
         $this->assertLastErrorIs(InvalidProductQuantityException::class);
+    }
+
+    /**
+     * @Then I should get error that product is out of stock
+     */
+    public function assertLastErrorIsProductOutOfStock()
+    {
+        $this->assertLastErrorIs(ProductOutOfStockException::class);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -161,6 +161,17 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should contain 2 products "Mug Today is a good day"
 
   @order-from-bo
+  Scenario: Add product with quantity higher than stock is forbidden
+    Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Mug Today is a good day |
+      | amount        | 1500                    |
+      | price         | 16                      |
+      | free_shipping | true                    |
+    Then I should get error that product is out of stock
+    Then order "bo_order1" should contain 0 products "Mug Today is a good day"
+
+  @order-from-bo
   Scenario: Update product in order
     When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
       | amount        | 3                       |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Adding more precise check in add product handler, so that it returns the expected exception rather than generic OrderException when `$cart->updateQty` fails This was initially designed to fix #18238 But actually the behaviour described is normal because the product used in example is allowed to be out of stock
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Travis tests green

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18246)
<!-- Reviewable:end -->
