### PR TITLE
Fix translation export not working

### DIFF
--- a/src/Core/Addon/Theme/ThemeExporter.php
+++ b/src/Core/Addon/Theme/ThemeExporter.php
@@ -114,11 +114,7 @@ class ThemeExporter
                 $catalogueDir = $this->translationsExporter->exportCatalogues($theme->getName(), $locale);
             }
 
-            $catalogueDirParts = explode(DIRECTORY_SEPARATOR, $catalogueDir);
-            array_pop($catalogueDirParts); // Remove locale
-
-            $cataloguesDir = implode(DIRECTORY_SEPARATOR, $catalogueDirParts);
-            $this->fileSystem->mirror($cataloguesDir, $translationsDir);
+            $this->fileSystem->mirror($catalogueDir, $translationsDir);
         }
     }
 

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -36,6 +36,7 @@ use Symfony\Component\Validator\Validation;
 
 class TranslationService
 {
+    const DEFAULT_THEME = 'classic';
     /**
      * @var Container
      */
@@ -114,7 +115,7 @@ class TranslationService
         $factory = $this->container->get('ps.translations_factory');
 
         if ($this->requiresThemeTranslationsFactory($theme, $type)) {
-            if ('classic' === $theme) {
+            if ($this->isDefaultTheme($theme)) {
                 $type = 'front';
             } else {
                 $type = $theme;
@@ -154,7 +155,7 @@ class TranslationService
      */
     public function listDomainTranslation($locale, $domain, $theme = null, $search = null, $module = null)
     {
-        if (!empty($theme) && 'classic' !== $theme) {
+        if (!empty($theme) && !$this->isDefaultTheme($theme)) {
             $translationProvider = $this->container->get('prestashop.translation.theme_provider');
             $translationProvider->setThemeName($theme);
         } else {
@@ -179,7 +180,7 @@ class TranslationService
             'data' => array(),
         );
         $treeDomain = preg_split('/(?=[A-Z])/', $domain, -1, PREG_SPLIT_NO_EMPTY);
-        if (!empty($theme) && 'classic' !== $theme) {
+        if (!empty($theme) && !$this->isDefaultTheme($theme)) {
             $defaultCatalog = current($translationProvider->getThemeCatalogue()->all());
         } else {
             $defaultCatalog = current($translationProvider->getDefaultCatalogue()->all());
@@ -351,5 +352,15 @@ class TranslationService
         }
 
         return $resetTranslationSuccessfully;
+    }
+
+    /**
+     * @param string $theme
+     *
+     * @return bool
+     */
+    private function isDefaultTheme($theme)
+    {
+        return static::DEFAULT_THEME === $theme;
     }
 }

--- a/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
+++ b/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
@@ -99,11 +99,13 @@ class ThemeExporter
     }
 
     /**
+     * Extracts the theme's translations and bundles them in a zip file
+     *
      * @param string $themeName
      * @param string $locale
      * @param bool $rootDir
      *
-     * @return string
+     * @return string Full path to the zip file
      */
     public function createZipArchive($themeName, $locale, $rootDir = false)
     {
@@ -115,11 +117,14 @@ class ThemeExporter
     }
 
     /**
+     * Extracts the theme's default catalogue by analyzing its files, applies all translations,
+     * then exports it as XLIFF files in a temporary directory
+     *
      * @param string $themeName
      * @param string $locale
      * @param bool $rootDir
      *
-     * @return string
+     * @return string The directory where the files have been exported
      */
     public function exportCatalogues($themeName, $locale, $rootDir = false)
     {
@@ -196,7 +201,7 @@ class ThemeExporter
      * @param string $locale
      * @param bool $rootDir
      *
-     * @return \Symfony\Component\Translation\MessageCatalogue
+     * @return MessageCatalogue
      */
     protected function getCatalogueExtractedFromTemplates($themeName, $locale, $rootDir = false)
     {
@@ -227,6 +232,7 @@ class ThemeExporter
     {
         $finder = Finder::create();
 
+        /** @var \SplFileInfo $file */
         foreach ($finder->in($archiveParentDirectory . DIRECTORY_SEPARATOR . $locale)->files() as $file) {
             $destinationFilename = preg_replace('#(\.xlf)$#', ".$locale\$1", $file->getPathname());
             if ($this->filesystem->exists($destinationFilename)) {

--- a/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
+++ b/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Translation\Exporter;
 
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
+use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\TranslationToolsBundle\Translation\Dumper\XliffFileDumper;
 use PrestaShop\TranslationToolsBundle\Translation\Extractor\Util\Flattenizer;
 use PrestaShopBundle\Translation\Extractor\ThemeExtractor;
@@ -129,8 +130,9 @@ class ThemeExporter
 
         try {
             $themeCatalogue = $this->themeProvider->getThemeCatalogue();
-        } catch (\Exception $exception) {
-            $themeCatalogue = new MessageCatalogue($locale, array());
+        } catch (FileNotFoundException $exception) {
+            // if the theme doesn't have translation files (eg. the default theme)
+            $themeCatalogue = new MessageCatalogue($locale);
         }
         $databaseCatalogue = $this->themeProvider->getDatabaseCatalogue($themeName);
 

--- a/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
+++ b/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
@@ -133,31 +133,30 @@ class ThemeExporter
             $themeCatalogue = new MessageCatalogue($locale, array());
         }
         $databaseCatalogue = $this->themeProvider->getDatabaseCatalogue($themeName);
-        $databaseCatalogue = $this->addLocaleToDomain($locale, $databaseCatalogue);
 
         $mergedTranslations->addCatalogue($themeCatalogue);
         $mergedTranslations->addCatalogue($databaseCatalogue);
 
         $this->updateCatalogueMetadata($mergedTranslations);
 
-        $archiveParentDirectory = $this->makeArchiveParentDirectory($themeName, $locale);
+        $archiveDirectory = $this->getExportDir($themeName);
 
-        if ($this->ensureFileBelongsToExportDirectory($archiveParentDirectory)) {
+        if ($this->ensureFileBelongsToExportDirectory($archiveDirectory)) {
             // Clean up previously exported archives
-            $this->filesystem->remove($archiveParentDirectory);
+            $this->filesystem->remove($archiveDirectory);
         }
 
-        $this->filesystem->mkdir($archiveParentDirectory);
+        $this->filesystem->mkdir($archiveDirectory);
 
         $this->dumper->dump($mergedTranslations, array(
-            'path' => $archiveParentDirectory,
+            'path' => $archiveDirectory,
             'default_locale' => $locale,
             'root_dir' => $rootDir,
         ));
 
-        $this->renameCatalogues($locale, $archiveParentDirectory);
+        $this->renameCatalogues($locale, $archiveDirectory);
 
-        return $archiveParentDirectory;
+        return $archiveDirectory;
     }
 
     /**
@@ -227,19 +226,12 @@ class ThemeExporter
         $finder = Finder::create();
 
         foreach ($finder->in($archiveParentDirectory . DIRECTORY_SEPARATOR . $locale)->files() as $file) {
-            $parentDirectoryParts = explode(DIRECTORY_SEPARATOR, dirname($file));
-            $destinationFilenameParts = array(
-                $archiveParentDirectory,
-                $parentDirectoryParts[count($parentDirectoryParts) - 1] . '.' . $locale . '.xlf',
-            );
-            $destinationFilename = implode(DIRECTORY_SEPARATOR, $destinationFilenameParts);
+            $destinationFilename = preg_replace('#(\.xlf)$#', ".$locale\$1", $file->getPathname());
             if ($this->filesystem->exists($destinationFilename)) {
                 $this->filesystem->remove($destinationFilename);
             }
             $this->filesystem->rename($file->getPathname(), $destinationFilename);
         }
-
-        $this->filesystem->remove($archiveParentDirectory . DIRECTORY_SEPARATOR . $locale);
     }
 
     /**

--- a/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
+++ b/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
@@ -48,7 +48,7 @@ class ThemeExtractor
     private $catalog;
 
     /**
-     * @var array the list of Translation dumpers
+     * @var DumperInterface[] the list of Translation dumpers
      */
     private $dumpers = array();
 
@@ -96,11 +96,13 @@ class ThemeExtractor
     }
 
     /**
+     * Extracts wordings from template files and dumps them as XLIFF files
+     *
      * @param Theme $theme
      * @param string $locale
      * @param bool $rootDir
      *
-     * @return mixed
+     * @return void
      *
      * @throws \Exception
      */

--- a/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
+++ b/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
@@ -148,7 +148,7 @@ class ThemeExtractor
     {
         $defaultCatalogue = $this->themeProvider
             ->setLocale($locale)
-            ->getDefaultCatalogue();
+            ->getDefaultCatalogue(false);
 
         if (empty($defaultCatalogue)) {
             return;

--- a/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
@@ -151,8 +151,11 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the default (aka not translated) catalogue
      *
+     * @param bool $empty [default=true] Remove translations and return an empty catalogue
+     *
+     * @return MessageCatalogue|MessageCatalogueInterface
      * @throws FileNotFoundException
      */
     public function getDefaultCatalogue($empty = true)
@@ -253,7 +256,7 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
     }
 
     /**
-     * @param array $paths a list of paths when we can look for translations
+     * @param string|string[] $paths a list of paths when we can look for translations
      * @param string $locale the Symfony (not the PrestaShop one) locale
      * @param string|null $pattern a regular expression
      *
@@ -267,7 +270,9 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the path to the directory where the default (aka not translated) catalogue is
+     *
+     * @return string
      */
     abstract public function getDefaultResourceDirectory();
 }

--- a/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
@@ -139,7 +139,10 @@ class ThemeProvider extends AbstractProvider
             $baseDir = $this->resourceDirectory;
         }
 
-        $resourceDirectory = $baseDir . '/' . $this->themeName . '/translations/' . $this->getLocale();
+        $resourceDirectory = implode(
+            DIRECTORY_SEPARATOR,
+            [$baseDir, $this->themeName, 'translations', $this->getLocale()]
+        );
         $this->filesystem->mkdir($resourceDirectory);
 
         return $resourceDirectory;

--- a/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Translation\Provider;
 
+use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\TranslationToolsBundle\Translation\Extractor\Util\Flattenizer;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
@@ -224,7 +225,7 @@ class ThemeProvider extends AbstractProvider
     /**
      * @return MessageCatalogueInterface
      *
-     * @throws \Exception
+     * @throws FileNotFoundException
      */
     public function getThemeCatalogue()
     {

--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
@@ -82,7 +82,7 @@ class TranslationFinder
     }
 
     /**
-     * @param $paths
+     * @param string|string[] $paths
      * @param $pattern
      *
      * @return Finder

--- a/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
+++ b/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
@@ -54,7 +54,7 @@ class TranslatorLanguageLoader
     /**
      * Loads a language into a translator
      *
-     * @param TranslatorInterface $translator Translator to modifiy
+     * @param TranslatorInterface $translator Translator to modify
      * @param string $locale Locale code for the language to load
      * @param bool $withDB [default=true] Whether to load translations from the database or not
      * @param Theme|null $theme [default=false] Currently active theme (Front office only)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | This change fixes the theme translation export feature. Read below for more.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16555
| How to test?  | Read below

## The issue

- The translation export feature was exporting a single file called `fr-FR.xlf` (for the French example). 
- Already existing translations were being ignored
- Only translations performed through the database were actually exported

## Why it was happening

First, there were multiple problems regarding conventions:

- paths in return values (sometimes it expected the path to include the locale, sometimes not)
- domain names in message catalogues (with or without dots, with or without the locale suffix...)

Then, when loading theme translations for export, the suite went like this:

`ThemeExporter::exportCatalogues()` calls `ThemeExtractor::extract()`, which extracts the theme's "default catalogue" by interpreting .tpl files using TranslationToolsBundle. After that, `extract()` overrides that catalogue using the core's "default catalogue" – more on this in a moment. Finally, it dumps this catalogue in XLF files.

Back to `exportCatalogues()`, the extracted and enriched catalogue is loaded from the XLF files built above, and further enriched by loading translations found in the theme itself (if XLF files are found), then in the database. This catalogue is dumped again to XLF files, zipped and sent away.

So, one of the problems was that the inconsistencies in conventions led to problems in the name of the output files (hence the file named `fr-FR.xlf`). The other problem was during the enrichment process. 

Earlier I described that the catalogue was enriched using the core's "default catalogue". This is actually a language abuse, because it actually pulls the _translated_ catalogue, not _default_ one. This catalogue was being emptied out for some reason, by default[1]. This resulted in all wordings from the theme also found in the core catalogue being emptied out from the theme's catalogue. This also meant that wordings were translated to an empty string, therefore removed from the exported catalogue.

Since we're actually loading the translated catalogue, not the default one, I think it would make more sense to _keep_ those translations. I solved this by simply not emptying out that "default catalogue" loaded from the core.

[1]: Update: looks like this was done to empty out not translated fields in the translation interface, so this PR introduces a regression where you can't know if a theme is fully translated or not (not translated fields will be filled with the original wording).

## How to test

#### First case: using the classic theme

1. Export the theme's translations in a given language. You should basically get a zip file containing several files, all of them start with "Shop", and they are all translated to that language (or at least to the same extent as the core).
2. Now go to the back office's translation section for that theme, and change some translations. Export the theme again. The xlf file for the related domain should be impacted by the modifications you made.
3. Export the theme. It should contain all of the translation files for all the installed languages and include any modifications you made. FYI: this uses the same code as the "export theme translations" feature, only that it does it for ALL the installed languages at once.

#### Second case: using a custom theme (NOT classic), that includes translation files

Repeat steps from the classic theme. The exported files should be the same as the ones you already had for that theme, and when you modify things in the translation interface, they should be exported as well.

#### Third case: using a custom theme (NOT classic), NO translation files included in it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18293)
<!-- Reviewable:end -->
