### PR TITLE
Fix issue when there is a quantity discount on combination products

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3195,13 +3195,12 @@ class ProductCore extends ObjectModel
 
         $cart_quantity = 0;
         if ((int) $id_cart) {
-            $cache_id = 'Product::getPriceStatic_' . (int) $id_product . '-' . (int) $id_product_attribute . '-' . (int) $id_cart;
+            $cache_id = 'Product::getPriceStatic_' . (int) $id_product . '-' . (int) $id_cart;
             if (!Cache::isStored($cache_id) || ($cart_quantity = Cache::retrieve($cache_id) != (int) $quantity)) {
                 $sql = 'SELECT SUM(`quantity`)
                 FROM `' . _DB_PREFIX_ . 'cart_product`
                 WHERE `id_product` = ' . (int) $id_product . '
                 AND `id_cart` = ' . (int) $id_cart;
-                $sql .= $id_product_attribute !== null ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '';
                 $cart_quantity = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
                 Cache::store($cache_id, $cart_quantity);
             } else {

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -582,4 +582,19 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
         $this->products[$productName]->addToCategories([$category->id]);
         $this->products[$productName]->save();
     }
+
+    /**
+     * @Then The price of each product :productName after reduction should be :priceWithReduction
+     */
+    public function productPriceAfterReduction($productName, $priceWithReduction)
+    {
+        $this->checkProductWithNameExists($productName);
+        $productPricesList = $this->getCurrentCart()->getProducts(true);
+
+        foreach ($productPricesList as $productPrices) {
+            if ($this->products[$productName]->id == $productPrices['id_product'] && $productPrices['price_with_reduction'] != $priceWithReduction) {
+                throw new \RuntimeException(sprintf('Expects %s, got %s instead', $priceWithReduction, $productPrices['price_with_reduction']));
+            }
+        }
+    }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_combination.feature
@@ -39,8 +39,11 @@ Feature: Add product combination in cart
     Given there is a product in the catalog named "product7" with a price of 24.324 and 1000 items in stock
     Given product "product7" has a combination named "combi1" with 100 items in stock
     Given product "product7" has a combination named "combi2" with 100 items in stock
-    When I add 2 items of combination "combi1" of product "product7"
+    When I add 1 items of combination "combi1" of product "product7"
     When I add 1 items of combination "combi2" of product "product7"
-    Then I should have 2 items of combination "combi1" of product "product7" in my cart
+    Then I should have 1 items of combination "combi1" of product "product7" in my cart
     Then I should have 1 items of combination "combi2" of product "product7" in my cart
+    Then The price of each product "product7" after reduction should be 24.324
+    When I add 1 items of combination "combi2" of product "product7"
+    Then I should have 2 items of combination "combi2" of product "product7" in my cart
     Then The price of each product "product7" after reduction should be 19.324

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_combination.feature
@@ -3,6 +3,7 @@ Feature: Add product combination in cart
   As a customer
   I must be able to correctly add product combinations in my cart
 
+  @add-combinations-to-cart
   Scenario: Add combination in cart
     Given I have an empty default cart
     Given there is a product in the catalog named "product7" with a price of 24.324 and 1000 items in stock
@@ -12,6 +13,7 @@ Feature: Add product combination in cart
     Then I should have 11 items of combination "combi1" of product "product7" in my cart
     Then the remaining available stock for combination "combi1" of product "product7" should be 489
 
+  @add-combinations-to-cart
   Scenario: Cannot add combination in cart with quantity exceeding availability
     Given I have an empty default cart
     Given there is a product in the catalog named "product7" with a price of 19.812 and 1000 items in stock
@@ -20,6 +22,7 @@ Feature: Add product combination in cart
     Then I should have 0 items of combination "combi1" of product "product7" in my cart
     Then the remaining available stock for combination "combi1" of product "product7" should be 500
 
+  @add-combinations-to-cart
   Scenario: Be able to add out of stock combination if configuration allows it
     Given order out of stock products is allowed
     Given I have an empty default cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_combination.feature
@@ -28,3 +28,16 @@ Feature: Add product combination in cart
     When I add 600 items of combination "combi1" of product "product7"
     Then I should have 600 items of combination "combi1" of product "product7" in my cart
     Then the remaining available stock for combination "combi1" of product "product7" should be -100
+
+  @add-combinations-to-cart
+  Scenario: Product combinations are taken into account by price rules based on quantity
+    Given there is a specific price rule named "priceRuleCombination" with an amount discount of 5 and minimum quantity of 3
+    Given I have an empty default cart
+    Given there is a product in the catalog named "product7" with a price of 24.324 and 1000 items in stock
+    Given product "product7" has a combination named "combi1" with 100 items in stock
+    Given product "product7" has a combination named "combi2" with 100 items in stock
+    When I add 2 items of combination "combi1" of product "product7"
+    When I add 1 items of combination "combi2" of product "product7"
+    Then I should have 2 items of combination "combi1" of product "product7" in my cart
+    Then I should have 1 items of combination "combi2" of product "product7" in my cart
+    Then The price of each product "product7" after reduction should be 19.324


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Quantity discount on same products having different attributes is broken: for example two same sweat with different colors would not be counted as 2 products  
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18049
| How to test?  | See steps in the issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18427)
<!-- Reviewable:end -->

So, this PR is actually a revert of this pr: #16404, which was a remake of this pr: #8542 

It added an element in the cache key of the **getPriceStatic** method: the id_attribute of the product, supposedly to reduce the number of queries. There was 2 problems with this modification:

**1/** Adding an element to a cache key usually increases the number of queries, to make it diminishing the number of query the PR modified the query by adding the product's **id_product_attribute**. This is a patch, not a fix, the query was modified not for a functional purpose but in order to match the condition just above the query.

**2/** It introduces a bug, as rGaillard and jocel1 warned us:  https://github.com/PrestaShop/PrestaShop/pull/8542#issuecomment-349587244
Here we want the product quantity, including same products having different attributes, otherwise the **priceCalculation** method won't apply the price rules based on quantity. 



