### PR TITLE
Use scandir instead of readdir to get sorted entities

### DIFF
--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -177,10 +177,9 @@ class XmlLoader
     public function getSortedEntities()
     {
         // Browse all XML files from data/xml directory
-        $entities = array();
-        $dependencies = array();
-        $fd = opendir($this->data_path);
-        while ($file = readdir($fd)) {
+        $entities = [];
+        $dependencies = [];
+        foreach (scandir($this->data_path) as $file) {
             if (preg_match('#^(.+)\.xml$#', $file, $m)) {
                 $entity = $m[1];
                 $xml = $this->loadEntity($entity);
@@ -199,7 +198,6 @@ class XmlLoader
                 $entities[] = $entity;
             }
         }
-        closedir($fd);
 
         // Sort entities to populate database in good order (E.g. zones before countries)
         do {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Readdir function return an incorrect order depending on the server you're running it. Use scandir instead
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Installation must work as before, tests are green. If you want to go further, you can compare the database table `ps_configuration`.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18451)
<!-- Reviewable:end -->
