### PR TITLE
Fix redirect on API calls when id_shop=all is used

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -382,7 +382,7 @@ class ShopCore extends ObjectModel
             Configuration::getMultiShopValues('PS_MEDIA_SERVER_3')
         );
 
-        if ((!$id_shop && defined('_PS_ADMIN_DIR_')) || Tools::isPHPCLI() || in_array($http_host, $all_media)) {
+        if ((!$id_shop && defined('_PS_ADMIN_DIR_')) || ('all' === $id_shop && defined('_PS_API_IN_USE_')) || Tools::isPHPCLI() || in_array($http_host, $all_media)) {
             // If in admin, we can access to the shop without right URL
             if ((!$id_shop && Tools::isPHPCLI()) || defined('_PS_ADMIN_DIR_')) {
                 $id_shop = (int) Configuration::get('PS_SHOP_DEFAULT');

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -28,6 +28,8 @@ use PrestaShop\PrestaShop\Adapter\ContainerBuilder;
 
 ob_start();
 
+define('_PS_API_IN_USE_', true);
+
 require_once dirname(__FILE__).'/../config/config.inc.php';
 
 // Cart is needed for some requests


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Without this fix, you can't add a product in ALL SHOPS context, because Shop::initialize redirects to the defautl shop URL. This behavior was already handled for PHP CLI, but not for the API.
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12412 
| How to test?  | <ol><li>Activate mulsithop, with 2 groups (eg: "Default" and "Stores"), with at least 1 shop in each group</li><li>Activate webservices and create a key with full access (all resources and all shops)</li><li>Create a product in API with a POST call to /api/products?id_shop=all&ws_key=YOUR_API_KEY</li></ol> Without this fix, you will receive an HTTP 302 response status, with a "Location: URL_OF_DEFAULT_SHOP" header (and the product is not created).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18280)
<!-- Reviewable:end -->
