### PR TITLE
Grid row delete confirmation modal - Advanced parameters > Webservice

### DIFF
--- a/src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -50,6 +49,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class WebserviceKeyDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use DeleteActionTrait;
+
     /**
      * @var array
      */
@@ -154,20 +155,11 @@ final class WebserviceKeyDefinitionFactory extends AbstractGridDefinitionFactory
                             ])
                         )
                         ->add(
-                            (new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'method' => 'DELETE',
-                                'route' => 'admin_webservice_keys_delete',
-                                'route_param_name' => 'webserviceKeyId',
-                                'route_param_field' => 'id_webservice_account',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                            ])
+                            $this->buildDeleteAction(
+                                'admin_webservice_keys_delete',
+                                'webserviceKeyId',
+                                'id_webservice_account'
+                            )
                         ),
                 ])
             );

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/webservice.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/webservice.yml
@@ -44,7 +44,7 @@ admin_webservice_keys_edit:
 
 admin_webservice_keys_delete:
     path: /{webserviceKeyId}/delete
-    methods: DELETE
+    methods: [DELETE, POST]
     defaults:
         _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Webservice:delete'
         _legacy_controller: AdminWebservice


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Advanced parameters > Webservice
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Advanced parameters > Webservice in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18364)
<!-- Reviewable:end -->
