### PR TITLE
Fix wrong number of orders when filter 'New client' on

### DIFF
--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -86,15 +86,6 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
      */
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        $newCustomerSubSelect = $this->connection
-            ->createQueryBuilder()
-            ->select('so.id_order')
-            ->from($this->dbPrefix . 'orders', 'so')
-            ->where('so.id_customer = o.id_customer')
-            ->andWhere('so.id_order < o.id_order')
-            ->setMaxResults(1)
-        ;
-
         $qb = $this
             ->getBaseQueryBuilder($searchCriteria->getFilters())
             ->addSelect('o.id_order, o.reference, o.total_paid_tax_incl, os.paid, osl.name AS osname')
@@ -103,8 +94,8 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
             ->addSelect('cu.`id_customer` IS NULL as `deleted_customer`')
             ->addSelect('os.color, o.payment, s.name AS shop_name')
             ->addSelect('o.date_add, cu.company, cl.name AS country_name, o.invoice_number, o.delivery_number')
-            ->addSelect('IF ((' . $newCustomerSubSelect->getSQL() . ') > 0, 0, 1) AS new')
         ;
+        $qb = $this->addNewCustomerField($qb);
 
         $this->applySorting($qb, $searchCriteria);
 
@@ -122,8 +113,16 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
      */
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        return $this->getBaseQueryBuilder($searchCriteria->getFilters())
-            ->select('COUNT(o.id_order)');
+        $qb = $this->getBaseQueryBuilder($searchCriteria->getFilters());
+        if (isset($searchCriteria->getFilters()['new'])) {
+            $qb = $this->addNewCustomerField($qb->addSelect('o.id_order as o_id_order'));
+            $qb = $this->applyNewCustomerFilter($qb, $searchCriteria->getFilters());
+            $qb->select('count(o_id_order)');
+        } else {
+            $qb->select('count(o.id_order)');
+        }
+
+        return $qb;
     }
 
     /**
@@ -229,6 +228,25 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
         }
 
         return $qb;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     *
+     * @return QueryBuilder
+     */
+    private function addNewCustomerField(QueryBuilder $qb)
+    {
+        $newCustomerSubSelect = $this->connection
+            ->createQueryBuilder()
+            ->select('so.id_order')
+            ->from($this->dbPrefix . 'orders', 'so')
+            ->where('so.id_customer = o.id_customer')
+            ->andWhere('so.id_order < o.id_order')
+            ->setMaxResults(1)
+        ;
+
+        return $qb->addSelect('IF ((' . $newCustomerSubSelect->getSQL() . ') > 0, 0, 1) AS new');
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.7.x
| Description?  | When filter by 'new client' in the page order, the number of orders (in the header) was wrong. This PR fixes it
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18248
| How to test?  | 1. Go to 'BO > Orders' page<br>2. Filter by column 'New client' Value 'Yes'<br>3. See that the number of orders in the header of the table should be equal to the number of order in the table. (see below)

![Capture d’écran 2020-03-24 à 14 24 12](https://user-images.githubusercontent.com/2168836/77430359-59cb9100-6ddb-11ea-9324-9545f1d57647.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18288)
<!-- Reviewable:end -->
