### PR TITLE
Grid row delete confirmation modal - Shop parameters > Traffic SEO > SEO URLs

### DIFF
--- a/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
+++ b/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
@@ -36,7 +36,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
  */
 trait DeleteActionTrait
 {
-    protected function buildDeleteAction(string $deleteRouteName, string $deleteRouteParamName, string $deleteRouteParamField): RowActionInterface
+    protected function buildDeleteAction(string $deleteRouteName, string $deleteRouteParamName, string $deleteRouteParamField, string $method = 'POST'): RowActionInterface
     {
         return (new SubmitRowAction('delete'))
             ->setName($this->trans('Delete', [], 'Admin.Actions'))
@@ -46,6 +46,7 @@ trait DeleteActionTrait
                 'route_param_name' => $deleteRouteParamName,
                 'route_param_field' => $deleteRouteParamField,
                 'confirm_message' => $this->trans('Are you sure you want to delete the selected item?', [], 'Admin.Notifications.Warning'),
+                'method' => $method,
                 'modal_options' => new ModalOptions([
                     'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
                     'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),

--- a/src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -47,6 +46,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class MetaGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use DeleteActionTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -119,20 +120,11 @@ final class MetaGridDefinitionFactory extends AbstractGridDefinitionFactory
                             ])
                         )
                         ->add(
-                            (new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'method' => 'DELETE',
-                                'route' => 'admin_metas_delete',
-                                'route_param_name' => 'metaId',
-                                'route_param_field' => 'id_meta',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                            ])
+                            $this->buildDeleteAction(
+                                'admin_metas_delete',
+                                'metaId',
+                                'id_meta'
+                            )
                         ),
                 ])
             );

--- a/src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class MetaGridDefinitionFactory is responsible for adding definition for Seo & urls list.
@@ -123,7 +124,8 @@ final class MetaGridDefinitionFactory extends AbstractGridDefinitionFactory
                             $this->buildDeleteAction(
                                 'admin_metas_delete',
                                 'metaId',
-                                'id_meta'
+                                'id_meta',
+                                Request::METHOD_DELETE
                             )
                         ),
                 ])

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/meta.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/meta.yml
@@ -34,7 +34,7 @@ admin_metas_edit:
 
 admin_metas_delete:
   path: /{metaId}/delete
-  methods: DELETE
+  methods: [DELETE, POST]
   defaults:
     _controller: 'PrestaShopBundle:Admin\Configure\ShopParameters\Meta:delete'
     _legacy_controller: AdminMeta

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/meta.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/meta.yml
@@ -34,7 +34,7 @@ admin_metas_edit:
 
 admin_metas_delete:
   path: /{metaId}/delete
-  methods: [DELETE, POST]
+  methods: DELETE
   defaults:
     _controller: 'PrestaShopBundle:Admin\Configure\ShopParameters\Meta:delete'
     _legacy_controller: AdminMeta


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Shop parameters > Traffic SEO > SEO URLs
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Shop parameters > Traffic SEO > SEO URLs in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18358)
<!-- Reviewable:end -->
