### PR TITLE
Functional tests - Add test 'Export languages' in translations page

### DIFF
--- a/tests/puppeteer/campaigns/functional/BO/11_international/04_translations/03_exportLanguage.js
+++ b/tests/puppeteer/campaigns/functional/BO/11_international/04_translations/03_exportLanguage.js
@@ -73,7 +73,7 @@ describe('Sort taxes', async () => {
         this,
         'testIdentifier',
         `exportLanguage${test.args.language.name}Theme${test.args.theme}`,
-        baseContext
+        baseContext,
       );
       await this.pageObjects.translationsPage.exportLanguage(test.args.language.name, test.args.theme);
       const fileExist = await files.checkFileExistence(test.args.filename);

--- a/tests/puppeteer/campaigns/functional/BO/11_international/04_translations/03_exportLanguage.js
+++ b/tests/puppeteer/campaigns/functional/BO/11_international/04_translations/03_exportLanguage.js
@@ -1,0 +1,84 @@
+require('module-alias/register');
+// Using chai
+const {expect} = require('chai');
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+// Importing pages
+const BOBasePage = require('@pages/BO/BObasePage');
+const LoginPage = require('@pages/BO/login');
+const DashboardPage = require('@pages/BO/dashboard');
+const TranslationsPage = require('@pages/BO/international/translations');
+const {Languages} = require('@data/demo/languages');
+const files = require('@utils/files');
+// Test context imports
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_international_localization_translations_exportLanguage';
+
+let browser;
+let page;
+
+// Init objects needed
+const init = async function () {
+  return {
+    boBasePage: new BOBasePage(page),
+    loginPage: new LoginPage(page),
+    dashboardPage: new DashboardPage(page),
+    translationsPage: new TranslationsPage(page),
+  };
+};
+
+describe('Sort taxes', async () => {
+  // before and after functions
+  before(async function () {
+    browser = await helper.createBrowser();
+    page = await helper.newTab(browser);
+    await helper.setDownloadBehavior(page);
+    this.pageObjects = await init();
+  });
+  after(async () => {
+    await helper.closeBrowser(browser);
+  });
+  // Login into BO and go to translations page
+  loginCommon.loginBO();
+
+  it('should go to translations page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToTranslationsPage', baseContext);
+    await this.pageObjects.boBasePage.goToSubMenu(
+      this.pageObjects.boBasePage.internationalParentLink,
+      this.pageObjects.boBasePage.translationsLink,
+    );
+    const pageTitle = await this.pageObjects.translationsPage.getPageTitle();
+    await expect(pageTitle).to.contains(this.pageObjects.translationsPage.pageTitle);
+  });
+
+  const tests = [
+    {
+      args:
+        {
+          testIdentifier: 'sortByIdDesc', language: Languages.english, theme: 'classic', filename: 'classic.en-US.zip',
+        },
+    },
+    {
+      args:
+        {
+          testIdentifier: 'sortByIdDesc', language: Languages.french, theme: 'classic', filename: 'classic.fr-FR.zip',
+        },
+    },
+  ];
+
+  tests.forEach((test) => {
+    it(`Export language '${test.args.language.name}' for theme '${test.args.theme}'`, async function () {
+      await testContext.addContextItem(
+        this,
+        'testIdentifier',
+        `exportLanguage${test.args.language.name}Theme${test.args.theme}`,
+        baseContext
+      );
+      await this.pageObjects.translationsPage.exportLanguage(test.args.language.name, test.args.theme);
+      const fileExist = await files.checkFileExistence(test.args.filename);
+      await expect(fileExist, `File ${test.args.filename} was not downloaded`).to.be.true;
+      await files.deleteFile(`${global.BO.DOWNLOAD_PATH}/${test.args.filename}`);
+    });
+  });
+});

--- a/tests/puppeteer/pages/BO/BObasePage.js
+++ b/tests/puppeteer/pages/BO/BObasePage.js
@@ -86,6 +86,8 @@ module.exports = class BOBasePage extends CommonPage {
     this.taxesLink = '#subtab-AdminParentTaxes';
     // Localization
     this.localizationLink = '#subtab-AdminParentLocalization';
+    // Translations
+    this.translationsLink = '#subtab-AdminTranslations';
 
     // Shop Parameters
     this.shopParametersParentLink = '#subtab-ShopParameters';

--- a/tests/puppeteer/pages/BO/international/translations/index.js
+++ b/tests/puppeteer/pages/BO/international/translations/index.js
@@ -1,0 +1,33 @@
+require('module-alias/register');
+const BOBasePage = require('@pages/BO/BObasePage');
+
+module.exports = class Translations extends BOBasePage {
+  constructor(page) {
+    super(page);
+
+    this.pageTitle = 'Translations • ';
+
+    // Selectors
+    //Export language form
+    this.exportLanguageForm = 'form[action*=\'translations/export\']';
+    this.exportLanguageSelect = '#form_iso_code';
+    this.exportLanguageThemeSelect = '#form_theme_name';
+    this.exportLanguageButton = `${this.exportLanguageForm} .card-footer button`;
+  }
+
+  /*
+  Methods
+   */
+
+  /**
+   * Export language
+   * @param language
+   * @param theme
+   * @return {Promise<void>}
+   */
+  async exportLanguage(language, theme) {
+    await this.selectByVisibleText(this.exportLanguageSelect, language);
+    await this.selectByVisibleText(this.exportLanguageThemeSelect, theme);
+    await this.page.click(this.exportLanguageButton);
+  }
+};

--- a/tests/puppeteer/pages/BO/international/translations/index.js
+++ b/tests/puppeteer/pages/BO/international/translations/index.js
@@ -8,7 +8,7 @@ module.exports = class Translations extends BOBasePage {
     this.pageTitle = 'Translations • ';
 
     // Selectors
-    //Export language form
+    // Export language form
     this.exportLanguageForm = 'form[action*=\'translations/export\']';
     this.exportLanguageSelect = '#form_iso_code';
     this.exportLanguageThemeSelect = '#form_theme_name';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add test 'Export languages' in translations page
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `DOWNLOAD_PATH="downloadPath" TEST_PATH="functional/BO/11_international/04_translations/*" URL_FO=shopUrl/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18465)
<!-- Reviewable:end -->
