### PR TITLE
Return null when value is an empty string in ArabicToLatinDigitDataTransformer

### DIFF
--- a/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
@@ -62,8 +62,8 @@ final class ArabicToLatinDigitDataTransformer implements DataTransformerInterfac
      */
     public function reverseTransform($value)
     {
-        if (null === $value) {
-            return  $value;
+        if (null === $value || '' === $value) {
+            return null;
         }
 
         return $this->arabicToLatinDigitConverter->convert($value);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Filters were broken in order page when filtering by id, this PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18291
| How to test?  | Try to filter orders by id, no error should be thrown and results should be ok

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18294)
<!-- Reviewable:end -->
