### PR TITLE
Grid row delete confirmation modal - Advanced parameters > Team > Employees

### DIFF
--- a/src/Core/Grid/Definition/Factory/EmployeeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/EmployeeGridDefinitionFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -53,6 +52,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class EmployeeGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use DeleteActionTrait;
+
     /**
      * @var string
      */
@@ -167,19 +168,11 @@ final class EmployeeGridDefinitionFactory extends AbstractGridDefinitionFactory
                             ])
                         )
                         ->add(
-                            (new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                                'route' => 'admin_employees_delete',
-                                'route_param_name' => 'employeeId',
-                                'route_param_field' => 'id_employee',
-                            ])
+                            $this->buildDeleteAction(
+                                'admin_employees_delete',
+                                'employeeId',
+                                'id_employee'
+                            )
                         ),
                 ])
             );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Advanced parameters > Team > Employees
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Advanced parameters > Team > Employees in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18360)
<!-- Reviewable:end -->
