### PR TITLE
Grid row delete confirmation modal - Design > Pages

### DIFF
--- a/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -55,6 +54,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 final class CmsPageCategoryDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
+    use DeleteActionTrait;
 
     const GRID_ID = 'cms_page_category';
 
@@ -172,20 +172,12 @@ final class CmsPageCategoryDefinitionFactory extends AbstractGridDefinitionFacto
                                 'route_param_field' => 'id_cms_category',
                             ])
                         )
-                        ->add((new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'method' => 'DELETE',
-                                'route' => 'admin_cms_pages_category_delete',
-                                'route_param_name' => 'cmsCategoryId',
-                                'route_param_field' => 'id_cms_category',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                            ])
+                        ->add(
+                            $this->buildDeleteAction(
+                                'admin_cms_pages_category_delete',
+                                'cmsCategoryId',
+                                'id_cms_category'
+                            )
                         ),
                 ])
             )

--- a/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
@@ -46,6 +46,7 @@ use PrestaShop\PrestaShop\Core\Multistore\MultistoreContextCheckerInterface;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -176,7 +177,8 @@ final class CmsPageCategoryDefinitionFactory extends AbstractGridDefinitionFacto
                             $this->buildDeleteAction(
                                 'admin_cms_pages_category_delete',
                                 'cmsCategoryId',
-                                'id_cms_category'
+                                'id_cms_category',
+                                Request::METHOD_DELETE
                             )
                         ),
                 ])

--- a/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
@@ -33,7 +33,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -56,6 +55,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
+    use DeleteActionTrait;
 
     const GRID_ID = 'cms_page';
 
@@ -181,20 +181,12 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
                                 'clickable_row' => true,
                             ])
                         )
-                        ->add((new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'method' => 'DELETE',
-                                'route' => 'admin_cms_pages_delete',
-                                'route_param_name' => 'cmsId',
-                                'route_param_field' => 'id_cms',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                            ])
+                        ->add(
+                            $this->buildDeleteAction(
+                                'admin_cms_pages_delete',
+                                'cmsId',
+                                'id_cms'
+                            )
                         ),
                 ])
             )

--- a/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
@@ -47,6 +47,7 @@ use PrestaShop\PrestaShop\Core\Multistore\MultistoreContextCheckerInterface;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -185,7 +186,8 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
                             $this->buildDeleteAction(
                                 'admin_cms_pages_delete',
                                 'cmsId',
-                                'id_cms'
+                                'id_cms',
+                                Request::METHOD_DELETE
                             )
                         ),
                 ])


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Design > Pages
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Design > Pages in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18355)
<!-- Reviewable:end -->
