### PR TITLE
Set currency to avoid specific price conversion

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -391,7 +391,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             $specificPrice = new SpecificPrice();
             $specificPrice->id_shop = 0;
             $specificPrice->id_shop_group = 0;
-            $specificPrice->id_currency = 0;
+            $specificPrice->id_currency = $order->id_currency;
             $specificPrice->id_country = 0;
             $specificPrice->id_group = 0;
             $specificPrice->id_customer = $order->id_customer;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Avoid specific price conversion when the product price is set manually on order edit
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18433 
| How to test?  | - First create a secondary currency for your shop<br>- Go to FO, create an order with the secondary currency.<br>- Go to BO, to the created order, click on "Add a product" button<br>- Select a product and change it's price<br>- Add the product : The "Total" is wrong, when "Products" is right.<br>- The behaviour must be correct for the HT and TTC price modifications

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18453)
<!-- Reviewable:end -->
