### PR TITLE
Do not stack free shipping vouchers on total: shipping fees applied once

### DIFF
--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -200,8 +200,14 @@ class Calculator
     public function getDiscountTotal()
     {
         $amount = new AmountImmutable();
+        $isFreeShippingAppliedToAmount = false;
         foreach ($this->cartRules as $cartRule) {
+            if ($isFreeShippingAppliedToAmount && (bool) $cartRule->getRuleData()['free_shipping']) {
+                $initialShippingFees = $this->getFees()->getInitialShippingFees();
+                $amount = $amount->sub($initialShippingFees);
+            }
             $amount = $amount->add($cartRule->getDiscountApplied());
+            $isFreeShippingAppliedToAmount = (bool) $cartRule->getRuleData()['free_shipping'];
         }
 
         $allowedMaxDiscount = $this->getRowTotalWithoutDiscount();

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -202,12 +202,14 @@ class Calculator
         $amount = new AmountImmutable();
         $isFreeShippingAppliedToAmount = false;
         foreach ($this->cartRules as $cartRule) {
-            if ($isFreeShippingAppliedToAmount && (bool) $cartRule->getRuleData()['free_shipping']) {
-                $initialShippingFees = $this->getFees()->getInitialShippingFees();
-                $amount = $amount->sub($initialShippingFees);
+            if ((bool) $cartRule->getRuleData()['free_shipping']) {
+                if ($isFreeShippingAppliedToAmount) {
+                    $initialShippingFees = $this->getFees()->getInitialShippingFees();
+                    $amount = $amount->sub($initialShippingFees);
+                }
+                $isFreeShippingAppliedToAmount = true;
             }
             $amount = $amount->add($cartRule->getDiscountApplied());
-            $isFreeShippingAppliedToAmount = (bool) $cartRule->getRuleData()['free_shipping'];
         }
 
         $allowedMaxDiscount = $this->getRowTotalWithoutDiscount();

--- a/src/Core/Cart/Fees.php
+++ b/src/Core/Cart/Fees.php
@@ -64,6 +64,12 @@ class Fees
      */
     protected $isProcessed = false;
 
+    public function __construct()
+    {
+        $this->shippingFees = new AmountImmutable();
+    }
+
+
     /**
      * @param Cart $cart
      * @param CartRowCollection $cartRowCollection

--- a/src/Core/Cart/Fees.php
+++ b/src/Core/Cart/Fees.php
@@ -69,7 +69,6 @@ class Fees
         $this->shippingFees = new AmountImmutable();
     }
 
-
     /**
      * @param Cart $cart
      * @param CartRowCollection $cartRowCollection

--- a/tests/Integration/Behaviour/Features/Context/AbstractPrestaShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/AbstractPrestaShopFeatureContext.php
@@ -41,11 +41,19 @@ abstract class AbstractPrestaShopFeatureContext implements BehatContext
 
     protected function checkFixtureExists(array $fixtures, $fixtureName, $fixtureIndex)
     {
+        $searchLength = 10;
+
         if (!isset($fixtures[$fixtureIndex])) {
             $fixtureNames = array_keys($fixtures);
-            $firstFixtureNames = array_splice($fixtureNames, 0, 5);
+            $firstFixtureNames = array_splice($fixtureNames, 0, $searchLength);
             $firstFixtureNamesStr = implode(',', $firstFixtureNames);
-            throw new \Exception($fixtureName . ' named "' . $fixtureIndex . '" was not added in fixtures. First 5 added are: ' . $firstFixtureNamesStr);
+            throw new \Exception(sprintf(
+                '%s named "%s" was not added in fixtures. First %d added are: %s',
+                $fixtureName,
+                $fixtureIndex,
+                $searchLength,
+                $firstFixtureNamesStr
+            ));
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/AbstractPrestaShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/AbstractPrestaShopFeatureContext.php
@@ -47,7 +47,7 @@ abstract class AbstractPrestaShopFeatureContext implements BehatContext
             $fixtureNames = array_keys($fixtures);
             $firstFixtureNames = array_splice($fixtureNames, 0, $searchLength);
             $firstFixtureNamesStr = implode(',', $firstFixtureNames);
-            throw new \Exception(sprintf(
+            throw new \RuntimeException(sprintf(
                 '%s named "%s" was not added in fixtures. First %d added are: %s',
                 $fixtureName,
                 $fixtureIndex,

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
@@ -41,7 +41,6 @@ Feature: Cart rule (amount) calculation with one cart rule offering free shippin
     Given cart rule "cartrule6" has a discount code "foo6"
     Given cart rule "cartrule7" offers free shipping
     Given cart rule "cartrule7" has a discount code "foo7"
-    Given cart rule "cartrule8" offers free shipping
     Given cart rule "cartrule8" has a discount code "foo8"
     When I add 1 items of product "product1" in my cart
     When I use the discount "cartrule5"

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
@@ -26,3 +26,29 @@ Feature: Cart rule (amount) calculation with one cart rule offering free shippin
     When I use the discount "cartrule4"
     Then my cart total should be 14.812 tax included
     Then my cart total using previous calculation method should be 14.812 tax included
+
+  Scenario: One product in cart, four different cartRules offering free shipping
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a cart rule named "cartrule5" that applies an amount discount of 5.0 with priority 4, quantity of 100 and quantity per user 10
+    Given there is a cart rule named "cartrule6" that applies no discount with priority 5, quantity of 100 and quantity per user 10
+    Given there is a cart rule named "cartrule7" that applies no discount with priority 6, quantity of 100 and quantity per user 10
+    Given there is a cart rule named "cartrule8" that applies an amount discount of 5.0 with priority 4, quantity of 100 and quantity per user 10
+    Given cart rule "cartrule5" offers free shipping
+    Given cart rule "cartrule5" has a discount code "foo5"
+    Given cart rule "cartrule6" offers free shipping
+    Given cart rule "cartrule6" has a discount code "foo6"
+    Given cart rule "cartrule7" offers free shipping
+    Given cart rule "cartrule7" has a discount code "foo7"
+    Given cart rule "cartrule8" offers free shipping
+    Given cart rule "cartrule8" has a discount code "foo8"
+    When I add 1 items of product "product1" in my cart
+    When I use the discount "cartrule5"
+    Then my cart total should be 14.812 tax included
+    When I use the discount "cartrule6"
+    Then my cart total should be 14.812 tax included
+    When I use the discount "cartrule7"
+    Then my cart total should be 14.812 tax included
+    When I use the discount "cartrule8"
+    Then my cart total should be 9.8 tax included


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Do not remove shipping fees twice even if multiple 'free shipping' vouchers are used
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/17875
| How to test?  | See below

## How to test

Steps from https://github.com/PrestaShop/PrestaShop/issues/17875
1. Go to BO => Catalog => Discounts, create two cart rules with free shipping
2. Go to FO, create an order with paid shipping
3. Add the two cart rules
4. Shipping price is deducted twice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18321)
<!-- Reviewable:end -->
