### PR TITLE
Grid row delete confirmation modal - Catalog > Brands > Brands

### DIFF
--- a/src/Core/Grid/Definition/Factory/ManufacturerGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ManufacturerGridDefinitionFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\LinkGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
@@ -52,6 +51,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 final class ManufacturerGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
+    use DeleteActionTrait;
 
     const GRID_ID = 'manufacturer';
 
@@ -144,19 +144,12 @@ final class ManufacturerGridDefinitionFactory extends AbstractGridDefinitionFact
                                 'route_param_field' => 'id_manufacturer',
                             ])
                         )
-                        ->add((new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'route' => 'admin_manufacturers_delete',
-                                'route_param_name' => 'manufacturerId',
-                                'route_param_field' => 'id_manufacturer',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                            ])
+                        ->add(
+                            $this->buildDeleteAction(
+                                'admin_manufacturers_delete',
+                                'manufacturerId',
+                                'id_manufacturer'
+                            )
                         ),
                 ])
             );

--- a/src/Core/Grid/Definition/Factory/ManufacturerGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ManufacturerGridDefinitionFactory.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class ManufacturerGridDefinitionFactory is responsible for creating Manufacturers grid definition.
@@ -148,7 +149,8 @@ final class ManufacturerGridDefinitionFactory extends AbstractGridDefinitionFact
                             $this->buildDeleteAction(
                                 'admin_manufacturers_delete',
                                 'manufacturerId',
-                                'id_manufacturer'
+                                'id_manufacturer',
+                                Request::METHOD_DELETE
                             )
                         ),
                 ])

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
@@ -51,7 +51,7 @@ admin_manufacturers_edit:
 
 admin_manufacturers_delete:
   path: /{manufacturerId}/delete
-  methods: POST
+  methods: [POST, DELETE]
   defaults:
     _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Manufacturer:delete'
     _legacy_controller: AdminManufacturers


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Catalog > Brands > Brands
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Catalog > Brands > Brands in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18325)
<!-- Reviewable:end -->
