### PR TITLE
Functional tests - Add tests helper card for brands and suppliers

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/03_catalog/05_brandsAndSuppliers/brands/08_helperCard.js
+++ b/tests/puppeteer/campaigns/functional/BO/03_catalog/05_brandsAndSuppliers/brands/08_helperCard.js
@@ -1,0 +1,67 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const BrandsPage = require('@pages/BO/catalog/brands');
+// Test context imports
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_catalog_brandsAndSuppliers_brands_helperCard';
+
+let browser;
+let page;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    brandsPage: new BrandsPage(page),
+  };
+};
+
+describe('Helper card', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+
+  // Login into BO and go to brands page
+  loginCommon.loginBO();
+
+  it('should go to brands page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToBrandsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.catalogParentLink,
+      this.pageObjects.boBasePage.brandsAndSuppliersLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.brandsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.brandsPage.pageTitle);
+  });
+
+  it('should open the help side bar and check the document language', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'openHelpSidebar', baseContext);
+    const isHelpSidebarVisible = await this.pageObjects.brandsPage.openHelpSideBar();
+    await expect(isHelpSidebarVisible).to.be.true;
+    const documentURL = await this.pageObjects.brandsPage.getHelpDocumentURL();
+    await expect(documentURL).to.contains('country=en');
+  });
+
+  it('should close the help side bar', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'closeHelpSidebar', baseContext);
+    const isHelpSidebarVisible = await this.pageObjects.brandsPage.closeHelpSideBar();
+    await expect(isHelpSidebarVisible).to.be.true;
+  });
+});

--- a/tests/puppeteer/campaigns/functional/BO/03_catalog/05_brandsAndSuppliers/suppliers/03_helperCard.js
+++ b/tests/puppeteer/campaigns/functional/BO/03_catalog/05_brandsAndSuppliers/suppliers/03_helperCard.js
@@ -1,0 +1,76 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const BrandsPage = require('@pages/BO/catalog/brands');
+const SuppliersPage = require('@pages/BO/catalog/suppliers');
+// Test context imports
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_catalog_brandsAndSuppliers_suppliers_helperCard';
+
+let browser;
+let page;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    brandsPage: new BrandsPage(page),
+    suppliersPage: new SuppliersPage(page),
+  };
+};
+
+describe('Helper card', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+
+  // Login into BO and go to suppliers page
+  loginCommon.loginBO();
+
+  it('should go to brands page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToBrandsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.catalogParentLink,
+      this.pageObjects.boBasePage.brandsAndSuppliersLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.brandsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.brandsPage.pageTitle);
+  });
+
+  it('should go to suppliers page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToSuppliersPage', baseContext);
+    await this.pageObjects.brandsPage.goToSubTabSuppliers();
+    const pageTitle = await this.pageObjects.suppliersPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.suppliersPage.pageTitle);
+  });
+
+  it('should open the help side bar and check the document language', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'openHelpSidebar', baseContext);
+    const isHelpSidebarVisible = await this.pageObjects.suppliersPage.openHelpSideBar();
+    await expect(isHelpSidebarVisible).to.be.true;
+    const documentURL = await this.pageObjects.suppliersPage.getHelpDocumentURL();
+    await expect(documentURL).to.contains('country=en');
+  });
+
+  it('should close the help side bar', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'closeHelpSidebar', baseContext);
+    const isHelpSidebarVisible = await this.pageObjects.suppliersPage.closeHelpSideBar();
+    await expect(isHelpSidebarVisible).to.be.true;
+  });
+});


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add tests helper card for brands and suppliers
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/03_catalog/05_brandsAndSuppliers/brands/08_helperCard.js" URL_FO=shopUrl/ npm run specific-test` <br> `TEST_PATH="functional/BO/03_catalog/05_brandsAndSuppliers/suppliers/03_helperCard.js" URL_FO=shopUrl/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18367)
<!-- Reviewable:end -->
