### PR TITLE
Fix currency symbol in orders list

### DIFF
--- a/src/Core/Grid/Data/Factory/OrderGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/OrderGridDataFactory.php
@@ -53,11 +53,6 @@ final class OrderGridDataFactory implements GridDataFactoryInterface
     private $contextLocale;
 
     /**
-     * @var string
-     */
-    private $contextCurrencyIsoCode;
-
-    /**
      * @var ConfigurationInterface
      */
     private $configuration;
@@ -67,19 +62,16 @@ final class OrderGridDataFactory implements GridDataFactoryInterface
      * @param RepositoryInterface $localeRepository
      * @param ConfigurationInterface $configuration
      * @param string $contextLocale
-     * @param string $contextCurrencyIsoCode
      */
     public function __construct(
         GridDataFactoryInterface $dataFactory,
         RepositoryInterface $localeRepository,
         ConfigurationInterface $configuration,
-        $contextLocale,
-        $contextCurrencyIsoCode
+        $contextLocale
     ) {
         $this->dataFactory = $dataFactory;
         $this->localeRepository = $localeRepository;
         $this->contextLocale = $contextLocale;
-        $this->contextCurrencyIsoCode = $contextCurrencyIsoCode;
         $this->configuration = $configuration;
     }
 
@@ -101,7 +93,7 @@ final class OrderGridDataFactory implements GridDataFactoryInterface
 
             $record['total_paid_tax_incl'] = $locale->formatPrice(
                 $record['total_paid_tax_incl'],
-                $this->contextCurrencyIsoCode
+                $record['iso_code']
             );
 
             $record['is_invoice_available'] = $isInvoicesEnabled && $record['invoice_number'];

--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -90,6 +90,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
             ->getBaseQueryBuilder($searchCriteria->getFilters())
             ->addSelect($this->getCustomerField() . ' AS `customer`')
             ->addSelect('o.id_order, o.reference, o.total_paid_tax_incl, os.paid, osl.name AS osname')
+            ->addSelect('o.id_currency, cur.iso_code')
             ->addSelect('o.current_state, o.id_customer')
             ->addSelect('cu.`id_customer` IS NULL as `deleted_customer`')
             ->addSelect('os.color, o.payment, s.name AS shop_name')
@@ -137,6 +138,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
             ->createQueryBuilder()
             ->from($this->dbPrefix . 'orders', 'o')
             ->leftJoin('o', $this->dbPrefix . 'customer', 'cu', 'o.id_customer = cu.id_customer')
+            ->leftJoin('o', $this->dbPrefix . 'currency', 'cur', 'o.id_currency = cur.id_currency')
             ->innerJoin('o', $this->dbPrefix . 'address', 'a', 'o.id_address_delivery = a.id_address')
             ->innerJoin('a', $this->dbPrefix . 'country', 'c', 'a.id_country = c.id_country')
             ->innerJoin(

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -257,7 +257,6 @@ services:
             - '@prestashop.core.localization.locale.repository'
             - '@prestashop.adapter.legacy.configuration'
             - '@=service("prestashop.adapter.legacy.context").getContext().language.getLocale()'
-            - "@=service('prestashop.adapter.legacy.context').getContext().currency.iso_code"
 
     prestashop.core.grid.data.factory.catalog_price_rule:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Display correct currency symbol for the orders list.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18330 
| How to test?  | <br>In BO : Add a second currency to shop<br>In FO : Make an order with the new currency<br>In BO : Go to order list, the currency symbol must be the second currency one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18419)
<!-- Reviewable:end -->
