### PR TITLE
Grid row delete confirmation modal - Advanced parameters > DB > Backups

### DIFF
--- a/src/Core/Grid/Definition/Factory/BackupDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/BackupDefinitionFactory.php
@@ -30,7 +30,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
@@ -41,6 +40,8 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
  */
 final class BackupDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use DeleteActionTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -116,20 +117,11 @@ final class BackupDefinitionFactory extends AbstractGridDefinitionFactory
                             ])
                         )
                         ->add(
-                            (new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'method' => 'DELETE',
-                                'route' => 'admin_backups_delete',
-                                'route_param_name' => 'deleteFileName',
-                                'route_param_field' => 'file_name',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                            ])
+                            $this->buildDeleteAction(
+                                'admin_backups_delete',
+                                'deleteFileName',
+                                'file_name'
+                            )
                         ),
                 ])
             );

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/backup.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/backup.yml
@@ -38,7 +38,7 @@ admin_backup_download:
 
 admin_backups_delete:
     path: /{deleteFileName}
-    methods: [DELETE]
+    methods: [DELETE, POST]
     defaults:
         _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Backup:delete'
         _legacy_controller: 'AdminBackup'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Advanced parameters > DB > Backups
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Advanced parameters > DB > Backups in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18363)
<!-- Reviewable:end -->
