### PR TITLE
Avoid timeout in image regeneration

### DIFF
--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -638,8 +638,9 @@ class AdminImagesControllerCore extends AdminController
     protected function _regenerateThumbnails($type = 'all', $deleteOldImages = false)
     {
         $this->start_time = time();
-        ini_set('max_execution_time', $this->max_execution_time); // ini_set may be disabled, we need the real value
-        $this->max_execution_time = (int) ini_get('max_execution_time');
+        if(ini_set('max_execution_time', $this->max_execution_time)) { // ini_set may be disabled, we need the real value
+            $this->max_execution_time = (int) ini_get('max_execution_time');
+        }
         $languages = Language::getLanguages(false);
 
         $process = [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In my XAMPP test system ini_set returns false and ini_get returns 0 even though the values are set (permission issue). This is causing unneccessary timeout on image regeneration after 4 seconds
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18405)
<!-- Reviewable:end -->
