### PR TITLE
Grid row delete confirmation modal - Advanced parameters > Team > Profiles

### DIFF
--- a/src/Core/Grid/Definition/Factory/ProfileGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProfileGridDefinitionFactory.php
@@ -32,7 +32,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\AccessibilityCheckerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -49,6 +48,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class ProfileGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use DeleteActionTrait;
+
     /**
      * @var string
      */
@@ -134,20 +135,12 @@ final class ProfileGridDefinitionFactory extends AbstractGridDefinitionFactory
                                 'clickable_row' => true,
                             ])
                         )
-                        ->add((new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'route' => 'admin_profiles_delete',
-                                'route_param_name' => 'profileId',
-                                'route_param_field' => 'id_profile',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                                'accessibility_checker' => $this->deleteProfileAccessibilityChecker,
-                            ])
+                        ->add(
+                            $this->buildDeleteAction(
+                                'admin_profiles_delete',
+                                'profileId',
+                                'id_profile'
+                            )
                         ),
                 ])
             )


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Advanced parameters > Team > Profiles
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Advanced parameters > Team > Profiles in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18361)
<!-- Reviewable:end -->
