### PR TITLE
Add modal to customer address listing on bulk action

### DIFF
--- a/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
@@ -290,6 +291,11 @@ final class AddressGridDefinitionFactory extends AbstractFilterableGridDefinitio
                     ->setOptions([
                         'submit_route' => 'admin_addresses_delete_bulk',
                         'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
+                        'modal_options' => new ModalOptions([
+                            'title' => $this->trans('Delete selected addresses?', [], 'Admin.Actions'),
+                            'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
+                            'confirm_button_class' => 'btn-danger',
+                        ]),
                     ])
             );
     }

--- a/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
@@ -290,10 +290,11 @@ final class AddressGridDefinitionFactory extends AbstractFilterableGridDefinitio
                     ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
                     ->setOptions([
                         'submit_route' => 'admin_addresses_delete_bulk',
-                        'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
+                        'confirm_message' => $this->trans('Are you sure you want to delete the selected address(es)?', [], 'Admin.Notifications.Warning'),
                         'modal_options' => new ModalOptions([
-                            'title' => $this->trans('Delete selected addresses?', [], 'Admin.Actions'),
+                            'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
                             'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
+                            'close_button_label' => $this->trans('Cancel', [], 'Admin.Actions'),
                             'confirm_button_class' => 'btn-danger',
                         ]),
                     ])

--- a/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
@@ -54,6 +54,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class AddressGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
+
     public const GRID_ID = 'address';
 
     /**
@@ -286,18 +288,7 @@ final class AddressGridDefinitionFactory extends AbstractFilterableGridDefinitio
     {
         return (new BulkActionCollection())
             ->add(
-                (new SubmitBulkAction('delete_selection'))
-                    ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                    ->setOptions([
-                        'submit_route' => 'admin_addresses_delete_bulk',
-                        'confirm_message' => $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Notifications.Warning'),
-                        'modal_options' => new ModalOptions([
-                            'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
-                            'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
-                            'close_button_label' => $this->trans('Cancel', [], 'Admin.Actions'),
-                            'confirm_button_class' => 'btn-danger',
-                        ]),
-                    ])
+                $this->buildBulkDeleteAction('admin_cms_pages_bulk_delete')
             );
     }
 }

--- a/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
@@ -28,10 +28,8 @@ namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
-use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollectionInterface;
-use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;

--- a/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
@@ -290,7 +290,7 @@ final class AddressGridDefinitionFactory extends AbstractFilterableGridDefinitio
                     ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
                     ->setOptions([
                         'submit_route' => 'admin_addresses_delete_bulk',
-                        'confirm_message' => $this->trans('Are you sure you want to delete the selected address(es)?', [], 'Admin.Notifications.Warning'),
+                        'confirm_message' => $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Notifications.Warning'),
                         'modal_options' => new ModalOptions([
                             'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
                             'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),

--- a/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
@@ -286,7 +286,7 @@ final class AddressGridDefinitionFactory extends AbstractFilterableGridDefinitio
     {
         return (new BulkActionCollection())
             ->add(
-                $this->buildBulkDeleteAction('admin_cms_pages_bulk_delete')
+                $this->buildBulkDeleteAction('admin_addresses_delete_bulk')
             );
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add modal to customer address listing on bulk action (deletion)
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18414
| How to test?  | 1- Go in BO's customer address listing page<br> 2- select one or more addresses<br> 3- Click on "grouped actions", "delete", a modal should appear

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18464)
<!-- Reviewable:end -->
