### PR TITLE
Functional tests - Add 'Confirmation delete modal' to tests Seo and Url

### DIFF
--- a/tests/puppeteer/pages/BO/shopParameters/trafficAndSeo/seoAndUrls/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/trafficAndSeo/seoAndUrls/index.js
@@ -34,6 +34,9 @@ module.exports = class SeoAndUrls extends BOBasePage {
     this.switchFriendlyUrlLabel = 'label[for=\'meta_settings_form_set_up_urls_friendly_url_%TOGGLE\']';
     this.switchAccentedUrlLabel = 'label[for=\'meta_settings_form_set_up_urls_accented_url_%TOGGLE\']';
     this.saveSeoAndUrlFormButton = '#main-div form:nth-child(1) div:nth-child(1) div.card-footer button';
+    // Delete modal
+    this.confirmDeleteModal = '#meta-grid-confirm-modal';
+    this.confirmDeleteButton = `${this.confirmDeleteModal} button.btn-confirm-submit`;
   }
 
   /* header methods */
@@ -75,15 +78,27 @@ module.exports = class SeoAndUrls extends BOBasePage {
    * @return {Promise<textContent>}
    */
   async deleteSeoUrlPage(row = 1) {
-    this.dialogListener(true);
     await Promise.all([
       this.page.click(this.dropdownToggleButton.replace('%ROW', row)),
       this.waitForVisibleSelector(
         `${this.dropdownToggleButton}[aria-expanded='true']`.replace('%ROW', row),
       ),
     ]);
-    await this.clickAndWaitForNavigation(this.deleteRowLink.replace('%ROW', row));
+    // Click on delete and wait for modal
+    await Promise.all([
+      this.page.click(this.deleteRowLink.replace('%ROW', row)),
+      this.waitForVisibleSelector(`${this.confirmDeleteModal}.show`),
+    ]);
+    await this.confirmDeleteSeoUrlPage();
     return this.getTextContent(this.alertSuccessBlockParagraph);
+  }
+
+  /**
+   * Confirm delete with in modal
+   * @return {Promise<void>}
+   */
+  async confirmDeleteSeoUrlPage() {
+    await this.clickAndWaitForNavigation(this.confirmDeleteButton);
   }
 
   /* Reset methods */


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add 'Confirmation delete modal' to tests Seo and Url (to merge after #18358  )
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | no tests needed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18380)
<!-- Reviewable:end -->
