### PR TITLE
Fix wrong images for combinations in Cart view page

### DIFF
--- a/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
@@ -33,6 +33,7 @@ use Customer;
 use DateTime;
 use Gender;
 use Group;
+use Link;
 use Order;
 use PrestaShop\PrestaShop\Adapter\ImageManager;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
@@ -60,13 +61,19 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
     private $locale;
 
     /**
+     * @var Link
+     */
+    private $contextLink;
+
+    /**
      * @param ImageManager $imageManager
      * @param Locale $locale
      */
-    public function __construct(ImageManager $imageManager, Locale $locale)
+    public function __construct(ImageManager $imageManager, Locale $locale, Link $contextLink)
     {
         $this->imageManager = $imageManager;
         $this->locale = $locale;
+        $this->contextLink = $contextLink;
     }
 
     /**
@@ -201,8 +208,6 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
         $formattedProducts = [];
 
         foreach ($products as $product) {
-            $image = Product::getCover($product['id_product']);
-
             $formattedProduct = [
                 'id' => $product['id_product'],
                 'name' => $product['name'],
@@ -216,7 +221,7 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
                 'unit_price' => $product['product_price'],
                 'total_price_formatted' => $this->locale->formatPrice($product['product_total'], $currency->iso_code),
                 'unit_price_formatted' => $this->locale->formatPrice($product['product_price'], $currency->iso_code),
-                'image' => $this->imageManager->getThumbnailForListing($image['id_image']),
+                'image_url' => $this->contextLink->getImageLink($product['link_rewrite'], $product['id_image'], 'small_default'),
             ];
 
             if (isset($product['customizationQuantityTotal'])) {

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
@@ -87,6 +87,7 @@ services:
     arguments:
       - '@prestashop.adapter.image_manager'
       - "@prestashop.core.localization.locale.context_locale"
+      - '@=service("prestashop.adapter.legacy.context").getContext().link'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForViewing'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
@@ -43,7 +43,8 @@
         {% for product in cartView.cartSummary.products %}
           {% if product.customization is not empty %}
             <tr>
-              <td>{{ product.image|raw }}</td>
+              <td>
+                <img src="{{ product.image_url}}" alt="" class="imgm img-thumbnail" /></td>
               <td>
                 <a href="{{ path('admin_product_form', {'id': product.id}) }}">
                   {{ product.name }}
@@ -92,7 +93,7 @@
               </td>
 
               <td></td>
-              <td>{{ product.customization.quantity }}</td>
+              <td></td>
               <td></td>
               <td></td>
             </tr>
@@ -100,7 +101,7 @@
 
           {% if product.customization is empty or product.cart_quantity > product.customization_quantity %}
             <tr>
-              <td>{{ product.image|raw }}</td>
+              <td><img src="{{ product.image_url}}" alt="" class="imgm img-thumbnail" /></td>
               <td>
                 <a href="{{ path('admin_product_form', {'id': product.id}) }}">
                   {{ product.name }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In Orders -> Shipping carts -> Cart view page, product images displayed are not correct when product contains combinations.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | issued by #18312, but moved to develop because carts page is not enabled yet in 1.7.7
| How to test?  | Go to Orders -> Shipping carts and select a cart which has products with combinations. (you can create a cart in create order page). Make sure that product images are correct. ( e.g. if you have product `.. black cushion` and `...white cushion` then you should see images with black and white cushions accordingly. Previously it would show only black ones.)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18315)
<!-- Reviewable:end -->
