### PR TITLE
Fix messages block in order view page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1096,16 +1096,16 @@ class OrderController extends CommonController
 
         $routesCollection = $this->get('router')->getRouteCollection();
 
-        if (
-            null !== $routesCollection &&
+        if (null !== $routesCollection &&
             !$orderMessageForm->isValid() &&
-            $viewRoute = $routesCollection->get('admin_orders_view')) {
+            $viewRoute = $routesCollection->get('admin_orders_view')
+        ) {
+            $attributes = $viewRoute->getDefaults();
+            $attributes['orderId'] = $orderId;
+
             return $this->forward(
                 $viewRoute->getDefault('_controller'),
-                [
-                    'orderId' => $orderId,
-                ],
-                $viewRoute->getDefaults()
+                $attributes
             );
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Order;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\OrderMessageConstraint;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\TextWithLengthCounterType;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
@@ -77,7 +78,7 @@ class OrderMessageType extends AbstractType
             ])
             ->add('message', TextWithLengthCounterType::class, [
                 'input' => 'textarea',
-                'max_length' => 600,
+                'max_length' => OrderMessageConstraint::MAX_MESSAGE_LENGTH,
                 'position' => 'after',
                 'constraints' => [
                     new NotBlank([
@@ -96,10 +97,10 @@ class OrderMessageType extends AbstractType
                         ]
                     ),
                     new Length([
-                        'max' => 600,
+                        'max' => OrderMessageConstraint::MAX_MESSAGE_LENGTH,
                         'maxMessage' => $this->trans(
                             'This field cannot be longer than %limit% characters',
-                            ['%limit%' => 600],
+                            ['%limit%' => OrderMessageConstraint::MAX_MESSAGE_LENGTH],
                             'Admin.Notifications.Error'
                         ),
                     ]),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Customer service->message and Order view ->message length constraints were different (one being 600 and another 1200). Now both will have max length of 1200 symbols. Also bug mentioned in #18030 is fixed.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #18030
| How to test?  | **Check length:**`Sell->Customer service->Order messages edit` And `Sell->Orders->View order messages block` must have the same maximum length. **Check bug:** go to order view page messages block and do following: inspect the textarea element and remove the 'max-length' attribute. Then fill in random text with more than 1200 symbols and submit. Page should display error message that maximum allowed length is only 1200 and strange html should not appear at the top of the page anymore (reference #18030 for more info).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18326)
<!-- Reviewable:end -->
