### PR TITLE
Grid row delete confirmation modal - Catalog > Monitoring

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/monitoring/index.js
+++ b/admin-dev/themes/new-theme/js/pages/monitoring/index.js
@@ -70,6 +70,7 @@ $(() => {
     grid.addExtension(new ReloadListActionExtension());
     grid.addExtension(new FiltersResetExtension());
     grid.addExtension(new AsyncToggleColumnExtension());
+    grid.addExtension(new SubmitRowActionExtension());
     grid.addExtension(new LinkRowActionExtension());
     grid.addExtension(new FiltersSubmitButtonEnablerExtension());
   });

--- a/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
+++ b/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
@@ -41,8 +41,7 @@ trait DeleteActionTrait
         string $deleteRouteParamName,
         string $deleteRouteParamField,
         string $method = 'POST',
-        array $extraRouteParams = [],
-        array $translations = []
+        array $extraRouteParams = []
     ): RowActionInterface {
         return (new SubmitRowAction('delete'))
             ->setName($this->trans('Delete', [], 'Admin.Actions'))
@@ -52,20 +51,12 @@ trait DeleteActionTrait
                 'route_param_name' => $deleteRouteParamName,
                 'route_param_field' => $deleteRouteParamField,
                 'extra_route_params' => $extraRouteParams,
-                'confirm_message' => array_key_exists('confirm_message', $translations) ?
-                    $translations['confirm_message'] :
-                    $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Global'),
+                'confirm_message' => $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Global'),
                 'method' => $method,
                 'modal_options' => new ModalOptions([
-                    'title' => array_key_exists('modal_options.title', $translations) ?
-                        $translations['modal_options.title'] :
-                        $this->trans('Delete selection', [], 'Admin.Actions'),
-                    'confirm_button_label' => array_key_exists('modal_options.confirm_button_label', $translations) ?
-                        $translations['modal_options.confirm_button_label'] :
-                        $this->trans('Delete', [], 'Admin.Actions'),
-                    'close_button_label' => array_key_exists('modal_options.close_button_label', $translations) ?
-                        $translations['modal_options.close_button_label'] :
-                        $this->trans('Cancel', [], 'Admin.Actions'),
+                    'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
+                    'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
+                    'close_button_label' => $this->trans('Cancel', [], 'Admin.Actions'),
                     'confirm_button_class' => 'btn-danger',
                 ]),
             ])

--- a/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
+++ b/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
@@ -36,8 +36,14 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
  */
 trait DeleteActionTrait
 {
-    protected function buildDeleteAction(string $deleteRouteName, string $deleteRouteParamName, string $deleteRouteParamField, string $method = 'POST'): RowActionInterface
-    {
+    protected function buildDeleteAction(
+        string $deleteRouteName,
+        string $deleteRouteParamName,
+        string $deleteRouteParamField,
+        string $method = 'POST',
+        array $extraRouteParams = [],
+        array $translations = []
+    ): RowActionInterface {
         return (new SubmitRowAction('delete'))
             ->setName($this->trans('Delete', [], 'Admin.Actions'))
             ->setIcon('delete')
@@ -45,12 +51,21 @@ trait DeleteActionTrait
                 'route' => $deleteRouteName,
                 'route_param_name' => $deleteRouteParamName,
                 'route_param_field' => $deleteRouteParamField,
-                'confirm_message' => $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Global'),
+                'extra_route_params' => $extraRouteParams,
+                'confirm_message' => array_key_exists('confirm_message', $translations) ?
+                    $translations['confirm_message'] :
+                    $this->trans('Are you sure you want to delete the selected item?', [], 'Admin.Notifications.Warning'),
                 'method' => $method,
                 'modal_options' => new ModalOptions([
-                    'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
-                    'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
-                    'close_button_label' => $this->trans('Cancel', [], 'Admin.Actions'),
+                    'title' => array_key_exists('modal_options.title', $translations) ?
+                        $translations['modal_options.title'] :
+                        $this->trans('Delete selection', [], 'Admin.Actions'),
+                    'confirm_button_label' => array_key_exists('modal_options.confirm_button_label', $translations) ?
+                        $translations['modal_options.confirm_button_label'] :
+                        $this->trans('Delete', [], 'Admin.Actions'),
+                    'close_button_label' => array_key_exists('modal_options.close_button_label', $translations) ?
+                        $translations['modal_options.close_button_label'] :
+                        $this->trans('Cancel', [], 'Admin.Actions'),
                     'confirm_button_class' => 'btn-danger',
                 ]),
             ])

--- a/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
+++ b/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
@@ -54,7 +54,7 @@ trait DeleteActionTrait
                 'extra_route_params' => $extraRouteParams,
                 'confirm_message' => array_key_exists('confirm_message', $translations) ?
                     $translations['confirm_message'] :
-                    $this->trans('Are you sure you want to delete the selected item?', [], 'Admin.Notifications.Warning'),
+                    $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Global'),
                 'method' => $method,
                 'modal_options' => new ModalOptions([
                     'title' => array_key_exists('modal_options.title', $translations) ?

--- a/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\IdentifierColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\DeleteActionTrait;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
@@ -47,6 +48,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 abstract class AbstractProductGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use DeleteActionTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -187,16 +190,19 @@ abstract class AbstractProductGridDefinitionFactory extends AbstractGridDefiniti
                     ])
             )
             ->add(
-                (new LinkRowAction('delete'))
-                    ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                    ->setIcon('delete')
-                    ->setOptions([
-                        'route' => 'admin_product_unit_action',
-                        'route_param_name' => 'id',
-                        'route_param_field' => 'id_product',
-                        'extra_route_params' => ['action' => 'delete'],
-                        'confirm_message' => $this->trans('Delete selected item?', [], 'Admin.Notifications.Warning'),
-                    ])
+                $this->buildDeleteAction(
+                    'admin_product_unit_action',
+                    'id',
+                    'id_product',
+                    ['action' => 'delete'],
+                    [
+                        'confirm_message' => $this->trans(
+                            'Delete selected item?',
+                            [],
+                            'Admin.Advparameters.Feature'
+                        ),
+                    ]
+                )
             );
     }
 }

--- a/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
@@ -196,14 +196,7 @@ abstract class AbstractProductGridDefinitionFactory extends AbstractGridDefiniti
                     'id',
                     'id_product',
                     Request::METHOD_DELETE,
-                    ['action' => 'delete'],
-                    [
-                        'confirm_message' => $this->trans(
-                            'Delete selected item?',
-                            [],
-                            'Admin.Notifications.Warning'
-                        ),
-                    ]
+                    ['action' => 'delete']
                 )
             );
     }

--- a/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
@@ -199,7 +199,7 @@ abstract class AbstractProductGridDefinitionFactory extends AbstractGridDefiniti
                         'confirm_message' => $this->trans(
                             'Delete selected item?',
                             [],
-                            'Admin.Advparameters.Feature'
+                            'Admin.Notifications.Warning'
                         ),
                     ]
                 )

--- a/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
@@ -42,6 +42,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Defines reusable grids for product listing in monitoring page
@@ -194,6 +195,7 @@ abstract class AbstractProductGridDefinitionFactory extends AbstractGridDefiniti
                     'admin_product_unit_action',
                     'id',
                     'id_product',
+                    Request::METHOD_DELETE,
                     ['action' => 'delete'],
                     [
                         'confirm_message' => $this->trans(

--- a/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
@@ -195,7 +195,7 @@ abstract class AbstractProductGridDefinitionFactory extends AbstractGridDefiniti
                     'admin_product_unit_action',
                     'id',
                     'id_product',
-                    Request::METHOD_DELETE,
+                    Request::METHOD_POST,
                     ['action' => 'delete']
                 )
             );

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/submit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/submit.html.twig
@@ -39,7 +39,7 @@
 {% set extra_route_params = action.options.extra_route_params %}
 
 {% for name, field in extra_route_params %}
-  {% set route_params = route_params|merge({ (name) : (record[field]) }) %}
+  {% set route_params = route_params|merge({ (name) : (record[field] ?? field) }) %}
 {% endfor %}
 
 <a class="{{ class }}"


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Catalog > Monitoring
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Catalog > Monitoring in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18322)
<!-- Reviewable:end -->
