### PR TITLE
Fix Order.getInvoicesCollection() query

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1976,6 +1976,7 @@ class OrderCore extends ObjectModel
     {
         $order_invoices = new PrestaShopCollection('OrderInvoice');
         $order_invoices->where('id_order', '=', $this->id);
+        $order_invoices->where('number', '!=', 0);
 
         return $order_invoices;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Avoid "dummy" invoices with number 0 to be returned. It is the case when a delivery slip exists but not an invoice. And it generates a "double" payment under the conditions described below
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Place an order that is paid and invoice is not yet generated. Change order state to Preparation (previously configured with paid = true, delivery = true, invoice = false). Without the fix a "double" payment is automatically created.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18468)
<!-- Reviewable:end -->
