### PR TITLE
Fix h1 on brandlist and supplierlist module that shouldn't be an h1

### DIFF
--- a/themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl
+++ b/themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl
@@ -25,11 +25,16 @@
 
 <div id="search_filters_brands">
   <section class="facet">
-    <h1 class="h6 text-uppercase facet-label">
-      {if $display_link_brand}<a href="{$page_link}" title="{l s='Brands' d='Shop.Theme.Catalog'}">{/if}
-        {l s='Brands' d='Shop.Theme.Catalog'}
-      {if $display_link_brand}</a>{/if}
-    </h1>
+    {if $display_link_brand}
+      <a href="{$page_link}" class="h6 text-uppercase facet-label" title="{l s='brands' d='shop.theme.catalog'}">
+        {l s='brands' d='shop.theme.catalog'}
+      </a>
+    {else}
+      <p class="h6 text-uppercase facet-label">
+        {l s='brands' d='shop.theme.catalog'}
+      </p>
+    {/if}
+
     <div>
       {if $brands}
         {include file="module:ps_brandlist/views/templates/_partials/$brand_display_type.tpl" brands=$brands}

--- a/themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl
+++ b/themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl
@@ -27,11 +27,11 @@
   <section class="facet">
     {if $display_link_brand}
       <a href="{$page_link}" class="h6 text-uppercase facet-label" title="{l s='brands' d='shop.theme.catalog'}">
-        {l s='brands' d='shop.theme.catalog'}
+        {l s='Brands' d='Shop.Theme.Catalog'}
       </a>
     {else}
       <p class="h6 text-uppercase facet-label">
-        {l s='brands' d='shop.theme.catalog'}
+        {l s='Brands' d='Shop.Theme.Catalog'}
       </p>
     {/if}
 

--- a/themes/classic/modules/ps_supplierlist/views/templates/hook/ps_supplierlist.tpl
+++ b/themes/classic/modules/ps_supplierlist/views/templates/hook/ps_supplierlist.tpl
@@ -25,11 +25,16 @@
 
 <div id="search_filters_suppliers">
   <section class="facet">
-    <h1 class="h6 text-uppercase facet-label">
-      {if $display_link_supplier}<a href="{$page_link}" title="{l s='Suppliers' d='Shop.Theme.Catalog'}">{/if}
+    {if $display_link_supplier}
+      <a href="{$page_link}" class="h6 text-uppercase facet-label" title="{l s='Suppliers' d='Shop.Theme.Catalog'}">
         {l s='Suppliers' d='Shop.Theme.Catalog'}
-      {if $display_link_supplier}</a>{/if}
-    </h1>
+      </a>
+    {else}
+      <p class="h6 text-uppercase facet-label">
+        {l s='Suppliers' d='Shop.Theme.Catalog'}
+      </p>
+    {/if}
+
     <div>
       {if $suppliers}
         {include file="module:ps_supplierlist/views/templates/_partials/$supplier_display_type.tpl" suppliers=$suppliers}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There was an H1 on brandlist and supplierlist module on category page filters that shouldnt be an h1
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18409.
| How to test?  | Install the ps_brandlist module, Go to the FO => Categories page, Scroll down to ps_brandlist block, Inspect element, See error: the title of ps_brandlist module has H1 instead of a simple link with h6 class

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18459)
<!-- Reviewable:end -->
