### PR TITLE
Allow Object models to define their own methods of validation

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1150,12 +1150,12 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         // Check field validator
         if (!in_array('validate', $skip) && !empty($data['validate'])) {
-            $callable = $data['validate'];
-            if (!is_callable($callable)) {
-                $callable = 'Validate::' . $data['validate'];
+            $functionName = $data['validate'];
+            if (!is_callable($functionName)) {
+                $functionName = 'Validate::' . $data['validate'];
             }
 
-            if (!is_callable($callable)) {
+            if (!is_callable($functionName)) {
                 throw new PrestaShopException(
                     $this->trans(
                         'Validation function not found: %s.',
@@ -1166,20 +1166,20 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             }
 
             if (!empty($value)) {
-                $is_valid = true;
+                $isValid = true;
                 if (Tools::strtolower($data['validate']) === 'iscleanhtml') {
-                    if (!call_user_func(['Validate', $data['validate']], $value, $ps_allow_html_iframe)) {
-                        $is_valid = false;
+                    if (!call_user_func($functionName, $value, $ps_allow_html_iframe)) {
+                        $isValid = false;
+                    }
+                } else {
+                    if (!call_user_func($functionName, $value)) {
+                        $isValid = false;
                     }
                 }
 
-                if (!call_user_func($callable, $value)) {
-                    $is_valid = false;
-                }
-
-                if (!$is_valid) {
+                if (!$isValid) {
                     if ($human_errors) {
-                        return $this->trans('The %s field is invalid.', [$this->displayFieldName($field, get_class($this))], 'Admin.Notifications.Error');
+                        return $this->trans('The %s field is invalid.', [self::displayFieldName($field, get_class($this))], 'Admin.Notifications.Error');
                     }
 
                     return $this->trans('Property %s is not valid', [get_class($this) . '->' . $field], 'Admin.Notifications.Error');

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1150,27 +1150,39 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         // Check field validator
         if (!in_array('validate', $skip) && !empty($data['validate'])) {
-            if (!method_exists('Validate', $data['validate'])) {
-                throw new PrestaShopException($this->trans('Validation function not found: %s.', [$data['validate']], 'Admin.Notifications.Error'));
+            $callable = $data['validate'];
+            if (!is_callable($callable)) {
+                $callable = 'Validate::' . $data['validate'];
+            }
+
+            if (!is_callable($callable)) {
+                throw new PrestaShopException(
+                    $this->trans(
+                        'Validation function not found: %s.',
+                        [$data['validate']],
+                        'Admin.Notifications.Error'
+                    )
+                );
             }
 
             if (!empty($value)) {
-                $res = true;
-                if (Tools::strtolower($data['validate']) == 'iscleanhtml') {
+                $is_valid = true;
+                if (Tools::strtolower($data['validate']) === 'iscleanhtml') {
                     if (!call_user_func(['Validate', $data['validate']], $value, $ps_allow_html_iframe)) {
-                        $res = false;
-                    }
-                } else {
-                    if (!call_user_func(['Validate', $data['validate']], $value)) {
-                        $res = false;
+                        $is_valid = false;
                     }
                 }
-                if (!$res) {
+
+                if (!call_user_func($callable, $value)) {
+                    $is_valid = false;
+                }
+
+                if (!$is_valid) {
                     if ($human_errors) {
                         return $this->trans('The %s field is invalid.', [$this->displayFieldName($field, get_class($this))], 'Admin.Notifications.Error');
-                    } else {
-                        return $this->trans('Property %s is not valid', [get_class($this) . '->' . $field], 'Admin.Notifications.Error');
                     }
+
+                    return $this->trans('Property %s is not valid', [get_class($this) . '->' . $field], 'Admin.Notifications.Error');
                 }
             }
         }

--- a/tests-legacy/Unit/Classes/ObjectModelTest.php
+++ b/tests-legacy/Unit/Classes/ObjectModelTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace LegacyTests\Unit\Classes;
+
+use LegacyTests\TestCase\UnitTestCase;
+use Alias;
+
+class ObjectModelTest extends UnitTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        Alias::$definition['fields']['fullname'] = [
+        'type' => Alias::TYPE_STRING,
+        'validate' => 'isString'
+        ];
+
+        Alias::$definition['fields']['gender'] = [
+            'type' => Alias::TYPE_STRING,
+            'validate' => 'LegacyTests\Unit\Classes\CustomValidator::isValidGender',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function teardown()
+    {
+        unset(
+            Alias::$definition['fields']['fullname'],
+            Alias::$definition['fields']['gender']
+        );
+    }
+
+    public function testValidateField()
+    {
+        $alias = new Alias();
+
+        self::assertTrue($alias->validateField('fullname', 'Mickaël Andrieu'));
+        self::assertTrue($alias->validateField('gender', 'MALE'));
+    }
+}
+
+class CustomValidator {
+    public static function isValidGender($value)
+    {
+        return in_array($value, [
+            'MALE',
+            'FEMALE',
+            'NOT_BINARY',
+        ]);
+    }
+}

--- a/tests-legacy/Unit/Classes/ObjectModelTest.php
+++ b/tests-legacy/Unit/Classes/ObjectModelTest.php
@@ -36,11 +36,19 @@ class ObjectModelTest extends UnitTestCase
      */
     protected function setUp()
     {
+        # Old retro compatible way
         Alias::$definition['fields']['fullname'] = [
         'type' => Alias::TYPE_STRING,
         'validate' => 'isString'
         ];
 
+        # What should be documented post 1.7.8
+        Alias::$definition['fields']['whatever'] = [
+            'type' => Alias::TYPE_INT,
+            'validate' => 'Validate::isInt'
+        ];
+
+        # What is also possible post 1.7.8
         Alias::$definition['fields']['gender'] = [
             'type' => Alias::TYPE_STRING,
             'validate' => 'LegacyTests\Unit\Classes\CustomValidator::isValidGender',
@@ -54,6 +62,7 @@ class ObjectModelTest extends UnitTestCase
     {
         unset(
             Alias::$definition['fields']['fullname'],
+            Alias::$definition['fields']['whatever'],
             Alias::$definition['fields']['gender']
         );
     }
@@ -63,10 +72,14 @@ class ObjectModelTest extends UnitTestCase
         $alias = new Alias();
 
         self::assertTrue($alias->validateField('fullname', 'Mickaël Andrieu'));
+        self::assertNotTrue($alias->validateField('whatever', 'not a number'));
         self::assertTrue($alias->validateField('gender', 'MALE'));
     }
 }
 
+/**
+ * This class must be only used for this test !
+ */
 class CustomValidator {
     public static function isValidGender($value)
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you need specific validation rules you have to override Validate class, this contribution fixes this issue
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | This fixes an issue: we can't override the Validate class twice, so...
| How to test?  | By writing tests, obviously

```
<?php

class A extends ObjectModel
{
    public $id;
    public $a;
    public $b;
 
    public static $definition = [
        'table' => 'a',
        'primary' => 'id',
        'fields' => [
            'a' => ['type' => self::TYPE_INT, 'validate' => 'A::isFoo'],
            'b' => ['type' => self::TYPE_INT, 'validate' => 'isInt'],
        ]
    ];

    public static function isFoo($value)
    {
        return false;
    }
}
```
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18434)
<!-- Reviewable:end -->
