### PR TITLE
Functional tests - Add 'Confirmation delete modal' to tests design pages

### DIFF
--- a/tests/puppeteer/pages/BO/design/pages/index.js
+++ b/tests/puppeteer/pages/BO/design/pages/index.js
@@ -101,14 +101,18 @@ module.exports = class Pages extends BOBasePage {
   async deleteRowInTable(table, row) {
     const listTableToggleDropDown = await this.replaceAll(this.listTableToggleDropDown, '%TABLE', table);
     const deleteRowLink = await this.replaceAll(this.deleteRowLink, '%TABLE', table);
+    const confirmDeleteModal = await this.replaceAll(this.confirmDeleteModal, '%TABLE', table);
     // Click on dropDown
     await Promise.all([
       this.page.click(listTableToggleDropDown.replace('%ROW', row)),
       this.waitForVisibleSelector(`${listTableToggleDropDown}[aria-expanded='true']`.replace('%ROW', row)),
     ]);
     // Click on delete and wait for modal
-    this.dialogListener();
-    await this.clickAndWaitForNavigation(deleteRowLink.replace('%ROW', row));
+    await Promise.all([
+      this.page.click(deleteRowLink.replace('%ROW', row)),
+      this.waitForVisibleSelector(`${confirmDeleteModal}.show`),
+    ]);
+    await this.confirmDeleteFromTable(table);
     return this.getTextContent(this.alertSuccessBlockParagraph);
   }
 
@@ -139,16 +143,16 @@ module.exports = class Pages extends BOBasePage {
       this.page.click(bulkActionsDeleteButton),
       this.waitForVisibleSelector(`${confirmDeleteModal}.show`),
     ]);
-    await this.confirmDeleteWithBulkActions(table);
+    await this.confirmDeleteFromTable(table);
     return this.getTextContent(this.alertSuccessBlockParagraph);
   }
 
   /**
-   * Confirm delete with in modal
+   * Confirm delete in modal
    * @param table
    * @return {Promise<void>}
    */
-  async confirmDeleteWithBulkActions(table) {
+  async confirmDeleteFromTable(table) {
     await this.clickAndWaitForNavigation(this.confirmDeleteButton.replace('%TABLE', table));
   }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add 'Confirmation delete modal' to tests pages (to merge after #18355 )
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | no tests needed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18380)
<!-- Reviewable:end -->
