### PR TITLE
Grid row delete confirmation modal - Advanced parameters > Emails

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/email/index.js
+++ b/admin-dev/themes/new-theme/js/pages/email/index.js
@@ -32,6 +32,7 @@ import FiltersResetExtension from '@components/grid/extension/filters-reset-exte
 import SortingExtension from '@components/grid/extension/sorting-extension';
 import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
 import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
+import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
 import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import FiltersSubmitButtonEnablerExtension
@@ -48,6 +49,7 @@ $(() => {
   emailLogsGrid.addExtension(new SortingExtension());
   emailLogsGrid.addExtension(new BulkActionCheckboxExtension());
   emailLogsGrid.addExtension(new SubmitBulkExtension());
+  emailLogsGrid.addExtension(new SubmitRowActionExtension());
   emailLogsGrid.addExtension(new SubmitGridExtension());
   emailLogsGrid.addExtension(new LinkRowActionExtension());
   emailLogsGrid.addExtension(new FiltersSubmitButtonEnablerExtension());

--- a/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SubmitGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
@@ -51,6 +50,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use DeleteActionTrait;
+
     /**
      * @var string the URL to reset Grid filters
      */
@@ -160,18 +161,11 @@ final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
                 ->setOptions([
                     'actions' => (new RowActionCollection())
                         ->add(
-                            (new LinkRowAction('delete'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'route' => 'admin_emails_delete',
-                                'route_param_name' => 'mailId',
-                                'route_param_field' => 'id_mail',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                            ])
+                            $this->buildDeleteAction(
+                                'admin_emails_delete',
+                                'mailId',
+                                'id_mail'
+                            )
                         ),
                 ])
             );

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/email.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/email.yml
@@ -49,7 +49,7 @@ admin_emails_delete_all:
 
 admin_emails_delete:
     path: /delete/{mailId}
-    methods: [GET]
+    methods: [POST]
     defaults:
         _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Email:delete'
         _legacy_controller: AdminEmails


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Advanced parameters > Emails
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Advanced parameters > Emails in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18359)
<!-- Reviewable:end -->
