### PR TITLE
Modify the quantity input type from text type to number type

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig
@@ -44,7 +44,7 @@
     {{ form_row(addProductRowForm.price_tax_included) }}
   </td>
   <td class="pr-2">
-    {{ form_row(addProductRowForm.quantity) }}
+    {{ form_row(addProductRowForm.quantity, {'type':'number'}) }}
   </td>
   <td id="addProductLocation"></td>
   <td id="addProductRefunded"></td>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | This PR is a suggestion of the use of HTML5 number input type instead of text input type for quantity input. This input type has some advantages for front and back validation as discussed [here.](https://github.com/PrestaShop/PrestaShop/pull/18200)
| Type?         | improvement
| Category?     | BO 
| BC breaks?    |no
| Deprecations? | no
| Fixed ticket? |  Fixes nothing, but will help fixing another issue number 18031
| How to test?  | Go to migrated order view page and add a product to order.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18254)
<!-- Reviewable:end -->

PS: If suggestion approved, this feature should also be ported to edit product.