### PR TITLE
Grid row delete confirmation modal - International > Taxes

### DIFF
--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -44,18 +44,18 @@ function confirm_modal(
       `<p>${question}</p>` +
       `</div>` +
       `<div class="modal-footer">` +
-      `<a href="#" id="confirm_modal_left_button" class="btn btn-primary">${left_button_txt}</a>` +
-      `<a href="#" id="confirm_modal_right_button" class="btn btn-primary">${right_button_txt}</a>` +
+      `<a href="#" id="confirm-modal-left-button" class="btn btn-primary">${left_button_txt}</a>` +
+      `<a href="#" id="confirm-modal-right-button" class="btn btn-primary">${right_button_txt}</a>` +
       `</div>` +
       `</div>` +
       `</div>` +
       `</div>`
   );
-  confirmModal.find('#confirm_modal_left_button').click(() => {
+  confirmModal.find('#confirm-modal-left-button').click(() => {
     left_button_callback();
     confirmModal.modal('hide');
   });
-  confirmModal.find('#confirm_modal_right_button').click(() => {
+  confirmModal.find('#confirm-modal-right-button').click(() => {
     right_button_callback();
     confirmModal.modal('hide');
   });

--- a/admin-dev/themes/new-theme/js/components/grid/extension/submit-bulk-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/submit-bulk-action-extension.js
@@ -84,7 +84,7 @@ export default class SubmitBulkActionExtension {
     const confirmButtonClass = $submitBtn.data('confirmButtonClass');
 
     const modal = new ConfirmModal({
-      id: `${grid.getId()}_grid_confirm_modal`,
+      id: `${grid.getId()}-grid-confirm-modal`,
       confirmTitle,
       confirmMessage,
       confirmButtonLabel,

--- a/admin-dev/themes/new-theme/js/components/modal.js
+++ b/admin-dev/themes/new-theme/js/components/modal.js
@@ -73,7 +73,7 @@ export default function ConfirmModal(params, confirmCallback) {
  *
  */
 function Modal({
-  id = 'confirm_modal',
+  id = 'confirm-modal',
   confirmTitle,
   confirmMessage = '',
   closeButtonLabel = 'Close',

--- a/src/Core/Grid/Definition/Factory/TaxGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/TaxGridDefinitionFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -50,6 +49,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 final class TaxGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
+    use DeleteActionTrait;
 
     /**
      * {@inheritdoc}
@@ -126,19 +126,11 @@ final class TaxGridDefinitionFactory extends AbstractGridDefinitionFactory
                             ])
                         )
                         ->add(
-                            (new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                                'route' => 'admin_taxes_delete',
-                                'route_param_name' => 'taxId',
-                                'route_param_field' => 'id_tax',
-                            ])
+                            $this->buildDeleteAction(
+                                'admin_taxes_delete',
+                                'taxId',
+                                'id_tax'
+                            )
                         ),
                 ])
             )

--- a/tests/puppeteer/pages/BO/catalog/brands/index.js
+++ b/tests/puppeteer/pages/BO/catalog/brands/index.js
@@ -20,7 +20,7 @@ module.exports = class Brands extends BOBasePage {
     // Bulk Actions
     this.selectAllRowsLabel = `${this.gridPanel} tr.column-filters .md-checkbox i`;
     this.bulkActionsToggleButton = `${this.gridPanel} button.js-bulk-actions-btn`;
-    this.confirmDeleteModal = '#%TABLE_grid_confirm_modal';
+    this.confirmDeleteModal = '#%TABLE-grid-confirm-modal';
     this.confirmDeleteButton = 'button.btn-confirm-submit';
     // Filters
     this.filterColumn = `${this.gridTable} #%TABLE_%FILTERBY`;

--- a/tests/puppeteer/pages/BO/catalog/files/index.js
+++ b/tests/puppeteer/pages/BO/catalog/files/index.js
@@ -34,7 +34,7 @@ module.exports = class Files extends BOBasePage {
     this.selectAllRowsLabel = `${this.gridPanel} tr.column-filters .md-checkbox i`;
     this.bulkActionsToggleButton = `${this.gridPanel} button.js-bulk-actions-btn`;
     this.bulkActionsDeleteButton = '#attachment_grid_bulk_action_delete_selection';
-    this.confirmDeleteModal = '#attachment_grid_confirm_modal';
+    this.confirmDeleteModal = '#attachment-grid-confirm-modal';
     this.confirmDeleteButton = `${this.confirmDeleteModal} button.btn-confirm-submit`;
   }
 

--- a/tests/puppeteer/pages/BO/catalog/suppliers/index.js
+++ b/tests/puppeteer/pages/BO/catalog/suppliers/index.js
@@ -22,7 +22,7 @@ module.exports = class Suppliers extends BOBasePage {
     this.bulkActionsEnableButton = `${this.gridPanel} #supplier_grid_bulk_action_suppliers_enable_selection`;
     this.bulkActionsDisableButton = `${this.gridPanel} #supplier_grid_bulk_action_suppliers_disable_selection`;
     this.bulkActionsDeleteButton = `${this.gridPanel} #supplier_grid_bulk_action_delete_selection`;
-    this.confirmDeleteModal = '#supplier_grid_confirm_modal';
+    this.confirmDeleteModal = '#supplier-grid-confirm-modal';
     this.confirmDeleteButton = `${this.confirmDeleteModal} button.btn-confirm-submit`;
     // Filters
     this.filterColumn = `${this.gridTable} #supplier_%FILTERBY`;

--- a/tests/puppeteer/pages/BO/design/pages/index.js
+++ b/tests/puppeteer/pages/BO/design/pages/index.js
@@ -28,7 +28,7 @@ module.exports = class Pages extends BOBasePage {
     this.bulkActionsDeleteButton = '#%TABLE_grid_bulk_action_delete_selection';
     this.bulkActionsEnableButton = '#%TABLE_grid_bulk_action_enable_selection';
     this.bulkActionsDisableButton = '#%TABLE_grid_bulk_action_disable_selection';
-    this.confirmDeleteModal = '#%TABLE_grid_confirm_modal';
+    this.confirmDeleteModal = '#%TABLE-grid-confirm-modal';
     this.confirmDeleteButton = `${this.confirmDeleteModal} button.btn-confirm-submit`;
     // Filters
     this.filterColumn = `${this.gridTable} #%TABLE_%FILTERBY`;

--- a/tests/puppeteer/pages/BO/international/languages/index.js
+++ b/tests/puppeteer/pages/BO/international/languages/index.js
@@ -35,7 +35,7 @@ module.exports = class Languages extends LocalizationBasePage {
     this.bulkActionsEnableButton = '#language_grid_bulk_action_enable_selection';
     this.bulkActionsDisableButton = '#language_grid_bulk_action_disable_selection';
     this.bulkActionsDeleteButton = '#language_grid_bulk_action_delete_selection';
-    this.confirmDeleteModal = '#language_grid_confirm_modal';
+    this.confirmDeleteModal = '#language-grid-confirm-modal';
     this.confirmDeleteButton = `${this.confirmDeleteModal} button.btn-confirm-submit`;
     // Sort Selectors
     this.tableHead = `${this.gridTable} thead`;

--- a/tests/puppeteer/pages/BO/international/taxes/index.js
+++ b/tests/puppeteer/pages/BO/international/taxes/index.js
@@ -23,7 +23,7 @@ module.exports = class Taxes extends BOBasePage {
     this.deleteSelectionButton = `${this.taxesGridPanelDiv} #tax_grid_bulk_action_delete_selection`;
     this.selectAllLabel = `${this.taxesGridPanelDiv} #tax_grid tr.column-filters .md-checkbox i`;
     this.taxesGridTable = `${this.taxesGridPanelDiv} #tax_grid_table`;
-    this.confirmDeleteModal = '#tax_grid_confirm_modal';
+    this.confirmDeleteModal = '#tax-grid-confirm-modal';
     this.confirmDeleteButton = `${this.confirmDeleteModal} button.btn-confirm-submit`;
     // Filters
     this.taxesFilterColumnInput = `${this.taxesGridTable} #tax_%FILTERBY`;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> International > Taxes
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to International > Taxes in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18365)
<!-- Reviewable:end -->
