### PR TITLE
Grid row delete confirmation modal - Advanced parameters > DB > SQL Requests

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/sql-manager/index.js
+++ b/admin-dev/themes/new-theme/js/pages/sql-manager/index.js
@@ -31,6 +31,7 @@ import SortingExtension from '@components/grid/extension/sorting-extension';
 import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
 import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
 import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
+import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import FiltersSubmitButtonEnablerExtension
   from '@components/grid/extension/filters-submit-button-enabler-extension';
@@ -47,6 +48,7 @@ class SqlManagerPage {
     requestSqlGrid.addExtension(new LinkRowActionExtension());
     requestSqlGrid.addExtension(new SubmitGridExtension());
     requestSqlGrid.addExtension(new SubmitBulkExtension());
+    requestSqlGrid.addExtension(new SubmitRowActionExtension());
     requestSqlGrid.addExtension(new BulkActionCheckboxExtension());
     requestSqlGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
 

--- a/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
+++ b/src/Core/Grid/Definition/Factory/DeleteActionTrait.php
@@ -45,7 +45,7 @@ trait DeleteActionTrait
                 'route' => $deleteRouteName,
                 'route_param_name' => $deleteRouteParamName,
                 'route_param_field' => $deleteRouteParamField,
-                'confirm_message' => $this->trans('Are you sure you want to delete the selected item?', [], 'Admin.Notifications.Warning'),
+                'confirm_message' => $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Global'),
                 'method' => $method,
                 'modal_options' => new ModalOptions([
                     'title' => $this->trans('Delete selection', [], 'Admin.Actions'),

--- a/src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class RequestSqlGridDefinitionFactory is responsible for creating RequestSql grid definition.
@@ -162,7 +163,8 @@ final class RequestSqlGridDefinitionFactory extends AbstractGridDefinitionFactor
                                 $this->buildDeleteAction(
                                     'admin_sql_requests_delete',
                                     'sqlRequestId',
-                                    'id_request_sql'
+                                    'id_request_sql',
+                                    Request::METHOD_DELETE
                                 )
                             ),
                     ])

--- a/src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php
@@ -47,6 +47,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class RequestSqlGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use DeleteActionTrait;
+
     /**
      * @var string
      */
@@ -157,15 +159,11 @@ final class RequestSqlGridDefinitionFactory extends AbstractGridDefinitionFactor
                                     ])
                             )
                             ->add(
-                                (new LinkRowAction('delete'))
-                                    ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                                    ->setIcon('delete')
-                                    ->setOptions([
-                                        'confirm_message' => $this->trans('Delete selected item?', [], 'Admin.Notifications.Warning'),
-                                        'route' => 'admin_sql_requests_delete',
-                                        'route_param_name' => 'sqlRequestId',
-                                        'route_param_field' => 'id_request_sql',
-                                    ])
+                                $this->buildDeleteAction(
+                                    'admin_sql_requests_delete',
+                                    'sqlRequestId',
+                                    'id_request_sql'
+                                )
                             ),
                     ])
             );

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/sql_request.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/sql_request.yml
@@ -44,7 +44,7 @@ admin_sql_requests_edit:
 
 admin_sql_requests_delete:
     path: /{sqlRequestId}/delete
-    methods: [GET]
+    methods: [POST]
     defaults:
         _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\SqlManager:delete'
         _legacy_controller: AdminRequestSql

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/sql_request.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/sql_request.yml
@@ -44,7 +44,7 @@ admin_sql_requests_edit:
 
 admin_sql_requests_delete:
     path: /{sqlRequestId}/delete
-    methods: [POST]
+    methods: [GET, DELETE]
     defaults:
         _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\SqlManager:delete'
         _legacy_controller: AdminRequestSql


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Advanced parameters > DB > SQL Requests
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Advanced parameters > DB > SQL Requests in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18362)
<!-- Reviewable:end -->
