### PR TITLE
Fix count query with customer filter

### DIFF
--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -88,14 +88,15 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
     {
         $qb = $this
             ->getBaseQueryBuilder($searchCriteria->getFilters())
+            ->addSelect($this->getCustomerField() . ' AS `customer`')
             ->addSelect('o.id_order, o.reference, o.total_paid_tax_incl, os.paid, osl.name AS osname')
             ->addSelect('o.current_state, o.id_customer')
-            ->addSelect('CONCAT(LEFT(cu.`firstname`, 1), \'. \', cu.`lastname`) AS `customer`')
             ->addSelect('cu.`id_customer` IS NULL as `deleted_customer`')
             ->addSelect('os.color, o.payment, s.name AS shop_name')
             ->addSelect('o.date_add, cu.company, cl.name AS country_name, o.invoice_number, o.delivery_number')
         ;
-        $qb = $this->addNewCustomerField($qb);
+
+        $this->addNewCustomerField($qb);
 
         $this->applySorting($qb, $searchCriteria);
 
@@ -115,7 +116,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
     {
         $qb = $this->getBaseQueryBuilder($searchCriteria->getFilters());
         if (isset($searchCriteria->getFilters()['new'])) {
-            $qb = $this->addNewCustomerField($qb->addSelect('o.id_order as o_id_order'));
+            $this->addNewCustomerField($qb->addSelect('o.id_order as o_id_order'));
             $qb = $this->applyNewCustomerFilter($qb, $searchCriteria->getFilters());
             $qb->select('count(o_id_order)');
         } else {
@@ -168,11 +169,10 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
             'reference' => 'o.`reference`',
             'company' => 'cu.`company`',
             'payment' => 'o.`payment`',
+            'customer' => $this->getCustomerField(),
         ];
 
-        $havingLikeComparisonFilters = [
-            'customer' => 'customer',
-        ];
+        $havingLikeComparisonFilters = [];
 
         $dateComparisonFilters = [
             'date_add' => 'o.`date_add`',
@@ -232,8 +232,6 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
 
     /**
      * @param QueryBuilder $qb
-     *
-     * @return QueryBuilder
      */
     private function addNewCustomerField(QueryBuilder $qb)
     {
@@ -246,7 +244,15 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
             ->setMaxResults(1)
         ;
 
-        return $qb->addSelect('IF ((' . $newCustomerSubSelect->getSQL() . ') > 0, 0, 1) AS new');
+        $qb->addSelect('IF ((' . $newCustomerSubSelect->getSQL() . ') > 0, 0, 1) AS new');
+    }
+
+    /**
+     * @return string
+     */
+    private function getCustomerField()
+    {
+        return 'CONCAT(LEFT(cu.`firstname`, 1), \'. \', cu.`lastname`)';
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In the order pages, an error was thrown when filtering by customer. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18263
| How to test?  | 1. Go to BO => Orders page<br>2. Filter by a customer<br>3. No error should be thrown and the number of orders (the title of the section) should match the number of orders in the list

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18305)
<!-- Reviewable:end -->
