### PR TITLE
Functional tests - Add test for order setting gift options

### DIFF
--- a/tests/puppeteer/campaigns/data/demo/tax.js
+++ b/tests/puppeteer/campaigns/data/demo/tax.js
@@ -2,7 +2,6 @@ module.exports = {
   DefaultFrTax: {
     id: 1,
     name: 'TVA FR 20%',
-    frName: 'FR Taux standard (20%)',
     rate: 20,
     enabled: true,
   },

--- a/tests/puppeteer/campaigns/data/demo/tax.js
+++ b/tests/puppeteer/campaigns/data/demo/tax.js
@@ -1,8 +1,9 @@
 module.exports = {
   DefaultFrTax: {
-    id: '1',
+    id: 1,
     name: 'TVA FR 20%',
-    rate: '20',
+    frName: 'FR Taux standard (20%)',
+    rate: 20,
     enabled: true,
   },
 };

--- a/tests/puppeteer/campaigns/functional/BO/11_international/03_taxes/01_filterAndQuickEditTaxes.js
+++ b/tests/puppeteer/campaigns/functional/BO/11_international/03_taxes/01_filterAndQuickEditTaxes.js
@@ -71,9 +71,13 @@ describe('Filter And Quick Edit taxes', async () => {
         },
       },
       {
-        args: {
-          testIdentifier: 'filterRate', filterType: 'input', filterBy: 'rate', filterValue: DefaultFrTax.rate.toString(),
-        },
+        args:
+          {
+            testIdentifier: 'filterRate',
+            filterType: 'input',
+            filterBy: 'rate',
+            filterValue: DefaultFrTax.rate.toString(),
+          },
       },
       {
         args:

--- a/tests/puppeteer/campaigns/functional/BO/11_international/03_taxes/01_filterAndQuickEditTaxes.js
+++ b/tests/puppeteer/campaigns/functional/BO/11_international/03_taxes/01_filterAndQuickEditTaxes.js
@@ -62,7 +62,7 @@ describe('Filter And Quick Edit taxes', async () => {
     const tests = [
       {
         args: {
-          testIdentifier: 'filterId', filterType: 'input', filterBy: 'id_tax', filterValue: DefaultFrTax.id,
+          testIdentifier: 'filterId', filterType: 'input', filterBy: 'id_tax', filterValue: DefaultFrTax.id.toString(),
         },
       },
       {
@@ -72,7 +72,7 @@ describe('Filter And Quick Edit taxes', async () => {
       },
       {
         args: {
-          testIdentifier: 'filterRate', filterType: 'input', filterBy: 'rate', filterValue: DefaultFrTax.rate,
+          testIdentifier: 'filterRate', filterType: 'input', filterBy: 'rate', filterValue: DefaultFrTax.rate.toString(),
         },
       },
       {

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/giftOptions/01_giftOptions.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/giftOptions/01_giftOptions.js
@@ -40,7 +40,7 @@ const init = async function () {
   };
 };
 
-describe('Enable/Disable terms of service', async () => {
+describe('Update gift options ', async () => {
   // before and after functions
   before(async function () {
     browser = await helper.createBrowser();

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/giftOptions/01_giftOptions.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/giftOptions/01_giftOptions.js
@@ -94,7 +94,7 @@ describe('Update gift options ', async () => {
           action: 'enable',
           wantedStatus: true,
           price: 1,
-          tax: DefaultFrTax.frName,
+          tax: 'FR Taux standard (20%)',
           taxValue: DefaultFrTax.rate / 100,
           isRecyclablePackage: false,
         },

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/giftOptions/01_giftOptions.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/giftOptions/01_giftOptions.js
@@ -201,7 +201,7 @@ describe('Enable/Disable terms of service', async () => {
         await expect(isStepAddressComplete, 'Step Address is not complete').to.be.true;
       });
 
-      it(`should gift checkbox visibility be '${test.args.wantedStatus}'`, async function () {
+      it(`should check that gift checkbox visibility is '${test.args.wantedStatus}'`, async function () {
         await testContext.addContextItem(
           this,
           'testIdentifier',
@@ -233,19 +233,21 @@ describe('Enable/Disable terms of service', async () => {
         });
       }
 
-      it(`should recyclable package checkbox visibility be '${test.args.isRecyclablePackage}'`, async function () {
-        await testContext.addContextItem(
-          this,
-          'testIdentifier',
-          `checkRecyclableVisibility${test.args.testIdentifier}`,
-          baseContext,
-        );
-        const isRecyclableCheckboxVisible = await this.pageObjects.checkoutPage.isRecyclableCheckboxVisible();
-        await expect(
-          isRecyclableCheckboxVisible,
-          'Gift checkbox has not the correct status',
-        ).to.equal(test.args.isRecyclablePackage);
-      });
+      it(
+        `should check that recyclable package checkbox visibility is '${test.args.isRecyclablePackage}'`,
+        async function () {
+          await testContext.addContextItem(
+            this,
+            'testIdentifier',
+            `checkRecyclableVisibility${test.args.testIdentifier}`,
+            baseContext,
+          );
+          const isRecyclableCheckboxVisible = await this.pageObjects.checkoutPage.isRecyclableCheckboxVisible();
+          await expect(
+            isRecyclableCheckboxVisible,
+            'Gift checkbox has not the correct status',
+          ).to.equal(test.args.isRecyclablePackage);
+        });
 
       it('should sign out from FO', async function () {
         await testContext.addContextItem(

--- a/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/giftOptions/01_giftOptions.js
+++ b/tests/puppeteer/campaigns/functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/giftOptions/01_giftOptions.js
@@ -1,0 +1,277 @@
+require('module-alias/register');
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_orderSettings_giftOptions';
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const OrderSettingsPage = require('@pages/BO/shopParameters/orderSettings');
+const ProductPage = require('@pages/FO/product');
+const FOBasePage = require('@pages/FO/FObasePage');
+const HomePage = require('@pages/FO/home');
+const CartPage = require('@pages/FO/cart');
+const CheckoutPage = require('@pages/FO/checkout');
+const FOLoginPage = require('@pages/FO/login');
+// Importing data
+const {DefaultAccount} = require('@data/demo/customer');
+const {DefaultFrTax} = require('@data/demo/tax');
+
+let browser;
+let page;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    orderSettingsPage: new OrderSettingsPage(page),
+    productPage: new ProductPage(page),
+    foBasePage: new FOBasePage(page),
+    homePage: new HomePage(page),
+    cartPage: new CartPage(page),
+    checkoutPage: new CheckoutPage(page),
+    foLoginPage: new FOLoginPage(page),
+  };
+};
+
+describe('Enable/Disable terms of service', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+  // Login into BO and go to Shop Parameters > Order Settings page
+  loginCommon.loginBO();
+
+  it('should go to \'Shop Parameters > Order Settings\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToOrderSettingsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.shopParametersParentLink,
+      this.pageObjects.boBasePage.orderSettingsLink,
+    );
+    await this.pageObjects.boBasePage.closeSfToolBar();
+    const pageTitle = await this.pageObjects.orderSettingsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.orderSettingsPage.pageTitle);
+  });
+
+  const tests = [
+    {
+      args:
+        {
+          testIdentifier: 'GiftEnabledNoPriceNoTax',
+          action: 'enable',
+          wantedStatus: true,
+          price: 0,
+          tax: 'None',
+          isRecyclablePackage: false,
+        },
+    },
+    {
+      args:
+        {
+          testIdentifier: 'GiftEnabledWithPriceNoTax',
+          action: 'enable',
+          wantedStatus: true,
+          price: 1,
+          tax: 'None',
+          isRecyclablePackage: false,
+        },
+    },
+    {
+      args:
+        {
+          testIdentifier: 'GiftEnabledWithPriceAndTax',
+          action: 'enable',
+          wantedStatus: true,
+          price: 1,
+          tax: DefaultFrTax.frName,
+          taxValue: DefaultFrTax.rate / 100,
+          isRecyclablePackage: false,
+        },
+    },
+    {
+      args:
+        {
+          testIdentifier: 'GiftEnabledWithRecyclablePackage',
+          action: 'enable',
+          wantedStatus: true,
+          price: 0,
+          tax: 'None',
+          isRecyclablePackage: true,
+        },
+    },
+    {
+      args:
+        {
+          testIdentifier: 'GiftDisabled',
+          action: 'disable',
+          wantedStatus: false,
+          price: 0,
+          tax: 'None',
+          isRecyclablePackage: false,
+        },
+    },
+  ];
+  tests.forEach((test) => {
+    describe(`Set gift option with status: '${test.args.wantedStatus}', price: '${test.args.price}', `
+      + `tax: '${test.args.tax}', recyclable package: '${test.args.isRecyclablePackage}'`, async () => {
+      it(
+        `should ${test.args.action} gift options with price '€${test.args.price} and tax '${test.args.tax}`,
+        async function () {
+          await testContext.addContextItem(
+            this,
+            'testIdentifier',
+            `setOptions${test.args.testIdentifier}`,
+            baseContext,
+          );
+          const result = await this.pageObjects.orderSettingsPage.setGiftOptions(
+            test.args.wantedStatus,
+            test.args.price,
+            test.args.tax,
+            test.args.isRecyclablePackage,
+          );
+          await expect(result).to.contains(this.pageObjects.orderSettingsPage.successfulUpdateMessage);
+        },
+      );
+
+      it('should view my shop', async function () {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          `viewMyShopToCheck${test.args.testIdentifier}`,
+          baseContext,
+        );
+        page = await this.pageObjects.boBasePage.viewMyShop();
+        this.pageObjects = await init();
+        await this.pageObjects.homePage.changeLanguage('en');
+        const isHomePage = await this.pageObjects.homePage.isHomePage();
+        await expect(isHomePage, 'Fail to open FO home page').to.be.true;
+      });
+
+      it('should go to login page', async function () {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          `goToLoginPageFOToCheck${test.args.testIdentifier}`,
+          baseContext,
+        );
+        await this.pageObjects.homePage.goToLoginPage();
+        const pageTitle = await this.pageObjects.foLoginPage.getPageTitle();
+        await expect(pageTitle, 'Fail to open FO login page').to.contains(this.pageObjects.foLoginPage.pageTitle);
+      });
+
+      it('should sign in with default customer', async function () {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          `sighInFOToCheck${test.args.testIdentifier}`,
+          baseContext,
+        );
+        await this.pageObjects.foLoginPage.customerLogin(DefaultAccount);
+        const isCustomerConnected = await this.pageObjects.foLoginPage.isCustomerConnected();
+        await expect(isCustomerConnected, 'Customer is not connected').to.be.true;
+      });
+
+      it('should go to shipping step in checkout', async function () {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          `goToShippingStep${test.args.testIdentifier}`,
+          baseContext,
+        );
+        await this.pageObjects.foLoginPage.goToHomePage();
+        // Go to the first product page
+        await this.pageObjects.homePage.goToProductPage(4);
+        // Add the product to the cart
+        await this.pageObjects.productPage.addProductToTheCart();
+        // Proceed to checkout the shopping cart
+        await this.pageObjects.cartPage.clickOnProceedToCheckout();
+        // Address step - Go to delivery step
+        const isStepAddressComplete = await this.pageObjects.checkoutPage.goToDeliveryStep();
+        await expect(isStepAddressComplete, 'Step Address is not complete').to.be.true;
+      });
+
+      it(`should gift checkbox visibility be '${test.args.wantedStatus}'`, async function () {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          `checkGiftVisibility${test.args.testIdentifier}`,
+          baseContext,
+        );
+        const isGiftCheckboxVisible = await this.pageObjects.checkoutPage.isGiftCheckboxVisible();
+        await expect(
+          isGiftCheckboxVisible,
+          'Gift checkbox has not the correct status',
+        ).to.equal(test.args.wantedStatus);
+      });
+
+      if (test.args.wantedStatus) {
+        it('should check gift price and tax', async function () {
+          await testContext.addContextItem(
+            this,
+            'testIdentifier',
+            `checkGiftPrice${test.args.testIdentifier}`,
+            baseContext,
+          );
+          const giftPrice = await this.pageObjects.checkoutPage.getGiftPrice();
+          await expect(giftPrice, 'Gift price is incorrect').to.equal(
+            test.args.price === 0 ? 'Free'
+              : `€${parseFloat(
+                test.args.price * (test.args.tax === 'None' ? 1 : (1 + test.args.taxValue)),
+              ).toFixed(2)}`,
+          );
+        });
+      }
+
+      it(`should recyclable package checkbox visibility be '${test.args.isRecyclablePackage}'`, async function () {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          `checkRecyclableVisibility${test.args.testIdentifier}`,
+          baseContext,
+        );
+        const isRecyclableCheckboxVisible = await this.pageObjects.checkoutPage.isRecyclableCheckboxVisible();
+        await expect(
+          isRecyclableCheckboxVisible,
+          'Gift checkbox has not the correct status',
+        ).to.equal(test.args.isRecyclablePackage);
+      });
+
+      it('should sign out from FO', async function () {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          `sighOutFOAfterCheck${test.args.testIdentifier}`,
+          baseContext,
+        );
+        await this.pageObjects.checkoutPage.goToHomePage();
+        await this.pageObjects.homePage.logout();
+        const isCustomerConnected = await this.pageObjects.homePage.isCustomerConnected();
+        await expect(isCustomerConnected, 'Customer should be disconnected').to.be.false;
+      });
+
+      it('should go back to BO', async function () {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          `goBackToBoAfterCheck${test.args.testIdentifier}`,
+          baseContext,
+        );
+        page = await this.pageObjects.checkoutPage.closePage(browser, 1);
+        this.pageObjects = await init();
+        const pageTitle = await this.pageObjects.orderSettingsPage.getPageTitle();
+        await expect(pageTitle).to.contains(this.pageObjects.orderSettingsPage.pageTitle);
+      });
+    });
+  });
+});

--- a/tests/puppeteer/pages/BO/shopParameters/orderSettings/index.js
+++ b/tests/puppeteer/pages/BO/shopParameters/orderSettings/index.js
@@ -17,6 +17,12 @@ module.exports = class OrderSettings extends BOBasePage {
     this.enableTermsOfServiceLabel = `${this.generalForm} label[for='form_general_enable_tos_%TOGGLE']`;
     this.pageForTermsAndConditionsSelect = '#form_general_tos_cms_id';
     this.saveGeneralFormButton = `${this.generalForm} .card-footer button`;
+    // Gift options form
+    this.giftWrappingToogle = `${this.generalForm} label[for='form_gift_options_enable_gift_wrapping_%TOGGLE']`;
+    this.giftWrappingPriceInput = '#form_gift_options_gift_wrapping_price';
+    this.giftWrappingTaxSelect = '#form_gift_options_gift_wrapping_tax_rules_group';
+    this.recycledPackagingToogle = `${this.generalForm} label[for='form_gift_options_offer_recyclable_pack_%TOGGLE']`;
+    this.saveGiftOptionsFormButton = `${this.generalForm} div:nth-of-type(2) .card-footer button`;
   }
 
   /*
@@ -79,6 +85,25 @@ module.exports = class OrderSettings extends BOBasePage {
       await this.selectByVisibleText(this.pageForTermsAndConditionsSelect, pageName);
     }
     await this.clickAndWaitForNavigation(this.saveGeneralFormButton);
+    return this.getTextContent(this.alertSuccessBlock);
+  }
+
+  /**
+   * Set gift options form
+   * @param wantedStatus
+   * @param price
+   * @param tax
+   * @param recyclePackagingStatus
+   * @return {Promise<string>}
+   */
+  async setGiftOptions(wantedStatus = false, price = 0, tax = 'none', recyclePackagingStatus = false) {
+    await this.page.click(this.giftWrappingToogle.replace('%TOGGLE', wantedStatus ? 1 : 0));
+    if (wantedStatus) {
+      await this.setValue(this.giftWrappingPriceInput, price.toString());
+      await this.selectByVisibleText(this.giftWrappingTaxSelect, tax);
+    }
+    await this.page.click(this.recycledPackagingToogle.replace('%TOGGLE', recyclePackagingStatus ? 1 : 0));
+    await this.clickAndWaitForNavigation(this.saveGiftOptionsFormButton);
     return this.getTextContent(this.alertSuccessBlock);
   }
 };

--- a/tests/puppeteer/pages/FO/FObasePage.js
+++ b/tests/puppeteer/pages/FO/FObasePage.js
@@ -8,6 +8,7 @@ module.exports = class Home extends CommonPage {
     // Selectors for home page
     this.content = '#content';
     this.desktopLogo = '#_desktop_logo';
+    this.desktopLogoLink = `${this.desktopLogo} a`;
     this.cartProductsCount = '#_desktop_cart span.cart-products-count';
     this.cartLink = '#_desktop_cart a';
     this.userInfoLink = '#_desktop_user_info';
@@ -34,7 +35,7 @@ module.exports = class Home extends CommonPage {
    */
   async goToHomePage() {
     await this.waitForVisibleSelector(this.desktopLogo);
-    await this.clickAndWaitForNavigation(this.desktopLogo);
+    await this.clickAndWaitForNavigation(this.desktopLogoLink);
   }
 
   /**

--- a/tests/puppeteer/pages/FO/checkout.js
+++ b/tests/puppeteer/pages/FO/checkout.js
@@ -28,6 +28,11 @@ module.exports = class Checkout extends FOBasePage {
     this.emailInput = `${this.checkoutLoginForm} input[name='email']`;
     this.passwordInput = `${this.checkoutLoginForm} input[name='password']`;
     this.personalInformationContinueButton = `${this.checkoutLoginForm} #login-form footer button`;
+    // Gift selectors
+    this.giftCheckbox = '#input_gift';
+    this.recycableGiftCheckbox = '#input_recyclable';
+    this.cartSubtotalGiftWrappingDiv = '#cart-subtotal-gift_wrapping';
+    this.cartSubtotalGiftWrappingValueSpan = `${this.cartSubtotalGiftWrappingDiv} span.value`;
   }
 
   /*
@@ -134,5 +139,30 @@ module.exports = class Checkout extends FOBasePage {
    */
   isConditionToApproveCheckboxVisible() {
     return this.elementVisible(this.conditionToApproveCheckbox, 1000);
+  }
+
+  /**
+   * Check if gift checkbox is visible
+   * @return {boolean}
+   */
+  isGiftCheckboxVisible() {
+    return this.elementVisible(this.giftCheckbox, 1000);
+  }
+
+  /**
+   * Check if recyclable checkbox is visible
+   * @return {boolean}
+   */
+  isRecyclableCheckboxVisible() {
+    return this.elementVisible(this.recycableGiftCheckbox, 1000);
+  }
+
+  /**
+   * Get gift price from cart summary
+   * @return {Promise<string>}
+   */
+  async getGiftPrice() {
+    await this.changeCheckboxValue(this.giftCheckbox, true);
+    return this.getTextContent(this.cartSubtotalGiftWrappingValueSpan);
   }
 };


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add functional test for order setting gift options
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/13_shopParameters/02_orderSettings/01_orderSettings/giftOptions/*" URL_FO=shopUrl/ npm run specific-test`
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18426)
<!-- Reviewable:end -->
