### PR TITLE
Grid row delete confirmation modal - Shop parameters > Contacts

### DIFF
--- a/src/Core/Grid/Definition/Factory/ContactGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ContactGridDefinitionFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -48,6 +47,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class ContactGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use DeleteActionTrait;
+
     /**
      * @var string
      */
@@ -145,20 +146,11 @@ final class ContactGridDefinitionFactory extends AbstractGridDefinitionFactory
                             ])
                         )
                         ->add(
-                            (new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'method' => 'POST',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                                'route' => 'admin_contacts_delete',
-                                'route_param_name' => 'contactId',
-                                'route_param_field' => 'id_contact',
-                            ])
+                            $this->buildDeleteAction(
+                                'admin_contacts_delete',
+                                'contactId',
+                                'id_contact'
+                            )
                         ),
                 ])
             );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Shop parameters > Contacts
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Shop parameters > Contacts in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18366)
<!-- Reviewable:end -->
