### PR TITLE
Change error message for invalid product quantity

### DIFF
--- a/app/Resources/translations/default/AdminNotificationsError.xlf
+++ b/app/Resources/translations/default/AdminNotificationsError.xlf
@@ -1344,36 +1344,6 @@ Comment: check if some ids are in list_skip_actions and forbid deletion</note>
         <target>Please fill in all the required fields.</target>
         <note>Line: 558</note>
       </trans-unit>
-      <trans-unit id="3a092130bd08641faa55f5abc9e4a1f4">
-        <source>Positive product quantity is required</source>
-        <target>Positive product quantity is required</target>
-        <note>Line: 536</note>
-      </trans-unit>
-      <trans-unit id="47e91b4ed6651aa6a51f65afa98102df">
-        <source>Selected language cannot be used because is disabled</source>
-        <target>Selected language cannot be used because is disabled</target>
-        <note>Line: 542</note>
-      </trans-unit>
-      <trans-unit id="86f57ed3b1fc0dc03e6cb040ec54add3">
-        <source>Selected currency cannot be used because it is deleted</source>
-        <target>Selected currency cannot be used because it is deleted</target>
-        <note>Line: 548</note>
-      </trans-unit>
-      <trans-unit id="f956270d456bfab7964f3a3e690d9482">
-        <source>Selected currency cannot be used because it is disabled</source>
-        <target>Selected currency cannot be used because it is disabled</target>
-        <note>Line: 552</note>
-      </trans-unit>
-      <trans-unit id="3e74675c59f263c1cbb391eca17051ee">
-        <source>Custom field text cannot be longer than %limit% characters</source>
-        <target>Custom field text cannot be longer than %limit% characters</target>
-        <note>Line: 562</note>
-      </trans-unit>
-      <trans-unit id="a923575984949608ce04c4984806ec2a">
-        <source>There are not enough products in stock</source>
-        <target>There are not enough products in stock</target>
-        <note>Line: 568</note>
-      </trans-unit>
     </body>
   </file>
   <file original="src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php" source-language="en-US" target-language="en" datatype="plaintext">

--- a/app/Resources/translations/default/AdminOrderscustomersNotification.xlf
+++ b/app/Resources/translations/default/AdminOrderscustomersNotification.xlf
@@ -929,11 +929,6 @@
         <target>Order #%d cannot be loaded.</target>
         <note>Line: 1408</note>
       </trans-unit>
-      <trans-unit id="3354cb02aba47cf9f44d703b25a0a777">
-        <source>Please enter a positive quantity.</source>
-        <target>Please enter a positive quantity.</target>
-        <note>Line: 1422</note>
-      </trans-unit>
       <trans-unit id="2a11327ffe3e46a9ffadddf38b4b9fff">
         <source>Please enter a maximum quantity of [1].</source>
         <target>Please enter a maximum quantity of [1].</target>

--- a/app/Resources/translations/default/AdminOrderscustomersNotification.xlf
+++ b/app/Resources/translations/default/AdminOrderscustomersNotification.xlf
@@ -919,11 +919,6 @@
         <target>A return product was successfully created.</target>
         <note>Line: 552</note>
       </trans-unit>
-      <trans-unit id="4c8098d3dded08ff50537ed2814277ca">
-        <source>You cannot edit the cart once the order delivered</source>
-        <target>You cannot edit the cart once the order delivered</target>
-        <note>Line: 1405</note>
-      </trans-unit>
       <trans-unit id="918093e8ad4567f6b99e9851eab8bc69">
         <source>Order #%d cannot be loaded.</source>
         <target>Order #%d cannot be loaded.</target>

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
@@ -533,23 +533,23 @@ class CartController extends FrameworkBundleAdminController
             CartRuleValidityException::class => $e->getMessage(),
             CartConstraintException::class => [
                 CartConstraintException::INVALID_QUANTITY => $this->trans(
-                    'Positive product quantity is required',
+                    'Positive product quantity is required.',
                     'Admin.Notifications.Error'
                 ),
             ],
             LanguageException::class => [
                 LanguageException::NOT_ACTIVE => $this->trans(
-                    'Selected language cannot be used because is disabled',
+                    'Selected language cannot be used because is disabled.',
                     'Admin.Notifications.Error'
                 ),
             ],
             CurrencyException::class => [
                 CurrencyException::IS_DELETED => $this->trans(
-                    'Selected currency cannot be used because it is deleted',
+                    'Selected currency cannot be used because it is deleted.',
                     'Admin.Notifications.Error'
                 ),
                 CurrencyException::IS_DISABLED => $this->trans(
-                    'Selected currency cannot be used because it is disabled',
+                    'Selected currency cannot be used because it is disabled.',
                     'Admin.Notifications.Error'
                 ),
             ],
@@ -559,14 +559,14 @@ class CartController extends FrameworkBundleAdminController
                     'Admin.Notifications.Error'
                 ),
                 CustomizationConstraintException::FIELD_IS_TOO_LONG => $this->trans(
-                    'Custom field text cannot be longer than %limit% characters',
+                    'Custom field text cannot be longer than %limit% characters.',
                     'Admin.Notifications.Error',
                     ['%limit%' => CustomizationSettings::MAX_TEXT_LENGTH]
                 ),
             ],
             ProductOutOfStockException::class => $this->trans(
-                'There are not enough products in stock',
-                'Admin.Notifications.Error'
+                'There are not enough products in stock.',
+                'Admin.Catalog.Notification'
             ),
             FileUploadException::class => [
                 UPLOAD_ERR_INI_SIZE => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1430,8 +1430,8 @@ class OrderController extends CommonController
             ),
             InvalidCancelProductException::class => [
                 InvalidCancelProductException::INVALID_QUANTITY => $this->trans(
-                    'Please enter a positive quantity.',
-                    'Admin.Orderscustomers.Notification'
+                    'Positive product quantity is required',
+                    'Admin.Notifications.Error'
                 ),
                 InvalidCancelProductException::QUANTITY_TOO_HIGH => $this->trans(
                     'Please enter a maximum quantity of [1].',
@@ -1478,8 +1478,8 @@ class OrderController extends CommonController
                 ),
             ],
             InvalidProductQuantityException::class => $this->trans(
-                'Please enter a positive quantity.',
-                'Admin.Orderscustomers.Notification'
+                'Positive product quantity is required',
+                'Admin.Notifications.Error'
             ),
         ];
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1409,7 +1409,7 @@ class OrderController extends CommonController
         }
 
         return [
-            CannotEditDeliveredOrderProductException::class => $this->trans('You cannot edit the cart once the order delivered', 'Admin.Orderscustomers.Notification'),
+            CannotEditDeliveredOrderProductException::class => $this->trans('You cannot edit the cart once the order delivered.', 'Admin.Orderscustomers.Notification'),
             OrderNotFoundException::class => $e instanceof OrderNotFoundException ?
                 $this->trans(
                     'Order #%d cannot be loaded.',
@@ -1430,7 +1430,7 @@ class OrderController extends CommonController
             ),
             InvalidCancelProductException::class => [
                 InvalidCancelProductException::INVALID_QUANTITY => $this->trans(
-                    'Positive product quantity is required',
+                    'Positive product quantity is required.',
                     'Admin.Notifications.Error'
                 ),
                 InvalidCancelProductException::QUANTITY_TOO_HIGH => $this->trans(
@@ -1478,7 +1478,7 @@ class OrderController extends CommonController
                 ),
             ],
             InvalidProductQuantityException::class => $this->trans(
-                'Positive product quantity is required',
+                'Positive product quantity is required.',
                 'Admin.Notifications.Error'
             ),
         ];
@@ -1533,7 +1533,7 @@ class OrderController extends CommonController
         return [
             OrderNotFoundException::class => $exception instanceof OrderNotFoundException ?
                 $this->trans(
-                    'Order #%d cannot be loaded',
+                    'Order #%d cannot be loaded.',
                     'Admin.Orderscustomers.Notification',
                     ['#%d' => $exception->getOrderId()->getValue()]
                 ) : '',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Change error message or invalid product quantity
| Type?         | bug fix
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18106
| How to test?  | Try to refund a product and set a negative quantity the error message should be `Positive product quantity is required`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18420)
<!-- Reviewable:end -->
