### PR TITLE
Grid row delete confirmation modal - International > Localization > Currencies

### DIFF
--- a/src/Core/Grid/Definition/Factory/CurrencyGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CurrencyGridDefinitionFactory.php
@@ -47,6 +47,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class CurrencyGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use DeleteActionTrait;
+
     const GRID_ID = 'currency';
 
     /**
@@ -133,6 +135,13 @@ final class CurrencyGridDefinitionFactory extends AbstractGridDefinitionFactory
                                     'Admin.Notifications.Warning'
                                 ),
                             ])
+                        )
+                        ->add(
+                            $this->buildDeleteAction(
+                                'admin_currencies_delete',
+                                'currencyId',
+                                'id_currency'
+                            )
                         ),
                 ])
             )

--- a/src/Core/Grid/Definition/Factory/CurrencyGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CurrencyGridDefinitionFactory.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class CurrencyGridDefinitionFactory is responsible for defining definition for currency list located in
@@ -140,7 +141,8 @@ final class CurrencyGridDefinitionFactory extends AbstractGridDefinitionFactory
                             $this->buildDeleteAction(
                                 'admin_currencies_delete',
                                 'currencyId',
-                                'id_currency'
+                                'id_currency',
+                                Request::METHOD_DELETE
                             )
                         ),
                 ])


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> International > Localization > Currencies
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to International > Localization > Currencies in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18357)
<!-- Reviewable:end -->
