### PR TITLE
Add target options to index grid of orders on customer column

### DIFF
--- a/src/Core/Grid/Column/Type/Common/LinkColumn.php
+++ b/src/Core/Grid/Column/Type/Common/LinkColumn.php
@@ -63,9 +63,11 @@ final class LinkColumn extends AbstractColumn
             ])
             ->setDefined([
                 'icon',
+                'target',
             ])
             ->setAllowedTypes('field', ['string', 'null'])
             ->setAllowedTypes('icon', ['string', 'null'])
+            ->setAllowedTypes('target', ['string', 'null'])
             ->setAllowedTypes('sortable', 'bool')
             ->setAllowedTypes('route', 'string')
             ->setAllowedTypes('route_param_name', 'string')

--- a/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
@@ -208,6 +208,7 @@ final class OrderGridDefinitionFactory extends AbstractGridDefinitionFactory
                     'route' => 'admin_customers_view',
                     'route_param_name' => 'customerId',
                     'route_param_field' => 'id_customer',
+                    'target' => '_blank',
                 ])
             )
             ->add((new OrderPriceColumn('total_paid_tax_incl'))

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/link.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/link.html.twig
@@ -36,7 +36,13 @@
 {% endif %}
 
 {% block link %}
-<a class="{{ class }}" href="{{ path(column.options.route, { (column.options.route_param_name) : record[column.options.route_param_field]}) }}">
+<a 
+  class="{{ class }}"
+  href="{{ path(column.options.route, { (column.options.route_param_name) : record[column.options.route_param_field]}) }}"
+  {% if column.options.target is defined %}
+    target="{{ column.options.target }}"
+  {% endif %}
+>
   {% if column.options.icon is defined %}
     <i class="material-icons">{{ column.options.icon }}</i>
   {% endif %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | We wants customer links to display on a new tab of our browsers on migrated Orders list
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18105.
| How to test?  | Go on migrated Orders list and click on customer link, it should open in a new tab

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18265)
<!-- Reviewable:end -->
