### PR TITLE
Functional tests - Add 'Confirmation delete modal' to tests currencies

### DIFF
--- a/tests/puppeteer/pages/BO/international/currencies/index.js
+++ b/tests/puppeteer/pages/BO/international/currencies/index.js
@@ -35,6 +35,9 @@ module.exports = class Currencies extends LocalizationBasePage {
     this.dropdownToggleButton = `${this.actionsColumn} a.dropdown-toggle`;
     this.dropdownToggleMenu = `${this.actionsColumn} div.dropdown-menu`;
     this.deleteRowLink = `${this.dropdownToggleMenu} a[data-url*='/delete']`;
+    // Delete modal
+    this.confirmDeleteModal = '#currency-grid-confirm-modal';
+    this.confirmDeleteButton = `${this.confirmDeleteModal} button.btn-confirm-submit`;
   }
 
   /* Header Methods */
@@ -172,14 +175,26 @@ module.exports = class Currencies extends LocalizationBasePage {
    * @return {Promise<textContent>}
    */
   async deleteCurrency(row = 1) {
-    this.dialogListener(true);
     await Promise.all([
       this.page.click(this.dropdownToggleButton.replace('%ROW', row)),
       this.waitForVisibleSelector(
         `${this.dropdownToggleButton}[aria-expanded='true']`.replace('%ROW', row),
       ),
     ]);
-    await this.clickAndWaitForNavigation(this.deleteRowLink.replace('%ROW', row));
+    // Click on delete and wait for modal
+    await Promise.all([
+      this.page.click(this.deleteRowLink.replace('%ROW', row)),
+      this.waitForVisibleSelector(`${this.confirmDeleteModal}.show`),
+    ]);
+    await this.confirmDeleteCurrency();
     return this.getTextContent(this.alertSuccessBlockParagraph);
+  }
+
+  /**
+   * Confirm delete in modal
+   * @return {Promise<void>}
+   */
+  async confirmDeleteCurrency() {
+    await this.clickAndWaitForNavigation(this.confirmDeleteButton);
   }
 };


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add 'Confirmation delete modal' to tests currencies (to merge after #18357  )
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | no tests needed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18380)
<!-- Reviewable:end -->
