### PR TITLE
Grid row delete confirmation modal - International > Localization > Languages

### DIFF
--- a/src/Core/Grid/Definition/Factory/LanguageGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LanguageGridDefinitionFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -53,6 +52,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 final class LanguageGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
+    use DeleteActionTrait;
 
     const GRID_ID = 'language';
 
@@ -163,19 +163,11 @@ final class LanguageGridDefinitionFactory extends AbstractGridDefinitionFactory
                             ])
                         )
                         ->add(
-                            (new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                                'route' => 'admin_languages_delete',
-                                'route_param_name' => 'languageId',
-                                'route_param_field' => 'id_lang',
-                            ])
+                            $this->buildDeleteAction(
+                                'admin_languages_delete',
+                                'languageId',
+                                'id_lang'
+                            )
                         ),
                 ])
             );

--- a/src/Core/Grid/Definition/Factory/LanguageGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LanguageGridDefinitionFactory.php
@@ -45,6 +45,7 @@ use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class LanguageGridDefinitionFactory creates definition for languages grid.
@@ -166,7 +167,8 @@ final class LanguageGridDefinitionFactory extends AbstractGridDefinitionFactory
                             $this->buildDeleteAction(
                                 'admin_languages_delete',
                                 'languageId',
-                                'id_lang'
+                                'id_lang',
+                                Request::METHOD_DELETE
                             )
                         ),
                 ])

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/language.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/language.yml
@@ -36,7 +36,7 @@ admin_languages_edit:
 
 admin_languages_delete:
   path: /{languageId}/delete
-  methods: [POST]
+  methods: [POST, DELETE]
   defaults:
     _controller: 'PrestaShopBundle:Admin\Improve\International\Language:delete'
     _legacy_controller: AdminLanguages


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> International > Localization > Languages
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to International > Localization > Languages in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18356)
<!-- Reviewable:end -->
