### PR TITLE
Functional tests - Wait for navigation in go to maintenance tab function

### DIFF
--- a/tests/puppeteer/pages/BO/shopParameters/general/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/general/index.js
@@ -25,7 +25,7 @@ module.exports = class shopParamsGeneral extends BOBasePage {
    * @return {Promise<void>}
    */
   async goToSubTabMaintenance() {
-    await this.page.click(this.maintenanceNavItemLink, {waitUntil: 'networkidle2'});
+    await this.clickAndWaitForNavigation(this.maintenanceNavItemLink);
   }
 
   /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix nightly 26/03 by waiting for navigation in go to maintenance tab function
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/13_shopParameters/01_general/maintenance/*" URL_FO=shopUrl/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18332)
<!-- Reviewable:end -->
