### PR TITLE
Grid row delete confirmation modal - Catalog > Brands > Addresses

### DIFF
--- a/src/Core/Grid/Definition/Factory/ManufacturerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ManufacturerAddressGridDefinitionFactory.php
@@ -30,7 +30,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\LinkGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
@@ -49,6 +48,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 final class ManufacturerAddressGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
+    use DeleteActionTrait;
 
     const GRID_ID = 'manufacturer_address';
 
@@ -135,19 +135,12 @@ final class ManufacturerAddressGridDefinitionFactory extends AbstractGridDefinit
                                 'clickable_row' => true,
                             ])
                         )
-                        ->add((new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'route' => 'admin_manufacturer_addresses_delete',
-                                'route_param_name' => 'addressId',
-                                'route_param_field' => 'id_address',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                            ])
+                        ->add(
+                            $this->buildDeleteAction(
+                                'admin_manufacturer_addresses_delete',
+                                'addressId',
+                                'id_address'
+                            )
                         ),
                 ])
             )

--- a/src/Core/Grid/Definition/Factory/ManufacturerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ManufacturerAddressGridDefinitionFactory.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShopBundle\Form\Admin\Type\CountryChoiceType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class ManufacturerAddressGridDefinitionFactory is responsible for creating Manufacturers address grid definition.
@@ -139,7 +140,8 @@ final class ManufacturerAddressGridDefinitionFactory extends AbstractGridDefinit
                             $this->buildDeleteAction(
                                 'admin_manufacturer_addresses_delete',
                                 'addressId',
-                                'id_address'
+                                'id_address',
+                                Request::METHOD_DELETE
                             )
                         ),
                 ])

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
@@ -130,7 +130,7 @@ admin_manufacturer_addresses_edit:
 
 admin_manufacturer_addresses_delete:
   path: addresses/{addressId}/delete
-  methods: POST
+  methods: [POST, DELETE]
   defaults:
     _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Manufacturer:deleteAddress'
     _legacy_controller: AdminManufacturers


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Catalog > Brands > Adrdresses
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Catalog > Brands > Adrdresses in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18324)
<!-- Reviewable:end -->
