### PR TITLE
Fix BO - Order - Wrong declination reference displayed on pack composition

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -349,7 +349,7 @@ class PackCore extends Product
             if (Combination::isFeatureActive() && isset($line['id_product_attribute_item']) && $line['id_product_attribute_item']) {
                 $line['cache_default_attribute'] = $line['id_product_attribute'] = $line['id_product_attribute_item'];
 
-                $sql = 'SELECT agl.`name` AS group_name, al.`name` AS attribute_name,  pai.`id_image` AS id_product_attribute_image
+                $sql = 'SELECT pa.`reference` AS attribute_reference, agl.`name` AS group_name, al.`name` AS attribute_name,  pai.`id_image` AS id_product_attribute_image
 				FROM `' . _DB_PREFIX_ . 'product_attribute` pa
 				' . Shop::addSqlAssociation('product_attribute', 'pa') . '
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_combination` pac ON pac.`id_product_attribute` = ' . $line['id_product_attribute_item'] . '
@@ -367,6 +367,13 @@ class PackCore extends Product
                 if (isset($attr_name[0]['id_product_attribute_image']) && $attr_name[0]['id_product_attribute_image']) {
                     $line['id_image'] = $attr_name[0]['id_product_attribute_image'];
                 }
+                
+                if(isset($attr_name[0]['attribute_reference'])){
+					$line['reference'] = $attr_name[0]['attribute_reference'];
+				}else{
+					$line['reference'] = '';
+				}
+                
                 $line['name'] .= "\n";
                 foreach ($attr_name as $value) {
                     $line['name'] .= ' ' . $value['group_name'] . '-' . $value['attribute_name'];

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -368,11 +368,7 @@ class PackCore extends Product
                     $line['id_image'] = $attr_name[0]['id_product_attribute_image'];
                 }
 
-                if (isset($attr_name[0]['attribute_reference'])) {
-                    $line['reference'] = $attr_name[0]['attribute_reference'];
-                } else {
-                    $line['reference'] = '';
-                }
+                $line['reference'] = $attr_name[0]['attribute_reference'] ?? '';
 
                 $line['name'] .= "\n";
                 foreach ($attr_name as $value) {

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -367,13 +367,13 @@ class PackCore extends Product
                 if (isset($attr_name[0]['id_product_attribute_image']) && $attr_name[0]['id_product_attribute_image']) {
                     $line['id_image'] = $attr_name[0]['id_product_attribute_image'];
                 }
-                
-                if(isset($attr_name[0]['attribute_reference'])){
-					$line['reference'] = $attr_name[0]['attribute_reference'];
-				}else{
-					$line['reference'] = '';
-				}
-                
+
+                if (isset($attr_name[0]['attribute_reference'])) {
+                    $line['reference'] = $attr_name[0]['attribute_reference'];
+                } else {
+                    $line['reference'] = '';
+                }
+
                 $line['name'] .= "\n";
                 foreach ($attr_name as $value) {
                     $line['name'] .= ' ' . $value['group_name'] . '-' . $value['attribute_name'];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | In the BO => Order page => when a pack is ordered => the combination reference is not displayed, product reference is displayed instead.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/18370
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/18370 by @khouloudbelguith 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18374)
<!-- Reviewable:end -->
